### PR TITLE
refs #715 fixed converting NULL -> a string; was giving "0" - this is…

### DIFF
--- a/examples/test/qore/vars/string.qtest
+++ b/examples/test/qore/vars/string.qtest
@@ -21,6 +21,7 @@ class StringTest inherits QUnit::Test {
         addTestCase("Regex test", \testRegex());
         addTestCase("Chomp and trim test", \testChompAndTrim());
         addTestCase("Float strings test", \testFloat());
+        addTestCase("String conversion test", \testConversions());
         set_return_value(main());
     }
 
@@ -321,5 +322,8 @@ class StringTest inherits QUnit::Test {
         assertEq(sprintf("%g", 1.5), "1.5", "%f float");
         assertEq(sprintf("%g", 1.5n), "1.5", "%f number");
     }
-}
 
+    testConversions() {
+        assertEq("", string(NULL));
+    }
+}

--- a/include/qore/intern/QoreTypeInfo.h
+++ b/include/qore/intern/QoreTypeInfo.h
@@ -1886,9 +1886,13 @@ protected:
          return true;
 
       if (t == NT_INT
-          || t == NT_BOOLEAN
-          || t == NT_NULL) {
+          || t == NT_BOOLEAN) {
          discard(n.assign(new QoreStringNodeMaker(QLLD, n.getAsBigInt())), xsink);
+         return true;
+      }
+
+      if (t == NT_NULL) {
+         n.assign(NullString->stringRefSelf());
          return true;
       }
 

--- a/lib/QoreStringNode.cpp
+++ b/lib/QoreStringNode.cpp
@@ -5,7 +5,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
… a new bug introduced in 0.8.12 related to the internal QoreValue API changes; added a test
