### PR TITLE
Windows fixes:

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -481,6 +481,10 @@
     - fixed a bug where the type of subtraction of two numbers was inferred as NOTHING during parsing (<a href="https://github.com/qorelanguage/qore/issues/636">issue 636</a>)
     - fixed a bug on Windows with @ref Qore::Dir::create() (<a href="https://github.com/qorelanguage/qore/issues/643">issue 643</a>)
     - fixed a bug where CRLF line endings were not handled correctly by the %exec-class parse directive (<a href="https://github.com/qorelanguage/qore/issues/653">issue 653</a>)
+    - fixed a bug on Windows where @ref Qore::glob() would return paths beginning with \c "." by default (<a href="https://github.com/qorelanguage/qore/issues/660">issue 660</a>)
+    - fixed a bug on Windows where @ref Qore::glob() would fail on \c "\*" or \c "/*" (<a href="https://github.com/qorelanguage/qore/issues/664">issue 664</a>)
+    - fixed a bug on Windows where @ref Qore::glob() would not return paths in sorted order by default (<a href="https://github.com/qorelanguage/qore/issues/665">issue 665</a>)
+    - fixed a bug on Windows where the @ref Qore::Dir class would incorrectly normalize UNC paths by stripping the leading backslash (<a href="https://github.com/qorelanguage/qore/issues/666">issue 666</a>)
 
     @section qore_0811 Qore 0.8.11
 

--- a/examples/test/qore/functions/glob.qtest
+++ b/examples/test/qore/functions/glob.qtest
@@ -1,0 +1,33 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+
+%requires ../../../../qlib/Util.qm
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class GlobTest
+
+public class GlobTest inherits QUnit::Test {
+    constructor() : Test("GlobTest", "1.0") {
+        addTestCase("glob Tests", \globTests());
+
+        # Return for compatibility with test harness that checks return value.
+        set_return_value(main());
+    }
+
+    globTests() {
+        list l = glob("*");
+        # make sure that glob() does not return paths beginning with "." by default (issue 660)
+        assertEq((), (map $1, l, $1 =~ /^\./));
+        # make sure that glob() returns a sorted list of paths by default (issue 665)
+        assertEq(l, sort(l));
+
+        # make sure that glob("/*") succeeds (issue 664)
+        chdir(tmp_location());
+        assertEq(False, glob("/*").empty());
+    }
+}

--- a/include/qore/intern/glob.h
+++ b/include/qore/intern/glob.h
@@ -1,9 +1,10 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
 /*
   glob.h
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -35,12 +36,18 @@
 
 #include <string>
 #include <vector>
+#include <algorithm>
 
 #include <qore/intern/QoreRegexNode.h>
 
 typedef int (*glob_error_t)(const char *, int);
 
 #ifdef _WIN32
+
+// some glob options
+#define GLOB_NONE 0
+#define GLOB_NOSORT (1 << 0)
+
 class QoreGlobWin {
 protected:
    typedef std::vector<std::string> names_t;
@@ -48,7 +55,7 @@ protected:
 
 public:
    size_t gl_pathc;
-   const char **gl_pathv;
+   const char** gl_pathv;
 
    DLLLOCAL QoreGlobWin() : gl_pathc(0), gl_pathv(0) {
    }
@@ -57,14 +64,18 @@ public:
       reset();
    }
 
-   DLLLOCAL int set(const char *pattern, int flags, glob_error_t errfunc) {
+   DLLLOCAL int set(const char* pattern, int flags, glob_error_t errfunc) {
       assert(!flags);
       assert(!errfunc);
       reset();
 
-      char *dirp = q_dirname(pattern);
+      // normalize the path
+      QoreString path(pattern);
+      q_normalize_path(path);
+
+      char* dirp = q_dirname(path.c_str());
       unsigned len = strlen(dirp);
-      QoreString dir(dirp, len, len + 1, QCS_DEFAULT); 
+      QoreString dir(dirp, len, len + 1, QCS_DEFAULT);
 
       // set the pattern to get all files in the directory, and then match according to glob() rules
       dir.concat("\\*.*");
@@ -73,7 +84,12 @@ public:
       ON_BLOCK_EXIT(::FindClose, h);
 
       // make regex pattern
-      QoreString str(q_basenameptr(pattern));
+      QoreString str(q_basenameptr(path.c_str()));
+
+      // check if we should get files that start with a "."
+      bool get_dot = (str[0] == '.');
+      //printd(5, "QoreGlobWin::set() path: '%s' dir: '%s' str: '%s' get_dot: %d\n", path.c_str(), dir.c_str(), str.c_str());
+
       str.replaceAll(".", "\\.");
       str.replaceAll("?", ".");
       str.replaceAll("*", ".*");
@@ -86,6 +102,8 @@ public:
 	 return -1;
 
       while (FindNextFile(h, &pfd)) {
+         if (pfd.cFileName[0] == '.' && !get_dot)
+            continue;
 	 if (qrn->exec(pfd.cFileName, strlen(pfd.cFileName))) {
 	    names.push_back(pfd.cFileName);
 	    //printd(5, "QoreGlobWin::set(pattern='%s') dir='%s' regex='%s' %s MATCHED\n", pattern, dir.getBuffer(), str.getBuffer(), pfd.cFileName);
@@ -93,9 +111,12 @@ public:
       }
 
       if (names.size()) {
+         if (!(flags & GLOB_NOSORT))
+            std::sort(names.begin(), names.end());
+
 	 gl_pathc = names.size();
 
-	 gl_pathv = (const char **)malloc(sizeof(char *) * names.size());
+	 gl_pathv = (const char**)malloc(sizeof(char*) * names.size());
 	 for (unsigned i = 0; i < names.size(); ++i) {
 	    gl_pathv[i] = names[i].c_str();
 	 }

--- a/lib/glob.cpp
+++ b/lib/glob.cpp
@@ -1,9 +1,9 @@
 /*
-  windows-lib.cpp
+  glob.cpp
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
refs #660 glob() does not return paths starting with "." by default
refs #664 glob() works with * or /\* in all cases
refs #665 glob() returns a sorted list by default
refs #666 Dir works with UNC paths
