### PR TITLE
refs #1241 updated the docs for SQLStatement::fetchColumns() to refle…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -2,6 +2,15 @@
 
     @tableofcontents
 
+    @section qore_08123 Qore 0.8.12.3
+
+    @par Release Summary
+    Bugfix release; see details below
+
+    @subsection qore_08123_bug_fixes Bug Fixes in Qore
+
+    - fixed the documentation (and DB modules) where the SQLStatement::fetchColumns() was inconsistent; now it will return a empty hash when no more rows are available to fetch (<a href="https://github.com/qorelanguage/qore/issues/1241">issue 1241</a>)
+
     @section qore_08122 Qore 0.8.12.2
 
     @par Release Summary

--- a/examples/test/qlib/SqlUtil/SqlUtilTestBase.qm
+++ b/examples/test/qlib/SqlUtil/SqlUtilTestBase.qm
@@ -82,6 +82,7 @@ public class SqlTestBase inherits QUnit::Test {
         addTestCase("Upsert", \upsertTest());
         addTestCase("BulkInsert", \bulkInsertTest());
         addTestCase("BulkUpsert", \bulkUpsertTest());
+        addTestCase("fetchColumns", \fetchColumnsTest());
     }
 
     globalTearDown() {
@@ -722,7 +723,7 @@ public class SqlTestBase inherits QUnit::Test {
                 continue;
             }
             *list rows = table.selectRows (t.value.in, \sql);
-            assertEq (t.value.out.count, rows.size(), "checking offset / limit " + t.key);
+            assertEq(t.value.out.count, rows.size(), "checking offset / limit " + t.key);
 
             foreach hash row in (rows) {
                 int rn = $#;
@@ -730,6 +731,13 @@ public class SqlTestBase inherits QUnit::Test {
                     assertEq (d.value, row{d.key}, sprintf ("checking offset / limit %s row %s column %s", t.key, rn, d.key));
             }
         }
+    }
+
+    fetchColumnsTest() {
+        if (!table) testSkip("no DB connection");
+
+        SQLStatement stmt = table.getRowIterator(("where": ("id": op_cne("id"))));
+        assertEq({}, stmt.fetchColumns(10));
     }
 
     static string getColumnName(string n) {

--- a/lib/QC_SQLStatement.qpp
+++ b/lib/QC_SQLStatement.qpp
@@ -673,9 +673,9 @@ list SQLStatement::fetchRows(softint rows = -1) {
 //! Retrieves a block of rows as a hash of lists with the maximum number of rows determined by the argument passed; automatically advances the row pointer; with this call it is not necessary to call SQLStatement::next().
 /** If the argument passed is omitted or less than or equal to zero, then all available rows from the current row position are retrieved, also if fewer rows are available than requested then only the rows available are retrieved.
 
-    If no more rows are available then a hash is returned where each key value is an empty list.
-
     @param rows The maximum number of rows to retrieve, if this argument is omitted, negative, or equal to zero, then all available rows from the current row position are retrieved
+
+    @return a hash (giving column names) of lists (giving row values for each column) of data returned; each list will have at most \a rows elements (unless \a rows is negative, in which case all available rows are returned).  If the total number of rows available is less than \a rows (if \a rows is positive), then the last data returned by this method may return short lists.  If no more rows are available, then an empty hash is returned
 
     @par Example:
     @code{.py}


### PR DESCRIPTION
…ct the fact that an empty hash is returned when no data is available
