### PR TITLE
refs #940 changed sort_descending_stable to preserve the order of items

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -537,6 +537,7 @@
     - fixed a bug where duplicate global variable declarations caused a crash (<a href="https://github.com/qorelanguage/qore/issues/891">issue 891</a>)
     - fixed a memory leak in @ref Qore::SQL::DatasourcePool "DatasourcePool" initialization when the minimum connections cannot be established (<a href="https://github.com/qorelanguage/qore/issues/994">issue 994</a>)
     - fixed handling of NaN values in logical operators (<a href="https://github.com/qorelanguage/qore/issues/915">issue 915</a>)
+    - fixed sort_descending_stable so that it keeps (instead of reversing) the original order of items that compare equal (<a href="https://github.com/qorelanguage/qore/issues/940">issue 940</a>)
 
     @section qore_0811 Qore 0.8.11
 

--- a/examples/test/qore/vars/array.qtest
+++ b/examples/test/qore/vars/array.qtest
@@ -44,6 +44,7 @@ public class ArrayTest inherits QUnit::Test {
         addTestCase("String and binary element dereference test", \testElementDereference(), NOTHING);
         addTestCase("Range test", \testRange(), NOTHING);
         addTestCase("Pseudomethods test", \testPseudomethods(), NOTHING);
+        addTestCase("Stable descending sort", \sortDescStable(), NOTHING);
 
         # Return for compatibility with test harness that checks return value.
         set_return_value(main());
@@ -136,6 +137,17 @@ public class ArrayTest inherits QUnit::Test {
               ( "key1" : 7, "key2" : "six" ),
               ( "key1" : 8, "key2" : "two" ),
               ( "key1" : 9, "key2" : "three" ) );
+        list r_stable_sorted_hl =
+            ( ( "key1" : 9, "key2" : "three" ),
+              ( "key1" : 8, "key2" : "two" ),
+              ( "key1" : 7, "key2" : "six" ),
+              ( "key1" : 6, "key2" : "four" ),
+              ( "key1" : 5, "key2" : "nine" ),
+              ( "key1" : 4, "key2" : "one" ),
+              ( "key1" : 3, "key2" : "five" ),
+              ( "key1" : 3, "key2" : "five-o" ),
+              ( "key1" : 2, "key2" : "seven" ),
+              ( "key1" : 1, "key2" : "eight" ) );
         Sort s();
 
         code hash_compare = int sub (hash l, hash r) { return l.key1 <=> r.key1; };
@@ -161,7 +173,6 @@ public class ArrayTest inherits QUnit::Test {
         assertEq(stable_sorted_hl, sort_stable(hl, "hash_sort_callback"), "third sort_stable() with callback");
         assertEq(stable_sorted_hl, sort_stable(hl, hash_compare), "sort_stable() with closure callback");
 
-        list r_stable_sorted_hl = reverse(stable_sorted_hl);
         assertEq(r_stable_sorted_hl, sort_descending_stable(hl, \SC::hash_sort_callback()), "first sort_descending_stable() with callback");
         assertEq(r_stable_sorted_hl, sort_descending_stable(hl, \s.compare()), "second sort_descending_stable() with callback");
         assertEq(r_stable_sorted_hl, sort_descending_stable(hl, "hash_sort_callback"), "third sort_descending_stable() with callback");
@@ -247,5 +258,12 @@ public class ArrayTest inherits QUnit::Test {
         assertEq('1-2-3-4-a', pseudoList.join('-'), "<list>::join");
         assertEq(5, pseudoList.lsize(), "<list>::lsize");
         assertEq(True, pseudoList.contains(2), "<list>::contains");
+    }
+
+    sortDescStable() {
+        list x = map ($1, 1), range(1,9);
+        code f = int sub(list l, list r) { return l[1] <=> r[1]; };
+        list s = sort_descending_stable(x, f);
+        assertEq(x, s);
     }
 }

--- a/lib/QoreListNode.cpp
+++ b/lib/QoreListNode.cpp
@@ -549,7 +549,7 @@ int QoreListNode::mergesort(const ResolvedCallReferenceNode* fr, bool ascending,
 	 return -1;
       int rc = (int)rv->getAsBigInt();
       if ((ascending && rc <= 0)
-	  || (!ascending && rc > 0))
+	  || (!ascending && rc >= 0))
 	 push(left.getAndClear(li++));
       else
 	 push(right.getAndClear(ri++));


### PR DESCRIPTION
that compare equal
