### PR TITLE
fixed a regression introduced in the fix for bug #170

### DIFF
--- a/lib/QoreTimeZoneManager.cpp
+++ b/lib/QoreTimeZoneManager.cpp
@@ -184,6 +184,8 @@ QoreZoneInfo::QoreZoneInfo(QoreString &root, std::string &n_name, ExceptionSink 
                printd(1, "QoreZoneInfo::QoreZoneInfo() skipping invalid transition [%d] at %d\n", i, t.time);
                QoreDSTTransitions.erase(di);
                di = prev;
+               if (i < first_pos)
+                 --first_pos;
             }
          }
          ++di;


### PR DESCRIPTION
refs #259 

when invalid bands are removed from the list, the "first_pos" offset needs to be updated if the band removed is before "first_pos"

this needs to be applied to 0.8.11.1 and develop
