### PR TITLE
refs #380 ensure that all on_exit and on_error statements are execute…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -420,6 +420,7 @@
     - fixed a bug where \c select(2) was called after \c EINTR without reinitializing the descriptor array argument (<a href="https://github.com/qorelanguage/qore/issues/435">bug 435</a>)
     - fixed a crashing bug on all platforms where select(2) was being called with socket descriptor values > \c FD_SETSIZE (<a href="https://github.com/qorelanguage/qore/issues/436">bug 436</a>)
     - fixed a bug where @ref Qore::HTTPClient::get() and @ref Qore::HTTPClient::post() would try to retrieve a message body even if <tt>Content-Length: 0</tt> was returned (or if no \c Content-Length header was returned at all) which would result in a deadlock (<a href="https://github.com/qorelanguage/qore/issues/434">bug 434</a>) until the server would close the connection
+    - fixed a bug where @ref on_exit and @ref on_error statements were not being executed if an exception was raised in an earlier-executed @ref on_exit, @ref on_error, or @ref on_success statement (<a href="https://github.com/qorelanguage/qore/issues/380">bug 380</a>)
 
     @section qore_0811 Qore 0.8.11
 

--- a/examples/test/qore/vars/statement.qtest
+++ b/examples/test/qore/vars/statement.qtest
@@ -202,9 +202,9 @@ class StatementTest inherits QUnit::Test {
         # bug 380: on_(exit|error) need to be run even if there is an active exception
         int i = 0;
         try {
-            on_exit
+            on_error
                 ++i;
-            on_error {
+            on_exit {
                 ++i;
                 throw True;
             }

--- a/examples/test/qore/vars/statement.qtest
+++ b/examples/test/qore/vars/statement.qtest
@@ -198,6 +198,19 @@ class StatementTest inherits QUnit::Test {
         assertEq(99, v, "third on_exit");
         assertTrue(err, "on_error");
         assertFalse(success, "on_success");
+
+        # bug 380: on_(exit|error) need to be run even if there is an active exception
+        int i = 0;
+        try {
+            on_exit
+                ++i;
+            on_error {
+                ++i;
+                throw True;
+            }
+        }
+        catch (hash ex) {
+        }
+        assertEq(i, 2);
     }
 }
-

--- a/examples/test/qore/vars/statement.qtest
+++ b/examples/test/qore/vars/statement.qtest
@@ -211,6 +211,6 @@ class StatementTest inherits QUnit::Test {
         }
         catch (hash ex) {
         }
-        assertEq(i, 2);
+        assertEq(2, i);
     }
 }

--- a/lib/OnBlockExitStatement.cpp
+++ b/lib/OnBlockExitStatement.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/lib/StatementBlock.cpp
+++ b/lib/StatementBlock.cpp
@@ -232,7 +232,7 @@ int StatementBlock::execIntern(QoreValue& return_value, ExceptionSink* xsink) {
 	    if ((*i).second) {
 	       nrc = (*i).second->execImpl(return_value, &obe_xsink);
 	       // bug 380: make sure and merge every exception after every conditional execution to ensure
-	       // that all on_(exit|success) statements are executed
+	       // that all on_(exit|error) statements are executed even if exceptions are thrown
 	       if (obe_xsink) {
 		  xsink->assimilate(obe_xsink);
 		  if (!error)


### PR DESCRIPTION
…d even if an exception is raised in another queued on_\* block, added tests + relnotes
