### PR TITLE
Edited port number used for HTTPClient test.

### DIFF
--- a/examples/test/qore/classes/HTTPClient/HTTPClient.qtest
+++ b/examples/test/qore/classes/HTTPClient/HTTPClient.qtest
@@ -13,7 +13,7 @@
 
 class HttpTestServer {
     public {
-        const Port = 19881;
+        const Port = 49876;
     }
 
     private {


### PR DESCRIPTION
Edited the port number used for the test as it was failing with "BIND-ERROR: Bad file descriptor" on my computer. Now it matches the port number used in HttpServer test.
