### PR TITLE
refs #4 fixed a bug reporting the parse location with duplicate hash …

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -346,6 +346,7 @@
       - fixed \c "uop_lower()" and \c "uop_upper()" operators to allow nesting (<a href="https://github.com/qorelanguage/qore/issues/657">issue 657</a>)
       - fixed a bug where SqlUtil was generating invalid SQL for some DBs where a wilcard was used with explicit column names (<a href="https://github.com/qorelanguage/qore/issues/708">issue 708</a>)
       - fixed a bug where updating an index without any source constraints caused an invalid exception to be raised (<a href="https://github.com/qorelanguage/qore/issues/768">issue 768</a>)
+      - fixed a bug in \c AbstractTable::update() with sequence operators (<a href="https://github.com/qorelanguage/qore/issues/942">issue 942</a>)
     - <a href="../../modules/OracleSqlUtil/html/index.html">OracleSqlUtil</a> module fixes:
       - fixed a bug where column names that are reserved words were not quoted in generated SQL
       - fixed bugs in \c cop_seq() and \c cop_seq_currval() (<a href="https://github.com/qorelanguage/qore/issues/624">issue 624</a>)

--- a/examples/test/qlib/SqlUtil/OracleSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/OracleSqlUtil.qtest
@@ -162,6 +162,12 @@ class OracleTest inherits SqlTestBase {
             );
 
         assertEq(("id": 2, "seq": 1, "seq_currval": 1), table.selectRow(sh));
+        assertEq(("id": 2, "seq": 2, "seq_currval": 2), table.selectRow(sh));
+        assertEq(("id": 2, "seq": 3, "seq_currval": 3), table.selectRow(sh));
+
+        assertEq(1, table.update(("id": uop_seq("oracle_test_seq")), ("id": 2)));
+        sh."where".id = 4;
+        assertEq(("id": 4, "seq": 5, "seq_currval": 5), table.selectRow(sh));
     }
 
     testPseudoColumns() {

--- a/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
@@ -210,6 +210,12 @@ class PgsqlTest inherits SqlTestBase {
             );
 
         assertEq(("id": 2, "seq": 1, "seq_currval": 1), table.selectRow(sh));
+        assertEq(("id": 2, "seq": 2, "seq_currval": 2), table.selectRow(sh));
+        assertEq(("id": 2, "seq": 3, "seq_currval": 3), table.selectRow(sh));
+
+        assertEq(1, table.update(("id": uop_seq("pgsql_test_seq")), ("id": 2)));
+        sh."where".id = 4;
+        assertEq(("id": 4, "seq": 5, "seq_currval": 5), table.selectRow(sh));
     }
 
     private usageIntern() {

--- a/include/qore/intern/QoreException.h
+++ b/include/qore/intern/QoreException.h
@@ -4,7 +4,7 @@
 
   Qore programming language exception handling support
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -46,7 +46,7 @@ struct QoreExceptionBase {
    QoreListNode *callStack;
    AbstractQoreNode *err, *desc, *arg;
 
-   DLLLOCAL QoreExceptionBase(AbstractQoreNode *n_err, AbstractQoreNode *n_desc, AbstractQoreNode *n_arg = 0, int n_type = ET_SYSTEM) 
+   DLLLOCAL QoreExceptionBase(AbstractQoreNode *n_err, AbstractQoreNode *n_desc, AbstractQoreNode *n_arg = 0, int n_type = ET_SYSTEM)
       : type(n_type), callStack(new QoreListNode), err(n_err), desc(n_desc), arg(n_arg) {
    }
 
@@ -124,7 +124,7 @@ public:
 
    DLLLOCAL QoreException(const QoreProgramLocation &n_loc, const char *n_err, AbstractQoreNode *n_desc, AbstractQoreNode *n_arg = 0, int n_type = ET_SYSTEM) : QoreExceptionBase(new QoreStringNode(n_err), n_desc, n_arg, n_type), QoreExceptionLocation(n_loc), next(0) {
    }
-   
+
    DLLLOCAL void del(ExceptionSink *xsink);
 
    DLLLOCAL QoreException *rethrow() {
@@ -141,7 +141,7 @@ public:
       }
       if (!fn)
          fn = "<unknown>";
-   
+
       QoreHashNode *h = getStackHash(CT_RETHROW, 0, fn, get_runtime_location());
       l->insert(h);
 
@@ -168,7 +168,7 @@ struct qore_es_private {
       thread_exit = false;
       head = tail = 0;
    }
-   
+
    DLLLOCAL ~qore_es_private() {
    }
 

--- a/lib/QoreException.cpp
+++ b/lib/QoreException.cpp
@@ -3,7 +3,7 @@
 
   Qore programming language exception handling support
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/lib/QoreHashNode.cpp
+++ b/lib/QoreHashNode.cpp
@@ -958,8 +958,8 @@ AbstractQoreNode* HashAssignmentHelper::operator*() const {
    return **priv;
 }
 
-void QoreParseHashNode::doDuplicateWarning(QoreProgramLocation& loc, const char* key) {
-   qore_program_private::makeParseWarning(getProgram(), loc, QP_WARN_DUPLICATE_HASH_KEY, "DUPLICATE-HASH-KEY", "hash key '%s' has already been given in this hash; the value given in the last occurrence will be assigned to the hash; to avoid seeing this warning, remove the extraneous key definitions or turn off the warning by using '%%disable-warning duplicate-hash-key' in your code", key);
+void QoreParseHashNode::doDuplicateWarning(const QoreProgramLocation& newloc, const char* key) {
+   qore_program_private::makeParseWarning(getProgram(), newloc, QP_WARN_DUPLICATE_HASH_KEY, "DUPLICATE-HASH-KEY", "hash key '%s' has already been given in this hash; the value given in the last occurrence will be assigned to the hash; to avoid seeing this warning, remove the extraneous key definitions or turn off the warning by using '%%disable-warning duplicate-hash-key' in your code", key);
 }
 
 int QoreParseHashNode::getAsString(QoreString& str, int foff, ExceptionSink* xsink) const {

--- a/lib/parser.ypp
+++ b/lib/parser.ypp
@@ -4,7 +4,7 @@
 
    Qore Programming Language
 
-   Copyright (C) 2003 - 2015 David Nichols
+   Copyright (C) 2003 - 2016 David Nichols
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -88,8 +88,9 @@ class HashElement {
 public:
    AbstractQoreNode* key;
    AbstractQoreNode* value;
+   QoreProgramLocation loc;
 
-   DLLLOCAL HashElement(AbstractQoreNode* k, AbstractQoreNode* v) : key(k), value(v) {
+   DLLLOCAL HashElement(AbstractQoreNode* k, AbstractQoreNode* v, int sl, int el) : key(k), value(v), loc(sl, el) {
       //traceout("HashElement::HashElement()");
    }
 
@@ -99,7 +100,7 @@ public:
    }
 
    DLLLOCAL void addDelete(QoreParseHashNode* h) {
-      h->add(key, value);
+      h->add(key, value, loc);
       key = value = 0;
       delete this;
    }
@@ -2742,7 +2743,7 @@ hash:
 
 hash_element:
         exp ':' exp
-	{ $$ = new HashElement($1, $3); }
+	{ $$ = new HashElement($1, $3, @1.first_line, @3.last_line); }
 	;
 
 alt_hash:

--- a/qlib/FreetdsSqlUtil.qm
+++ b/qlib/FreetdsSqlUtil.qm
@@ -1043,6 +1043,23 @@ my any $v = $c.name;
                     "placeholder": "next value for %v",
                 ),
                 );
+
+            #! a hash of default update operator definitions for FreeTDS
+            const FreetdsUopMap = DefaultUopMap + (
+                COP_SEQ: (
+                    "nocolumn": True,
+                    "withalias": True,
+                    "code": string sub (*string cve, string arg) {
+                        return sprintf("next value for %s", arg);
+                    }
+                ),
+                COP_SEQ_CURRVAL: (
+                    "nocolumn": True,
+                    "code": string sub (*string cve, string arg) {
+                        throw "SEQUENCE-ERROR", sprintf("cannot select the current value of sequence %y because this database does not support this operation", arg);
+                    }
+                ),
+                );
         }
 
         private {
@@ -1221,6 +1238,11 @@ my any $v = $c.name;
         #! returns the insert operator map for this object
         private hash getInsertOperatorMap() {
             return FreetdsIopMap;
+        }
+
+        #! returns the raw (default) update operator map for this object
+        private hash getRawUpdateOperatorMap() {
+            return FreetdsUopMap;
         }
 
         #! returns the select options for this driver

--- a/qlib/OracleSqlUtil.qm
+++ b/qlib/OracleSqlUtil.qm
@@ -1959,6 +1959,22 @@ my any $v = $c.name;
                 ),
                 );
 
+            #! a hash of default update operator definitions for Oracle
+            const OracleUopMap = DefaultUopMap + (
+                COP_SEQ: (
+                    "nocolumn": True,
+                    "code": string sub (*string cve, string arg) {
+                        return sprintf("%s.nextval", arg);
+                    }
+                ),
+                COP_SEQ_CURRVAL: (
+                    "nocolumn": True,
+                    "code": string sub (*string cve, string arg) {
+                        return sprintf("%s.currval", arg);
+                    }
+                ),
+                );
+
             #! a hash of valid pseudocolumns
             const OraclePseudoColumnHash = (
                 "rowid": True,
@@ -2627,6 +2643,11 @@ my any $v = $c.name;
         #! returns the insert operator map for this object
         private hash getInsertOperatorMap() {
             return OracleIopMap;
+        }
+
+        #! returns the raw (default) update operator map for this object
+        private hash getRawUpdateOperatorMap() {
+            return OracleUopMap;
         }
 
         #! returns a hash of valid pseudocolumns

--- a/qlib/PgsqlSqlUtil.qm
+++ b/qlib/PgsqlSqlUtil.qm
@@ -1438,6 +1438,23 @@ my any $v = $c.name;
                     "placeholder": "currval(%v)",
                 ),
                 );
+
+            #! a hash of default update operator definitions for PostgreSQL
+            const PgsqlUopMap = DefaultUopMap + (
+                COP_SEQ: (
+                    "nocolumn": True,
+                    "code": string sub (*string cve, string arg) {
+                        return sprintf("nextval('%s')", arg);
+                    }
+                ),
+                COP_SEQ_CURRVAL: (
+                    "nocolumn": True,
+                    "withalias": True,
+                    "code": string sub (*string cve, string arg) {
+                        return sprintf("currval('%s')", arg);
+                    }
+                ),
+                );
         }
 
         private {
@@ -1538,6 +1555,11 @@ my any $v = $c.name;
         #! returns the insert operator map for this object
         private hash getInsertOperatorMap() {
             return PgsqlIopMap;
+        }
+
+        #! returns the raw (default) update operator map for this object
+        private hash getRawUpdateOperatorMap() {
+            return PgsqlUopMap;
         }
 
         private bool checkExistenceImpl() {

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -141,6 +141,7 @@ module SqlUtil {
     - fixed @ref SqlUtil::uop_lower() and @ref SqlUtil::uop_upper() operators to allow nesting (<a href="https://github.com/qorelanguage/qore/issues/657">issue 657</a>)
     - fixed a bug where SqlUtil was generating invalid SQL for some DBs where a wilcard was used with explicit column names (<a href="https://github.com/qorelanguage/qore/issues/708">issue 708</a>)
     - fixed a bug where updating an index without any source constraints caused an invalid exception to be raised (<a href="https://github.com/qorelanguage/qore/issues/768">issue 768</a>)
+    - fixed a bug in @ref SqlUtil::AbstractTable::update() "AbstractTable::update()" with sequence operators (<a href="https://github.com/qorelanguage/qore/issues/942">issue 942</a>)
 
     @subsection sqlutilv1_2 SqlUtil v1.2
     - added insert operator support; for example, for inserting with values from sequences
@@ -2637,8 +2638,6 @@ sql: select 1 as as_int,1.2 as as_float,3.2 as as_numeric,to_timestamp('20150421
         COP_APPEND: True,
         COP_UPPER: True,
         COP_LOWER: True,
-        COP_SEQ: True,
-        COP_SEQ_CURRVAL: True,
         COP_MINUS: (
             "sqlvalue": True,
             "code": string sub (string cve, any arg) {
@@ -2664,6 +2663,24 @@ sql: select 1 as as_int,1.2 as as_float,3.2 as as_numeric,to_timestamp('20150421
             },
         ),
         COP_SUBSTR: True,
+        COP_SEQ: (
+            "nocolumn": True,
+            "code": string sub (*string cve, string arg) {
+                throw "SEQUENCE-ERROR", sprintf("cannot select sequence %y because this database does not support sequences", arg);
+            }
+        ),
+        COP_SEQ_CURRVAL: (
+            "nocolumn": True,
+            "code": string sub (*string cve, string arg) {
+                throw "SEQUENCE-ERROR", sprintf("cannot select the current value of sequence %y because this database does not support sequences", arg);
+            }
+        ),
+        COP_COALESCE: (
+            "columnargs": True,
+            "code": string sub (*string cve, softlist args) {
+                return sprintf("coalesce(%s)", (foldl $1 + "," + $2, args));
+            }
+        ),
         );
     #@}
 
@@ -12390,6 +12407,24 @@ int ucnt = table.update(("id": id), ("name": name));
 
             if (cmd.sqlvalue)
                 uh.arg = getSqlValue(uh.arg);
+            else if (cmd.argcolumn) {
+                if (!cmd.argoptional || uh.arg) {
+                    if (uh.arg.typeCode() != NT_STRING)
+                        throw "UPDATE-ERROR", sprintf("%s: expecting a string column designation for update operator %y; got type %y instead", getDesc(), uh.uop, uh.arg.type());
+                    uh.arg = getColumnNameIntern(uh.arg, NOTHING, False);
+                }
+            }
+            else if (cmd.columnargs) {
+                if (uh.arg.typeCode() != NT_LIST)
+                    throw "UPDATE-ERROR", sprintf("%s: expecting a list of column designators for update operator %y; got type %y instead", getDesc(), uh.uop, uh.arg.type());
+                foreach any narg in (\uh.arg) {
+                    switch (narg.typeCode()) {
+                        case NT_STRING: narg = getColumnNameIntern(narg, NOTHING, False); break;
+                        case NT_HASH: narg = doColumnOperatorIntern(narg, NOTHING, False); break;
+                        default: throw "COLUMN-ERROR", sprintf("%s: expecting a string column designator or a update operator hash; got %y in position %d/%d instead", getDesc(), narg, $#, uh.arg.lsize());
+                    }
+                }
+            }
 
             string arg = (uh.nest ? getUpdateExpression(col, uh.nest) : col);
 
@@ -13840,8 +13875,16 @@ string sql = table.getAlignSqlString(table2);
         /** override in subclasses to return driver-specific options
         */
         private hash getUpdateOperatorMap() {
-            return getColumnOperatorMap().(DefaultUopMap.keys())
-                + DefaultUopMap.(select DefaultUopMap.keys(), DefaultUopMap{$1}.typeCode() == NT_HASH);
+            hash uom = getRawUpdateOperatorMap();
+            return getColumnOperatorMap().(uom.keys())
+                + (map {$1.key: $1.value}, uom.pairIterator(), $1.value.typeCode() == NT_HASH);
+        }
+
+        #! returns the raw (default) update operator map for this object
+        /** override in subclasses to return driver-specific options
+        */
+        private hash getRawUpdateOperatorMap() {
+            return DefaultUopMap;
         }
 
         #! returns a hash of valid pseudocolumns


### PR DESCRIPTION
…keys

refs #942 fixed a bug in AbstractTable::update() with sequence operators
