### PR TITLE
refs #584 fixed TimeZone::date(string) to always return a date in the…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -455,6 +455,7 @@
     - fixed a bug where a non-numeric define specified on the command line could cause a crash (<a href="https://github.com/qorelanguage/qore/issues/583">issue 583</a>)
     - fixed a bug where the @ref Qore::SQL::SQLStatement::describe() method would not grab the transation lock even when statements were implicitly executed (<a href="https://github.com/qorelanguage/qore/issues/591">issue 591</a>)
     - fixed the order of initialization of class members (<a href="https://github.com/qorelanguage/qore/issues/42">issue 42</a>)
+    - fixed a bug in @ref Qore::TimeZone::date(string) where the date returned was in the current contextual time zone and not that of the object (<a href="https://github.com/qorelanguage/qore/issues/584">issue 584</a>)
 
     @section qore_0811 Qore 0.8.11
 

--- a/examples/test/qore/vars/date.qtest
+++ b/examples/test/qore/vars/date.qtest
@@ -212,6 +212,9 @@ class DateTest inherits QUnit::Test {
 
         # test for issue #259
         assertEq(7200, new TimeZone("Europe/Vienna").date("1980-07-01").info().utc_secs_east);
+
+        # test for issue #584
+        assertEq(-14400, new TimeZone("America/New_York").date("1980-07-01").info().utc_secs_east);
     }
 
     testDate(date d, int y, int w, int day, int n, reference ri) {

--- a/lib/DateTimeNode.cpp
+++ b/lib/DateTimeNode.cpp
@@ -5,7 +5,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/lib/ql_time.qpp
+++ b/lib/ql_time.qpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -341,7 +341,7 @@ DateTimeNode* make_date_with_mask(const AbstractQoreZoneInfo* tz, const QoreStri
 //@{
 
 //! Returns the current date and time with a resolution to the millisecond
-/** 
+/**
     @return the current date and time with a resolution to the millisecond
 
     @par Example:
@@ -364,7 +364,7 @@ date now_ms() [flags=CONSTANT] {
 }
 
 //! Returns the current date and time with a resolution to the microsecond
-/** 
+/**
     @return the current date and time with a resolution to the microsecond
 
     @par Example:
@@ -387,7 +387,7 @@ date now_us() [flags=CONSTANT] {
 }
 
 //! Returns the current UTC date and time with a resolution to the microsecond
-/** 
+/**
     @return the current UTC date and time with a resolution to the microsecond
 
     @par Example:
@@ -404,7 +404,7 @@ date now_utc() [flags=CONSTANT] {
 }
 
 //! Returns a formatted string for a date argument passed
-/** 
+/**
     @param format a string giving the format for the date; see @ref date_formatting for more information about this string
     @param dt the date to use for the string output
 
@@ -425,14 +425,14 @@ string format_date(string format, date dt) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing format_date() [flags=RUNTIME_NOOP] {
 }
 
-//! Returns the current date and time with a resolution to the second 
-/** 
-    @return the current date and time with a resolution to the second 
+//! Returns the current date and time with a resolution to the second
+/**
+    @return the current date and time with a resolution to the second
 
     @par Example:
     @code{.py}
@@ -450,9 +450,9 @@ date now() [flags=CONSTANT] {
    return DateTimeNode::makeAbsolute(currentTZ(), (int64)time(0), 0);
 }
 
-//! Returns the current date and time with a resolution to the second 
-/** 
-    @return the current date and time with a resolution to the second 
+//! Returns the current date and time with a resolution to the second
+/**
+    @return the current date and time with a resolution to the second
 
     @par Example:
     @code{.py}
@@ -468,7 +468,7 @@ date localtime() [flags=CONSTANT] {
 }
 
 //! Returns the date and time in the local time zone corresponding to the integer arguments passed, which are interpreted as the number of seconds and microseconds since Jan 1, 1970, 00:00:00 Z (UTC)
-/** 
+/**
     @param secs the number of seconds and microseconds since Jan 1, 1970, 00:00:00 Z (UTC)
     @param us a microsecond offset for the time returned
 
@@ -486,7 +486,7 @@ date localtime(softint secs, softint us = 0) [flags=CONSTANT] {
 }
 
 //! Returns the date and time in the local time zone corresponding to the date argument passed
-/** 
+/**
     @param dt a date to process; if the date passed is in the local time zone, then the same value is returned
 
     @return the date and time in the local time zone corresponding to the date argument passed
@@ -495,7 +495,7 @@ date localtime(softint secs, softint us = 0) [flags=CONSTANT] {
     @code{.py}
 date dt = localtime(2012-01-19T15:00:00-07:00);
     @endcode
-    
+
     @see gmtime(date)
 */
 date localtime(date dt) [flags=CONSTANT] {
@@ -503,7 +503,7 @@ date localtime(date dt) [flags=CONSTANT] {
 }
 
 //! Returns the current UTC (GMT) time with a resolution of a second
-/** 
+/**
     @return the current UTC (GMT) time with a resolution of a second
 
     @par Example:
@@ -520,7 +520,7 @@ date gmtime() [flags=CONSTANT] {
 }
 
 //! Returns a date/time value in UTC (GMT) from arguments giving the number of seconds and microseconds since Jan 1, 1970, 00:00:00 Z (UTC)
-/** 
+/**
     @param secs the number of seconds and microseconds since Jan 1, 1970, 00:00:00 Z (UTC)
     @param us a microsecond offset for the time returned
 
@@ -538,7 +538,7 @@ date gmtime(softint secs, softint us = 0) [flags=CONSTANT] {
 }
 
 //! Returns the date and time in UTC (GMT) corresponding to the date argument passed
-/** 
+/**
     @param dt a date to process; if the date passed is already in UTC, then the same value is returned
 
     @return the date and time in UTC (GMT) corresponding to the date argument passed
@@ -555,11 +555,11 @@ date gmtime(date dt) [flags=CONSTANT] {
 }
 
 //! Returns the number of seconds since January 1, 1970 00:00:00 in the local time zone for the given date
-/** 
+/**
     @param dt The date to process
 
     @return the number of seconds since January 1, 1970 00:00:00 in the local time zone for the given date
-    
+
     @par Example:
     @code{.py}
 int secs = timegm(dt);
@@ -572,13 +572,13 @@ int timegm(date dt) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing timegm() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns the number of seconds of the date and time in local time passed since Jan 1, 1970, 00:00:00 Z (UTC); negative values are returned for dates before the epoch
-/** 
+/**
     @param dt The date to process
 
     @return the number of seconds of the date and time in local time passed since Jan 1, 1970, 00:00:00 Z (UTC); negative values are returned for dates before the epoch
@@ -597,13 +597,13 @@ int get_epoch_seconds(date dt) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing get_epoch_seconds() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns the number of seconds of the date and time in local time passed since Jan 1, 1970, 00:00:00 Z (UTC); negative values are returned for dates before the epoch
-/** 
+/**
     @param dt The date to process
 
     @return the number of seconds of the date and time in local time passed since Jan 1, 1970, 00:00:00 Z (UTC); negative values are returned for dates before the epoch
@@ -622,13 +622,13 @@ int mktime(date dt) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing mktime() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns a @ref relative_dates "relative date/time value" in years based on the integer argument passed to be used in date arithmetic
-/** 
+/**
     @param years the number of years to return
 
     @return a @ref relative_dates "relative date/time value" in years based on the integer argument passed to be used in date arithmetic
@@ -652,13 +652,13 @@ date years(softint years) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing years() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns a @ref relative_dates "relative date/time value" in months based on the integer argument passed to be used in date arithmetic
-/** 
+/**
     @param months the number of months to return
 
     @return a @ref relative_dates "relative date/time value" in months based on the integer argument passed to be used in date arithmetic
@@ -682,13 +682,13 @@ date months(softint months) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing months() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns a @ref relative_dates "relative date/time value" in days based on the integer argument passed to be used in date arithmetic
-/** 
+/**
     @param days the number of days to return
 
     @return a @ref relative_dates "relative date/time value" in days based on the integer argument passed to be used in date arithmetic
@@ -712,13 +712,13 @@ date days(softint days) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing days() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns a @ref relative_dates "relative date/time value" in hours based on the integer argument passed to be used in date arithmetic
-/** 
+/**
     @param hours the number of hours to return
 
     @return a @ref relative_dates "relative date/time value" in hours based on the integer argument passed to be used in date arithmetic
@@ -742,13 +742,13 @@ date hours(softint hours) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing hours() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns a @ref relative_dates "relative date/time value" in minutes based on the integer argument passed to be used in date arithmetic
-/** 
+/**
     @param minutes the number of minutes to return
 
     @return a @ref relative_dates "relative date/time value" in minutes based on the integer argument passed to be used in date arithmetic
@@ -772,13 +772,13 @@ date minutes(softint minutes) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing minutes() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns a @ref relative_dates "relative date/time value" in seconds based on the integer argument passed to be used in date arithmetic
-/** 
+/**
     @param seconds the number of seconds to return
 
     @return a @ref relative_dates "relative date/time value" in seconds based on the integer argument passed to be used in date arithmetic
@@ -802,13 +802,13 @@ date seconds(softint seconds) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing seconds() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns a @ref relative_dates "relative date/time value" in milliseconds based on the integer argument passed to be used in date arithmetic
-/** 
+/**
     @param ms the number of milliseconds to return
 
     @return a @ref relative_dates "relative date/time value" in milliseconds based on the integer argument passed to be used in date arithmetic
@@ -827,7 +827,7 @@ date rd = milliseconds(100);
     - seconds(softint)
     - microseconds(softint)
 */
-date milliseconds(softint ms) [flags=CONSTANT] {   
+date milliseconds(softint ms) [flags=CONSTANT] {
    int64 secs = ms / 1000;
    ms -= (secs * 1000);
    int64 minutes = secs / 60;
@@ -839,13 +839,13 @@ date milliseconds(softint ms) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing milliseconds() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns a @ref relative_dates "relative date/time value" in microseconds based on the integer argument passed to be used in date arithmetic
-/** 
+/**
     @param us the number of microseconds to return
 
     @return a @ref relative_dates "relative date/time value" in microseconds based on the integer argument passed to be used in date arithmetic
@@ -876,7 +876,7 @@ date microseconds(softint us) [flags=CONSTANT] {
 }
 
 //! Returns an integer corresponding to the literal year value in the date (does not calculate a duration)
-/** 
+/**
     @param dt the date value; can be either a @ref relative_dates "relative" or @ref absolute_dates "absolute" date
 
     @return an integer corresponding to the year value in the date
@@ -893,13 +893,13 @@ int get_years(date dt) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing get_years() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns an integer corresponding to the literal month value in the date (does not calculate a duration)
-/** 
+/**
     @param dt the date value; can be either a @ref relative_dates "relative" or @ref absolute_dates "absolute" date
 
     @return an integer corresponding to the month value in the date
@@ -916,13 +916,13 @@ int get_months(date dt) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing get_months() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns an integer corresponding to the literal day value in the date (does not calculate a duration)
-/** 
+/**
     @param dt the date value; can be either a @ref relative_dates "relative" or @ref absolute_dates "absolute" date
 
     @return an integer corresponding to the day value in the date
@@ -939,13 +939,13 @@ int get_days(date dt) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing get_days() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns an integer corresponding to the literal hour value in the date (does not calculate a duration)
-/** 
+/**
     @param dt the date value; can be either a @ref relative_dates "relative" or @ref absolute_dates "absolute" date
 
     @return an integer corresponding to the hour value in the date
@@ -962,13 +962,13 @@ int get_hours(date dt) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing get_hours() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns an integer corresponding to the literal minute value in the date (does not calculate a duration)
-/** 
+/**
     @param dt the date value; can be either a @ref relative_dates "relative" or @ref absolute_dates "absolute" date
 
     @return an integer corresponding to the minute value in the date
@@ -985,13 +985,13 @@ int get_minutes(date dt) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing get_minutes() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns an integer corresponding to the literal second value in the date (does not calculate a duration)
-/** 
+/**
     @param dt the date value; can be either a @ref relative_dates "relative" or @ref absolute_dates "absolute" date
 
     @return an integer corresponding to the literal second value in the date (does not calculate a duration)
@@ -1010,13 +1010,13 @@ int get_seconds(date dt) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing get_seconds() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns an integer corresponding to the literal millisecond value in the date (does not calculate a duration)
-/** 
+/**
     @param dt the date value; can be either a @ref relative_dates "relative" or @ref absolute_dates "absolute" date
 
     @return an integer corresponding to the literal millisecond value in the date (does not calculate a duration)
@@ -1035,13 +1035,13 @@ int get_milliseconds(date dt) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing get_milliseconds() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns an integer corresponding to the literal microsecond value in the date (does not calculate a duration)
-/** 
+/**
     @param dt the date value; can be either a @ref relative_dates "relative" or @ref absolute_dates "absolute" date
 
     @return an integer corresponding to the literal microsecond value in the date (does not calculate a duration)
@@ -1060,7 +1060,7 @@ int get_microseconds(date dt) [flags=CONSTANT] {
 }
 
 //! Returns midnight on the date passed (strips the time component on the new value)
-/** 
+/**
     @param dt the date to process
 
     @return midnight on the date passed (strips the time component on the new value)
@@ -1079,13 +1079,13 @@ date get_midnight(date dt) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing get_midnight() [flags=RUNTIME_NOOP] {
 }
 
 //! Returns an integer representing the ordinal day number in the year (corresponding to the <a href="http://en.wikipedia.org/wiki/ISO_8601#Ordinal_dates">ISO-8601 day number</a>) for the @ref absolute_dates "absolute date" value passed
-/** 
+/**
     @param dt an @ref absolute_dates "absolute date" value to get the ordinal day number
 
     @return an integer representing the ordinal day number in the year (corresponding to the <a href="http://en.wikipedia.org/wiki/ISO_8601#Ordinal_dates">ISO-8601 day number</a>) for the @ref absolute_dates "absolute date" value passed; if a @ref relative_dates "relative date" value is passed, then this function will return 0
@@ -1097,13 +1097,13 @@ int getDayNumber(date dt) [flags=CONSTANT,DEPRECATED] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing getDayNumber() [flags=RUNTIME_NOOP,DEPRECATED] {
 }
 
 //! Returns an integer representing the ordinal day number in the year (corresponding to the <a href="http://en.wikipedia.org/wiki/ISO_8601#Ordinal_dates">ISO-8601 day number</a>) for the @ref absolute_dates "absolute date" value passed
-/** 
+/**
     @param dt an @ref absolute_dates "absolute date" value to get the ordinal day number
 
     @return an integer representing the ordinal day number in the year (corresponding to the <a href="http://en.wikipedia.org/wiki/ISO_8601#Ordinal_dates">ISO-8601 day number</a>) for the @ref absolute_dates "absolute date" value passed; if a @ref relative_dates "relative date" value is passed, then this function will return 0
@@ -1122,7 +1122,7 @@ int get_day_number(date dt) [flags=CONSTANT] {
 }
 
 //! Returns an integer representing the day of the week for the @ref absolute_dates "absolute date" value passed (0=Sunday, 6=Saturday)
-/** 
+/**
     @param dt an @ref absolute_dates "absolute date" value to get the number for the day of the week
 
     @return an integer representing the day of the week for the @ref absolute_dates "absolute date" value passed (0=Sunday, 6=Saturday); if a @ref relative_dates "relative date" value is passed, then this function will return 0
@@ -1136,13 +1136,13 @@ int getDayOfWeek(date dt) [flags=CONSTANT,DEPRECATED] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing getDayOfWeek() [flags=RUNTIME_NOOP,DEPRECATED] {
 }
 
 //! Returns an integer representing the day of the week for the @ref absolute_dates "absolute date" value passed (0=Sunday, 6=Saturday)
-/** 
+/**
     @param dt an @ref absolute_dates "absolute date" value to get the number for the day of the week
 
     @return an integer representing the day of the week for the @ref absolute_dates "absolute date" value passed (0=Sunday, 6=Saturday); if a @ref relative_dates "relative date" value is passed, then this function will return 0
@@ -1163,7 +1163,7 @@ int get_day_of_week(date dt) [flags=CONSTANT] {
 }
 
 //! Returns an integer representing the ISO-8601 day of the week for the @ref absolute_dates "absolute date" value passed (1=Monday, 7=Sunday)
-/** 
+/**
     @param dt an @ref absolute_dates "absolute date" value to get the number for the day of the week
 
     @return an integer representing the day of the week for the @ref absolute_dates "absolute date" value passed (1=Monday, 7=Sunday); if a @ref relative_dates "relative date" value is passed, then this function will return 7
@@ -1178,13 +1178,13 @@ int getISODayOfWeek(date dt) [flags=CONSTANT,DEPRECATED] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing getISODayOfWeek() [flags=RUNTIME_NOOP,DEPRECATED] {
 }
 
 //! Returns an integer representing the ISO-8601 day of the week for the @ref absolute_dates "absolute date" value passed (1=Monday, 7=Sunday)
-/** 
+/**
     @param dt an @ref absolute_dates "absolute date" value to get the number for the day of the week
 
     @return an integer representing the day of the week for the @ref absolute_dates "absolute date" value passed (1=Monday, 7=Sunday); if a @ref relative_dates "relative date" value is passed, then this function will return 7
@@ -1228,7 +1228,7 @@ hash getISOWeekHash(date dt) [flags=CONSTANT,DEPRECATED] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing getISOWeekHash() [flags=RUNTIME_NOOP,DEPRECATED] {
 }
@@ -1263,7 +1263,7 @@ hash get_iso_week_hash(date dt) [flags=CONSTANT] {
 }
 
 //! Returns a string representing the ISO-8601 calendar week information for the @ref absolute_dates "absolute date" passed (ex: 2006-01-01 = "2005-W52-7")
-/** 
+/**
     @param dt the date to get information for
 
     @return a string representing the ISO-8601 calendar week information for the @ref absolute_dates "absolute date" passed (ex: 2006-01-01 = "2005-W52-7"); if a @ref relative_dates "relative date" value is passed, then this function will return \c "1970-W01-1"
@@ -1286,13 +1286,13 @@ string getISOWeekString(date dt) [flags=CONSTANT,DEPRECATED] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing getISOWeekString() [flags=RUNTIME_NOOP,DEPRECATED] {
 }
 
 //! Returns a string representing the ISO-8601 calendar week information for the @ref absolute_dates "absolute date" passed (ex: 2006-01-01 = "2005-W52-7")
-/** 
+/**
     @param dt the date to get information for
 
     @return a string representing the ISO-8601 calendar week information for the @ref absolute_dates "absolute date" passed (ex: 2006-01-01 = "2005-W52-7"); if a @ref relative_dates "relative date" value is passed, then this function will return \c "1970-W01-1"
@@ -1358,14 +1358,14 @@ date get_date_from_iso_week(softint year, softint week, softint day = 1) [flags=
 }
 
 //! Returns an integer representing the system time in milliseconds (1/1000 second intervals since Jan 1, 1970 00:00)
-/** 
+/**
     @return an integer representing the system time in milliseconds (1/1000 second intervals since Jan 1, 1970 00:00)
 
     @par Example:
     @code{.py}
 int ms = clock_getmillis();
     @endcode
-    
+
     @see
     - clock_getnanos()
     - clock_getmicros()
@@ -1375,7 +1375,7 @@ int clock_getmillis() [flags=CONSTANT] {
 }
 
 //! Returns an integer representing the system time in nanoseconds (1/1000000000 second intervals) since Jan 1, 1970 00:00:00Z
-/** 
+/**
     @return an integer representing the system time in nanoseconds (1/1000000000 second intervals) since Jan 1, 1970 00:00:00Z
 
     @par Example:
@@ -1392,7 +1392,7 @@ int clock_getnanos() [flags=CONSTANT] {
 }
 
 //! Returns an integer representing the system time in microseconds (1/1000000 second intervals) since Jan 1, 1970 00:00:00Z
-/** 
+/**
     @return an integer representing the system time in microseconds (1/1000000 second intervals) since Jan 1, 1970 00:00:00Z
 
     @par Example:
@@ -1425,7 +1425,7 @@ date date_ms(softint ms) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 nothing date_ms() [flags=RUNTIME_NOOP] {
 }
@@ -1493,12 +1493,12 @@ int ms = get_duration_milliseconds(PT2M15S3u); # returns 135000
     - get_duration_seconds()
     - get_duration_microseconds()
 */
-int get_duration_milliseconds(date dt) [flags=CONSTANT] {  
+int get_duration_milliseconds(date dt) [flags=CONSTANT] {
    return dt->getRelativeMilliseconds();
 }
 
 //! Returns an integer value representing the the number of microseconds of duration in the value of the date passed (can be either a @ref relative_dates "relative" or @ref absolute_dates "absolute" date)
-/** 
+/**
     @param dt a @ref relative_dates "relative" or @ref absolute_dates "absolute" date argument
 
     @return an integer value representing the the number of microseconds of duration in the value of the date passed; if the argument is a @ref relative_dates "relative date", the value is normalized to microseconds and the integer microseconds value is returned, if the argument is an @ref absolute_dates "absolute date", the duration in microseconds is calculated from the present time; so if the present time is sent as an argument, 0 is returned, if a future date is used, the number of microseconds from the present time to the future date is returned, if an @ref absolute_dates "absolute date" in the past is passed as an argument, also 0 is returned (the function does not calculate microsecond differences for @ref absolute_dates "absolute dates" in the past (for this use @ref date_time_arithmetic instead); this function can only return a negative value if passed a relative date/time value
@@ -1549,7 +1549,7 @@ float get_duration_seconds_f(date dt) [flags=CONSTANT] {
 }
 
 //! Returns a hash of @ref date_info_hash "broken-down date/time information" for the given date argument (can be either a @ref relative_dates "relative" or @ref absolute_dates "absolute" date)
-/** 
+/**
     @param dt the date to return information for
 
     @return a hash of @ref date_info_hash "broken-down date/time information" for the given date argument
@@ -1566,7 +1566,7 @@ hash date_info(date dt) [flags=CONSTANT] {
 }
 
 //! Returns a hash of @ref date_info_hash "broken-down date/time information" for the current date and time
-/** 
+/**
     @return a hash of @ref date_info_hash "broken-down date/time information" for the current date and time
 
     @par Example:
@@ -1583,7 +1583,7 @@ hash date_info() [flags=CONSTANT] {
 }
 
 //! Returns @ref True if the argument is an @ref relative_dates "relative date/time value", @ref False if not
-/** 
+/**
     @param dt the date to check
 
     @return @ref True if the argument is an @ref relative_dates "relative date/time value", @ref False if not
@@ -1600,14 +1600,14 @@ bool is_date_relative(date dt) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 bool is_date_relative() [flags=NOOP] {
    return false;
 }
 
 //! Returns @ref True if the argument is an @ref absolute_dates "absolute date/time value", @ref False if not
-/** 
+/**
     @param dt the date to check
 
     @return @ref True if the argument is an @ref absolute_dates "absolute date/time value", @ref False if not
@@ -1624,7 +1624,7 @@ bool is_date_absolute(date dt) [flags=CONSTANT] {
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
-/** 
+/**
  */
 bool is_date_absolute() [flags=NOOP] {
    return false;
@@ -1634,7 +1634,7 @@ bool is_date_absolute() [flags=NOOP] {
 /** This function is included because the date() function is used to convert values to dates (similar to a C/C++ cast)
 
     @param dt the date to return
-    
+
     @return the date passed
  */
 date date(date dt) [flags=CONSTANT] {
@@ -1642,7 +1642,7 @@ date date(date dt) [flags=CONSTANT] {
 }
 
 //! Converts the argument to a date and returns the date
-/** 
+/**
     @param dtstr string a string to bo converted literally to an @ref absolute_dates "absolute date/time value"; if no time zone information is present, the local time zone is assumed
 
     @return the @ref absolute_dates "absolute date/time value" corresponding to the string argument passed
@@ -1666,7 +1666,7 @@ date date(string dtstr) [flags=CONSTANT] {
 }
 
 //! The argument is assumed to be the number of seconds and fractions of a second since 1970-01-01 in the local time zone; this value is used to produce the date value that is returned
-/** 
+/**
     @param f the number of seconds and fractions of a second since 1970-01-01 in the local time zone
 
     @return a date corresponding to the number of seconds and fractions of a second since 1970-01-01 in the local time zone passed as the sole argument
@@ -1681,7 +1681,7 @@ date date(float f) [flags=CONSTANT] {
 }
 
 //! The argument is assumed to be the number of seconds since 1970-01-01 in the local time zone; this value is used to produce the date value that is returned
-/** 
+/**
     @param i the number of seconds since 1970-01-01 in the local time zone
 
     @return a date corresponding to the number of seconds since 1970-01-01 in the local time zone passed as the sole argument
@@ -1714,10 +1714,10 @@ date date(null[doc] null) [flags=CONSTANT] {
 }
 
 //! Returns the @ref date "date/time" value corresponding to parsing a string argument according to a @ref date_mask "format mask"
-/** 
+/**
     @param dtstr a string giving a date
     @param mask the mask for the date value; see @ref date_mask for information on the format of the @ref date_mask "format mask"
-    
+
     @return the @ref date "date/time" value corresponding to parsing the \a dtstr string argument according to \a mask serving as a @ref date_mask "format mask"
 
     @par Example:

--- a/lib/qore_date_private.cpp
+++ b/lib/qore_date_private.cpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -197,7 +197,7 @@ void qore_absolute_time::set(const char* str, const AbstractQoreZoneInfo* n_zone
 
    // we need at least YYYYMMDD
    if (len < 8) {
-      set(zone, 0, 0);
+      set(n_zone, 0, 0);
       return;
    }
 
@@ -205,7 +205,7 @@ void qore_absolute_time::set(const char* str, const AbstractQoreZoneInfo* n_zone
 
    int year = get_uint(p, 4);
    if (year < 0) {
-      set(zone, 0, 0);
+      set(n_zone, 0, 0);
       return;
    }
 
@@ -217,7 +217,7 @@ void qore_absolute_time::set(const char* str, const AbstractQoreZoneInfo* n_zone
 
    int month = get_uint(p, 2);
    if (month < 0) {
-      set(zone, year, 1, 1, 0, 0, 0, 0);
+      set(n_zone, year, 1, 1, 0, 0, 0, 0);
       return;
    }
 
@@ -225,14 +225,14 @@ void qore_absolute_time::set(const char* str, const AbstractQoreZoneInfo* n_zone
       if (*p == '-')
          ++p;
       else {
-         set(zone, year, month, 1, 0, 0, 0, 0);
+         set(n_zone, year, month, 1, 0, 0, 0, 0);
          return;
       }
    }
 
    int day = get_uint(p, 2);
    if (day < 0) {
-      set(zone, year, month, 1, 0, 0, 0, 0);
+      set(n_zone, year, month, 1, 0, 0, 0, 0);
       return;
    }
 
@@ -248,7 +248,7 @@ void qore_absolute_time::set(const char* str, const AbstractQoreZoneInfo* n_zone
 
    int hour = get_uint(p, 2);
    if (hour < 0) {
-      set(zone, year, month, day, 0, 0, 0, 0);
+      set(n_zone, year, month, day, 0, 0, 0, 0);
       return;
    }
 
@@ -260,7 +260,7 @@ void qore_absolute_time::set(const char* str, const AbstractQoreZoneInfo* n_zone
 
    int minute = get_uint(p, 2);
    if (minute < 0) {
-      set(zone, year, month, day, hour, 0, 0, 0);
+      set(n_zone, year, month, day, hour, 0, 0, 0);
       return;
    }
 
@@ -268,19 +268,19 @@ void qore_absolute_time::set(const char* str, const AbstractQoreZoneInfo* n_zone
       if (*p == ':')
          ++p;
       else {
-         set(zone, year, month, day, hour, minute, 0, 0);
+         set(n_zone, year, month, day, hour, minute, 0, 0);
          return;
       }
    }
 
    int second = get_uint(p, 2);
    if (second < 0) {
-      set(zone, year, month, day, hour, minute, 0, 0);
+      set(n_zone, year, month, day, hour, minute, 0, 0);
       return;
    }
 
    if (!*p) {
-      set(zone, year, month, day, hour, minute, second, 0);
+      set(n_zone, year, month, day, hour, minute, second, 0);
       return;
    }
 
@@ -288,7 +288,7 @@ void qore_absolute_time::set(const char* str, const AbstractQoreZoneInfo* n_zone
    if (*p == '.') {
       ++p;
       if (!isdigit(*p)) {
-         set(zone, year, month, day, hour, minute, second, 0);
+         set(n_zone, year, month, day, hour, minute, second, 0);
          return;
       }
 
@@ -311,7 +311,7 @@ void qore_absolute_time::set(const char* str, const AbstractQoreZoneInfo* n_zone
       }
 
       if (!*p) {
-         set(zone, year, month, day, hour, minute, second, us);
+         set(n_zone, year, month, day, hour, minute, second, us);
          return;
       }
    }
@@ -323,7 +323,7 @@ void qore_absolute_time::set(const char* str, const AbstractQoreZoneInfo* n_zone
       ++p;
 
    if (*p == 'Z') {
-      zone = 0;
+      n_zone = 0;
       ++p;
    }
    else if (*p == '+' || *p == '-') {
@@ -331,7 +331,7 @@ void qore_absolute_time::set(const char* str, const AbstractQoreZoneInfo* n_zone
 
       ++p;
       if (!isdigit(*p)) {
-         set(zone, year, month, day, hour, minute, second, us);
+         set(n_zone, year, month, day, hour, minute, second, us);
          return;
       }
 
@@ -350,8 +350,8 @@ void qore_absolute_time::set(const char* str, const AbstractQoreZoneInfo* n_zone
 
 	 if (!isdigit(*p)) {
             // ignore any time zone passed
-            zone = findCreateOffsetZone(offset * mult);
-            set(zone, year, month, day, hour, minute, second, us);
+            n_zone = findCreateOffsetZone(offset * mult);
+            set(n_zone, year, month, day, hour, minute, second, us);
             return;
          }
 
@@ -370,8 +370,8 @@ void qore_absolute_time::set(const char* str, const AbstractQoreZoneInfo* n_zone
 
 	    if (!isdigit(*p)) {
                // ignore any time zone passed
-               zone = findCreateOffsetZone(offset * mult);
-               set(zone, year, month, day, hour, minute, second, us);
+               n_zone = findCreateOffsetZone(offset * mult);
+               set(n_zone, year, month, day, hour, minute, second, us);
                return;
             }
 
@@ -387,10 +387,10 @@ void qore_absolute_time::set(const char* str, const AbstractQoreZoneInfo* n_zone
       }
 
       // ignore any time zone passed
-      zone = findCreateOffsetZone(offset * mult);
+      n_zone = findCreateOffsetZone(offset * mult);
    }
 
-   set(zone, year, month, day, hour, minute, second, us);
+   set(n_zone, year, month, day, hour, minute, second, us);
 }
 
 int64 qore_absolute_time::getRelativeMicroseconds() const {


### PR DESCRIPTION
… time zone of the object and not in the current contextual time zone, added a test
