### PR TITLE
Raw SQL statement is logged by default

### DIFF
--- a/qlib/TableMapper.qm
+++ b/qlib/TableMapper.qm
@@ -1256,10 +1256,19 @@ InboundTableMapperIterator i(input, mapper);
             return m_table.getDatasource();
         }
 
+        private initStatement() {
+            string sql;
+            m_stmt = m_table.getRowIterator(m_sh, \sql);
+            if (info_log) {
+                info_log("Mapper: %s: %n", self.className(), sql);
+                info_log("Mapper: %s: binding: %y", self.className(), m_sh."where");
+            }
+        }
+
         #! returns a description of the input record based on the @ref Qore::SQLStatement decribe()
         *hash getInputRecord() {
             if (!m_stmt)
-                m_stmt = m_table.getRowIterator(m_sh);
+                initStatement();
             HashIterator it(m_stmt.describe());
             while (it.next()) {
                 hash c = it.getValue();
@@ -1276,7 +1285,7 @@ InboundTableMapperIterator i(input, mapper);
          */
         SqlStatementMapperIterator iterator() {
             if (!m_stmt)
-                m_stmt = m_table.getRowIterator(m_sh);
+                initStatement();
             return new SqlStatementMapperIterator(m_stmt, mapc, m_opts);
         }
 
@@ -1292,7 +1301,7 @@ InboundTableMapperIterator i(input, mapper);
          */
         *hash getData() {
             if (!m_stmt)
-                m_stmt = m_table.getRowIterator(m_sh);
+                initStatement();
 
             *list tmp = mapAll(m_stmt.fetchRows(select_block));
 
@@ -1327,7 +1336,7 @@ InboundTableMapperIterator i(input, mapper);
          */
         *list getDataRows() {
             if (!m_stmt)
-                m_stmt = m_table.getRowIterator(m_sh);
+                initStatement();
 
             return mapAll(m_stmt.fetchRows(select_block));
         }


### PR DESCRIPTION
custom logging (raw qore):

```
lister:TableMapper pvanek$ qore t.q
Mapper: SqlStatementOutboundMapper: "select * from omquser.H3G_IT_SHIPPED_ITEMS"
Mapper: SqlStatementOutboundMapper: binding: null
```

Qorus regression test:

```
2015.11.28 13:44:43.232825 T102: ID 10: WI 1: regression1(75/0): regression_example info: Mapper: QorusSqlStatementOutboundMapper: "select uuid from omquser.regression_example where in_transit = %v and qorus_wfiid = %v"
2015.11.28 13:44:43.233275 T102: ID 10: WI 1: regression1(75/0): regression_example info: Mapper: QorusSqlStatementOutboundMapper: binding: {in_transit: 5, qorus_wfiid: 137083}
2015.11.28 13:44:43.234233 T102: ID 10: WI 1: regression1(75/0): Mapper "regression-out-sql-statement": input: {uuid: "f0350061-001a-4477-9e02-abd7c740ce35"}
2015.11.28 13:44:43.234799 T102: ID 10: WI 1: regression1(75/0): Mapper "regression-out-sql-statement": output: {uuid_mapped: "f0350061-001a-4477-9e02-abd7c740ce35", some_const: "foobar"}
2015.11.28 13:44:43.235228 T102: ID 10: WI 1: regression1(75/0): OK: QorusSqlStatementOutboundMapper::getDataRows
```
