### PR TITLE
refs #754 sequence value placeholder output buffers are now always bo…

### DIFF
--- a/examples/test/qlib/TableMapper/TableMapper.qtest
+++ b/examples/test/qlib/TableMapper/TableMapper.qtest
@@ -1,0 +1,154 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+
+%exec-class TableMapperTest
+
+%requires ../../../../qlib/QUnit.qm
+%requires ../../../../qlib/SqlUtil.qm
+%requires ../../../../qlib/Schema.qm
+%requires ../../../../qlib/TableMapper.qm
+
+public class TableMapperTestSchema inherits AbstractSchema {
+    public {
+        const T_TableMapperTest = (
+            "columns": (
+                "id": c_number(True),
+                "string": c_varchar(50, True),
+            ),
+            );
+
+        const Tables = (
+            "table_mapper_test": T_TableMapperTest,
+            );
+
+        const Sequences = (
+            "seq_table_mapper_test": {},
+            );
+    }
+
+    constructor(AbstractDatasource ds, *string dts, *string its) : AbstractSchema(ds, dts, its) {
+    }
+
+    private *hash getTablesImpl() {
+        return Tables;
+    }
+
+    private *hash getSequencesImpl() {
+        return Sequences;
+    }
+
+    string getNameImpl() {
+        return "TableMapperTestSchema";
+    }
+
+    string getVersionImpl() {
+        return "1.0";
+    }
+
+    log(string fmt) {
+        delete argv;
+    }
+
+    logpf(string fmt) {
+        delete argv;
+    }
+
+    logProgress(string fmt) {
+        delete argv;
+    }
+}
+
+public class TableMapperTest inherits QUnit::Test {
+    private {
+        AbstractSchema schema;
+        AbstractTable table;
+
+        const Map1 = (
+            "id": ("sequence": "seq_table_mapper_test"),
+            "string": True,
+            );
+
+        const Input1 = (("string": "string_1"), ("string": "string_2"));
+
+        const MyOpts = Opts + (
+            "connstr": "c,conn=s",
+            );
+
+        const OptionColumn = 22;
+    }
+
+    constructor(any args, *hash mopts) : Test("TableMapperTest", "1.0", \args, mopts) {
+        Datasource ds;
+        try {
+            ds = getDatasource();
+            # create the test schema
+            schema = new TableMapperTestSchema(ds);
+            schema.align(False, m_options.verbose);
+            # get table object
+            table = (new Table(schema.getDatasource(), "table_mapper_test")).getTable();
+
+            # add test cases
+            addTestCase("InboundTableMapper", \inboundTableMapperTest());
+        }
+        catch (hash ex) {
+            if (m_options.verbose)
+                printf("%s: %s\n", ex.err, ex.desc);
+            # skip tests if we can't create the datasource
+        }
+
+        set_return_value(main());
+    }
+
+    globalTearDown() {
+        # drop the test schema
+        if (schema)
+            schema.drop(False, m_options.verbose);
+    }
+
+    private usageIntern() {
+        TestReporter::usageIntern(OptionColumn);
+        printOption("-c,--conn=ARG", "set DB connection argument (ex: \"driver:user/pass@db\")", OptionColumn);
+    }
+
+    inboundTableMapperTest() {
+        if (!table)
+            testSkip("no DB connection");
+
+        {
+            on_exit table.rollback();
+
+            InboundTableMapper mapper(table, Map1);
+            checkMap((map mapper.insertRow($1), Input1), Input1);
+            checkMap(table.selectRows(("orderby": "id")), Input1);
+        }
+
+        {
+            on_exit table.rollback();
+
+            InboundTableMapper mapper(table, Map1);
+            map mapper.queueData($1), Input1;
+            checkMap((map $1, mapper.flush().contextIterator()), Input1);
+            checkMap(table.selectRows(("orderby": "id")), Input1);
+        }
+    }
+
+    checkMap(list l, list il) {
+        foreach hash h in (l) {
+            assertEq(Type::Int, h.id.type(), "id type for row " + $#);
+            assertEq(il[$#].string, h.string);
+        }
+    }
+
+    Datasource getDatasource() {
+        if (!m_options.connstr)
+            m_options.connstr = ENV.QORE_DB_CONNSTR_ORACLE ?? ENV.QORE_DB_CONNSTR_PGSQL ?? ENV.QORE_DB_CONNSTR_MYSQL ?? ENV.QORE_DB_CONNSTR_FREETDS ?? ENV.QORE_DB_CONNSTR_SYBASE;
+        Datasource ds(m_options.connstr);
+        ds.open();
+        return ds;
+    }
+}

--- a/examples/test/qlib/TableMapper/TableMapper.qtest
+++ b/examples/test/qlib/TableMapper/TableMapper.qtest
@@ -10,6 +10,11 @@
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/SqlUtil.qm
+# load all possible SqlUtil driver-specific modules to ensure that our version is used when testing
+%requires ../../../../qlib/OracleSqlUtil.qm
+%requires ../../../../qlib/PgsqlSqlUtil.qm
+%requires ../../../../qlib/MysqlSqlUtil.qm
+%requires ../../../../qlib/FreetdsSqlUtil.qm
 %requires ../../../../qlib/Schema.qm
 %requires ../../../../qlib/TableMapper.qm
 

--- a/qlib/FreetdsSqlUtil.qm
+++ b/qlib/FreetdsSqlUtil.qm
@@ -1647,12 +1647,21 @@ order by
 
         private *hash doReturningImpl(hash opt, reference sql, list args) {
             list l = ();
-            foreach softstring k in (opt.returning) {
-                *FreetdsColumn c = columns{k};
+            foreach any v in (opt.returning) {
+                hash rh;
+                switch (v.typeCode()) {
+                    case NT_STRING: rh.key = v; break;
+                    case NT_HASH: rh = v; break;
+                    default: throw "RETURNING-ERROR", sprintf("got type %y in \"returning\" option; expected \"string\" or \"hash\"", v.type());
+                }
+                if (!rh.key.val() || rh.key.typeCode() != NT_STRING)
+                    throw "RETURNING-ERROR", sprintf("got %y for \"returning\" option key value instead of name of output column", rh.key.type());
+
+                *FreetdsColumn c = columns{rh.key};
                 if (!c)
-                    throw "COLUMN-ERROR", sprintf("%s.%s is not a valid column for the \"returning\" option (valid columns: %y)", name, k, columns.keys());
-                l += k;
-                args += c.qore_type ?* Type::String;
+                    throw "COLUMN-ERROR", sprintf("%s.%s is not a valid column for the \"returning\" option (valid columns: %y)", name, rh.key, columns.keys());
+                l += rh.key;
+                args += rh.type ?* c.qore_type ?* Type::String;
             }
             if (l) {
                 throw "UNIMPLEMENTED", "output not yet implemented";

--- a/qlib/OracleSqlUtil.qm
+++ b/qlib/OracleSqlUtil.qm
@@ -2697,12 +2697,21 @@ my any $v = $c.name;
 
         private *hash doReturningImpl(hash opt, reference sql, list args) {
             list l = ();
-            foreach softstring k in (opt.returning) {
-                *OracleColumn c = columns{k};
+            foreach any v in (opt.returning) {
+                hash rh;
+                switch (v.typeCode()) {
+                    case NT_STRING: rh.key = v; break;
+                    case NT_HASH: rh = v; break;
+                    default: throw "RETURNING-ERROR", sprintf("got type %y in \"returning\" option; expected \"string\" or \"hash\"", v.type());
+                }
+                if (!rh.key.val() || rh.key.typeCode() != NT_STRING)
+                    throw "RETURNING-ERROR", sprintf("got %y for \"returning\" option key value instead of name of output column", rh.key.type());
+
+                *OracleColumn c = columns{rh.key};
                 if (!c)
-                    throw "COLUMN-ERROR", sprintf("%s.%s is not a valid column for the \"returning\" clause (valid columns: %y)", name, k, columns.keys());
-                l += k;
-                args += c.qore_type ?* Type::String;
+                    throw "COLUMN-ERROR", sprintf("%s.%s is not a valid column for the \"returning\" clause (valid columns: %y)", name, rh.key, columns.keys());
+                l += rh.key;
+                args += rh.type ?* c.qore_type ?* Type::String;
             }
             sql += sprintf(" returning %s into %s", (foldl $1 + "," + $2, l), (foldl $1 + "," + $2, (map ":" + $1, l)));
 

--- a/qlib/PgsqlSqlUtil.qm
+++ b/qlib/PgsqlSqlUtil.qm
@@ -1976,12 +1976,20 @@ my any $v = $c.name;
 
         private *hash doReturningImpl(hash opt, reference sql, list args) {
             list l = ();
-            foreach softstring k in (opt.returning) {
-                *PgsqlColumn c = columns{k};
+            foreach any v in (opt.returning) {
+                hash rh;
+                switch (v.typeCode()) {
+                    case NT_STRING: rh.key = v; break;
+                    case NT_HASH: rh = v; break;
+                    default: throw "RETURNING-ERROR", sprintf("got type %y in \"returning\" option; expected \"string\" or \"hash\"", v.type());
+                }
+                if (!rh.key.val() || rh.key.typeCode() != NT_STRING)
+                    throw "RETURNING-ERROR", sprintf("got %y for \"returning\" option key value instead of name of output column", rh.key.type());
+                *PgsqlColumn c = columns{rh.key};
                 if (!c)
-                    throw "COLUMN-ERROR", sprintf("%s.%s is not a valid column for the \"returning\" clause (valid columns: %y)", name, k, columns.keys());
-                l += k;
-                args += c.qore_type ?* Type::String;
+                    throw "COLUMN-ERROR", sprintf("%s.%s is not a valid column for the \"returning\" clause (valid columns: %y)", name, rh.key, columns.keys());
+                l += rh.key;
+                args += rh.type ?* c.qore_type ?* Type::String;
             }
             sql += sprintf(" returning %s", (foldl $1 + "," + $2, l));
 

--- a/qlib/Schema.qm
+++ b/qlib/Schema.qm
@@ -40,6 +40,9 @@
 # enable all warnings
 %enable-all-warnings
 
+# strict args
+%strict-args
+
 module Schema {
     version = "1.1";
     desc = "user module for working with SQL schemas";

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -5976,6 +5976,21 @@ AbstractDatabase db("pgsql:user/pass@db%host");
                     opt = l;
                     break;
                 }
+                case "stringhashlist": {
+                    softlist l = opt;
+                    foreach any v in (l) {
+                        switch (v.typeCode()) {
+                            case NT_STRING:
+                            case NT_HASH:
+                                break;
+                            default:
+                                throw err, sprintf("%s: key %y element %d/%d (first is 0) has type %y, expecting \"string\" or \"hash\" (value: %y)", tag, k, $#, l.size(), v.type(), opt);
+                        }
+                    }
+
+                    opt = l;
+                    break;
+                }
                 case "softstringinthashlist": {
                     softlist l = opt;
                     foreach any v in (l) {
@@ -7725,12 +7740,16 @@ Table table("pgsql:user/pass@db%host", "table");
 
             #! generic SQL insert options
             /** In addition to any @ref SqlDataCallbackOptions, the following keys can be set for this option:
-                - \c returning: a list of \c "returning" columns
+                - \c returning: a list having elements of one of the two following types:
+                  - @ref type_string "string": column names to return the value inserted
+                  - @ref type_hash "hash": a hash having the following keys:
+                    - \c "key": (required) the column name to return
+                    - \c "type": (optional) the data type for the output placeholder buffer (ex: @ref Qore::Type::Number "Type::Number")
 
                 @note using \c "returning" with a database that does not support this clause will cause an exception to be thrown; see @ref SqlUtil::AbstractTable::hasReturning()
             */
             const InsertOptions = SqlDataCallbackOptions + (
-                "returning": "softstringlist",
+                "returning": "stringhashlist",
             );
 
             #! default upsert option keys

--- a/qlib/TableMapper.qm
+++ b/qlib/TableMapper.qm
@@ -187,8 +187,8 @@ on_error table1.rollback();
     @section tablemapperkeys TableMapper Specification Format
 
     The mapper hash is made up of target (ie output) column names as the key values assigned to field specifications as specified in @ref mapperkeys, plus the following hash options:
-    - \c "sequence": a name of a sequence to use to populate the column
-    - \c "sequence_currval": a name of a sequence to use to return the current value of the sequence; this is useful when assigning the same sequence value to multiple columns
+    - \c "sequence": a name of a sequence to use to populate the column; the output buffers for this option are bound as type @ref type_number "number", so the output type depends on the database driver's number option setting (for example, with \c "optimal-numbers", the values here are generally returned as strings)
+    - \c "sequence_currval": a name of a sequence to use to return the current value of the sequence; this is useful when assigning the same sequence value to multiple columns; the output buffers for this option are bound as type @ref type_number "number", so the output type depends on the database driver's number option setting (for example, with \c "optimal-numbers", the values here are generally returned as strings)
 
     In both cases, the actual value inserted in the table is available in the following APIs:
       - @ref TableMapper::InboundTableMapper::insertRow()
@@ -524,12 +524,13 @@ InboundTableMapper mapper(table, DbMapper);
             *hash rh;
 
             if (unstable_input || (insert_block == 1))
-                rh = table.insert(h, ("returning": ret_args));
+                rh = table.insert(h, ("returning": getReturning()));
             else {
                 # when executing for the first time on stable input data, get an SQLStatement for the SQL used to insert
                 if (!stmt) {
                     string sql;
-                    rh = table.insert(h, \sql, ("returning": ret_args));
+                    out_args = map Type::Number, ret_args;
+                    rh = table.insert(h, \sql, ("returning": getReturning()));
                     stmt = new SQLStatement(table.getDatasource());
                     stmt.prepare(sql);
                 }
@@ -537,7 +538,7 @@ InboundTableMapper mapper(table, DbMapper);
                     # remove sequences
                     map remove h.$1, ret_args;
                     # execute the SQLStatement on the args
-                    stmt.execArgs(h.values());
+                    stmt.execArgs(h.values() + out_args);
                     rh = stmt.getOutput();
                 }
             }
@@ -730,8 +731,8 @@ on_error table_mapper.rollback();
                     # update sequences to a single value for the insert
                     if (ret_args && hbuf{ret_args[0]}.typeCode() == NT_LIST)
                         map hbuf.$1 = hbuf.$1[0], ret_args;
-                    out_args = map Type::Number, ret_args.iterator();
-                    rh = table.insert(hbuf, \sql, ("returning": ret_args));
+                    out_args = map Type::Number, ret_args;
+                    rh = table.insert(hbuf, \sql, ("returning": getReturning()));
                     # create the statement for future inserts
                     stmt = new SQLStatement(table.getDatasource());
                     stmt.prepare(sql);
@@ -769,6 +770,11 @@ on_error table_mapper.rollback();
 
             # return all data inserted
             return rv;
+        }
+
+        #! returns a list argument for the SqlUtil "returning" option, if applicable
+        *list getReturning() {
+            return map ("key": $1, "type": Type::Int), ret_args;
         }
 
         #! ignore logging from Mapper since we may have to log sequence values; output logged manually in insertRow()


### PR DESCRIPTION
…und with Type::Number and therefore returned as integers if the "optimal-numbers" option is set on the DBI driver (this is the default)

refs #755 the placeholder buffer type for the "returning" option can now be set explicitly; this allows for DB types without any known qore type equivalent to be returned
