### PR TITLE
refs #38 allow object members to refer to self when initialized with closures

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -346,6 +346,7 @@
     - fixed a bug handling closure-bound local variables when closures are created in the background operator expression that caused a core dump
     - fixed the precedence of the @ref assignment_operator "assignment operator (=)"; now the precedence of this operator is the same as the other assignment operators (@ref plus_equals_operator "+=", @ref minus_equals_operator "-=", @ref multiply_equals_operator "*=", and @ref divide_equals_operator "/=", etc); this does not break any code, but does align %Qore with other programming languages (such as C, among others) and allows for expressions such as @code a = b += 2@endcode to be correctly parsed
     - fixed a parse-time bug in the @ref trim "trim operator" where the operator's return type was incorrectly returned as @ref int_type "int" instead of the type of the lvalue
+    - fixed a bug initializing object members with a closure that refers to \a self
 
     @section qore_0811 Qore 0.8.11
 

--- a/examples/test/qore/vars/members.qtest
+++ b/examples/test/qore/vars/members.qtest
@@ -1,0 +1,27 @@
+#!/usr/bin/env qr
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%requires ../../../../qlib/QUnit.qm
+
+%new-style
+
+# allow child Program objects to have more liberal permissions than the parent
+%no-child-restrictions
+
+%exec-class MemberTest
+
+public class MemberTest inherits QUnit::Test {
+    constructor() : Test("MemberTest", "1.0") {
+        addTestCase("self test", \selfTest());
+
+        # Return for compatibility with test harness that checks return value.
+        set_return_value(main());
+    }
+
+    selfTest() {
+        Program p(PO_NEW_STYLE);
+        p.parse("class A {public {code f = sub() { return self; };}} A a();", "member-test-1");
+
+        testAssertion("member-self", \p.run(), NOTHING, new TestResultValue(NOTHING));
+    }
+}


### PR DESCRIPTION
this fixes the bug handling self bound into closures assigned in member initialization, but there is still a memory leak which will be fixed in #37 