### PR TITLE
Bugfix/44 memory leaks

### DIFF
--- a/examples/test/qlib/SqlUtil/smoke.qtest
+++ b/examples/test/qlib/SqlUtil/smoke.qtest
@@ -1,4 +1,4 @@
-#!/usr/bin/env qore 
+#!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
 %require-types
@@ -29,7 +29,7 @@ if (!connstr) {
             case /^el6/:
             case /^el5/:
             case /^manatee/:
-            case /^xbox/: connstr = "oracle:omquser/omquser@xbox"; break;
+            case /^xbox/: connstr = "pgsql:omquser/omquser@omquser"; break;
             default: {
                 stderr.printf("cannot detect DB connect string from hostname and QORE_DB_CONNSTR environment variable not set; cannot run SqlUtil tests\n");
                 return;
@@ -67,9 +67,9 @@ const TEST_SCHEMA_TABLES = (
 
 const T_SOME_TABLE = (
     "columns" : (
-        "id"    : ( "native_type" : "number", "notnull" : True ),
-        "col_a" : ( "native_type" : "varchar2", "character_semantics" : True, "notnull" : True, "size" : "25"),
-        "col_b" : ( "native_type" : "varchar2", "character_semantics" : True, "size" : "25"),
+        "id"    : ( "qore_type" : SqlUtil::NUMERIC, "notnull" : True ),
+        "col_a" : ( "qore_type" : SqlUtil::VARCHAR, "notnull" : True, "size" : "25"),
+        "col_b" : ( "qore_type" : SqlUtil::VARCHAR, "size" : "25"),
     )
 );
 
@@ -85,7 +85,7 @@ my hash opts = (
 # CREATE TABLE test
 db.dropTableIfExists(TEST_TABLE_NAME);
 db.getAlignSql(TEST_SCHEMA, opts);
-my Table table(connstr, TEST_TABLE_NAME);
+my Table table(ds, TEST_TABLE_NAME);
 t.ok(table.checkExistence(), "create table: existence of 3-columned table checked");
 
 # INSERT test
@@ -111,7 +111,7 @@ t.cmp(elements data.id, 0, "delete: no rows with removed id found");
 
 # DROP TABLE test
 db.dropTableIfExists(TEST_TABLE_NAME);
-my Table removed_table(connstr, TEST_TABLE_NAME);
+my Table removed_table(ds, TEST_TABLE_NAME);
 t.ok(!removed_table.checkExistence(), "drop table: no table found");
 
 # }}}

--- a/include/qore/intern/ConstantList.h
+++ b/include/qore/intern/ConstantList.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   constants can only be defined when parsing
   constants values will be substituted during the 2nd parse phase

--- a/include/qore/intern/QoreObjectIntern.h
+++ b/include/qore/intern/QoreObjectIntern.h
@@ -156,12 +156,7 @@ public:
 
    DLLLOCAL qore_object_private(QoreObject* n_obj, const QoreClass *oc, QoreProgram* p, QoreHashNode* n_data);
 
-   DLLLOCAL ~qore_object_private() {
-      assert(!pgm);
-      assert(!data);
-      assert(!privateData);
-      assert(!rset);
-   }
+   DLLLOCAL ~qore_object_private();
 
    DLLLOCAL void plusEquals(const AbstractQoreNode* v, AutoVLock& vl, ExceptionSink* xsink) {
       if (!v)

--- a/include/qore/intern/RSet.h
+++ b/include/qore/intern/RSet.h
@@ -200,6 +200,11 @@ public:
       return valid;
    }
 
+   /* return values:
+      -1: error, rset invalid
+      0: cannot delete
+      1: the rset has been invalidated already, the object can be deleted
+   */
    DLLLOCAL int canDelete(int ref_copy, int rcount);
 
 #ifdef DEBUG

--- a/include/qore/intern/qore_program_private.h
+++ b/include/qore/intern/qore_program_private.h
@@ -32,6 +32,8 @@
 #ifndef _QORE_QORE_PROGRAM_PRIVATE_H
 #define _QORE_QORE_PROGRAM_PRIVATE_H
 
+#define QPP_DBG_LVL 5
+
 extern QoreListNode* ARGV, * QORE_ARGV;
 extern QoreHashNode* ENV;
 
@@ -436,7 +438,7 @@ public:
         requires_exception(false), tclear(0),
         exceptions_raised(0), ptid(0), pwo(n_parse_options), dom(0), pend_dom(0), thread_local_storage(0), twaiting(0),
         thr_init(0), exec_class_rv(0), pgm(n_pgm) {
-      //printd(5, "qore_program_private_base::qore_program_private_base() this: %p pgm: %p po: "QLLD"\n", this, pgm, n_parse_options);
+      printd(QPP_DBG_LVL, "qore_program_private_base::qore_program_private_base() this: %p pgm: %p po: "QLLD"\n", this, pgm, n_parse_options);
 
       if (p_pgm)
 	 setParent(p_pgm, n_parse_options);
@@ -462,7 +464,7 @@ public:
 
 #ifdef DEBUG
    DLLLOCAL ~qore_program_private_base() {
-      //printd(5, "qore_program_private_base::~qore_program_private_base() this: %p pgm: %p\n", this, pgm);
+      printd(QPP_DBG_LVL, "qore_program_private_base::~qore_program_private_base() this: %p pgm: %p\n", this, pgm);
    }
 #endif
 
@@ -530,8 +532,13 @@ public:
       assert(!exec_class_rv);
    }
 
+   DLLLOCAL void depRef() {
+      printd(QPP_DBG_LVL, "qore_program_private::depRef() this: %p pgm: %p %d->%d\n", this, pgm, dc.reference_count(), dc.reference_count() + 1);
+      dc.ROreference();
+   }
+
    DLLLOCAL void depDeref(ExceptionSink* xsink) {
-      //printd(5, "qore_program_private::depDeref() this: %p pgm: %p %d->%d\n", this, pgm, dc.reference_count(), dc.reference_count() - 1);
+      printd(QPP_DBG_LVL, "qore_program_private::depDeref() this: %p pgm: %p %d->%d\n", this, pgm, dc.reference_count(), dc.reference_count() - 1);
       if (dc.ROdereference()) {
          del(xsink);
          delete pgm;

--- a/lib/ConstantList.cpp
+++ b/lib/ConstantList.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -106,9 +106,13 @@ int ConstantEntry::scanValue(const AbstractQoreNode* n) const {
 	 return 0;
       }
 
+      // do not allow any closure or structure containing a closure to be copied directly into the parse tree
+      // since a recursive loop can be created: https://github.com/qorelanguage/qore/issues/44
+      case NT_RUNTIME_CLOSURE:
       // could have any value and could change at runtime
       case NT_OBJECT:
       case NT_FUNCREF:
+         //printd(5, "ConstantEntry::scanValue() this: %p n: %p nt: %d\n", this, n, get_node_type(n));
 	 return -1;
    }
 

--- a/lib/QoreNamespace.cpp
+++ b/lib/QoreNamespace.cpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -911,7 +911,7 @@ AbstractQoreNode* qore_root_ns_private::parseResolveBarewordIntern(const QorePro
 
    bool abr = (bool)(parse_get_parse_options() & PO_ALLOW_BARE_REFS);
 
-   // if bare refs are enabled, first look for a local variablee
+   // if bare refs are enabled, first look for a local variable
    if (abr) {
       bool in_closure;
       LocalVar* id = find_local_var(bword, in_closure);

--- a/lib/QoreObject.cpp
+++ b/lib/QoreObject.cpp
@@ -46,7 +46,7 @@ qore_object_private::qore_object_private(QoreObject* n_obj, const QoreClass* oc,
    obj(n_obj) {
    //printd(5, "qore_object_private::qore_object_private() this: %p obj: %p '%s'\n", this, obj, oc->getName());
 #ifdef QORE_DEBUG_OBJ_REFS
-   printd(QORE_DEBUG_OBJ_REFS, "qore_object_private::qore_object_private() obj: %p, pgm: %p, class: %s, references 0->1\n", obj, p, oc->getName());
+   printd(QORE_DEBUG_OBJ_REFS, "qore_object_private::qore_object_private() this: %p obj: %p, pgm: %p, class: %s, references 0->1\n", this, obj, p, oc->getName());
 #endif
    /* instead of referencing the class, we reference the program, because the
       program contains the namespace that contains the class, and the class'
@@ -61,6 +61,14 @@ qore_object_private::qore_object_private(QoreObject* n_obj, const QoreClass* oc,
 #ifdef DEBUG
    n_data->priv->is_obj = true;
 #endif
+}
+
+qore_object_private::~qore_object_private() {
+   //printd(5, "qore_object_private::~qore_object_private() this: %p obj: %p '%s'\n", this, obj, theclass ? theclass->getName() : "<n/a>");
+   assert(!pgm);
+   assert(!data);
+   assert(!privateData);
+   assert(!rset);
 }
 
 // returns true if a lock error has occurred and the transaction should be aborted or restarted; the rsection lock is held when this function is called

--- a/lib/QoreProgram.cpp
+++ b/lib/QoreProgram.cpp
@@ -5,7 +5,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -342,7 +342,7 @@ void qore_program_private::waitForTerminationAndClear(ExceptionSink* xsink) {
       // purge thread resources before clearing pgm
       purge_pgm_thread_resources(pgm, xsink);
 
-      //printd(5, "qore_program_private::waitForTerminationAndClear() this: %p clr: %d\n", this, clr);
+      printd(5, "qore_program_private::waitForTerminationAndClear() this: %p clr: %d\n", this, clr);
       // delete all global variables, etc
       qore_root_ns_private::clearData(*RootNS, xsink);
 
@@ -702,7 +702,7 @@ QoreThreadLock* QoreProgram::getParseLock() {
 }
 
 void QoreProgram::deref(ExceptionSink* xsink) {
-   //printd(5, "QoreProgram::deref() this: %p %d->%d\n", this, reference_count(), reference_count() - 1);
+   printd(QPP_DBG_LVL, "QoreProgram::deref() this: %p priv: %p %d->%d\n", this, priv, reference_count(), reference_count() - 1);
    if (ROdereference())
       priv->clear(xsink);
 }
@@ -795,8 +795,7 @@ QoreNamespace* QoreProgram::getQoreNS() const {
 }
 
 void QoreProgram::depRef() {
-   //printd(5, "QoreProgram::depRef() this: %p %d->%d\n", this, priv->dc.reference_count(), priv->dc.reference_count() + 1);
-   priv->dc.ROreference();
+   priv->depRef();
 }
 
 void QoreProgram::depDeref(ExceptionSink* xsink) {


### PR DESCRIPTION
the problem was that the RSet was marked invalid without dereferencing the objects in the set - this caused the Qore destructors to be run properly (hence the gc.qtest succeeded) but the actual memory was never freed; the actual fix was in `lib/RSet.cpp`

last known remaining memory leak will be solved with #527
