### PR TITLE
refs #855 fixed a bug where the delete and remove operators would inc…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -524,6 +524,7 @@
     - fixed a bug where \c CALL-WITH-TYPE-ERROR exceptions were thrown based on the parse options in the caller instead of in the target when calling across a @ref Qore::Program "Program" barrier (<a href="https://github.com/qorelanguage/qore/issues/841">issue 841</a>)
     - fixed a bug where @ref Qore::is_writable() and @ref Qore::is_readable() could return an incorrect value in some cases (<a href="https://github.com/qorelanguage/qore/issues/852">issue 852</a>)
     - fixed a bug where @ref Qore::format_number() would return an invalid string when the number of decimals to be returned was 0 (<a href="https://github.com/qorelanguage/qore/issues/851">issue 851</a>)
+    - fixed a bug where the @ref delete "delete" and @ref "remove" operators would incorrectly create hash keys when attempting to delete inside complex hash structures with non-existent keys (<a href="https://github.com/qorelanguage/qore/issues/855">issue 855</a>)
 
     @section qore_0811 Qore 0.8.11
 

--- a/examples/test/qore/operators/operators.qtest
+++ b/examples/test/qore/operators/operators.qtest
@@ -11,6 +11,12 @@
 
 %exec-class Test
 
+class DataTest {
+    public {
+        hash b;
+    }
+}
+
 class Test inherits QUnit::Test {
     constructor() : QUnit::Test("operators", "1.0", \ARGV) {
         addTestCase("basic operator tests", \basicTests());
@@ -20,6 +26,7 @@ class Test inherits QUnit::Test {
         addTestCase("post/pre inc/dec", \postPreIncDec());
         addTestCase("identity assignment", \idAssignment());
         addTestCase("assignment type restriction test", \assignmentTypeRestrictionTest());
+        addTestCase("delete/remove test", \deleteRemoveTest());
         set_return_value(main());
     }
 
@@ -301,5 +308,34 @@ class Test inherits QUnit::Test {
         assertThrows("RUNTIME-TYPE-ERROR", sub () {si = x;});
         assertThrows("RUNTIME-TYPE-ERROR", sub () {sn = x;});
         assertThrows("RUNTIME-TYPE-ERROR", sub () {ss = x;});
+    }
+
+    deleteRemoveTest() {
+        {
+            hash a.b.c = 1;
+            # should have no effect
+            delete a.a.c;
+            assertEq(("b": ("c": 1)), a);
+        }
+        {
+            hash a.b.c = 1;
+            # should have no effect
+            remove a.a.c;
+            assertEq(("b": ("c": 1)), a);
+        }
+        {
+            DataTest a();
+            a.b.c.d = 1;
+            # should have no effect
+            delete a.b.c.c;
+            assertEq(("c": ("d": 1)), a.b);
+        }
+        {
+            DataTest a();
+            a.b.c.d = 1;
+            # should have no effect
+            remove a.b.c.c;
+            assertEq(("c": ("d": 1)), a.b);
+        }
     }
 }

--- a/lib/QoreObject.cpp
+++ b/lib/QoreObject.cpp
@@ -250,7 +250,7 @@ int qore_object_private::getLValue(const char* key, LValueHelper& lvh, bool inte
 
    qolhm.stay_locked();
 
-   //printd(5, "qore_object_private::getLValue() this: %p %s::%s type %s\n", this, theclass->getName(), key, mti->getName());
+   //printd(5, "qore_object_private::getLValue() this: %p %s::%s type %s for_remove: %d\n", this, theclass->getName(), key, mti->getName(), for_remove);
    // save lvalue type info
    lvh.setTypeInfo(mti);
 

--- a/lib/Variable.cpp
+++ b/lib/Variable.cpp
@@ -378,11 +378,17 @@ int LValueHelper::doHashObjLValue(const QoreTreeNode* tree, bool for_remove) {
       }
 
       //printd(5, "LValueHelper::doHashObjLValue() def: %s member %s \"%s\"\n", QCS_DEFAULT->getCode(), mem->getEncoding()->getCode(), mem->getBuffer());
-      resetPtr(h->getKeyValuePtr(mem->getBuffer()));
+      AbstractQoreNode** ptr = for_remove ? h->getExistingValuePtr(mem->getBuffer()) : h->getKeyValuePtr(mem->getBuffer());
+      if (!ptr) {
+	 assert(for_remove);
+	 return -1;
+      }
+
+      resetPtr(ptr);
       return 0;
    }
 
-   //printd(5, "LValueHelper::doHashObjLValue() obj: %p member: %s\n", o, mem->getBuffer());
+   //printd(5, "LValueHelper::doHashObjLValue() obj: %p member: '%s'\n", o, mem->getBuffer());
 
    // clear ocvec when we get to an object
    ocvec.clear();


### PR DESCRIPTION
…orrectly create hash keys when attempting to delete inside complex hash structures with non-existent keys, added tests & updated relnotes
