### PR TITLE
implementation of #776 Mapper.qm: empty string "" is mapped to NOTHIN…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -272,6 +272,7 @@
       - implemented support for views for DML in the OracleTable class
       - implemented support for Oracle pseudocolumns in queries
       - return lists from Oracle's data dictionary ordered
+      - implemented AbstractTable::emptyStringsAsNull()
     - <a href="../../modules/PgsqlSqlUtil/html/index.html">PgsqlSqlUtil</a> module updates:
       - added support for the following datatypes and aliases: \c bool, \c float, \c int, \c timetz, \c timestamptz, \c varbit
     - <a href="../../modules/MysqlSqlUtil/html/index.html">MysqlSqlUtil</a> module updates:

--- a/examples/test/qlib/Mapper/mapper.qtest
+++ b/examples/test/qlib/Mapper/mapper.qtest
@@ -39,6 +39,7 @@ public class MapperTest inherits QUnit::Test {
             "indextest1" : ("index" : 0),
             "indextest2" : ("index" : 1),
             "indextest3" : ("index" : "a"),
+            "empty_string" : "EmptyString",
         );
 
         const MapInput = ((
@@ -48,6 +49,7 @@ public class MapperTest inherits QUnit::Test {
             "OrderDate": "02.01.2014 10:37:45.103948",
             "UnitPrice": "1.543,50",
             "StoreInfo": ("StoreName": "Store1"),
+            "EmptyString" : "",
             "Products": ((
                 "ProductName": "Widget 1",
                 "Quantity": 1,
@@ -60,6 +62,7 @@ public class MapperTest inherits QUnit::Test {
             "OrderDate": "04.01.2014 19:21:08.882634",
             "UnitPrice": "9,95",
             "StoreInfo": ("StoreName": "Store2"),
+            "EmptyString" : "",
             "Products": ((
                 "ProductName": "Widget X",
                 "Quantity": 4,
@@ -94,6 +97,7 @@ public class MapperTest inherits QUnit::Test {
             "indextest1" : 0,
             "indextest2" : 1,
             "indextest3" : "a0",
+            "empty_string" : "",
             ), (
             "id": 2,
             "name": "Steve Austin",
@@ -118,6 +122,7 @@ public class MapperTest inherits QUnit::Test {
             "indextest1" : 1,
             "indextest2" : 2,
             "indextest3" : "a1",
+            "empty_string" : "",
             ),
         );
     }
@@ -129,6 +134,7 @@ public class MapperTest inherits QUnit::Test {
         addTestCase("Test 'input' option", \testMapperOptionInput());
         addTestCase("Bulk Test", \testMapperBulk());
         addTestCase("Index test", \testMapperIndex());
+        addTestCase("Empty String test", \testEmptyString());
         set_return_value(main());
     }
 
@@ -192,5 +198,15 @@ public class MapperTest inherits QUnit::Test {
             assertEq(rec, MapOutput[ix]);
             ix++;
         }
+    }
+
+    testEmptyString() {
+        Mapper m(DataMap, m_opts + ( "empty_strings_to_nothing" : True ) );
+        list l = m.mapAll(MapInput);
+        list o = MapOutput;
+        # simulate "old empty string to NOTHING conversion"
+        o[0].empty_string = NOTHING;
+        o[1].empty_string = NOTHING;
+        assertEq(l, o);
     }
 }

--- a/examples/test/qlib/TableMapper/TableMapper.qtest
+++ b/examples/test/qlib/TableMapper/TableMapper.qtest
@@ -56,14 +56,17 @@ public class TableMapperTestSchema inherits AbstractSchema {
     }
 
     log(string fmt) {
+        #vprintf(fmt + "\n", argv);
         delete argv;
     }
 
     logpf(string fmt) {
+        #vprintf(fmt + "\n", argv);
         delete argv;
     }
 
     logProgress(string fmt) {
+        #vprintf(fmt + "\n", argv);
         delete argv;
     }
 }
@@ -84,7 +87,7 @@ public class TableMapperTest inherits QUnit::Test {
                        );
         const Output1 = (("string" : "string_1"),
                          ("string" : "string_2"),
-                         ("string" : NOTHING),
+                         ("string" : ""),
                         );
 
         const MyOpts = Opts + (
@@ -129,12 +132,16 @@ public class TableMapperTest inherits QUnit::Test {
         if (!table)
             testSkip("no DB connection");
 
+        list output1 = Output1;
+        if (table.bindEmptyStringsAsNull())
+            output1[2].string = NULL;
+
         {
             on_exit table.rollback();
 
             InboundTableMapper mapper(table, Map1);
-            checkMap((map mapper.insertRow($1), Input1), Input1, Output1);
-            checkMap(table.selectRows(("orderby": "id")), Input1, Output1);
+            checkMap((map mapper.insertRow($1), Input1), Input1, output1);
+            checkMap(table.selectRows(("orderby": "id")), Input1, output1);
         }
 
         {
@@ -142,8 +149,8 @@ public class TableMapperTest inherits QUnit::Test {
 
             InboundTableMapper mapper(table, Map1);
             map mapper.queueData($1), Input1;
-            checkMap((map $1, mapper.flush().contextIterator()), Input1, Output1);
-            checkMap(table.selectRows(("orderby": "id")), Input1, Output1);
+            checkMap((map $1, mapper.flush().contextIterator()), Input1, output1);
+            checkMap(table.selectRows(("orderby": "id")), Input1, output1);
         }
     }
 

--- a/examples/test/qlib/TableMapper/TableMapper.qtest
+++ b/examples/test/qlib/TableMapper/TableMapper.qtest
@@ -84,7 +84,7 @@ public class TableMapperTest inherits QUnit::Test {
                        );
         const Output1 = (("string" : "string_1"),
                          ("string" : "string_2"),
-                         ("string" : NULL),
+                         ("string" : NOTHING),
                         );
 
         const MyOpts = Opts + (
@@ -133,7 +133,7 @@ public class TableMapperTest inherits QUnit::Test {
             on_exit table.rollback();
 
             InboundTableMapper mapper(table, Map1);
-            checkMap((map mapper.insertRow($1), Input1), Input1, Input1);
+            checkMap((map mapper.insertRow($1), Input1), Input1, Output1);
             checkMap(table.selectRows(("orderby": "id")), Input1, Output1);
         }
 
@@ -142,7 +142,7 @@ public class TableMapperTest inherits QUnit::Test {
 
             InboundTableMapper mapper(table, Map1);
             map mapper.queueData($1), Input1;
-            checkMap((map $1, mapper.flush().contextIterator()), Input1, Input1);
+            checkMap((map $1, mapper.flush().contextIterator()), Input1, Output1);
             checkMap(table.selectRows(("orderby": "id")), Input1, Output1);
         }
     }
@@ -150,7 +150,9 @@ public class TableMapperTest inherits QUnit::Test {
     checkMap(list l, list il, list ol) {
         foreach hash h in (l) {
             assertEq(Type::Int, h.id.type(), "id type for row " + $#);
-            assertEq(ol[$#].string, h.string);
+            any hval = h.string === NULL ? NOTHING : h.string;
+            any oval = ol[$#].string === NULL ? NOTHING : ol[$#].string;
+            assertEq(oval, hval);
         }
     }
 

--- a/examples/test/qlib/TableMapper/TableMapper.qtest
+++ b/examples/test/qlib/TableMapper/TableMapper.qtest
@@ -23,7 +23,7 @@ public class TableMapperTestSchema inherits AbstractSchema {
         const T_TableMapperTest = (
             "columns": (
                 "id": c_number(True),
-                "string": c_varchar(50, True),
+                "string": c_varchar(50, C_NULL),
             ),
             );
 
@@ -78,7 +78,14 @@ public class TableMapperTest inherits QUnit::Test {
             "string": True,
             );
 
-        const Input1 = (("string": "string_1"), ("string": "string_2"));
+        const Input1 = (("string": "string_1"),
+                        ("string": "string_2"),
+                        ("string": ""),
+                       );
+        const Output1 = (("string" : "string_1"),
+                         ("string" : "string_2"),
+                         ("string" : NULL),
+                        );
 
         const MyOpts = Opts + (
             "connstr": "c,conn=s",
@@ -126,8 +133,8 @@ public class TableMapperTest inherits QUnit::Test {
             on_exit table.rollback();
 
             InboundTableMapper mapper(table, Map1);
-            checkMap((map mapper.insertRow($1), Input1), Input1);
-            checkMap(table.selectRows(("orderby": "id")), Input1);
+            checkMap((map mapper.insertRow($1), Input1), Input1, Input1);
+            checkMap(table.selectRows(("orderby": "id")), Input1, Output1);
         }
 
         {
@@ -135,15 +142,15 @@ public class TableMapperTest inherits QUnit::Test {
 
             InboundTableMapper mapper(table, Map1);
             map mapper.queueData($1), Input1;
-            checkMap((map $1, mapper.flush().contextIterator()), Input1);
-            checkMap(table.selectRows(("orderby": "id")), Input1);
+            checkMap((map $1, mapper.flush().contextIterator()), Input1, Input1);
+            checkMap(table.selectRows(("orderby": "id")), Input1, Output1);
         }
     }
 
-    checkMap(list l, list il) {
+    checkMap(list l, list il, list ol) {
         foreach hash h in (l) {
             assertEq(Type::Int, h.id.type(), "id type for row " + $#);
-            assertEq(il[$#].string, h.string);
+            assertEq(ol[$#].string, h.string);
         }
     }
 

--- a/qlib/Mapper.qm
+++ b/qlib/Mapper.qm
@@ -267,6 +267,7 @@ public namespace Mapper {
                 "output_log": "a call reference / closure for input record logging",
                 "timezone": "the default output timezone for date/time values",
                 "runtime": "runtime options as a hash (see also setRuntime(), replaceRuntime())",
+                "empty_strings_to_nothing": "converts out record's empty strings and into NOTHING - actually the value is deleted",
                 );
 
             #! default known mapper hash field keys (can be extended by subclassing and reimplementing validKeys())
@@ -285,6 +286,7 @@ public namespace Mapper {
                 "date_format": True,
                 "number_format": True,
                 "runtime" : True,
+                "empty_strings_to_nothing" : True,
                 );
 
             #! default known field types (can be extended by subclassing and reimplementing validTypes() and mapFieldType())
@@ -358,6 +360,11 @@ public namespace Mapper {
             /** @since Mapper 1.1
              */
             *hash m_runtime;
+
+            #! flag to enforce deletion of the empty string in the output record
+            /** @since Mapper 1.1
+             */
+            bool m_empty_strings_to_nothing = False;
         }
 
         #! builds the object based on a hash providing field mappings, data constraints, and optionally custom mapping logic
@@ -475,6 +482,10 @@ Mapper mapv(DataMap);
                           self.className(), opts.runtime.type(), opts.runtime);
                 }
                 m_runtime = opts.runtime;
+            }
+
+            if (opts.empty_strings_to_nothing) {
+                m_empty_strings_to_nothing = parse_boolean(opts.empty_strings_to_nothing);
             }
         }
 
@@ -869,7 +880,7 @@ Mapper mapv(DataMap);
                     }
                 }
 
-                if (v === "" || v === NULL)
+                if ((m_empty_strings_to_nothing && v === "") || v === NULL)
                     delete v;
 
                 if (m.type)

--- a/qlib/OracleSqlUtil.qm
+++ b/qlib/OracleSqlUtil.qm
@@ -263,6 +263,7 @@ my hash $schema = (
     - implemented support for @ref SqlUtil::cop_cast() operator
     - fixed bugs in @ref SqlUtil::cop_seq() and @ref SqlUtil::cop_seq_currval() (<a href="https://github.com/qorelanguage/qore/issues/624">issue 624</a>)
     - return lists from Oracle's data dictionary ordered
+    - implemented @ref OracleSqlUtil::OracleTable::bindEmptyStringsAsNull()
 
     @subsection v11 OracleSqlUtil v1.1
     - fixed selects with "limit" but no "offset"
@@ -2687,6 +2688,13 @@ my any $v = $c.name;
 
         #! returns @ref Qore::True "True" because the oracle driver supports array binds / bulk DML operations
         bool hasArrayBind() {
+            return True;
+        }
+
+        #! returns @ref True because Oracle treats empty strings like @ref NULL on insert
+        /** @since OracleSqlUtil 1.2
+        */
+        bool bindEmptyStringsAsNull() {
             return True;
         }
 

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -118,6 +118,7 @@ module SqlUtil {
     - column aliases (defined with @ref SqlUtil::cop_as()) can now be used in the @ref where_clauses "where hash argument" and in join criteria
     - removed all APIs that handle implicit transactions; APIs must commit transactions explicitly (<a href="https://github.com/qorelanguage/qore/issues/533">issue 533</a>)
     - @ref sql_cop_funcs "column operator functions" can be used in @ref where_clauses "where hashes" and in @ref select_option_join "join conditions": (<a href="https://github.com/qorelanguage/qore/issues/529">issue 529</a>)
+    - implemented @ref SqlUtil::AbstractTable::bindEmptyStringsAsNull()
     - fixed a bug with queries using a \a desc argument with the @ref select_option_orderby "orderby" query option with multiple sort columns; the \c "desc" string was added only to the last column but should have been added to all columns
     - fixed a bug where foreign key constraints with supporting indexes were not tracked and therefore schema alignment on DBs that automatically create indexes for foreign key constraints would fail
     - fixed a bug where driver-specific objects were not included when dropping a schema
@@ -13549,6 +13550,13 @@ string sql = table.getAlignSqlString(table2);
         #! returns a list of column names for use in SQL strings; subclasses can process the argument list in case a column name is a reserved word
         list getColumnSqlNames(softlist cols) {
             return cols;
+        }
+
+        #! returns @ref True if the DB treats empty strings as @ref NULL, @ref False if not; by default this method returns @ref False
+        /** @since SqlUtil 1.3
+        */
+        bool bindEmptyStringsAsNull() {
+            return False;
         }
 
         #! returns @ref Qore::True "True" if the underlying DB driver supports bulk DML operations

--- a/qlib/TableMapper.qm
+++ b/qlib/TableMapper.qm
@@ -391,8 +391,7 @@ InboundTableMapper mapper(table, DbMapper);
             # Bug #787: Mapper.qm: empty string "" is mapped to NOTHING by default
             # converting "" to NOTHING makes proper idenitfiication of NULLs
             # in not null columns in Oracle. Remember: '' == NULL in oracle db.
-            if (table.getDatasource().getConfigHash().type == "oracle"
-                && !exists opts.empty_strings_to_nothing) {
+            if (table.bindEmptyStringsAsNull() && !exists opts.empty_strings_to_nothing) {
                 opts.empty_strings_to_nothing = True;
             }
 
@@ -420,12 +419,12 @@ InboundTableMapper mapper(table, DbMapper);
         private mapFieldType(string key, hash m, reference v, hash rec) {
             if (m.sequence) {
                 if (!has_returning) {
-                    try {
+                    #try {
                         v = db.getNextSequenceValue(m.sequence);
-                    }
-                    catch (hash ex) {
-                        throw ex.err, sprintf("%s (sequence: %y)", ex.desc, m.sequence), ex.arg;
-                    }
+                    #}
+                    #catch (hash ex) {
+                        #throw ex.err, sprintf("%s (sequence: %y)", ex.desc, m.sequence), ex.arg;
+                    #}
                 }
                 else
                     return;

--- a/qlib/TableMapper.qm
+++ b/qlib/TableMapper.qm
@@ -388,6 +388,14 @@ InboundTableMapper mapper(table, DbMapper);
             # setup output description for Mapper
             opts.output = InboundTableMapper::getOutputRecord(opts.name, table, opts.output);
 
+            # Bug #787: Mapper.qm: empty string "" is mapped to NOTHING by default
+            # converting "" to NOTHING makes proper idenitfiication of NULLs
+            # in not null columns in Oracle. Remember: '' == NULL in oracle db.
+            if (table.getDatasource().getConfigHash().type == "oracle"
+                && !exists opts.empty_strings_to_nothing) {
+                opts.empty_strings_to_nothing = True;
+            }
+
             setup(mapv, opts);
 
             # set options with defaults

--- a/qlib/TableMapper.qm
+++ b/qlib/TableMapper.qm
@@ -389,7 +389,7 @@ InboundTableMapper mapper(table, DbMapper);
             opts.output = InboundTableMapper::getOutputRecord(opts.name, table, opts.output);
 
             # Bug #787: Mapper.qm: empty string "" is mapped to NOTHING by default
-            # converting "" to NOTHING makes proper idenitfiication of NULLs
+            # converting "" to NOTHING makes proper identification of NULLs
             # in not null columns in Oracle. Remember: '' == NULL in oracle db.
             if (table.bindEmptyStringsAsNull() && !exists opts.empty_strings_to_nothing) {
                 opts.empty_strings_to_nothing = True;


### PR DESCRIPTION
…G by default

@davidnich @gamato please check. The first implementation draft. Actually I think the "delete empty string" is not required at all because when user wants to map "", he expects "". Also for all DBs except Oracle "" != NULL, and Oracle makes implicit auto-conversion in this case...
