### PR TITLE
Change BZ2_DEFAULT_COMPRESSION to 3

### DIFF
--- a/lib/ql_compression.qpp
+++ b/lib/ql_compression.qpp
@@ -49,7 +49,7 @@
 #endif
 
 #ifndef BZ2_DEFAULT_COMPRESSION
-#define BZ2_DEFAULT_COMPRESSION 9
+#define BZ2_DEFAULT_COMPRESSION 3
 #endif
 
 class qore_bz_stream : public bz_stream {


### PR DESCRIPTION
Based on my measurements it's a good trade-off between compression level and CPU load.
