### PR TITLE
refs #905 fixed a bug in the HttpServer where requests with supported…

### DIFF
--- a/qlib/HttpServerUtil.qm
+++ b/qlib/HttpServerUtil.qm
@@ -795,7 +795,7 @@ public class HttpServer::AbstractHttpRequestHandler {
     hash handleRequest(HttpListenerInterface listener, Socket s, hash cx, hash hdr, *data body) {
         # classic, non-streaming interface
         if (!stream) {
-            any rv = handleRequest(cx, hdr, getMessageBody(s, hdr, body));
+            any rv = handleRequest(cx, hdr, body ?? getMessageBody(s, hdr, body));
             switch (rv.typeCode()) {
                 case NT_HASH: return rv;
                 case NT_STRING:

--- a/qlib/RestClient.qm
+++ b/qlib/RestClient.qm
@@ -388,7 +388,7 @@ rest.setContentEncoding("gzip");
             - @ref RestClient::RestClient::getSendEncoding() "RestClient::getSendEncoding()"
             - @ref RestClient::RestClient::setSendEncoding() "RestClient::setSendEncoding()"
 
-            @since %restClient 1.3
+            @since %RestClient 1.3
         */
         setContentEncoding(string enc = "auto") {
             if (enc == "auto")


### PR DESCRIPTION
… content-encodings could not be processed

invisible = bug introduced in 0.8.12
