### PR TITLE
refs #1099 fixed an issue where an internal C++ API (QoreProgram::par…

### DIFF
--- a/command-line.cpp
+++ b/command-line.cpp
@@ -892,7 +892,7 @@ int qore_main_intern(int argc, char* argv[], int other_po) {
       bool mod_errs = false;
 
       // set parse defines
-      qpgm->parseCmdLineDefines(defmap, xsink, wsink, warnings);
+      qpgm->parseCmdLineDefines(xsink, wsink, warnings, defmap);
 
       if (xsink.isException()) {
          rc = 2;

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -82,6 +82,7 @@
     - fixed a bug resolving base class method calls during parse initialization (<a href="https://github.com/qorelanguage/qore/issues/1075">issue 1075</a>)
     - fixed a bug causing an infinite loop in decompression functions (<a href="https://github.com/qorelanguage/qore/issues/966">issue 966</a>)
     - fixed thread memory handling bug with some operator expressions and the @ref background "background operator" (<a href="https://github.com/qorelanguage/qore/issues/1096">issue 1096</a>)
+    - fixed an issue where an internal C++ API (QoreProgram::parseCmdLineDefines()) performed a needless copy of a data structure (<a href="https://github.com/qorelanguage/qore/issues/1099">issue 1099</a>)
 
     @section qore_0812 Qore 0.8.12
 

--- a/include/qore/QoreProgram.h
+++ b/include/qore/QoreProgram.h
@@ -595,10 +595,8 @@ public:
    */
    DLLEXPORT void parseCmdLineDefines(ExceptionSink& xs, ExceptionSink& ws, int w, const std::map<std::string, std::string>& defmap);
 
-#ifdef _QORE_LIB_INTERN
-   // deprecated function still part of the ABI 
+   // deprecated function still part of the ABI
    DLLEXPORT void parseCmdLineDefines(const std::map<std::string, std::string> defmap, ExceptionSink& xs, ExceptionSink& ws, int w);
-#endif
 
    DLLLOCAL QoreProgram(QoreProgram* pgm, int64 po, bool ec = false, const char* ecn = 0);
 

--- a/include/qore/QoreProgram.h
+++ b/include/qore/QoreProgram.h
@@ -587,12 +587,18 @@ public:
    DLLEXPORT void parseDefine(const char* str, AbstractQoreNode* val);
 
    //! defines a parse-time variables
-   /** @param defmap a map of variable names to values
+   /**
        @param xs exception sink for errors
        @param ws exception sink for warnings
        @param w warnings mask
+       @param defmap a map of variable names to values
    */
+   DLLEXPORT void parseCmdLineDefines(ExceptionSink& xs, ExceptionSink& ws, int w, const std::map<std::string, std::string>& defmap);
+
+#ifdef _QORE_LIB_INTERN
+   // deprecated function still part of the ABI 
    DLLEXPORT void parseCmdLineDefines(const std::map<std::string, std::string> defmap, ExceptionSink& xs, ExceptionSink& ws, int w);
+#endif
 
    DLLLOCAL QoreProgram(QoreProgram* pgm, int64 po, bool ec = false, const char* ecn = 0);
 

--- a/lib/QoreProgram.cpp
+++ b/lib/QoreProgram.cpp
@@ -1229,6 +1229,11 @@ void QoreProgram::parseDefine(const char* str, AbstractQoreNode* val) {
 }
 
 void QoreProgram::parseCmdLineDefines(const std::map<std::string, std::string> defmap, ExceptionSink& xs, ExceptionSink& ws, int wm) {
+   const std::map<std::string, std::string>& dm = defmap;
+   parseCmdLineDefines(xs, ws, wm, dm);
+}
+
+void QoreProgram::parseCmdLineDefines(ExceptionSink& xs, ExceptionSink& ws, int wm, const std::map<std::string, std::string>& defmap) {
    ProgramRuntimeParseCommitContextHelper pch(&xs, this);
    if (xs)
       return;


### PR DESCRIPTION
…seCmdLineDefines()) performed a needless copy of a data structure

@tethal I'm not sure why I got the linking error with g++ 5.4.0 - may be a bug in my gcc/binutils build(s) - also not sure if this is the right way to fix this problem - please check
