### PR TITLE
refs #821 updated HttpServer::http_get_url_from_bind() to enclose IPv…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -305,6 +305,7 @@
       - fixed a bug in the <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module where chunked sends were not received and decoded properly in all cases for handlers that did not explicitly handle chunked messages
       - fixed a bug in HttpServer::addListener() with an integer argument; a UNIX socket was opened instead of a wildcard listener on the given port
       - fixed typos causing bugs in HTTP error logging (<a href="https://github.com/qorelanguage/qore/issues/308">issue 308</a>)
+      - fixed a bug formatting IPv6 host addresses in the return value to \c HttpServer::http_get_url_from_bind() (<a href="https://github.com/qorelanguage/qore/issues/821">issue 821</a>)
     - <a href="../../modules/RestClient/html/index.html">RestClient</a> module fixes:
       - fixed bugs where URI strings were improperly encoded and decoded (also fixed in the <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module)
       - fixed a bug where URI paths were sent as relative paths instead of absolute paths
@@ -516,6 +517,7 @@
     - fixed a bug with socket connection refused handling on Windows where connections were waiting until the timeout instead of returning an error immediately (<a href="https://github.com/qorelanguage/qore/issues/763">issue 763</a>)
     - fixed a bug where it was not possible to escape an escape character before a \c '$' character in a regular expression substitution target string (<a href="https://github.com/qorelanguage/qore/issues/777">issue 777</a>)
     - fixed a bug where object member references were treated as expressions returning a constant value which could cause a crash when used in an expression used to initialize a constant value at parse time (<a href="https://github.com/qorelanguage/qore/issues/817">issue 817</a>)
+    - fxied a bug parsing IPv6 localhost (\c "::") with @ref Qore::parse_url() (<a href="https://github.com/qorelanguage/qore/issues/822">issue 822</a>)
 
     @section qore_0811 Qore 0.8.11
 

--- a/examples/test/qlib/HttpServerUtil/HttpServerUtil.qtest
+++ b/examples/test/qlib/HttpServerUtil/HttpServerUtil.qtest
@@ -1,0 +1,27 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+
+%requires ../../../../qlib/QUnit.qm
+%requires ../../../../qlib/Mime.qm
+%requires ../../../../qlib/HttpServerUtil.qm
+
+%exec-class HttpServerUtilTest
+
+public class HttpServerUtilTest inherits QUnit::Test {
+    constructor() : Test("HttpServerUtilTest", "1.0") {
+        addTestCase("funcs", \funcTests());
+
+        # Return for compatibility with test harness that checks the process's return value
+        set_return_value(main());
+    }
+
+    funcTests() {
+        assertEq("https://[fe80::468a:5bff:fe86:43ee]:8011", http_get_url_from_bind("https://fe80::468a:5bff:fe86:43ee:8011"));
+        assertEq("http://[::]", http_get_url_from_bind("::"));
+    }
+}

--- a/examples/test/qore/functions/parse_url.qtest
+++ b/examples/test/qore/functions/parse_url.qtest
@@ -31,5 +31,8 @@ public class parseUrlTest inherits QUnit::Test {
         # windows file paths
         assertEq(("protocol": "file", "path": "c:\\tmp"), parse_url("file://c:\\tmp"));
         assertEq(("protocol": "file", "path": "\\\\share\\dir"), parse_url("file://\\\\share\\dir"));
+
+        # IPv6 localhost
+        assertEq(("host": "::"), parse_url("::"));
     }
 }

--- a/lib/QoreURL.cpp
+++ b/lib/QoreURL.cpp
@@ -106,10 +106,13 @@ private:
       bool has_port = false;
       // see if there's a port
       if ((p = (char* )strrchr(pos, ':'))) {
-	 *p = '\0';
-	 port = atoi(p + 1);
-	 has_port = true;
-	 printd(5, "QoreURL::parse_intern port=%d\n", port);
+         // see if it's Ipv6 localhost (::)
+         if (p != (pos + 1) || *pos != ':') {
+            *p = '\0';
+            port = atoi(p + 1);
+            has_port = true;
+            printd(5, "QoreURL::parse_intern port=%d\n", port);
+         }
       }
 
       // there is no hostname if there is no port specification and

--- a/qlib/HttpServerUtil.qm
+++ b/qlib/HttpServerUtil.qm
@@ -232,6 +232,10 @@ public namespace HttpServer {
                 h.host = (!host || host == gethostname()) ? "localhost" : host;
         }
 
+        # encose IPv6 addresses in "[]"
+        if (h.host =~ /^[[:xdigit:]:]+$/)
+            h.host = "[" + h.host + "]";
+
         string login = h.password ? (h.password + ":") : "";
         if (h.username)
             login += sprintf("%s@", h.password);


### PR DESCRIPTION
…6 addresses in square brackets

refs #822 fixed parse_url("::")
