### PR TITLE
Add new SqlUtil feature "synonyms" and review features returned from *SqlUtil modules

### DIFF
--- a/qlib/FreetdsSqlUtil.qm
+++ b/qlib/FreetdsSqlUtil.qm
@@ -621,7 +621,8 @@ my any $v = $c.name;
         }
 
         private list featuresImpl() {
-            return (DB_SEQUENCES, DB_TABLES, DB_VIEWS);
+            return (DB_TABLES, DB_VIEWS, DB_SEQUENCES,
+                    DB_FUNCTIONS, DB_PROCEDURES);
         }
 
         private FreetdsSequence makeSequenceImpl(string name, number start = 1, number increment = 1, *softnumber end, *hash opts) {

--- a/qlib/OracleSqlUtil.qm
+++ b/qlib/OracleSqlUtil.qm
@@ -1122,7 +1122,7 @@ my any $v = $c.name;
 
         private list featuresImpl() {
             return list(DB_FUNCTIONS, DB_MVIEWS, DB_PACKAGES, DB_PROCEDURES,
-                        DB_SEQUENCES, DB_TABLES, DB_TYPES, DB_VIEWS);
+                        DB_SEQUENCES, DB_TABLES, DB_TYPES, DB_VIEWS, DB_SYNONYMS);
         }
 
         private OracleSequence makeSequenceImpl(string name, number start = 1, number increment = 1, *softnumber end, *hash opts) {

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -1800,7 +1800,7 @@ public namespace SqlUtil {
 
     #! Feature: functions
     public const DB_FUNCTIONS = "functions";
-    #! Feature: materialized views/snapshots
+    #! Feature: materialized views / snapshots
     public const DB_MVIEWS = "materialized views";
     #! Feature: packages
     public const DB_PACKAGES = "packages";
@@ -1814,6 +1814,8 @@ public namespace SqlUtil {
     public const DB_TYPES = "named types";
     #! Feature: views
     public const DB_VIEWS = "views";
+    #! Feature: synonyms
+    public const DB_SYNONYMS = "synonyms";
     #@}
 
     /* @defgroup SqlTypeConstants SQL Type Constants


### PR DESCRIPTION
This is required to properly support transparent handling of different databases.
