### PR TITLE
refs #529 SqlUtil operator functions can now be used in where hashes …

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -254,6 +254,7 @@
       - removed all APIs that handle implicit transactions; APIs must commit transactions explicitly
       - \a orderby and \a groupby select options now take positive integers as column identifiers
       - column aliases (defined with cop_as()) can now be used in the where hash argument and in join criteria
+      - column operator functions can be used in the where clause and in join conditions (<a href="https://github.com/qorelanguage/qore/issues/529">issue 529</a>)
     - <a href="../../modules/OracleSqlUtil/html/index.html">OracleSqlUtil</a> module updates:
       - implemented support for views for DML in the OracleTable class
       - implemented support for Oracle pseudocolumns in queries

--- a/examples/test/qlib/SqlUtil/SqlUtilTestBase.qm
+++ b/examples/test/qlib/SqlUtil/SqlUtilTestBase.qm
@@ -183,10 +183,11 @@ public class SqlTestBase inherits QUnit::Test {
                 # cop_as (cop_divide ("id", cop_value(2)), "cop_divide"),
                 # cop_as (cop_multiply ("id", cop_value(2)), "cop_multiply"),
                 ),
-                "where": ("id": 2)
+                "where": ("id": 2, "cop_lower": cop_lower("cop_upper")),
                 );
 
-        *hash row = table.selectRow (soh);
+        string sql; on_error printf("sql: %s\n", sql);
+        *hash row = table.selectRow (soh, \sql);
 
         hash expect = (
                 "cop_cast": "2",

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -115,6 +115,7 @@ module SqlUtil {
     - implemented support for numeric column arguments for the @ref select_option_orderby "orderby" and @ref select_option_groupby "groupby" options
     - column aliases (defined with @ref SqlUtil::cop_as()) can now be used in the @ref where_clauses "where hash argument" and in join criteria
     - removed all APIs that handle implicit transactions; APIs must commit transactions explicitly (<a href="https://github.com/qorelanguage/qore/issues/533">issue 533</a>)
+    - @ref sql_cop_funcs "column operator functions" can be used in @ref where_clauses "where hashes" and in @ref select_option_join "join conditions": (<a href="https://github.com/qorelanguage/qore/issues/529">issue 529</a>)
     - fixed a bug with queries using a \a desc argument with the @ref select_option_orderby "orderby" query option with multiple sort columns; the \c "desc" string was added only to the last column but should have been added to all columns
     - fixed a bug where foreign key constraints with supporting indexes were not tracked and therefore schema alignment on DBs that automatically create indexes for foreign key constraints would fail
     - fixed a bug where driver-specific objects were not included when dropping a schema
@@ -1976,7 +1977,9 @@ public namespace SqlUtil {
     public const DefaultCopMap = (
         COP_AS: (
             "arg": Type::String,
-            "code": string sub (string cve, string arg) {
+            "withalias": True,
+            "code": string sub (string cve, string arg, reference psch) {
+                psch{arg} = cve;
                 return sprintf("%s as %s", cve, arg);
             },
         ),
@@ -3672,7 +3675,8 @@ int rows_updated = t.update(("permission_type": uop_lower()));
 select * from table where name != other_name and ((type != 'C' and validation flag is not null) or (expiration_date >= %v))
         @endverbatim
 
-        @param h the hash of expressions to combine with \c "or" logic
+        @param h1 the hash of expressions to combine with \c "or" logic
+        @param ... remaining expressions to combine with \c "or" logic
 
         @return a hash with a fake column name (\c "_OR_" with a numeric prefix for uniqueness) for use in a where operation description hash for use in @ref where_clauses "where clauses"
 
@@ -3683,7 +3687,7 @@ select * from table where name != other_name and ((type != 'C' and validation fl
         l += h2;
         if (argv)
             l += argv;
-        return (sprintf("%d:_OR_", rand() % 100000): make_op(OP_OR, l));
+        return (sprintf("%d:_OR_", rand() % 10000000): make_op(OP_OR, l));
     }
     #@}
 
@@ -11356,13 +11360,8 @@ string sql = table.getSelectSql(sh, \args);
                             if (!cv.cop)
                                 throw "SELECT-ERROR", sprintf("%s: missing column operator in \"columns\" hash element %d/%d; the \"columns\" select option must be assigned to a list of strings giving the column names or a list of column operator hashes as returned from column operator functions; this element is missing hash key \"cop\" giving the column operator; keys provided: %y", getDesc(), $# + 1, qh.columns.lsize(), cv.keys());
                             try {
-                                string val = doColumnOperatorIntern(cv, jch, boolean(qh.join), ch);
+                                string val = doColumnOperatorIntern(cv, jch, boolean(qh.join), ch, psch, \psch);
                                 ce += val;
-                                # add any column aliases to pseudo-column hash
-                                if (cv.cop == COP_AS) {
-                                    val =~ s/ as .*$//;
-                                    psch{cv.arg} = val;
-                                }
                             }
                             catch (hash ex) {
                                 # rethrow exception with additional contextual information
@@ -11512,7 +11511,10 @@ string sql = table.getSelectSql(sh, \args);
                     if (value[0].typeCode() != NT_STRING)
                         throw "SELECT-ERROR", sprintf("%s: expecting a string argument to the \"having\" condition in the first position giving the column operator code for column %y; got type %y instead (value: %y)", getDesc(), key, value[0].type(), value[0]);
 
-                    string hstr = doColumnOperatorIntern(value[0], NOTHING, getColumnExpressionIntern(key, jch, boolean(qh.join), ch), cm, jch, boolean(qh.join), ch);
+                    *hash psch_copy = psch;
+                    string hstr = doColumnOperatorIntern(value[0], NOTHING, getColumnExpressionIntern(key, jch, boolean(qh.join), ch, psch), cm, jch, boolean(qh.join), ch, psch);
+                    if (psch_copy != psch)
+                        throw "HAVING-ERROR", sprintf("%s: cannot use column operator functions in the having clause with column alias specifications", getDesc());
                     hl += doWhereExpressionIntern(hstr, value[1], \args, jch, boolean(qh.join), ch);
                 }
                 if (hl)
@@ -11585,7 +11587,7 @@ string sql = table.getSelectSql(sh, \args);
                         if (cv.toInt() == cv)
                             do_int(cv.toInt());
                         else
-                            ce += getColumnNameIntern(cv, jch, boolean(qh.join), ch, psch, True);
+                            ce += getColumnNameIntern(cv, jch, boolean(qh.join), ch, psch);
                         break;
                     }
 
@@ -11614,21 +11616,21 @@ string sql = table.getSelectSql(sh, \args);
             return getSqlName();
         }
 
-        private string getColumnExpressionIntern(any cvc, *hash jch, bool join, *hash ch) {
+        private string getColumnExpressionIntern(any cvc, *hash jch, bool join, *hash ch, *hash psch) {
             switch (cvc.typeCode()) {
                 case NT_HASH:
-                    return doColumnOperatorIntern(cvc, jch, join, ch);
+                    return doColumnOperatorIntern(cvc, jch, join, ch, psch);
                 case NT_STRING:
-                    return getColumnNameIntern(cvc, jch, join, ch);
+                    return getColumnNameIntern(cvc, jch, join, ch, psch);
             }
             throw "SELECT-ERROR", sprintf("%s: column operator hash %y has an invalid \"column\" key; expecting a string column specification or a column operator description hash", getDesc(), cvc);
         }
 
-        private string doColumnOperatorIntern(hash cvc, *hash jch, bool join, *hash ch, *hash psch) {
-            return doColumnOperatorIntern(cvc.cop, cvc.arg, (cvc.column ? getColumnExpressionIntern(cvc.column, jch, join, ch) : NOTHING), getColumnOperatorMap(), jch, join, ch, psch);
+        private string doColumnOperatorIntern(hash cvc, *hash jch, bool join, *hash ch, *hash psch, *reference psch_ref) {
+            return doColumnOperatorIntern(cvc.cop, cvc.arg, (cvc.column ? getColumnExpressionIntern(cvc.column, jch, join, ch, psch) : NOTHING), getColumnOperatorMap(), jch, join, ch, psch, \psch_ref);
         }
 
-        private string doColumnOperatorIntern(any cop, any arg, *string cve, hash cm, *hash jch, bool join, *hash ch, *hash psch) {
+        private string doColumnOperatorIntern(any cop, any arg, *string cve, hash cm, *hash jch, bool join, *hash ch, *hash psch, *reference psch_ref) {
             if (cop.typeCode() != NT_STRING)
                 throw "SELECT-ERROR", sprintf("%s: invalid column operator code %y; use column operator functions to create valid column specifications with supported column operators", getDesc(), cop);
 
@@ -11659,10 +11661,10 @@ string sql = table.getSelectSql(sh, \args);
             if (!exists cve && !cmd.nocolumn)
                 throw "SELECT-ERROR", sprintf("%s: column operator %y requires a column argument name but none was provided", getDesc(), cop);
 
-            return cmd.code(cve, arg);
+            return cmd.withalias ? cmd.code(cve, arg, \psch_ref) : cmd.code(cve, arg);
         }
 
-        private string getColumnNameIntern(string cv, *hash jch, bool join, *hash ch, *hash psch, *bool subst_psch) {
+        private string getColumnNameIntern(string cv, *hash jch, bool join, *hash ch, *hash psch) {
             # remove any disposable unique prefix
             cv =~ s/^[0-9]+://;
             # return the name if it's a "technical name" (starts with "_")
@@ -11680,7 +11682,8 @@ string sql = table.getSelectSql(sh, \args);
                 if (cv != "*" && !jch{tp}.describe().hasKey(cv) && !psch{cv})
                     throw "SELECT-ERROR", sprintf("%s: query references unknown column \"%s.%s\" (%y is aliased to table %y); known columns: %y", getDesc(), tp, cv, tp, jch{tp}.getSqlName(), jch{tp}.describe().keys());
             }
-            else if (psch{cv} && subst_psch && psch{cv}.typeCode() == NT_STRING) {
+            # substitute aliases with their actual definition
+            else if (psch{cv} && psch{cv}.typeCode() == NT_STRING) {
                 return psch{cv};
             }
             else if (ch) {
@@ -11750,6 +11753,14 @@ string sql = table.getSelectSql(sh, \args);
         private string doWhereExpressionIntern(string cn, any we, reference args, *hash jch, bool join = False, *hash ch, *hash psch) {
             int wt = we.typeCode();
             if (wt == NT_HASH) {
+                if (we.cop) {
+                    *hash psch_copy = psch;
+                    string val = doColumnOperatorIntern(we, jch, join, ch, psch, \psch_copy);
+                    if (psch_copy != psch)
+                        throw "WHERE-ERROR", sprintf("%s: cannot use column operator function %y in the where clause with column alias specifications", getDesc(), we.cop);
+                    return sprintf("%s = %s", cn, val);
+                }
+
                 if (!we.op)
                     throw "WHERE-ERROR", sprintf("%s: argument to key %y is a hash without an \"op\" key: %y", getDesc(), cn, we);
 


### PR DESCRIPTION
…and join condition hashes, also fixed general column alias references to use the original expression, also the COP_AS column operator now uses the "withalias" option so alias handling is now generic across all column operators
