### PR TITLE
refs #1215 call quick_exit() instead of exit() to avoid crashes relat…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -15,6 +15,7 @@
     - fixed a bug where @ref Qore::FtpClient::get() "FtpClient:get()" would fail with an exception when retrieving an empty file (<a href="https://github.com/qorelanguage/qore/issues/1255">issue 1255</a>)
     - fixed a bug where executing a call reference to a deleted object method would cause a crash (<a href="https://github.com/qorelanguage/qore/issues/1268">issue 1268</a>)
     - fixed a bug where Qore would allow methods to be called on already deleted objects under certain conditions (<a href="https://github.com/qorelanguage/qore/issues/1270">issue 1270</a>)
+    - fixed a bug where calling @ref Qore::exit() "exit()" in a multithreaded program could result in a segmentation fault (<a href="https://github.com/qorelanguage/qore/issues/1215">issue 1215</a>)
 
     @section qore_08122 Qore 0.8.12.2
 

--- a/lib/ExceptionSink.cpp
+++ b/lib/ExceptionSink.cpp
@@ -30,6 +30,8 @@
 
 #include <qore/Qore.h>
 
+#include <stdlib.h>
+
 ExceptionSink::ExceptionSink() : priv(new qore_es_private) {
 }
 
@@ -99,9 +101,9 @@ void ExceptionSink::clear() {
 
 AbstractQoreNode* ExceptionSink::raiseException(const char *err, const char *fmt, ...) {
    QoreStringNode *desc = new QoreStringNode;
-   
+
    va_list args;
-   
+
    while (true) {
       va_start(args, fmt);
       int rc = desc->vsprintf(fmt, args);
@@ -126,9 +128,9 @@ AbstractQoreNode* ExceptionSink::raiseErrnoException(const char *err, int en, Qo
 
 AbstractQoreNode* ExceptionSink::raiseErrnoException(const char *err, int en, const char *fmt, ...) {
    QoreStringNode *desc = new QoreStringNode;
-   
+
    va_list args;
-   
+
    while (true) {
       va_start(args, fmt);
       int rc = desc->vsprintf(fmt, args);
@@ -157,9 +159,9 @@ AbstractQoreNode* ExceptionSink::raiseExceptionArg(const char* err, AbstractQore
 
 AbstractQoreNode* ExceptionSink::raiseExceptionArg(const char* err, AbstractQoreNode* arg, const char* fmt, ...) {
    QoreStringNode *desc = new QoreStringNode;
-   
+
    va_list args;
-   
+
    while (true) {
       va_start(args, fmt);
       int rc = desc->vsprintf(fmt, args);
@@ -240,6 +242,6 @@ void ExceptionSink::outOfMemory() {
    priv->insert(ex);
 #else
    printf("OUT OF MEMORY: aborting\n");
-   exit(1);
+   quick_exit(1);
 #endif
 }

--- a/lib/QoreSignal.cpp
+++ b/lib/QoreSignal.cpp
@@ -100,7 +100,7 @@ void QoreSignalManager::init(bool disable_signal_mask) {
       ExceptionSink xsink;
       if (start_signal_thread(&xsink)) {
 	 xsink.handleExceptions();
-	 exit(1);
+	 quick_exit(1);
       }
    }
 }

--- a/lib/ql_lib.qpp
+++ b/lib/ql_lib.qpp
@@ -207,7 +207,7 @@ int system(string command) [dom=EXTERNAL_PROCESS] {
       // exec pgm like system(): sh -c "command"
       execl("/bin/sh", "sh", "-c", command->getBuffer(), NULL);
       fprintf(stderr, "execvp() failed in child process for target '/bin/sh' with error code %d: %s\n", errno, strerror(errno));
-      exit(-1);
+      quick_exit(-1);
       //qore_exit_process(-1);
    }
    if (pid == -1)


### PR DESCRIPTION
…ed to cleanup code executed in an inappropriate context
