### PR TITLE
refs #562 improved QUnit output when types are different but the valu…

### DIFF
--- a/lib/QoreSocket.cpp
+++ b/lib/QoreSocket.cpp
@@ -1,3 +1,4 @@
+/* -*- indent-tabs-mode: nil -*- */
 /*
   QoreSocket.cpp
 

--- a/qlib/QUnit.qm
+++ b/qlib/QUnit.qm
@@ -760,8 +760,17 @@ addTestCase(obj);
 
     #! Helper function for printing out human-readable comparison of two values.
     private string printUnexpectedData(any exp, any act, *bool neg, *bool soft_comparisons) {
-        string expected = sprintf("%N", exp);
-        string actual = neg ? "<identical>" : sprintf("%N", act);
+        string expected;
+        string actual;
+        # if values are "soft equal", then they must have different types, so we make the type differences explicit here
+        if (exp == act) {
+            expected = sprintf("(%s) %N", exp.type(), exp);
+            actual = neg ? "<identical>" : sprintf("(%s) %N", act.type(), act);
+        }
+        else {
+            expected = sprintf("%N", exp);
+            actual = neg ? "<identical>" : sprintf("%N", act);
+        }
         list expectedLines = expected.split("\n");
         list actualLines = actual.split("\n");
 
@@ -879,7 +888,7 @@ assertEqSoft("5", functionThatShouldReturnFive());
         @param name the name or description of the assertion
      */
     public assertEqSoft(any expected, any actual, *string name = NOTHING) {
-        *TestCase tc = get_thread_data("tc");
+        TestCase tc = getTestCase("assertEqSoft");
         # increment assertion count
         tc.incAssertions();
         ++num_asserts;
@@ -905,7 +914,7 @@ assertEq(5, functionThatShouldReturnFive());
         @param name the name or description of the assertion
      */
     public assertEq(any expected, any actual, *string name = NOTHING) {
-        *TestCase tc = get_thread_data("tc");
+        TestCase tc = getTestCase("assertEq");
         # increment assertion count
         tc.incAssertions();
         ++num_asserts;
@@ -958,9 +967,7 @@ assertThrows("DIVISION-BY-ZERO", "division by zero found in integer expression",
         @param args optional arguments to the code
      */
     public assertThrows(string expectedErr, *string expectedDesc, code theCode, *softlist args) {
-        *TestCase tc = get_thread_data("tc");
-        if (!tc)
-            throw "TEST-ERROR", sprintf("cannot test assertion while not executing a test case; testAssertion() can only be called in code executed in a test case (added with %s::addTestCase())", self.className());
+        TestCase tc = getTestCase("assertEqThrows");
         tc.incAssertions();
         ++num_asserts;
 
@@ -990,6 +997,14 @@ assertThrows("DIVISION-BY-ZERO", sub(int a) {print(5/a);}, 0);
      */
     public assertThrows(string expectedErr, code theCode, *softlist args) {
         assertThrows(expectedErr, NOTHING, theCode, args);
+    }
+
+    #! returns the current test case
+    TestCase getTestCase(string meth) {
+        *TestCase tc = get_thread_data("tc");
+        if (!tc)
+            throw "TEST-ERROR", sprintf("cannot test assertion while not executing a test case; %s() can only be called in code executed in a test case (added with %s::addTestCase())", meth, self.className());
+        return tc;
     }
 
     #! Fails the test anconditionally
@@ -1143,9 +1158,7 @@ fail("Unexpected code executed");
      * @return the result of the \a condition call, if the immediate value has any further use
      */
     public any testAssertion(string name, code condition, *softlist args, QUnit::AbstractTestResult expectedResult = new QUnit::TestResultSuccess()) {
-        *TestCase tc = get_thread_data("tc");
-        if (!tc)
-            throw "TEST-ERROR", sprintf("cannot test assertion %s while not executing a test case; testAssertion() can only be called in code executed in a test case (added with %s::addTestCase())", name, self.className());
+        TestCase tc = getTestCase("testAssertion");
         tc.incAssertions();
         ++num_asserts;
 


### PR DESCRIPTION
…es are equal with soft comparisons and appear equal when output with %N

new output:

<pre>
david@quasar:~/src/qore/git/qore/qlib$ qore -lQUnit -ne 'Test t("a", "1.0"); t.addTestCase("t", \t()); t.main(); sub t() { t.assertEq(1, 1n); }'
QUnit Test "a" v1.0
FAILURE: t: 1 assertion, 0 succeeded
Assertion failure at <command-line>:1
-----
    >> Expected: (integer) 1, Actual: (number) 1
-----
Ran 1 test case, 1 error (1 assertion, 0 succeeded)
</pre>
