### PR TITLE
refs #465 fixed a bug with the SQLStatement class when used with a Da…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -100,7 +100,7 @@
     - new pseudo-methods:
       - @ref <date>::dayNumber()
       - @ref <date>::dayOfWeek()
-      - @ref <date>::getRelativeSecondsFloat()
+      - @ref <date>::durationSecondsFloat()
       - @ref <date>::isoDayOfWeek()
       - @ref <date>::isoWeekHash()
       - @ref <date>::isoWeekString()
@@ -201,7 +201,7 @@
     - <a href="../../modules/FixedLengthUtil/html/index.html">FixedLengthUtil</a> module:
       - added this new module for handling fixed length line data
     - <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module updates:
-        - <a href="../../modules/HttpServerUtil/html/index.html">HttpServerUtil</a> module split from the <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module containing supporting definitions for handler classes and other code interfacing with the <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module
+      - <a href="../../modules/HttpServerUtil/html/index.html">HttpServerUtil</a> module split from the <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module containing supporting definitions for handler classes and other code interfacing with the <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module
       - added the PermissiveAuthenticator class
       - translate \c "+" (plus) to \c " " (space) in the query portion of URIs in parse_uri_query()
       - implemented support for notifying persistent connections when the connection is terminated while a persistent connection is in place
@@ -422,6 +422,7 @@
     - fixed a bug where @ref on_exit and @ref on_error statements were not being executed if an exception was raised in an earlier-executed @ref on_exit, @ref on_error, or @ref on_success statement (<a href="https://github.com/qorelanguage/qore/issues/380">bug 380</a>)
     - fixed a bug where @ref Qore::HTTPClient::get() and @ref Qore::HTTPClient::post() would try to retrieve a message body even if <tt>Content-Length: 0</tt> was returned (or if no \c Content-Length header was returned at all) which would result in a deadlock until the server would close the connection (<a href="https://github.com/qorelanguage/qore/issues/434">bug 434</a>)
     - fixed a bug where regular expression substitution would go into an infinite loop when used with an empty pattern and the global flag (@ref Qore::RE_Global, <a href="https://github.com/qorelanguage/qore/issues/329">bug 329</a>)
+    - fixed a bug with connection handling in the @ref Qore::SQL::SQLStatement "SQLStatement" class; an exception is now thrown if a @ref Qore::SQL::SQLStatement "SQLStatement" object tries to execute its prepared SQL on a connection other than the original connection used to prepare the statement (<a href="https://github.com/qorelanguage/qore/issues/465">bug 465</a>)
 
     @section qore_0811 Qore 0.8.11
 
@@ -1143,7 +1144,7 @@ class MyConcreteClass inherits MyAbstractClass {
     - the @ref foreach "foreach statement" now iterates objects derived from @ref Qore::AbstractIterator "AbstractIterator" automatically
     - added a @ref Qore::Option::HAVE_SYMLINK "HAVE_SYMLINK" constant for the symlink() function added in qore 0.8.5
     - added the @ref Qore::SQL::SQLStatement::memberGate() "SQLStatement::memberGate()" method so @ref Qore::SQL::SQLStatement "SQLStatement" objects can be dereferenced directly to a column value when iterated with @ref Qore::SQL::SQLStatement::next() "SQLStatement::next()"; also this method will throw exceptions when an unknown column name is used so that typos in column names can be caught (instead of being silently ignored producing hard to find bugs)
-    - implemented @ref Qore::SQL::Datasource::constructor(string) "Datasource::constructor(string)" and @ref Qore::SQL::DatasourcePool::constructor(string) "DatasourcePool::constructor(string)" variants to allow for creating datasources from a string that can be parsed by Qore::SQL::parse_datasource(string) "parse_datasource(string)"
+    - implemented @ref Qore::SQL::Datasource::constructor() "Datasource::constructor(string)" and @ref Qore::SQL::DatasourcePool::constructor() "DatasourcePool::constructor(string)" variants to allow for creating datasources from a string that can be parsed by Qore::SQL::parse_datasource(string) "parse_datasource(string)"
     - added the following new DBI-related functions:
       - @ref Qore::SQL::dbi_get_driver_list() "dbi_get_driver_list()"
       - @ref Qore::SQL::dbi_get_driver_capability_list(string) "dbi_get_driver_capability_list(string)"

--- a/examples/test/qore/classes/SQLStatement/SQLStatement.qtest
+++ b/examples/test/qore/classes/SQLStatement/SQLStatement.qtest
@@ -1,0 +1,137 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+
+%requires ../../../../../qlib/QUnit.qm
+
+%try-module oracle
+%define NoOracle
+%endtry
+
+%exec-class SQLStatementTest
+
+class SQLStatementTest inherits QUnit::Test {
+    public {
+        const MyOpts = Opts + (
+            "connstr": "c,conn=s",
+            );
+
+        const OptionColumn = 22;
+    }
+
+    private {
+        DatasourcePool dsp;
+        Datasource ds;
+    }
+
+    constructor() : Test("SQLStatementTest", "1.0", \ARGV, MyOpts) {
+        try {
+            dsp = getDatasourcePool();
+            ds = new Datasource(dsp.getConfigHash());
+            ds.open();
+        }
+        catch (hash ex) {
+            if (m_options.verbose)
+                printf("%s: %s\n", ex.err, ex.desc);
+            # skip tests if we can't create the datasource
+        }
+
+        if (dsp) {
+            on_success dsp.commit();
+            on_error dsp.rollback();
+
+            try {
+                dsp.exec("drop table test");
+            }
+            catch (hash ex) {
+            }
+
+            dsp.exec("create table test (string varchar2(20))");
+        }
+
+        addTestCase("Transaction Test", \transTest());
+
+        set_return_value(main());
+    }
+
+    globalTearDown() {
+        # drop the test schema
+        if (dsp) {
+            on_success dsp.commit();
+            on_error dsp.rollback();
+
+            dsp.exec("drop table test");
+        }
+    }
+
+    private usageIntern() {
+        TestReporter::usageIntern(OptionColumn);
+        printOption("-c,--conn=ARG", "set DB connection argument (ex: \"oracle:user/pass@db\")", OptionColumn);
+    }
+
+    DatasourcePool getDatasourcePool() {
+        if (!m_options.connstr)
+            m_options.connstr = ENV.QORE_DB_CONNSTR_ORACLE ?? "oracle:omquser/omquser@xbox";
+        DatasourcePool dsp(m_options.connstr);
+        if (dsp.getDriverName() != "oracle")
+            throw "ORACLE-ERROR", sprintf("cannot execute these tests on a connection using driver %y; expecting \"oracle\"", dsp.getDriverName());
+        return dsp;
+    }
+
+    transTest() {
+        if (!dsp)
+            testSkip("no DB connection");
+
+        {
+            SQLStatement stmt(dsp);
+            on_error dsp.rollback();
+
+            stmt.prepare("insert into test (string) values (%v)");
+            stmt.exec("hi");
+            assertEq(1, stmt.affectedRows());
+
+            int rc = dsp.exec("update test set string = %v where string = %v", "hi1", "hi");
+            assertEq(1, rc);
+            dsp.commit();
+
+            # test that an exception is thrown when we try to execute a stmt prepared on another connection
+            assertThrows("SQLSTATEMENT-ERROR", sub () {stmt.exec("hi2");});
+        }
+
+        {
+            SQLStatement stmt(dsp);
+            on_error dsp.rollback();
+
+            stmt.prepare("insert into test (string) values (%v)");
+            dsp.commit();
+
+            # test that an exception is thrown when we try to execute a stmt prepared on another connection
+            assertThrows("SQLSTATEMENT-ERROR", sub () {stmt.exec("hi2");});
+        }
+        {
+            SQLStatement stmt(ds);
+            on_error ds.rollback();
+            on_success ds.commit();
+
+            ds.exec("delete from test");
+            stmt.prepare("insert into test (string) values (%v)");
+            stmt.exec("hi");
+            assertEq(1, stmt.affectedRows());
+
+            softint rc = ds.exec("update test set string = %v where string = %v", "hi1", "hi");
+            assertEq(1, rc);
+            ds.commit();
+
+            # this will succeed with a Datasource since it's the same connection
+            stmt.exec("hi2");
+            assertEq(1, stmt.affectedRows());
+
+            rc = ds.selectRow("select count(1) cnt from test").cnt;
+            assertEq(2, rc);
+        }
+    }
+}

--- a/include/qore/SQLStatement.h
+++ b/include/qore/SQLStatement.h
@@ -4,8 +4,8 @@
 
   Qore Programming Language
 
-  Copyright (C) 2006 - 2015 Qore Technologies, sro
-  
+  Copyright (C) 2006 - 2016 Qore Technologies, sro
+
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
   to deal in the Software without restriction, including without limitation

--- a/include/qore/intern/DatasourcePool.h
+++ b/include/qore/intern/DatasourcePool.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -276,7 +276,7 @@ public:
    }
 
    DLLLOCAL virtual Datasource* helperEndAction(char cmd, bool new_transaction, ExceptionSink* xsink) {
-      //printd(0, "DatasourcePool::helperEndAction() cmd=%d, nt=%d\n", cmd, new_transaction);
+      //printd(5, "DatasourcePool::helperEndAction() cmd: %d '%s', nt: %d\n", cmd, DAH_TEXT(cmd), new_transaction);
       if (cmd == DAH_RELEASE) {
          freeDS();
          return 0;

--- a/include/qore/intern/DatasourceStatementHelper.h
+++ b/include/qore/intern/DatasourceStatementHelper.h
@@ -4,8 +4,8 @@
 
   Qore Programming Language
 
-  Copyright (C) 2006 - 2015 Qore Technologies, sro
-  
+  Copyright (C) 2006 - 2016 Qore Technologies, sro
+
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
   to deal in the Software without restriction, including without limitation

--- a/include/qore/intern/QoreSQLStatement.h
+++ b/include/qore/intern/QoreSQLStatement.h
@@ -4,8 +4,8 @@
 
   Qore Programming Language
 
-  Copyright (C) 2006 - 2015 Qore Technologies, sro
-  
+  Copyright (C) 2006 - 2016 Qore Technologies, sro
+
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
   to deal in the Software without restriction, including without limitation
@@ -49,6 +49,8 @@ class QoreSQLStatement : public AbstractPrivateData, public SQLStatement {
 protected:
    DLLLOCAL static const char* stmt_statuses[];
 
+   // Datasource used to prepare the statement
+   Datasource* stmtds;
    // helper object for acquiring a Datasource pointer
    DatasourceStatementHelper* dsh;
    // copy of SQL string
@@ -69,9 +71,9 @@ protected:
    DLLLOCAL int defineIntern(ExceptionSink* xsink);
    DLLLOCAL int prepareIntern(ExceptionSink* xsink);
    DLLLOCAL int prepareArgs(bool n_raw, const QoreString& n_str, const QoreListNode* args, ExceptionSink* xsink);
-      
+
 public:
-   DLLLOCAL QoreSQLStatement() : dsh(0), prepare_args(0), status(STMT_IDLE), raw(false), validp(false) {
+   DLLLOCAL QoreSQLStatement() : stmtds(0), dsh(0), prepare_args(0), status(STMT_IDLE), raw(false), validp(false) {
    }
 
    DLLLOCAL ~QoreSQLStatement();

--- a/include/qore/intern/sql_statement_private.h
+++ b/include/qore/intern/sql_statement_private.h
@@ -4,8 +4,8 @@
 
   Qore Programming Language
 
-  Copyright (C) 2006 - 2015 Qore Technologies, sro
-  
+  Copyright (C) 2006 - 2016 Qore Technologies, sro
+
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
   to deal in the Software without restriction, including without limitation
@@ -41,6 +41,6 @@ struct sql_statement_private {
 
    DLLLOCAL sql_statement_private() : ds(0), data(0) {
    }
-}; 
+};
 
 #endif

--- a/lib/DatasourcePool.cpp
+++ b/lib/DatasourcePool.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -215,7 +215,7 @@ QoreString* DatasourcePool::getAndResetSQL() {
 
 void DatasourcePool::freeDS() {
    // remove from thread resource list
-   //printd(5, "DatasourcePool::freeDS() remove_thread_resource(this: %p), tid: %d\n", this, tid);
+   //printd(5, "DatasourcePool::freeDS() remove_thread_resource(this: %p)\n", this);
    remove_thread_resource(this);
 
    int tid = gettid();
@@ -318,6 +318,7 @@ Datasource* DatasourcePool::getDSIntern(bool& new_ds, int64& wait_total, Excepti
    thread_use_t::iterator i = tmap.find(tid);
    if (i != tmap.end()) {
       ++stats_hits;
+      //printd(5, "DatasourcePool::getDSIntern() this: %p returning already allocated ds: %p\n", this, pool[i->second]);
       return pool[i->second];
    }
 
@@ -392,7 +393,7 @@ Datasource* DatasourcePool::getDSIntern(bool& new_ds, int64& wait_total, Excepti
    sl.unlock();
 
    // add to thread resource list
-   //printd(5, "DatasourcePool::getDS() set_thread_resource(this: %p), tid: %d\n", this, gettid());
+   //printd(5, "DatasourcePool::getDSIntern() set_thread_resource(this: %p) ds: %p\n", this, ds);
    set_thread_resource(this);
 
    assert(ds);

--- a/lib/QC_SQLStatement.qpp
+++ b/lib/QC_SQLStatement.qpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -57,6 +57,7 @@
     - Most commands are executed implicitly; for example, in the example above there is no call to SQLStatement::exec() as it is executed implicitly in the initial call to SQLStatement::next().
     - Current column values in query results iterated with SQLStatement::next() as above can also be dereferenced directly from the SQLStatement object by using the column name in lower case as a member name (using SQLStatement::memberGate(), see that method for an example)
     - Query results can also be returned in blocks using SQLStatement::fetchRows() and SQLStatement::fetchColumns() ("rows" and "columns" in this case refer to the output data format; also using these methods there is no need to call SQLStatement::next())
+    - When using an SQLStatement object with a DatasourcePool, the statement must be prepared and executed on the same connection.  Attempts to execute a prepared statement on another connection will cause an \c SQLSTATEMENT-ERROR exception to be raised.
 
     The following methods are useful when executing all statements:
     - SQLStatement::prepare()
@@ -407,7 +408,7 @@ foreach my hash $h in ($l) {
 }
     @endcode
 
-    @throw SQLSTATEMENT-ERROR No %SQL has been set with SQLStatement::prepare()
+    @throw SQLSTATEMENT-ERROR No %SQL has been set with SQLStatement::prepare(); the SQLStatement uses a DatasourcePool an the statement was prepared on another connection
 
     @note Exceptions could be thrown by the DBI driver when the statement is prepared or when attempting to bind the given arguments to buffer specifications or when the statement is executed; see the relevant DBI driver docs for more information
 
@@ -440,7 +441,7 @@ foreach my hash $h in ($l) {
 }
     @endcode
 
-    @throw SQLSTATEMENT-ERROR No %SQL has been set with SQLStatement::prepare() or SQLStatement::prepareRaw()
+    @throw SQLSTATEMENT-ERROR No %SQL has been set with SQLStatement::prepare() or SQLStatement::prepareRaw(); the SQLStatement uses a DatasourcePool an the statement was prepared on another connection
 
     @note Exceptions could be thrown by the DBI driver when the statement is prepared or when attempting to bind the given arguments to buffer specifications or when the statement is executed; see the relevant DBI driver docs for more information
 

--- a/lib/QoreSQLStatement.cpp
+++ b/lib/QoreSQLStatement.cpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2006 - 2015 Qore Technologies, sro
+  Copyright (C) 2006 - 2016 Qore Technologies, sro
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -47,7 +47,16 @@ public:
    bool nt; // new transaction flag
 
    DLLLOCAL DBActionHelper(QoreSQLStatement& n_stmt, ExceptionSink* n_xsink, char n_cmd = DAH_NOCHANGE) : stmt(n_stmt), xsink(n_xsink), valid(false), cmd(n_cmd), nt(false) {
+      Datasource* oldds = stmt.priv->ds;
+      //printd(5, "DBActionHelper::DBActionHelper() old ds: %p cmd: %s\n", stmt.priv->ds, DAH_TEXT(cmd));
       stmt.priv->ds = stmt.dsh->helperStartAction(xsink, nt);
+
+      // if we are trying to start a new transaction on a new Datasource connection, but we have
+      // already prepared the statement on another connection, we have to raise an exception
+      // otherwise the statement will actually be executed on the original connection which is
+      // cached in the driver (https://github.com/qorelanguage/qore/issues/465)
+      if (oldds && stmt.priv->ds != oldds && cmd == DAH_ACQUIRE)
+         xsink->raiseException("SQLSTATEMENT-ERROR", "statement was prepared on another Datasource; you must close the statement before executing this action on a new connection");
 
       //printd(5, "DBActionHelper::DBActionHelper() ds: %p cmd: %s nt: %d\n", stmt.priv->ds, DAH_TEXT(cmd), nt);
       valid = *xsink ? false : true;
@@ -150,7 +159,6 @@ int QoreSQLStatement::closeIntern(ExceptionSink* xsink) {
       return 0;
 
    assert(priv->ds);
-
    int rc = qore_dbi_private::get(*priv->ds->getDriver())->stmt_close(this, xsink);
    assert(!priv->data);
    status = STMT_IDLE;
@@ -175,9 +183,12 @@ int QoreSQLStatement::prepareArgs(bool n_raw, const QoreString& n_str, const Qor
 }
 
 int QoreSQLStatement::prepareIntern(ExceptionSink* xsink) {
+   //assert(!stmtds);
    int rc = qore_dbi_private::get(*priv->ds->getDriver())->stmt_prepare(this, str, prepare_args, xsink);
-   if (!rc)
+   if (!rc) {
       status = STMT_PREPARED;
+      //stmtds = ds;
+   }
    else
       closeIntern(xsink);
    return rc;

--- a/lib/SQLStatement.cpp
+++ b/lib/SQLStatement.cpp
@@ -4,8 +4,8 @@
 
   Qore Programming Language
 
-  Copyright (C) 2006 - 2015 Qore Technologies, sro
-  
+  Copyright (C) 2006 - 2016 Qore Technologies, sro
+
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
   to deal in the Software without restriction, including without limitation

--- a/lib/ql_thread.qpp
+++ b/lib/ql_thread.qpp
@@ -389,7 +389,7 @@ hash get_all_thread_call_stacks() [dom=THREAD_CONTROL,THREAD_INFO] {
     When exceptions are thrown by this function, thread-local resources are also cleaned up at the same time.
 
     @see
-    - thread_resources
+    - @ref thread_resources
     - mark_thread_resources()
     - remove_thread_resource()
     - set_thread_resource()
@@ -423,7 +423,7 @@ catch ($ex) {
     @note may not throw an exception even if there are thread resources in place that get cleaned up in case the @ref Qore::Thread::AbstractThreadResource::cleanup() method performs the cleanup but does not throw an exception
 
     @see
-    - thread_resources
+    - @ref thread_resources
     - mark_thread_resources()
     - remove_thread_resource()
     - set_thread_resource()
@@ -461,7 +461,7 @@ catch ($ex) {
     @note may not throw an exception even if there are thread resources in place that get cleaned up in case the @ref Qore::Thread::AbstractThreadResource::cleanup() method performs the cleanup but does not throw an exception
 
     @see
-    - thread_resources
+    - @ref thread_resources
     - mark_thread_resources()
     - remove_thread_resource()
     - set_thread_resource()
@@ -496,7 +496,7 @@ catch ($ex) {
     @endcode
 
     @see
-    - thread_resources
+    - @ref thread_resources
     - remove_thread_resource()
     - set_thread_resource()
     - throw_thread_resource_exceptions()
@@ -603,7 +603,7 @@ set_thread_resource($obj);
     @param resource the thread resource to set
 
     @see
-    - thread_resources
+    - @ref thread_resources
     - mark_thread_resources()
     - remove_thread_resource()
     - throw_thread_resource_exceptions()
@@ -628,7 +628,7 @@ remove_thread_resource($obj);
     @return True if the resource was removed, False if not
 
     @see
-    - thread_resources
+    - @ref thread_resources
     - mark_thread_resources()
     - set_thread_resource()
     - throw_thread_resource_exceptions()
@@ -651,7 +651,7 @@ set_thread_resource(\func(), code);
     @param resource the callable thread resource to set
 
     @see
-    - thread_resources
+    - @ref thread_resources
     - mark_thread_resources()
     - remove_thread_resource()
     - throw_thread_resource_exceptions()
@@ -675,7 +675,7 @@ remove_thread_resource(\func());
     @return True if the resource was removed, False if not
 
     @see
-    - thread_resources
+    - @ref thread_resources
     - mark_thread_resources()
     - set_thread_resource()
     - throw_thread_resource_exceptions()


### PR DESCRIPTION
…tasourcePool where statements prepared on one connection were then executed on another connection because the drivers cache the connection (the underlying Datasource object) when the statement is prepared; now in such cases an SQLSTATEMENT-ERROR exception is raised
