### PR TITLE
refs #899 fixed URI path construction in the RestClient when there is…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -314,6 +314,7 @@
       - fixed bugs where URI strings were improperly encoded and decoded (also fixed in the <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module)
       - fixed a bug where URI paths were sent as relative paths instead of absolute paths
       - fixed issues where multiple leading \c "/" chars were sometimes present in the request URI path
+      - fixed an issue where a trailing \c "/" char was sometimes added to the request URI path (<a href="https://github.com/qorelanguage/qore/issues/899">issue 899</a>)
     - <a href="../../modules/CsvUtil/html/index.html">CsvUtil</a> module fixes:
       - fixed a bug where the \c "format" field option was not usable with fields assigned type \c "*date"
       - fixed the default field type as "*string" (from "string") to avoid parsing and outputting empty strings for missing input data
@@ -370,6 +371,7 @@
       - fixed a bug where an error calling an internal nonexistent method would be reported with an incorrect error message
       - send errors are now reported in the \c AbstractRestStreamRequestHandler object so they can be properly logged (<a href="https://github.com/qorelanguage/qore/issues/734">issue 734</a>)
       - unknown REST class errors with the base class are now reported consistently like all other such errors (<a href="https://github.com/qorelanguage/qore/issues/859">issue 859</a>)
+      - fixed an issue where request URI paths with multiple consecutive \c "/" chars were handled incorrectly (<a href="https://github.com/qorelanguage/qore/issues/900">issue 900</a>)
     - <a href="../../modules/Util/html/index.html">Util</a> module fixes:
       - fixed \c normalize_dir_windows() handling of UNC paths (<a href="https://github.com/qorelanguage/qore/issues/813">issue 813</a>)
     - fixed a memory error in error-handling with type errors when parsing user module headers that could cause a crash

--- a/qlib/RestClient.qm
+++ b/qlib/RestClient.qm
@@ -607,12 +607,13 @@ hash ans = rest.post("/orders/1");
         private nothing preparePath(reference path) {
             # prepare path
             *string p = getConnectionPath();
+
             # strip trailing "/" off the connection path
             p =~ s/\/+$//;
             # strip leading "/" off the given path
             path =~ s/^\/+//;
             if (p.val())
-                path = p + (exists path ? ("/" + path) : "");
+                path = p + (path.val() ? ("/" + path) : "");
             # ensure path is absolute
             if (path !~ /^\//)
                 splice path, 0, 0, "/";

--- a/qlib/RestHandler.qm
+++ b/qlib/RestHandler.qm
@@ -869,7 +869,12 @@ public namespace RestHandler {
                 splice ah.method, 0, 1;
 
             # get class chain
-            *list cl = ah.method ? ah.method.split("/") : NOTHING;
+            *list cl;
+            if (ah.method) {
+                # combine continuous "/" chars into a single one
+                ah.method =~ s/\/\/+/\//g;
+                cl = ah.method.split("/");
+            }
 
             # get initial class
             *string cls = shift cl;


### PR DESCRIPTION
… a contextual base path and an empty request path

refs #900 fixed URI path handling in requests with multiple consecutive / chars
