### PR TITLE
Bugfix/976 fixed broken break and continue

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -20,6 +20,7 @@
       - fixed a bug with \c SqlStatementOutboundMapper; it would throw an error if the required \c "table" or \c "sh" options were used and only worked with subclasses that declared these options (<a href="https://github.com/qorelanguage/qore/issues/981">issue 981</a>)
     - fixed a bug where optional arguments were not handled correctly in some rare cases (<a href="https://github.com/qorelanguage/qore/issues/974">issue 974</a>)
     - fixed a bug causing a crash when parse_base64_string_to_string was called with an empty string (<a href="https://github.com/qorelanguage/qore/issues/996">issue 996</a>)
+    - fixed a bug where break and continue statements were accepted outside of loops (<a href="https://github.com/qorelanguage/qore/issues/976">issue 976</a>)
 
     @section qore_0812 Qore 0.8.12
 

--- a/examples/test/qore/misc/break_continue.qtest
+++ b/examples/test/qore/misc/break_continue.qtest
@@ -1,0 +1,70 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+%no-child-restrictions
+
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class BreakAndContinueTest
+
+class  BreakAndContinueTest inherits QUnit::Test {
+    constructor() : QUnit::Test("break and continue test", "1.0") {
+        addTestCase("continue in switch", \continueInSwitch());
+        addTestCase("break allowed", \breakAllowed());
+        addTestCase("break not allowed", \breakNotAllowed());
+        addTestCase("continue allowed", \continueAllowed());
+        addTestCase("continue not allowed", \continueNotAllowed());
+        set_return_value(main());
+    }
+
+    continueInSwitch() {
+        string s = "";
+        for (int i = 0; i < 2; ++i) {
+            s += i;
+            switch (i) {
+                case 0:
+                    continue;
+            }
+            s += "x";
+        }
+        assertEq("01x", s);
+    }
+
+    breakAllowed() {
+        switch(0) { case 0: break; }
+        while (True) { break; }
+        for (;;) { break; }
+        summarize ({'a': (1)}) by (%a) { break; }
+        do { break; } while (True);
+        foreach int i in (0, 1) { if (i == 0) { break; } }
+        context ({'a': (1)}) { break; }
+    }
+
+    breakNotAllowed() {
+        Program p();
+        assertThrows("BREAK-NOT-ALLOWED", \p.parse(), ("sub f() { break; }", ""));
+        assertThrows("BREAK-NOT-ALLOWED", \p.parse(), ("sub f() { do { sub() {break;}(); } while (False); }", ""));
+        assertThrows("BREAK-NOT-ALLOWED", \p.parse(), ("sub f() { do { on_exit break; } while (False); }", ""));
+    }
+
+    continueAllowed() {
+        while (!(int i)) { i = 1; continue; }
+        for (int i; !i; ++i) { continue; }
+        summarize ({'a': (1)}) by (%a) { continue; }
+        do { continue; } while (False);
+        foreach int i in (0, 1) { if (i == 0) { continue; } }
+        context ({'a': (1)}) { continue; }
+    }
+
+    continueNotAllowed() {
+        Program p();
+        assertThrows("CONTINUE-NOT-ALLOWED", \p.parse(), ("sub f() { continue; }", ""));
+        assertThrows("CONTINUE-NOT-ALLOWED", \p.parse(), ("sub f() { switch(0) {case 0: continue; }}", ""));
+        assertThrows("CONTINUE-NOT-ALLOWED", \p.parse(), ("sub f() { do { sub() {continue;}(); } while (False); }", ""));
+        assertThrows("CONTINUE-NOT-ALLOWED", \p.parse(), ("sub f() { do { on_exit continue; } while (False); }", ""));
+    }
+}

--- a/include/qore/intern/AbstractStatement.h
+++ b/include/qore/intern/AbstractStatement.h
@@ -45,6 +45,8 @@
 #define PF_FOR_ASSIGNMENT        (1 << 3)
 #define PF_CONST_EXPRESSION      (1 << 4)
 #define PF_TOP_LEVEL             (1 << 5) //!< parsing at the top-level of the program
+#define PF_BREAK_OK              (1 << 6)
+#define PF_CONTINUE_OK           (1 << 7)
 
 // all definitions in this file are private to the library and subject to change
 

--- a/include/qore/intern/BreakStatement.h
+++ b/include/qore/intern/BreakStatement.h
@@ -41,6 +41,8 @@ private:
       return RC_BREAK;
    }
    DLLLOCAL virtual int parseInitImpl(LocalVar *oflag, int pflag = 0) {
+      if (!(pflag & PF_BREAK_OK))
+         parseException("BREAK-NOT-ALLOWED", "break statements are only allowed in switch and loop statements");
       return 0;
    }
 

--- a/include/qore/intern/ContinueStatement.h
+++ b/include/qore/intern/ContinueStatement.h
@@ -41,6 +41,8 @@ private:
       return RC_CONTINUE;
    }
    DLLLOCAL virtual int parseInitImpl(LocalVar *oflag, int pflag = 0) {
+      if (!(pflag & PF_CONTINUE_OK))
+         parseException("CONTINUE-NOT-ALLOWED", "continue statements are only allowed in loop statements");
       return 0;
    }
 

--- a/lib/ContextStatement.cpp
+++ b/lib/ContextStatement.cpp
@@ -180,7 +180,7 @@ int ContextStatement::parseInitImpl(LocalVar *oflag, int pflag) {
 
    // initialize statement block
    if (code)
-      code->parseInitImpl(oflag, pflag);
+      code->parseInitImpl(oflag, pflag | PF_BREAK_OK | PF_CONTINUE_OK);
 
    // save local variables
    if (lvids)

--- a/lib/DoWhileStatement.cpp
+++ b/lib/DoWhileStatement.cpp
@@ -61,7 +61,7 @@ int DoWhileStatement::parseInitImpl(LocalVar *oflag, int pflag) {
    pflag &= (~PF_TOP_LEVEL);
 
    if (code)
-      code->parseInitImpl(oflag, pflag);
+      code->parseInitImpl(oflag, pflag | PF_BREAK_OK | PF_CONTINUE_OK);
    if (cond) {
       const QoreTypeInfo *argTypeInfo = 0;
       cond = cond->parseInit(oflag, pflag, lvids, argTypeInfo);

--- a/lib/ForEachStatement.cpp
+++ b/lib/ForEachStatement.cpp
@@ -337,7 +337,7 @@ int ForEachStatement::parseInitImpl(LocalVar *oflag, int pflag) {
       list = list->parseInit(oflag, pflag, lvids, argTypeInfo);
    }
    if (code)
-      code->parseInitImpl(oflag, pflag);
+      code->parseInitImpl(oflag, pflag | PF_BREAK_OK | PF_CONTINUE_OK);
 
    // save local variables
    if (lvids)

--- a/lib/ForStatement.cpp
+++ b/lib/ForStatement.cpp
@@ -104,7 +104,7 @@ int ForStatement::parseInitImpl(LocalVar *oflag, int pflag) {
       ignore_return_value(iterator);
    }
    if (code)
-      code->parseInitImpl(oflag, pflag);
+      code->parseInitImpl(oflag, pflag | PF_BREAK_OK | PF_CONTINUE_OK);
 
    // save local variables
    if (lvids)

--- a/lib/OnBlockExitStatement.cpp
+++ b/lib/OnBlockExitStatement.cpp
@@ -47,7 +47,7 @@ int OnBlockExitStatement::execImpl(QoreValue& return_value, ExceptionSink *xsink
 
 int OnBlockExitStatement::parseInitImpl(LocalVar *oflag, int pflag) {
    if (code)
-      code->parseInitImpl(oflag, pflag & ~PF_TOP_LEVEL);
+      code->parseInitImpl(oflag, pflag & ~(PF_TOP_LEVEL | PF_BREAK_OK | PF_CONTINUE_OK));
 
    return 0;
 }

--- a/lib/SummarizeStatement.cpp
+++ b/lib/SummarizeStatement.cpp
@@ -102,7 +102,7 @@ int SummarizeStatement::parseInitImpl(LocalVar *oflag, int pflag) {
 
    // initialize statement block
    if (code)
-      code->parseInitImpl(oflag, pflag);
+      code->parseInitImpl(oflag, pflag | PF_BREAK_OK | PF_CONTINUE_OK);
 
    // save local variables
    if (lvars)

--- a/lib/SwitchStatement.cpp
+++ b/lib/SwitchStatement.cpp
@@ -121,7 +121,7 @@ int SwitchStatement::execImpl(QoreValue& return_value, ExceptionSink *xsink) {
 
 	 w = w->next;
       }
-      if (rc == RC_BREAK || rc == RC_CONTINUE)
+      if (rc == RC_BREAK)
 	 rc = 0;
    }
 
@@ -191,7 +191,7 @@ int SwitchStatement::parseInitImpl(LocalVar *oflag, int pflag) {
       }
 
       if (w->code)
-	 w->code->parseInitImpl(oflag, pflag);
+	 w->code->parseInitImpl(oflag, pflag | PF_BREAK_OK);
       w = w->next;
    }
 

--- a/lib/WhileStatement.cpp
+++ b/lib/WhileStatement.cpp
@@ -75,7 +75,7 @@ int WhileStatement::parseInitImpl(LocalVar *oflag, int pflag) {
       cond = cond->parseInit(oflag, pflag, lvids, argTypeInfo);
    }
    if (code)
-      code->parseInitImpl(oflag, pflag);
+      code->parseInitImpl(oflag, pflag | PF_BREAK_OK | PF_CONTINUE_OK);
 
    // save local variables
    if (lvids)

--- a/qlib/HttpServer.qm
+++ b/qlib/HttpServer.qm
@@ -1514,7 +1514,7 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
                     phi.clear();
 
                 if (rv.reply_sent)
-                    continue;
+                    return;
             }
 
             sendReply(listener, s, handler, rv, \cx, hdr, head);

--- a/qlib/Util.qm
+++ b/qlib/Util.qm
@@ -618,7 +618,6 @@ hash: (1 member)
             do_break = False;
 
             i += 2;
-            continue;
         };
 
         # process other values


### PR DESCRIPTION
- fixed continue in a switch nested in a loop
- break and continue report error when used outside of a loop
- removed invalid continue from Util.qm
- fixed an invalid use of continue in HTTPServer.qm
