### PR TITLE
refs #1075 use the BCList object to resolve base classes rather than …

### DIFF
--- a/include/qore/intern/QoreClassIntern.h
+++ b/include/qore/intern/QoreClassIntern.h
@@ -1505,7 +1505,6 @@ public:
    }
    DLLLOCAL int add(QoreClass* thisclass, QoreClass* qc, bool is_virtual);
    DLLLOCAL int addBaseClassesToSubclass(QoreClass* thisclass, QoreClass* sc, bool is_virtual);
-   //DLLLOCAL bool isBaseClass(QoreClass* qc) const;
    DLLLOCAL QoreClass* getClass(qore_classid_t cid) const;
    //DLLLOCAL void execConstructors(QoreObject* o, BCEAList* bceal, ExceptionSink* xsink) const;
    DLLLOCAL void execDestructors(QoreObject* o, ExceptionSink* xsink) const;

--- a/include/qore/intern/QoreClassIntern.h
+++ b/include/qore/intern/QoreClassIntern.h
@@ -1505,7 +1505,7 @@ public:
    }
    DLLLOCAL int add(QoreClass* thisclass, QoreClass* qc, bool is_virtual);
    DLLLOCAL int addBaseClassesToSubclass(QoreClass* thisclass, QoreClass* sc, bool is_virtual);
-   DLLLOCAL bool isBaseClass(QoreClass* qc) const;
+   //DLLLOCAL bool isBaseClass(QoreClass* qc) const;
    DLLLOCAL QoreClass* getClass(qore_classid_t cid) const;
    //DLLLOCAL void execConstructors(QoreObject* o, BCEAList* bceal, ExceptionSink* xsink) const;
    DLLLOCAL void execDestructors(QoreObject* o, ExceptionSink* xsink) const;
@@ -1660,6 +1660,8 @@ public:
    DLLLOCAL void resolveCopy();
 
    DLLLOCAL MethodVariantBase* matchNonAbstractVariant(const std::string& name, MethodVariantBase* v) const;
+
+   DLLLOCAL bool isBaseClass(QoreClass* qc) const;
 };
 
 // BCEANode

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -1500,6 +1500,20 @@ const QoreClass* BCNode::parseGetClass(const qore_class_private& qc, bool& n_pri
    return rv;
 }
 
+bool BCList::isBaseClass(QoreClass* qc) const {
+   for (bclist_t::const_iterator i = begin(), e = end(); i != e; ++i) {
+      QoreClass* sc = (*i)->sclass;
+      assert(sc);
+      //printd(5, "BCList::isBaseClass() %p %s (%d) == %s (%d)\n", this, qc->getName(), qc->getID(), sc->getName(), sc->getID());
+      if (qc->getID() == sc->getID() || (sc->priv->scl && sc->priv->scl->isBaseClass(qc))) {
+	 //printd(5, "BCList::isBaseClass() %p %s (%d) TRUE\n", this, qc->getName(), qc->getID());
+	 return true;
+      }
+   }
+   //printd(5, "BCList::isBaseClass() %p %s (%d) FALSE\n", this, qc->getName(), qc->getID());
+   return false;
+}
+
 int BCList::initialize(QoreClass* cls, bool& has_delete_blocker, qcp_set_t& qcp_set) {
    printd(5, "BCList::parseInit(%s) this: %p empty: %d\n", cls->getName(), this, empty());
    for (bclist_t::iterator i = begin(), e = end(); i != e;) {
@@ -2303,21 +2317,6 @@ void QoreClass::addPrivateMember(const char* mname, const QoreTypeInfo* n_typeIn
    priv->addPrivateMember(mname, n_typeInfo, initial_value);
 }
 
-bool BCSMList::isBaseClass(QoreClass* qc) const {
-   class_list_t::const_iterator i = begin();
-   while (i != end()) {
-      QoreClass* sc = (*i).first;
-      printd(5, "BCSMList::isBaseClass() %p %s (%d) == %s (%d)\n", this, qc->getName(), qc->getID(), sc->getName(), sc->getID());
-      if (qc->getID() == sc->getID() || (sc->priv->scl && sc->priv->scl->sml.isBaseClass(qc))) {
-	 //printd(5, "BCSMList::isBaseClass() %p %s (%d) TRUE\n", this, qc->getName(), qc->getID());
-	 return true;
-      }
-      ++i;
-   }
-   //printd(5, "BCSMList::isBaseClass() %p %s (%d) FALSE\n", this, qc->getName(), qc->getID());
-   return false;
-}
-
 int BCSMList::addBaseClassesToSubclass(QoreClass* thisclass, QoreClass* sc, bool is_virtual) {
    //printd(5, "BCSMList::addBaseClassesToSubclass(this: %s, sc: %s) size: %d\n", thisclass->getName(), sc->getName());
    for (class_list_t::const_iterator i = begin(), e = end(); i != e; ++i) {
@@ -2803,7 +2802,7 @@ const QoreMethod* qore_class_private::parseResolveSelfMethod(NamedScope* nme) {
       return 0;
 
    // see if class is base class of this class
-   if (qc != cls && (!scl || !scl->sml.isBaseClass(qc))) {
+   if (qc != cls && (!scl || !scl->isBaseClass(qc))) {
       parse_error("'%s' is not a base class of '%s'", qc->getName(), name.c_str());
       return 0;
    }


### PR DESCRIPTION
…BCSMList, which should be theoretically more efficient in case of a complex hierarchy where a class is inherited more than once, but it can happen that BCSMList has not yet been populated while BCList is OK, therefore we need to use BCList
