### PR TITLE
refs #370 implemented an API change for the wop_or() function; now it…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -236,7 +236,7 @@
       - implemented support for DBA management actions
       - implemented support for driver-dependent pseudocolumns
       - implemented per-column support for the \c "desc" keyword in orderby expressions
-      - implemented the \c "op_wop()" function to allow SQL expressions to be combined with \c "or" as well as the default \c "and"
+      - implemented the \c "wop_or()" function to allow complex SQL expressions to be generated with \c "or" as well as \c "and"
       - implemented AbstractTable::getBulkUpsertClosure() to better support bulk SQL merge operations
     - <a href="../../modules/OracleSqlUtil/html/index.html">OracleSqlUtil</a> module updates:
       - implemented support for views for DML in the OracleTable class

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 # @file SqlUtil.qm Qore user module for working with SQL data
 
-/*  SqlUtil.qm Copyright (C) 2013 - 2015 Qore Technologies, sro
+/*  SqlUtil.qm Copyright (C) 2013 - 2016 Qore Technologies, sro
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -109,6 +109,7 @@ module SqlUtil {
     - implemented per-column support for the \c "desc" keyword in orderby expressions
     - implemented support for \c "or" logic in @ref where_clauses
     - implemented AbstractTable::getBulkUpsertClosure() to better support bulk SQL merge operations
+    - implemented @ref SqlUtil::wop_or() to allow for generating complex SQL strings with \a "or" and \a "and" expressions
     - fixed a bug with queries using a \a desc argument with the \a orderby query option with multiple sort columns; the \c "desc" string was added only to the last column but should have been added to all columns
     - fixed a bug where foreign key constraints with supporting indexes were not tracked and therefore schema alignment on DBs that automatically create indexes for foreign key constraints would fail
     - fixed a bug where driver-specific objects were not included when dropping a schema
@@ -3318,7 +3319,7 @@ int rows_updated = t.update(("permission_type": uop_lower()));
             },
         ),
         OP_OR: (
-            "code": string sub (object t, string cn, any arg, reference args, *hash jch, bool join = False, *hash ch, *hash psch) {
+            "code": string sub (object t, string cn, list arg, reference args, *hash jch, bool join = False, *hash ch, *hash psch) {
                 return t.getOrClause(arg, \args, jch, join, ch, psch);
             },
         ),
@@ -3620,18 +3621,28 @@ int rows_updated = t.update(("permission_type": uop_lower()));
         return make_op(OP_CEQ, arg);
     }
 
-    #! returns a hash with a fake \c "_OR_" column name; combines all hash elements in the argument with \c "or" logic for the SQL expressions for use in @ref where_clauses "where clauses" when comparing the values of two columns
+    #! returns a hash with a fake \c "_OR_" column name; the list of arguments to the function is combined such that each hash in the list generates SQL expressions combined with \a "and" logic, and each of those clauses is combined with \a "or" logic; this is for use in @ref where_clauses "where clauses"
     /** @par Example:
         @code
-*list rows = table.selectRows(("where": ("name": op_ceq("other_name")) + wop_or("type": "C", "expiration_date": op_ge(date))));
+*list rows = table.selectRows(("where": ("name": op_ceq("other_name")) + wop_or(("type": "C", "validation_flag": op_ne(NULL)), ("expiration_date": op_ge(date)))));
         @endcode
+        Generates:
+        @verbatim
+select * from table where name != other_name and ((type != 'C' and validation flag is not null) or (expiration_date >= %v))
+        @endverbatim
 
         @param h the hash of expressions to combine with \c "or" logic
 
-        @return a hash with a fake column name of \c "_OR_" with a where operation description hash for use in @ref where_clauses "where clauses"
+        @return a hash with a fake column name (\c "_OR_" with a numeric prefix for uniqueness) for use in a where operation description hash for use in @ref where_clauses "where clauses"
+
+        @note a random prefix is used so that multiple uses of the function can be used to generate a single @ref where_clauses "where clause hash"
     */
-    public hash sub wop_or(hash h) {
-        return ("_OR_": make_op(OP_OR, h));
+    public hash sub wop_or(hash h1, hash h2) {
+        softlist l = h1;
+        l += h2;
+        if (argv)
+            l += argv;
+        return (sprintf("%d:_OR_", rand() % 100000): make_op(OP_OR, l));
     }
     #@}
 
@@ -14608,11 +14619,11 @@ string sql = table.getSelectSql(sh, \args);
         }
 
         private string getColumnNameIntern(string cv, *hash jch, bool join, *hash ch, *hash psch) {
+            # remove any disposable unique prefix
+            cv =~ s/^[0-9]+://;
             # return the name if it's a "technical name" (starts with "_")
             if (cv =~ /^_/)
                 return cv;
-            # remove any disposable unique prefix
-            cv =~ s/^[0-9]+://;
 
             # see if we have a table.column spec
             *string tp = (cv =~ x/(\w+)\.\w+/)[0];
@@ -14719,9 +14730,19 @@ string sql = table.getSelectSql(sh, \args);
             return sprintf("%s = %v", cn);
         }
 
+        string getOrClause(list arglist, reference args, *hash jch, bool join = False, *hash ch, *hash psch) {
+            list l = ();
+            foreach hash h in (arglist) {
+                string str = getOrClause(h, \args, jch, join, ch, psch);
+                if (str)
+                    l += str;
+            }
+            return l ? ("(" + (foldl $1 + " or " + $2, l) + ")") : "";
+        }
+
         string getOrClause(hash arg, reference args, *hash jch, bool join = False, *hash ch, *hash psch) {
             *list wl = getWhereClauseIntern(arg, \args, NOTHING, jch, join, ch, psch);
-            return wl ? ("(" + (foldl $1 + " or " + $2, wl) + ")") : "";
+            return wl ? ("(" + (foldl $1 + " and " + $2, wl) + ")") : "";
         }
 
         private list getOrderByListUnlocked(*hash qh, *hash jch, *hash ch) {


### PR DESCRIPTION
… takes a list of hashes (at least two), each hash argument generates an expression where each hash key is a part of the expression joined by "and", and each of these expressions is then joined by "or"; this allows for much more flexibility in generating SQL strings from where hashes

ex:

```
qore -l SqlUtil -ne 'Datasource ds("oracle:omq/omq@xbox"); Table t(ds, "system_properties"); printf("%s\n", t.getSelectSql(("where": wop_or(("value": "schema-version", "keyname": "key1"), ("1:value": "something")) + ("domain": "dom") + wop_or(("domain": "x", "keyname": "y"), ("value": 1)))));'
select * from omq.system_properties where ((value = %v and keyname = %v) or (value = %v)) and domain = %v and ((domain = %v and keyname = %v) or (value = %v))
```
