### PR TITLE
fixed thread resource cleanup when user thread resources are cleaned …

### DIFF
--- a/examples/test/qore/threads/thread-resources.qtest
+++ b/examples/test/qore/threads/thread-resources.qtest
@@ -126,6 +126,9 @@ class ThreadResourcesTest inherits QUnit::Test {
         set_thread_resource(inc, 2);
         testNullAssertion("no-exception-5", \throw_thread_resource_exceptions());
         assertEq(3, i);
+
+        # make sure thread resource can be cleaned up automatically when threads are terminated
+        background sub () {TRS btrs(); set_thread_resource(btrs);}();
     }
 
     threadResourceSandboxingTests() {

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -1862,11 +1862,11 @@ namespace {
          {
             ta->run(&xsink);
 
-            // delete any thread data
-            thread_data.get()->del(&xsink);
-
             // cleanup thread resources
             purge_thread_resources(&xsink);
+
+            // delete any thread data
+            thread_data.get()->del(&xsink);
 
             xsink.handleExceptions();
 
@@ -1928,15 +1928,15 @@ namespace {
             if (rv)
                rv->deref(&xsink);
 
+            // cleanup thread resources
+            purge_thread_resources(&xsink);
+
             int tid = btp->tid;
             // dereference current Program object
             btp->del(&xsink);
 
             // delete any thread data
             thread_data.get()->del(&xsink);
-
-            // cleanup thread resources
-            purge_thread_resources(&xsink);
 
             xsink.handleExceptions();
 


### PR DESCRIPTION
…up when a thread terminates

the fix was to ensure that thread resouce cleanup routines are run before thread-local data are destroyed and in particular before the Program is dereferenced (and therefore thread-local data for the Program is destroyed which is needed to execute user-level thread cleanup code in the same thread)
added a test case to qore/threads/thread-resources.qtest
