### PR TITLE
fixed memory leak related to recursive references in member initialization

### DIFF
--- a/examples/test/qore/misc/gc.qtest
+++ b/examples/test/qore/misc/gc.qtest
@@ -1,15 +1,15 @@
 #!/usr/bin/env qr
+# -*- mode: qore; indent-tabs-mode: nil -*-
 
 %require-types
 %enable-all-warnings
 %new-style
 
-%requires UnitTest
+%requires ../../../../qlib/QUnit.qm
 
-my UnitTest unit();
-gc_tests();
+%exec-class DgcTest
 
-class GcTest { 
+class GcTest {
     public {
         code inc;
         any a;
@@ -25,162 +25,192 @@ class GcTest {
         inc = i;
         o = obj;
     }
-    
+
     destructor() {
         # increment static counter in destructor
         call_function(inc);
-    } 
-    
+    }
+
     set(*GcTest obj) {
         o = obj;
     }
 }
 
-sub gc_tests() {
-    if (!HAVE_DETERMINISTIC_GC)
-        return;
-
-    my int cnt = 0;
-    my code inc = sub () { ++cnt; };
-
-    # make circular references
-    {
-        my GcTest obj1(inc);
-        obj1.a = obj1;
+class GcTest1 {
+    public {
+        code inc;
+        any a = self;
     }
-    unit.cmp(cnt, 1, "recursive gc 1");
 
-    {
-        my GcTest obj2(inc);
-        obj2.a = obj2;
+    constructor(code i) {
+        inc = i;
     }
-    unit.cmp(cnt, 2, "recursive gc 2");
 
-    {
-        my GcTest obj3(inc);
-        obj3.a.a = obj3;
+    destructor() {
+        # increment static counter in destructor
+        inc();
     }
-    unit.cmp(cnt, 3, "recursive gc 3");
+}
 
-    {
-        my GcTest obj4(inc);
-        obj4.a = list(obj4);
+class DgcTest inherits QUnit::Test {
+    constructor() : Test("GcTest", "1.0") {
+	addTestCase("GcTests", \gcTests());
+
+        # Return for compatibility with test harness that checks the return value
+        set_return_value(main());
     }
-    unit.cmp(cnt, 4, "recursive gc 4");
 
-    {
-        my GcTest obj5(inc);
-        my GcTest obj6(inc);
-        obj5.a = obj6;
-        obj6.b = obj5;
+    gcTests() {
+	if (!HAVE_DETERMINISTIC_GC)
+	    testSkip("HAVE_DETERMINISTIC_GC is not defined");
+
+	int cnt = 0;
+	code inc = sub () { ++cnt; };
+
+	# make circular references
+	{
+	    GcTest obj1(inc);
+	    obj1.a = obj1;
+	}
+	testAssertionValue("recursive gc 1", cnt, 1);
+
+	{
+	    GcTest obj2(inc);
+	    obj2.a = obj2;
+	}
+	testAssertionValue("recursive gc 2", cnt, 2);
+
+	{
+	    GcTest obj3(inc);
+	    obj3.a.a = obj3;
+	}
+	testAssertionValue("recursive gc 3", cnt, 3);
+
+	{
+	    GcTest obj4(inc);
+	    obj4.a = list(obj4);
+	}
+	testAssertionValue("recursive gc 4", cnt, 4);
+
+	{
+	    GcTest obj5(inc);
+	    GcTest obj6(inc);
+	    obj5.a = obj6;
+	    obj6.b = obj5;
+	}
+	testAssertionValue("recursive gc 6", cnt, 6);
+
+	{
+	    GcTest obj7(inc);
+	    obj7.a = obj7;
+	    obj7.b = obj7;
+	}
+	testAssertionValue("recursive gc 7", cnt, 7);
+
+	{
+	    GcTest obj8(inc);
+	    GcTest obj9(inc);
+
+	    obj8.a = ("a": obj9, "b": obj9);
+	    obj9.b = obj8;
+	    obj9.c = obj8;
+	}
+	testAssertionValue("recursive gc 9", cnt, 9);
+
+	{
+	    GcTest obj10(inc);
+	    GcTest obj11(inc);
+	    obj10.set(obj11);
+	    obj11.set(obj10);
+	}
+	testAssertionValue("recursive gc 11", cnt, 11);
+
+	{
+	    GcTest obj12(inc);
+	    {
+		GcTest obj13(inc);
+
+		obj12.a = obj13;
+		obj13.a = obj12;
+	    }
+	}
+	testAssertionValue("recursive gc 13-1", cnt, 13);
+
+	{
+	    GcTest t1(inc);
+	    GcTest t2(inc);
+	    t1.set(t2);
+	    t2.set(t1);
+	    t1.set();
+
+	    testAssertionValue("recursive gc 13-2", cnt, 13);
+	}
+	testAssertionValue("recursive gc 15-1", cnt, 15);
+
+	{
+	    GcTest t1(inc);
+	    t1.set(t1);
+	    t1.set();
+
+	    testAssertionValue("recursive gc 15-2", cnt, 15);
+	}
+	testAssertionValue("recursive gc 16-1", cnt, 16);
+
+	{
+	    GcTest t1(inc);
+	    {
+		GcTest t2(inc);
+		t1.set(t2);
+		t2.b = t1;
+		{
+		    GcTest t3(inc);
+		    t2.set(t3);
+		    t2.b = t1;
+		    {
+			GcTest t4(inc);
+			t3.set(t4);
+			t4.set(t1);
+			t3.b = t2;
+			t4.b = t3;
+		    }
+		}
+	    }
+	    testAssertionValue("recursive gc 16-2", cnt, 16);
+	}
+	testAssertionValue("recursive gc 20-1", cnt, 20);
+
+	{
+	    GcTest t1(inc);
+	    {
+		GcTest t2(inc);
+		t1.set(t2);
+		t2.b = t1;
+		{
+		    GcTest t3(inc);
+		    t2.set(t3);
+		    t3.b = t2;
+		    t3.c = t1;
+		    t1.b = t3;
+		    {
+			GcTest t4(inc);
+			t3.set(t4);
+			t4.set(t1);
+			t4.b = t2;
+			t4.c = t3;
+			t2.c = t4;
+			t1.c = t4;
+		    }
+		}
+	    }
+
+	    testAssertionValue("recursive gc 20-2", cnt, 20);
+
+	}
+	testAssertionValue("recursive gc 24", cnt, 24);
+
+	{
+	    GcTest1 t1(inc);
+	}
+	testAssertionValue("recursive gc 25", cnt, 25);
     }
-    unit.cmp(cnt, 6, "recursive gc 6");
-
-    {
-        my GcTest obj7(inc);
-        obj7.a = obj7;
-        obj7.b = obj7;
-    }
-    unit.cmp(cnt, 7, "recursive gc 7");
-
-    {
-        my GcTest obj8(inc);
-        my GcTest obj9(inc);
-        
-        obj8.a = ("a": obj9, "b": obj9);
-        obj9.b = obj8;
-        obj9.c = obj8;
-    }
-    unit.cmp(cnt, 9, "recursive gc 9");
-
-    {
-        my GcTest obj10(inc);
-        my GcTest obj11(inc);
-        obj10.set(obj11);
-        obj11.set(obj10);
-    }
-    unit.cmp(cnt, 11, "recursive gc 11");
-
-    {
-        my GcTest obj12(inc);
-        {
-            my GcTest obj13(inc);
-            
-            obj12.a = obj13;
-            obj13.a = obj12;
-        }
-    }
-    unit.cmp(cnt, 13, "recursive gc 13-1");
-
-    {
-        my GcTest t1(inc);
-        my GcTest t2(inc);
-        t1.set(t2);
-        t2.set(t1);
-        t1.set();
-
-        unit.cmp(cnt, 13, "recursive gc 13-2");
-    }
-    unit.cmp(cnt, 15, "recursive gc 15-1");
-
-    {
-        my GcTest t1(inc);
-        t1.set(t1);
-        t1.set();
-
-        unit.cmp(cnt, 15, "recursive gc 15-2");
-    }
-    unit.cmp(cnt, 16, "recursive gc 16-1");
-
-    {
-        my GcTest t1(inc);
-        {
-            my GcTest t2(inc);
-            t1.set(t2);
-            t2.b = t1;
-            {
-                my GcTest t3(inc);
-                t2.set(t3);
-                t2.b = t1;
-                {
-                    my GcTest t4(inc);
-                    t3.set(t4);
-                    t4.set(t1);
-                    t3.b = t2;
-                    t4.b = t3;
-                }
-            }
-        }
-        unit.cmp(cnt, 16, "recursive gc 16-2");
-    }
-    unit.cmp(cnt, 20, "recursive gc 20");
-
-    {
-        my GcTest t1(inc);
-        {
-            my GcTest t2(inc);
-            t1.set(t2);
-            t2.b = t1;
-            {
-                my GcTest t3(inc);
-                t2.set(t3);
-                t3.b = t2;
-                t3.c = t1;
-                t1.b = t3;
-                {
-                    my GcTest t4(inc);
-                    t3.set(t4);
-                    t4.set(t1);
-                    t4.b = t2;
-                    t4.c = t3;
-                    t2.c = t4;
-                    t1.c = t4;
-                }
-            }
-        }
-
-        unit.cmp(cnt, 20, "recursive gc 20-2");
-
-    }
-    unit.cmp(cnt, 24, "recursive gc 24");
 }

--- a/include/qore/intern/QoreClassIntern.h
+++ b/include/qore/intern/QoreClassIntern.h
@@ -2335,7 +2335,7 @@ public:
       return scl ? scl->isPublicOrPrivateMember(mem, priv) : 0;
    }
 
-   DLLLOCAL int initMembers(QoreObject& o, ExceptionSink* xsink) const;
+   DLLLOCAL int initMembers(QoreObject& o, bool& need_scan, ExceptionSink* xsink) const;
 
    DLLLOCAL int initVar(const char* vname, QoreVarInfo& vi, ExceptionSink* xsink) const {
       if (vi.exp) {

--- a/include/qore/intern/Variable.h
+++ b/include/qore/intern/Variable.h
@@ -399,7 +399,11 @@ private:
    nvec_t tvec;
    lvid_set_t* lvid_set;
    ocvec_t ocvec;
+
+   // flag if the changed value was a container before the assignment
    bool before;
+
+   // recursive delta: change to recursive reference count
    int rdt;
 
    QoreObject* robj;
@@ -410,6 +414,9 @@ public:
 
    DLLLOCAL LValueHelper(const ReferenceNode& ref, ExceptionSink* xsink, bool for_remove = false);
    DLLLOCAL LValueHelper(const AbstractQoreNode* exp, ExceptionSink* xsink, bool for_remove = false);
+
+   // to scan objects after initialization
+   DLLLOCAL LValueHelper(QoreObject& obj, ExceptionSink* xsink);
 
    DLLLOCAL ~LValueHelper();
 


### PR DESCRIPTION
fixed recursive references in member initialization; increment the object count and scan the object after member initialization if needed

ported gc.qtest to QUnit and added a test for this case

release notes are covered under the general DGC notes since this is an aspect of DGC
