### PR TITLE
refs #777 fixed escaping in regular expression substitution expressio…

### DIFF
--- a/doxygen/lang/180_operators.dox.tmpl
+++ b/doxygen/lang/180_operators.dox.tmpl
@@ -1302,7 +1302,7 @@ if (x !== y)
     @section regex_match_operator Regular Expression Match Operator (=~)
 
     @par Synopsis
-    Checks for a regular expression match; returns @ref Qore::True "True" if the expression matches the string, @ref Qore::False "False" if not. See @ref regex_options for the meaning of the \c i, \c s, \c x, and \c m options after the regular expression.\n\n
+    Checks for a regular expression match; returns @ref Qore::True "True" if the expression matches the string, @ref Qore::False "False" if not. See @ref qore_regex_options for the meaning of the \c i, \c s, \c x, and \c m options after the regular expression.\n\n
     See @ref qore_regex for more information about regular expression support in %Qore.
 
     @par Syntax
@@ -1327,7 +1327,7 @@ if (str =~ /hello/)
     @section regex_no_match_operator Regular Expression No Match Operator (!~)
 
     @par Synopsis
-    Checks for a regular expression non match; returns @ref Qore::True "True" if the expression does not match the string, @ref Qore::False "False" if it does. See @ref regex_options for the meaning of the \c i, \c s, \c x, and \c m options after the regular expression.\n\n
+    Checks for a regular expression non match; returns @ref Qore::True "True" if the expression does not match the string, @ref Qore::False "False" if it does. See @ref qore_regex_options for the meaning of the \c i, \c s, \c x, and \c m options after the regular expression.\n\n
     See @ref qore_regex for more information about regular expression support in %Qore.
 
     @par Syntax
@@ -1352,7 +1352,7 @@ if (str !~ /hello/)
     @section regex_subst_operator Regular Expression Substitution Operator
 
     @par Synopsis
-    Looks for a regular expression match in a string, and, if found, substitutes the matched string with a new string. Subpattern backreferences are supported in the target string, <tt>$1</tt>=first subpattern, <tt>$2</tt>=second subpattern, etc... See @ref regex_options for the meaning of the \c i, \c s, \c x, and \c m options after the regular expression.\n\n
+    Looks for a regular expression match in a string, and, if found, substitutes the matched string with a new string. Subpattern backreferences are supported in the target string, <tt>$1</tt>=first subpattern, <tt>$2</tt>=second subpattern, etc... See @ref qore_regex_options for the meaning of the \c i, \c s, \c x, and \c m options after the regular expression.\n\n
     See @ref qore_regex for more information about regular expression support in %Qore.
 
     @par Syntax
@@ -1377,7 +1377,7 @@ str =~ s/(\w+) +(\w+)/$2, $1/;
     @section regex_extract_operator Regular Expression Pattern Extraction Operator
 
     @par Synopsis
-    Matches regular expression patterns (enclosed in parentheses) in a string and returns a list giving the text matched for each pattern. If the regular expression does not match, then no value (@ref nothing) is returned. See @ref regex_options for the meaning of the \c i, \c s, \c x, and \c m options after the regular expression.\n\n
+    Matches regular expression patterns (enclosed in parentheses) in a string and returns a list giving the text matched for each pattern. If the regular expression does not match, then no value (@ref nothing) is returned. See @ref qore_regex_options for the meaning of the \c i, \c s, \c x, and \c m options after the regular expression.\n\n
     See @ref qore_regex for more information about regular expression support in %Qore.
 
     @par Syntax

--- a/doxygen/lang/185_qore_regex.dox.tmpl
+++ b/doxygen/lang/185_qore_regex.dox.tmpl
@@ -2,9 +2,43 @@
 
     @tableofcontents
 
+    @section qore_regex_intro Qore Regular Expression Introduction
+
     Regular expression functionality in %Qore is provided by <a href="http://www.pcre.org">PCRE: Perl-Compatible Regular Expression library</a>.
 
-    Using this library, %Qore implements regular expression pattern matching using the same syntax and semantics as <a href="http://www.perl.org">Perl 5</a>.
+    Using this library, %Qore implements regular expression pattern matching using very simple syntax with semantics similar
+    to those of <a href="http://www.perl.org">Perl 5</a>.
+    One difference between %Qore and Perl to keep in mind is that @ref qore_regex_backreferences "backreferences" in %Qore
+    are referenced as \c $1, \c $2, \c $3, etc which differs from Perl's syntax (which uses numbered backslashes instead).
+
+    @par Examples:
+    @code{.py}
+    # call process() if the string starts with an alphanumeric character
+    if (str =~ /^[[:alnum:]]/)
+        process(str);
+    @endcode
+    @code{.py}
+    # example of using regular expressions in a switch statement
+    switch (str) {
+        case /^[^[:alnum:]]/: return True;
+        case /^[0-9]/: return False;
+        default: throw "ERROR", sprintf("invalid string %y", str);
+    }
+    @endcode
+    @code{.py}
+    # regular expression substitution + ignore case & global options
+    str =~ s/abc/xyz/gi;
+    @endcode
+    @code{.py}
+    # prefix all non-alphanumeric characters with a backslash
+    str =~ s/([^[:alnum:]])/\\$1/g;
+    @endcode
+    @code{.py}
+    # regular expression substring extraction
+    *list l = (str =~ x/(?:(\w+):(\w+):)(\w+)/);
+    @endcode
+
+    @section qore_regex_operators Qore Regular Expression Operators
 
     The following is a list of operators based on regular expressions (or similar to regular expressions in the case of the transliteration operator).
 
@@ -18,7 +52,8 @@
 
     See the table below for valid regular expression options.
 
-    @anchor regex_options
+    @subsection qore_regex_options Qore Regular Expression Operator Options
+
     <b>Regular Expression Options</b>
     |!Option|!Description
     |\c i|Ignores case when matching
@@ -27,6 +62,8 @@
     |\c x|ignores whitespace characters and enables comments prefixed by <tt>#</tt>
     |\c g|makes global substitutions or global extractions (only applicable with the substitution and extraction operators)
 
+    @section qore_regex_functions Qore Regular Expression Functions
+
     The following is a list of functions providing regular expression functionality where the pattern may be given at run-time:
 
     <b>Regular Expression Functions</b>
@@ -34,4 +71,19 @@
     |regex()|Returns @ref Qore::True "True" if the regular expression matches a string
     |regex_subst()|Substitutes a pattern in a string based on regular expressions and returns the new string
     |regex_extract()|Returns a list of substrings in a string based on matching patterns defined by a regular expression
+
+    @subsection qore_regex_backreferences Qore Regular Expression Backreferences
+
+    Qore uses <tt>$</tt><i>num</i> for backreferences in regular expression substitution expressions.  The first backreference is \c $1, the second $2, and so on.
+
+    @par Example
+    @code{.py}
+    # prefix all non-alphanumeric characters with a backslash
+    str =~ s/([^[:alnum:]])/\\$1/g;
+    @endcode
+    @code{.py}
+    # remove parentheses from string at the beginning of the line
+    str =~ s/^\((.*)\)/$1/;
+    @endcode
+
 */

--- a/examples/test/qore/misc/regex.qtest
+++ b/examples/test/qore/misc/regex.qtest
@@ -506,8 +506,6 @@ class RegexTest inherits QUnit::Test {
         ## by the positions of their opening parentheses, left to right), so that
         ## (e.g.) '\([bc]\)\1' matches 'bb' or 'cc' but not 'bc'.
 
-
-
         # Metacharacters
 
         t = 'Empty string';
@@ -567,6 +565,13 @@ class RegexTest inherits QUnit::Test {
         s = 'abc0923_%^';
         s =~ s/([^[:alnum:]])/\\$1/g;
         assertEq("abc0923\\_\\%\\^", s);
+
+        # regex subst target escapes
+        s = "t.q";
+        s =~ s/\./\./g;
+        assertEq("t.q", s);
+        s =~ s/\./\\./g;
+        assertEq("t\\.q", s);
     }
 
     test329() {

--- a/lib/RegexSubstNode.cpp
+++ b/lib/RegexSubstNode.cpp
@@ -138,7 +138,7 @@ void RegexSubstNode::parse() {
 // static function
 void RegexSubstNode::concat(QoreString *cstr, int *ovector, int olen, const char *ptr, const char *target, int rc) {
    while (*ptr) {
-      if (*ptr == '\\' && *(ptr+1) == '\\' && *(ptr+2) == '$') {
+      if (*ptr == '\\' && *(ptr+1) == '\\') {
 	 ++ptr;
 	 cstr->concat(*(ptr++));
       }
@@ -161,6 +161,7 @@ void RegexSubstNode::concat(QoreString *cstr, int *ovector, int olen, const char
       else
 	 cstr->concat(*(ptr++));
    }
+   //printd(5, "RegexSubstNode::concat() target: '%s' cstr: '%s'\n", target, cstr->c_str());
 }
 
 #define SUBST_OVECSIZE 30

--- a/lib/scanner.lpp
+++ b/lib/scanner.lpp
@@ -1174,6 +1174,7 @@ RTIME           PT(-?[0-9]+[HMSu])+
                                            yylval->RegexSubst->concatTarget('\n');
                                         }
       \\\/                              yylval->RegexSubst->concatTarget('/');
+      \\\.                              yylval->RegexSubst->concatTarget('.');
       \\.                               { yylval->RegexSubst->concatTarget('\\'); yylval->RegexSubst->concatTarget(yytext[1]); }
       [^\n\\/]+                         {
                                            char* yptr = yytext;


### PR DESCRIPTION
…ns to match the old behavior (and Perl's), added new tests, updated docs
