### PR TITLE
refs #1163 addressed compatibility issues introduced in FixedLengthUt…

### DIFF
--- a/examples/test/qlib/CsvUtil/csvutil.qtest
+++ b/examples/test/qlib/CsvUtil/csvutil.qtest
@@ -6,6 +6,7 @@
 %require-types
 %strict-args
 
+%requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/CsvUtil.qm
 
@@ -39,17 +40,19 @@ UK,1234567893,\"Sony, Xperia S\",31052012";
 }
 
     constructor() : Test("CsvUtilTest", "1.0") {
-        addTestCase("Basic CSV tests", \csvTest(), NOTHING);
-        addTestCase("Optional field CSV tests", \csvOptionalFieldTest(), NOTHING);
-        addTestCase("Multi-type CSV tests", \csvMultiTest(), NOTHING);
-        addTestCase("Single-type CSV tests", \csvSingleTest(), NOTHING);
-        addTestCase("Single-type CSV map tests", \csvSingleMapTest(), NOTHING);
+        addTestCase("Basic CSV tests", \csvTest());
+        addTestCase("Optional field CSV tests", \csvOptionalFieldTest());
+        addTestCase("Multi-type CSV tests", \csvMultiTest());
+        addTestCase("Single-type CSV tests", \csvSingleTest());
+        addTestCase("Single-type CSV map tests", \csvSingleMapTest());
 
         addTestCase("Escaping", \escapeTest());
-        addTestCase("Old style CSV tests", \csvOldStyleMultiTest(), NOTHING);
-        addTestCase("Multi-type resolve CSV tests", \csvMultiResolveTest(), NOTHING);
+        addTestCase("Old style CSV tests", \csvOldStyleMultiTest());
+        addTestCase("Multi-type resolve CSV tests", \csvMultiResolveTest());
 
-        addTestCase("Config stress", \csvConfig(), NOTHING);
+        addTestCase("Config stress", \csvConfig());
+
+        addTestCase("CSV file iterator", \csvFileIterator());
 
         # Return for compatibility with test harness that checks return value.
         set_return_value(main());
@@ -486,7 +489,6 @@ UK,1234567893,28052012";
             "1234,A,1,2\n";
 
         hash Specs = (
-
             "type2_value1_0" : (
                 "col1" : (
                     "type"   : "int",
@@ -620,6 +622,25 @@ UK,1234567893,28052012";
         );
         MyCsvDataIterator i(Data, Specs, GlobalOptions);
         testAssertion("multi type resolving", \equalsIterated(), (new ListIterator(Result), i));
+    }
+
+    csvFileIterator() {
+        string file = tmp_location() + "/test-file.csv";
+        unlink(file);
+        {
+            File f();
+            f.open2(file, O_WRONLY | O_CREAT);
+            f.write("a,b,c\n1,2,3\n");
+        }
+        on_exit unlink(file);
+
+        CsvFileIterator i(file);
+        assertEq(True, i.hasCallableMethod("hstat"));
+        assertEq(True, i.hasCallableMethod("stat"));
+        assertEq(True, i.hasCallableMethod("getFileName"));
+        assertEq(True, i.hasCallableMethod("getEncoding"));
+
+        assertEq((("0": "a", "1": "b", "2": "c"), ("0": "1", "1": "2", "2": "3")), (map $1, i));
     }
 }
 

--- a/examples/test/qlib/FixedLengthUtil/FixedLengthFileIterator.qtest
+++ b/examples/test/qlib/FixedLengthUtil/FixedLengthFileIterator.qtest
@@ -47,7 +47,7 @@ class Test inherits QUnit::Test {
             "encoding"     : "UTF-8",
             "eol"          : "\n",
             "ignore_empty" : True,
-            "timezone"     : "UTC", # used if not in some date column specification
+            "timezone"     : "UTC", # used if not overridden in date field specifications
             );
     }
 
@@ -67,6 +67,9 @@ class Test inherits QUnit::Test {
         on_exit unlink(file);
 
         FixedLengthFileIterator i(file, Specs, GlobalOptions);
+        assertEq(True, i.hasCallableMethod("hstat"));
+        assertEq(True, i.hasCallableMethod("stat"));
+        assertEq(True, i.hasCallableMethod("getFileName"));
         testAssertionValue("line 1 is there", i.next(), True);
         testAssertionValue("line 1 content check", i.getValue(), ("type": "type1", "record": ("col1" : 11111, "col2" : "bb")));
         testAssertionValue("line 2 is there", i.next(), True);

--- a/examples/test/qlib/FixedLengthUtil/FixedLengthFileIterator.qtest
+++ b/examples/test/qlib/FixedLengthUtil/FixedLengthFileIterator.qtest
@@ -70,6 +70,7 @@ class Test inherits QUnit::Test {
         assertEq(True, i.hasCallableMethod("hstat"));
         assertEq(True, i.hasCallableMethod("stat"));
         assertEq(True, i.hasCallableMethod("getFileName"));
+        assertEq(True, i.hasCallableMethod("getEncoding"));
         testAssertionValue("line 1 is there", i.next(), True);
         testAssertionValue("line 1 content check", i.getValue(), ("type": "type1", "record": ("col1" : 11111, "col2" : "bb")));
         testAssertionValue("line 2 is there", i.next(), True);

--- a/include/qore/intern/InputStreamLineIterator.h
+++ b/include/qore/intern/InputStreamLineIterator.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2016 Qore Technologies, sro
+  Copyright (C) 2016 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/include/qore/intern/QoreClassIntern.h
+++ b/include/qore/intern/QoreClassIntern.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/lib/Function.cpp
+++ b/lib/Function.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2016 David Nichols
+  Copyright (C) 2003 - 2016 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/lib/QC_InputStreamLineIterator.qpp
+++ b/lib/QC_InputStreamLineIterator.qpp
@@ -3,7 +3,7 @@
 /*
   Qore Programming Language
 
-  Copyright (C) 2016 Qore Technologies, sro
+  Copyright (C) 2016 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -150,4 +150,16 @@ while (i.next()) {
  */
 int InputStreamLineIterator::index() [flags=CONSTANT] {
    return isli->index();
+}
+
+//! Returns the @ref character_encoding "character encoding" for the @ref InputStreamLineIterator
+/** @par Example:
+    @code{.py}
+string encoding = i.getEncoding();
+    @endcode
+
+    @return the @ref character_encoding "character encoding" for the @ref InputStreamLineIterator
+ */
+string InputStreamLineIterator::getEncoding() [flags=CONSTANT] {
+   return new QoreStringNode(isli->getEncoding());
 }

--- a/qlib/CsvUtil.qm
+++ b/qlib/CsvUtil.qm
@@ -692,7 +692,6 @@ public namespace CsvUtil {
 
             # data source iterator
             AbstractLineIterator lineIterator;
-
         }
 
         #! creates the AbstractCsvIterator with an option hash in single-type mode
@@ -817,7 +816,6 @@ public namespace CsvUtil {
 
         #! process specification and assing internal data for resolving
         private processSpec(hash spec) {
-
             m_specs           = spec;
 
             m_resolve_by_rule = hash();
@@ -1340,6 +1338,11 @@ while (i.next()) {
         - @ref abstractcsviterator_option_field_hash
      */
     public class CsvFileIterator inherits CsvUtil::AbstractCsvIterator {
+        private {
+            #! the path of the file being iterated
+            string m_file_path;
+        }
+
         #! Creates the CsvFileIterator in single-type mode with the path of the file to read and an option hash
         /** @param path the path to the CSV file to read
             @param opts a hash of optional options; see @ref abstractcsviterator_options for more information
@@ -1347,19 +1350,42 @@ while (i.next()) {
             @throw ABSTRACTCSVITERATOR-ERROR invalid or unknown option; invalid data type for option; \c "header_names" is @ref Qore::True "True" and \c "header_lines" is 0 or \c "headers" is also present; unknown field type
          */
         constructor(string path, *hash opts) : AbstractCsvIterator(new InputStreamLineIterator(new FileInputStream(path), opts.encoding, opts.eol), opts) {
+            m_file_path = path;
         }
+
         #! Creates the CsvFileIterator in multi-type mode with the path of the file to read and optionally an option hash
         /** @param path the path to the CSV file to read
             @param spec a hash of field and type definition; see @ref abstractcsviterator_option_field_hash for more information
             @param opts a hash of optional options; see @ref abstractcsviterator_options for more information
          */
         constructor(string path, hash spec, hash opts) : AbstractCsvIterator(new InputStreamLineIterator(new FileInputStream(path), opts.encoding, opts.eol), spec, opts) {
+            m_file_path = path;
         }
 
+        #! calls AbstractCsvIterator::memberGate()
         any memberGate(string name) {
             return AbstractCsvIterator::memberGate(name);
         }
 
+        #! Returns the character encoding for the file
+        string getEncoding() {
+            return cast<InputStreamLineIterator>(lineIterator).getEncoding();
+        }
+
+        #! Returns the file path/name used to open the file
+        string getFileName() {
+            return m_file_path;
+        }
+
+        #! Returns a @ref stat_hash "stat hash" of the underlying file
+        hash hstat() {
+            return Qore::hstat(m_file_path);
+        }
+
+        #! Returns a @ref stat_list "stat list" of the underlying file
+        list stat() {
+            return Qore::stat(m_file_path);
+        }
     } # CsvFileIterator class
 
     #! The CsvDataIterator class allows arbitrary CSV string data to be iterated on a record basis

--- a/qlib/FixedLengthUtil.qm
+++ b/qlib/FixedLengthUtil.qm
@@ -711,7 +711,7 @@ map printf("%y\n", $1), i;
 public class FixedLengthUtil::FixedLengthFileIterator inherits FixedLengthUtil::FixedLengthAbstractIterator {
     private {
         #! the path of the file being iterated
-        string filepath;
+        string m_file_path;
     }
 
     #! Instantiates the FixedLengthFileIterator object
@@ -721,7 +721,7 @@ public class FixedLengthUtil::FixedLengthFileIterator inherits FixedLengthUtil::
         @param opts Global options; see @ref fixedlengthglobals for more information
     */
     constructor(string path, hash spec, *hash opts) : FixedLengthAbstractIterator(new InputStreamLineIterator(new FileInputStream(path), opts.encoding, opts.eol), spec, opts) {
-        filepath = path;
+        m_file_path = path;
         # do not convert every string to the same encoding
         m_opts.input_encoding = remove m_opts.encoding;
     }
@@ -733,17 +733,17 @@ public class FixedLengthUtil::FixedLengthFileIterator inherits FixedLengthUtil::
 
     #! Returns the file path/name used to open the file
     string getFileName() {
-        return filepath;
+        return m_file_path;
     }
 
     #! Returns a @ref stat_hash "stat hash" of the underlying file
     hash hstat() {
-        return Qore::hstat(filepath);
+        return Qore::hstat(m_file_path);
     }
 
     #! Returns a @ref stat_list "stat list" of the underlying file
     list stat() {
-        return Qore::stat(filepath);
+        return Qore::stat(m_file_path);
     }
 }
 

--- a/qlib/FixedLengthUtil.qm
+++ b/qlib/FixedLengthUtil.qm
@@ -708,26 +708,31 @@ map printf("%y\n", $1), i;
     @see
     - @ref FixedLengthUtil::FixedLengthIterator "FixedLengthIterator" for a stream-based class providing the same functionality as this class in a more generic way
 */
-public class FixedLengthUtil::FixedLengthFileIterator inherits FixedLengthUtil::FixedLengthAbstractIterator {
-    private {
-        string m_file_path;
-    }
-
+public class FixedLengthUtil::FixedLengthFileIterator inherits Qore::FileLineIterator, FixedLengthUtil::FixedLengthAbstractIterator {
     #! Instantiates the FixedLengthFileIterator object.
     /**
         @param path File path to read
         @param spec Fixed-length line specification; see @ref fixedlengthspec for more information
         @param opts Global options; see @ref fixedlengthglobals for more information
     */
-    constructor(string path, hash spec, *hash opts) : FixedLengthAbstractIterator(new InputStreamLineIterator(new FileInputStream(path), opts.encoding, opts.eol), spec, opts) {
-        m_file_path = path;
+    constructor(string path, hash spec, *hash opts) : FileLineIterator(path, opts.encoding, opts.eol), FixedLengthAbstractIterator(self, spec, opts) {
         # do not convert every string to the same encoding
         m_opts.input_encoding = remove m_opts.encoding;
     }
 
-    #! Return the file name (including path, if used)
-    string getFileName() {
-        return m_file_path;
+    #! Moves the current line / record position to the next line / record; returns @ref False if there are no more lines to iterate
+    /** This method will return @ref True again after it returns @ref False once if the file being iterated has data that can be iterated, otherwise it will always return @ref False. The iterator object should not be used to retrieve a value after this method returns @ref False.
+        @return @ref False if there are no lines / records to iterate (in which case the iterator object is invalid and should not be used); @ref True if successful (meaning that the iterator object is valid)
+
+        @note that empty lines are ignored if "ignore_empty" option is in effect
+     */
+    bool next() {
+        bool status = FileLineIterator::next();
+        if (m_opts.ignore_empty) {
+            while (status && getLine() == '')
+                status = FileLineIterator::next();
+        }
+        return status;
     }
 }
 
@@ -1133,6 +1138,9 @@ w.write(data);
 */
 public class FixedLengthUtil::FixedLengthFileWriter inherits FixedLengthUtil::FixedLengthAbstractWriter {
     private {
+        #! file name
+        string file;
+        #! file object
         File m_file();
     }
 
@@ -1143,12 +1151,13 @@ public class FixedLengthUtil::FixedLengthFileWriter inherits FixedLengthUtil::Fi
         @param opts Global options; see @ref fixedlengthglobals for valid values
     */
     constructor(string file_name, hash specs, *hash opts) : FixedLengthUtil::FixedLengthAbstractWriter(specs, opts)  {
+        file = file_name;
         m_file.open2(file_name, O_WRONLY | O_CREAT | m_opts.file_flags, NOTHING, opts.encoding);
     }
 
     #! Return the file name (including path, if used)
     string getFileName() {
-        return m_file.getFileName();
+        return file;
     }
 
     #! Renders a single line for a single input record hash to the output file

--- a/qlib/FixedLengthUtil.qm
+++ b/qlib/FixedLengthUtil.qm
@@ -708,31 +708,42 @@ map printf("%y\n", $1), i;
     @see
     - @ref FixedLengthUtil::FixedLengthIterator "FixedLengthIterator" for a stream-based class providing the same functionality as this class in a more generic way
 */
-public class FixedLengthUtil::FixedLengthFileIterator inherits Qore::FileLineIterator, FixedLengthUtil::FixedLengthAbstractIterator {
-    #! Instantiates the FixedLengthFileIterator object.
+public class FixedLengthUtil::FixedLengthFileIterator inherits FixedLengthUtil::FixedLengthAbstractIterator {
+    private {
+        #! the path of the file being iterated
+        string filepath;
+    }
+
+    #! Instantiates the FixedLengthFileIterator object
     /**
         @param path File path to read
         @param spec Fixed-length line specification; see @ref fixedlengthspec for more information
         @param opts Global options; see @ref fixedlengthglobals for more information
     */
-    constructor(string path, hash spec, *hash opts) : FileLineIterator(path, opts.encoding, opts.eol), FixedLengthAbstractIterator(self, spec, opts) {
+    constructor(string path, hash spec, *hash opts) : FixedLengthAbstractIterator(new InputStreamLineIterator(new FileInputStream(path), opts.encoding, opts.eol), spec, opts) {
+        filepath = path;
         # do not convert every string to the same encoding
         m_opts.input_encoding = remove m_opts.encoding;
     }
 
-    #! Moves the current line / record position to the next line / record; returns @ref False if there are no more lines to iterate
-    /** This method will return @ref True again after it returns @ref False once if the file being iterated has data that can be iterated, otherwise it will always return @ref False. The iterator object should not be used to retrieve a value after this method returns @ref False.
-        @return @ref False if there are no lines / records to iterate (in which case the iterator object is invalid and should not be used); @ref True if successful (meaning that the iterator object is valid)
+    #! Returns the character encoding for the file
+    string getEncoding() {
+        return m_opts.input_encoding ?? get_default_encoding();
+    }
 
-        @note that empty lines are ignored if "ignore_empty" option is in effect
-     */
-    bool next() {
-        bool status = FileLineIterator::next();
-        if (m_opts.ignore_empty) {
-            while (status && getLine() == '')
-                status = FileLineIterator::next();
-        }
-        return status;
+    #! Returns the file path/name used to open the file
+    string getFileName() {
+        return filepath;
+    }
+
+    #! Returns a @ref stat_hash "stat hash" of the underlying file
+    hash hstat() {
+        return Qore::hstat(filepath);
+    }
+
+    #! Returns a @ref stat_list "stat list" of the underlying file
+    list stat() {
+        return Qore::stat(filepath);
     }
 }
 


### PR DESCRIPTION
…il when porting to streams

Note that FixedLengthFileIterator was not modified to inherit FileLineIterator because it would inherit two iterator classes that way, instead it implements the missing methods and is therefore a cleaner and more consistent class than the one implemented in FixedLengthUtil for Qore 0.8.12

@gamato and @tmandys: please approve for ondra to merge - mainly if the above is good enough in your opinion - otherwise we will need to completely rework the FixedLengthUtil module
