### PR TITLE
refs #398 accommodate for the situation where the Datasource*::exec()…

### DIFF
--- a/qlib/FreetdsSqlUtil.qm
+++ b/qlib/FreetdsSqlUtil.qm
@@ -1460,5 +1460,11 @@ order by
             *hash h = execData(opt, sql, args);
             return h ? map {$1.key: $1.value[0]}, h.pairIterator() : h;
         }
+
+        private softbool tryUpdate(string sql, hash row, Columns cols, list updc) {
+            list args = row{updc}.values() + row{cols.keys()}.values();
+            any x = ds.vexec(sql, args);
+            return x.typeCode() == NT_HASH ? x.firstValue() : x;
+        }
     }
 }

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -15211,7 +15211,6 @@ int ucnt = table.updateNoCommit(("id": id), ("name": name));
 
         private softbool tryUpdate(string sql, hash row, Columns cols, list updc) {
             list args = row{updc}.values() + row{cols.keys()}.values();
-            #printf("sql: %s args: %y\n", sql, args);
             return ds.vexec(sql, args);
         }
 


### PR DESCRIPTION
… method can return a hash when inserting into an updatable view with the freetds driver
