### PR TITLE
refs #416 fixed a particular egregious bug where a bareword in parent…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -408,6 +408,7 @@
     - fixed a bug where a warning was not always issued when square brackets were used on unsuitable types (<a href="https://github.com/qorelanguage/qore/issues/184">bug 184</a>), internally ported the square bracket operator to the C++ QoreOperatorNode hierarchy
     - fixed a bug handling return type information for method and pseudo-method calls; uninitialized memory could be used which could cause a runtime crash (<a href="https://github.com/qorelanguage/qore/issues/364">bug 364</a>)
     - corrected the name of the @ref modulo_operator "modulo operator" (was incorrectly referred to as the "modula" operator earlier: <a href="">bug 389</a>)
+    - fixed a bug handling identifiers in parentheses used to dereference hashes or objects; the identifer is not resolved properly whereas previoulsy it was incorrectly interpreted as a string literal (<a href="https://github.com/qorelanguage/qore/issues/416">bug 416</a>)
 
     @section qore_0811 Qore 0.8.11
 

--- a/examples/test/qore/vars/bare-ref-test.qtest
+++ b/examples/test/qore/vars/bare-ref-test.qtest
@@ -33,8 +33,9 @@ public class BarerefTest inherits QUnit::Test {
     }
 
     constructor() : Test("BarerefTest", "1.0") {
-        addTestCase("Closures test", \closuresTest(), NOTHING);
-        addTestCase("Skipped test", \lvarTest(), NOTHING);
+        addTestCase("Closures test", \closuresTest());
+        addTestCase("Skipped test", \lvarTest());
+        addTestCase("Deref test", \derefTest());
 
         # Return for compatibility with test harness that checks return value.
         set_return_value(main());
@@ -105,10 +106,10 @@ public class BarerefTest inherits QUnit::Test {
     }
 
     lvarTest() {
-        my int a = 1;
-        my any b = "1";
+        int a = 1;
+        any b = "1";
         our any c = 2.1;
-   	    my (int a1, string b1, any c1) = (2, "four", "hi");
+        my (int a1, string b1, any c1) = (2, "four", "hi");
         our (int a2, string b2, any c2) = (4, "eight", "hello");
 
         testAssertionValue("var test 1", a, 1);
@@ -122,4 +123,16 @@ public class BarerefTest inherits QUnit::Test {
         testAssertionValue("var test 9", c2, "hello");
     }
 
+    derefTest() {
+        string a = "b";
+        hash h = (
+            "a": "a",
+            "b": "b",
+            );
+
+        assertEq("a", h.a);
+        # the following line should use the lvar a's value "b" to dereference the hash
+        # https://github.com/qorelanguage/qore/issues/416
+        assertEq("b", h.(a));
+    }
 }

--- a/include/qore/intern/BarewordNode.h
+++ b/include/qore/intern/BarewordNode.h
@@ -1,11 +1,11 @@
 /* -*- mode: c++; indent-tabs-mode: nil -*- */
 /*
   BarewordNode.h
- 
+
   Qore Programming Language
- 
-  Copyright (C) 2003 - 2015 David Nichols
- 
+
+  Copyright (C) 2003 - 2016 David Nichols
+
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
   to deal in the Software without restriction, including without limitation
@@ -36,13 +36,15 @@
 class BarewordNode : public ParseNoEvalNode {
 protected:
    QoreProgramLocation loc;
+   // if true it means the node was given in parentheses
+   bool finalized;
 
    DLLLOCAL AbstractQoreNode *parseInitImpl(LocalVar *oflag, int pflag, int &lvids, const QoreTypeInfo *&typeInfo);
 
    DLLLOCAL virtual const QoreTypeInfo *getTypeInfo() const {
       return 0;
    }
-      
+
 public:
    char *str;
 
@@ -67,6 +69,15 @@ public:
    DLLLOCAL QoreStringNode *makeQoreStringNode();
    // returns the string, caller now owns the memory
    DLLLOCAL char *takeString();
+
+   DLLLOCAL bool isFinalized() const {
+      return finalized;
+   }
+
+   DLLLOCAL void setFinalized() {
+      assert(!finalized);
+      finalized = true;
+   }
 };
 
 #endif

--- a/lib/BarewordNode.cpp
+++ b/lib/BarewordNode.cpp
@@ -1,10 +1,10 @@
 /*
   BarewordNode.cpp
- 
+
   Qore Programming Language
- 
-  Copyright (C) 2003 - 2015 David Nichols
- 
+
+  Copyright (C) 2003 - 2016 David Nichols
+
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
   to deal in the Software without restriction, including without limitation
@@ -32,7 +32,7 @@
 #include <qore/intern/QoreNamespaceIntern.h>
 
 // object takes over ownership of str
-BarewordNode::BarewordNode(char *c_str, int sline, int eline) : ParseNoEvalNode(NT_BAREWORD), loc(sline, eline), str(c_str) {
+BarewordNode::BarewordNode(char *c_str, int sline, int eline) : ParseNoEvalNode(NT_BAREWORD), loc(sline, eline), finalized(false), str(c_str) {
 }
 
 BarewordNode::~BarewordNode() {

--- a/lib/parser.ypp
+++ b/lib/parser.ypp
@@ -992,21 +992,27 @@ struct ParserScopedOrNothingTypeStruct : public ParserTypeStruct {
 
 static AbstractQoreNode* process_dot(AbstractQoreNode* l, AbstractQoreNode* r) {
    qore_type_t rtype = r->getType();
-   if (rtype == NT_BAREWORD) {
-      BarewordNode* b = reinterpret_cast<BarewordNode*>(r);
-      AbstractQoreNode* rv = new QoreTreeNode(l, OP_OBJECT_REF, b->makeQoreStringNode());
-      b->deref();
-      return rv;
-   }
+   switch (rtype) {
+      case NT_BAREWORD: {
+         BarewordNode* b = reinterpret_cast<BarewordNode*>(r);
+         if (!b->isFinalized()) {
+            AbstractQoreNode* rv = new QoreTreeNode(l, OP_OBJECT_REF, b->makeQoreStringNode());
+            b->deref();
+            return rv;
+         }
+         break;
+      }
 
-   if (rtype == NT_FUNCTION_CALL) {
-      FunctionCallNode* f = reinterpret_cast<FunctionCallNode*>(r);
-      assert(!f->getFunction());
-      if (!f->isFinalized()) {
-         MethodCallNode* m = new MethodCallNode(f->takeName(), f->takeArgs());
-         f->deref();
+      case NT_FUNCTION_CALL: {
+         FunctionCallNode* f = reinterpret_cast<FunctionCallNode*>(r);
+         assert(!f->getFunction());
+         if (!f->isFinalized()) {
+            MethodCallNode* m = new MethodCallNode(f->takeName(), f->takeArgs());
+            f->deref();
 
-         return new QoreDotEvalOperatorNode(l, m);
+            return new QoreDotEvalOperatorNode(l, m);
+         }
+         break;
       }
    }
 
@@ -3135,6 +3141,9 @@ exp_c:  scalar
                     break;
                  case NT_FUNCTION_CALL:
                     reinterpret_cast<FunctionCallNode*>($2)->setFinalized();
+                    break;
+                 case NT_BAREWORD:
+                    reinterpret_cast<BarewordNode*>($2)->setFinalized();
                     break;
               }
            }


### PR DESCRIPTION
…heses used to dereference a hash or object was treated as a string literal instead of being resolved and used as an expression as intended
