### PR TITLE
refs #538 issue a more correct error message in case a socket operati…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -442,6 +442,7 @@
     - fixed a bug where nested lists were not parsed correctly in some cases (<a href="https://github.com/qorelanguage/qore/issues/320">issue 320</a>)
     - fixed a bug where the type of catch parameter was ignored (<a href="https://github.com/qorelanguage/qore/issues/28">issue 28</a>)
     - fixed a bug where namespace hierarchies were not indexed during parse time when added to already-committed namespaces which lead to symbol resolution errors for valid code (<a href="https://github.com/qorelanguage/qore/issues/538">issue 538</a>)
+    - fixed a bug where a @ref Qore::Socket "Socket" operation attempted in another thread while a callback operation on the same socket was in progress would result in a confusing error message (<a href="https://github.com/qorelanguage/qore/issues/530">issue 530</a>)
 
     @section qore_0811 Qore 0.8.11
 

--- a/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
@@ -107,9 +107,13 @@ class PgsqlTest inherits SqlTestBase {
             "smallint": 100,
             "integer": 1928381,
             "bigint": 2198374739812,
-            "smallserial": 100,
-            "serial": 39484392,
-            "bigserial": 129383948393,
+
+            # "serial" types are not true types but merely a notational convenience for creating unique identifier columns
+            # tests will fail if these types are included
+            #"smallserial": 100,
+            #"serial": 39484392,
+            #"bigserial": 129383948393,
+
             "real": 1.5,
             "double precision": 3.1415927,
             "float": 3.141592653589793238,

--- a/include/qore/QoreSocket.h
+++ b/include/qore/QoreSocket.h
@@ -3,10 +3,10 @@
   QoreSocket.h
 
   IPv4, IPv6, unix socket class with SSL support
-  
+
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   will unlink (delete) UNIX domain socket files when closed
 
@@ -50,12 +50,13 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
-#define QSE_MISC_ERR  0 //!< error in errno
-#define QSE_RECV_ERR -1 //!< error in recv()
-#define QSE_NOT_OPEN -2 //!< socket is not open
-#define QSE_TIMEOUT  -3 //!< timeout occured
-#define QSE_SSL_ERR  -4 //!< SSL error occured
-#define QSE_IN_OP    -5 //!< in another operation (socket call made in socket callback)
+#define QSE_MISC_ERR      0 //!< error in errno
+#define QSE_RECV_ERR     -1 //!< error in recv()
+#define QSE_NOT_OPEN     -2 //!< socket is not open
+#define QSE_TIMEOUT      -3 //!< timeout occured
+#define QSE_SSL_ERR      -4 //!< SSL error occured
+#define QSE_IN_OP        -5 //!< in another operation (socket call made in socket callback)
+#define QSE_IN_OP_THREAD -6 //!< in another operation (socket call made in another thread while a callback operation is in progress)
 
 class Queue;
 
@@ -127,13 +128,13 @@ class QoreSocket {
 
 private:
    //! private implementation of the class
-   struct qore_socket_private *priv; 
+   struct qore_socket_private *priv;
 
    //! private constructor, not exported in the library's public interface
    DLLLOCAL QoreSocket(int n_sock, int n_sfamily, int n_stype, int s_prot, const QoreEncoding *csid);
 
    DLLLOCAL static void convertHeaderToHash(QoreHashNode* h, char* p);
-      
+
    //! this function is not implemented; it is here as a private function in order to prohibit it from being used
    DLLLOCAL QoreSocket(const QoreSocket&);
 
@@ -552,7 +553,7 @@ public:
    DLLEXPORT int acceptAndReplace(int timeout_ms, ExceptionSink* xsink);
 
    //! sets an open socket to the listening state
-   /** 
+   /**
        @return 0 for OK, not 0 if an error occured
    */
    DLLEXPORT int listen();
@@ -567,16 +568,16 @@ public:
    DLLEXPORT int listen(int backlog);
 
    //! sends binary data on a connected socket
-   /** 
+   /**
        @param buf the data to send
        @param size the size of the data to send
 
        @return 0 for OK, not 0 if an error occured
    */
    DLLEXPORT int send(const char* buf, qore_size_t size);
-  
+
    //! sends binary data on a connected socket
-   /** 
+   /**
        @param buf the data to send
        @param size the size of the data to send
        @param xsink if an error occurs in socket communication, the Qore-language exception information will be added here
@@ -584,7 +585,7 @@ public:
        @return 0 for OK, not 0 if an error occured
    */
    DLLEXPORT int send(const char* buf, qore_size_t size, ExceptionSink* xsink);
-  
+
    //! sends binary data on a connected socket
    /**
        @param buf the data to send
@@ -597,7 +598,7 @@ public:
    DLLEXPORT int send(const char* buf, qore_size_t size, int timeout_ms, ExceptionSink* xsink);
 
    //! sends string data on a connected socket, converts the string encoding to the socket's encoding if necessary
-   /** 
+   /**
        @param msg the string to send (must not be 0)
        @param xsink if an error occurs in converting the string's character encoding or in socket communication, the Qore-language exception information will be added here
 
@@ -616,7 +617,7 @@ public:
    DLLEXPORT int send(const QoreString *msg, int timeout_ms, ExceptionSink* xsink);
 
    //! sends binary data on a connected socket
-   /** 
+   /**
        @param msg the data to send
 
        @return 0 for OK, not 0 if an error occured
@@ -624,7 +625,7 @@ public:
    DLLEXPORT int send(const BinaryNode* msg);
 
    //! sends binary data on a connected socket
-   /** 
+   /**
        @param msg the data to send
        @param xsink if an error occurs in socket communication, the Qore-language exception information will be added here
 
@@ -643,7 +644,7 @@ public:
    DLLEXPORT int send(const BinaryNode* msg, int timeout_ms, ExceptionSink* xsink);
 
    //! sends untranslated data from an open file descriptor
-   /** 
+   /**
        @param fd a file descriptor, open for reading
        @param size the number of bytes to send (-1 = send all until EOF)
 
@@ -1119,7 +1120,7 @@ public:
    //! receive a certain number of bytes with a timeout value and return a QoreStringNode, caller owns the reference count returned
    /** The socket must be connected before this call is made.
        @param bufsize number of bytes to read from the socket; if <= 0, read all data available from the socket until the socket is closed from the other side
-       @param timeout_ms in milliseconds, -1=never timeout, 0=do not block, return immediately if there is no data waiting 
+       @param timeout_ms in milliseconds, -1=never timeout, 0=do not block, return immediately if there is no data waiting
        @param xsink if an error occurs, the Qore-language exception information will be added here
        @return the data read as a QoreStringNode tagged with the socket's QoreEncoding, caller owns the reference count returned (0 if an error occurs)
        @see QoreEncoding
@@ -1517,7 +1518,7 @@ public:
        @param pkey the private key to use for the connection, may be 0 if no private key should be used
        @param xsink if an error occurs, the Qore-language exception information will be added here
 
-       @return 0 if OK, not 0 on error	  
+       @return 0 if OK, not 0 on error
    */
    DLLEXPORT int upgradeClientToSSL(X509* cert, EVP_PKEY* pkey, ExceptionSink* xsink);
 
@@ -1529,7 +1530,7 @@ public:
        @param timeout_ms timeout in milliseconds, -1 = never timeout
        @param xsink if an error occurs, the Qore-language exception information will be added here
 
-       @return 0 if OK, not 0 on error	  
+       @return 0 if OK, not 0 on error
    */
    DLLEXPORT int upgradeServerToSSL(X509* cert, EVP_PKEY* pkey, int timeout_ms, ExceptionSink* xsink);
 
@@ -1541,7 +1542,7 @@ public:
        @param timeout_ms timeout in milliseconds, -1 = never timeout
        @param xsink if an error occurs, the Qore-language exception information will be added here
 
-       @return 0 if OK, not 0 on error	  
+       @return 0 if OK, not 0 on error
    */
    DLLEXPORT int upgradeClientToSSL(X509* cert, EVP_PKEY* pkey, int timeout_ms, ExceptionSink* xsink);
 
@@ -1552,7 +1553,7 @@ public:
        @param pkey the private key to use for the connection, may be 0 if no private key should be used
        @param xsink if an error occurs, the Qore-language exception information will be added here
 
-       @return 0 if OK, not 0 on error	  
+       @return 0 if OK, not 0 on error
    */
    DLLEXPORT int upgradeServerToSSL(X509* cert, EVP_PKEY* pkey, ExceptionSink* xsink);
 

--- a/include/qore/common.h
+++ b/include/qore/common.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -89,6 +89,7 @@ enum qore_license_t {
 #if defined _MSC_VER || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__)
 #define _Q_WINDOWS 1
 #ifdef _WIN64
+#define _Q_WINDOWS 1
 #define _Q_WINDOWS64 1
 #endif
 #endif

--- a/include/qore/intern/qore_socket_private.h
+++ b/include/qore/intern/qore_socket_private.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -75,6 +75,7 @@ DLLLOCAL int sock_get_error();
 DLLLOCAL void qore_socket_error(ExceptionSink* xsink, const char* err, const char* cdesc, const char* mname = 0, const char* host = 0, const char* svc = 0, const struct sockaddr *addr = 0);
 DLLLOCAL void qore_socket_error_intern(int rc, ExceptionSink* xsink, const char* err, const char* cdesc, const char* mname = 0, const char* host = 0, const char* svc = 0, const struct sockaddr *addr = 0);
 DLLLOCAL void se_in_op(const char* meth, ExceptionSink* xsink);
+DLLLOCAL void se_in_op_thread(const char* meth, ExceptionSink* xsink);
 DLLLOCAL void se_not_open(const char* meth, ExceptionSink* xsink);
 DLLLOCAL void se_timeout(const char* meth, int timeout_ms, ExceptionSink* xsink);
 DLLLOCAL void se_closed(const char* mname, ExceptionSink* xsink);
@@ -223,13 +224,14 @@ struct qore_socket_private {
       tp_us_min             // throughput: minimum time for transfer to be considered
       ;
    AbstractQoreNode* callback_arg;
-   bool del, in_op, http_exp_chunked_body;
+   bool del, http_exp_chunked_body;
+   int in_op;
 
    DLLLOCAL qore_socket_private(int n_sock = QORE_INVALID_SOCKET, int n_sfamily = AF_UNSPEC, int n_stype = SOCK_STREAM, int n_prot = 0, const QoreEncoding* n_enc = QCS_DEFAULT) :
       sock(n_sock), sfamily(n_sfamily), port(-1), stype(n_stype), sprot(n_prot), enc(n_enc),
       ssl(0), cb_queue(0), warn_queue(0), buflen(0), bufoffset(0), tl_warning_us(0), tp_warning_bs(0),
       tp_bytes_sent(0), tp_bytes_recv(0), tp_us_sent(0), tp_us_recv(0), tp_us_min(0),
-      callback_arg(0), del(false), in_op(false), http_exp_chunked_body(false) {
+      callback_arg(0), del(false), http_exp_chunked_body(false), in_op(-1) {
       //sendTimeout = recvTimeout = -1
    }
 
@@ -247,8 +249,8 @@ struct qore_socket_private {
 
    DLLLOCAL int close() {
       int rc = close_internal();
-      if (in_op)
-         in_op = false;
+      if (in_op >= 0)
+         in_op = -1;
       if (http_exp_chunked_body)
          http_exp_chunked_body = false;
       sfamily = AF_UNSPEC;
@@ -425,7 +427,7 @@ struct qore_socket_private {
    DLLLOCAL int listen(int backlog = 20) {
       if (sock == QORE_INVALID_SOCKET)
 	 return QSE_NOT_OPEN;
-      if (in_op)
+      if (in_op >= 0)
          return QSE_IN_OP;
 #ifdef _Q_WINDOWS
       if (::listen(sock, backlog)) {
@@ -468,10 +470,15 @@ struct qore_socket_private {
 	    xsink->raiseException("SOCKET-NOT-OPEN", "socket must be opened, bound, and in a listening state before new connections can be accepted");
 	 return QSE_NOT_OPEN;
       }
-      if (in_op) {
+      if (in_op >= 0) {
+         if (in_op == gettid()) {
+            if (xsink)
+               se_in_op("accept", xsink);
+            return QSE_IN_OP;
+         }
          if (xsink)
-            se_in_op("accept", xsink);
-         return QSE_IN_OP;
+            se_in_op_thread("accept", xsink);
+         return QSE_IN_OP_THREAD;
       }
 
       int rc;
@@ -1584,10 +1591,14 @@ struct qore_socket_private {
 	 rc = QSE_NOT_OPEN;
 	 return 0;
       }
-      if (in_op) {
+      if (in_op >= 0) {
+         if (in_op == gettid()) {
+            if (xsink)
+               se_in_op("recv", xsink);
+            return 0;
+         }
          if (xsink)
-            se_in_op("recv", xsink);
-         rc = QSE_IN_OP;
+            se_in_op_thread("recv", xsink);
          return 0;
       }
 
@@ -1638,10 +1649,14 @@ struct qore_socket_private {
 	 rc = QSE_NOT_OPEN;
 	 return 0;
       }
-      if (in_op) {
+      if (in_op >= 0) {
+         if (in_op == gettid()) {
+            if (xsink)
+               se_in_op("recv", xsink);
+            return 0;
+         }
          if (xsink)
-            se_in_op("recv", xsink);
-         rc = QSE_IN_OP;
+            se_in_op_thread("recv", xsink);
          return 0;
       }
 
@@ -1695,10 +1710,14 @@ struct qore_socket_private {
 	 rc = QSE_NOT_OPEN;
 	 return 0;
       }
-      if (in_op) {
+      if (in_op >= 0) {
+         if (in_op == gettid()) {
+            if (xsink)
+               se_in_op("recvBinary", xsink);
+            return 0;
+         }
          if (xsink)
-            se_in_op("recvBinary", xsink);
-         rc = QSE_IN_OP;
+            se_in_op_thread("recvBinary", xsink);
          return 0;
       }
 
@@ -1744,10 +1763,14 @@ struct qore_socket_private {
 	 rc = QSE_NOT_OPEN;
 	 return 0;
       }
-      if (in_op) {
+      if (in_op >= 0) {
+         if (in_op == gettid()) {
+            if (xsink)
+               se_in_op("recvBinary", xsink);
+            return 0;
+         }
          if (xsink)
-            se_in_op("recvBinary", xsink);
-         rc = QSE_IN_OP;
+            se_in_op_thread("recvBinary", xsink);
          return 0;
       }
 
@@ -1962,10 +1985,15 @@ struct qore_socket_private {
          se_not_open(mname, xsink);
 	 return QSE_NOT_OPEN;
       }
-      if (in_op) {
+      if (in_op >= 0) {
+         if (in_op == gettid()) {
+            if (xsink)
+               se_in_op(mname, xsink);
+            return 0;
+         }
          if (xsink)
-            se_in_op(mname, xsink);
-         return QSE_IN_OP;
+            se_in_op_thread(mname, xsink);
+         return 0;
       }
 
       PrivateQoreSocketThroughputHelper th(this, true);
@@ -2157,10 +2185,15 @@ struct qore_socket_private {
 
 	 return QSE_NOT_OPEN;
       }
-      if (in_op) {
+      if (in_op >= 0) {
+         if (in_op == gettid()) {
+            if (xsink)
+               se_in_op(mname, xsink);
+            return 0;
+         }
          if (xsink)
-            se_in_op(mname, xsink);
-         return QSE_IN_OP;
+            se_in_op_thread(mname, xsink);
+         return 0;
       }
 
       PrivateQoreSocketThroughputHelper th(this, true);
@@ -2250,8 +2283,12 @@ struct qore_socket_private {
          se_not_open("readHTTPChunkedBodyBinary", xsink);
          return 0;
       }
-      if (in_op) {
-         se_in_op("readHTTPChunkedBodyBinary", xsink);
+      if (in_op >= 0) {
+         if (in_op == gettid()) {
+            se_in_op("readHTTPChunkedBodyBinary", xsink);
+            return 0;
+         }
+         se_in_op_thread("readHTTPChunkedBodyBinary", xsink);
          return 0;
       }
 
@@ -2402,8 +2439,12 @@ struct qore_socket_private {
          se_not_open("readHTTPChunkedBody", xsink);
          return 0;
       }
-      if (in_op) {
-         se_in_op("readHTTPChunkedBody", xsink);
+      if (in_op >= 0) {
+         if (in_op == gettid()) {
+            se_in_op("readHTTPChunkedBody", xsink);
+            return 0;
+         }
+         se_in_op_thread("readHTTPChunkedBody", xsink);
          return 0;
       }
 
@@ -2779,10 +2820,15 @@ struct qore_socket_private {
 	    se_not_open(meth, xsink);
 	 return QSE_NOT_OPEN;
       }
-      if (in_op) {
+      if (in_op >= 0) {
+         if (in_op == gettid()) {
+            if (xsink)
+               se_in_op(meth, xsink);
+            return 0;
+         }
          if (xsink)
-            se_in_op(meth, xsink);
-         return QSE_IN_OP;
+            se_in_op_thread(meth, xsink);
+         return 0;
       }
 
       PrivateQoreSocketThroughputHelper th(this, false);

--- a/lib/QoreSocket.cpp
+++ b/lib/QoreSocket.cpp
@@ -5,7 +5,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -40,6 +40,11 @@
 void se_in_op(const char* meth, ExceptionSink* xsink) {
    assert(xsink);
    xsink->raiseException("SOCKET-IN-CALLBACK", "calls to Socket::%s() cannot be made from a callback on an operation on the same socket", meth);
+}
+
+void se_in_op_thread(const char* meth, ExceptionSink* xsink) {
+   assert(xsink);
+   xsink->raiseException("SOCKET-IN-CALLBACK", "calls to Socket::%s() cannot be made from another thread while a callback operation is in progress on the same socket", meth);
 }
 
 void se_not_open(const char* meth, ExceptionSink* xsink) {
@@ -248,11 +253,13 @@ void concat_target(QoreString& str, const struct sockaddr *addr, const char* typ
 }
 
 qore_socket_op_helper::qore_socket_op_helper(qore_socket_private* sock) : s(sock) {
-   s->in_op = true;
+   assert(s->in_op == -1);
+   s->in_op = gettid();;
 }
 
 qore_socket_op_helper::~qore_socket_op_helper() {
-   s->in_op = false;
+   assert(s->in_op >= 0);
+   s->in_op = -1;
 }
 
 SSLSocketHelperHelper::SSLSocketHelperHelper(qore_socket_private* sock) : s(sock) {
@@ -490,6 +497,9 @@ void QoreSocket::doException(int rc, const char* meth, int timeout_ms, Exception
 	 break;
       case QSE_IN_OP:
 	 se_in_op(meth, xsink);
+	 break;
+      case QSE_IN_OP_THREAD:
+	 se_in_op_thread(meth, xsink);
 	 break;
       default:
 	 xsink->raiseException("SOCKET-ERROR", "unknown internal error code %d in Socket::%s() call", rc, meth);


### PR DESCRIPTION
…on is attempted on a socket while a background thread has a callback action in progress on that socket

also removed all *serial types from PgsqlSqlUtil.qtest since they cause tests to fail since they are not true types
