### PR TITLE
refs #1047 fixes a bug in AbstractAuthenticator::do401() where the ms…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -15,6 +15,8 @@
 
     @subsection qore_0813_bug_fixes Bug Fixes in Qore
     - fixed a bug causing the AbstractQuantifiedBidirectionalIterator not being available (<a href="https://github.com/qorelanguage/qore/issues/968">issue 968</a>)
+    - <a href="../../modules/HttpServerUtil/html/index.html">HttpServerUtil</a> module fixes:
+      - fixed a bug where the \a msg arg to \c AbstractAuthenticator::do401() was ignored (<a href="https://github.com/qorelanguage/qore/issues/1047">issue 1047</a>)
     - <a href="../../modules/SqlUtil/html/index.html">SqlUtil</a> module fixes:
       - fixed a bug in update and upsert statement generation when the given data does not have enough columns to use the unique index found, an error message is generated that contains all the columns names instead of just the column names required by the index (<a href="https://github.com/qorelanguage/qore/issues/1013">issue 1013</a>)
     - <a href="../../modules/TableMapper/html/index.html">TableMapper</a> module fixes:

--- a/qlib/HttpServerUtil.qm
+++ b/qlib/HttpServerUtil.qm
@@ -22,7 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%requires qore >= 0.8.12
+%requires qore >= 0.8.13
 # need mime definitions
 %requires Mime >= 1.0
 %requires Util >= 1.0
@@ -30,7 +30,7 @@
 %new-style
 
 module HttpServerUtil {
-    version = "0.3.11";
+    version = "0.3.12";
     desc = "HttpServerUtil class definition";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -69,6 +69,9 @@ module HttpServerUtil {
     - <a href="http://www.qore.org/manual/modules/xml/current/SoapHandler/html/index.html">SoapHandler</a>: provides infrastructure for implementing SOAP server-side services using the HttpServer module
 
     @section httpserverutil_relnotes HttpServerUtil Module Release Notes
+
+    @subsection httputil0311 HttpServerUtil 0.3.12
+    - fixed a bug in AbstractAuthenticator::do401() where the \a msg argument was ignored (<a href="https://github.com/qorelanguage/qore/issues/1047">issue 1047</a>)
 
     @subsection httputil0311 HttpServerUtil 0.3.11
     - initial version of the module
@@ -409,7 +412,7 @@ public class HttpServer::AbstractAuthenticator {
     private hash do401(string msg = "Authentication is required to access this server") {
         return (
             "code": 401,
-            "body": "Authentication is required to access this server",
+            "body": msg,
             "hdr": getAuthHeader(),
             );
     }


### PR DESCRIPTION
…g arg was ignored
