### PR TITLE
refs #817 fixed a bug where object member references were treated as …

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -513,6 +513,7 @@
     - fixed a bug on Windows where @ref Qore::glob() returned files matched without the leading path component (<a href="https://github.com/qorelanguage/qore/issues/761">issue 761</a>)
     - fixed a bug with socket connection refused handling on Windows where connections were waiting until the timeout instead of returning an error immediately (<a href="https://github.com/qorelanguage/qore/issues/763">issue 763</a>)
     - fixed a bug where it was not possible to escape an escape character before a \c '$' character in a regular expression substitution target string (<a href="https://github.com/qorelanguage/qore/issues/777">issue 777</a>)
+    - fixed a bug where object member references were treated as expressions returning a constant value which could cause a crash when used in an expression used to initialize a constant value at parse time (<a href="https://github.com/qorelanguage/qore/issues/817">issue 817</a>)
 
     @section qore_0811 Qore 0.8.11
 

--- a/examples/test/qore/classes/Program/program.qtest
+++ b/examples/test/qore/classes/Program/program.qtest
@@ -66,6 +66,7 @@ class ProgramTest inherits QUnit::Test {
 	addTestCase("Program test", \programTest());
 	addTestCase("Combine test", \combineTest());
         addTestCase("Int assignments test", \intAssignmentsTest());
+        addTestCase("constant exp test", \constantExpressionTest());
 	set_return_value(main());
     }
 
@@ -165,6 +166,13 @@ class ProgramTest inherits QUnit::Test {
             p.parse("any h = {}; int i = h;", "");
 
             assertEq(NOTHING, p.run());
+        }
+    }
+
+    constantExpressionTest() {
+        {
+            Program p(PO_NEW_STYLE);
+            assertThrows("ILLEGAL-MEMBER-REFERENCE", \p.parse(), ("class T {public {int i;} t() {while (True) {switch (1) {case 1+i: break;}}}}", ""));
         }
     }
 }

--- a/lib/SelfVarrefNode.cpp
+++ b/lib/SelfVarrefNode.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -67,6 +67,9 @@ char *SelfVarrefNode::takeString() {
 
 AbstractQoreNode *SelfVarrefNode::parseInitImpl(LocalVar *oflag, int pflag, int &lvids, const QoreTypeInfo *&typeInfo) {
    printd(5, "SelfVarrefNode::parseInit() SELF_REF '%s' oflag=%p\n", str, oflag);
+   if (pflag & PF_CONST_EXPRESSION)
+      parseException(loc, "ILLEGAL-MEMBER-REFERENCE", "member '%s' referenced illegally in an expression executed at parse time to initialize a constant value", str);
+
    if (!oflag)
       parse_error(loc, "cannot reference member \"%s\" when not in an object context", str);
    else {

--- a/lib/VarRefNode.cpp
+++ b/lib/VarRefNode.cpp
@@ -3,7 +3,7 @@
 
   Qore programming language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
…expressions returning a constant value which could cause a crash when used in an expression used to initialize a constant value at parse time
