### PR TITLE
refs #744 declare bash in the hash bang for run_tests.sh so it will r…

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 print_usage ()
 {
@@ -108,4 +108,3 @@ if [ $PRINT_TEXT -eq 1 ]; then
 fi
 
 exit $FAILED_TEST_COUNT
-


### PR DESCRIPTION
…un on systems where /bin/sh is not bash (ex: Solaris)
