### PR TITLE
TreeMap updates and related fixes to the HttpServer module

### DIFF
--- a/examples/test/qore/classes/TreeMap/TreeMap.qtest
+++ b/examples/test/qore/classes/TreeMap/TreeMap.qtest
@@ -9,7 +9,7 @@ public class TreeMapTest inherits QUnit::Test {
 
     private {
         TreeMap tm();
-    } 
+    }
 
     public {
         hash objs = {};
@@ -20,6 +20,8 @@ public class TreeMapTest inherits QUnit::Test {
         addTestCase("left-most element in the tree is not ignored", \testFirst());
         addTestCase("right-most element in the tree is not ignored", \testLast());
         addTestCase("correct reference counting", \testRefCount());
+        addTestCase("take", \testTake());
+        addTestCase("getAll", \testGetAll());
 
         set_return_value(main());
     }
@@ -80,17 +82,37 @@ public class TreeMapTest inherits QUnit::Test {
                     MyObject o3("obj3", self);
 
                     testAssertion("obj1 still exists", \equals(), (True, objs{"obj1"}));
-                    tm2.put("key", o2); 
+                    tm2.put("key", o2);
                     testAssertion("obj1 has been destroyed", \equals(), (False, objs{"obj1"}));
                     tm2.put("key", o3);
                     h{"x"} = tm2.get("key");
                     testAssertion("obj2 still exists", \equals(), (True, objs{"obj2"}));
-                }   
+                }
                 testAssertion("obj2 has been destroyed", \equals(), (False, objs{"obj2"}));
             }
             testAssertion("obj3 still exists", \equals(), (True, objs{"obj3"}));
-        }   
+        }
         testAssertion("obj3 has been destroyed", \equals(), (False, objs{"obj3"}));
+    }
+
+    testTake() {
+        TreeMap tm();
+
+        tm.put("a", 1);
+        tm.put("b", 2);
+        testAssertionValue("get-1", tm.get("a"), 1);
+        testAssertionValue("get-2", tm.get("b"), 2);
+        testAssertionValue("get-3", tm.get("c"));
+        testAssertionValue("take-1", tm.take("a"), 1);
+        testAssertionValue("get-4", tm.get("a"));
+    }
+
+    testGetAll() {
+        TreeMap tm();
+
+        tm.put("a", 1);
+        tm.put("b", 2);
+        testAssertionValue("getAll", tm.getAll(), ("a": 1, "b": 2));
     }
 }
 
@@ -105,7 +127,7 @@ class MyObject {
         treeMapTest = tmt;
         treeMapTest.objs{name} = True;
     }
-    
+
     destructor() {
         treeMapTest.objs{name} = False;
     }

--- a/lib/QC_TreeMap.qpp
+++ b/lib/QC_TreeMap.qpp
@@ -81,6 +81,8 @@ TreeMap::copy() {
 /**
     @param path the path to which \c value will be mapped
     @param value the value to put into the TreeMap
+
+    @see TreeMap::remove()
  */
 nothing TreeMap::put(string path, any value) {
    tm->put(path, value, xsink);
@@ -91,6 +93,26 @@ nothing TreeMap::put(string path, any value) {
     @param path the path to lookup
     @return the value pointed to by the longest prefix of \c path or NOTHING if no such mapping exists
  */
-any TreeMap::get(string path) [flags=CONSTANT] {
+any TreeMap::get(string path) [flags=RET_VALUE_ONLY] {
    return tm->get(path, xsink);
+}
+
+//! Removes a value from the TreeMap and returns the value removed
+/** The \c path must be an exact match
+
+    @param path the path to remove
+
+    @return the value removed from the TreeMap or @ref nothing if no exact match was found
+
+    @see TreeMap::put()
+*/
+any TreeMap::take(string path) {
+   return tm->take(path, xsink);
+}
+
+//! Retrieves the entire TreeMap as a hash; returns @ref nothing if the TreeMap is empty
+/** @return the entire TreeMap as a hash or returns @ref nothing if the TreeMap is empty
+ */
+*hash TreeMap::getAll() [flags=CONSTANT] {
+   return tm->getAll();
 }

--- a/qlib/HttpServer.qm
+++ b/qlib/HttpServer.qm
@@ -335,6 +335,9 @@ class HttpServer::HttpHandlerList {
 
     #! sets a request handler according to the arguments given
     setHandler(string name, string path, bool isregex = True, *softlist content, HttpServer::AbstractHttpRequestHandler obj, *softlist special_headers) {
+        # paths are passed without the leading "/", so they have to be like this in the treemap
+        if (path =~ /^\//)
+            path = path.substr(1);
         if (handlers{name})
             throw "SETHANDLER-ERROR", sprintf("HTTP request handler %y already exists", name);
 
@@ -422,6 +425,9 @@ class HttpServer::DynamicHttpHandlerList inherits HttpServer::HttpHandlerList {
 
     #! sets a dynamic request handler according to the arguments given
     setHandler(string name, string path, bool isregex, *softlist content_type, HttpServer::AbstractHttpRequestHandler obj, *softlist special_headers) {
+        # paths are passed without the leading "/", so they have to be like this in the treemap
+        if (path =~ /^\//)
+            path = path.substr(1);
         DynamicHandlerInfo dhi(name, obj, path, isregex, content_type, special_headers);
 
         dhl.writeLock();
@@ -431,6 +437,10 @@ class HttpServer::DynamicHttpHandlerList inherits HttpServer::HttpHandlerList {
             throw "SETHANDLER-ERROR", sprintf("dynamic HTTP request handler %y already exists (dynamic handlers: %y)", name, handlers.keys());
 
 	handlers{name} = dhi;
+
+        if (!isregex && path) {
+            treeMap.put(path, dhi);
+        }
     }
 
     #! remove dynamic handler
@@ -447,6 +457,10 @@ class HttpServer::DynamicHttpHandlerList inherits HttpServer::HttpHandlerList {
 
             # remove the handler from the list
             DynamicHandlerInfo dhi = remove handlers{name};
+
+            # remove handler from treemap if applicable
+            if (!dhi.isregex && exists dhi.path)
+                treeMap.take(dhi.path);
 
             # take a copy of a reference to the Counter
             c = dhi.counter;


### PR DESCRIPTION
added TreeMap::take() and TreeMap::getAll() + tests
added a RWLock to TreeMap for thread-safety
updated HttpServer to add paths used with dynamic handlers to the treemap and remove them when the dynamic handler is removed
updated the HttpServer to "justify" URL paths by removing any leading '/' char
