### PR TITLE
refs #353 updated REST modules to use the latest JSON (and XML and YA…

### DIFF
--- a/qlib/RestClient.qm
+++ b/qlib/RestClient.qm
@@ -36,15 +36,15 @@
 
 %requires Mime >= 1.3
 
-%try-module yaml
+%try-module yaml >= 0.5
 %define NoYaml
 %endtry
 
-%try-module xml
+%try-module xml >= 1.3
 %define NoXml
 %endtry
 
-%try-module json
+%try-module json >= 1.5
 %define NoJson
 %endtry
 
@@ -143,19 +143,19 @@ public namespace RestClient {
 %ifndef NoJson
                 "json": (
                     "ct": MimeTypeJson,
-                    "out": \makeJSONString(),
+                    "out": \make_json(),
                 ),
 %endif
 %ifndef NoYaml
                 "yaml": (
                     "ct": MimeTypeYaml,
-                    "out": \makeYAML(),
+                    "out": \make_yaml(),
                 ),
 %endif
 %ifndef NoXml
                 "xml": (
                     "ct": MimeTypeXml,
-                    "out": \makeXMLRPCValueString(),
+                    "out": \make_xmlrpc_value(),
                 ),
 %endif
                 };
@@ -164,13 +164,13 @@ public namespace RestClient {
 %ifndef NoYaml
             const DeserializeYaml = (
                     "code": "yaml",
-                    "in": \parseYAML(),
+                    "in": \parse_yaml(),
                 );
 %endif
 %ifndef NoXml
             const DeserializeXmlRpc = (
                     "code": "xml",
-                    "in": \parseXMLRPCValue(),
+                    "in": \parse_xmlrpc_value(),
                 );
 %endif
 
@@ -179,7 +179,7 @@ public namespace RestClient {
 %ifndef NoJson
                 MimeTypeJson: (
                     "code": "json",
-                    "in": \parseJSON(),
+                    "in": \parse_json(),
                 ),
 %endif
 %ifndef NoYaml

--- a/qlib/RestHandler.qm
+++ b/qlib/RestHandler.qm
@@ -38,15 +38,15 @@
 %requires HttpServerUtil >= 0.3.11
 %requires Mime >= 1.3
 
-%try-module yaml
+%try-module yaml >= 0.5
 %define NoYaml
 %endtry
 
-%try-module xml
+%try-module xml >= 1.3
 %define NoXml
 %endtry
 
-%try-module json
+%try-module json >= 1.5
 %define NoJson
 %endtry
 
@@ -680,25 +680,25 @@ public namespace RestHandler {
             const MimeDataTypes = (
 %ifndef NoJson
                 MimeTypeJsonRpc: (
-                    "serialize": \makeJSONString(),
-                    "deserialize": \parseJSON(),
+                    "serialize": \make_json(),
+                    "deserialize": \parse_json(),
                 ),
 %endif
 %ifndef NoYaml
                 MimeTypeYaml: (
-                    "serialize": \makeYAML(),
-                    "deserialize": \parseYAML(),
+                    "serialize": \make_yaml(),
+                    "deserialize": \parse_yaml(),
                 ),
 
                 MimeTypeYamlRpc: (
-                    "serialize": \makeYAML(),
-                    "deserialize": \parseYAML(),
+                    "serialize": \make_yaml(),
+                    "deserialize": \parse_yaml(),
                 ),
 %endif
 %ifndef NoXml
                 MimeTypeXml: (
-                    "serialize": \makeXMLRPCValueString(),
-                    "deserialize": \parseXMLRPCValue(),
+                    "serialize": \make_xmlrpc_value(),
+                    "deserialize": \parse_xmlrpc_value(),
                 ),
 %endif
                 MimeTypeHtml: (


### PR DESCRIPTION
…ML) function names and to ensure that only modules supporting the required API level are loaded

depends on: https://github.com/qorelanguage/module-json/pull/3 
