### PR TITLE
refs #271 fixed a bug where time components of absolute date/time val…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -373,6 +373,7 @@
     - fixed minor bugs with directive parsing, mostly related to error reporting
     - fixed bugs in relative date arithmetic where operands were swapped with the @ref minus_operator "- operator" if the first operand was a @ref relative_dates "relative date/time value", additionally an operation with the @ref minus_operator "- operator" where the first operand is a @ref relative_dates "relative date" and the second operand is a @ref absolute_dates "absolute date" is now calculated using the @ref absolute_dates "absolute date"'s epoch offset (offset in seconds and microseconds from \c 1970-01-01Z), and a @ref relative_dates "relative date/time value" is produced
     - fixed a bug normalizing the result of date arithmetic between hour and minute components of @ref relative_dates "relative date/time value"
+    - fixed a bug where time components of absolute date/time values before the UNIX epoch were returned with invalid values
 
     @section qore_0811 Qore 0.8.11
 

--- a/examples/test/qore/vars/date.qtest
+++ b/examples/test/qore/vars/date.qtest
@@ -170,6 +170,19 @@ class DateTest inherits QUnit::Test {
         testAssertionValue("SingleValueIterator::getValue() (copy)", ni.getValue(), 2012-01-01);
         testAssertionValue("SingleValueIterator::next() (copy)", ni.next(), False);
         testAssertionValue("SingleValueIterator::valid() (copy)", ni.valid(), False);
+
+        # time components for dates before the epoch must be returned correctly
+        date1 = 1969-12-31T20:15:25;
+        assertEq(20, date1.hours());
+        assertEq(15, date1.minutes());
+        assertEq(25, date1.seconds());
+        assertEq(0, date1.microseconds());
+
+        date1 = 1969-12-31T20:15:25.123456;
+        assertEq(20, date1.hours());
+        assertEq(15, date1.minutes());
+        assertEq(25, date1.seconds());
+        assertEq(123456, date1.microseconds());
     }
 
     timeZoneTests() {

--- a/examples/test/qore/vars/date.qtest
+++ b/examples/test/qore/vars/date.qtest
@@ -183,7 +183,19 @@ class DateTest inherits QUnit::Test {
         assertEq(15, date1.minutes());
         assertEq(25, date1.seconds());
         assertEq(123456, date1.microseconds());
-    }
+
+        date1 = 1947-05-10T21:59:12.002341;
+        assertEq(21, date1.hours());
+        assertEq(59, date1.minutes());
+        assertEq(12, date1.seconds());
+        assertEq(2341, date1.microseconds());
+
+        date1 = 1947-05-10T23:59:12.002341;
+        assertEq(23, date1.hours());
+        assertEq(59, date1.minutes());
+        assertEq(12, date1.seconds());
+        assertEq(2341, date1.microseconds());
+}
 
     timeZoneTests() {
         testAssertionValue("UTC offset", (new TimeZone("Europe/Prague")).UTCOffset(), 3600);

--- a/include/qore/intern/qore_date_private.h
+++ b/include/qore/intern/qore_date_private.h
@@ -654,24 +654,39 @@ public:
    }
 
    DLLLOCAL int getHour() const {
-      int h = (int)(((epoch + zone->getUTCOffset(epoch)) % SECS_PER_DAY) / SECS_PER_HOUR);
-      if (h < 0)
-         h += 23;
-      return h;
+      if (epoch >= 0)
+         return (int)(((epoch + zone->getUTCOffset(epoch)) % SECS_PER_DAY) / SECS_PER_HOUR);
+
+      qore_time_info info;
+      const char* zname;
+      bool isdst;
+      int offset = zone->getUTCOffset(epoch, isdst, zname);
+      info.set(epoch, us, offset, isdst, zname, zone);
+      return info.hour;
    }
 
    DLLLOCAL int getMinute() const {
-      int m = (int)(((epoch + zone->getUTCOffset(epoch)) % SECS_PER_HOUR) / SECS_PER_MINUTE);
-      if (m < 0)
-         m += 59;
-      return m;
+      if (epoch >= 0)
+         return (int)(((epoch + zone->getUTCOffset(epoch)) % SECS_PER_HOUR) / SECS_PER_MINUTE);
+
+      qore_time_info info;
+      const char* zname;
+      bool isdst;
+      int offset = zone->getUTCOffset(epoch, isdst, zname);
+      info.set(epoch, us, offset, isdst, zname, zone);
+      return info.minute;
    }
 
    DLLLOCAL int getSecond() const {
-      int s = (int)((epoch + zone->getUTCOffset(epoch)) % SECS_PER_MINUTE);
-      if (s < 0)
-         s += 60;
-      return s;
+      if (epoch >= 0)
+         return ((epoch + zone->getUTCOffset(epoch)) % SECS_PER_MINUTE);
+
+      qore_time_info info;
+      const char* zname;
+      bool isdst;
+      int offset = zone->getUTCOffset(epoch, isdst, zname);
+      info.set(epoch, us, offset, isdst, zname, zone);
+      return info.second;
    }
 
    DLLLOCAL int getMillisecond() const {

--- a/include/qore/intern/qore_date_private.h
+++ b/include/qore/intern/qore_date_private.h
@@ -654,15 +654,24 @@ public:
    }
 
    DLLLOCAL int getHour() const {
-      return (int)(((epoch + zone->getUTCOffset(epoch)) % SECS_PER_DAY) / SECS_PER_HOUR);
+      int h = (int)(((epoch + zone->getUTCOffset(epoch)) % SECS_PER_DAY) / SECS_PER_HOUR);
+      if (h < 0)
+         h += 23;
+      return h;
    }
 
    DLLLOCAL int getMinute() const {
-      return (int)(((epoch + zone->getUTCOffset(epoch)) % SECS_PER_HOUR) / SECS_PER_MINUTE);
+      int m = (int)(((epoch + zone->getUTCOffset(epoch)) % SECS_PER_HOUR) / SECS_PER_MINUTE);
+      if (m < 0)
+         m += 59;
+      return m;
    }
 
    DLLLOCAL int getSecond() const {
-      return (int)((epoch + zone->getUTCOffset(epoch)) % SECS_PER_MINUTE);
+      int s = (int)((epoch + zone->getUTCOffset(epoch)) % SECS_PER_MINUTE);
+      if (s < 0)
+         s += 60;
+      return s;
    }
 
    DLLLOCAL int getMillisecond() const {


### PR DESCRIPTION
…ues before the UNIX epoch were returned with invalid values
