### PR TITLE
refs #1086 improved password masking; covers XML-RPC encoding in mess…

### DIFF
--- a/qlib/HttpServer.qm
+++ b/qlib/HttpServer.qm
@@ -2195,8 +2195,8 @@ class HttpServer::HttpListener inherits Qore::Socket, HttpServer::HttpListenerIn
                     if (body) {
                         if (body.typeCode() == NT_STRING) {
                             string bstr = body.size() > BodyLogLimit ? body.substr(0, BodyLogLimit) + "..." : body;
-                            # attempt to mask any password
-                            bstr =~ s/(pass\w*[=:\s]*).*/$1<masked>.../; #/;
+                            # attempt to mask any password in the message body
+                            bstr =~ s/(pass(?:word)?"?[=:>\s]*).*/$1<masked>.../; #/;
                             bstr = replace(bstr, "\n", "\\n");
                             bstr = replace(bstr, "\r", "\\r");
                             bstr = replace(bstr, "\t", "\\t");

--- a/qlib/RestHandler.qm
+++ b/qlib/RestHandler.qm
@@ -609,7 +609,7 @@ public namespace RestHandler {
 
             # try to mask passwords in args
             string astr = sprintf("%y", args);
-            astr =~ s/(pass\w*[=:\s]*).*/$1<masked>.../; #/;
+            astr =~ s/(pass(?:word)?:\s*)"([^"]*)"/$1"<masked>"/;
             rh.logDebug("REST DBG: class %y: dispatching method %y args: %s", name(), mn, astr);
             return dispatchStream(listener, rh, s, mn, args, cx);
         }
@@ -671,7 +671,10 @@ public namespace RestHandler {
             }
             catch (hash ex) {
                 if (ex.err == "METHOD-DOES-NOT-EXIST") {
-                    rh.logError("DISPATCH-ERROR: cannot dispatch to unimplemented method %y: class %y, args: %y", mn, name(), ah);
+                    # try to mask passwords in args
+                    string astr = sprintf("%y", ah);
+                    astr =~ s/(pass(?:word)?:\s*)"([^"]*)"/$1"<masked>"/;
+                    rh.logError("DISPATCH-ERROR: cannot dispatch to unimplemented method %y: class %y, args: %s", mn, name(), astr);
                     # see if alternate methods would work
                     list hl = ();
                     # break flag
@@ -819,7 +822,7 @@ public namespace RestHandler {
             if (b) {
                 string bstr = b.typeCode() == NT_STRING ? trim(b) : sprintf("%y", b);
                 # try to mask passwords in the message body
-                bstr =~ s/(pass\w*[=:\s]*).*/$1<masked>.../; #/;
+                bstr =~ s/(pass(?:word)?"?[=:>\s]*).*/$1<masked>.../; #/;
                 logDebug("REST DBG: body: %s", bstr);
             }
 


### PR DESCRIPTION
…age bodies, targeted masking in YAML output (%y sprintf formatting), added masking to debug log messages for REST API calls with an invalid HTTP method
