### PR TITLE
refs #601 the minimum transfer size to get a SOCKET-THROUGHPUT-WARNIN…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -79,6 +79,10 @@
       - @ref Qore::Thread::Queue::clearError()
     - updated methods:
       - @ref Qore::TimeZone::constructor() "TimeZone::constructor()": now accepts a path to the zoneinfo file if the @ref Qore::PO_NO_FILESYSTEM sandboxing restrictions is not set
+    - \c "SOCKET-THROUGHPUT-WARNINGS" are no longer raised if the transfer size is less than 1024 bytes; this affects:
+      - @ref Qore::FtpClient::setWarningQueue()
+      - @ref Qore::HTTPClient::setWarningQueue()
+      - @ref Qore::Socket::setWarningQueue()
     - new functions:
       - @ref Qore::create_object()
       - @ref Qore::create_object_args()

--- a/include/qore/intern/qore_socket_private.h
+++ b/include/qore/intern/qore_socket_private.h
@@ -68,6 +68,10 @@
 #define CHF_PROCESS (1 << 1)
 #define CHF_REQUEST (1 << 2)
 
+#ifndef DEFAULT_SOCKET_MIN_THRESHOLD_BYTES
+#define DEFAULT_SOCKET_MIN_THRESHOLD_BYTES 1024
+#endif
+
 DLLLOCAL void concat_target(QoreString& str, const struct sockaddr *addr, const char* type = "target");
 DLLLOCAL int do_read_error(qore_offset_t rc, const char* method_name, int timeout_ms, ExceptionSink* xsink);
 DLLLOCAL int sock_get_raw_error();

--- a/lib/QC_FtpClient.qpp
+++ b/lib/QC_FtpClient.qpp
@@ -963,7 +963,9 @@ ftp.setWarningQueue(5000, 5000, queue, "socket-1");
 
     @see FtpClient::clearWarningQueue()
 
-    @since Qore 0.8.9
+    @since
+    - %Qore 0.8.9
+    - %Qore 0.8.12 the minimum threshold for a warning is a transfer of at least 1024 bytes, smaller transfers will not result in a warning
  */
 nothing FtpClient::setWarningQueue(int warning_ms, int warning_bs, Queue[Queue] queue, any arg, timeout min_ms = 1s) {
    ReferenceHolder<Queue> q(queue, xsink);

--- a/lib/QC_HTTPClient.qpp
+++ b/lib/QC_HTTPClient.qpp
@@ -1126,7 +1126,9 @@ httpclient.setWarningQueue(5000, 5000, queue, "socket-1");
 
     @see HTTPClient::clearWarningQueue()
 
-    @since Qore 0.8.9
+    @since
+    - %Qore 0.8.9
+    - %Qore 0.8.12 the minimum threshold for a warning is a transfer of at least 1024 bytes, smaller transfers will not result in a warning
  */
 nothing HTTPClient::setWarningQueue(int warning_ms, int warning_bs, Queue[Queue] queue, any arg, timeout min_ms = 1s) {
    ReferenceHolder<Queue> q(queue, xsink);

--- a/lib/QC_Socket.qpp
+++ b/lib/QC_Socket.qpp
@@ -2597,7 +2597,9 @@ sock.setWarningQueue(5000, 5000, queue, "socket-1");
 
     @see Socket::clearWarningQueue()
 
-    @since %Qore 0.8.9
+    @since
+    - %Qore 0.8.9
+    - %Qore 0.8.12 the minimum threshold for a warning is a transfer of at least 1024 bytes, smaller transfers will not result in a warning
  */
 nothing Socket::setWarningQueue(int warning_ms, int warning_bs, Queue[Queue] queue, any arg, timeout min_ms = 1s) {
    ReferenceHolder<Queue> q(queue, xsink);

--- a/lib/QoreSocket.cpp
+++ b/lib/QoreSocket.cpp
@@ -741,7 +741,7 @@ PrivateQoreSocketThroughputHelper::~PrivateQoreSocketThroughputHelper() {
 void PrivateQoreSocketThroughputHelper::finalize(int64 bytes) {
    //printd(5, "PrivateQoreSocketThroughputHelper::finalize() bytes: "QLLD" us: "QLLD" (min: "QLLD") bs: %.6f threshold: %.6f\n", bytes, (q_clock_getmicros() - start), sock->tp_us_min, ((double)bytes / ((double)(q_clock_getmicros() - start) / (double)1000000.0)), sock->tp_warning_bs);
 
-   if (bytes <= 0)
+   if (bytes < DEFAULT_SOCKET_MIN_THRESHOLD_BYTES)
       return;
 
    if (send)


### PR DESCRIPTION
…G raised is 1024 bytes
