### PR TITLE
Removed DLLLOCAL from pure virtual methods introduced with streams

### DIFF
--- a/include/qore/InputStream.h
+++ b/include/qore/InputStream.h
@@ -51,7 +51,7 @@ public:
     * @param xsink the exception sink
     * @return the number of bytes read, 0 indicates the end of the stream
     */
-   DLLLOCAL virtual int64 read(void *ptr, int64 limit, ExceptionSink *xsink) = 0;
+   virtual int64 read(void *ptr, int64 limit, ExceptionSink *xsink) = 0;
 
 protected:
    /**

--- a/include/qore/OutputStream.h
+++ b/include/qore/OutputStream.h
@@ -48,7 +48,7 @@ public:
     * @brief Flushes any buffered (unwritten) bytes, closes the output stream and releases resources.
     * @param xsink the exception sink
     */
-   DLLLOCAL virtual void close(ExceptionSink* xsink) = 0;
+   virtual void close(ExceptionSink* xsink) = 0;
 
    /**
     * @brief Writes bytes to the output stream.
@@ -56,7 +56,7 @@ public:
     * @param count the number of bytes to write, must be &gt;= 0
     * @param xsink the exception sink
     */
-   DLLLOCAL virtual void write(const void *ptr, int64 count, ExceptionSink *xsink) = 0;
+   virtual void write(const void *ptr, int64 count, ExceptionSink *xsink) = 0;
 
 protected:
    /**

--- a/include/qore/Transform.h
+++ b/include/qore/Transform.h
@@ -49,7 +49,7 @@ public:
     * @param xsink the exception sink
     * @return a pair (rc, wc) where rc is the number of bytes read from src and wc is the number of bytes written to dst
     */
-   DLLLOCAL virtual std::pair<int64, int64> apply(const void *src, int64 srcLen, void *dst, int64 dstLen,
+   virtual std::pair<int64, int64> apply(const void *src, int64 srcLen, void *dst, int64 dstLen,
          ExceptionSink *xsink) = 0;
 
 protected:


### PR DESCRIPTION
refs #869 
