### PR TITLE
refs #1255 added a test and a relnote for the fix to FtpClient::get()…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -12,6 +12,7 @@
     - fixed the documentation (and DB modules) where the SQLStatement::fetchColumns() was inconsistent; now it will return a empty hash when no more rows are available to fetch (<a href="https://github.com/qorelanguage/qore/issues/1241">issue 1241</a>)
     - added I/O timeout support to the @ref Qore::FtpClient "FtpClient" class (<a href="https://github.com/qorelanguage/qore/issues/1252">issue 1252</a>)
     - fixed bugs in @ref Qore::Socket::recv() "Socket::recv()" and @ref Qore::Socket::recvBinary() "Socket::recvBinary()" with <tt>size = 0</tt> where @ref nothing could be returned which is invalid according to the methods' declared return types (<a href="https://github.com/qorelanguage/qore/issues/1260">issue 1260</a>)
+    - fixed a bug where  @ref Qore::FtpClient::get() "FtpClient:get()" would fail with an exception when retrieving an empty file (<a href="https://github.com/qorelanguage/qore/issues/1255">issue 1255</a>)
 
     @section qore_08122 Qore 0.8.12.2
 

--- a/examples/test/qore/classes/FtpClient/FtpClient.qtest
+++ b/examples/test/qore/classes/FtpClient/FtpClient.qtest
@@ -17,6 +17,7 @@ class FtpServer {
         Counter cnt();
         bool quit;
         hash broken;
+        bool get_empty;
 
         const PollInterval = 500ms;
     }
@@ -168,9 +169,11 @@ class FtpServer {
                 if (doBroken("retr", data))
                     break;
 
-                # write a bunch of data and then exit
-                for (int i = 0; i < 200; ++i)
-                    data.send("testing abcdefghijklmnopqrstuvwxyz 0123456789\n");
+                if (!get_empty) {
+                    # write a bunch of data and then exit
+                    for (int i = 0; i < 200; ++i)
+                        data.send("testing abcdefghijklmnopqrstuvwxyz 0123456789\n");
+                }
 
                 data.close();
                 ftpSend(ns, 226, "Transfer completed.");
@@ -237,6 +240,10 @@ class FtpServer {
     setBroken(string cmd, timeout v) {
         broken{cmd} = v;
     }
+
+    setGetEmpty(bool v = True) {
+        get_empty = v;
+    }
 }
 
 class FtpTest inherits QUnit::Test {
@@ -267,7 +274,7 @@ class FtpTest inherits QUnit::Test {
         # set valid flag; skip tests if no connection can be made
         url = ARGV[0] ?? ENV.QORE_FTPTEST_URL ?? Url;
 
-        #addTestCase("FtpClient class test case", \testFtpClient());
+        addTestCase("FtpClient class test case", \testFtpClient());
         addTestCase("FtpClient simulated server", \testFtpClientSim());
         set_return_value(main());
     }
@@ -373,5 +380,11 @@ class FtpTest inherits QUnit::Test {
         serv.setBroken("retr", 2s);
         fc.setTimeout(1ms);
         assertThrows("SOCKET-TIMEOUT", \fc.get(), (local_path, local_path));
+
+        fc.setTimeout(60s);
+        serv.setBroken("retr", 0);
+        serv.setGetEmpty();
+        assertEq(NOTHING, fc.get(local_path, local_path));
+        assertEq("", ReadOnlyFile::readTextFile(local_path));
     }
 }

--- a/examples/test/qore/classes/FtpClient/FtpClient.qtest
+++ b/examples/test/qore/classes/FtpClient/FtpClient.qtest
@@ -16,13 +16,15 @@ class FtpServer {
         Socket s();
         Counter cnt();
         bool quit;
+        int verbose;
         hash broken;
         bool get_empty;
 
         const PollInterval = 500ms;
     }
 
-    constructor(int port) {
+    constructor(int port, int verbose = 0) {
+        self.verbose = verbose;
         s.bindINET("localhost", port.toString(), True);
         if (s.listen())
             throw "FTPSERVER-ERROR", strerror();
@@ -49,7 +51,8 @@ class FtpServer {
 
     private ftpSend(Socket ns, int code, string msg) {
         string str = sprintf("%d %s\r\n", code, vsprintf(msg, argv));
-        #printf("MSG: %s", str);
+        if (verbose > 2)
+            printf("FTP > %s", str);
         ns.send(str);
     }
 
@@ -65,14 +68,15 @@ class FtpServer {
                     break;
             }
             catch (hash ex) {
-                if (ex.err == "SOCKET-NOT-OPEN")
+                if (ex.err == "SOCKET-NOT-OPEN" || ex.err == "SOCKET-CLOSED")
                     return "";
                 if (ex.err != "SOCKET-TIMEOUT")
                     rethrow;
             }
         }
         trim str;
-        #printf("CMD: %s\n", str);
+        if (verbose > 2)
+            printf("FTP < %s\n", str);
         return str;
     }
 
@@ -114,7 +118,7 @@ class FtpServer {
         while (True) {
             string cmd = ftpGetCommand(ns);
             if (quit || cmd == "")
-                return;
+                break;
 
             if (cmd =~ /^EPSV$/i) {
                 termWaitData(data, dcnt, \dataquit);
@@ -169,6 +173,7 @@ class FtpServer {
                 if (doBroken("retr", data))
                     break;
 
+                printf("get: empty %y\n", get_empty);
                 if (!get_empty) {
                     # write a bunch of data and then exit
                     for (int i = 0; i < 200; ++i)
@@ -229,12 +234,16 @@ class FtpServer {
         on_exit dcnt.dec();
 
         while (!dataquit) {
-            Socket ns = data.accept(PollInterval);
+            *Socket ns = data.accept(PollInterval);
             if (ns) {
                 data = ns;
                 return;
             }
         }
+    }
+
+    int getPort() {
+        return s.getSocketInfo().port;
     }
 
     setBroken(string cmd, timeout v) {
@@ -274,7 +283,7 @@ class FtpTest inherits QUnit::Test {
         # set valid flag; skip tests if no connection can be made
         url = ARGV[0] ?? ENV.QORE_FTPTEST_URL ?? Url;
 
-        addTestCase("FtpClient class test case", \testFtpClient());
+        #addTestCase("FtpClient class test case", \testFtpClient());
         addTestCase("FtpClient simulated server", \testFtpClientSim());
         set_return_value(main());
     }
@@ -344,14 +353,13 @@ class FtpTest inherits QUnit::Test {
             port = m_options.port;
         else if (ENV.FTPCLIENT_TEST_PORT)
             port = ENV.FTPCLIENT_TEST_PORT.toInt();
-        else {
-            srand(clock_getmicros());
-            port = 10000 + (rand() % 40000);
-        }
+        else
+            port = 0;
 
-        FtpServer serv(port);
+        FtpServer serv(port, m_options.verbose);
         on_exit serv.shutdown();
 
+        port = serv.getPort();
         FtpClient fc("ftp://user:pass@localhost:" + port);
         assertEq(NOTHING, fc.connect());
 
@@ -386,5 +394,6 @@ class FtpTest inherits QUnit::Test {
         serv.setGetEmpty();
         assertEq(NOTHING, fc.get(local_path, local_path));
         assertEq("", ReadOnlyFile::readTextFile(local_path));
+        assertEq("", fc.getAsString(local_path));
     }
 }

--- a/examples/test/qore/classes/Socket/Socket.qtest
+++ b/examples/test/qore/classes/Socket/Socket.qtest
@@ -6,7 +6,7 @@
 %require-types
 %strict-args
 
-%requires ../../../../qlib/QUnit.qm
+%requires ../../../../../qlib/QUnit.qm
 
 %exec-class SocketTest
 
@@ -42,12 +42,14 @@ class SocketTest inherits QUnit::Test {
     private {
         any o;
         any fam;
-        binary xbinary;
-        string xstring;
 
-        Queue queue;
-        Counter counter;
-        Counter stopc;
+        const XString = "This is a binary string";
+        const XBinary = Qore::binary(XString);
+
+        Counter counter(1);
+
+        Queue queue();
+        Counter stopc();
 
         int server_port;
         int client_port;
@@ -58,25 +60,62 @@ class SocketTest inherits QUnit::Test {
     constructor() : QUnit::Test("Socket test", "1.0") {
         process_command_line();
 
-        addTestCase("Test socket", \testSocket());
+        addTestCase("Client/Server Socket tests", \clientServerSocketTest());
+        addTestCase("Unconnected Socket tests", \unconnectedSocketTest());
+        addTestCase("Random Port tests", \randomPortSocketTest());
         set_return_value(main());
     }
 
-    globalSetUp() {
-        xstring = "This is a binary string";
-        xbinary = Qore::binary(xstring);
+    randomPortSocketTest() {
+        Socket s();
+        # bind on a random port
+        s.bindINET("localhost", 0);
+        # get port bound
+        hash h = s.getSocketInfo();
+        if (m_options.verbose > 2)
+            printf("port: %d\n", h.port);
 
-        counter = new Counter(1);
+        assertEq(True, h.port > 0);
+        assertEq(h.port, s.getPort());
+        if (s.listen())
+            throw "LISTEN-ERROR", strerror();
+
+        Counter c(1);
+
+        string str = "hello";
+        code sendMsg = sub () {
+            Socket ns();
+            ns.connectINET("localhost", h.port, 10s);
+            ns.send(str);
+            assertEq(str, ns.recv(str.size()));
+            c.dec();
+        };
+        background sendMsg();
+
+        Socket ns = s.accept(10s);
+        assertEq(str, ns.recv(str.size()));
+        ns.send(str);
+        c.waitForZero();
     }
 
-    testSocket() {
-        # create event queue and start listening thread if necessary
-        if (o.events) {
-            queue = new Queue();
-            background listen();
-        }
+    unconnectedSocketTest() {
+        Socket s();
+        assertThrows("SOCKET-NOT-OPEN", \s.recv(), 1);
+        assertThrows("SOCKET-NOT-OPEN", \s.recvi1());
+        assertThrows("SOCKET-NOT-OPEN", \s.recvBinary(), 1);
+        assertThrows("SOCKET-NOT-OPEN", \s.send(), "1");
+        assertThrows("SOCKET-NOT-OPEN", \s.sendi1(), 1);
 
-        stopc = new Counter();
+        assertEq(NOTHING, s.verifyPeerCertificate());
+        assertEq(NOTHING, s.getSSLCipherName());
+        assertEq(NOTHING, s.getSSLCipherVersion());
+    }
+
+    clientServerSocketTest() {
+        # create event queue and start listening thread if necessary
+        if (o.events)
+            background listen();
+
         if (!exists o.server) {
             stopc.inc();
             background server_thread();
@@ -206,11 +245,11 @@ class SocketTest inherits QUnit::Test {
 
     private receive_messages(Socket s, string who) {
         any m = s.recv();
-        assertEq(xstring, m, who + " string");
+        assertEq(XString, m, who + " string");
         s.send("OK");
 
         m = s.recvBinary();
-        assertEq(xbinary, m, who + " binary");
+        assertEq(XBinary, m, who + " binary");
         s.send("OK");
 
         m = s.recvi1();
@@ -244,16 +283,16 @@ class SocketTest inherits QUnit::Test {
         m = s.readHTTPHeader();
         assertEq("POST", m.method, who + " HTTP header method");
         m = s.recv(m."content-length");
-        assertEq(xstring, m, who + " HTTP message body");
+        assertEq(XString, m, who + " HTTP message body");
 
         s.sendHTTPResponse(200, "OK", "1.1", http_headers, "OK");
     }
 
     private send_messages(Socket s) {
-        SocketTest::check_send(s.send(xstring), "string");
+        SocketTest::check_send(s.send(XString), "string");
         get_response(s);
 
-        SocketTest::check_send(s.send(xbinary), "binary");
+        SocketTest::check_send(s.send(XBinary), "binary");
         get_response(s);
 
         SocketTest::check_send(s.sendi1(i1), "i1");
@@ -271,7 +310,7 @@ class SocketTest inherits QUnit::Test {
         get_response(s);
         SocketTest::check_send(s.sendi8LSB(i8), "i8LSB");
         get_response(s);
-        s.sendHTTPMessage("POST", "none", "1.1", http_headers, xstring);
+        s.sendHTTPMessage("POST", "none", "1.1", http_headers, XString);
         get_http_response(s);
     }
 

--- a/lib/QC_FtpClient.qpp
+++ b/lib/QC_FtpClient.qpp
@@ -366,7 +366,9 @@ ftp.get("file.txt", "/tmp/file-1.txt");
     @throw FTP-FILE-OPEN-ERROR Could not create the local file
     @throw FTP-GET-ERROR There was an error retrieving the file
 
-    @note see FtpClient::connect() for additional exceptions that could be thrown when connections are implicitly established
+    @note
+    - see FtpClient::connect() for additional exceptions that could be thrown when connections are implicitly established
+    - any existing file with the same name is truncated before writing
 
     @see FtpClient::getAsString(), FtpClient::getAsData()
  */

--- a/lib/QoreFtpClient.cpp
+++ b/lib/QoreFtpClient.cpp
@@ -1035,7 +1035,7 @@ int QoreFtpClient::get(const char* remotepath, const char* localname, ExceptionS
 
    printd(FTPDEBUG, "QoreFtpClient::get(%s) %s\n", remotepath, ln);
    // open local file
-   int fd = open(ln, O_WRONLY|O_CREAT, 0644);
+   int fd = open(ln, O_WRONLY|O_CREAT|O_TRUNC, 0644);
    if (fd < 0) {
       xsink->raiseErrnoException("FTP-FILE-OPEN-ERROR", errno, "%s", ln);
       if (ln != localname)

--- a/lib/QoreSocket.cpp
+++ b/lib/QoreSocket.cpp
@@ -539,7 +539,7 @@ int qore_socket_private::recv(int fd, qore_offset_t size, int timeout_ms, Except
       return 0;
    if (sock == QORE_INVALID_SOCKET) {
       printd(5, "QoreSocket::send() ERROR: sock: %d size: "QSD"\n", sock, size);
-      se_not_open("Socket", "send", xsink);
+      se_not_open("Socket", "recv", xsink);
       return -1;
    }
 


### PR DESCRIPTION
… where it can retrieve an empty file without throwing an exception, the fix was actually made with the fixes for #1252 

also added tests for #1260 because it turns out this works
