### PR TITLE
temporary parse context during cmd line define processing

### DIFF
--- a/command-line.cpp
+++ b/command-line.cpp
@@ -948,7 +948,7 @@ int qore_main_intern(int argc, char* argv[], int other_po) {
 	    qpgm->parse(cl_pgm, "<command-line>", &xsink, &wsink, warnings);
 	 else if (program_file_name)
 	    qpgm->parseFile(program_file_name, &xsink, &wsink, warnings, only_first_except);
-	 else if (!xsink.isException())
+	 else
 	    qpgm->parse(stdin, "<stdin>", &xsink, &wsink, warnings);
       }
 

--- a/command-line.cpp
+++ b/command-line.cpp
@@ -889,12 +889,18 @@ int qore_main_intern(int argc, char* argv[], int other_po) {
    ExceptionSink wsink, xsink;
    {
       QoreProgramHelper qpgm(parse_options, xsink);
+      bool mod_errs = false;
 
       // set parse defines
       qpgm->parseCmdLineDefines(defmap, xsink, wsink, warnings);
 
+      if (xsink.isException()) {
+         rc = 2;
+         xsink.handleExceptions();
+         goto exit;
+      }
+
       // load any modules requested on the command-line
-      bool mod_errs = false;
       for (cl_mod_list_t::iterator i = cl_mod_list.begin(), e = cl_mod_list.end(); i != e; ++i) {
 	 // display any error messages
 	 SimpleRefHolder<QoreStringNode> err(MM.parseLoadModule((*i).c_str(), *qpgm));

--- a/command-line.cpp
+++ b/command-line.cpp
@@ -891,8 +891,7 @@ int qore_main_intern(int argc, char* argv[], int other_po) {
       QoreProgramHelper qpgm(parse_options, xsink);
 
       // set parse defines
-      for (defmap_t::iterator i = defmap.begin(), e = defmap.end(); i != e; ++i)
-	 qpgm->parseDefine(i->first.c_str(), i->second.c_str());
+      qpgm->parseCmdLineDefines(defmap, xsink, wsink, warnings);
 
       // load any modules requested on the command-line
       bool mod_errs = false;
@@ -949,7 +948,7 @@ int qore_main_intern(int argc, char* argv[], int other_po) {
 	    qpgm->parse(cl_pgm, "<command-line>", &xsink, &wsink, warnings);
 	 else if (program_file_name)
 	    qpgm->parseFile(program_file_name, &xsink, &wsink, warnings, only_first_except);
-	 else
+	 else if (!xsink.isException())
 	    qpgm->parse(stdin, "<stdin>", &xsink, &wsink, warnings);
       }
 

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -451,6 +451,7 @@
     - fixed a bug where local variable declarations in class member initialization expressions caused a crash (<a href="https://github.com/qorelanguage/qore/issues/574">issue 574</a>)
     - fixed a bug where HTTP data in HTTP socket events was modified even though it was shared which caused data consistency problems and crashes in the worst case (<a href="https://github.com/qorelanguage/qore/issues/576">issue 576</a>)
     - fixed a bug where the `+=` operator handled NOTHING values incorrectly (<a href="https://github.com/qorelanguage/qore/issues/582">issue 582</a>)
+    - fixed a bug where the a non-numeric define specified on the command line could cause a crash (<a href="https://github.com/qorelanguage/qore/issues/583">issue 583</a>)
 
     @section qore_0811 Qore 0.8.11
 

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -451,7 +451,7 @@
     - fixed a bug where local variable declarations in class member initialization expressions caused a crash (<a href="https://github.com/qorelanguage/qore/issues/574">issue 574</a>)
     - fixed a bug where HTTP data in HTTP socket events was modified even though it was shared which caused data consistency problems and crashes in the worst case (<a href="https://github.com/qorelanguage/qore/issues/576">issue 576</a>)
     - fixed a bug where the `+=` operator handled NOTHING values incorrectly (<a href="https://github.com/qorelanguage/qore/issues/582">issue 582</a>)
-    - fixed a bug where the a non-numeric define specified on the command line could cause a crash (<a href="https://github.com/qorelanguage/qore/issues/583">issue 583</a>)
+    - fixed a bug where a non-numeric define specified on the command line could cause a crash (<a href="https://github.com/qorelanguage/qore/issues/583">issue 583</a>)
 
     @section qore_0811 Qore 0.8.11
 

--- a/include/qore/QoreProgram.h
+++ b/include/qore/QoreProgram.h
@@ -586,15 +586,13 @@ public:
    */
    DLLEXPORT void parseDefine(const char* str, AbstractQoreNode* val);
 
-   //! defines a parse-time variable; call only at parse time (or before parsing)
-   /** @param str the name of the variable
-       @param val a string value that will be parsed and converted to a qore value
-
-       @note if this function is called at runtime it could cause a crash
-
-       @see runtimeDefine()
+   //! defines a parse-time variables
+   /** @param defmap a map of variable names to values
+       @param xs exception sink for errors
+       @param ws exception sink for warnings
+       @param w warnings mask
    */
-   DLLEXPORT void parseDefine(const char* str, const char* val);
+   DLLEXPORT void parseCmdLineDefines(const std::map<std::string, std::string> defmap, ExceptionSink& xs, ExceptionSink& ws, int w);
 
    DLLLOCAL QoreProgram(QoreProgram* pgm, int64 po, bool ec = false, const char* ecn = 0);
 

--- a/lib/QoreProgram.cpp
+++ b/lib/QoreProgram.cpp
@@ -1227,15 +1227,28 @@ void QoreProgram::parseDefine(const char* str, AbstractQoreNode* val) {
    priv->parseDefine(qoreCommandLineLocation, str, val);
 }
 
-void QoreProgram::parseDefine(const char* str, const char* val) {
-   QoreString arg(val);
-   arg.trim();
-
-   bool ok;
-   AbstractQoreNode* v = qore_parse_get_define_value(str, arg, ok);
-   if (!ok)
+void QoreProgram::parseCmdLineDefines(const std::map<std::string, std::string> defmap, ExceptionSink& xs, ExceptionSink& ws, int wm) {
+   ProgramRuntimeParseCommitContextHelper pch(&xs, this);
+   if (xs)
       return;
-   priv->parseDefine(qoreCommandLineLocation, str, v);
+
+   priv->startParsing(&xs, &ws, wm);
+
+   for (std::map<std::string, std::string>::const_iterator it = defmap.begin(); it != defmap.end(); ++it) {
+      const char *str = it->first.c_str();
+      const char *val = it->second.c_str();
+      QoreString arg(val);
+      arg.trim();
+
+      bool ok;
+      AbstractQoreNode* v = qore_parse_get_define_value(str, arg, ok);
+      if (!ok)
+         break;
+      priv->parseDefine(qoreCommandLineLocation, str, v);
+   }
+
+   priv->parseSink = 0;
+   priv->warnSink = 0;
 }
 
 QoreProgram* QoreProgram::programRefSelf() const {


### PR DESCRIPTION
refs #583 fixes a crash when non-numeric define value is specified on the command line
