### PR TITLE
implement support for notifications when HTTP listeners have been asynchronously started

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -190,6 +190,8 @@
         - HttpServer::setListenerLogOptions()
         - HttpServer::setListenerLogOptionsID()
       - improved performance matching request URIs to handlers
+      - added the HttpServer::listenerStarted() method to allow for reporting when listeners are actually running since they are started asynchronously
+      - added the \c "ssl" key to the listener socket info hash
     - <a href="../../modules/Schema/html/index.html">Schema</a> module updates:
       - added the following public functions to make column definitions easier:
         - c_char()

--- a/qlib/HttpServer.qm
+++ b/qlib/HttpServer.qm
@@ -136,6 +136,8 @@ log("started listener on %s", lh.desc);
         - otherwise, the first (in order of their registration) handler with regexp that matches the request URI is chosen
       - if no path matches the request, the same logic as before applies
     - fixed a bug in @ref HttpServer::HttpServer::addListener() with an integer argument; a UNIX socket was opened instead of a wildcard listener on the given port
+    - added the @ref HttpServer::HttpServer::listenerStarted() method to allow for reporting when listeners are actually running since they are started asynchronously
+    - added the \c "ssl" key to the listener socket info hash
 
     @subsection http0310 HttpServer 0.3.10
     - if an error occurs receiving a message with chunked transfer encoding, send the response immediately before reading the rest of the chunked transfer
@@ -881,6 +883,11 @@ public class HttpServer::HttpServer inherits HttpServer::AbstractLogger {
     #! waits for all listeners to be stopped; call after calling HttpServer::stopNoWait()
     waitStop() {
         c.waitForZero();
+    }
+
+    # only called from listeners; do not call externally
+    listenerStarted(int id, hash sinfo) {
+        log("HTTP listener %d started on %s", id, sinfo.desc);
     }
 
     # only called from the listeners - do not call externally
@@ -1728,15 +1735,12 @@ class HttpServer::HttpListener inherits Qore::Socket, HttpServer::HttpListenerIn
         }
 
 	# save socket port/path
-        socket_info = getSocketInfo();
+        socket_info = getSocketInfo() + ("ssl": ssl);
 
 	# make 'desc' key for logging
 	socket_info.desc = socket_info.address_desc;
 	if (socket_info.port)
 	    socket_info.desc += ":" + socket_info.port;
-
-	# set TCP_NODELAY
-	#setNoDelay(True);
 
 	# set listening state on socket
 	if (listen(ListenQueue))
@@ -1939,6 +1943,7 @@ class HttpServer::HttpListener inherits Qore::Socket, HttpServer::HttpListenerIn
     private mainThread() {
         on_exit	cThreads.dec();
 
+        serv.listenerStarted(id, socket_info);
         # DEBUG
         #printf("HTTP DEBUG: %y: mainThread() started TID %d\n", socket, gettid());
 


### PR DESCRIPTION
refs #200 
added the HttpServer::listenerStarted() method to allow for reporting when listeners are actually running since they are started asynchronously
added the "ssl" key to the listener socket info hash

added #201 for tests
