### PR TITLE
refs #365 fixed a bug in SqlUtil generating select statements for tab…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -276,6 +276,7 @@
       - fixed a bug in subquery handling where bind-by-value arguments from the subquery were lost
       - fixed a bug in the partition by/over operator where column names as given in the query argument hash were not properly recognized
       - fixed a bug in schema alignment; when aligning a schema and an index supporting a PK constraint is introduced in the new schema, the alignment would fail when a constraint is attempted to be disabled that doesn't exist
+      - fixed a bug generating select statements for tables accessed through a synonym when used with join clauses; previously inconsistent schema prefixes could be used which could cause errors parsing the SQL statements generated
     - <a href="../../modules/OracleSqlUtil/html/index.html">OracleSqlUtil</a> module fixes:
       - fixed a bug where column names that are reserved words were not quoted in generated SQL
     - <a href="../../modules/PgsqlSqlUtil/html/index.html">PgsqlSqlUtil</a> module fixes:

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -115,6 +115,7 @@ module SqlUtil {
     - fixed a bug in subquery handling where bind-by-value arguments from the subquery were lost
     - fixed a bug in the partition by/over operator where column names as given in the query argument hash were not properly recognized
     - fixed a bug in schema alignment; when aligning a schema and an index supporting a PK constraint is introduced in the new schema, the alignment would fail when a constraint is attempted to be disabled that doesn't exist
+    - fixed a bug generating select statements for tables accessed through a synonym when used with join clauses; previously inconsistent schema prefixes could be used which could cause errors parsing the SQL statements generated
 
     @subsection sqlutilv1_2 SqlUtil v1.2
     - added insert operator support; for example, for inserting with values from sequences
@@ -14284,9 +14285,13 @@ string sql = table.getSelectSql(sh, \args);
         }
 
         string getSelectSqlUnlocked(*hash qh, reference args, *hash opt) {
+            # we first get column & table info in case we are referencing a table through a synonym
+            # so the getSelectSqlName() will refer to the proper schema owner
+            getColumnsUnlocked();
             return getSelectSqlUnlockedIntern(qh, getSelectSqlName(qh), \args, NOTHING, opt);
         }
 
+        # column & table information must be retrieved before calling this function
         string getSelectSqlUnlockedIntern(*hash qh, string from, reference args, *hash ch, *hash opt) {
             # get pseudo-column hash
             *hash psch = getPseudoColumnHash();
@@ -14319,8 +14324,6 @@ string sql = table.getSelectSql(sh, \args);
 
             # if we have a "superquery" argument, then we need to track which columns are in this subquery
             hash mch;
-
-            getColumnsUnlocked();
 
             string cstr;
             # make query


### PR DESCRIPTION
…les accessed through a synonym when used with join clauses; previously inconsistent schema prefixes could be used which could cause errors parsing the SQL statements generated

after the fix:

```
qore -lSqlUtil -ne 'Datasource ds("oracle:staging/staging@el7"); Table t(ds, "test"); Table t1(ds, "test1"); printf("%s\n", t.getSelectSql(("join": join_inner(t1, "t1", ("string": "string")))));'
select * from h3g_omif.test inner join h3g_omif.test1 t1 on (h3g_omif.test.string = t1.string)
```
