### PR TITLE
refs #647 fixed a crash related to qore library shutdowns while user thread resources were set based on classes in user modules

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -311,7 +311,7 @@
       - fixed a bug where wildcard columns in join tables were not working (<a href="https://github.com/qorelanguage/qore/issues/499">issue 499</a>)
       - fixed a bug in op_in() where invalid SQL was generated with an argument of 0 (<a href="https://github.com/qorelanguage/qore/issues/500">issue 500</a>)
       - fixed bugs in \c cop_seq() and \c cop_seq_currval() (<a href="https://github.com/qorelanguage/qore/issues/624">issue 624</a>)
-      - fixed a buf in \c join_inner() where the \a cond argument was ignored (<a href="https://github.com/qorelanguage/qore/issues/645">issue 645</a>)
+      - fixed a bug in \c join_inner() where the \a cond argument was ignored (<a href="https://github.com/qorelanguage/qore/issues/645">issue 645</a>)
     - <a href="../../modules/OracleSqlUtil/html/index.html">OracleSqlUtil</a> module fixes:
       - fixed a bug where column names that are reserved words were not quoted in generated SQL
       - fixed bugs in \c cop_seq() and \c cop_seq_currval() (<a href="https://github.com/qorelanguage/qore/issues/624">issue 624</a>)

--- a/lib/qore-main.cpp
+++ b/lib/qore-main.cpp
@@ -161,6 +161,12 @@ void qore_init(qore_license_t license, const char *def_charset, bool show_module
 // unloaded in case there are any module-specific thread
 // cleanup functions to be run...
 void qore_cleanup() {
+   // purge thread resources before deleting modules
+   {
+      ExceptionSink xsink;
+      purge_thread_resources(&xsink);
+   }
+
    // first delete all user modules
    QMM.delUser();
 
@@ -173,12 +179,6 @@ void qore_cleanup() {
    // stop signal manager
    QSM.del();
 #endif
-
-   // purge thread resources before deleting modules
-   {
-      ExceptionSink xsink;
-      purge_thread_resources(&xsink);
-   }
 
    // delete all loadable modules
    QMM.cleanup();

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -130,7 +130,7 @@ module SqlUtil {
     - fixed a bug in @ref SqlUtil::cop_value() where an exception was thrown with an argument of 0 (<a href="https://github.com/qorelanguage/qore/issues/511">issue 511</a>)
     - fixed @ref SqlUtil::cop_count() operator to allow other operators as its argument (<a href="https://github.com/qorelanguage/qore/issues/517">issue 517</a>)
     - fixed bugs in @ref SqlUtil::cop_seq() and @ref SqlUtil::cop_seq_currval() (<a href="https://github.com/qorelanguage/qore/issues/624">issue 624</a>)
-    - fixed a buf in @ref SqlUtil::join_inner() where the \a cond argument was ignored (<a href="https://github.com/qorelanguage/qore/issues/645">issue 645</a>)
+    - fixed a bug in @ref SqlUtil::join_inner() where the \a cond argument was ignored (<a href="https://github.com/qorelanguage/qore/issues/645">issue 645</a>)
 
     @subsection sqlutilv1_2 SqlUtil v1.2
     - added insert operator support; for example, for inserting with values from sequences


### PR DESCRIPTION
refs #645 fixed typos in docs

@tethal I wasn't able to make a test for this, but I had a test case in a Qorus test script that would crash when stream operations would fail due to the Oracle server being down.  So now it's fixed, but there's no test :(
