### PR TITLE
closes #527 ensure that closures are scanned properly when assigned i…

### DIFF
--- a/include/qore/intern/QoreObjectIntern.h
+++ b/include/qore/intern/QoreObjectIntern.h
@@ -40,14 +40,21 @@
 #include <set>
 #include <vector>
 
+//#define _QORE_CYCLE_CHECK 1
+#ifdef _QORE_CYCLE_CHECK
+#define QORE_DEBUG_OBJ_REFS 0
+#define QRO_LVL 0
+#else
+#define QORE_DEBUG_OBJ_REFS 5
+#define QRO_LVL 1
+#endif
+
 #include <qore/intern/QoreClassIntern.h>
 #include <qore/intern/RSection.h>
 #include <qore/intern/RSet.h>
 
 #define OS_OK            0
 #define OS_DELETED      -1
-
-#define QRO_LVL 1
 
 // object access constants
 #define QOA_OK           0

--- a/include/qore/intern/RSet.h
+++ b/include/qore/intern/RSet.h
@@ -37,13 +37,6 @@
 
 #include <set>
 
-//#define _QORE_CYCLE_CHECK 1
-#ifdef _QORE_CYCLE_CHECK
-#define QORE_DEBUG_OBJ_REFS 0
-#else
-#define QORE_DEBUG_OBJ_REFS 5
-#endif
-
 class RSet;
 class RSetHelper;
 


### PR DESCRIPTION
…n an lvalue assignment expression; fixed a bug with locking regarding closure scans

after the fix with valgrind on test/qlib/Mapper/mapper.qtest:

<pre>
==19017== LEAK SUMMARY:
==19017==    definitely lost: 0 bytes in 0 blocks
==19017==    indirectly lost: 0 bytes in 0 blocks
==19017==      possibly lost: 0 bytes in 0 blocks
==19017==    still reachable: 73,776 bytes in 10 blocks
==19017==                       of which reachable via heuristic:
==19017==                         newarray           : 48 bytes in 2 blocks
==19017==         suppressed: 0 bytes in 0 blocks
</pre>
