### PR TITLE
refs #565 allow column aliases to be referred to in the where clause

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -246,6 +246,7 @@
       - implemented AbstractTable::getBulkUpsertClosure() to better support bulk SQL merge operations
       - removed all APIs that handle implicit transactions; APIs must commit transactions explicitly
       - \a orderby and \a groupby select options now take positive integers as column identifiers
+      - column aliases (defined with cop_as()) can now be used in the where hash argument and in join criteria
     - <a href="../../modules/OracleSqlUtil/html/index.html">OracleSqlUtil</a> module updates:
       - implemented support for views for DML in the OracleTable class
       - implemented support for Oracle pseudocolumns in queries

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -113,6 +113,7 @@ module SqlUtil {
     - implemented @ref SqlUtil::cop_cast() operator for converting [column] value into another datatype
     - implemented @ref SqlUtil::cop_sum() aggregate operator for returning sum of column values
     - implemented support for numeric column arguments for the @ref select_option_orderby "orderby" and @ref select_option_groupby "groupby" options
+    - column aliases (defined with @ref SqlUtil::cop_as()) can now be used in the @ref where_clauses "where hash argument" and in join criteria
     - removed all APIs that handle implicit transactions; APIs must commit transactions explicitly (<a href="https://github.com/qorelanguage/qore/issues/533">issue 533</a>)
     - fixed a bug with queries using a \a desc argument with the @ref select_option_orderby "orderby" query option with multiple sort columns; the \c "desc" string was added only to the last column but should have been added to all columns
     - fixed a bug where foreign key constraints with supporting indexes were not tracked and therefore schema alignment on DBs that automatically create indexes for foreign key constraints would fail
@@ -11655,9 +11656,8 @@ string sql = table.getSelectSql(sh, \args);
                 if (cv != "*" && !jch{tp}.describe().hasKey(cv) && !psch{cv})
                     throw "SELECT-ERROR", sprintf("%s: query references unknown column \"%s.%s\" (%y is aliased to table %y); known columns: %y", getDesc(), tp, cv, tp, jch{tp}.getSqlName(), jch{tp}.describe().keys());
             }
-            else if (psch{cv}) {
-                if (subst_psch && psch{cv}.typeCode() == NT_STRING)
-                    cv = psch{cv};
+            else if (psch{cv} && subst_psch && psch{cv}.typeCode() == NT_STRING) {
+                return psch{cv};
             }
             else if (ch) {
                 if (!ch{cv} && !psch{cv})


### PR DESCRIPTION
this was partially implemented in the implementation for #509 but was broken when aliases were used in complex queries with join clauses
