### PR TITLE
refs #339 better fix for the case when the socket is closed during an…

### DIFF
--- a/include/qore/intern/SSLSocketHelper.h
+++ b/include/qore/intern/SSLSocketHelper.h
@@ -49,6 +49,7 @@ private:
    SSL_METHOD_CONST SSL_METHOD* meth;
    SSL_CTX* ctx;
    SSL* ssl;
+   unsigned refs;
 
    DLLLOCAL int setIntern(const char* meth, int sd, X509* cert, EVP_PKEY* pk, ExceptionSink* xsink);
 
@@ -56,21 +57,36 @@ private:
    DLLLOCAL int doSSLRW(const char* mname, void* buf, int num, int timeout_ms, bool read, ExceptionSink* xsink);
 
    // non-blocking I/O helper
-   DLLLOCAL int doSSLUpgradeNonBlockingIO(int rc, const char* mname, int timeout_ms, const char* ssl_func, bool& closed, ExceptionSink* xsink);
-   
-public:
-   DLLLOCAL SSLSocketHelper(qore_socket_private& n_qs) : qs(n_qs), meth(0), ctx(0), ssl(0) {
-   }
+   DLLLOCAL int doSSLUpgradeNonBlockingIO(int rc, const char* mname, int timeout_ms, const char* ssl_func, ExceptionSink* xsink);
 
-   ~SSLSocketHelper() {
+   DLLLOCAL ~SSLSocketHelper() {
       if (ssl)
          SSL_free(ssl);
       if (ctx)
          SSL_CTX_free(ctx);
    }
 
-   // if closed is returned as true, then the SSLSocketHelper object has been deleted
-   DLLLOCAL bool sslError(ExceptionSink* xsink, bool& closed, const char* meth, const char* msg, bool always_error = true);
+   // must be called with refs > 1
+   DLLLOCAL bool sslError(ExceptionSink* xsink, const char* meth, const char* msg, bool always_error = true);
+
+public:
+   DLLLOCAL SSLSocketHelper(qore_socket_private& n_qs) : qs(n_qs), meth(0), ctx(0), ssl(0), refs(1) {
+   }
+
+   // we do not need atomic dereferences here, all operations must be already locked
+   DLLLOCAL bool deref() {
+      if (!--refs) {
+         delete this;
+         return true;
+      }
+      return false;
+   }
+
+   // we do not need atomic dereferences here, all operations must be already locked
+   DLLLOCAL void ref() {
+      ++refs;
+   }
+
    DLLLOCAL int setClient(const char* mname, int sd, X509* cert, EVP_PKEY* pk, ExceptionSink* xsink);
    DLLLOCAL int setServer(const char* mname, int sd, X509* cert, EVP_PKEY* pk, ExceptionSink* xsink);
    // returns 0 for success
@@ -89,6 +105,20 @@ public:
    DLLLOCAL const char* getCipherVersion() const;
    DLLLOCAL X509* getPeerCertificate() const;
    DLLLOCAL long verifyPeerCertificate() const;
+};
+
+class SSLSocketReferenceHelper {
+protected:
+   SSLSocketHelper* s;
+
+public:
+   DLLLOCAL SSLSocketReferenceHelper(SSLSocketHelper* n_s) : s(n_s) {
+      s->ref();
+   }
+
+   DLLLOCAL ~SSLSocketReferenceHelper() {
+      s->deref();
+   }
 };
 
 #endif

--- a/include/qore/intern/qore_socket_private.h
+++ b/include/qore/intern/qore_socket_private.h
@@ -234,6 +234,10 @@ struct qore_socket_private {
       assert(!warn_queue);
    }
 
+   DLLLOCAL bool isOpen() {
+      return sock != QORE_INVALID_SOCKET;
+   }
+
    DLLLOCAL int close() {
       int rc = close_internal();
       if (in_op)
@@ -279,7 +283,7 @@ struct qore_socket_private {
 	 // if an SSL connection has been established, shut it down first
 	 if (ssl) {
 	    ssl->shutdown();
-	    delete ssl;
+	    ssl->deref();
 	    ssl = 0;
 	 }
 

--- a/lib/QoreSocket.cpp
+++ b/lib/QoreSocket.cpp
@@ -261,30 +261,31 @@ SSLSocketHelperHelper::SSLSocketHelperHelper(qore_socket_private* sock) : s(sock
 }
 
 void SSLSocketHelperHelper::error() {
-   delete s->ssl;
+   s->ssl->deref();
    s->ssl = 0;
 }
 
 int SSLSocketHelper::setIntern(const char* mname, int sd, X509* cert, EVP_PKEY* pk, ExceptionSink* xsink) {
+   SSLSocketReferenceHelper ssrh(this);
+
    assert(!ssl);
    assert(!ctx);
    ctx = SSL_CTX_new(meth);
-   bool closed = false;
    if (!ctx) {
-      sslError(xsink, closed, mname, "SSL_CTX_new");
+      sslError(xsink, mname, "SSL_CTX_new");
       assert(*xsink);
       return -1;
    }
    if (cert) {
       if (!SSL_CTX_use_certificate(ctx, cert)) {
-	 sslError(xsink, closed, mname, "SSL_CTX_use_certificate");
+	 sslError(xsink, mname, "SSL_CTX_use_certificate");
 	 assert(*xsink);
 	 return -1;
       }
    }
    if (pk) {
       if (!SSL_CTX_use_PrivateKey(ctx, pk)) {
-	 sslError(xsink, closed, mname, "SSL_CTX_use_PrivateKey");
+	 sslError(xsink, mname, "SSL_CTX_use_PrivateKey");
 	 assert(*xsink);
 	 return -1;
       }
@@ -292,7 +293,7 @@ int SSLSocketHelper::setIntern(const char* mname, int sd, X509* cert, EVP_PKEY* 
 
    ssl = SSL_new(ctx);
    if (!ssl) {
-      sslError(xsink, closed, mname, "SSL_new");
+      sslError(xsink, mname, "SSL_new");
       assert(*xsink);
       return -1;
    }
@@ -319,9 +320,10 @@ int SSLSocketHelper::setServer(const char* mname, int sd, X509* cert, EVP_PKEY* 
 
 // returns 0 for success
 int SSLSocketHelper::connect(const char* mname, int timeout_ms, ExceptionSink* xsink) {
+   SSLSocketReferenceHelper ssrh(this);
+
    int rc;
 
-   bool closed = false;
    if (timeout_ms >= 0) {
       if (qs.set_non_blocking(true, xsink))
 	 return qs.close_and_exit();
@@ -329,8 +331,8 @@ int SSLSocketHelper::connect(const char* mname, int timeout_ms, ExceptionSink* x
       while (true) {
 	 rc = SSL_connect(ssl);
 
-	 if (rc == -1 && !(rc = doSSLUpgradeNonBlockingIO(rc, mname, timeout_ms, "SSL_connect", closed, xsink))) {
-	    if (closed)
+	 if (rc == -1 && !(rc = doSSLUpgradeNonBlockingIO(rc, mname, timeout_ms, "SSL_connect", xsink))) {
+	    if (!qs.isOpen())
 	       break;
 	    continue;
 	 }
@@ -338,16 +340,15 @@ int SSLSocketHelper::connect(const char* mname, int timeout_ms, ExceptionSink* x
 	 break;
       }
 
-      if (!closed && qs.set_non_blocking(false, xsink))
+      if (qs.isOpen() && qs.set_non_blocking(false, xsink))
 	 return qs.close_and_exit();
    }
    else
       rc = SSL_connect(ssl);
 
    if (rc <= 0) {
-      if (!closed)
-	 sslError(xsink, closed, mname, "SSL_connect", true);
-      assert(*xsink);
+      if (!*xsink)
+	 sslError(xsink, mname, "SSL_connect", true);
       return -1;
    }
 
@@ -356,9 +357,10 @@ int SSLSocketHelper::connect(const char* mname, int timeout_ms, ExceptionSink* x
 
 // returns 0 for success
 int SSLSocketHelper::accept(const char* mname, int timeout_ms, ExceptionSink* xsink) {
+   SSLSocketReferenceHelper ssrh(this);
+
    int rc;
 
-   bool closed = false;
    if (timeout_ms >= 0) {
       if (qs.set_non_blocking(true, xsink))
 	 return qs.close_and_exit();
@@ -366,8 +368,8 @@ int SSLSocketHelper::accept(const char* mname, int timeout_ms, ExceptionSink* xs
       while (true) {
 	 rc = SSL_accept(ssl);
 
-	 if (rc == -1 && !(rc = doSSLUpgradeNonBlockingIO(rc, mname, timeout_ms, "SSL_accept", closed, xsink))) {
-	    if (closed)
+	 if (rc == -1 && !(rc = doSSLUpgradeNonBlockingIO(rc, mname, timeout_ms, "SSL_accept", xsink))) {
+	    if (!qs.isOpen())
 	       break;
 	    continue;
 	 }
@@ -375,7 +377,7 @@ int SSLSocketHelper::accept(const char* mname, int timeout_ms, ExceptionSink* xs
 	 break;
       }
 
-      if (!closed && qs.set_non_blocking(false, xsink))
+      if (qs.isOpen() && qs.set_non_blocking(false, xsink))
 	 return qs.close_and_exit();
    }
    else
@@ -383,8 +385,8 @@ int SSLSocketHelper::accept(const char* mname, int timeout_ms, ExceptionSink* xs
 
    if (rc <= 0) {
       //printd(5, "SSLSocketHelper::accept() rc: %d\n", rc);
-      if (!closed)
-	 sslError(xsink, closed, mname, "SSL_accept", true);
+      if (!*xsink)
+	 sslError(xsink, mname, "SSL_accept", true);
       assert(*xsink);
       return -1;
    }
@@ -402,8 +404,8 @@ int SSLSocketHelper::shutdown() {
 // returns 0 for success
 int SSLSocketHelper::shutdown(ExceptionSink* xsink) {
    if (SSL_shutdown(ssl) < 0) {
-      bool closed = false;
-      sslError(xsink, closed, "shutdownSSL", "SSL_shutdown");
+      SSLSocketReferenceHelper ssrh(this);
+      sslError(xsink, "shutdownSSL", "SSL_shutdown");
       return -1;
    }
    return 0;
@@ -495,6 +497,8 @@ void QoreSocket::doException(int rc, const char* meth, int timeout_ms, Exception
 }
 
 int SSLSocketHelper::doSSLRW(const char* mname, void* buf, int size, int timeout_ms, bool read, ExceptionSink* xsink) {
+   SSLSocketReferenceHelper ssrh(this);
+
    if (timeout_ms < 0) {
       while (true) {
          int rc = read ? SSL_read(ssl, buf, size) : SSL_write(ssl, buf, size);
@@ -507,8 +511,7 @@ int SSLSocketHelper::doSSLRW(const char* mname, void* buf, int size, int timeout
 #endif
 
             if (xsink) {
-	       bool closed = false;
-	       if (!sslError(xsink, closed, mname, read ? "SSL_read" : "SSL_write", false))
+	       if (!sslError(xsink, mname, read ? "SSL_read" : "SSL_write", false))
 		  rc = 0;
 	    }
          }
@@ -560,8 +563,7 @@ int SSLSocketHelper::doSSLRW(const char* mname, void* buf, int size, int timeout
          }
          else if (err == SSL_ERROR_SYSCALL) {
             if (xsink) {
-	       bool closed = false;
-               if (!sslError(xsink, closed, mname, read ? "SSL_read" : "SSL_write")) {
+               if (!sslError(xsink, mname, read ? "SSL_read" : "SSL_write")) {
                   if (!rc)
                      xsink->raiseException("SOCKET-SSL-ERROR", "error in Socket::%s(): the openssl library reported an EOF condition that violates the SSL protocol while calling SSL_%s()", mname, read ? "read" : "write");
                   else if (rc == -1) {
@@ -569,7 +571,7 @@ int SSLSocketHelper::doSSLRW(const char* mname, void* buf, int size, int timeout
 
 #ifdef ECONNRESET
                      // close the socket if connection reset received
-		     if (!closed && sock_get_error() == ECONNRESET)
+		     if (qs.isOpen() && sock_get_error() == ECONNRESET)
 			qs.close();
 #endif
 		  }
@@ -586,8 +588,7 @@ int SSLSocketHelper::doSSLRW(const char* mname, void* buf, int size, int timeout
             //printd(5, "SSLSocketHelper::doSSLRW(buf: %p, size: %d, to: %d) rc: %d err: %d\n", buf, size, timeout_ms, rc, err);
 	    // always throw an exception if an error occurs while writing
             if (xsink) {
-	       bool closed = false;
-	       if (!sslError(xsink, closed, mname, read ? "SSL_read" : "SSL_write", !read))
+	       if (!sslError(xsink, mname, read ? "SSL_read" : "SSL_write", !read))
 		  rc = 0;
 	    }
             else {
@@ -604,9 +605,10 @@ int SSLSocketHelper::doSSLRW(const char* mname, void* buf, int size, int timeout
 
 // if we close the connection due to a socket error, then the SSLSocketHelper object is deleted, therefore have to ensure that we do not access
 // "this" after the connection is closed
-int SSLSocketHelper::doSSLUpgradeNonBlockingIO(int rc, const char* mname, int timeout_ms, const char* ssl_func, bool& closed, ExceptionSink* xsink) {
+int SSLSocketHelper::doSSLUpgradeNonBlockingIO(int rc, const char* mname, int timeout_ms, const char* ssl_func, ExceptionSink* xsink) {
+   SSLSocketReferenceHelper ssrh(this);
+
    assert(xsink);
-   assert(!closed);
 
    int err = SSL_get_error(ssl, rc);
 
@@ -631,7 +633,7 @@ int SSLSocketHelper::doSSLUpgradeNonBlockingIO(int rc, const char* mname, int ti
    }
 
    if (err == SSL_ERROR_SYSCALL) {
-      if (!sslError(xsink, closed, mname, ssl_func)) {
+      if (!sslError(xsink, mname, ssl_func)) {
 	 if (!rc)
 	    xsink->raiseException("SOCKET-SSL-ERROR", "error in Socket::%s(): the openssl library reported an EOF condition that violates the SSL protocol while calling %s()", mname, ssl_func);
 	 else if (rc == -1) {
@@ -640,7 +642,7 @@ int SSLSocketHelper::doSSLUpgradeNonBlockingIO(int rc, const char* mname, int ti
 #ifdef ECONNRESET
 	    // close the socket if connection reset received
 	    // do not access "this" after the connection is closed since the SSLSocketHelper has been deleted
-	    if (!closed && sock_get_error() == ECONNRESET)
+	    if (qs.isOpen() && sock_get_error() == ECONNRESET)
 	       qs.close();
 #endif
 	 }
@@ -653,7 +655,7 @@ int SSLSocketHelper::doSSLUpgradeNonBlockingIO(int rc, const char* mname, int ti
 
    //printd(5, "SSLSocketHelper::doSSLNonBlockingIO(buf: %p, size: %d, to: %d) rc: %d err: %d\n", buf, size, timeout_ms, rc, err);
    // always throw an exception if an error occurs while writing
-   if (!sslError(xsink, closed, mname, ssl_func, true))
+   if (!sslError(xsink, mname, ssl_func, true))
       return 0;
 
    return !*xsink ? 0 : QSE_SSL_ERR;
@@ -677,18 +679,14 @@ int SSLSocketHelper::read(const char* mname, char* buf, int size, int timeout_ms
    return doSSLRW(mname, buf, size, timeout_ms, true, xsink);
 }
 
-// returns true if an error was raised, false if not
-// if we close the connection due to a socket error, then the SSLSocketHelper object is deleted, therefore have to ensure that we do not access
-// "this" after the connection is closed
-bool SSLSocketHelper::sslError(ExceptionSink* xsink, bool& closed, const char* mname, const char* func, bool always_error) {
-   assert(!closed);
+// returns true if an error was raised or the connection was closed, false if not
+bool SSLSocketHelper::sslError(ExceptionSink* xsink, const char* mname, const char* func, bool always_error) {
+   assert(refs > 1);
+
    long e = ERR_get_error();
    do {
       if (!e || e == SSL_ERROR_ZERO_RETURN) {
-	 if (!closed) {
-	    closed = true;
-	    qs.close();
-	 }
+	 qs.close();
 	 //printd(0, "SSLSocketHelper::sslError() Socket::%s() (%s) socket closed by remote end\n", mname, func);
 	 if (always_error)
 	    xsink->raiseException("SOCKET-SSL-ERROR", "error in Socket::%s(): the %s() call could not be completed because the TLS/SSL connection was terminated", mname, func);
@@ -699,16 +697,15 @@ bool SSLSocketHelper::sslError(ExceptionSink* xsink, bool& closed, const char* m
 	 xsink->raiseException("SOCKET-SSL-ERROR", "error in Socket::%s(): %s(): %s", mname, func, buf);
 #ifdef ECONNRESET
 	 // close the socket if connection reset received
-	 if (e == SSL_ERROR_SYSCALL && sock_get_error() == ECONNRESET && !closed) {
+	 if (e == SSL_ERROR_SYSCALL && sock_get_error() == ECONNRESET) {
 	    //printd(5, "SSLSocketHelper::sslError() Socket::%s() (%s) socket closed by remote end\n", mname, func);
-	    closed = true;
 	    qs.close();
 	 }
 #endif
       }
    } while ((e = ERR_get_error()));
 
-   return *xsink || closed;
+   return *xsink || !qs.isOpen();
 }
 
 PrivateQoreSocketTimeoutHelper::PrivateQoreSocketTimeoutHelper(qore_socket_private* s, const char* o) : PrivateQoreSocketTimeoutBase(s->tl_warning_us ? s : 0), op(o) {


### PR DESCRIPTION
… SSL operation and the SSLSocketHelper object is deleted; eliminated the "closed" arguments and made sure that the SSLSocketHelper object stays in place during all SSL operations even if the socket is closed
