### PR TITLE
refs #1201 fixed Datasource::getOption() and Datasource::setOption() …

### DIFF
--- a/doxygen/lang/245_parse_directives.dox.tmpl
+++ b/doxygen/lang/245_parse_directives.dox.tmpl
@@ -1083,7 +1083,7 @@ i+ =4;
     @ref Qore::PO_NO_TOP_LEVEL_STATEMENTS
 
     @par Description:
-    Disallows top level code from this point on, any top level statements before this directive are still allowed and become part of the @ref Program context.
+    Disallows top level code from this point on, any top level statements before this directive are still allowed and become part of the @ref Qore::Program "Program" context.
 
     <hr>
     @section perl-bool-eval %perl-bool-eval

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -27,6 +27,8 @@
     - fixed bugs in <string>::getEncoded() and <string>::getDecoded() regarding @ref Qore::CE_XML "CE_XML" and @ref Qore::CE_NONASCII "CE_NONASCII" (<a href="https://github.com/qorelanguage/qore/issues/1193">1193</a>)
     - fixed bugs where @ref Qore::call_object_method() and @ref Qore::call_object_method_args() allowed private methods to be called from outside the class (<a href="https://github.com/qorelanguage/qore/issues/1194">1194</a>)
     - fixed a bug where @ref deprecated methods were being internally registered as @ref RUNTIME_NOOP (<a href="https://github.com/qorelanguage/qore/issues/1197">1197</a>)
+    - fixed bugs where the @ref Qore::SQL::Datasource "Datasource" class would open a connection to the server in the constructor before options were set and where a server connection was required to call @ref Qore::SQL::Datasource::getOption() "Datasource::getOption()" or @ref Qore::SQL::Datasource::setOption() "Datasource::setOption()" (<a href="https://github.com/qorelanguage/qore/issues/1201">1201</a>)
+    - fixed memory errors in the @ref Qore::Thread::Queue "Queue" class where spurious exceptions could be raised (<a href="https://github.com/qorelanguage/qore/issues/1202">1202</a>)
 
     @section qore_0812 Qore 0.8.12
 
@@ -297,8 +299,8 @@
       - column aliases (defined with cop_as()) can now be used in the where hash argument and in join criteria
       - column operator functions can be used in the where clause and in join conditions (<a href="https://github.com/qorelanguage/qore/issues/529">issue 529</a>)
       - implemented the \c "cop_coalesce()" column operation function to support the \c "COALESCE" operator in queries (<a href="https://github.com/qorelanguage/qore/issues/671">issue 671</a>)
-      - implemented @ref SqlUtil::cop_substr() and @ref SqlUtil::uop_substr() operators (<a href="https://github.com/qorelanguage/qore/issues/801">issue 801</a>)
-      - implemented @ref SqlUtil::op_substr() where operator (<a href="https://github.com/qorelanguage/qore/issues/883">issue 883</a>)
+      - implemented \c SqlUtil::cop_substr() and \c SqlUtil::uop_substr() operators (<a href="https://github.com/qorelanguage/qore/issues/801">issue 801</a>)
+      - implemented \c SqlUtil::op_substr() where operator (<a href="https://github.com/qorelanguage/qore/issues/883">issue 883</a>)
       - implemented the \c "omit_update" upsert option for asymmetrical upserts (updates only update a subset of the columns inserted) (<a href="https://github.com/qorelanguage/qore/issues/791">issue 791</a>)
       - implemented the \c "UpsertUpdateOnly" upsert option (<a href="https://github.com/qorelanguage/qore/issues/793">issue 793</a>)
     - <a href="../../modules/OracleSqlUtil/html/index.html">OracleSqlUtil</a> module updates:
@@ -356,7 +358,7 @@
     - <a href="../../modules/Mapper/html/index.html">Mapper</a> module fixes:
       - moved field length checks after all transformations have been applied
       - fixed bugs in the \c "timezone" and \c "input_timezone" options, documented those options
-      - fixed a bug where \c "constant" field tags assigned to a value that evaluated to boolean @ref False were not recognized (<a href="https://github.com/qorelanguage/qore/issues/610">issue 610</a>)
+      - fixed a bug where \c "constant" field tags assigned to a value that evaluated to boolean @ref Qore::False "False" were not recognized (<a href="https://github.com/qorelanguage/qore/issues/610">issue 610</a>)
     - <a href="../../modules/SqlUtil/html/index.html">SqlUtil</a> module fixes:
       - fixed a bug with queries using a \a desc argument with the \a orderby query option with multiple sort columns; the \c "desc" string was added only to the last column but should have been added to all columns
       - fixed a bug where foreign key constraints with supporting indexes were not tracked and therefore schema alignment on DBs that automatically create indexes for foreign key constraints would fail
@@ -391,7 +393,7 @@
       - \c schema member incorrectly set by @ref Qore::SQL::AbstractDatasource::getUserName() "AbstractDatasource::getUserName()" instead of @ref Qore::SQL::AbstractDatasource::getDBName() "AbstractDatasource::getDBName()" (<a href="https://github.com/qorelanguage/qore/pull/519">issue 519</a>)
     -  <a href="../../modules/WebUtil/html/index.html">WebUtil</a> module fixes:
       - fixed a bug where template programs with @ref Qore::PO_ALLOW_BARE_REFS set did not work
-      - fixed a bug serviing index files in @ref WebUtil::FileHandler::tryServeRequest() "FileHandler::tryServeRequest()" where index files could be incorrectly served with a \c "204 No Content" response (<a href="https://github.com/qorelanguage/qore/issues/616">issue 616</a>)
+      - fixed a bug serviing index files in \c FileHandler::tryServeRequest() where index files could be incorrectly served with a \c "204 No Content" response (<a href="https://github.com/qorelanguage/qore/issues/616">issue 616</a>)
     - <a href="../../modules/WebSocketHandler/html/index.html">WebSocketHandler</a> module fixes:
       - fixed a bug where the connection object was deleted when the connection closes which could cause excess exceptions in multithreaded server code
       - added the WebSocketConnection::connectionClosed() method to be called when the connection is closed
@@ -562,7 +564,7 @@
     - fixed a bug where \c CALL-WITH-TYPE-ERROR exceptions were thrown based on the parse options in the caller instead of in the target when calling across a @ref Qore::Program "Program" barrier (<a href="https://github.com/qorelanguage/qore/issues/841">issue 841</a>)
     - fixed a bug where @ref Qore::is_writable() and @ref Qore::is_readable() could return an incorrect value in some cases (<a href="https://github.com/qorelanguage/qore/issues/852">issue 852</a>)
     - fixed a bug where @ref Qore::format_number() would return an invalid string when the number of decimals to be returned was 0 (<a href="https://github.com/qorelanguage/qore/issues/851">issue 851</a>)
-    - fixed a bug where the @ref delete "delete" and @ref "remove" operators would incorrectly create hash keys when attempting to delete inside complex hash structures with non-existent keys (<a href="https://github.com/qorelanguage/qore/issues/855">issue 855</a>)
+    - fixed a bug where the @ref delete "delete" and @ref remove "remove" operators would incorrectly create hash keys when attempting to delete inside complex hash structures with non-existent keys (<a href="https://github.com/qorelanguage/qore/issues/855">issue 855</a>)
     - fixed a bug where duplicate global variable declarations caused a crash (<a href="https://github.com/qorelanguage/qore/issues/891">issue 891</a>)
     - fixed a memory leak in @ref Qore::SQL::DatasourcePool "DatasourcePool" initialization when the minimum connections cannot be established (<a href="https://github.com/qorelanguage/qore/issues/994">issue 994</a>)
     - fixed handling of NaN values in logical operators (<a href="https://github.com/qorelanguage/qore/issues/915">issue 915</a>)
@@ -639,8 +641,8 @@
       - fixed selects with "limit" but no "offset"
       - convert date/time values to timestamps with microseconds resolution instead of dates with second resolution when dynamically inserting values as strings in SQL (binding by value not affected)
     - <a href="../../modules/CsvUtil/html/index.html">CsvUtil</a> module updates:
-      - added the \c "write-headers" option to @ref CsvUtil::AbstractCsvWriter and subclasses to enable headers to be suppressed
-      - added the \c "optimal-quotes" option to @ref CsvUtil::AbstractCsvWriter and subclasses to enable more efficient csv output (now the default)
+      - added the \c "write-headers" option to \c CsvUtil::AbstractCsvWriter and subclasses to enable headers to be suppressed
+      - added the \c "optimal-quotes" option to \c CsvUtil::AbstractCsvWriter and subclasses to enable more efficient csv output (now the default)
     - added @ref Qore::SQL::AbstractDatasource::currentThreadInTransaction() "AbstractDatasource::currentThreadInTransaction()" which is reimplemented as @ref Qore::SQL::Datasource::currentThreadInTransaction() "Datasource::currentThreadInTransaction()" and @ref Qore::SQL::DatasourcePool::currentThreadInTransaction() "DatasourcePool::currentThreadInTransaction()"; the base class method throws an exception when called; it was not added as an abstract method in order to not break existing subclasses of AbstractDatasource
     - enhanced module license support
       - module license strings may now be specified in binary and user modules
@@ -734,7 +736,7 @@
       - return a 400 \c "Bad Request" error if an unsupported HTTP method is used in a REST Call
     - added new \c UpsertInsertOnly upsert strategy to <a href="../../modules/SqlUtil/html/index.html">SqlUtil</a>
     - new pseudo-methods:
-      - @ref <value>::sizep(): returns @ref Qore::True "True" if the type can return a non-zero size (@ref Qore::True "True" for containers including @ref binary "binary objects" and @ref string "strings", @ref False for everything else)
+      - @ref <value>::sizep(): returns @ref Qore::True "True" if the type can return a non-zero size (@ref Qore::True "True" for containers including @ref binary "binary objects" and @ref string "strings", @ref Qore::False "False" for everything else)
       - @ref <string>::getLine(): finds lines in a string buffer
     - <a href="../../modules/Mime/html/index.html">Mime.qm</a> module updates:
       - added mime type for WSDL files (\c "application/wsdl+xml")

--- a/include/qore/intern/QoreLibIntern.h
+++ b/include/qore/intern/QoreLibIntern.h
@@ -326,6 +326,7 @@ enum qore_call_t {
 #define DAH_NOCHANGE  0 // acquire lock temporarily
 #define DAH_ACQUIRE   1 // acquire lock and hold
 #define DAH_RELEASE   2 // release lock at end of action
+#define DAH_NOCONN    3 // acquire lock temporarily and do not make a connection
 
 #define DAH_TEXT(d) (d == DAH_RELEASE ? "RELEASE" : (d == DAH_ACQUIRE ? "ACQUIRE" : "NOCHANGE"))
 

--- a/include/qore/intern/QoreQueueIntern.h
+++ b/include/qore/intern/QoreQueueIntern.h
@@ -139,13 +139,13 @@ public:
    DLLLOCAL void pushAndTakeRef(AbstractQoreNode* n);
 
    // push at the end of the queue
-   DLLLOCAL void push(ExceptionSink* xsink, AbstractQoreNode* n, int timeout_ms = 0, bool *to = 0);
+   DLLLOCAL void push(ExceptionSink* xsink, AbstractQoreNode* n, int timeout_ms, bool& to);
 
    // insert at the beginning of the queue
-   DLLLOCAL void insert(ExceptionSink* xsink, AbstractQoreNode* n, int timeout_ms = 0, bool *to = 0);
+   DLLLOCAL void insert(ExceptionSink* xsink, AbstractQoreNode* n, int timeout_ms, bool& to);
 
-   DLLLOCAL AbstractQoreNode* shift(ExceptionSink* xsink, int timeout_ms = 0, bool *to = 0);
-   DLLLOCAL AbstractQoreNode* pop(ExceptionSink* xsink, int timeout_ms = 0, bool *to = 0);
+   DLLLOCAL AbstractQoreNode* shift(ExceptionSink* xsink, int timeout_ms, bool& to);
+   DLLLOCAL AbstractQoreNode* pop(ExceptionSink* xsink, int timeout_ms, bool& to);
 
    DLLLOCAL bool empty() const {
       return !len;

--- a/lib/ManagedDatasource.cpp
+++ b/lib/ManagedDatasource.cpp
@@ -134,6 +134,11 @@ ManagedDatasource *ManagedDatasource::copy() {
    return new ManagedDatasource(*this);
 }
 
+int ManagedDatasource::acquireLock(ExceptionSink *xsink) {
+   AutoLocker al(&ds_lock);
+   return grabLock(xsink);
+}
+
 int ManagedDatasource::startDBAction(ExceptionSink *xsink, bool &new_transaction) {
    AutoLocker al(&ds_lock);
 
@@ -401,15 +406,19 @@ QoreHashNode* ManagedDatasource::getOptionHash(ExceptionSink* xsink) {
    return Datasource::getOptionHash();
 }
 
+int ManagedDatasource::setOptionInit(const char* opt, const QoreValue val, ExceptionSink* xsink) {
+   return Datasource::setOption(opt, val, xsink);
+}
+
 int ManagedDatasource::setOption(const char* opt, const QoreValue val, ExceptionSink* xsink) {
-   DatasourceActionHelper dbah(*this, xsink);
+   DatasourceActionHelper dbah(*this, xsink, DAH_NOCONN);
    if (!dbah)
       return 0;
    return Datasource::setOption(opt, val, xsink);
 }
 
 AbstractQoreNode* ManagedDatasource::getOption(const char* opt, ExceptionSink* xsink) {
-   DatasourceActionHelper dbah(*this, xsink);
+   DatasourceActionHelper dbah(*this, xsink, DAH_NOCONN);
    if (!dbah)
       return 0;
    return Datasource::getOption(opt, xsink);

--- a/lib/QC_Datasource.qpp
+++ b/lib/QC_Datasource.qpp
@@ -42,7 +42,7 @@ static int ds_set_options(ManagedDatasource* ds, const QoreHashNode* opts, Excep
       if (!strcmp(hi.getKey(), "min") || !strcmp(hi.getKey(), "max"))
          continue;
 
-      if (ds->setOption(hi.getKey(), hi.getValue(), xsink))
+      if (ds->setOptionInit(hi.getKey(), hi.getValue(), xsink))
          return -1;
    }
    return 0;


### PR DESCRIPTION
…so that no connections to the server are ever requried to execute these, in the constructor() method these internal calls are also now made unlocked

refs #1202 fixed memory errors in the internal Queue class that could lead to spurious exceptions being raised
fixed release notes
