### PR TITLE
refs #184 fixed a bug where a warning was not always issued when squa…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -410,6 +410,7 @@ noinst_HEADERS = \
 	include/qore/intern/QoreHashMapSelectOperatorNode.h \
 	include/qore/intern/QoreChompOperatorNode.h \
 	include/qore/intern/QoreTrimOperatorNode.h \
+	include/qore/intern/QoreSquareBracketsOperatorNode.h \
 	include/qore/intern/QorePseudoMethods.h \
 	include/qore/intern/QoreHashIterator.h \
 	include/qore/intern/QoreListIterator.h \

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -396,6 +396,7 @@
     - fixed a bug where calls to @ref Qore::HTTPClient::setConnectTimeout() had no effect (<a href="https://github.com/qorelanguage/qore/issues/323">bug 323</a>)
     - fixed several bugs with logical comparison operators and arbitrary-precision numeric values (<a href="https://github.com/qorelanguage/qore/issues/330">bug 330</a>)
     - fixed a bug where @ref Qore::HashListIterator (and therefore @ref <hash>::contextIterator()) would not iterate a simple hash with non-list values once but would instead silently ignore the hash (<a href="https://github.com/qorelanguage/qore/issues/336">bug 336</a>)
+    - fixed a bug where a warning was not always issued when square brackets were used on unsuitable types (<a href="https://github.com/qorelanguage/qore/issues/184">bug 184</a>), internally ported the square bracket operator to the C++ QoreOperatorNode hierarchy
 
     @section qore_0811 Qore 0.8.11
 

--- a/examples/test/qore/vars/array.qtest
+++ b/examples/test/qore/vars/array.qtest
@@ -48,7 +48,7 @@ public class ArrayTest inherits QUnit::Test {
         # Return for compatibility with test harness that checks return value.
         set_return_value(main());
     }
-    
+
     testBasics() {
         my (list a, list b, list c, list d);
 
@@ -101,7 +101,7 @@ public class ArrayTest inherits QUnit::Test {
         c = a + b;
         assertEq(5, c[4], "second list list plus operator concatenation");
     }
-    
+
     testBasics2() {
         list lst1 = (3, 2, 4, 1, 6, 5);
         list lst2 = ("one", "two", "three", "four", "five", "six");
@@ -218,14 +218,14 @@ public class ArrayTest inherits QUnit::Test {
         assertEq((21, 2), (extract lst1, 1, 2, 4), "second list extract");
         assertEq((11, 4), lst1, "final list extract");
     }
-    
+
     testElementDereference() {
         string astr = "hello";
         binary bin = binary(astr);
         assertEq("l", astr[2], "string element dereference");
         assertEq(ord("o"), bin[4], "binary byte dereference");
     }
-    
+
     testRange() {
         assertEq((0, 1,), range(1), "range - basic test");
         assertEq((2, 3, 4, 5), range(2, 5), "range - boundaries test");
@@ -235,7 +235,7 @@ public class ArrayTest inherits QUnit::Test {
         assertEq((-10, -5, 0, 5, 10), range(-10, 10, 5), "range - asc test");
         assertEq((10, 5, 0, -5, -10), range(10, -10, 5), "range - descending step test");
     }
-    
+
     testPseudomethods() {
         list pseudoList = (1, 2, 3, 4, 'a');
         assertEq(NT_LIST, pseudoList.typeCode(), "<list>::typeCode");
@@ -249,4 +249,3 @@ public class ArrayTest inherits QUnit::Test {
         assertEq(True, pseudoList.contains(2), "<list>::contains");
     }
 }
-

--- a/include/qore/intern/Operator.h
+++ b/include/qore/intern/Operator.h
@@ -44,7 +44,7 @@ DLLLOCAL extern Operator *OP_BIN_AND, *OP_BIN_OR, *OP_BIN_NOT,
    *OP_BIN_XOR, *OP_MINUS, *OP_PLUS,
    *OP_MULT, *OP_SHIFT_LEFT, *OP_SHIFT_RIGHT,
    *OP_LOG_CMP,
-   *OP_LIST_REF, *OP_OBJECT_REF, *OP_ELEMENTS, *OP_KEYS, *OP_QUESTION_MARK,
+   *OP_OBJECT_REF, *OP_ELEMENTS, *OP_KEYS, *OP_QUESTION_MARK,
    *OP_SHIFT, *OP_POP, *OP_PUSH,
    *OP_UNSHIFT, *OP_REGEX_SUBST, *OP_LIST_ASSIGNMENT,
    *OP_REGEX_TRANS, *OP_REGEX_EXTRACT,
@@ -673,7 +673,7 @@ public:
          rr = r.getReferencedValue();
       return eval(lr ? *lr : l.getInternalNode(), rr ? *rr : r.getInternalNode(), ref_rv, xsink);
    }
-   
+
    DLLLOCAL QoreValue eval(const AbstractQoreNode* l, const AbstractQoreNode* r, bool ref_rv, ExceptionSink* xsink) const;
 
    DLLLOCAL const char* getName() const {

--- a/include/qore/intern/QoreOperatorNode.h
+++ b/include/qore/intern/QoreOperatorNode.h
@@ -136,6 +136,14 @@ public:
    DLLLOCAL AbstractQoreNode* getRight() {
       return right;
    }
+
+   DLLLOCAL const AbstractQoreNode* getLeft() const {
+      return left;
+   }
+
+   DLLLOCAL const AbstractQoreNode* getRight() const {
+      return right;
+   }
 };
 
 class QoreBoolBinaryOperatorNode : public QoreBinaryOperatorNode<> {
@@ -264,5 +272,6 @@ public:
 #include <qore/intern/QoreValueCoalescingOperatorNode.h>
 #include <qore/intern/QoreChompOperatorNode.h>
 #include <qore/intern/QoreTrimOperatorNode.h>
+#include <qore/intern/QoreSquareBracketsOperatorNode.h>
 
 #endif

--- a/include/qore/intern/QoreSquareBracketsOperatorNode.h
+++ b/include/qore/intern/QoreSquareBracketsOperatorNode.h
@@ -1,0 +1,63 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+  QoreSquareBracketsOperatorNode.h
+
+  Qore Programming Language
+
+  Copyright (C) 2003 - 2015 David Nichols
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+
+  Note that the Qore library is released under a choice of three open-source
+  licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+  information.
+*/
+
+#ifndef _QORE_QORESQUAREBRACKETSOPERATORNODE_H
+
+#define _QORE_QORESQUAREBRACKETSOPERATORNODE_H
+
+class QoreSquareBracketsOperatorNode : public QoreBinaryOperatorNode<> {
+OP_COMMON
+protected:
+   const QoreTypeInfo* typeInfo;
+
+   DLLLOCAL QoreValue evalValueImpl(bool& needs_deref, ExceptionSink* xsink) const;
+
+   DLLLOCAL virtual AbstractQoreNode* parseInitImpl(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo);
+
+   DLLLOCAL AbstractQoreNode* parseInitIntern(const char *name, LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo);
+
+public:
+   DLLLOCAL QoreSquareBracketsOperatorNode(AbstractQoreNode* n_left, AbstractQoreNode* n_right) : QoreBinaryOperatorNode<>(n_left, n_right), typeInfo(0) {
+   }
+
+
+   DLLLOCAL virtual const QoreTypeInfo* getTypeInfo() const {
+      return typeInfo;
+   }
+
+   DLLLOCAL virtual bool hasEffect() const {
+      return false;
+   }
+
+   DLLLOCAL static QoreValue doSquareBrackets(QoreValue l, QoreValue r, ExceptionSink* xsink);
+};
+
+#endif

--- a/include/qore/intern/QoreTreeNode.h
+++ b/include/qore/intern/QoreTreeNode.h
@@ -1,11 +1,11 @@
 /* -*- mode: c++; indent-tabs-mode: nil -*- */
 /*
   QoreTreeNode.h
- 
+
   Qore Programming Language
- 
+
   Copyright (C) 2003 - 2015 David Nichols
- 
+
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
   to deal in the Software without restriction, including without limitation
@@ -46,7 +46,7 @@ protected:
    DLLLOCAL virtual const QoreTypeInfo *getTypeInfo() const {
       return returnTypeInfo;
    }
-      
+
 public:
    AbstractQoreNode *left;
    AbstractQoreNode *right;
@@ -73,7 +73,7 @@ public:
          bool for_assignment = pflag & PF_FOR_ASSIGNMENT;
          if (for_assignment && left->getType() == NT_TREE) {
             QoreTreeNode *t = reinterpret_cast<QoreTreeNode *>(left);
-            if (t->getOp() != OP_LIST_REF && t->getOp() != OP_OBJECT_REF) {
+            if (t->getOp() != OP_OBJECT_REF) {
                parse_error("expression used for assignment requires an lvalue but an expression with the %s operator is used instead", t->getOp()->getName());
                return;
             }
@@ -86,7 +86,7 @@ public:
          // and the value is not an lvalue
          if (left && for_assignment && check_lvalue(left))
             parse_error("expression used for assignment requires an lvalue, got '%s' instead", left->getTypeName());
- 
+
          //printd(5, "QoreTreeNode::leftParseInit() this=%p new left=%p (%s)\n", this, left, get_type_name(left));
       }
    }

--- a/include/qore/intern/Variable.h
+++ b/include/qore/intern/Variable.h
@@ -59,6 +59,7 @@ enum qore_var_t {
 
 class Var;
 class ScopedObjectCallNode;
+class QoreSquareBracketsOperatorNode;
 
 union qore_gvar_ref_u {
    bool b;
@@ -384,7 +385,7 @@ protected:
          *v = n;
    }
 
-   DLLLOCAL int doListLValue(const QoreTreeNode* tree, bool for_remove);
+   DLLLOCAL int doListLValue(const QoreSquareBracketsOperatorNode* op, bool for_remove);
    DLLLOCAL int doHashObjLValue(const QoreTreeNode* tree, bool for_remove);
 
    DLLLOCAL int makeInt(const char* desc);

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -263,6 +263,7 @@ libqore_la_SOURCES = \
 	QoreValueCoalescingOperatorNode.cpp \
 	QoreChompOperatorNode.cpp \
 	QoreTrimOperatorNode.cpp \
+	QoreSquareBracketsOperatorNode.cpp \
 	QorePseudoMethods.cpp \
 	QoreHTTPClient.cpp \
 	QoreHttpClientObject.cpp \

--- a/lib/Operator.cpp
+++ b/lib/Operator.cpp
@@ -1753,7 +1753,6 @@ Operator *OperatorList::add(Operator *o) {
 
 // checks for illegal "self" assignments in an object context
 void check_self_assignment(AbstractQoreNode* n, LocalVar* selfid) {
-   // if it's a tree: go to root expression
    qore_type_t ntype = n->getType();
 
    // if it's a variable reference
@@ -1763,25 +1762,6 @@ void check_self_assignment(AbstractQoreNode* n, LocalVar* selfid) {
          parse_error("illegal assignment to 'self' in an object context");
       return;
    }
-
-   /*
-      // otherwise it's a tree: go to root expression
-      while (tree->left->getType() == NT_TREE) {
-	 n = tree->left;
-	 tree = reinterpret_cast<QoreTreeNode*>(n);
-      }
-   }
-
-   if (tree->left->getType() != NT_VARREF)
-      return;
-
-   VarRefNode* v = reinterpret_cast<VarRefNode*>(tree->left);
-
-   // left must be variable reference, check if the tree is
-   // a list reference; if so, it's invalid
-   if (v->getType() == VT_LOCAL && v->ref.id == selfid && tree->getOp() == OP_LIST_REF)
-      parse_error("illegal conversion of 'self' to a list");
-   */
 }
 
 static AbstractQoreNode* check_op_list_assignment(QoreTreeNode* tree, LocalVar* oflag, int pflag, int &lvids, const QoreTypeInfo*& resultTypeInfo, const char* name, const char* desc) {

--- a/lib/Operator.cpp
+++ b/lib/Operator.cpp
@@ -50,7 +50,7 @@ DLLLOCAL extern const QoreTypeInfo* bigIntFloatOrNumberTypeInfo, * floatOrNumber
 Operator *OP_BIN_AND, *OP_BIN_OR, *OP_BIN_NOT, *OP_BIN_XOR, *OP_MINUS, *OP_PLUS,
    *OP_MULT, *OP_SHIFT_LEFT, *OP_SHIFT_RIGHT,
    *OP_LOG_CMP,
-   *OP_LIST_REF, *OP_OBJECT_REF, *OP_ELEMENTS, *OP_KEYS,
+   *OP_OBJECT_REF, *OP_ELEMENTS, *OP_KEYS,
    *OP_SHIFT, *OP_POP, *OP_PUSH,
    *OP_UNSHIFT, *OP_REGEX_SUBST, *OP_LIST_ASSIGNMENT,
    *OP_REGEX_TRANS, *OP_REGEX_EXTRACT,
@@ -566,40 +566,6 @@ static AbstractQoreNode* op_transliterate(const AbstractQoreNode* left, const Ab
 
    // reference for return value
    return ref_rv ? nv->refSelf() : 0;
-}
-
-static AbstractQoreNode* op_list_ref(const AbstractQoreNode* left, const AbstractQoreNode* index, ExceptionSink* xsink) {
-   QoreNodeEvalOptionalRefHolder lp(left, xsink);
-
-   // return 0 if left side is not a list or string (or exception)
-   if (!lp || *xsink)
-      return 0;
-
-   qore_type_t t = lp->getType();
-   if (t != NT_LIST && t != NT_STRING && t != NT_BINARY)
-      return 0;
-
-   AbstractQoreNode* rv = 0;
-   int ind = index->integerEval(xsink);
-   if (!*xsink) {
-      // get value
-      if (t == NT_LIST) {
-	 const QoreListNode* l = reinterpret_cast<const QoreListNode*>(*lp);
-	 rv = l->get_referenced_entry(ind);
-      }
-      else if (t == NT_BINARY) {
-	 const BinaryNode* b = reinterpret_cast<const BinaryNode*>(*lp);
-	 if (ind < 0 || (unsigned)ind >= b->size())
-	    return 0;
-	 return new QoreBigIntNode(((unsigned char* )b->getPtr())[ind]);
-      }
-      else if (ind >= 0) {
-	 const QoreStringNode* lpstr = reinterpret_cast<const QoreStringNode*>(*lp);
-	 rv = lpstr->substr(ind, 1, xsink);
-      }
-      //printd(5, "op_list_ref() index=%d, rv=%p\n", ind, rv);
-   }
-   return rv;
 }
 
 // for the member name, a string is required.  non-string arguments will
@@ -1785,10 +1751,12 @@ Operator *OperatorList::add(Operator *o) {
    return o;
 }
 
-// checks for illegal $self assignments in an object context
+// checks for illegal "self" assignments in an object context
 void check_self_assignment(AbstractQoreNode* n, LocalVar* selfid) {
-   // if it's a variable reference
+   // if it's a tree: go to root expression
    qore_type_t ntype = n->getType();
+
+   // if it's a variable reference
    if (ntype == NT_VARREF) {
       VarRefNode* v = reinterpret_cast<VarRefNode*>(n);
       if (v->getType() == VT_LOCAL && v->ref.id == selfid)
@@ -1796,15 +1764,12 @@ void check_self_assignment(AbstractQoreNode* n, LocalVar* selfid) {
       return;
    }
 
-   if (ntype != NT_TREE)
-      return;
-
-   QoreTreeNode* tree = reinterpret_cast<QoreTreeNode*>(n);
-
-   // otherwise it's a tree: go to root expression
-   while (tree->left->getType() == NT_TREE) {
-      n = tree->left;
-      tree = reinterpret_cast<QoreTreeNode*>(n);
+   /*
+      // otherwise it's a tree: go to root expression
+      while (tree->left->getType() == NT_TREE) {
+	 n = tree->left;
+	 tree = reinterpret_cast<QoreTreeNode*>(n);
+      }
    }
 
    if (tree->left->getType() != NT_VARREF)
@@ -1814,8 +1779,9 @@ void check_self_assignment(AbstractQoreNode* n, LocalVar* selfid) {
 
    // left must be variable reference, check if the tree is
    // a list reference; if so, it's invalid
-   if (v->getType() == VT_LOCAL && v->ref.id == selfid  && tree->getOp() == OP_LIST_REF)
+   if (v->getType() == VT_LOCAL && v->ref.id == selfid && tree->getOp() == OP_LIST_REF)
       parse_error("illegal conversion of 'self' to a list");
+   */
 }
 
 static AbstractQoreNode* check_op_list_assignment(QoreTreeNode* tree, LocalVar* oflag, int pflag, int &lvids, const QoreTypeInfo*& resultTypeInfo, const char* name, const char* desc) {
@@ -2074,41 +2040,6 @@ static AbstractQoreNode* check_op_multiply(QoreTreeNode* tree, LocalVar* oflag, 
       returnTypeInfo = 0;
 
    //printd(5, "check_op_multiply() %s %s = %s\n", leftTypeInfo->getName(), rightTypeInfo->getName(), returnTypeInfo->getName());
-
-   return tree;
-}
-
-static AbstractQoreNode* check_op_list_ref(QoreTreeNode* tree, LocalVar* oflag, int pflag, int &lvids, const QoreTypeInfo*& returnTypeInfo, const char* name, const char* desc) {
-   const QoreTypeInfo *leftTypeInfo = 0;
-   tree->leftParseInit(oflag, pflag, lvids, leftTypeInfo);
-
-   const QoreTypeInfo *rightTypeInfo = 0;
-   tree->rightParseInit(oflag, pflag, lvids, rightTypeInfo);
-
-   if (tree->constArgs())
-      return tree->evalSubst(returnTypeInfo);
-
-   if (leftTypeInfo->hasType()) {
-      // if we are trying to convert to a list
-      if (pflag & PF_FOR_ASSIGNMENT) {
-	 // only throw a parse exception if parse exceptions are enabled
-	 if (!leftTypeInfo->parseAcceptsReturns(NT_LIST) && getProgram()->getParseExceptionSink()) {
-	    QoreStringNode* edesc = new QoreStringNode("cannot convert lvalue defined as ");
-	    leftTypeInfo->getThisType(*edesc);
-	    edesc->sprintf(" to a list using the '[]' operator in an assignment expression");
-	    qore_program_private::makeParseException(getProgram(), "PARSE-TYPE-ERROR", edesc);
-	 }
-      }
-      else if (!listTypeInfo->parseAccepts(leftTypeInfo)
-	  && !stringTypeInfo->parseAccepts(leftTypeInfo)
-	  && !binaryTypeInfo->parseAccepts(leftTypeInfo)) {
-	 QoreStringNode* edesc = new QoreStringNode("left-hand side of the expression with the '[]' operator is ");
-	 leftTypeInfo->getThisType(*edesc);
-	 edesc->concat(" and so this expression will always return NOTHING; the '[]' operator only returns a value within the legal bounds of lists, strings, and binary objects");
-	 qore_program_private::makeParseWarning(getProgram(), QP_WARN_INVALID_OPERATION, "INVALID-OPERATION", edesc);
-	 returnTypeInfo = nothingTypeInfo;
-      }
-   }
 
    return tree;
 }
@@ -2437,10 +2368,6 @@ void OperatorList::init() {
 
    OP_SHIFT_RIGHT = add(new Operator(2, ">>", "shift-right", 1, false, false, check_op_returns_integer));
    OP_SHIFT_RIGHT->addFunction(op_shift_right_int);
-
-   // cannot validate return type here yet
-   OP_LIST_REF = add(new Operator(2, "[]", "list, string, or binary dereference", 0, false, false, check_op_list_ref));
-   OP_LIST_REF->addFunction(NT_ALL, NT_ALL, op_list_ref);
 
    // cannot validate return type here yet
    OP_OBJECT_REF = add(new Operator(2, ".", "hash/object-reference", 0, false, false, check_op_object_ref));

--- a/lib/QoreLib.cpp
+++ b/lib/QoreLib.cpp
@@ -1462,12 +1462,17 @@ int check_lvalue(AbstractQoreNode* node, bool assignment) {
    if (ntype == NT_CLASS_VARREF)
       return 0;
 
+   if (ntype == NT_OPERATOR) {
+      QoreSquareBracketsOperatorNode* op = dynamic_cast<QoreSquareBracketsOperatorNode*>(node);
+      if (op) {
+	 return check_lvalue(op->getLeft(), assignment);
+      }
+      return -1;
+   }
+
    if (ntype == NT_TREE) {
-      const QoreTreeNode* t = reinterpret_cast<const QoreTreeNode*>(node);
-      if (t->getOp() == OP_LIST_REF || t->getOp() == OP_OBJECT_REF)
-	 return check_lvalue(t->left);
-      else
-	 return -1;
+      QoreTreeNode* t = reinterpret_cast<QoreTreeNode*>(node);
+      return t->getOp() == OP_OBJECT_REF ? check_lvalue(t->left, assignment) : -1;
    }
    return -1;
 }

--- a/lib/QoreSquareBracketsOperatorNode.cpp
+++ b/lib/QoreSquareBracketsOperatorNode.cpp
@@ -1,0 +1,133 @@
+/*
+  QoreSquareBracketsOperatorNode.cpp
+
+  Qore Programming Language
+
+  Copyright (C) 2003 - 2015 David Nichols
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+
+  Note that the Qore library is released under a choice of three open-source
+  licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+  information.
+*/
+
+#include <qore/Qore.h>
+
+QoreString QoreSquareBracketsOperatorNode::op_str("[] operator expression");
+
+AbstractQoreNode* QoreSquareBracketsOperatorNode::parseInitImpl(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& returnTypeInfo) {
+   // turn off "return value ignored" flags
+   pflag &= ~(PF_RETURN_VALUE_IGNORED);
+
+   assert(!typeInfo);
+   assert(!returnTypeInfo);
+
+   const QoreTypeInfo* lti = 0, *rti = 0;
+
+   left = left->parseInit(oflag, pflag, lvids, lti);
+   right = right->parseInit(oflag, pflag & ~(PF_FOR_ASSIGNMENT), lvids, rti);
+
+   if (lti->hasType()) {
+      // if we are trying to convert to a list
+      if (pflag & PF_FOR_ASSIGNMENT) {
+	 // only throw a parse exception if parse exceptions are enabled
+	 if (!lti->parseAcceptsReturns(NT_LIST) && getProgram()->getParseExceptionSink()) {
+	    QoreStringNode* edesc = new QoreStringNode("cannot convert lvalue defined as ");
+	    lti->getThisType(*edesc);
+	    edesc->sprintf(" to a list using the '[]' operator in an assignment expression");
+	    qore_program_private::makeParseException(getProgram(), "PARSE-TYPE-ERROR", edesc);
+	 }
+      }
+      else {
+	 if (lti->isType(NT_STRING)) {
+	    returnTypeInfo = stringOrNothingTypeInfo;
+	 }
+	 else if (lti->isType(NT_BINARY)) {
+	    returnTypeInfo = binaryOrNothingTypeInfo;
+	 }
+	 else if (!listTypeInfo->parseAccepts(lti)
+	     && !stringTypeInfo->parseAccepts(lti)
+	     && !binaryTypeInfo->parseAccepts(lti)) {
+	    QoreStringNode* edesc = new QoreStringNode("left-hand side of the expression with the '[]' operator is ");
+	    lti->getThisType(*edesc);
+	    edesc->concat(" and so this expression will always return NOTHING; the '[]' operator only returns a value within the legal bounds of lists, strings, and binary objects");
+	    qore_program_private::makeParseWarning(getProgram(), QP_WARN_INVALID_OPERATION, "INVALID-OPERATION", edesc);
+	    returnTypeInfo = nothingTypeInfo;
+	 }
+      }
+   }
+
+   // see if the rhs is a type that can be converted to an integer, if not raise an invalid operation warning
+   if (rti->hasType()
+       && !bigIntTypeInfo->parseAccepts(rti)
+       && !floatTypeInfo->parseAccepts(rti)
+       && !numberTypeInfo->parseAccepts(rti)
+       && !boolTypeInfo->parseAccepts(rti)
+       && !dateTypeInfo->parseAccepts(rti)) {
+	    QoreStringNode* edesc = new QoreStringNode("the offset operand expression with the '[]' operator is ");
+	    rti->getThisType(*edesc);
+	    edesc->concat(" and so will always evaluate to zero");
+	    qore_program_private::makeParseWarning(getProgram(), QP_WARN_INVALID_OPERATION, "INVALID-OPERATION", edesc);
+   }
+
+   // see if both arguments are constants, then eval immediately and substitute this node with the result
+   if (right && right->is_value()) {
+      if (left && left->is_value()) {
+         SimpleRefHolder<QoreSquareBracketsOperatorNode> del(this);
+         ParseExceptionSink xsink;
+         AbstractQoreNode* rv = QoreSquareBracketsOperatorNode::evalImpl(*xsink);
+         return rv ? rv : &Nothing;
+      }
+   }
+
+   typeInfo = returnTypeInfo;
+   return this;
+}
+
+QoreValue QoreSquareBracketsOperatorNode::evalValueImpl(bool& needs_deref, ExceptionSink* xsink) const {
+   ValueEvalRefHolder lh(left, xsink);
+   if (*xsink)
+      return QoreValue();
+   ValueEvalRefHolder rh(right, xsink);
+   if (*xsink)
+      return QoreValue();
+
+   return doSquareBrackets(*lh, *rh, xsink);
+}
+
+QoreValue QoreSquareBracketsOperatorNode::doSquareBrackets(QoreValue l, QoreValue r, ExceptionSink* xsink) {
+   qore_type_t t = l.getType();
+
+   int64 offset = r.getAsBigInt();
+   switch (t) {
+      case NT_LIST:
+	 return l.get<const QoreListNode>()->get_referenced_entry(offset);
+      case NT_STRING:
+	 return l.get<const QoreStringNode>()->substr(offset, 1, xsink);
+      case NT_BINARY: {
+	 const BinaryNode* b = l.get<const BinaryNode>();
+	 if (offset < 0 || (size_t)offset >= b->size())
+	    return QoreValue();
+	 return (int64)(((unsigned char*)b->getPtr())[offset]);
+      }
+   }
+
+   return QoreValue();
+}

--- a/lib/QoreSquareBracketsOperatorNode.cpp
+++ b/lib/QoreSquareBracketsOperatorNode.cpp
@@ -80,6 +80,7 @@ AbstractQoreNode* QoreSquareBracketsOperatorNode::parseInitImpl(LocalVar* oflag,
        && !floatTypeInfo->parseAccepts(rti)
        && !numberTypeInfo->parseAccepts(rti)
        && !boolTypeInfo->parseAccepts(rti)
+       && !stringTypeInfo->parseAccepts(rti)
        && !dateTypeInfo->parseAccepts(rti)) {
 	    QoreStringNode* edesc = new QoreStringNode("the offset operand expression with the '[]' operator is ");
 	    rti->getThisType(*edesc);

--- a/lib/Variable.cpp
+++ b/lib/Variable.cpp
@@ -1083,29 +1083,29 @@ void LValueRemoveHelper::doRemove(AbstractQoreNode* lvalue) {
       return;
    }
 
+   if (t == NT_OPERATOR) {
+      const QoreSquareBracketsOperatorNode* op = dynamic_cast<const QoreSquareBracketsOperatorNode*>(lvalue);
+      if (op) {
+         LValueHelper lvhb(op, xsink, true);
+         if (!lvhb)
+            return;
+
+         bool static_assignment = false;
+         QoreValue tmp = lvhb.remove(static_assignment);
+         if (static_assignment)
+            tmp.ref();
+         rv.assignAssumeInitial(tmp);
+         return;
+      }
+   }
+
    // could be any type if in a background expression
    if (t != NT_TREE) {
       rv.assignInitial(lvalue ? lvalue->refSelf() : 0);
       return;
    }
 
-   // can be only a list or object (hash) reference
-
-   // if it's a list reference, see if the reference exists, if so, then remove it
-   const QoreSquareBracketsOperatorNode* op = dynamic_cast<const QoreSquareBracketsOperatorNode*>(lvalue);
-   if (op) {
-      LValueHelper lvhb(op, xsink, true);
-      if (!lvhb)
-	 return;
-
-      bool static_assignment = false;
-      QoreValue tmp = lvhb.remove(static_assignment);
-      if (static_assignment)
-	 tmp.ref();
-      rv.assignAssumeInitial(tmp);
-      return;
-   }
-
+   // can be only a list reference
    // must be a tree
    assert(t == NT_TREE);
    QoreTreeNode* tree = reinterpret_cast<QoreTreeNode*>(lvalue);

--- a/lib/parser.ypp
+++ b/lib/parser.ypp
@@ -3239,7 +3239,7 @@ exp
     | exp '%' exp                       { $$ = new QoreModulaOperatorNode($1, $3); }
     | exp '/' exp                       { $$ = new QoreDivisionOperatorNode($1, $3); }
     | exp '*' exp                       { $$ = new QoreTreeNode($1, OP_MULT, $3); }
-    | exp '[' exp ']'                   { $$ = new QoreTreeNode($1, OP_LIST_REF, $3); }
+    | exp '[' exp ']'                   { $$ = new QoreSquareBracketsOperatorNode($1, $3); }
     | exp '{' exp '}'                   { $$ = new QoreTreeNode($1, OP_OBJECT_REF, $3); }
     | exp '.' exp                       { $$ = process_dot($1, $3); }
     | exp DOT_KW_IDENTIFIER             { $$ = new QoreTreeNode($1, OP_OBJECT_REF, $2); }
@@ -3293,7 +3293,7 @@ exp_n
     | exp_n '%' exp                     { $$ = new QoreModulaOperatorNode($1, $3); }
     | exp_n '/' exp                     { $$ = new QoreDivisionOperatorNode($1, $3); }
     | exp_n '*' exp                     { $$ = new QoreTreeNode($1, OP_MULT, $3); }
-    | exp_n '[' exp ']'                 { $$ = new QoreTreeNode($1, OP_LIST_REF, $3); }
+    | exp_n '[' exp ']'                 { $$ = new QoreSquareBracketsOperatorNode($1, $3); }
     | exp_n '{' exp '}'                 { $$ = new QoreTreeNode($1, OP_OBJECT_REF, $3); }
     | exp_n '.' exp                     { $$ = process_dot($1, $3); }
     | exp_n DOT_KW_IDENTIFIER           { $$ = new QoreTreeNode($1, OP_OBJECT_REF, $2); }

--- a/lib/single-compilation-unit.cpp
+++ b/lib/single-compilation-unit.cpp
@@ -197,6 +197,7 @@
 #include "QoreValueCoalescingOperatorNode.cpp"
 #include "QoreChompOperatorNode.cpp"
 #include "QoreTrimOperatorNode.cpp"
+#include "QoreSquareBracketsOperatorNode.cpp"
 #include "QoreValue.cpp"
 #include "ql_thread.cpp"
 #include "ql_time.cpp"


### PR DESCRIPTION
…re brackets were used on unsuitable types by porting the square bracket operator to the C++ QoreOperatorNode hierarchy and addiing additional parse-time checks
