### PR TITLE
refs #759 aligned QC_SOCKET visibility with other declarations

### DIFF
--- a/include/qore/intern/QC_HTTPClient.h
+++ b/include/qore/intern/QC_HTTPClient.h
@@ -34,7 +34,7 @@
 
 DLLEXPORT extern qore_classid_t CID_HTTPCLIENT;
 DLLEXPORT extern QoreClass *QC_HTTPCLIENT;
-DLLEXPORT extern QoreClass *QC_SOCKET;
+DLLLOCAL extern QoreClass *QC_SOCKET;
 DLLLOCAL QoreClass *initHTTPClientClass(QoreNamespace& ns);
 
 class HTTPInfoRefHelper {


### PR DESCRIPTION
maybe only was broken on clang...
