### PR TITLE
Push and unshift operator now use the default value for softlist

### DIFF
--- a/doxygen/lang/180_operators.dox.tmpl
+++ b/doxygen/lang/180_operators.dox.tmpl
@@ -520,9 +520,9 @@ if (!exists $error_code)
 
     <b>Arguments Processed by shift</b>
     |!Argument|!Processing
-    |\a lvalue|Returns the first element of the list, and the list is modified by having the first element removed from the list.  If the \a lvalue is not a list, no action is performed and the operator returns no value (@ref nothing)
+    |\a lvalue|Returns the first element of the list, and the list is modified by having the first element removed from the list. If the \a lvalue is an empty list, the operator returns no value (@ref nothing).
 
-    This operator does not throw any exceptions.
+    This operator throws an exception if the \a lvalue is not a list.
 
     <hr>
     @section pop Pop Operator (pop)
@@ -541,9 +541,9 @@ if (!exists $error_code)
 
     <b>Arguments Processed by pop</b>
     |!Argument|!Processing
-    |\a lvalue|Returns the last element of the list, and the list is modified, having the last element removed from the list. If the \a lvalue is not a list, no action is performed and the operator returns no value (@ref nothing)
+    |\a lvalue|Returns the last element of the list, and the list is modified, having the last element removed from the list. If the \a lvalue is an empty list, the operator returns no value (@ref nothing).
 
-    This operator does not throw any exceptions.
+    This operator throws an exception if the \a lvalue is not a list.
 
     <hr>
     @section chomp Chomp Operator (chomp)
@@ -1624,32 +1624,32 @@ if ($x || $y)
     @section unshift Unshift Operator (unshift)
 
     @par Synopsis
-    Inserts an element into the first position of a list and moves all other elements up one position.
+    Inserts an element into the first position of a list, moves all other elements up one position and returns the list processed. Throws an exception if the \a lvalue is not a list.
 
     @par Syntax
     <tt><b>unshift</b></tt> \a lvalue, \a expression
 
     @par Return Type
-    @ref any_type "any"
+    @ref list_type "list"
 
     @par Example
     @code{.py} unshift $list, "one";@endcode
 
     <b>Arguments Processed by unshift</b>
     |!Argument|!Processing
-    |All|Inserts the value of \a expression as the first element in the list given by \a lvalue. All other elements in the list are moved forward.
+    |All|Inserts the value of \a expression as the first element in the list given by \a lvalue. All other elements in the list are moved forward. If \a expression evaluates to a list, this list will be appended as the last element of \a lvalue. To concatenate lists, use the @ref plus_operator "plus operator".
 
     <hr>
     @section push Push Operator (push)
 
     @par Synopsis
-    Adds one element to the end of a list and returns the list processed (or @ref nothing if the \a lvalue is not a list).
+    Adds one element to the end of a list and returns the list processed. Throws an exception if the \a lvalue is not a list.
 
     @par Syntax
     <tt><b>push</b></tt> \a lvalue, \a expression
 
     @par Return Type
-    @ref list_type "list" or @ref nothing (if the lvalue is not a list)
+    @ref list_type "list"
 
     @par Example
     @code{.py} push $list, "last";@endcode

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -14,6 +14,7 @@
     @subsection qore_0812_compatibility Changes That Can Affect Backwards-Compatibility
     - fixed broken list parsing; in previous releases, %Qore's parser re-wrote lists without parentheses used as top-level statements with certain assignment operators (@ref assignment_operator "=", @ref plus_equals_operator "+=", @ref minus_equals_operator "-=", @ref multiply_equals_operator "*=", and @ref divide_equals_operator "/=", but not with others) so that statements like <tt>list l = 1, 2, 3;</tt> were valid assignments.   Due to operator precedence, such statements should normally be interpreted as <tt>(list l = 1), 2, 3;</tt>, which is not a valid expression.  Not only were the rules applied with only some assignment operators, but such lists were only rewritten if used as top-level statements, therefore the rules were applied inconsistenctly depending on where the expression was located in the parse tree.  As of %Qore 0.8.12, these inconsistencies have been eliminated by default from %Qore; all lists are processed according to the precedence rules defined in @ref operators.  This could break old code that relied on the old, broken behavior.  To get the old behavior, use the @ref broken-list-parsing "%broken-list-parsing" parse directive.
     - the %Qore parser has been updated to no longer accept multi-character operators with whitespace bewtween them; it is believed that this was never used and simply caused the parser to be needlessly complicated and caused %Qore to be less compatible with other languages
+    - the @ref push "push", @ref unshift "unshift", @ref pop "pop" and @ref shift "shift" operators now throw an exception when their first operand is not a list
 
     @subsection qore_0812_new_features New Features in Qore
     - new \c qr binary that assumes @ref new-style "%new-style" with %Qore code to make it easier to write programs in @ref new-style "%new-style"
@@ -382,6 +383,7 @@
     - fixed a bug normalizing the result of date arithmetic between hour and minute components of @ref relative_dates "relative date/time value"
     - fixed a bug where time components of absolute date/time values before the UNIX epoch were returned with invalid values
     - fixed a bug where the @ref exec-class "%exec-class" directive did not check for classes with unimplemented abstract variants
+    - fixed a bug where the @ref push "push" and @ref unshift "unshift" operators applied to a variable declared as softlist did not use the default value
 
     @section qore_0811 Qore 0.8.11
 

--- a/examples/test/qore/operators/list_ops.qtest
+++ b/examples/test/qore/operators/list_ops.qtest
@@ -1,0 +1,155 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class Test
+
+class Test inherits QUnit::Test {
+    constructor() : QUnit::Test("list operators", "1.0", \ARGV) {
+        addTestCase("push element", \pushElement());
+        addTestCase("push list", \pushList());
+        addTestCase("push empty list", \pushEmptyList());
+        addTestCase("push element to empty list", \pushElementToEmptyList());
+        addTestCase("push empty list to empty list", \pushEmptyListToEmptyList());
+        addTestCase("push element to nothing", \pushElementToNothing());
+        addTestCase("push element after delete", \pushElementAfterDelete());
+        addTestCase("unshift element", \unshiftElement());
+        addTestCase("unshift list", \unshiftList());
+        addTestCase("unshift empty list", \unshiftEmptyList());
+        addTestCase("unshift element to empty list", \unshiftElementToEmptyList());
+        addTestCase("unshift empty list to empty list", \unshiftEmptyListToEmptyList());
+        addTestCase("unshift element to nothing", \unshiftElementToNothing());
+        addTestCase("unshift element after delete", \unshiftElementAfterDelete());
+        set_return_value(main());
+    }
+
+    pushElement() {
+        list l = (1, 2);
+        assertEq((1, 2, 3), push l, 3);
+        assertEq((1, 2, 3), l);
+    }
+
+    pushList() {
+        list l = (1, 2);
+        assertEq((1, 2, (3,)), push l, (3,));
+        assertEq((1, 2, (3,)), l);
+    }
+
+    pushEmptyList() {
+        list l = (1, 2);
+        assertEq((1, 2, ()), push l, ());
+        assertEq((1, 2, ()), l);
+    }
+
+    pushElementToEmptyList() {
+        list l = ();
+        assertEq((3,), push l, 3);
+        assertEq((3,), l);
+    }
+
+    pushEmptyListToEmptyList() {
+        #list l = ();
+        #broken, see issue #320
+        #assertEq(((),), push l, ());
+        #assertEq(((),), l);
+    }
+
+    pushElementToNothing() {
+        list l1;
+        *list l2;
+        softlist l3;
+        *softlist l4;
+        assertEq((3,), push l1, 3);
+        assertEq(NOTHING, push l2, 3);
+        assertEq((3,), push l3, 3);
+        assertEq(NOTHING, push l4, 3);
+    }
+
+    pushElementAfterDelete() {
+        list l1 = (1, 2);
+        *list l2 = (1, 2);
+        softlist l3 = (1, 2);
+        *softlist l4 = (1, 2);
+
+        delete l1;
+        delete l2;
+        delete l3;
+        delete l4;
+
+        assertEq((3,), push l1, 3);
+        assertEq(NOTHING, push l2, 3);
+        assertEq((3,), push l3, 3);
+        assertEq(NOTHING, push l4, 3);
+    }
+
+
+
+
+
+
+    unshiftElement() {
+        list l = (1, 2);
+        assertEq((3, 1, 2), unshift l, 3);
+        assertEq((3, 1, 2), l);
+    }
+
+    unshiftList() {
+        list l = (1, 2);
+        assertEq(((3,), 1, 2), unshift l, (3,));
+        assertEq(((3,), 1, 2), l);
+    }
+
+    unshiftEmptyList() {
+        list l = (1, 2);
+        assertEq(((), 1, 2), unshift l, ());
+        assertEq(((), 1, 2), l);
+    }
+
+    unshiftElementToEmptyList() {
+        list l = ();
+        assertEq((3,), unshift l, 3);
+        assertEq((3,), l);
+    }
+
+    unshiftEmptyListToEmptyList() {
+        #list l = ();
+        #broken, see issue #320
+        #assertEq(((),), unshift l, ());
+        #assertEq(((),), l);
+    }
+
+    unshiftElementToNothing() {
+        list l1;
+        *list l2;
+        softlist l3;
+        *softlist l4;
+        assertEq((3,), unshift l1, 3);
+#see comment in issue #215
+#        assertEq(NOTHING, unshift l2, 3);
+        assertEq((3,), unshift l3, 3);
+#        assertEq(NOTHING, unshift l4, 3);
+    }
+
+    unshiftElementAfterDelete() {
+        list l1 = (1, 2);
+        *list l2 = (1, 2);
+        softlist l3 = (1, 2);
+        *softlist l4 = (1, 2);
+
+        delete l1;
+        delete l2;
+        delete l3;
+        delete l4;
+
+        assertEq((3,), unshift l1, 3);
+#        assertEq(NOTHING, unshift l2, 3);
+        assertEq((3,), unshift l3, 3);
+#        assertEq(NOTHING, unshift l4, 3);
+    }
+}

--- a/examples/test/qore/operators/list_ops.qtest
+++ b/examples/test/qore/operators/list_ops.qtest
@@ -26,6 +26,12 @@ class Test inherits QUnit::Test {
         addTestCase("unshift empty list to empty list", \unshiftEmptyListToEmptyList());
         addTestCase("unshift element to nothing", \unshiftElementToNothing());
         addTestCase("unshift element after delete", \unshiftElementAfterDelete());
+        addTestCase("pop basics", \popBasics());
+        addTestCase("pop from nothing", \popFromNothing());
+        addTestCase("pop after delete", \popAfterDelete());
+        addTestCase("shift basics", \shiftBasics());
+        addTestCase("shift from nothing", \shiftFromNothing());
+        addTestCase("shift after delete", \shiftAfterDelete());
         set_return_value(main());
     }
 
@@ -66,9 +72,9 @@ class Test inherits QUnit::Test {
         softlist l3;
         *softlist l4;
         assertEq((3,), push l1, 3);
-        assertEq(NOTHING, push l2, 3);
+        assertThrows("PUSH-ERROR", sub() { push l2, 3; });
         assertEq((3,), push l3, 3);
-        assertEq(NOTHING, push l4, 3);
+        assertThrows("PUSH-ERROR", sub() { push l4, 3; });
     }
 
     pushElementAfterDelete() {
@@ -83,14 +89,10 @@ class Test inherits QUnit::Test {
         delete l4;
 
         assertEq((3,), push l1, 3);
-        assertEq(NOTHING, push l2, 3);
+        assertThrows("PUSH-ERROR", sub() { push l2, 3; });
         assertEq((3,), push l3, 3);
-        assertEq(NOTHING, push l4, 3);
+        assertThrows("PUSH-ERROR", sub() { push l4, 3; });
     }
-
-
-
-
 
 
     unshiftElement() {
@@ -130,10 +132,9 @@ class Test inherits QUnit::Test {
         softlist l3;
         *softlist l4;
         assertEq((3,), unshift l1, 3);
-#see comment in issue #215
-#        assertEq(NOTHING, unshift l2, 3);
+        assertThrows("UNSHIFT-ERROR", sub() { unshift l2, 3; });
         assertEq((3,), unshift l3, 3);
-#        assertEq(NOTHING, unshift l4, 3);
+        assertThrows("UNSHIFT-ERROR", sub() { unshift l4, 3; });
     }
 
     unshiftElementAfterDelete() {
@@ -148,8 +149,90 @@ class Test inherits QUnit::Test {
         delete l4;
 
         assertEq((3,), unshift l1, 3);
-#        assertEq(NOTHING, unshift l2, 3);
+        assertThrows("UNSHIFT-ERROR", sub() { unshift l2, 3; });
         assertEq((3,), unshift l3, 3);
-#        assertEq(NOTHING, unshift l4, 3);
+        assertThrows("UNSHIFT-ERROR", sub() { unshift l4, 3; });
+    }
+
+
+    popBasics() {
+        list l = (1, 2);
+        assertEq(2, pop l);
+        assertEq((1,), l);
+        assertEq(1, pop l);
+        assertEq((), l);
+        assertEq(NOTHING, pop l);
+        assertEq((), l);
+    }
+
+    popFromNothing() {
+        list l1;
+        *list l2;
+        softlist l3;
+        *softlist l4;
+        assertEq(NOTHING, pop l1);
+        assertThrows("POP-ERROR", sub() { pop l2; });
+        assertEq(NOTHING, pop l3);
+        assertThrows("POP-ERROR", sub() { pop l4; });
+    }
+
+    popAfterDelete() {
+        list l1 = (1, 2);
+        *list l2 = (1, 2);
+        softlist l3 = (1, 2);
+        *softlist l4 = (1, 2);
+
+        delete l1;
+        delete l2;
+        delete l3;
+        delete l4;
+
+        assertEq(NOTHING, pop l1);
+        assertThrows("POP-ERROR", sub() { pop l2; });
+        assertEq(NOTHING, pop l3);
+        assertThrows("POP-ERROR", sub() { pop l4; });
+    }
+
+
+    shiftBasics() {
+        list l = (1, 2);
+        assertEq(1, shift l);
+        assertEq((2,), l);
+        assertEq(2, shift l);
+        assertEq((), l);
+        assertEq(NOTHING, shift l);
+        assertEq((), l);
+    }
+
+    shiftFromNothing() {
+        list l1;
+        *list l2;
+        softlist l3;
+        *softlist l4;
+        assertEq(NOTHING, shift l1);
+        assertEq((), l1);
+        assertThrows("SHIFT-ERROR", sub() { shift l2; });
+        assertEq(NOTHING, shift l3);
+        assertEq((), l3);
+        assertThrows("SHIFT-ERROR", sub() { shift l4; });
+    }
+
+    shiftAfterDelete() {
+        list l1 = (1, 2);
+        *list l2 = (1, 2);
+        softlist l3 = (1, 2);
+        *softlist l4 = (1, 2);
+
+        delete l1;
+        delete l2;
+        delete l3;
+        delete l4;
+
+        assertEq(NOTHING, shift l1);
+        assertEq((), l1);
+        assertThrows("SHIFT-ERROR", sub() { shift l2; });
+        assertEq(NOTHING, shift l3);
+        assertEq((), l3);
+        assertThrows("SHIFT-ERROR", sub() { shift l4; });
     }
 }

--- a/lib/Operator.cpp
+++ b/lib/Operator.cpp
@@ -824,9 +824,13 @@ static AbstractQoreNode* op_unshift(const AbstractQoreNode* left, const Abstract
    if (!val)
       return 0;
 
-   // assign to a blank list if the lvalue has no value yet but is typed as a list
-   if (val.getType() == NT_NOTHING && val.getTypeInfo() == listTypeInfo && val.assign(listTypeInfo->getDefaultValue()))
-      return 0;
+   // assign to a blank list if the lvalue has no value yet but is typed as a list or a softlist
+   if (val.getType() == NT_NOTHING) {
+      if (val.getTypeInfo() == listTypeInfo && val.assign(listTypeInfo->getDefaultValue()))
+         return 0;
+      if (val.getTypeInfo() == softListTypeInfo && val.assign(softListTypeInfo->getDefaultValue()))
+         return 0;
+   }
 
    // value is not a list, so throw exception
    if (val.getType() != NT_LIST) {
@@ -909,9 +913,13 @@ static AbstractQoreNode* op_push(const AbstractQoreNode* left, const AbstractQor
    if (!val)
       return 0;
 
-   // assign to a blank list if the lvalue has no vaule yet but is typed as a list
-   if (val.getType() == NT_NOTHING && val.getTypeInfo() == listTypeInfo && val.assign(listTypeInfo->getDefaultValue()))
-      return 0;
+   // assign to a blank list if the lvalue has no value yet but is typed as a list or softlist
+   if (val.getType() == NT_NOTHING) {
+      if (val.getTypeInfo() == listTypeInfo && val.assign(listTypeInfo->getDefaultValue()))
+         return 0;
+      if (val.getTypeInfo() == softListTypeInfo && val.assign(softListTypeInfo->getDefaultValue()))
+         return 0;
+   }
 
    if (val.getType() != NT_LIST)
       return 0;

--- a/lib/Operator.cpp
+++ b/lib/Operator.cpp
@@ -859,8 +859,19 @@ static AbstractQoreNode* op_shift(const AbstractQoreNode* left, const AbstractQo
    if (!val)
       return 0;
 
-   if (val.getType() != NT_LIST)
+   // assign to a blank list if the lvalue has no value yet but is typed as a list or softlist
+   if (val.getType() == NT_NOTHING) {
+      if (val.getTypeInfo() == listTypeInfo && val.assign(listTypeInfo->getDefaultValue()))
+         return 0;
+      if (val.getTypeInfo() == softListTypeInfo && val.assign(softListTypeInfo->getDefaultValue()))
+         return 0;
+   }
+
+   // value is not a list, so throw exception
+   if (val.getType() != NT_LIST) {
+      xsink->raiseException("SHIFT-ERROR", "the argument to shift is not a list");
       return 0;
+   }
 
    // no exception can occurr here
    val.ensureUnique();
@@ -881,14 +892,21 @@ static AbstractQoreNode* op_pop(const AbstractQoreNode* left, const AbstractQore
    if (!val)
       return 0;
 
-   // assign to a blank list if the lvalue has no vaule yet but is typed as a list
-   if (val.getType() == NT_NOTHING && val.getTypeInfo() == listTypeInfo && val.assign(listTypeInfo->getDefaultValue()))
-      return 0;
+   // assign to a blank list if the lvalue has no value yet but is typed as a list or softlist
+   if (val.getType() == NT_NOTHING) {
+      if (val.getTypeInfo() == listTypeInfo && val.assign(listTypeInfo->getDefaultValue()))
+         return 0;
+      if (val.getTypeInfo() == softListTypeInfo && val.assign(softListTypeInfo->getDefaultValue()))
+         return 0;
+   }
 
-   if (val.getType() != NT_LIST)
+   // value is not a list, so throw exception
+   if (val.getType() != NT_LIST) {
+      xsink->raiseException("POP-ERROR", "the argument to pop is not a list");
       return 0;
+   }
 
-   // no exception can occurr here
+   // no exception can occur here
    val.ensureUnique();
 
    QoreListNode* l = reinterpret_cast<QoreListNode*>(val.getValue());
@@ -921,8 +939,11 @@ static AbstractQoreNode* op_push(const AbstractQoreNode* left, const AbstractQor
          return 0;
    }
 
-   if (val.getType() != NT_LIST)
+   // value is not a list, so throw exception
+   if (val.getType() != NT_LIST) {
+      xsink->raiseException("PUSH-ERROR", "first argument to push is not a list");
       return 0;
+   }
 
    // no exception can occurr here
    val.ensureUnique();


### PR DESCRIPTION
Described in #215 

Please see comment in that issue regarding another inconsistency of `unshift` vs `push` operators
