### PR TITLE
refs #362 fixed QoreDotEvalOperatorNode return type handling

### DIFF
--- a/include/qore/intern/QoreDotEvalOperatorNode.h
+++ b/include/qore/intern/QoreDotEvalOperatorNode.h
@@ -57,7 +57,7 @@ protected:
    }
 
 public:
-   DLLLOCAL QoreDotEvalOperatorNode(AbstractQoreNode *n_left, MethodCallNode *n_m) : left(n_left), m(n_m) {
+   DLLLOCAL QoreDotEvalOperatorNode(AbstractQoreNode *n_left, MethodCallNode *n_m) : left(n_left), m(n_m), returnTypeInfo(0) {
    }
 
    DLLLOCAL ~QoreDotEvalOperatorNode() {

--- a/lib/QoreDotEvalOperatorNode.cpp
+++ b/lib/QoreDotEvalOperatorNode.cpp
@@ -157,8 +157,8 @@ AbstractQoreNode *QoreDotEvalOperatorNode::evalImpl(bool &needs_deref, Exception
    return evalImpl(xsink);
 }
 
-AbstractQoreNode *QoreDotEvalOperatorNode::parseInitImpl(LocalVar *oflag, int pflag, int &lvids, const QoreTypeInfo *&returnTypeInfo) {
-   assert(!returnTypeInfo);
+AbstractQoreNode *QoreDotEvalOperatorNode::parseInitImpl(LocalVar *oflag, int pflag, int &lvids, const QoreTypeInfo *&expTypeInfo) {
+   assert(!expTypeInfo);
    const QoreTypeInfo *typeInfo = 0;
    left = left->parseInit(oflag, pflag, lvids, typeInfo);
 
@@ -183,6 +183,7 @@ AbstractQoreNode *QoreDotEvalOperatorNode::parseInitImpl(LocalVar *oflag, int pf
 
 	    // check parameters, if any
 	    lvids += m->parseArgs(oflag, pflag, meth->getFunction(), returnTypeInfo);
+	    expTypeInfo = returnTypeInfo;
 
 	    return this;
 	 }
@@ -223,7 +224,7 @@ AbstractQoreNode *QoreDotEvalOperatorNode::parseInitImpl(LocalVar *oflag, int pf
 	 parse_error(loc, "illegal call to private %s::copy() method", qc->getName());
 
       // do not save method pointer for copy methods
-      returnTypeInfo = qc->getTypeInfo();
+      expTypeInfo = returnTypeInfo = qc->getTypeInfo();
 #ifdef DEBUG
       typeInfo = 0;
       AbstractQoreNode *n = m->parseInit(oflag, pflag, lvids, typeInfo);
@@ -268,6 +269,7 @@ AbstractQoreNode *QoreDotEvalOperatorNode::parseInitImpl(LocalVar *oflag, int pf
 
    // check parameters, if any
    lvids += m->parseArgs(oflag, pflag, meth->getFunction(), returnTypeInfo);
+   expTypeInfo = returnTypeInfo;
 
    printd(5, "QoreDotEvalOperatorNode::parseInitImpl() %s::%s() method=%p (%s::%s()) (private=%s, static=%s) rv=%s\n", qc->getName(), mname, meth, meth ? meth->getClassName() : "n/a", mname, meth && meth->parseIsPrivate() ? "true" : "false", meth->isStatic() ? "true" : "false", returnTypeInfo->getName());
 

--- a/lib/QoreLib.cpp
+++ b/lib/QoreLib.cpp
@@ -1275,7 +1275,7 @@ void q_strerror(QoreString &str, int err) {
 
    str.allocate(str.strlen() + STRERR_BUFSIZE);
    // ignore strerror() error message
-#if defined(_GNU_SOURCE) && defined(LINUX)
+#if STRERROR_R_CHAR_P
    // we can't help but get this version because some of the Linux
    // header files define _GNU_SOURCE for us :-(
    str.concat(strerror_r(err, (char* )(str.getBuffer() + str.strlen()), STRERR_BUFSIZE));


### PR DESCRIPTION
made a compile fix already applied to develop for strerror_r()

this needs to be merged into develop afterwards as well but will need some tweaking
