### PR TITLE
refs #696 added the QoreMethod::execManaged() function to allow for o…

### DIFF
--- a/include/qore/QoreClass.h
+++ b/include/qore/QoreClass.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -165,6 +165,13 @@ public:
       overloaded)
    */
    DLLEXPORT const QoreTypeInfo* getUniqueReturnTypeInfo() const;
+
+   //! evaluates the method and returns the value, does not reference the object for the call
+   /** @note this method should only be used when the caller can guarantee that the object will not go out of scope during the call
+
+       @since %Qore 0.8.12
+    */
+   DLLEXPORT QoreValue execManaged(QoreObject* self, const QoreListNode* args, ExceptionSink* xsink) const;
 
    DLLLOCAL QoreMethod(const QoreClass* p_class, MethodFunctionBase* n_func, bool n_static = false);
 

--- a/include/qore/QoreObject.h
+++ b/include/qore/QoreObject.h
@@ -8,7 +8,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -2266,6 +2266,12 @@ void QoreMethod::assign_class(const QoreClass* p_class) {
    priv->parent_class = p_class;
 }
 
+QoreValue QoreMethod::execManaged(QoreObject* self, const QoreListNode* args, ExceptionSink* xsink) const {
+   // to ensure the object does not get referenced for the call
+   ObjectSubstitutionHelper osh(self);
+   return qore_method_private::eval(*this, self, args, xsink);
+}
+
 // FIXME: DEPRECATED API non functional
 bool QoreMethod::isSynchronized() const {
    return false;


### PR DESCRIPTION
…bject methods to be called without referencing the object for the call which allows binary modules to avoid race conditions where the object can go out of scope during the callback
