### PR TITLE
refs #88 fixed copy-on-write bugs in the = and += operators

### DIFF
--- a/examples/test/qore/operators/operators.qtest
+++ b/examples/test/qore/operators/operators.qtest
@@ -12,6 +12,7 @@
 class Test inherits QUnit::Test {
     constructor() : QUnit::Test("operators", "1.0", \ARGV) {
         addTestCase("basic operator tests", \basicTests());
+        addTestCase("lvalue tests", \lvalueTests());
         set_return_value(main());
     }
 
@@ -137,6 +138,16 @@ class Test inherits QUnit::Test {
             testAssertion("trim operator parse-time return value", \p.parse(), ("string sub test() {string str = \"a string \\n\"; string astr = trim str; return astr;}", "trim operator test"), new TestResultValue(NOTHING));
             testAssertionValue("trim operator", p.callFunction("test"), "a string");
         }
+    }
+
+    lvalueTests() {
+        # bug 88: lvalue reference-handling bug
+        hash h.a = 1;
+        h.b = h;
+        testAssertionValue("hash assignment", sprintf("%y", h), "{a: 1, b: {a: 1}}");
+        string str = "a";
+        h = (str: 1); h.b += h;
+        testAssertionValue("hash +=", sprintf("%y", h), "{a: 1, b: {a: 1}}");
     }
 
     static code mapClosure(any v) {

--- a/include/qore/QoreValue.h
+++ b/include/qore/QoreValue.h
@@ -327,6 +327,11 @@ protected:
 public:
    DLLEXPORT ValueEvalRefHolder(const AbstractQoreNode* exp, ExceptionSink* xs);
 
+   // ensures that the held value is referenced
+   /** if needs_deref is false and an AbstractQoreNode* is contained, then the value is referenced and needs_deref is set to true
+    */
+   DLLEXPORT void ensureReferencedValue();
+
    template<typename T>
    DLLLOCAL T* takeReferencedNode() {
       T* rv = v.take<T>();

--- a/lib/AbstractQoreNode.cpp
+++ b/lib/AbstractQoreNode.cpp
@@ -63,16 +63,12 @@ AbstractQoreNode::~AbstractQoreNode() {
 
 /*
 bool test(const AbstractQoreNode* n) {
-   if (n->getType() == NT_OBJECT) {
-      const QoreObject* obj = reinterpret_cast<const QoreObject*>(n);
-      //return !strcmp(obj->getClassName(), "T");
-      return !strcmp(obj->getClassName(), "SharedLogFile") && qore_object_private::hackId(*obj);
-   }
-   return false;
+   return n->getType() == NT_HASH;
 }
 
 static void break_ref() {}
 */
+
 void AbstractQoreNode::ref() const {
 #ifdef DEBUG
    /*
@@ -81,6 +77,7 @@ void AbstractQoreNode::ref() const {
       break_ref();
    }
    */
+
 #if TRACK_REFS
    if (type == NT_OBJECT) {
       const QoreObject *o = reinterpret_cast<const QoreObject*>(this);

--- a/lib/QoreAssignmentOperatorNode.cpp
+++ b/lib/QoreAssignmentOperatorNode.cpp
@@ -81,6 +81,10 @@ QoreValue QoreAssignmentOperatorNode::evalValueImpl(bool& needs_deref, Exception
    if (*xsink)
       return QoreValue();
 
+   // we have to ensure that the value is referenced before the assignment in case the lvalue
+   // is the same value, so it can be copied in the LValueHelper constructor
+   new_value.ensureReferencedValue();
+
    // get ptr to current value (lvalue is locked for the scope of the LValueHelper object)
    LValueHelper v(left, xsink);
    if (!v)
@@ -93,4 +97,3 @@ QoreValue QoreAssignmentOperatorNode::evalValueImpl(bool& needs_deref, Exception
    // reference return value if necessary
    return ref_rv ? v.getReferencedValue() : QoreValue();
 }
-

--- a/lib/QorePlusEqualsOperatorNode.cpp
+++ b/lib/QorePlusEqualsOperatorNode.cpp
@@ -73,6 +73,10 @@ QoreValue QorePlusEqualsOperatorNode::evalValueImpl(bool& needs_deref, Exception
    if (*xsink)
       return QoreValue();
 
+   // we have to ensure that the value is referenced before the assignment in case the lvalue
+   // is the same value, so it can be copied in the LValueHelper constructor
+   new_right.ensureReferencedValue();
+
    // get ptr to current value (lvalue is locked for the scope of the LValueHelper object)
    LValueHelper v(left, xsink);
    if (!v)

--- a/lib/QoreValue.cpp
+++ b/lib/QoreValue.cpp
@@ -442,6 +442,13 @@ ValueEvalRefHolder::ValueEvalRefHolder(const AbstractQoreNode* exp, ExceptionSin
    v = exp->eval(needs_deref, xsink);
 }
 
+void ValueEvalRefHolder::ensureReferencedValue() {
+   if (!needs_deref && v.type == QV_Node && v.v.n) {
+      v.v.n->ref();
+      needs_deref = true;
+   }
+}
+
 AbstractQoreNode* ValueEvalRefHolder::getReferencedValue() {
    if (v.type == QV_Node) {
       if (!needs_deref && v.v.n)


### PR DESCRIPTION
where lvalues could be modified and have their own value added or assigned to themselves creating a circular reference where none should be possible

this bug was introduced with the internal QoreValue API changes and therefore did not affect 0.8.11.1
