### PR TITLE
refs #490 do not mark the rset as "in_del" and then immediately retur…

### DIFF
--- a/examples/test/qore/misc/gc.qtest
+++ b/examples/test/qore/misc/gc.qtest
@@ -83,172 +83,190 @@ class GcClosureTest2 {
     }
 }
 
+namespace DtorOrder {
+    our string Result;
+
+    class C {
+        public {
+            C other;
+        }
+        destructor() {
+            Result += "+";
+            if (other) other.doSomething();
+            Result += "-";
+        }
+        doSomething() {
+            Result += "X";
+        }
+    }
+
+}
+
 class DgcTest inherits QUnit::Test {
     constructor() : Test("GcTest", "1.0") {
-	addTestCase("GcTests", \gcTests());
+        addTestCase("GcTests", \gcTests());
         addTestCase("ClosureTests", \closureTests());
+        addTestCase("Destructor order", \dtorOrder());
 
         # Return for compatibility with test harness that checks the return value
         set_return_value(main());
     }
 
     gcTests() {
-	if (!HAVE_DETERMINISTIC_GC)
-	    testSkip("HAVE_DETERMINISTIC_GC is not defined");
+        if (!HAVE_DETERMINISTIC_GC)
+            testSkip("HAVE_DETERMINISTIC_GC is not defined");
 
-	int cnt = 0;
-	code inc = sub () { ++cnt; };
+        int cnt = 0;
+        code inc = sub () { ++cnt; };
 
-	# make circular references
-	{
-	    GcTest obj1(inc);
-	    obj1.a = obj1;
-	}
-	testAssertionValue("recursive gc 1", cnt, 1);
+        # make circular references
+        {
+            GcTest obj1(inc);
+            obj1.a = obj1;
+        }
+        testAssertionValue("recursive gc 1", cnt, 1);
 
-	{
-	    GcTest obj2(inc);
-	    obj2.a = obj2;
-	}
-	testAssertionValue("recursive gc 2", cnt, 2);
+        {
+            GcTest obj2(inc);
+            obj2.a = obj2;
+        }
+        testAssertionValue("recursive gc 2", cnt, 2);
 
-	{
-	    GcTest obj3(inc);
-	    obj3.a.a = obj3;
-	}
-	testAssertionValue("recursive gc 3", cnt, 3);
+        {
+            GcTest obj3(inc);
+            obj3.a.a = obj3;
+        }
+        testAssertionValue("recursive gc 3", cnt, 3);
 
-	{
-	    GcTest obj4(inc);
-	    obj4.a = list(obj4);
-	}
-	testAssertionValue("recursive gc 4", cnt, 4);
+        {
+            GcTest obj4(inc);
+            obj4.a = list(obj4);
+        }
+        testAssertionValue("recursive gc 4", cnt, 4);
 
-	{
-	    GcTest obj5(inc);
-	    GcTest obj6(inc);
-	    obj5.a = obj6;
-	    obj6.b = obj5;
-	}
-	testAssertionValue("recursive gc 6", cnt, 6);
+        {
+            GcTest obj5(inc);
+            GcTest obj6(inc);
+            obj5.a = obj6;
+            obj6.b = obj5;
+        }
+        testAssertionValue("recursive gc 6", cnt, 6);
 
-	{
-	    GcTest obj7(inc);
-	    obj7.a = obj7;
-	    obj7.b = obj7;
-	}
-	testAssertionValue("recursive gc 7", cnt, 7);
+        {
+            GcTest obj7(inc);
+            obj7.a = obj7;
+            obj7.b = obj7;
+        }
+        testAssertionValue("recursive gc 7", cnt, 7);
 
-	{
-	    GcTest obj8(inc);
-	    GcTest obj9(inc);
+        {
+            GcTest obj8(inc);
+            GcTest obj9(inc);
 
-	    obj8.a = ("a": obj9, "b": obj9);
-	    obj9.b = obj8;
-	    obj9.c = obj8;
-	}
-	testAssertionValue("recursive gc 9", cnt, 9);
+            obj8.a = ("a": obj9, "b": obj9);
+            obj9.b = obj8;
+            obj9.c = obj8;
+        }
+        testAssertionValue("recursive gc 9", cnt, 9);
 
-	{
-	    GcTest obj10(inc);
-	    GcTest obj11(inc);
-	    obj10.set(obj11);
-	    obj11.set(obj10);
-	}
-	testAssertionValue("recursive gc 11", cnt, 11);
+        {
+            GcTest obj10(inc);
+            GcTest obj11(inc);
+            obj10.set(obj11);
+            obj11.set(obj10);
+        }
+        testAssertionValue("recursive gc 11", cnt, 11);
 
-	{
-	    GcTest obj12(inc);
-	    {
-		GcTest obj13(inc);
+        {
+            GcTest obj12(inc);
+            {
+                GcTest obj13(inc);
 
-		obj12.a = obj13;
-		obj13.a = obj12;
-	    }
-	}
-	testAssertionValue("recursive gc 13-1", cnt, 13);
+                obj12.a = obj13;
+                obj13.a = obj12;
+            }
+        }
+        testAssertionValue("recursive gc 13-1", cnt, 13);
 
-	{
-	    GcTest t1(inc);
-	    GcTest t2(inc);
-	    t1.set(t2);
-	    t2.set(t1);
-	    t1.set();
+        {
+            GcTest t1(inc);
+            GcTest t2(inc);
+            t1.set(t2);
+            t2.set(t1);
+            t1.set();
 
-	    testAssertionValue("recursive gc 13-2", cnt, 13);
-	}
-	testAssertionValue("recursive gc 15-1", cnt, 15);
+            testAssertionValue("recursive gc 13-2", cnt, 13);
+        }
+        testAssertionValue("recursive gc 15-1", cnt, 15);
 
-	{
-	    GcTest t1(inc);
-	    t1.set(t1);
-	    t1.set();
+        {
+            GcTest t1(inc);
+            t1.set(t1);
+            t1.set();
 
-	    testAssertionValue("recursive gc 15-2", cnt, 15);
-	}
-	testAssertionValue("recursive gc 16-1", cnt, 16);
+            testAssertionValue("recursive gc 15-2", cnt, 15);
+        }
+        testAssertionValue("recursive gc 16-1", cnt, 16);
 
-	{
-	    GcTest t1(inc);
-	    {
-		GcTest t2(inc);
-		t1.set(t2);
-		t2.b = t1;
-		{
-		    GcTest t3(inc);
-		    t2.set(t3);
-		    t2.b = t1;
-		    {
-			GcTest t4(inc);
-			t3.set(t4);
-			t4.set(t1);
-			t3.b = t2;
-			t4.b = t3;
-		    }
-		}
-	    }
-	    testAssertionValue("recursive gc 16-2", cnt, 16);
-	}
-	testAssertionValue("recursive gc 20-1", cnt, 20);
+        {
+            GcTest t1(inc);
+            {
+                GcTest t2(inc);
+                t1.set(t2);
+                t2.b = t1;
+                {
+                    GcTest t3(inc);
+                    t2.set(t3);
+                    t2.b = t1;
+                    {
+                        GcTest t4(inc);
+                        t3.set(t4);
+                        t4.set(t1);
+                        t3.b = t2;
+                        t4.b = t3;
+                    }
+                }
+            }
+            testAssertionValue("recursive gc 16-2", cnt, 16);
+        }
+        testAssertionValue("recursive gc 20-1", cnt, 20);
 
-	{
-	    GcTest t1(inc);
-	    {
-		GcTest t2(inc);
-		t1.set(t2);
-		t2.b = t1;
-		{
-		    GcTest t3(inc);
-		    t2.set(t3);
-		    t3.b = t2;
-		    t3.c = t1;
-		    t1.b = t3;
-		    {
-			GcTest t4(inc);
-			t3.set(t4);
-			t4.set(t1);
-			t4.b = t2;
-			t4.c = t3;
-			t2.c = t4;
-			t1.c = t4;
-		    }
-		}
-	    }
+        {
+            GcTest t1(inc);
+            {
+                GcTest t2(inc);
+                t1.set(t2);
+                t2.b = t1;
+                {
+                    GcTest t3(inc);
+                    t2.set(t3);
+                    t3.b = t2;
+                    t3.c = t1;
+                    t1.b = t3;
+                    {
+                        GcTest t4(inc);
+                        t3.set(t4);
+                        t4.set(t1);
+                        t4.b = t2;
+                        t4.c = t3;
+                        t2.c = t4;
+                        t1.c = t4;
+                    }
+                }
+            }
+            testAssertionValue("recursive gc 20-2", cnt, 20);
+        }
+        testAssertionValue("recursive gc 24", cnt, 24);
 
-	    testAssertionValue("recursive gc 20-2", cnt, 20);
-
-	}
-	testAssertionValue("recursive gc 24", cnt, 24);
-
-	{
-	    GcTest1 t1(inc);
-	}
-	testAssertionValue("recursive gc 25", cnt, 25);
+        {
+            GcTest1 t1(inc);
+        }
+        testAssertionValue("recursive gc 25", cnt, 25);
     }
 
     closureTests() {
-	int cnt = 0;
-	code inc = sub () { ++cnt; };
+        int cnt = 0;
+        code inc = sub () { ++cnt; };
 
         {
             GcClosureTest1 t1(inc);
@@ -260,5 +278,16 @@ class DgcTest inherits QUnit::Test {
             t2.f = sub() {print(t2);};
         }
         assertEq(2, cnt);
+    }
+
+    dtorOrder() {
+        DtorOrder::Result = "";
+        {
+            DtorOrder::C a();
+            DtorOrder::C b();
+            a.other = b;
+            b.other = a;
+        }
+        assertEq("+X-+-", DtorOrder::Result);
     }
 }

--- a/include/qore/intern/RSet.h
+++ b/include/qore/intern/RSet.h
@@ -145,7 +145,7 @@ protected:
    // we assume set::size() is O(1); this should be a safe assumption
    rset_t set;
    int acnt;
-   bool valid, in_del;
+   bool valid;
 
    DLLLOCAL void invalidateIntern() {
       assert(valid);
@@ -160,10 +160,10 @@ protected:
 public:
    QoreRWLock rwl;
 
-   DLLLOCAL RSet() : acnt(0), valid(true), in_del(false) {
+   DLLLOCAL RSet() : acnt(0), valid(true) {
    }
 
-   DLLLOCAL RSet(RObject* o) : acnt(0), valid(true), in_del(false) {
+   DLLLOCAL RSet(RObject* o) : acnt(0), valid(true) {
       set.insert(o);
    }
 
@@ -176,8 +176,8 @@ public:
       bool del = false;
       {
          QoreAutoRWWriteLocker al(rwl);
-         if (!in_del)
-            in_del = true;
+         if (valid)
+            valid = false;
          //printd(5, "RSet::deref() this: %p %d -> %d\n", this, acnt, acnt - 1);
          assert(acnt > 0);
          del = !--acnt;
@@ -197,7 +197,7 @@ public:
    }
 
    DLLLOCAL bool active() const {
-      return valid && !in_del;
+      return valid;
    }
 
    DLLLOCAL int canDelete(int ref_copy, int rcount);
@@ -207,10 +207,6 @@ public:
 
    DLLLOCAL bool isValid() const {
       return qore_check_this(this) ? valid : false;
-   }
-
-   DLLLOCAL bool isInDel() const {
-      return qore_check_this(this) ? in_del : false;
    }
 #endif
 

--- a/lib/QoreObject.cpp
+++ b/lib/QoreObject.cpp
@@ -624,7 +624,7 @@ void QoreObject::customDeref(ExceptionSink* xsink) {
                   return;
                }
 
-               printd(QRO_LVL, "QoreObject::customDeref() this: %p '%s' rset: %p (valid: %d in_del: %d) rcount: %d ref_copy: %d references: %d\n", this, getClassName(), priv->rset, priv->rset->isValid(), priv->rset->isInDel(), priv->rcount, ref_copy, references);
+               printd(QRO_LVL, "QoreObject::customDeref() this: %p '%s' rset: %p (valid: %d) rcount: %d ref_copy: %d references: %d\n", this, getClassName(), priv->rset, priv->rset->isValid(), priv->rcount, ref_copy, references);
 
                int rc;
                RSet* rs = priv->rset;


### PR DESCRIPTION
…n for all other objects in the set that they may be deleted; allow them to be deleted naturally after the first object is destroyed
