### PR TITLE
fix strerror_r code

### DIFF
--- a/cmake/unix-config.h.cmake
+++ b/cmake/unix-config.h.cmake
@@ -112,7 +112,7 @@
 #cmakedefine HAVE_GETHOSTBYNAME_R
 #cmakedefine HAVE_STRTOIMAX
 #cmakedefine HAVE_STRERROR_R
-#cmakedefine STRERROR_R_CHAR_P 1
+#cmakedefine STRERROR_R_CHAR_P
 
 /* OpenSSL */
 

--- a/lib/QoreLib.cpp
+++ b/lib/QoreLib.cpp
@@ -1412,7 +1412,7 @@ void q_strerror(QoreString &str, int err) {
 
    str.allocate(str.strlen() + STRERR_BUFSIZE);
    // ignore strerror() error message
-#if STRERROR_R_CHAR_P
+#ifdef STRERROR_R_CHAR_P
    // we can't help but get this version because some of the Linux
    // header files define _GNU_SOURCE for us :-(
    str.concat(strerror_r(err, (char* )(str.getBuffer() + str.strlen()), STRERR_BUFSIZE));


### PR DESCRIPTION
Use ifdef before STRERROR_R_CHAR_P because AC_FUNC_STRERROR_R and
QORE_STRERROR_R defines or does not define this depending on if strerror_r
returns char or int.
