### PR TITLE
refs #732 make sure that SSL errors are processed according to the do…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -497,6 +497,7 @@
     - fixed a bug where the @ref int_type "int" type restriction would accept any data type at runtime instead of throwing a \c RUNTIME-TYPE-ERROR exception (<a href="https://github.com/qorelanguage/qore/issues/683">issue 683</a>)
     - fixed bugs reporting the current method context with certain @ref Qore::HTTPClient "HTTPClient" methods that would report the @ref Qore::Socket "Socket" class instead (<a href="https://github.com/qorelanguage/qore/issues/689">issue 689</a>)
     - fixed a bug handling aborted HTTP chunked transfers; now any data available for reading on a socket when a chunked transfer is aborted is read instead of having a \c SOCKET-SEND-ERROR thrown when the remote end closes the socket during the transfer (<a href="https://github.com/qorelanguage/qore/issues/691">issue 691</a>)
+    - fixed a bug where SSL send failures did not cause an exception to be thrown in all cases (<a href="https://github.com/qorelanguage/qore/issues/732">issue 732</a>)
 
     @section qore_0811 Qore 0.8.11
 

--- a/include/qore/intern/qore_socket_private.h
+++ b/include/qore/intern/qore_socket_private.h
@@ -2038,7 +2038,6 @@ struct qore_socket_private {
 
       while (!done) {
          // if we have response data already, then we assume an error and abort
-         //if (aborted && isDataAvailable(0, mname, xsink)) {
          if (aborted) {
             bool data_available = tryReadSocketData(mname, xsink);
             //printd(5, "qore_socket_private::sendHttpChunkedWithCallback() this: %p aborted: %p iDA: %d\n", this, aborted, data_available);


### PR DESCRIPTION
…cs for SSL_write() when SSL_write() returns 0; previously when the remote shut down an SSL socket while writing, it would not necessarily cause an exception to be raised
