### PR TITLE
refs #552: fixes in cmake and file inclusion to compile on ubuntu 14.04

### DIFF
--- a/cmake/unix-config.h.cmake
+++ b/cmake/unix-config.h.cmake
@@ -112,7 +112,7 @@
 #cmakedefine HAVE_GETHOSTBYNAME_R
 #cmakedefine HAVE_STRTOIMAX
 #cmakedefine HAVE_STRERROR_R
-#cmakedefine STRERROR_R_CHAR_P
+#cmakedefine STRERROR_R_CHAR_P 1
 
 /* OpenSSL */
 

--- a/include/qore/intern/config.h
+++ b/include/qore/intern/config.h
@@ -38,7 +38,7 @@
 #endif
 
 #ifdef HAVE_UNIX_CONFIG_H
-#include "unix-config.h"
+#include <qore/intern/unix-config.h>
 #else
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #include "win32-config.h"

--- a/include/qore/intern/qore_socket_private.h
+++ b/include/qore/intern/qore_socket_private.h
@@ -46,9 +46,9 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
-#if defined HAVE_POLL_H && defined HAVE_POLL
+#if defined HAVE_POLL
 #include <poll.h>
-#elif defined HAVE_SYS_SELECT_H && defined HAVE_SELECT
+#elif defined HAVE_SELECT
 #include <sys/select.h>
 #elif (defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__
 #define HAVE_SELECT 1


### PR DESCRIPTION
using qit on qore-less Ubuntu 14.04 fails to compile qore due to missing dependencies and incorrect preprocessor defines. The fix possibly could break other builds, though...
