### PR TITLE
refs #1134 added a hack that allows for setting proper path in qore.p…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1653,6 +1653,13 @@ if test "${prefix}" = "NONE"; then
    prefix=${myprefix}
 fi
 
+# libdir that is set for Makefile in Makefile.am, but not set for configure in
+# configure.ac. This way (for example) config.status generates qore.pc from qore.pc.in
+# that points to incorrect libdir (using .../lib instead of .../lib64 on x64 machines,
+# for example). --PQ 03-Aug-2016
+libdir="\${exec_prefix}/lib${LIBSUFFIX}"
+AC_SUBST([libdir])
+
 # set module path
 if test "$windows" = yes; then
   winprefix=z:`echo ${myprefix}|sed 's/\//\\\\\\\\\\\\\\\\/g'`


### PR DESCRIPTION
…c; note that the entire situation is unfortunate, since qore.pc is generated from qore.pc.in either by cmake OR by autotools, whatever is actually used, and each of the build systems use slightly different way to initialize the variables to be substituted
