### PR TITLE
refs #146 fixed thread resource purging when purging thread resources…

### DIFF
--- a/examples/test/qore/threads/thread-resources.qtest
+++ b/examples/test/qore/threads/thread-resources.qtest
@@ -24,6 +24,10 @@ class ThreadResourcesTest inherits QUnit::Test {
     constructor() : QUnit::Test("ThreadResourcesTest", "1.0") {
         addTestCase("thread resource tests", \threadResourcesTests());
         addTestCase("thread resource sandboxing tests", \threadResourceSandboxingTests());
+
+	our TRS otrs();
+	set_thread_resource(otrs);
+
         set_return_value(main());
     }
 

--- a/lib/ThreadResourceList.cpp
+++ b/lib/ThreadResourceList.cpp
@@ -37,7 +37,7 @@
 Sequence ThreadResourceList::seq;
 
 void ThreadResourceList::set(AbstractThreadResource* atr) {
-   //printd(5, "TRL::set(atr: %p)\n", atr);
+   //printd(5, "TRL::set() this: %p atr: %p\n", this, atr);
    assert(trset.find(atr) == trset.end());
 
    atr->ref();
@@ -45,23 +45,34 @@ void ThreadResourceList::set(AbstractThreadResource* atr) {
 }
 
 bool ThreadResourceList::check(AbstractThreadResource* atr) const {
-   //printd(5, "TRL::set(atr: %p)\n", atr);
+   //printd(5, "TRL::check(atr: %p)\n", atr);
    return trset.find(atr) != trset.end();
 }
 
 void ThreadResourceList::purge(ExceptionSink* xsink) {
-   for (trset_t::iterator i = trset.begin(), e = trset.end(); i != e; ++i) {
-      //printd(5, "TRL::purge() cleaning up atr: %p\n", *i);
-      (*i)->cleanup(xsink);
-      (*i)->deref();
-   }
-   trset.clear();
+   while (true) {
+      trset_t::iterator i = trset.begin();
+      if (i == trset.end())
+	  break;
 
-   //printd(5, "TRL::purge() done\n");
+      AbstractThreadResource* atr = *i;
+      //printd(5, "TRL::purge() this: %p cleaning up atr: %p\n", this, atr);
+      // we have to remove the thread resource from the list before running cleanup in case of user thread resources
+      // where the cleanup routine will cause the object to be deleted and therefore for remove_thread_resource() to
+      // be called which can result in a crash
+      trset.erase(i);
+
+      atr->cleanup(xsink);
+      atr->deref();
+   }
+
+   //printd(5, "TRL::purge() this: %p done size: %d\n", this, trset.size());
 }
 
+void breakit() {}
 int ThreadResourceList::remove(AbstractThreadResource* atr) {
-   //printd(5, "TRL::remove(atr: %p)\n", atr);
+   //printd(5, "TRL::remove() this: %p atr: %p\n", this, atr);
+   breakit();
 
    trset_t::iterator i = trset.find(atr);
    if (i == trset.end())

--- a/lib/ThreadResourceList.cpp
+++ b/lib/ThreadResourceList.cpp
@@ -66,7 +66,7 @@ void ThreadResourceList::purge(ExceptionSink* xsink) {
       atr->deref();
    }
 
-   //printd(5, "TRL::purge() this: %p done size: %d\n", this, trset.size());
+   //printd(5, "TRL::purge() this: %p done\n", this);
 }
 
 void breakit() {}


### PR DESCRIPTION
… causes a user thread resource to go out of scope - this would cause a crash
