### PR TITLE
refs #1215 use _Exit() (C99) instead of quick_exit(), since it's not …

### DIFF
--- a/lib/ExceptionSink.cpp
+++ b/lib/ExceptionSink.cpp
@@ -242,6 +242,6 @@ void ExceptionSink::outOfMemory() {
    priv->insert(ex);
 #else
    printf("OUT OF MEMORY: aborting\n");
-   quick_exit(1);
+   _Exit(1);
 #endif
 }

--- a/lib/QoreSignal.cpp
+++ b/lib/QoreSignal.cpp
@@ -100,7 +100,7 @@ void QoreSignalManager::init(bool disable_signal_mask) {
       ExceptionSink xsink;
       if (start_signal_thread(&xsink)) {
 	 xsink.handleExceptions();
-	 quick_exit(1);
+	 _Exit(1);
       }
    }
 }

--- a/lib/ql_lib.qpp
+++ b/lib/ql_lib.qpp
@@ -207,7 +207,7 @@ int system(string command) [dom=EXTERNAL_PROCESS] {
       // exec pgm like system(): sh -c "command"
       execl("/bin/sh", "sh", "-c", command->getBuffer(), NULL);
       fprintf(stderr, "execvp() failed in child process for target '/bin/sh' with error code %d: %s\n", errno, strerror(errno));
-      quick_exit(-1);
+      _Exit(-1);
       //qore_exit_process(-1);
    }
    if (pid == -1)

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -1691,7 +1691,7 @@ QoreException* catchGetException() {
 void qore_exit_process(int rc) {
    // do not call exit here since it will try to execute cleanup, which will cause crashes
    // in multithreaded programs; call quick_exit() instead (issue
-   quick_exit(rc);
+   _Exit(rc);
 }
 
 // sets up the signal thread entry in the thread list


### PR DESCRIPTION
…supported in all c++ compilers before c++11
