### PR TITLE
refs #91 fixed an infinite recursion bug in Operator::eval()

### DIFF
--- a/include/qore/intern/Operator.h
+++ b/include/qore/intern/Operator.h
@@ -664,16 +664,16 @@ public:
    DLLLOCAL void addFunction(qore_type_t lt, qore_type_t rt, op_bigint_func_t f);
    DLLLOCAL void addFunction(qore_type_t lt, qore_type_t rt, op_float_func_t f);
 
-   DLLLOCAL QoreValue eval(const QoreValue l, const QoreValue r, bool ref_rv, int args, ExceptionSink* xsink) const {
+   DLLLOCAL QoreValue eval(const QoreValue l, const QoreValue r, bool ref_rv, ExceptionSink* xsink) const {
       ReferenceHolder<> lr(xsink);
       ReferenceHolder<> rr(xsink);
       if (l.type != QV_Node)
          lr = l.getReferencedValue();
       if (r.type != QV_Node)
          rr = r.getReferencedValue();
-      return eval(lr ? *lr : l.getInternalNode(), rr ? *rr : r.getInternalNode(), ref_rv, args, xsink);
+      return eval(lr ? *lr : l.getInternalNode(), rr ? *rr : r.getInternalNode(), ref_rv, xsink);
    }
-
+   
    DLLLOCAL QoreValue eval(const AbstractQoreNode* l, const AbstractQoreNode* r, bool ref_rv, ExceptionSink* xsink) const;
 
    DLLLOCAL const char* getName() const {

--- a/lib/QoreValueList.cpp
+++ b/lib/QoreValueList.cpp
@@ -87,7 +87,7 @@ int qore_value_list_private::mergesort(const ResolvedCallReferenceNode* fr, bool
 	 rc = (int)result->getAsBigInt();
       }
       else {
-	 ValueHolder result(OP_LOG_CMP->eval(lv, rv, true, 2, xsink), xsink);
+	 ValueHolder result(OP_LOG_CMP->eval(lv, rv, true, xsink), xsink);
 	 if (*xsink)
 	    return -1;
 	 rc = (int)result->getAsBigInt();
@@ -126,7 +126,7 @@ int qore_value_list_private::qsort(const ResolvedCallReferenceNode* fr, size_t l
 	    rc = (int)rv->getAsBigInt();
 	 }
 	 else {
-	    ValueHolder rv(OP_LOG_CMP->eval(entry[right], pivot, true, 2, xsink), xsink);
+	    ValueHolder rv(OP_LOG_CMP->eval(entry[right], pivot, true, xsink), xsink);
 	    if (*xsink)
 	       return -1;
 	    rc = (int)rv->getAsBigInt();
@@ -154,7 +154,7 @@ int qore_value_list_private::qsort(const ResolvedCallReferenceNode* fr, size_t l
 	    rc = (int)rv->getAsBigInt();
 	 }
 	 else {
-	    ValueHolder rv(OP_LOG_CMP->eval(entry[left], pivot, true, 2, xsink), xsink);
+	    ValueHolder rv(OP_LOG_CMP->eval(entry[left], pivot, true, xsink), xsink);
 	    if (*xsink)
 	       return -1;
 	    rc = (int)rv->getAsBigInt();


### PR DESCRIPTION
no relnotes because this bug is "invisible" (bug in unreleased code)

very difficult to write a test because QoreValueList is only used in argument handling for now
