### PR TITLE
CsvUtil single type resolve

### DIFF
--- a/examples/test/qlib/CsvUtil/csvutil.qtest
+++ b/examples/test/qlib/CsvUtil/csvutil.qtest
@@ -40,6 +40,7 @@ UK,1234567893,\"Sony, Xperia S\",31052012";
 
     constructor() : Test("CsvUtilTest", "1.0") {
         addTestCase("Basic CSV tests", \csvTest(), NOTHING);
+        addTestCase("Optional field CSV tests", \csvOptionalFieldTest(), NOTHING);
         addTestCase("Multi-type CSV tests", \csvMultiTest(), NOTHING);
         addTestCase("Single-type CSV tests", \csvSingleTest(), NOTHING);
         addTestCase("Single-type CSV map tests", \csvSingleMapTest(), NOTHING);
@@ -96,6 +97,26 @@ UK,1234567893,\"Sony, Xperia S\",31052012";
         testAssertion("CsvDataIterator header by idx 2", \equals(), (("0": "row1-1", "1": "row1-2", "2": "row1-3"), i.getValue()));
         testAssertion("CsvDataIterator header by idx 3", \equals(), (("row1-1", "row1-2", "row1-3"), i.getRecordList()));
         testAssertionValue("CsvDataIterator header by idx 4", i.getHeaders(), ("0", "1", "2"));
+    }
+
+    csvOptionalFieldTest() {
+        hash opts = ("fields": ("f1": "string", "f2": "int", "f3": ("type": "date", "format": "DDMMYYYY"), "f4": "*string", "f5": "*string"));
+        string input = "UK,1234567890,31052012,O1-4
+UK,1234567891,30052012,,O2-5
+UK,1234567892,29052012,O3-4
+UK,1234567893,28052012";
+
+        list records = (
+            ("f1": "UK", "f2": 1234567890, "f3": 2012-05-31, "f4": "O1-4", "f5": NOTHING),
+            ("f1": "UK", "f2": 1234567891, "f3": 2012-05-30, "f4": NOTHING, "f5": "O2-5"),
+            ("f1": "UK", "f2": 1234567892, "f3": 2012-05-29, "f4": "O3-4", "f5": NOTHING),
+            ("f1": "UK", "f2": 1234567893, "f3": 2012-05-28, "f4": NOTHING, "f5": NOTHING),
+        );
+
+        # Iterate through source
+        CsvDataIterator i(input, opts);
+        #list l = map $1, i;
+        testAssertion("CsvDataIterator optional fields", \equalsIterated(), (new ListIterator(records), i));
     }
 
     csvMultiTest() {

--- a/qlib/CsvUtil.qm
+++ b/qlib/CsvUtil.qm
@@ -656,7 +656,7 @@ public namespace CsvUtil {
 
             # list of idx to field transformarions, in order of spec
             hash m_resolve_by_idx;
-            
+
             # fake specs based on the first non-header row
             bool fakeHeaderNames;
 

--- a/qlib/CsvUtil.qm
+++ b/qlib/CsvUtil.qm
@@ -656,6 +656,9 @@ public namespace CsvUtil {
 
             # list of idx to field transformarions, in order of spec
             hash m_resolve_by_idx;
+            
+            # fake specs based on the first non-header row
+            bool fakeHeaderNames;
 
         }
 
@@ -782,6 +785,7 @@ public namespace CsvUtil {
             m_resolve_by_rule = hash();
             m_resolve_by_count = hash();
             m_resolve_by_idx = hash();
+            fakeHeaderNames = False;
 
             # setup type resolving from spec
             foreach string k in (m_specs.keyIterator()) {
@@ -891,6 +895,7 @@ public namespace CsvUtil {
                     list h = ();
                     map h += string($#), l;
                     prepareFieldsFromHeaders(h);
+                    fakeHeaderNames = True;
                 }
             }
 
@@ -1207,6 +1212,10 @@ while (i.next()) {
                 }
                 if (m_resolve_by_count{cnt}.size() > 1)
                     throw errname, sprintf("Line with recourd count %d was not automatically matched since the following records have this length: %y; you need to provide your own identifyTypeImpl() method or specify rules (record: %y)", cnt, m_resolve_by_count{cnt}, rec);
+            }
+            if (!rv && !fakeHeaderNames && m_specs.size() == 1 && exists m_specs{CSV_TYPE_SINGLE}) {
+                # where there is only one type then process it, e.g. when optional fields are not mentioned at the end of line
+                rv = CSV_TYPE_SINGLE;
             }
             if (!rv && !checkElementCounts) {
                 rv = CSV_TYPE_UNKNOWN;


### PR DESCRIPTION
- for backward compatability when only single type is defined then type is always resolved, i.e.
  trailing optional fields are assigned as NOTHING and excess fields are ignored
