### PR TITLE
refs #1292 destroy the Queue object when going out of scope to ensure…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -17,7 +17,9 @@
     - fixed a bug where Qore would allow methods to be called on already deleted objects under certain conditions (<a href="https://github.com/qorelanguage/qore/issues/1270">issue 1270</a>)
     - fixed a bug where calling @ref Qore::exit() "exit()" in a multithreaded program could result in a segmentation fault (<a href="https://github.com/qorelanguage/qore/issues/1215">issue 1215</a>)
     - fixed a bug where <a href="../../modules/HttpServer/html/index.html">HttpServer::addListener()</a> could not accept a bind on port 0 to mean any random port (<a href="https://github.com/qorelanguage/qore/issues/1284">issue 1284</a>)
-    - fixed a race condition in @ref garbage_collection "prompt collection" that could lead to a crash (<a href="https://github.com/qorelanguage/qore/issues/1284">issue 12
+    - fixed a race condition in @ref garbage_collection "prompt collection" that could lead to a crash (<a href="https://github.com/qorelanguage/qore/issues/1084">issue 1084</a>)
+    - fixed a bug clearing @ref Qore::Socket "Socket" event queues when the @ref Qore::Socket "Socket" goes out of scope that could lead to a crash (<a href="https://github.com/qorelanguage/qore/issues/1292">issue 1292</a>)
+    - fixed a bug with @ref Qore::FtpClient::setWarningQueue() "FtpClient::setWarningQueue()" that could cause a crash (<a href="https://github.com/qorelanguage/qore/issues/1293">issue 1293</a>)
 
     @section qore_08122 Qore 0.8.12.2
 

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -20,6 +20,7 @@
     - fixed a race condition in @ref garbage_collection "prompt collection" that could lead to a crash (<a href="https://github.com/qorelanguage/qore/issues/1084">issue 1084</a>)
     - fixed a bug clearing @ref Qore::Socket "Socket" event queues when the @ref Qore::Socket "Socket" goes out of scope that could lead to a crash (<a href="https://github.com/qorelanguage/qore/issues/1292">issue 1292</a>)
     - fixed a bug with @ref Qore::FtpClient::setWarningQueue() "FtpClient::setWarningQueue()" that could cause a crash (<a href="https://github.com/qorelanguage/qore/issues/1293">issue 1293</a>)
+    - fixed a bug where @ref Qore::FtpClient::pwd() returned invalid directory names (<a href="https://github.com/qorelanguage/qore/issues/1295">issue 1295</a>)
 
     @section qore_08122 Qore 0.8.12.2
 

--- a/examples/test/qore/classes/FtpClient/FtpClient.qtest
+++ b/examples/test/qore/classes/FtpClient/FtpClient.qtest
@@ -361,6 +361,8 @@ class FtpTest inherits QUnit::Test {
 
         port = serv.getPort();
         FtpClient fc("ftp://user:pass@localhost:" + port);
+        Queue q();
+        fc.setWarningQueue(20000, 20000, q, "test");
         assertEq(NOTHING, fc.connect());
 
         # create a local file to send

--- a/examples/test/qore/classes/FtpClient/FtpClient.qtest
+++ b/examples/test/qore/classes/FtpClient/FtpClient.qtest
@@ -345,6 +345,9 @@ class FtpTest inherits QUnit::Test {
         testAssertion("FtpClient mode-3", \fc.getMode(), NOTHING, new TestResultValue("pasv"));
         fc.disconnect();
         testAssertion("FtpClient mode-4", \fc.getMode(), NOTHING, new TestResultValue("pasv"));
+
+        # test for issue #1295
+        assertEq(False, fc.pwd() =~ /"/);
     }
 
     testFtpClientSim() {

--- a/include/qore/QoreQueue.h
+++ b/include/qore/QoreQueue.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2016 David Nichols
+  Copyright (C) 2003 - 2016 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -121,6 +121,8 @@ public:
    DLLEXPORT Queue(int max = -1);
 
    DLLEXPORT Queue* queueRefSelf() const;
+
+   DLLEXPORT virtual void deref(ExceptionSink* xsink);
 };
 
 #endif // _QORE_QOREQUEUE_H

--- a/include/qore/QoreString.h
+++ b/include/qore/QoreString.h
@@ -6,7 +6,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/lib/QoreFtpClient.cpp
+++ b/lib/QoreFtpClient.cpp
@@ -1,3 +1,4 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
 /*
   QoreFtpClient.cpp
 
@@ -70,12 +71,12 @@ public:
 
    DLLLOCAL inline ~FtpResp() {
       if (str)
-	 str->deref();
+         str->deref();
    }
 
    DLLLOCAL inline QoreStringNode* assign(QoreStringNode* s) {
       if (str)
-	 str->deref();
+         str->deref();
       str = s;
       return s;
    }
@@ -115,7 +116,7 @@ public:
       init();
 
       if (url)
-	 setURLIntern(url, xsink);
+         setURLIntern(url, xsink);
    }
 
    DLLLOCAL qore_ftp_private() {
@@ -124,29 +125,29 @@ public:
 
    DLLLOCAL ~qore_ftp_private() {
       if (host)
-	 free(host);
+         free(host);
       if (user)
-	 free(user);
+         free(user);
       if (pass)
-	 free(pass);
+         free(pass);
    }
 
    // private unlocked
    DLLLOCAL void setURLIntern(const QoreString *url_str, ExceptionSink* xsink) {
       QoreURL url(url_str);
       if (!url.getHost()) {
-	 xsink->raiseException("FTP-URL-ERROR", "no hostname given in URL '%s'", url_str->getBuffer());
-	 return;
+         xsink->raiseException("FTP-URL-ERROR", "no hostname given in URL '%s'", url_str->getBuffer());
+         return;
       }
 
       // verify protocol
       if (url.getProtocol()) {
-	 if (!url.getProtocol()->compare("ftps"))
-	    secure = secure_data = true;
-	 else if (url.getProtocol()->compare("ftp")) {
-	    xsink->raiseException("UNSUPPORTED-PROTOCOL", "'%s' not supported (expected 'ftp' or 'ftps')", url.getProtocol()->getBuffer());
-	    return;
-	 }
+         if (!url.getProtocol()->compare("ftps"))
+            secure = secure_data = true;
+         else if (url.getProtocol()->compare("ftp")) {
+            xsink->raiseException("UNSUPPORTED-PROTOCOL", "'%s' not supported (expected 'ftp' or 'ftps')", url.getProtocol()->getBuffer());
+            return;
+         }
       }
 
       // set username
@@ -172,16 +173,16 @@ public:
       AutoLocker al(m);
       control.setEventQueue(cbq, xsink);
       if (cbq)
-	 cbq->ref();
+         cbq->ref();
       data.setEventQueue(cbq, xsink);
    }
 
    DLLLOCAL void cleanup(ExceptionSink* xsink) {
       AutoLocker al(m);
       if (data.getQueue() && (data.getQueue() == control.getQueue())) {
-	 data.cleanup(xsink);
-	 control.setEventQueue(0, xsink);
-	 return;
+         data.cleanup(xsink);
+         control.setEventQueue(0, xsink);
+         return;
       }
 
       data.cleanup(xsink);
@@ -191,27 +192,27 @@ public:
    DLLLOCAL void do_event_send_msg(const char* cmd, const char* arg) {
       Queue *q = control.getQueue();
       if (q) {
-	 QoreHashNode* h = new QoreHashNode;
-	 h->setKeyValue("event", new QoreBigIntNode(QORE_EVENT_FTP_SEND_MESSAGE), 0);
-	 h->setKeyValue("source", new QoreBigIntNode(QORE_SOURCE_FTPCLIENT), 0);
-	 h->setKeyValue("id", new QoreBigIntNode(control.getObjectIDForEvents()), 0);
-	 h->setKeyValue("command", new QoreStringNode(cmd), 0);
-	 if (arg)
-	    h->setKeyValue("arg", new QoreStringNode(arg), 0);
-	 q->pushAndTakeRef(h);
+         QoreHashNode* h = new QoreHashNode;
+         h->setKeyValue("event", new QoreBigIntNode(QORE_EVENT_FTP_SEND_MESSAGE), 0);
+         h->setKeyValue("source", new QoreBigIntNode(QORE_SOURCE_FTPCLIENT), 0);
+         h->setKeyValue("id", new QoreBigIntNode(control.getObjectIDForEvents()), 0);
+         h->setKeyValue("command", new QoreStringNode(cmd), 0);
+         if (arg)
+            h->setKeyValue("arg", new QoreStringNode(arg), 0);
+         q->pushAndTakeRef(h);
       }
    }
 
    DLLLOCAL void do_event_msg_received(int code, const char* msg) {
       Queue *q = control.getQueue();
       if (q) {
-	 QoreHashNode* h = new QoreHashNode;
-	 h->setKeyValue("event", new QoreBigIntNode(QORE_EVENT_FTP_MESSAGE_RECEIVED), 0);
-	 h->setKeyValue("source", new QoreBigIntNode(QORE_SOURCE_FTPCLIENT), 0);
-	 h->setKeyValue("id", new QoreBigIntNode(control.getObjectIDForEvents()), 0);
-	 h->setKeyValue("code", new QoreBigIntNode(code), 0);
-	 h->setKeyValue("message", msg[0] ? new QoreStringNode(msg) : 0, 0);
-	 q->pushAndTakeRef(h);
+         QoreHashNode* h = new QoreHashNode;
+         h->setKeyValue("event", new QoreBigIntNode(QORE_EVENT_FTP_MESSAGE_RECEIVED), 0);
+         h->setKeyValue("source", new QoreBigIntNode(QORE_SOURCE_FTPCLIENT), 0);
+         h->setKeyValue("id", new QoreBigIntNode(control.getObjectIDForEvents()), 0);
+         h->setKeyValue("code", new QoreBigIntNode(code), 0);
+         h->setKeyValue("message", msg[0] ? new QoreStringNode(msg) : 0, 0);
+         q->pushAndTakeRef(h);
       }
    }
 
@@ -224,7 +225,7 @@ public:
       control.close();
       control_connected = false;
       if (!manual_mode)
-	 mode = FTP_MODE_UNKNOWN;
+         mode = FTP_MODE_UNKNOWN;
       data.close();
       loggedin = false;
    }
@@ -239,68 +240,68 @@ public:
       QoreStringNodeHolder resp(0);
       // if there is data in the buffer, then take it, otherwise read
       if (!buffer.strlen()) {
-	 resp = control.recv(timeout_ms, xsink);
-	 if (*xsink) {
-	    disconnectIntern();
-	    return 0;
-	 }
+         resp = control.recv(timeout_ms, xsink);
+         if (*xsink) {
+            disconnectIntern();
+            return 0;
+         }
       }
       else {
-	 qore_size_t len = buffer.strlen();
-	 resp = new QoreStringNode(buffer.giveBuffer(), len, len + 1, buffer.getEncoding());
+         qore_size_t len = buffer.strlen();
+         resp = new QoreStringNode(buffer.giveBuffer(), len, len + 1, buffer.getEncoding());
       }
       // see if we got the whole response
       if (resp && resp->getBuffer()) {
-	 const char* start = resp->getBuffer();
-	 const char* p = start;
-	 while (true) {
-	    if ((*p) == '\n') {
-	       if (p > (start + 3)) {
-		  // if we got the whole response
-		  if (isdigit(*start) && isdigit(start[1]) && isdigit(start[2]) && start[3] == ' ') {
-		     code = ((*start - 48) * 100) + ((start[1] - 48) * 10) + start[2] - 48;
-		     // if we read more data, then store it in the buffer
-		     if (p[1] != '\0') {
-			buffer.set(&p[1]);
-			resp->terminate(p - resp->getBuffer() + 1);
-		     }
-		     break;
-		  }
-	       }
-	       start = p + 1;
-	    }
-	    // if we have not got the whole message
-	    else if (*p == '\0') {
-	       QoreStringNodeHolder r(control.recv(timeout_ms, xsink));
-	       if (*xsink) {
-		  disconnectIntern();
-		  return 0;
-	       }
-	       if (!r) {
-		  disconnectIntern();
-		  xsink->raiseException("FTP-RECEIVE-ERROR", "short message received on control port");
-		  return 0;
-	       }
-	       //printd(FTPDEBUG, "QoreFtpClient::getResponse() read %s\n", r->getBuffer());
-	       // in case the buffer gets reallocated
-	       int pos = p - resp->getBuffer();
-	       // cannot maintain start across buffer reallocations
-	       size_t offset = p - start;
-	       resp->concat(*r);
-	       p = resp->getBuffer() + pos;
-	       start = p + offset;
-	    }
-	    p++;
-	 }
+         const char* start = resp->getBuffer();
+         const char* p = start;
+         while (true) {
+            if ((*p) == '\n') {
+               if (p > (start + 3)) {
+                  // if we got the whole response
+                  if (isdigit(*start) && isdigit(start[1]) && isdigit(start[2]) && start[3] == ' ') {
+                     code = ((*start - 48) * 100) + ((start[1] - 48) * 10) + start[2] - 48;
+                     // if we read more data, then store it in the buffer
+                     if (p[1] != '\0') {
+                        buffer.set(&p[1]);
+                        resp->terminate(p - resp->getBuffer() + 1);
+                     }
+                     break;
+                  }
+               }
+               start = p + 1;
+            }
+            // if we have not got the whole message
+            else if (*p == '\0') {
+               QoreStringNodeHolder r(control.recv(timeout_ms, xsink));
+               if (*xsink) {
+                  disconnectIntern();
+                  return 0;
+               }
+               if (!r) {
+                  disconnectIntern();
+                  xsink->raiseException("FTP-RECEIVE-ERROR", "short message received on control port");
+                  return 0;
+               }
+               //printd(FTPDEBUG, "QoreFtpClient::getResponse() read %s\n", r->getBuffer());
+               // in case the buffer gets reallocated
+               int pos = p - resp->getBuffer();
+               // cannot maintain start across buffer reallocations
+               size_t offset = p - start;
+               resp->concat(*r);
+               p = resp->getBuffer() + pos;
+               start = p + offset;
+            }
+            p++;
+         }
       }
       printd(FTPDEBUG, "QoreFtpClient::getResponse() %s", resp ? resp->getBuffer() : "NULL");
       if (resp) {
-	 resp->chomp();
-	 do_event_msg_received(code, resp->getBuffer() + 4);
+         resp->chomp();
+         do_event_msg_received(code, resp->getBuffer() + 4);
       }
       else {
-	 disconnectIntern();
-	 xsink->raiseException("FTP-RECEIVE-ERROR", "FTP server sent an empty response on the control port");
+         disconnectIntern();
+         xsink->raiseException("FTP-RECEIVE-ERROR", "FTP server sent an empty response on the control port");
       }
       return resp.release();
    }
@@ -309,7 +310,7 @@ public:
    DLLLOCAL int connectIntern(FtpResp *resp, ExceptionSink* xsink) {
       // connect to FTP port on remote machine
       if (control.connectINET(host, port, timeout_ms, xsink))
-	 return -1;
+         return -1;
 
       control_connected = 1;
 
@@ -317,7 +318,7 @@ public:
       resp->assign(getResponse(code, xsink));
 
       if (*xsink)
-	 return -1;
+         return -1;
 
       printd(FTPDEBUG, "qore_ftp_private::connectIntern() %s", resp->getBuffer());
 
@@ -325,8 +326,8 @@ public:
       // ex: 220 localhost FTP server (tnftpd 20040810) ready.
       // etc
       if ((code / 100) != 2) {
-	 xsink->raiseException("FTP-CONNECT-ERROR", "FTP server reported the following error: %s", resp->getBuffer());
-	 return -1;
+         xsink->raiseException("FTP-CONNECT-ERROR", "FTP server reported the following error: %s", resp->getBuffer());
+         return -1;
       }
 
       return 0;
@@ -338,16 +339,16 @@ public:
 
       QoreString c(cmd);
       if (arg) {
-	 c.concat(' ');
-	 c.concat(arg);
+         c.concat(' ');
+         c.concat(arg);
       }
       c.concat("\r\n");
       printd(FTPDEBUG, "QoreFtpClient::sendMsg() %s", c.getBuffer());
       if (control.send(c.getBuffer(), c.strlen(), timeout_ms, xsink) < 0) {
-	 disconnectIntern();
-	 if (!*xsink)
-	    xsink->raiseException("FTP-SEND-ERROR", q_strerror(errno));
-	 return 0;
+         disconnectIntern();
+         if (!*xsink)
+            xsink->raiseException("FTP-SEND-ERROR", q_strerror(errno));
+         return 0;
       }
 
       QoreStringNode* rsp = getResponse(code, xsink);
@@ -361,26 +362,26 @@ public:
 
       QoreStringNode* mr = sendMsg(code, "PBSZ", "0", xsink);
       if (!mr) {
-	 assert(*xsink);
-	 return -1;
+         assert(*xsink);
+         return -1;
       }
 
       resp->assign(mr);
       if (code != 200) {
-	 xsink->raiseException("FTPS-SECURE-DATA-ERROR", "response from FTP server to PBSZ 0 command: %s", resp->getBuffer());
-	 return -1;
+         xsink->raiseException("FTPS-SECURE-DATA-ERROR", "response from FTP server to PBSZ 0 command: %s", resp->getBuffer());
+         return -1;
       }
 
       mr = sendMsg(code, "PROT", "P", xsink);
       if (!mr) {
-	 assert(*xsink);
-	 return -1;
+         assert(*xsink);
+         return -1;
       }
 
       resp->assign(mr);
       if (code != 200) {
-	 xsink->raiseException("FTPS-SECURE-DATA-ERROR", "response from FTP server to PROT P command: %s", resp->getBuffer());
-	 return -1;
+         xsink->raiseException("FTPS-SECURE-DATA-ERROR", "response from FTP server to PROT P command: %s", resp->getBuffer());
+         return -1;
       }
 
       return 0;
@@ -392,26 +393,26 @@ public:
 
       QoreStringNode* mr = sendMsg(code, "AUTH", "TLS", xsink);
       if (!mr) {
-	 assert(*xsink);
-	 return -1;
+         assert(*xsink);
+         return -1;
       }
       resp->assign(mr);
 
       if (code != 234) {
-	 // RFC-2228 ADAT exchange not supported
-	 if (code == 334)
-	    xsink->raiseException("FTPS-AUTH-ERROR", "server requires unsupported ADAT exchange");
-	 else {
-	    xsink->raiseException("FTPS-AUTH-ERROR", "response from FTP server: %s", resp->getBuffer());
-	 }
-	 return -1;
+         // RFC-2228 ADAT exchange not supported
+         if (code == 334)
+            xsink->raiseException("FTPS-AUTH-ERROR", "server requires unsupported ADAT exchange");
+         else {
+            xsink->raiseException("FTPS-AUTH-ERROR", "response from FTP server: %s", resp->getBuffer());
+         }
+         return -1;
       }
 
       if (control.upgradeClientToSSL(0, 0, timeout_ms, xsink))
-	 return -1;
+         return -1;
 
       if (secure_data)
-	 return doProt(resp, xsink);
+         return doProt(resp, xsink);
 
       return 0;
    }
@@ -420,49 +421,49 @@ public:
       disconnectIntern();
 
       if (!host) {
-	 xsink->raiseException("FTP-CONNECT-ERROR", "no hostname set");
-	 return -1;
+         xsink->raiseException("FTP-CONNECT-ERROR", "no hostname set");
+         return -1;
       }
 
       FtpResp resp;
       if (connectIntern(&resp, xsink))
-	 return -1;
+         return -1;
 
       if (secure && doAuth(&resp, xsink))
-	 return -1;
+         return -1;
 
       int code;
 
       QoreStringNode* mr = sendMsg(code, "USER", user ? user : (char* )DEFAULT_USERNAME, xsink);
       if (!mr) {
-	 assert(*xsink);
-	 return -1;
+         assert(*xsink);
+         return -1;
       }
 
       resp.assign(mr);
 
       // if user not logged in immediately, continue
       if ((code / 100) != 2) {
-	 // if there is an error, then exit
-	 if (code != 331) {
-	    xsink->raiseException("FTP-LOGIN-ERROR", "response from FTP server: %s", resp.getBuffer());
-	    return -1;
-	 }
+         // if there is an error, then exit
+         if (code != 331) {
+            xsink->raiseException("FTP-LOGIN-ERROR", "response from FTP server: %s", resp.getBuffer());
+            return -1;
+         }
 
-	 // send password
-	 mr = sendMsg(code, "PASS", pass ? pass : (char* )DEFAULT_PASSWORD, xsink);
-	 if (!mr) {
-	    assert(*xsink);
-	    return -1;
-	 }
+         // send password
+         mr = sendMsg(code, "PASS", pass ? pass : (char* )DEFAULT_PASSWORD, xsink);
+         if (!mr) {
+            assert(*xsink);
+            return -1;
+         }
 
-	 resp.assign(mr);
+         resp.assign(mr);
 
-	 // if user not logged in for whatever reason, then exit
-	 if ((code / 100) != 2) {
-	    xsink->raiseException("FTP-LOGIN-ERROR", "response from FTP server: %s", resp.getBuffer());
-	    return -1;
-	 }
+         // if user not logged in for whatever reason, then exit
+         if ((code / 100) != 2) {
+            xsink->raiseException("FTP-LOGIN-ERROR", "response from FTP server: %s", resp.getBuffer());
+            return -1;
+         }
       }
 
       loggedin = true;
@@ -476,15 +477,15 @@ public:
       int code;
       QoreStringNode* mr = sendMsg(code, "TYPE", (char* )(t ? "I" : "A"), xsink);
       if (!mr) {
-	 assert(*xsink);
-	 return -1;
+         assert(*xsink);
+         return -1;
       }
 
       QoreStringNodeHolder resp(mr);
 
       if ((code / 100) != 2) {
-	 xsink->raiseException("FTP-ERROR", "can't set mode to '%c', FTP server responded: %s", (t ? 'I' : 'A'), resp->getBuffer());
-	 return -1;
+         xsink->raiseException("FTP-ERROR", "can't set mode to '%c', FTP server responded: %s", (t ? 'I' : 'A'), resp->getBuffer());
+         return -1;
       }
       return 0;
    }
@@ -492,17 +493,17 @@ public:
    // unlocked
    DLLLOCAL int acceptDataConnection(ExceptionSink* xsink) {
       if (data.acceptAndReplace(0)) {
-	 data.close();
-	 xsink->raiseErrnoException("FTP-CONNECT-ERROR", errno, "error accepting data connection");
-	 return -1;
+         data.close();
+         xsink->raiseErrnoException("FTP-CONNECT-ERROR", errno, "error accepting data connection");
+         return -1;
       }
 #ifdef DEBUG
       if (secure_data)
-	 printd(FTPDEBUG, "QoreFtpClient::acceptDataConnection() negotiating client SSL connection\n");
+         printd(FTPDEBUG, "QoreFtpClient::acceptDataConnection() negotiating client SSL connection\n");
 #endif
 
       if (secure_data && data.upgradeClientToSSL(0, 0, timeout_ms, xsink))
-	 return -1;
+         return -1;
 
       printd(FTPDEBUG, "QoreFtpClient::acceptDataConnection() accepted PORT data connection\n");
       return 0;
@@ -511,27 +512,27 @@ public:
    // unlocked
    DLLLOCAL int connectData(ExceptionSink* xsink) {
       switch (mode) {
-	 case FTP_MODE_UNKNOWN:
-	    if (!connectDataExtendedPassive(xsink))
-	       return 0;
-	    if (*xsink)
-	       return -1;
-	    if (!connectDataPassive(xsink))
-	       return 0;
-	    if (*xsink)
-	       return -1;
-	    if (!connectDataPort(xsink))
-	       return 0;
+         case FTP_MODE_UNKNOWN:
+            if (!connectDataExtendedPassive(xsink))
+               return 0;
+            if (*xsink)
+               return -1;
+            if (!connectDataPassive(xsink))
+               return 0;
+            if (*xsink)
+               return -1;
+            if (!connectDataPort(xsink))
+               return 0;
 
-	    if (!*xsink)
-	       xsink->raiseException("FTP-CONNECT-ERROR", "Could not negotiate data channel connection with FTP server");
-	    return -1;
-	 case FTP_MODE_EPSV:
-	    return connectDataExtendedPassive(xsink);
-	 case FTP_MODE_PASV:
-	    return connectDataPassive(xsink);
-	 case FTP_MODE_PORT:
-	    return connectDataPort(xsink);
+            if (!*xsink)
+               xsink->raiseException("FTP-CONNECT-ERROR", "Could not negotiate data channel connection with FTP server");
+            return -1;
+         case FTP_MODE_EPSV:
+            return connectDataExtendedPassive(xsink);
+         case FTP_MODE_PASV:
+            return connectDataPassive(xsink);
+         case FTP_MODE_PORT:
+            return connectDataPort(xsink);
       }
       return -1;
    }
@@ -559,13 +560,13 @@ public:
       int code;
       QoreStringNode* mr = sendMsg(code, "EPSV", 0, xsink);
       if (!mr) {
-	 assert(*xsink);
-	 return -1;
+         assert(*xsink);
+         return -1;
       }
 
       FtpResp resp(mr);
       if ((code / 100) != 2)
-	 return -1;
+         return -1;
 
       // ex: 229 Entering Extended Passive Mode (|||63519|)
       // get port for data connection
@@ -573,22 +574,22 @@ public:
 
       const char* s = strstr(resp.getBuffer(), "|||");
       if (!s) {
-	 xsink->raiseException("FTP-RESPONSE-ERROR", "cannot find port in EPSV response: %s", resp.getBuffer());
-	 return -1;
+         xsink->raiseException("FTP-RESPONSE-ERROR", "cannot find port in EPSV response: %s", resp.getBuffer());
+         return -1;
       }
       s += 3;
       char* end = (char* )strchr(s, '|');
       if (!end) {
-	 xsink->raiseException("FTP-RESPONSE-ERROR", "cannot find port in EPSV response: %s", resp.getBuffer());
-	 return -1;
+         xsink->raiseException("FTP-RESPONSE-ERROR", "cannot find port in EPSV response: %s", resp.getBuffer());
+         return -1;
       }
       *end = '\0';
 
       int data_port = atoi(s);
       if (data.connectINET(host, data_port, timeout_ms, xsink)) {
-	 if (!*xsink)
-	    xsink->raiseErrnoException("FTP-CONNECT-ERROR", errno, "could not connect to extended passive data port (%s:%d)", host, data_port);
-	 return -1;
+         if (!*xsink)
+            xsink->raiseErrnoException("FTP-CONNECT-ERROR", errno, "could not connect to extended passive data port (%s:%d)", host, data_port);
+         return -1;
       }
       printd(FTPDEBUG, "EPSV connected to %s:%d\n", host, data_port);
 
@@ -602,32 +603,32 @@ public:
       int code;
       QoreStringNode* mr = sendMsg(code, "PASV", 0, xsink);
       if (!mr) {
-	 assert(*xsink);
-	 return -1;
+         assert(*xsink);
+         return -1;
       }
 
       FtpResp resp(mr);
       if ((code / 100) != 2)
-	 return -1;
+         return -1;
 
       // reply ex: 227 Entering passive mode (127,0,0,1,28,46)
       // get port for data connection
       const char* s = strstr(resp.getBuffer(), "(");
       if (!s) {
-	 xsink->raiseException("FTP-RESPONSE-ERROR", "cannot parse PASV response: %s", resp.getBuffer());
-	 return -1;
+         xsink->raiseException("FTP-RESPONSE-ERROR", "cannot parse PASV response: %s", resp.getBuffer());
+         return -1;
       }
       int num[5];
       s++;
       const char* comma;
       for (int i = 0; i < 5; i++) {
-	 comma = strchr(s, ',');
-	 if (!comma) {
-	    xsink->raiseException("FTP-RESPONSE-ERROR", "cannot parse PASV response: %s", resp.getBuffer());
-	    return -1;
-	 }
-	 num[i] = atoi(s);
-	 s = comma + 1;
+         comma = strchr(s, ',');
+         if (!comma) {
+            xsink->raiseException("FTP-RESPONSE-ERROR", "cannot parse PASV response: %s", resp.getBuffer());
+            return -1;
+         }
+         num[i] = atoi(s);
+         s = comma + 1;
       }
       int dataport = (num[4] << 8) + atoi(s);
       class QoreString ip;
@@ -635,13 +636,13 @@ public:
       printd(FTPDEBUG,"qore_ftp_private::connectPassive() address: %s:%d\n", ip.getBuffer(), dataport);
 
       if (data.connectINET(ip.getBuffer(), dataport, timeout_ms, xsink)) {
-	 if (!*xsink)
-	    xsink->raiseErrnoException("FTP-CONNECT-ERROR", errno, "could not connect to passive data port (%s:%d)", ip.getBuffer(), dataport);
-	 return -1;
+         if (!*xsink)
+            xsink->raiseErrnoException("FTP-CONNECT-ERROR", errno, "could not connect to passive data port (%s:%d)", ip.getBuffer(), dataport);
+         return -1;
       }
 
       if (secure_data && data.upgradeClientToSSL(0, 0, timeout_ms, xsink))
-	 return -1;
+         return -1;
 
       mode = FTP_MODE_PASV;
       return 0;
@@ -654,14 +655,14 @@ public:
       socklen_t socksize = sizeof(struct sockaddr_in);
 
       if (getsockname(control.getSocket(), (struct sockaddr *)&add, &socksize) < 0) {
-	 xsink->raiseErrnoException("FTP-CONNECT-ERROR", errno, "cannot determine local interface address for data port connection");
-	 return -1;
+         xsink->raiseErrnoException("FTP-CONNECT-ERROR", errno, "cannot determine local interface address for data port connection");
+         return -1;
       }
       // bind to any port on local interface
       add.sin_port = 0;
       if (data.bind((struct sockaddr *)&add, sizeof (struct sockaddr_in))) {
-	 xsink->raiseErrnoException("FTP-CONNECT-ERROR", errno, "could not bind to any port on local interface");
-	 return -1;
+         xsink->raiseErrnoException("FTP-CONNECT-ERROR", errno, "could not bind to any port on local interface");
+         return -1;
       }
       // get port number
       int dataport = data.getPort();
@@ -669,15 +670,15 @@ public:
       // get ip address
       char ifname[80];
       if (!inet_ntop(AF_INET, &((struct sockaddr_in *)&add)->sin_addr, ifname, sizeof(ifname))) {
-	 data.close();
-	 xsink->raiseErrnoException("FTP-CONNECT-ERROR", errno, "cannot determine local interface address for data port connection");
-	 return -1;
+         data.close();
+         xsink->raiseErrnoException("FTP-CONNECT-ERROR", errno, "cannot determine local interface address for data port connection");
+         return -1;
       }
       printd(FTPDEBUG, "qore_ftp_private::connectDataPort() requesting connection to %s:%d\n", ifname, dataport);
       // change dots to commas for PORT message
       for (int i = 0; ifname[i]; i++)
-	 if (ifname[i] == '.')
-	    ifname[i] = ',';
+         if (ifname[i] == '.')
+            ifname[i] = ',';
 
       QoreString pconn;
       pconn.sprintf("%s,%d,%d", ifname, dataport >> 8, dataport & 255);
@@ -685,23 +686,23 @@ public:
 
       QoreStringNode* mr = sendMsg(code, "PORT", pconn.getBuffer(), xsink);
       if (!mr) {
-	 assert(*xsink);
-	 data.close();
-	 return -1;
+         assert(*xsink);
+         data.close();
+         return -1;
       }
 
       FtpResp resp(mr);
       // ex: 200 PORT command successful.
       if ((code / 100) != 2) {
-	 data.close();
-	 return -1;
+         data.close();
+         return -1;
       }
 
       if (data.listen()) {
-	 int en = errno;
-	 data.close();
-	 xsink->raiseErrnoException("FTP-CONNECT-ERROR", en, "error listening on data connection");
-	 return -1;
+         int en = errno;
+         data.close();
+         xsink->raiseErrnoException("FTP-CONNECT-ERROR", en, "error listening on data connection");
+         return -1;
       }
       printd(FTPDEBUG, "qore_ftp_private::connectDataPort() listening on port %d\n", dataport);
 
@@ -715,34 +716,34 @@ public:
    DLLLOCAL int pre_get(FtpResp &resp, const char* remotepath, ExceptionSink* xsink) {
       // set binary mode and establish data connection
       if (setBinaryMode(true, xsink) || connectData(xsink))
-	 return -1;
+         return -1;
 
       // setup the file transfer on the data channel
       int code;
 
       QoreStringNode* mr = sendMsg(code, "RETR", remotepath, xsink);
       if (!mr) {
-	 assert(*xsink);
-	 data.close();
-	 return -1;
+         assert(*xsink);
+         data.close();
+         return -1;
       }
 
       resp.assign(mr);
       //printf("%s", resp->getBuffer());
 
       if ((code / 100) != 1) {
-	 data.close();
-	 xsink->raiseException("FTP-GET-ERROR", "could not retrieve file, FTP server replied: %s", resp.getBuffer());
-	 return -1;
+         data.close();
+         xsink->raiseException("FTP-GET-ERROR", "could not retrieve file, FTP server replied: %s", resp.getBuffer());
+         return -1;
       }
 
       if ((mode == FTP_MODE_PORT && acceptDataConnection(xsink)) || *xsink) {
-	 data.close();
-	 return -1;
+         data.close();
+         return -1;
       }
       else if (secure_data && data.upgradeClientToSSL(0, 0, timeout_ms, xsink)) {
-	 data.close();
-	 return -1;
+         data.close();
+         return -1;
       }
 
       return 0;
@@ -765,7 +766,7 @@ public:
       control.setWarningQueue(xsink, warning_ms, warning_bs, wq, arg, min_ms);
       if (!*xsink) {
          wq->ref();
-	 data.setWarningQueue(xsink, warning_ms, warning_bs, wq, arg ? arg->refSelf() : 0, min_ms);
+         data.setWarningQueue(xsink, warning_ms, warning_bs, wq, arg ? arg->refSelf() : 0, min_ms);
       }
    }
 
@@ -839,7 +840,7 @@ QoreStringNode* QoreFtpClient::list(const char* path, bool long_list, ExceptionS
    if ((code / 100 != 1)) {
       priv->data.close();
       xsink->raiseException("FTP-LIST-ERROR", "FTP server returned an error to the %s command: %s",
-			    (long_list ? "LIST" : "NLST"), resp.getBuffer());
+                            (long_list ? "LIST" : "NLST"), resp.getBuffer());
       return 0;
    }
 
@@ -856,8 +857,8 @@ QoreStringNode* QoreFtpClient::list(const char* path, bool long_list, ExceptionS
    while (true) {
       int rc;
       if (!resp.assign(priv->data.recv(priv->timeout_ms, &rc))) {
-	 //printd(5, "read 0: ERR rc=%d l=%s\n", rc, l->getBuffer());
-	 break;
+         //printd(5, "read 0: ERR rc=%d l=%s\n", rc, l->getBuffer());
+         break;
       }
       //printd(5, "read 0: rc=%d: resp=%s l=%s\n", rc, resp.getBuffer(), l->getBuffer());
       l->concat(resp.getStr());
@@ -871,7 +872,7 @@ QoreStringNode* QoreFtpClient::list(const char* path, bool long_list, ExceptionS
    printd(5, "read done: code=%d LIST: %s\n", code, resp.getBuffer());
    if ((code / 100 != 2)) {
       xsink->raiseException("FTP-LIST-ERROR", "FTP server returned an error to the %s command: %s",
-			    (long_list ? "LIST" : "NLST"), resp.getBuffer());
+                            (long_list ? "LIST" : "NLST"), resp.getBuffer());
       return 0;
    }
    return l.release();
@@ -1041,7 +1042,7 @@ int QoreFtpClient::get(const char* remotepath, const char* localname, ExceptionS
    if (fd < 0) {
       xsink->raiseErrnoException("FTP-FILE-OPEN-ERROR", errno, "%s", ln);
       if (ln != localname)
-	 free(ln);
+         free(ln);
       return -1;
    }
 
@@ -1049,15 +1050,15 @@ int QoreFtpClient::get(const char* remotepath, const char* localname, ExceptionS
    {
       ON_BLOCK_EXIT(close, fd);
       if (priv->pre_get(resp, remotepath, xsink)) {
-	 // delete temporary file
-	 unlink(ln);
-	 if (ln != localname)
-	    free(ln);
-	 return -1;
+         // delete temporary file
+         unlink(ln);
+         if (ln != localname)
+            free(ln);
+         return -1;
       }
 
       if (ln != localname)
-	 free(ln);
+         free(ln);
 
       priv->data.recv(fd, -1, priv->timeout_ms, xsink);
       priv->data.close();
@@ -1072,7 +1073,7 @@ int QoreFtpClient::get(const char* remotepath, const char* localname, ExceptionS
    //printf("PUT: %s", resp->getBuffer());
    if ((code / 100 != 2)) {
       xsink->raiseException("FTP-GET-ERROR", "FTP server returned an error to the RETR command: %s",
-			    resp.getBuffer());
+                            resp.getBuffer());
       return -1;
    }
    return 0;
@@ -1107,7 +1108,7 @@ QoreStringNode* QoreFtpClient::getAsString(const char* remotepath, ExceptionSink
    //printf("PUT: %s", resp->getBuffer());
    if ((code / 100 != 2)) {
       xsink->raiseException("FTP-GETASSTRING-ERROR", "FTP server returned an error to the RETR command: %s",
-			    resp.getBuffer());
+                            resp.getBuffer());
       return 0;
    }
    return rv.release();
@@ -1142,7 +1143,7 @@ BinaryNode* QoreFtpClient::getAsBinary(const char* remotepath, ExceptionSink* xs
    //printf("PUT: %s", resp->getBuffer());
    if ((code / 100 != 2)) {
       xsink->raiseException("FTP-GETASBINARY-ERROR", "FTP server returned an error to the RETR command: %s",
-			    resp.getBuffer());
+                            resp.getBuffer());
       return 0;
    }
    return rv.release();
@@ -1313,7 +1314,7 @@ QoreStringNode* QoreFtpClient::getURL() const {
    if (priv->user) {
       url->concat(priv->user);
       if (priv->pass)
-	 url->sprintf(":%s", priv->pass);
+         url->sprintf(":%s", priv->pass);
       url->concat('@');
    }
    if (priv->host)

--- a/lib/QoreFtpClient.cpp
+++ b/lib/QoreFtpClient.cpp
@@ -760,11 +760,13 @@ public:
       data.clearWarningQueue(xsink);
    }
 
-   DLLLOCAL void setWarningQueue(ExceptionSink* xsink, int64 warning_ms, int64 warning_bs, class Queue* wq, AbstractQoreNode* arg, int64 min_ms) {
+   DLLLOCAL void setWarningQueue(ExceptionSink* xsink, int64 warning_ms, int64 warning_bs, Queue* wq, AbstractQoreNode* arg, int64 min_ms) {
       AutoLocker al(m);
       control.setWarningQueue(xsink, warning_ms, warning_bs, wq, arg, min_ms);
-      if (!*xsink)
-	 data.setWarningQueue(xsink, warning_ms, warning_bs, wq, arg, min_ms);
+      if (!*xsink) {
+         wq->ref();
+	 data.setWarningQueue(xsink, warning_ms, warning_bs, wq, arg ? arg->refSelf() : 0, min_ms);
+      }
    }
 
    DLLLOCAL QoreHashNode* getUsageInfo() const {

--- a/lib/QoreQueue.cpp
+++ b/lib/QoreQueue.cpp
@@ -35,6 +35,13 @@
 #include <sys/time.h>
 #include <errno.h>
 
+void Queue::deref(ExceptionSink* xsink) {
+   if (ROdereference()) {
+      priv->destructor(xsink);
+      delete this;
+   }
+}
+
 void qore_queue_private::destructor(ExceptionSink* xsink) {
    AutoLocker al(&l);
    if (read_waiting) {

--- a/lib/Variable.cpp
+++ b/lib/Variable.cpp
@@ -1,3 +1,4 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
 /*
   Variable.cpp
 
@@ -201,47 +202,47 @@ LValueHelper::~LValueHelper() {
    if (!(*vl.xsink)) {
       // see if we have any object count changes
       if (!ocvec.empty()) {
-	 // v could be 0 if the constructor taking QoreObject& was used (to scan objects after initialization)
-	 if (v) {
-	    if (rdt) {
-	       assert(*v);
-	       if (!obj_chg)
-		  obj_chg = true;
-	       inc_container_obj(ocvec[ocvec.size() - 1].con, rdt);
-	    }
-	    else {
-	       bool after = needs_scan(*v);
-	       if (before) {
-		  // we have to assume that the objects have changed when before and after = true
-		  if (!obj_chg)
-		     obj_chg = true;
-		  if (!after)
-		     inc_container_obj(ocvec[ocvec.size() - 1].con, -1);
-	       }
-	       else if (after) {
-		  if (!obj_chg)
-		     obj_chg = true;
-		  inc_container_obj(ocvec[ocvec.size() - 1].con, 1);
-	       }
-	    }
-	 }
+         // v could be 0 if the constructor taking QoreObject& was used (to scan objects after initialization)
+         if (v) {
+            if (rdt) {
+               assert(*v);
+               if (!obj_chg)
+                  obj_chg = true;
+               inc_container_obj(ocvec[ocvec.size() - 1].con, rdt);
+            }
+            else {
+               bool after = needs_scan(*v);
+               if (before) {
+                  // we have to assume that the objects have changed when before and after = true
+                  if (!obj_chg)
+                     obj_chg = true;
+                  if (!after)
+                     inc_container_obj(ocvec[ocvec.size() - 1].con, -1);
+               }
+               else if (after) {
+                  if (!obj_chg)
+                     obj_chg = true;
+                  inc_container_obj(ocvec[ocvec.size() - 1].con, 1);
+               }
+            }
+         }
 
-	 if (ocvec.size() > 1) {
-	    for (int i = ocvec.size() - 2; i >= 0; --i) {
-	       int dt = ocvec[i + 1].getDifference();
-	       if (dt)
-		  inc_container_obj(ocvec[i].con, dt);
+         if (ocvec.size() > 1) {
+            for (int i = ocvec.size() - 2; i >= 0; --i) {
+               int dt = ocvec[i + 1].getDifference();
+               if (dt)
+                  inc_container_obj(ocvec[i].con, dt);
 
-	       //printd(5, "LValueHelper::~LValueHelper() %s %p has obj: %d\n", get_type_name(ocvec[i].con), ocvec[i].con, (int)needs_scan(ocvec[i].con));
-	    }
-	 }
+               //printd(5, "LValueHelper::~LValueHelper() %s %p has obj: %d\n", get_type_name(ocvec[i].con), ocvec[i].con, (int)needs_scan(ocvec[i].con));
+            }
+         }
       }
 
       if (!obj_chg && (val ? val->needsScan() : needs_scan(*v)))
-	 obj_chg = true;
+         obj_chg = true;
       if (robj) {
-	 robj->tRef();
-	 obj_ref = true;
+         robj->tRef();
+         obj_ref = true;
       }
 
       //printd(5, "LValueHelper::~LValueHelper() robj: %p before: %d obj_chg: %d (val: %s v: %s)\n", robj, before, obj_chg, val ? val->getTypeName() : "null", v ? get_type_name(*v) : "null");
@@ -259,9 +260,9 @@ LValueHelper::~LValueHelper() {
    if (robj) {
       // recalculate recursive references for objects if necessary
       if (obj_chg)
-	 RSetHelper rsh(*robj);
+         RSetHelper rsh(*robj);
       if (obj_ref)
-	 robj->tDeref();
+         robj->tDeref();
    }
 }
 
@@ -359,7 +360,7 @@ int LValueHelper::doHashObjLValue(const QoreTreeNode* tree, bool for_remove) {
          ensureUnique();
          h = reinterpret_cast<QoreHashNode*>(getValue());
 
-	 ocvec.push_back(ObjCountRec(h));
+         ocvec.push_back(ObjCountRec(h));
       }
       else {
          if (for_remove)
@@ -374,14 +375,14 @@ int LValueHelper::doHashObjLValue(const QoreTreeNode* tree, bool for_remove) {
          saveTemp(getValue());
          assignIntern((h = new QoreHashNode));
 
-	 ocvec.push_back(ObjCountRec(h));
+         ocvec.push_back(ObjCountRec(h));
       }
 
       //printd(5, "LValueHelper::doHashObjLValue() def: %s member %s \"%s\"\n", QCS_DEFAULT->getCode(), mem->getEncoding()->getCode(), mem->getBuffer());
       AbstractQoreNode** ptr = for_remove ? h->getExistingValuePtr(mem->getBuffer()) : h->getKeyValuePtr(mem->getBuffer());
       if (!ptr) {
-	 assert(for_remove);
-	 return -1;
+         assert(for_remove);
+         return -1;
       }
 
       resetPtr(ptr);
@@ -451,13 +452,13 @@ int LValueHelper::doLValue(const AbstractQoreNode* n, bool for_remove) {
       reinterpret_cast<const StaticClassVarRefNode*>(n)->getLValue(*this);
    else if (ntype == NT_REFERENCE) {
       if (doLValue(reinterpret_cast<const ReferenceNode*>(n), for_remove))
-	 return -1;
+         return -1;
    }
    else if (ntype == NT_OPERATOR) {
       const QoreSquareBracketsOperatorNode* op = dynamic_cast<const QoreSquareBracketsOperatorNode*>(n);
       assert(op);
       if (doListLValue(op, for_remove))
-	 return -1;
+         return -1;
    }
    else {
       assert(n->getType() == NT_TREE);
@@ -465,7 +466,7 @@ int LValueHelper::doLValue(const AbstractQoreNode* n, bool for_remove) {
       const QoreTreeNode* tree = reinterpret_cast<const QoreTreeNode*>(n);
       assert(tree->getOp() == OP_OBJECT_REF);
       if (doHashObjLValue(tree, for_remove))
-	 return -1;
+         return -1;
    }
 
 #if 0
@@ -479,9 +480,9 @@ int LValueHelper::doLValue(const AbstractQoreNode* n, bool for_remove) {
    if (current_value && current_value->getType() == NT_REFERENCE) {
       const ReferenceNode* ref = reinterpret_cast<const ReferenceNode*>(current_value);
       if (val)
-	 val = 0;
+         val = 0;
       if (v)
-	 v = 0;
+         v = 0;
       return doLValue(ref, for_remove);
    }
 
@@ -601,7 +602,7 @@ int LValueHelper::makeNumber(const char* desc) {
 int64 LValueHelper::plusEqualsBigInt(int64 va, const char* desc) {
    if (val) {
       if (makeInt(desc))
-	 return 0;
+         return 0;
       return val->plusEqualsBigInt(va, getTempRef());
    }
 
@@ -616,7 +617,7 @@ int64 LValueHelper::plusEqualsBigInt(int64 va, const char* desc) {
 int64 LValueHelper::minusEqualsBigInt(int64 va, const char* desc) {
    if (val) {
       if (makeInt(desc))
-	 return 0;
+         return 0;
       return val->minusEqualsBigInt(va, getTempRef());
    }
 
@@ -631,7 +632,7 @@ int64 LValueHelper::minusEqualsBigInt(int64 va, const char* desc) {
 int64 LValueHelper::multiplyEqualsBigInt(int64 va, const char* desc) {
    if (val) {
       if (makeInt(desc))
-	 return 0;
+         return 0;
       return val->multiplyEqualsBigInt(va, getTempRef());
    }
 
@@ -648,7 +649,7 @@ int64 LValueHelper::divideEqualsBigInt(int64 va, const char* desc) {
 
    if (val) {
       if (makeInt(desc))
-	 return 0;
+         return 0;
       return val->divideEqualsBigInt(va, getTempRef());
    }
 
@@ -663,7 +664,7 @@ int64 LValueHelper::divideEqualsBigInt(int64 va, const char* desc) {
 int64 LValueHelper::orEqualsBigInt(int64 va, const char* desc) {
    if (val) {
       if (makeInt(desc))
-	 return 0;
+         return 0;
       return val->orEqualsBigInt(va, getTempRef());
    }
 
@@ -678,7 +679,7 @@ int64 LValueHelper::orEqualsBigInt(int64 va, const char* desc) {
 int64 LValueHelper::xorEqualsBigInt(int64 va, const char* desc) {
    if (val) {
       if (makeInt(desc))
-	 return 0;
+         return 0;
       return val->xorEqualsBigInt(va, getTempRef());
    }
 
@@ -693,7 +694,7 @@ int64 LValueHelper::xorEqualsBigInt(int64 va, const char* desc) {
 int64 LValueHelper::modulaEqualsBigInt(int64 va, const char* desc) {
    if (val) {
       if (makeInt(desc))
-	 return 0;
+         return 0;
       return val->modulaEqualsBigInt(va, getTempRef());
    }
 
@@ -708,7 +709,7 @@ int64 LValueHelper::modulaEqualsBigInt(int64 va, const char* desc) {
 int64 LValueHelper::andEqualsBigInt(int64 va, const char* desc) {
    if (val) {
       if (makeInt(desc))
-	 return 0;
+         return 0;
       return val->andEqualsBigInt(va, getTempRef());
    }
 
@@ -723,7 +724,7 @@ int64 LValueHelper::andEqualsBigInt(int64 va, const char* desc) {
 int64 LValueHelper::shiftLeftEqualsBigInt(int64 va, const char* desc) {
    if (val) {
       if (makeInt(desc))
-	 return 0;
+         return 0;
       return val->shiftLeftEqualsBigInt(va, getTempRef());
    }
 
@@ -738,7 +739,7 @@ int64 LValueHelper::shiftLeftEqualsBigInt(int64 va, const char* desc) {
 int64 LValueHelper::shiftRightEqualsBigInt(int64 va, const char* desc) {
    if (val) {
       if (makeInt(desc))
-	 return 0;
+         return 0;
       return val->shiftRightEqualsBigInt(va, getTempRef());
    }
 
@@ -753,7 +754,7 @@ int64 LValueHelper::shiftRightEqualsBigInt(int64 va, const char* desc) {
 int64 LValueHelper::preIncrementBigInt(const char* desc) {
    if (val) {
       if (makeInt(desc))
-	 return 0;
+         return 0;
       return val->preIncrementBigInt(getTempRef());
    }
 
@@ -767,7 +768,7 @@ int64 LValueHelper::preIncrementBigInt(const char* desc) {
 int64 LValueHelper::preDecrementBigInt(const char* desc) {
    if (val) {
       if (makeInt(desc))
-	 return 0;
+         return 0;
       return val->preDecrementBigInt(getTempRef());
    }
 
@@ -781,7 +782,7 @@ int64 LValueHelper::preDecrementBigInt(const char* desc) {
 int64 LValueHelper::postIncrementBigInt(const char* desc) {
    if (val) {
       if (makeInt(desc))
-	 return 0;
+         return 0;
       assert(val->isInt());
       return val->postIncrementBigInt(getTempRef());
    }
@@ -796,7 +797,7 @@ int64 LValueHelper::postIncrementBigInt(const char* desc) {
 int64 LValueHelper::postDecrementBigInt(const char* desc) {
    if (val) {
       if (makeInt(desc))
-	 return 0;
+         return 0;
       return val->postDecrementBigInt(getTempRef());
    }
 
@@ -810,7 +811,7 @@ int64 LValueHelper::postDecrementBigInt(const char* desc) {
 double LValueHelper::preIncrementFloat(const char* desc) {
    if (val) {
       if (makeFloat(desc))
-	 return 0;
+         return 0;
       return val->preIncrementFloat(getTempRef());
    }
 
@@ -824,7 +825,7 @@ double LValueHelper::preIncrementFloat(const char* desc) {
 double LValueHelper::preDecrementFloat(const char* desc) {
    if (val) {
       if (makeFloat(desc))
-	 return 0;
+         return 0;
       return val->preDecrementFloat(getTempRef());
    }
 
@@ -838,7 +839,7 @@ double LValueHelper::preDecrementFloat(const char* desc) {
 double LValueHelper::postIncrementFloat(const char* desc) {
    if (val) {
       if (makeFloat(desc))
-	 return 0;
+         return 0;
       return val->postIncrementFloat(getTempRef());
    }
 
@@ -852,7 +853,7 @@ double LValueHelper::postIncrementFloat(const char* desc) {
 double LValueHelper::postDecrementFloat(const char* desc) {
    if (val) {
       if (makeFloat(desc))
-	 return 0;
+         return 0;
       return val->postDecrementFloat(getTempRef());
    }
 
@@ -866,7 +867,7 @@ double LValueHelper::postDecrementFloat(const char* desc) {
 double LValueHelper::plusEqualsFloat(double va, const char* desc) {
    if (val) {
       if (makeFloat(desc))
-	 return 0;
+         return 0;
       return val->plusEqualsFloat(va, getTempRef());
    }
 
@@ -881,7 +882,7 @@ double LValueHelper::plusEqualsFloat(double va, const char* desc) {
 double LValueHelper::minusEqualsFloat(double va, const char* desc) {
    if (val) {
       if (makeFloat(desc))
-	 return 0;
+         return 0;
       return val->minusEqualsFloat(va, getTempRef());
    }
 
@@ -896,7 +897,7 @@ double LValueHelper::minusEqualsFloat(double va, const char* desc) {
 double LValueHelper::multiplyEqualsFloat(double va, const char* desc) {
    if (val) {
       if (makeFloat(desc))
-	 return 0;
+         return 0;
       return val->multiplyEqualsFloat(va, getTempRef());
    }
 
@@ -912,7 +913,7 @@ double LValueHelper::divideEqualsFloat(double va, const char* desc) {
    assert(va);
    if (val) {
       if (makeFloat(desc))
-	 return 0;
+         return 0;
       return val->divideEqualsFloat(va, getTempRef());
    }
 
@@ -1153,35 +1154,35 @@ void LValueRemoveHelper::doRemove(AbstractQoreNode* lvalue) {
       const QoreListNode* l = reinterpret_cast<const QoreListNode*>(*member);
 
       if (o)
-	 qore_object_private::takeMembers(*o, rv, lvh, l);
+         qore_object_private::takeMembers(*o, rv, lvh, l);
       else {
-	 unsigned old_count = qore_hash_private::getScanCount(*h);
+         unsigned old_count = qore_hash_private::getScanCount(*h);
 
-	 QoreHashNode* rvh = new QoreHashNode;
+         QoreHashNode* rvh = new QoreHashNode;
 #ifdef DEBUG
-	 // QoreLValue::assignInitial() can only return a value if it has an optimized type restriction; which "rv" does not have
-	 assert(!rv.assignInitial(rvh));
+         // QoreLValue::assignInitial() can only return a value if it has an optimized type restriction; which "rv" does not have
+         assert(!rv.assignInitial(rvh));
 #else
-	 rv.assignInitial(rvh);
+         rv.assignInitial(rvh);
 #endif
 
-	 ConstListIterator li(l);
-	 while (li.next()) {
-	    QoreStringValueHelper mem(li.getValue(), QCS_DEFAULT, xsink);
-	    if (*xsink)
-	       return;
+         ConstListIterator li(l);
+         while (li.next()) {
+            QoreStringValueHelper mem(li.getValue(), QCS_DEFAULT, xsink);
+            if (*xsink)
+               return;
 
-	    AbstractQoreNode* n = h->takeKeyValue(mem->getBuffer());
-	    if (*xsink)
-	       return;
+            AbstractQoreNode* n = h->takeKeyValue(mem->getBuffer());
+            if (*xsink)
+               return;
 
-	    // note that no exception can occur here
-	    rvh->setKeyValue(mem->getBuffer(), n, xsink);
-	    assert(!*xsink);
-	 }
+            // note that no exception can occur here
+            rvh->setKeyValue(mem->getBuffer(), n, xsink);
+            assert(!*xsink);
+         }
 
-	 if (old_count && !qore_hash_private::getScanCount(*h))
-	    lvh.setDelta(-1);
+         if (old_count && !qore_hash_private::getScanCount(*h))
+            lvh.setDelta(-1);
       }
 
       return;
@@ -1197,8 +1198,8 @@ void LValueRemoveHelper::doRemove(AbstractQoreNode* lvalue) {
    else {
       v = h->takeKeyValue(mem->getBuffer());
       if (needs_scan(v)) {
-	 if (!qore_hash_private::getScanCount(*h))
-	    lvh.setDelta(-1);
+         if (!qore_hash_private::getScanCount(*h))
+            lvh.setDelta(-1);
       }
    }
 
@@ -1278,18 +1279,18 @@ static bool check_closure_loop(ClosureVarValue* cvv, const AbstractQoreNode* n) 
    switch (get_node_type(n)) {
       case NT_RUNTIME_CLOSURE: return check_closure_loop_closure(cvv, reinterpret_cast<const QoreClosureBase*>(n));
       case NT_HASH: {
-	 ConstHashIterator hi(reinterpret_cast<const QoreHashNode*>(n));
-	 while (hi.next())
-	    if (check_closure_loop(cvv, hi.getValue()))
-	       return true;
-	 break;
+         ConstHashIterator hi(reinterpret_cast<const QoreHashNode*>(n));
+         while (hi.next())
+            if (check_closure_loop(cvv, hi.getValue()))
+               return true;
+         break;
       }
       case NT_LIST: {
-	 ConstListIterator li(reinterpret_cast<const QoreListNode*>(n));
-	 while (li.next())
-	    if (check_closure_loop(cvv, li.getValue()))
-	       return true;
-	 break;
+         ConstListIterator li(reinterpret_cast<const QoreListNode*>(n));
+         while (li.next())
+            if (check_closure_loop(cvv, li.getValue()))
+               return true;
+         break;
       }
    }
    return false;

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -62,13 +62,13 @@ for test in $TESTS; do
         echo "-------------------------------------"
     fi
 
-    if [ "$test" = "./examples/test/qore/classes/FtpClient/FtpClient.qtest" ]; then
-        echo "Skipping $test because it doesn't really test what it should. Need to fix it."
-        echo "-------------------------------------"; echo
-        PASSED_TEST_COUNT=$((PASSED_TEST_COUNT+1))
-        i=$((i+1))
-        continue
-    fi
+    #if [ "$test" = "./examples/test/qore/classes/FtpClient/FtpClient.qtest" ]; then
+    #    echo "Skipping $test because it doesn't really test what it should. Need to fix it."
+    #    echo "-------------------------------------"; echo
+    #    PASSED_TEST_COUNT=$((PASSED_TEST_COUNT+1))
+    #    i=$((i+1))
+    #    continue
+    #fi
 
     # Run single test.
     QORE_MODULE_DIR=./qlib:$QORE_MODULE_DIR LD_LIBRARY_PATH=$QORE_LIB_PATH $QORE $test $TEST_OUTPUT_FORMAT


### PR DESCRIPTION
… that all data is removed (ex: a socket warning queue goes out of scope when the Socket object is deleted)

refs #1293 fixed reference bugs in FtpClient::setWarningQueue()

re-enabled FtpClient.qtest and updated jenkins to use a controlled test FTP server
