### PR TITLE
refs #508 ReadOnlyFile::read(Text|Binary)File() return an empty objec…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -463,6 +463,9 @@
     - fixed the order of initialization of class members (<a href="https://github.com/qorelanguage/qore/issues/42">issue 42</a>)
     - fixed a bug in @ref Qore::TimeZone::date(string) where the date returned was in the current contextual time zone and not that of the object (<a href="https://github.com/qorelanguage/qore/issues/584">issue 584</a>)
     - fixed a bug parsing windows paths in URLs with @ref Qore::parse_url() (<a href="https://github.com/qorelanguage/qore/issues/618">issue 618</a>)
+    - fixed a bug in @ref Qore::TimeZone::constructor(string) on Windows when used with an absolute path (<a href="https://github.com/qorelanguage/qore/issues/626">issue 626</a>)
+    - fixed an I/O-handling bug in the @ref Qore::ReadOnlyFile and @ref Qore::File classes where I/O errors in read operations were silently ignored (<a href="https://github.com/qorelanguage/qore/issues/627">issue 627</a>)
+    - fixed bugs in @ref Qore::ReadOnlyFile::readTextFile() and @ref Qore::ReadOnlyFile::readBinaryFile() would return @ref nothing instead of an empty object when reading empty files; now empty objects are returned in these cases (<a href="https://github.com/qorelanguage/qore/issues/508">issue 508</a>)
 
     @section qore_0811 Qore 0.8.11
 

--- a/examples/test/qore/files/read.qtest
+++ b/examples/test/qore/files/read.qtest
@@ -45,6 +45,6 @@ class ReadTest inherits QUnit::Test {
         testAssertionValue('end position check', fr.getPos(), 11);
         testAssertionValue('read string check', s, String);
         testAssertionValue('ReadOnlyFile::readTextFile() string check', ReadOnlyFile::readTextFile(file), String);
-        testAssertionValue('ReadOnlyFile::readTextFile() no value check', ReadOnlyFile::readTextFile(tmp_location()));
+        assertThrows("FILE-OPEN2-ERROR", \ReadOnlyFile::readTextFile(), tmp_location() + DirSep + get_random_string());
     }
 }

--- a/include/qore/intern/qore_qf_private.h
+++ b/include/qore/intern/qore_qf_private.h
@@ -297,8 +297,12 @@ struct qore_qf_private {
 	 while (true) {
 	    rc = ::read(fd, buf, bs);
 	    // try again if we were interrupted by a signal
-	    if (rc >= 0 || errno != EINTR)
+	    if (rc >= 0)
 	       break;
+            if (errno != EINTR) {
+               xsink->raiseErrnoException("FILE-READ-ERROR", errno, "error reading file after "QLLD" bytes read", br);
+               break;
+            }
 	 }
 	 //printd(5, "readBlock(fd: %d, buf: %p, bs: %d) rc: %d\n", fd, buf, bs, rc);
 	 if (rc <= 0)
@@ -320,7 +324,7 @@ struct qore_qf_private {
 	 }
       }
       free(buf);
-      if (!br) {
+      if (*xsink) {
 	 if (bbuf)
 	    free(bbuf);
 	 return 0;

--- a/lib/QC_ReadOnlyFile.qpp
+++ b/lib/QC_ReadOnlyFile.qpp
@@ -639,7 +639,8 @@ int ReadOnlyFile::close() {
     @return the data read from the file, returned as a binary object.  @ref nothing is returned if end-of-file is encountered, however, if data has been read before EOF, the data read will be returned and @ref nothing (signifying EOF) will be returned on the next call to this method.
 
     @throw READONLYFILE-READ-BINARY-PARAMETER-ERROR zero size argument passed
-    @throw FILE-READ-ERROR file is not open
+    @throw FILE-READ-ERROR file is not open, or an I/O or other error occurred when reading the file
+
     @throw FILE-READ-TIMEOUT timeout limit exceeded
     @throw ILLEGAL-EXPRESSION this exception is only thrown if called with a system constant object (@ref stdin, @ref stdout, @ref stderr) when @ref no-terminal-io is set
 
@@ -973,9 +974,13 @@ string data = File::readTextFile(path);
 
     @return the contents of a text file as a string optionally tagged with the given @ref character_encoding "character encoding" or @ref nothing if the file is empty or cannot be read
 
-    @since %Qore 0.8.8
+    @throw FILE-READ-ERROR an I/O or other error occurred when reading the file
+
+    @since
+    - %Qore 0.8.8 introduced this method
+    - %Qore 0.8.12 changed the behavior of the method; either a string (possibly an empty string for an empty file) will be returned, or an exception will be raised
 */
-static *string ReadOnlyFile::readTextFile(string path, *string encoding) [dom=FILESYSTEM] {
+static string ReadOnlyFile::readTextFile(string path, *string encoding) [dom=FILESYSTEM] {
    const QoreEncoding *qe = encoding ? QEM.findCreate(encoding) : QCS_DEFAULT;
 
    QoreFile qf;
@@ -983,7 +988,10 @@ static *string ReadOnlyFile::readTextFile(string path, *string encoding) [dom=FI
    if (qf.open2(xsink, path->getBuffer(), O_RDONLY, 0777, qe))
       return QoreValue();
 
-   return qf.read(-1, xsink);
+   QoreStringNode* str = qf.read(-1, xsink);
+   if (!str && !*xsink)
+      str = new QoreStringNode(qe);
+   return str;
 }
 
 //! returns the contents of a binary file as a binary object
@@ -994,15 +1002,22 @@ binary data = File::readBinaryFile(path);
 
     @param path the path of the file to retrieve
 
-    @return the contents of a binary file as a binary object or @ref nothing if the file is empty or cannot be read
+    @return the contents of a binary file as a binary object
 
-    @since %Qore 0.8.8
+    @throw FILE-READ-ERROR an I/O or other error occurred when reading the file
+
+    @since
+    - %Qore 0.8.8 introduced this method
+    - %Qore 0.8.12 changed the behavior of the method; either a binary object (possibly an empty binary object for an empty file) will be returned, or an exception will be raised
 */
-static *binary ReadOnlyFile::readBinaryFile(string path) [dom=FILESYSTEM] {
+static binary ReadOnlyFile::readBinaryFile(string path) [dom=FILESYSTEM] {
    QoreFile qf;
 
    if (qf.open2(xsink, path->getBuffer()))
       return QoreValue();
 
-   return qf.readBinary(-1, xsink);
+   BinaryNode* b = qf.readBinary(-1, xsink);
+   if (!b && !*xsink)
+      b = new BinaryNode;
+   return b;
 }

--- a/lib/QC_TimeZone.qpp
+++ b/lib/QC_TimeZone.qpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -40,7 +40,7 @@ qclass TimeZone [arg=TimeZoneData* z];
 //! Creates the TimeZone object based on the region name (ex: \c "America/Chicago")
 /** @param region The region name for the time zone (ex: \c "America/Chicago"); if the zoneinfo file for the region cannot be found or parsed (on UNIX) or if the registry entry cannot be found (on Windows), then an exception is thrown
 
-    @note On Windows the zoneinfo region names (ex: \c "Europe/Prague") are converted to registry entries under <tt>HKEY_LOCAL_MACHINE SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Time Zones</tt> (ex: \c "Central Europe Standard Time")
+    @note On Windows the zoneinfo region names (ex: \c "Europe/Prague") are converted to registry entries under <tt>HKEY_LOCAL_MACHINE SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Time Zones</tt> (ex: \c "Central Europe Standard Time"); if an absolute path to a file is given as the argument, then a zoneinfo file is read and parsed from the given location
 
     @par Example:
     @code{.py}

--- a/lib/QoreFile.cpp
+++ b/lib/QoreFile.cpp
@@ -449,9 +449,13 @@ QoreStringNode *QoreFile::read(qore_offset_t size, ExceptionSink *xsink) {
    if (!buf)
       return 0;
 
-   QoreStringNode *str = new QoreStringNode(buf, size, size, priv->charset);
-   //str->terminate(buf[size - 1] ? size : size - 1);
-   str->terminate(size);
+   QoreStringNode* str;
+   if (size) {
+      str = new QoreStringNode(buf, size, size, priv->charset);
+      str->terminate(size);
+   }
+   else
+      str = new QoreStringNode(priv->charset);
    return str;
 }
 
@@ -473,7 +477,8 @@ int QoreFile::readBinary(BinaryNode &b, qore_offset_t size, ExceptionSink *xsink
    if (!buf)
       return -1;
 
-   b.append(buf, size);
+   if (size)
+      b.append(buf, size);
    free(buf);
    return 0;
 }

--- a/lib/QoreTimeZoneManager.cpp
+++ b/lib/QoreTimeZoneManager.cpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -281,15 +281,28 @@ const AbstractQoreZoneInfo *QoreTimeZoneManager::processFile(const char *fn, boo
    if (i != tzmap.end())
       return i->second;
 
-   //printd(5, "QoreTimeZoneManager::processFile() %s: loading from registry\n", fn);
 
-   std::auto_ptr<QoreWindowsZoneInfo> tzi(new QoreWindowsZoneInfo(fn, xsink));
-   if (!*(tzi.get())) {
-      return 0;
+   AbstractQoreZoneInfo* rv;
+
+   if (q_absolute_path_windows(fn)) {
+      //printd(5, "QoreTimeZoneManager::processFile() %s: loading absolute path\n", fn);
+      std::string name = fn;
+      std::auto_ptr<QoreZoneInfo> tzi(new QoreZoneInfo(*NullString, name, xsink));
+      if (!*(tzi.get())) {
+         //printd(1, "skipping %s/%s\n", root.getBuffer(), name.c_str());
+         return 0;
+      }
+      rv = tzi.release();
    }
+   else {
+      //printd(5, "QoreTimeZoneManager::processFile() %s: loading from registry\n", fn);
+      std::auto_ptr<QoreWindowsZoneInfo> tzi(new QoreWindowsZoneInfo(fn, xsink));
+      if (!*(tzi.get()))
+         return 0;
 
-   //printd(5, "QoreTimeZoneManager::processFile() %s -> %p\n", name.c_str(), tzi.get());
-   QoreWindowsZoneInfo *rv = tzi.release();
+      //printd(5, "QoreTimeZoneManager::processFile() %s -> %p\n", name.c_str(), tzi.get());
+      rv = tzi.release();
+   }
    tzmap[fn] = rv;
    ++tzsize;
 


### PR DESCRIPTION
…t when reading an empty file (instead of NOTHING)

refs #626 TimeZone::constructor(string) now loads zoneinfo files when given an absolute path
refs #627 fixed I/O-handling in the ReadOnlyFile and File classes; I/O errors on read are no longer silently ignored

@tethal note: also closes #508 
