### PR TITLE
refs #1005 removed math.h from includes, replaced with cmath, which is

### DIFF
--- a/include/qore/intern/qore_date_private.h
+++ b/include/qore/intern/qore_date_private.h
@@ -34,7 +34,7 @@
 #ifndef QORE_QORE_DATE_PRIVATE_H
 #define QORE_QORE_DATE_PRIVATE_H
 
-#include <math.h>
+#include <cmath>
 
 // note: this implementation does not yet take into account leap seconds,
 //       even if this information is available in the zoneinfo data

--- a/include/qore/intern/qore_number_private.h
+++ b/include/qore/intern/qore_number_private.h
@@ -33,7 +33,7 @@
 
 #define _QORE_QORE_NUMBER_PRIVATE_H
 
-#include <math.h>
+#include <cmath>
 #include <memory>
 
 // the number of consecutive trailing 0 or 9 digits that will be rounded in string output
@@ -264,7 +264,7 @@ struct qore_number_private : public qore_number_private_intern {
 
    DLLLOCAL bool lessThan(double right) const {
       MPFR_DECL_INIT(r, QORE_DEFAULT_PREC);
-      if (mpfr_nan_p(num) || isnan(right)) // If any of the "numbers" is NaN.
+      if (mpfr_nan_p(num) || std::isnan(right)) // If any of the "numbers" is NaN.
          return false;
       mpfr_set_d(r, right, QORE_MPFR_RND);
       return mpfr_less_p(num, r);
@@ -284,7 +284,7 @@ struct qore_number_private : public qore_number_private_intern {
 
    DLLLOCAL bool lessThanOrEqual(double right) const {
       MPFR_DECL_INIT(r, QORE_DEFAULT_PREC);
-      if (mpfr_nan_p(num) || isnan(right)) // If any of the "numbers" is NaN.
+      if (mpfr_nan_p(num) || std::isnan(right)) // If any of the "numbers" is NaN.
          return false;
       mpfr_set_d(r, right, QORE_MPFR_RND);
       return mpfr_lessequal_p(num, r);
@@ -304,7 +304,7 @@ struct qore_number_private : public qore_number_private_intern {
 
    DLLLOCAL bool greaterThan(double right) const {
       MPFR_DECL_INIT(r, QORE_DEFAULT_PREC);
-      if (mpfr_nan_p(num) || isnan(right)) // If any of the "numbers" is NaN.
+      if (mpfr_nan_p(num) || std::isnan(right)) // If any of the "numbers" is NaN.
          return false;
       mpfr_set_d(r, right, QORE_MPFR_RND);
       return mpfr_greater_p(num, r);
@@ -324,7 +324,7 @@ struct qore_number_private : public qore_number_private_intern {
 
    DLLLOCAL bool greaterThanOrEqual(double right) const {
       MPFR_DECL_INIT(r, QORE_DEFAULT_PREC);
-      if (mpfr_nan_p(num) || isnan(right)) // If any of the "numbers" is NaN.
+      if (mpfr_nan_p(num) || std::isnan(right)) // If any of the "numbers" is NaN.
          return false;
       mpfr_set_d(r, right, QORE_MPFR_RND);
       return mpfr_greaterequal_p(num, r);
@@ -343,7 +343,7 @@ struct qore_number_private : public qore_number_private_intern {
    }
 
    DLLLOCAL bool equals(double right) const {
-      if (mpfr_nan_p(num) || isnan(right)) // If any of the "numbers" is NaN.
+      if (mpfr_nan_p(num) || std::isnan(right)) // If any of the "numbers" is NaN.
          return false;
       return 0 == mpfr_cmp_d(num, right);
    }

--- a/lib/Function.cpp
+++ b/lib/Function.cpp
@@ -36,8 +36,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <assert.h>
-
-// FIXME: needed for the log10() call as a hack in float_minus_infinity_noop() below
+#include <cmath>
 
 // FIXME: xxx set parse location
 static void duplicateSignatureException(const char* cname, const char* name, const AbstractFunctionSignature* sig) {

--- a/lib/Function.cpp
+++ b/lib/Function.cpp
@@ -38,7 +38,6 @@
 #include <assert.h>
 
 // FIXME: needed for the log10() call as a hack in float_minus_infinity_noop() below
-#include <math.h>
 
 // FIXME: xxx set parse location
 static void duplicateSignatureException(const char* cname, const char* name, const AbstractFunctionSignature* sig) {

--- a/lib/Operator.cpp
+++ b/lib/Operator.cpp
@@ -34,6 +34,7 @@
 #include <qore/intern/QoreClassIntern.h>
 #include <qore/intern/AbstractIteratorHelper.h>
 
+#include <cmath>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/lib/Operator.cpp
+++ b/lib/Operator.cpp
@@ -34,7 +34,6 @@
 #include <qore/intern/QoreClassIntern.h>
 #include <qore/intern/AbstractIteratorHelper.h>
 
-#include <math.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -760,7 +759,7 @@ static AbstractQoreNode* op_plus_binary_binary(const AbstractQoreNode* left, con
 }
 
 static int64 op_cmp_double(double left, double right, ExceptionSink* xsink) {
-   if (isnan(left) || isnan(right)) {
+   if (std::isnan(left) || std::isnan(right)) {
       xsink->raiseException("NAN-COMPARE-ERROR", "NaN in logical comparison operator");
       return 1;
    }

--- a/lib/Pseudo_QC_Float.qpp
+++ b/lib/Pseudo_QC_Float.qpp
@@ -31,8 +31,6 @@
 
 #include <qore/Qore.h>
 
-#include <math.h>
-
 //! Methods in this pseudo-class can be executed on @ref float "floating-point values"
 /**
  */
@@ -136,7 +134,7 @@ if (f.nanp())
     @since %Qore 0.8.12
 */
 bool <float>::nanp() [flags=CONSTANT] {
-   return isnan(f) != 0;
+   return std::isnan(f) != 0;
 }
 
 //! Returns @ref True if the number is infinity (+ or -)
@@ -152,7 +150,7 @@ if (f.infp())
     @since %Qore 0.8.12
 */
 bool <float>::infp() [flags=CONSTANT] {
-   return isinf(f) != 0;
+   return std::isinf(f) != 0;
 }
 
 //! Returns -1 if the number is negative, 0 if it is zero, or 1 if it is positive

--- a/lib/Pseudo_QC_Float.qpp
+++ b/lib/Pseudo_QC_Float.qpp
@@ -30,6 +30,7 @@
 */
 
 #include <qore/Qore.h>
+#include <cmath>
 
 //! Methods in this pseudo-class can be executed on @ref float "floating-point values"
 /**

--- a/lib/ql_math.qpp
+++ b/lib/ql_math.qpp
@@ -33,7 +33,6 @@
 #include <qore/intern/ql_math.h>
 #include <qore/intern/qore_number_private.h>
 
-#include <math.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <limits.h>

--- a/lib/ql_math.qpp
+++ b/lib/ql_math.qpp
@@ -33,6 +33,7 @@
 #include <qore/intern/ql_math.h>
 #include <qore/intern/qore_number_private.h>
 
+#include <cmath>
 #include <stdlib.h>
 #include <stdio.h>
 #include <limits.h>


### PR DESCRIPTION
appropriate for c++11. Replaced isnan with std::isnan (also for isinf).
