### PR TITLE
refs #799 removed the "synchronized" keyword from FilePoller::run() s…

### DIFF
--- a/qlib/FilePoller.qm
+++ b/qlib/FilePoller.qm
@@ -406,7 +406,7 @@ public namespace FilePoller {
         }
 
         #! starts the polling operation
-        synchronized private run() {
+        private run() {
             on_exit sc.dec();
 
             while (runflag) {


### PR DESCRIPTION
…o that polling can be implemented by multiple threads
