### PR TITLE
refs #285 #286 bulk upsert operations are now supported properly:

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -221,6 +221,7 @@
       - implemented support for driver-dependent pseudocolumns
       - implemented per-column support for the \c "desc" keyword in orderby expressions
       - implemented the \c "op_wop()" function to allow SQL expressions to be combined with \c "or" as well as the default \c "and"
+      - implemented AbstractTable::getBulkUpsertClosure() to better support bulk SQL merge operations
     - <a href="../../modules/OracleSqlUtil/html/index.html">OracleSqlUtil</a> module updates:
       - implemented support for views for DML in the OracleTable class
       - implemented support for Oracle pseudocolumns in queries

--- a/examples/test/qlib/SqlUtil/FreetdsSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/FreetdsSqlUtil.qtest
@@ -214,20 +214,31 @@ class FreetdsTest inherits QUnit::Test {
         addTestCase("BulkInsert", \bulkInsertTest());
         addTestCase("BulkUpsert", \bulkUpsertTest());
 
-        # create the test schema
-        schema = new FreetdsTestSchema(getDatasource());
+        Datasource ds;
+        try {
+            ds = getDatasource();
+        }
+        catch (hash ex) {
+            # skip tests if we can't create the datasource
+        }
 
-        schema.align(False, m_options.verbose);
+        if (ds) {
+            # create the test schema
+            schema = new FreetdsTestSchema(ds);
 
-        # get table object
-        table = (new Table(schema.getDatasource(), "freetds_test")).getTable();
+            schema.align(False, m_options.verbose);
+
+            # get table object
+            table = (new Table(schema.getDatasource(), "freetds_test")).getTable();
+        }
 
         set_return_value(main());
     }
 
     globalTearDown() {
         # drop the test schema
-        schema.drop(False, m_options.verbose);
+        if (schema)
+            schema.drop(False, m_options.verbose);
     }
 
     private usageIntern() {
@@ -241,10 +252,14 @@ class FreetdsTest inherits QUnit::Test {
         Datasource ds(m_options.connstr);
         if (ds.getDriverName() != "freetds")
             throw "FREETDS-ERROR", sprintf("cannot execute the freetds tests on a connection using driver %y", ds.getDriverName());
+        ds.open();
         return ds;
     }
 
     insertTest() {
+        if (!table)
+            testSkip("no DB connection");
+
         on_success table.commit();
         on_error table.rollback();
 
@@ -252,6 +267,9 @@ class FreetdsTest inherits QUnit::Test {
     }
 
     upsertTest() {
+        if (!table)
+            testSkip("no DB connection");
+
         on_success table.commit();
         on_error table.rollback();
 
@@ -261,6 +279,9 @@ class FreetdsTest inherits QUnit::Test {
     }
 
     bulkInsertTest() {
+        if (!table)
+            testSkip("no DB connection");
+
         on_success table.commit();
         on_error table.rollback();
 
@@ -274,6 +295,9 @@ class FreetdsTest inherits QUnit::Test {
     }
 
     bulkUpsertTest() {
+        if (!table)
+            testSkip("no DB connection");
+
         on_success table.commit();
         on_error table.rollback();
 

--- a/examples/test/qlib/SqlUtil/FreetdsSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/FreetdsSqlUtil.qtest
@@ -1,0 +1,288 @@
+#!/usr/bin/env qr
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+
+%requires ../../../../qlib/QUnit.qm
+%requires ../../../../qlib/SqlUtil.qm
+%requires ../../../../qlib/BulkSqlUtil.qm
+%requires ../../../../qlib/FreetdsSqlUtil.qm
+%requires ../../../../qlib/Schema.qm
+
+%exec-class FreetdsTest
+
+class FreetdsTestSchema inherits AbstractSchema {
+    public {
+        const SchemaName = "FreetdsTestSchema";
+        const SchemaVersion = "1.0";
+    }
+
+    const GenericOptions = (
+        "replace": True,
+        );
+
+    const IndexOptions = {};
+
+    const ColumnOptions = {};
+
+    const T_FreetdsTest = (
+        "columns": (
+            "id": c_number(14, True),
+            "varchar_f": c_varchar(40, True),
+            "char_f": c_char(40, True),
+            "text_f": (
+                "native_type": "text",
+                "notnull": True,
+            ),
+            /*
+            "unitext_f": (
+                "native_type": "unitext",
+                "notnull": True,
+            ),
+            */
+            /*
+            "bit_f": (
+                "native_type": "bit",
+                "notnull": True,
+            ),
+            */
+            "tinyint_f": (
+                "native_type": "tinyint",
+                "notnull": True,
+            ),
+            "smallint_f": (
+                "native_type": "smallint",
+                "notnull": True,
+            ),
+            "int_f": (
+                "native_type": "int",
+                "notnull": True,
+            ),
+            "decimal_f": (
+                "native_type": "decimal",
+                "notnull": True,
+            ),
+            "float_f": (
+                "native_type": "float",
+                "notnull": True,
+            ),
+            "real_f": (
+                "native_type": "real",
+                "notnull": True,
+            ),
+            /*
+            "money_f": (
+                "native_type": "money",
+                "notnull": True,
+            ),
+            "smallmoney_f": (
+                "native_type": "smallmoney",
+                "notnull": True,
+            ),
+            */
+            "date_f": (
+                "native_type": "date",
+                "notnull": True,
+            ),
+            "time_f": (
+                "native_type": "time",
+                "notnull": True,
+            ),
+            "datetime_f": (
+                "native_type": "datetime",
+                "notnull": True,
+            ),
+            "smalldatetime_f": (
+                "native_type": "smalldatetime",
+                "notnull": True,
+            ),
+            /*
+            "binary_f": (
+                "native_type": "binary",
+                "notnull": True,
+            ),
+            "varbinary_f": (
+                "native_type": "varbinary",
+                "notnull": True,
+            ),
+            "image_f": (
+                "native_type": "image",
+                "notnull": True,
+            ),
+            */
+        ),
+        /*
+        "indexes": (
+            "pk_freetds_test": ("columns": ("id"), "unique": True),
+        ),
+        */
+        "primary_key": ("name": "pk_freetds_test", "columns": ("id")),
+        );
+
+    const Tables = (
+        "freetds_test": T_FreetdsTest,
+        );
+
+    constructor(AbstractDatasource ds, *string dts, *string its) :  AbstractSchema(ds, dts, its) {
+    }
+
+    private string getNameImpl() {
+        return SchemaName;
+    }
+
+    private string getVersionImpl() {
+        return SchemaVersion;
+    }
+
+    private *hash getTablesImpl() {
+        return Tables;
+    }
+
+    private *hash getIndexOptionsImpl() {
+        return IndexOptions;
+    }
+
+    private *hash getGenericOptionsImpl() {
+        return GenericOptions;
+    }
+
+    private *hash getColumnOptionsImpl() {
+        return ColumnOptions;
+    }
+}
+
+class FreetdsTest inherits QUnit::Test {
+    public {
+    }
+
+    private {
+        FreetdsTestSchema schema;
+        AbstractTable table;
+
+        const MyOpts = Opts + (
+            "connstr": "c,conn=s",
+            );
+
+        const OptionColumn = 22;
+
+        const Row = (
+            "varchar_f": "varchar",
+            "char_f": "char",
+            "text_f": "text",
+            #"unitext_f": "unitext",
+            #"bit_f": "",
+            "tinyint_f": 8,
+            "smallint_f": 1024,
+            "int_f": 12345,
+            "decimal_f": 1.5,
+            "float_f": 2.5,
+            "real_f": 5.5,
+            "date_f": 2015-01-01,
+            "time_f": 12:45,
+            "datetime_f": 2015-01-01T12:45:00.450,
+            "smalldatetime_f": 2015-01-01T12:45,
+            #"binary_f": <bead>,
+            #"varbinary_f": <bead>,
+            #"image_f": <bead>,
+            );
+
+        const InsertData = (
+            (
+             "id": 1,
+            ) + Row,
+            (
+             "id": 2,
+            ) + Row,
+            );
+
+        const UpsertData = (
+            (
+             "id": 2,
+            ) + Row,
+            (
+             "id": 3,
+            ) + Row,
+            );
+    }
+
+    constructor() : Test("FreetdsTest", "1.0", \ARGV, MyOpts) {
+        addTestCase("Insert", \insertTest());
+        addTestCase("Upsert", \upsertTest());
+        addTestCase("BulkInsert", \bulkInsertTest());
+        addTestCase("BulkUpsert", \bulkUpsertTest());
+
+        # create the test schema
+        schema = new FreetdsTestSchema(getDatasource());
+
+        schema.align(False, m_options.verbose);
+
+        # get table object
+        table = (new Table(schema.getDatasource(), "freetds_test")).getTable();
+
+        set_return_value(main());
+    }
+
+    globalTearDown() {
+        # drop the test schema
+        schema.drop(False, m_options.verbose);
+    }
+
+    private usageIntern() {
+        TestReporter::usageIntern(OptionColumn);
+        printOption("-c,--conn=ARG", "set DB connection argument (ex: \"freetds:user/pass@db\")", OptionColumn);
+    }
+
+    Datasource getDatasource() {
+        if (!m_options.connstr)
+            m_options.connstr = ENV.QORE_DB_CONNSTR_FREETDS ?? "freetds:test/test@mssql";
+        Datasource ds(m_options.connstr);
+        if (ds.getDriverName() != "freetds")
+            throw "FREETDS-ERROR", sprintf("cannot execute the freetds tests on a connection using driver %y", ds.getDriverName());
+        return ds;
+    }
+
+    insertTest() {
+        on_success table.commit();
+        on_error table.rollback();
+
+        map assertEq(NOTHING, table.insertNoCommit($1)), InsertData;
+    }
+
+    upsertTest() {
+        on_success table.commit();
+        on_error table.rollback();
+
+        code upsert = table.getUpsertClosure(InsertData[0]);
+        assertEq(AbstractTable::UR_Verified, upsert(UpsertData[0]));
+        assertEq(AbstractTable::UR_Inserted, upsert(UpsertData[1]));
+    }
+
+    bulkInsertTest() {
+        on_success table.commit();
+        on_error table.rollback();
+
+        table.delNoCommit();
+
+        BulkInsertOperation insert(table);
+        on_success insert.flush();
+        on_error insert.discard();
+
+        map assertEq(NOTHING, insert.queueData($1)), InsertData;
+    }
+
+    bulkUpsertTest() {
+        on_success table.commit();
+        on_error table.rollback();
+
+        table.delNoCommit();
+
+        BulkUpsertOperation insert(table);
+        on_success insert.flush();
+        on_error insert.discard();
+
+        map assertEq(NOTHING, insert.queueData($1)), UpsertData;
+    }
+}

--- a/qlib/BulkSqlUtil.qm
+++ b/qlib/BulkSqlUtil.qm
@@ -767,7 +767,7 @@ on_error ds.rollback();
         #! executes bulk DML upserts in the database with internally queued data
         private flushImpl() {
             if (!upsert)
-                upsert = table.getUpsertClosure(hbuf + cval, upsert_strategy);
+                upsert = table.getBulkUpsertClosure(hbuf + cval, upsert_strategy);
 
             # execute the SQLStatement on the args
             upsert(hbuf);

--- a/qlib/FreetdsSqlUtil.qm
+++ b/qlib/FreetdsSqlUtil.qm
@@ -995,6 +995,7 @@ where
 
             hash rv;
             foreach hash row in (qh.contextIterator()) {
+                row.column_name = row.column_name.lwr();
                 *hash th = FreetdsTypeMap.(row.data_type);
                 softint size = row.length;
                 switch (th.qore) {
@@ -1028,6 +1029,7 @@ where
 
             hash rv;
             foreach hash row in (qh.contextIterator()) {
+                row.column_name = row.column_name.lwr();
                 *hash th = FreetdsTypeMap.(row.data_type);
                 softint size = row.character_maximum_length ? row.character_maximum_length : row.numeric_precision;
                 switch (th.qore) {
@@ -1097,7 +1099,7 @@ where
 
             hash rv;
             for (int i = 1; i <= pkh.keycnt; ++i) {
-                string key = pkh{"col" + i};
+                string key = pkh{"col" + i}.lwr();
                 rv{key} = columns{key};
             }
             return new FreetdsPrimaryKey(pkh.constraint_name, rv);
@@ -1114,9 +1116,9 @@ where
                 return new FreetdsPrimaryKey();
 
             #printf("FreetdsTable::getPrimaryKeyImpl(): %s: %N\n", getName(), qh);
-            hash rv = map {$1: columns.$1}, qh.column_name;
+            hash rv = map {$1: columns.$1}, (map $1.lwr(), qh.column_name);
 
-            return new FreetdsPrimaryKey(pkh.constraint_name, rv);
+            return new FreetdsPrimaryKey(pkh.constraint_name.lwr(), rv);
         }
 
         private Indexes getIndexesImpl() {
@@ -1145,6 +1147,9 @@ where
             if (qh.index_name) {
                 hash ih;
                 foreach hash row in (qh.contextIterator()) {
+                    row.column_name = row.column_name.lwr();
+                    row.index_name = row.index_name.lwr();
+
                     if (!ih.(row.index_name)) {
                         ih.(row.index_name) = (
                             "unique": row.is_unique,
@@ -1212,10 +1217,11 @@ order by
             if (qh.constraint_name) {
                 hash ch;
                 foreach hash row in (qh.contextIterator()) {
-                    reference c = \ch.(row.constraint_name);
+                    reference c = \ch.(row.constraint_name.lwr());
+                    row.source_column = row.source_column.lwr();
                     c.columns.(row.source_column) = columns{row.source_column};
-                    c.target.table = row.target_table;
-                    c.target.columns.(row.target_column) = True;
+                    c.target.table = row.target_table.lwr();
+                    c.target.columns.(row.target_column.lwr()) = True;
                 }
 
                 foreach hash c in (ch.pairIterator()) {
@@ -1259,9 +1265,10 @@ order by
 	tc.constraint_name, c1.ordinal_position", schema, name);
             delete rv;
             foreach hash row in (qh.contextIterator()) {
-                reference ch = \rv.(row.constraint_name);
+                reference ch = \rv.(row.constraint_name.lwr());
                 if (!ch)
                     ch = new FreetdsUniqueConstraint(row.constraint_name, {}, row.status == "ENABLED");
+                row.column_name = row.column_name.lwr();
                 ch.add(row.column_name, columns{row.column_name});
             }
 
@@ -1336,16 +1343,15 @@ order by
         }
 
         private bool tryInsertImpl(string sql, hash row) {
-            ds.exec("begin");
-            ds.exec("savepoint " + FreetdsDatabase::FreeTDS_TempSavepoint);
+            ds.exec("begin tran");
+            ds.exec("save tran " + FreetdsDatabase::FreeTDS_TempSavepoint);
 
             try {
                 ds.vexec(sql, row.values());
-                ds.exec("release savepoint " + FreetdsDatabase::FreeTDS_TempSavepoint);
             }
             catch (hash ex) {
-                if (ex.desc =~ /duplicate key value/) {
-                    ds.exec("rollback to savepoint " + FreetdsDatabase::FreeTDS_TempSavepoint);
+                if (ex.desc =~ /Cannot insert duplicate/) {
+                    ds.exec("rollback tran " + FreetdsDatabase::FreeTDS_TempSavepoint);
                     return False;
                 }
                 rethrow;

--- a/qlib/OracleSqlUtil.qm
+++ b/qlib/OracleSqlUtil.qm
@@ -2606,6 +2606,11 @@ my any $v = $c.name;
             return m_isView ? "view" : "table";
         }
 
+        #! Oracle always supports bulk merging
+        code getBulkUpsertClosure(hash example_row, int upsert_strategy = AbstractTable::UpsertAuto) {
+            return getUpsertClosure(example_row, upsert_strategy);
+        }
+
         #! returns a closure for performing upserts; the upsert_strategy argument is ignored and a closure using an Oracle merge statement is returned
         private code getUpsertClosureUnlocked(hash row, int upsert_strategy = UpsertAuto) {
             Columns cols = checkUpsertRow(row, \upsert_strategy);

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -108,6 +108,7 @@ module SqlUtil {
     - implemented support for driver-dependent pseudocolumns
     - implemented per-column support for the \c "desc" keyword in orderby expressions
     - implemented support for \c "or" logic in @ref where_clauses
+    - implemented AbstractTable::getBulkUpsertClosure() to better support bulk SQL merge operations
     - fixed a bug with queries using a \a desc argument with the \a orderby query option with multiple sort columns; the \c "desc" string was added only to the last column but should have been added to all columns
     - fixed a bug where foreign key constraints with supporting indexes were not tracked and therefore schema alignment on DBs that automatically create indexes for foreign key constraints would fail
     - fixed a bug where driver-specific objects were not included when dropping a schema
@@ -9178,6 +9179,7 @@ table.upsert(row);
 
             @see
             - upsertNoCommit()
+            - getBulkUpsertClosure()
             - getUpsertClosure()
             - getUpsertClosureWithValidation()
          */
@@ -9203,6 +9205,7 @@ table.upsertNoCommit(row);
 
             @see
             - upsert()
+            - getBulkUpsertClosure()
             - getUpsertClosure()
             - getUpsertClosureWithValidation()
          */
@@ -9224,7 +9227,7 @@ map upsert($1), row_list;
             @param example_row a hash representing an example row to insert or update; every row passed to the upsert closure returned must have the same keys in the same order
             @param upsert_strategy see @ref upsert_options for possible values for the upsert strategy
 
-            @return a closure that can be executed given a hash argument representing a single row that will be updated or inserted in the database with the given upsert strategy; the closure returned does not check the input hash for validity; the closure has the following signature: @code int sub upsert(hash row) {} @endcode The return value of the closuse is an integer code giving the result of the update; see @ref upsert_results for more information
+            @return a closure that can be executed given a hash argument representing a single row that will be updated or inserted in the database with the given upsert strategy; the closure returned does not check the input hash for validity; the closure has the following signature: @code int sub upsert(hash row) {} @endcode The return value of the closure is an integer code giving the result of the update; see @ref upsert_results for more information
 
             @throw COLUMN-ERROR an unknown column was referenced in the hash to be inserted
             @throw UPSERT-ERROR no primary key, unique constraint, or unique index for upsert; not all columns of the unique constraint/index are used in the upsert statement
@@ -9234,10 +9237,42 @@ map upsert($1), row_list;
             @see
             - upsert()
             - upsertNoCommit()
+            - getBulkUpsertClosure()
             - getUpsertClosureWithValidation()
          */
         code getUpsertClosure(hash example_row, int upsert_strategy = AbstractTable::UpsertAuto) {
             return t.getUpsertClosure(example_row, upsert_strategy);
+        }
+
+        #! returns a closure that can be executed given a hash argument representing either a single row or a set of rows (where each key value is a list of column values) that will be updated or inserted in the database with the given upsert strategy; the table must have a unique key to do this; the closure returned does not check the input hash for validity
+        /** @par Example:
+            @code
+Datasource ds("pgsql:user/pass@db%localhost");
+Table table(ds, "table_name");
+code upsert = table.getBulkUpsertClosure(row, AbstractTable::UpsertSelectFirst);
+on_success ds.commit();
+on_error ds.rollback();
+upsert(row_hash);
+            @endcode
+
+            @param example_row a hash representing an example row to insert or update; every hash passed to the upsert closure returned must have the same keys in the same order
+            @param upsert_strategy see @ref upsert_options for possible values for the upsert strategy
+
+            @return a closure that can be executed given a hash argument representing either a single row or a set of rows (where each key value is a list of column values) that will be updated or inserted in the database with the given upsert strategy; the closure returned does not check the input hash for validity; the closure has the following signature: @code int sub upsert(hash row) {} @endcode The return value of the closure is always @ref SqlUtil::AbstractTable::UR_Verified; see @ref upsert_results for more information
+
+            @throw COLUMN-ERROR an unknown column was referenced in the hash to be inserted
+            @throw UPSERT-ERROR no primary key, unique constraint, or unique index for upsert; not all columns of the unique constraint/index are used in the upsert statement
+
+            @note the row values passed to the closure for upserting are not checked if they match the example row passed to the getUpsertClosure() method; passing non-conforming data will cause errors; see @ref SqlUtil::AbstractTable::getUpsertClosureWithValidation() for a similar method that returns a validating closure; the closure returned by this method is faster than the one returned by @ref SqlUtil::AbstractTable::getUpsertClosure() since there is no validation
+
+            @see
+            - upsert()
+            - upsertNoCommit()
+            - getUpsertClosure()
+            - getUpsertClosureWithValidation()
+         */
+        code getBulkUpsertClosure(hash example_row, int upsert_strategy = AbstractTable::UpsertAuto) {
+            return t.getBulkUpsertClosure(example_row, upsert_strategy);
         }
 
         #! returns a closure that can be executed given a hash argument representing a single row that will be updated or inserted in the database with the given upsert strategy; the table must have a unique key to do this; the closure returned validates the input hash for validity
@@ -9254,7 +9289,7 @@ map upsert($1), row_list;
             @param example_row a hash representing an example row to insert or update; every row passed to the upsert closure returned must have the same keys in the same order or the closure returned will throw an \c UPSERT-ERROR exception
             @param upsert_strategy see @ref upsert_options for possible values for the upsert strategy
 
-            @return a closure that can be executed given a hash argument representing a single row that will be updated or inserted in the database with the given upsert strategy; the closure has the following signature: @code int sub upsert(hash row) {} @endcode The return value of the closuse is an integer code giving the result of the update; see @ref upsert_results for more information
+            @return a closure that can be executed given a hash argument representing a single row that will be updated or inserted in the database with the given upsert strategy; the closure has the following signature: @code int sub upsert(hash row) {} @endcode The return value of the closure is an integer code giving the result of the update; see @ref upsert_results for more information
 
             @throw COLUMN-ERROR an unknown column was referenced in the hash to be inserted
             @throw UPSERT-ERROR no primary key, unique constraint, or unique index for upsert; not all columns of the unique constraint/index are used in the upsert statement
@@ -9264,6 +9299,7 @@ map upsert($1), row_list;
             @see
             - upsert()
             - upsertNoCommit()
+            - getBulkUpsertClosure()
             - getUpsertClosure()
          */
         code getUpsertClosureWithValidation(hash example_row, int upsert_strategy = AbstractTable::UpsertAuto) {
@@ -9298,6 +9334,7 @@ hash h = table.upsertFromIterator(i, AbstractTable::UpsertUpdateFirst);
             - upsertFromSelectNoCommit()
             - upsert()
             - upsertNoCommit()
+            - getBulkUpsertClosure()
             - getUpsertClosure()
         */
         *hash upsertFromIterator(Qore::AbstractIterator i, int upsert_strategy = AbstractTable::UpsertAuto, *hash opt) {
@@ -9332,6 +9369,7 @@ hash h = table.upsertFromIteratorNoCommit(i, AbstractTable::UpsertUpdateFirst);
             - upsertFromSelectNoCommit()
             - upsert()
             - upsertNoCommit()
+            - getBulkUpsertClosure()
             - getUpsertClosure()
         */
         *hash upsertFromIteratorNoCommit(Qore::AbstractIterator i, int upsert_strategy = AbstractTable::UpsertAuto, *hash opt) {
@@ -9374,6 +9412,7 @@ hash h = table.upsertFromSelect(table2, ("where": ("account_type": "CUSTOMER")),
             - upsertFromIteratorNoCommit()
             - upsert()
             - upsertNoCommit()
+            - getBulkUpsertClosure()
             - getUpsertClosure()
         */
         *hash upsertFromSelect(AbstractTable src, *hash sh, int upsert_strategy = AbstractTable::UpsertAuto, *hash opt) {
@@ -9418,6 +9457,7 @@ hash h = table.upsertFromSelectNoCommit(table2, ("where": ("account_type": "CUST
             - upsertFromIteratorNoCommit()
             - upsert()
             - upsertNoCommit()
+            - getBulkUpsertClosure()
             - getUpsertClosure()
         */
         *hash upsertFromSelectNoCommit(AbstractTable src, *hash sh, int upsert_strategy = AbstractTable::UpsertAuto, *hash opt) {
@@ -9460,6 +9500,7 @@ hash h = table.upsertFromSelect(table2, ("where": ("account_type": "CUSTOMER")),
             - upsertFromIteratorNoCommit()
             - upsert()
             - upsertNoCommit()
+            - getBulkUpsertClosure()
             - getUpsertClosure()
         */
         *hash upsertFromSelect(Table src, *hash sh, int upsert_strategy = AbstractTable::UpsertAuto, *hash opt) {
@@ -9504,6 +9545,7 @@ hash h = table.upsertFromSelectNoCommit(table2, ("where": ("account_type": "CUST
             - upsertFromIteratorNoCommit()
             - upsert()
             - upsertNoCommit()
+            - getBulkUpsertClosure()
             - getUpsertClosure()
         */
         *hash upsertFromSelectNoCommit(Table src, *hash sh, int upsert_strategy = AbstractTable::UpsertAuto, *hash opt) {
@@ -10543,6 +10585,7 @@ Triggers trig = table.getTriggers();
 
             /** @defgroup upsert_options Upsert Strategy Codes
                 These options are used with:
+                - @ref SqlUtil::AbstractTable::getBulkUpsertClosure()
                 - @ref SqlUtil::AbstractTable::getUpsertClosure()
                 - @ref SqlUtil::AbstractTable::getUpsertClosureWithValidation()
                 - @ref SqlUtil::AbstractTable::upsert()
@@ -13422,7 +13465,7 @@ table.upsert(row);
             @throw COLUMN-ERROR an unknown column was referenced in the hash to be inserted
             @throw UPSERT-ERROR no primary key, unique constraint, or unique index for upsert; not all columns of the unique constraint/index are used in the upsert statement
 
-            @note if upserting multiple rows; it's better to use getUpsertClosure() or getUpsertClosureWithValidation() and execute the closure on each row; when using this method, the overhead for setting up the upsert is made for each row which is very inefficient
+            @note if upserting multiple rows; it's better to use getBulkUpsertClosure(), getUpsertClosure(), or getUpsertClosureWithValidation() and execute the closure on each row; when using this method, the overhead for setting up the upsert is made for each row which is very inefficient
          */
         int upsert(hash row, int upsert_strategy = UpsertAuto) {
             on_success ds.commit();
@@ -13445,7 +13488,7 @@ table.upsertNoCommit(row);
             @throw COLUMN-ERROR an unknown column was referenced in the hash to be inserted
             @throw UPSERT-ERROR no primary key, unique constraint, or unique index for upsert; not all columns of the unique constraint/index are used in the upsert statement
 
-            @note if upserting multiple rows; it's better to use getUpsertClosure() or getUpsertClosureWithValidation() and execute the closure on each row; when using this method, the overhead for setting up the upsert is made for each row which is very inefficient
+            @note if upserting multiple rows; it's better to use getBulkUpsertClosure(), getUpsertClosure(), or getUpsertClosureWithValidation() and execute the closure on each row; when using this method, the overhead for setting up the upsert is made for each row which is very inefficient
          */
         int upsertNoCommit(hash row, int upsert_strategy = UpsertAuto) {
             l.lock();
@@ -13470,7 +13513,7 @@ map upsert($1), row_list;
             @param example_row a hash representing an example row to insert or update; every row passed to the upsert closure returned must have the same keys in the same order
             @param upsert_strategy see @ref upsert_options for possible values for the upsert strategy
 
-            @return a closure that can be executed given a hash argument representing a single row that will be updated or inserted in the database with the given upsert strategy; the closure returned does not check the input hash for validity; the closure has the following signature: @code int sub upsert(hash row) {} @endcode The return value of the closuse is an integer code giving the result of the update; see @ref upsert_results for more information
+            @return a closure that can be executed given a hash argument representing a single row that will be updated or inserted in the database with the given upsert strategy; the closure returned does not check the input hash for validity; the closure has the following signature: @code int sub upsert(hash row) {} @endcode The return value of the closure is an integer code giving the result of the update; see @ref upsert_results for more information
 
             @throw COLUMN-ERROR an unknown column was referenced in the hash to be inserted
             @throw UPSERT-ERROR no primary key, unique constraint, or unique index for upsert; not all columns of the unique constraint/index are used in the upsert statement
@@ -13482,6 +13525,44 @@ map upsert($1), row_list;
             on_exit l.unlock();
 
             return getUpsertClosureUnlocked(example_row, upsert_strategy);
+        }
+
+        #! returns a closure that can be executed given a hash argument representing either a single row or a set of rows (where each key value is a list of column values) that will be updated or inserted in the database with the given upsert strategy; the table must have a unique key to do this; the closure returned does not check the input hash for validity
+        /** @par Example:
+            @code
+Datasource ds("pgsql:user/pass@db%localhost");
+Table table(ds, "table_name");
+code upsert = table.getBulkUpsertClosure(row, AbstractTable::UpsertSelectFirst);
+on_success ds.commit();
+on_error ds.rollback();
+upsert(row_hash);
+            @endcode
+
+            @param example_row a hash representing an example row to insert or update; every hash passed to the upsert closure returned must have the same keys in the same order
+            @param upsert_strategy see @ref upsert_options for possible values for the upsert strategy
+
+            @return a closure that can be executed given a hash argument representing either a single row or a set of rows (where each key value is a list of column values) that will be updated or inserted in the database with the given upsert strategy; the closure returned does not check the input hash for validity; the closure has the following signature: @code int sub upsert(hash row) {} @endcode The return value of the closure is always @ref SqlUtil::AbstractTable::UR_Verified; see @ref upsert_results for more information
+
+            @throw COLUMN-ERROR an unknown column was referenced in the hash to be inserted
+            @throw UPSERT-ERROR no primary key, unique constraint, or unique index for upsert; not all columns of the unique constraint/index are used in the upsert statement
+
+            @note the row values passed to the closure for upserting are not checked if they match the example row passed to the getUpsertClosure() method; passing non-conforming data will cause errors; see @ref SqlUtil::AbstractTable::getUpsertClosureWithValidation() for a similar method that returns a validating closure; the closure returned by this method is faster than the one returned by @ref SqlUtil::AbstractTable::getUpsertClosure() since there is no validation
+
+            @see
+            - upsert()
+            - upsertNoCommit()
+            - getUpsertClosure()
+            - getUpsertClosureWithValidation()
+         */
+        code getBulkUpsertClosure(hash example_row, int upsert_strategy = AbstractTable::UpsertAuto) {
+            l.lock();
+            on_exit l.unlock();
+
+            code upsert = getUpsertClosureUnlocked(example_row, upsert_strategy);
+            return int sub (hash h) {
+                map upsert($1), h.contextIterator();
+                return UR_Verified;
+            };
         }
 
         #! returns a closure that can be executed given a hash argument representing a single row that will be updated or inserted in the database with the given upsert strategy; the table must have a unique key to do this; the closure returned checks the input hash for validity
@@ -13498,7 +13579,7 @@ map upsert($1), row_list;
             @param example_row a hash representing an example row to insert or update; every row passed to the upsert closure returned must have the same keys in the same order or the closure returned will throw an \c UPSERT-ERROR exception
             @param upsert_strategy see @ref upsert_options for possible values for the upsert strategy
 
-            @return a closure that can be executed given a hash argument representing a single row that will be updated or inserted in the database with the given upsert strategy; the closure has the following signature: @code int sub upsert(hash row) {} @endcode The return value of the closuse is an integer code giving the result of the update; see @ref upsert_results for more information
+            @return a closure that can be executed given a hash argument representing a single row that will be updated or inserted in the database with the given upsert strategy; the closure has the following signature: @code int sub upsert(hash row) {} @endcode The return value of the closure is an integer code giving the result of the update; see @ref upsert_results for more information
 
             @throw COLUMN-ERROR an unknown column was referenced in the hash to be inserted
             @throw UPSERT-ERROR no primary key, unique constraint, or unique index for upsert; not all columns of the unique constraint/index are used in the upsert statement


### PR DESCRIPTION
- a new API was added to SqlUtil to acquire a closure for bulk upsert operations
- BulkSqlUtil was updated to use that API
- SqlUtil simulated bulk operations by default
- OracleSqlUtil updated to use its efficient merge support in all cases (no bulk DML simulation with bulk upserts)
