### PR TITLE
refs #1088 fixed option handling when creating the internal Mapper ob…

### DIFF
--- a/examples/test/qlib/TableMapper/SqlStatementOutboundMapper.qtest
+++ b/examples/test/qlib/TableMapper/SqlStatementOutboundMapper.qtest
@@ -15,25 +15,26 @@
 
 # unused, but required for "select hash" argument
 const SELECT_HASH = (
-        "columns" : ("a", "b"),
-        "where" : ( "a" : 1 ),
+    "columns": ("a", "b"),
+    "where": ("a": 1),
     );
 
 const MAPV = (
-        "mapped_a": "a",
-        "mapped_b": "b",
-        "created_c" : ( "code": *string sub (*any v, hash rec) { return sprintf("%n - %n", rec.a, rec.b); } ),
-        "constant_d" : ( "constant" : 1 ),
+    "mapped_a": "a",
+    "mapped_b": "b",
+    "created_c": ("code": *string sub (*any v, hash rec) { return sprintf("%n - %n", rec.a, rec.b); }),
+    "constant_d": ("constant" : 1),
+    "runtime": ("runtime": "rt"),
     );
 
 const INPUT = (
-        ("a":1, "b" : 1),
-        ("a":1, "b" : 2),
+    ("a": 1, "b": 1),
+    ("a": 1, "b": 2),
     );
 
 const OUTPUT = (
-        ("mapped_a":1, "mapped_b" : 1, "created_c" : "1 - 1", "constant_d" : 1),
-        ("mapped_a":1, "mapped_b" : 2, "created_c" : "1 - 2", "constant_d" : 1),
+    ("mapped_a": 1, "mapped_b": 1, "created_c": "1 - 1", "constant_d": 1, "runtime": "rtv"),
+    ("mapped_a": 1, "mapped_b": 2, "created_c": "1 - 2", "constant_d": 1, "runtime": "rtv"),
     );
 
 # just return INPUTs as it would be returned by SQLStatement
@@ -169,7 +170,6 @@ class FakeAbstractTable inherits SqlUtil::AbstractTable {
 class Main inherits QUnit::DependencyInjectedTest {
 
     constructor() : DependencyInjectedTest("SqlStatementOutboundMapper", "1.0") {
-
         addTestCase("SqlStatementOutboundMapper iterator", \testIterator());
         addTestCase("SqlStatementOutboundMapper hash rows", \testHashRows());
         addTestCase("SqlStatementOutboundMapper context", \testContext());
@@ -188,7 +188,7 @@ class Main inherits QUnit::DependencyInjectedTest {
 
     private testIterator() {
         FakeAbstractTable t();
-        SqlStatementOutboundMapper m(t, SELECT_HASH, MAPV);
+        SqlStatementOutboundMapper m(t, SELECT_HASH, MAPV, ("runtime": ("rt": "rtv")));
         AbstractIterator it = m.iterator();
 
         int i = 0;
@@ -201,7 +201,7 @@ class Main inherits QUnit::DependencyInjectedTest {
 
     private testHashRows() {
         FakeAbstractTable t();
-        SqlStatementOutboundMapper m(t, SELECT_HASH, MAPV);
+        SqlStatementOutboundMapper m(t, SELECT_HASH, MAPV, ("runtime": ("rt": "rtv")));
         list l = ();
         while (*list tl = m.getDataRows()) {
             l += tl;
@@ -211,7 +211,7 @@ class Main inherits QUnit::DependencyInjectedTest {
 
     private testContext() {
         FakeAbstractTable t();
-        SqlStatementOutboundMapper m(t, SELECT_HASH, MAPV);
+        SqlStatementOutboundMapper m(t, SELECT_HASH, MAPV, ("runtime": ("rt": "rtv")));
         list l = ();
         while (*hash th = m.getData()) {
             map l += $1, th.contextIterator();

--- a/qlib/TableMapper.qm
+++ b/qlib/TableMapper.qm
@@ -1250,6 +1250,8 @@ InboundTableMapperIterator i(input, mapper);
             SQLStatement m_stmt;
             # a select_block size. Taken from options
             int select_block;
+            # original option hash
+            *hash m_orig_opts;
         }
 
         #! builds the object based on an optional hash providing field mappings, data constraints, and optionally custom mapping logic
@@ -1264,6 +1266,7 @@ InboundTableMapperIterator i(input, mapper);
             @throw MAP-ERROR invalid select_block size; must be >= 1 if present
         */
         constructor(hash mapv, *hash opts) {
+            m_orig_opts = opts;
             initOptions(\opts);
 
             setup(mapv, opts);
@@ -1316,7 +1319,7 @@ InboundTableMapperIterator i(input, mapper);
         SqlStatementMapperIterator iterator() {
             if (!m_stmt)
                 initStatement();
-            return new SqlStatementMapperIterator(m_stmt, mapc);
+            return new SqlStatementMapperIterator(m_stmt, mapc, m_orig_opts);
         }
 
         #! Retrieve mapped data as a hash of lists.


### PR DESCRIPTION
…ject with AbstractSqlStatementOutboundMapper::iterator(), added a test

afterwards needs to be updated with relnotes for 0.8.13 and applied to develop
