### PR TITLE
updated version to 0.8.12.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # Process this file with autoconf to produce a configure script.
 
 # AC_PREREQ(2.59)
-AC_INIT([qore], [0.8.12.2],
+AC_INIT([qore], [0.8.12.3],
         [David Nichols <david@qore.org>],
         [qore])
 AM_INIT_AUTOMAKE([no-dist-gzip dist-bzip2 tar-ustar])

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -9,7 +9,7 @@
 
     @subsection qore_08123_bug_fixes Bug Fixes in Qore
 
-    - fixed the documentation (and DB modules) where the SQLStatement::fetchColumns() was inconsistent; now it will return a empty hash when no more rows are available to fetch (<a href="https://github.com/qorelanguage/qore/issues/1241">issue 1241</a>)
+    - fixed the documentation (and DB modules) where @ref Qore::SQL::SQLStatement::fetchColumns() "SQLStatement::fetchColumns()" was inconsistent; now it will return a empty hash when no more rows are available to fetch (<a href="https://github.com/qorelanguage/qore/issues/1241">issue 1241</a>)
     - added I/O timeout support to the @ref Qore::FtpClient "FtpClient" class (<a href="https://github.com/qorelanguage/qore/issues/1252">issue 1252</a>)
     - fixed bugs in @ref Qore::Socket::recv() "Socket::recv()" and @ref Qore::Socket::recvBinary() "Socket::recvBinary()" with <tt>size = 0</tt> where @ref nothing could be returned which is invalid according to the methods' declared return types (<a href="https://github.com/qorelanguage/qore/issues/1260">issue 1260</a>)
     - fixed a bug where @ref Qore::FtpClient::get() "FtpClient:get()" would fail with an exception when retrieving an empty file (<a href="https://github.com/qorelanguage/qore/issues/1255">issue 1255</a>)

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -1689,6 +1689,9 @@ QoreException* catchGetException() {
 }
 
 void qore_exit_process(int rc) {
+   // call exit() in a single-threaded process; flushes file buffers, etc
+   if (thread_list.getNumThreads() <= 1)
+      exit(rc);
    // do not call exit here since it will try to execute cleanup, which will cause crashes
    // in multithreaded programs; call quick_exit() instead (issue
    _Exit(rc);

--- a/qore.spec-fedora
+++ b/qore.spec-fedora
@@ -3,7 +3,7 @@
 
 Summary: Multithreaded Programming Language
 Name: qore
-Version: 0.8.12.2
+Version: 0.8.12.3
 Release: 7%{?dist}
 License: LGPLv2+ or GPLv2+ or MIT
 Group: Development/Languages
@@ -32,7 +32,7 @@ Group: System Environment/Libraries
 Provides: qore-module(abi)%{?_isa} = 0.19
 Provides: qore-module(abi)%{?_isa} = 0.18
 Provides: libqore5 = %{version}
-Obsoletes: libqore5 < 0.8.12.2
+Obsoletes: libqore5 < 0.8.12.3
 # provided for backwards-compatibility with unversioned capabilities and will be removed when the ABI drops backwards-compatibility
 Provides: qore-module-api-0.18
 Provides: qore-module-api-0.17
@@ -160,6 +160,9 @@ make check
 %{_mandir}/man1/qore.1.*
 
 %changelog
+* Tue Sep 27 2016 David Nichols <david@qore.org> 0.8.12.3-1
+- updated to 0.8.12.3
+
 * Sat Sep 10 2016 David Nichols <david@qore.org> 0.8.12.2-1
 - updated to 0.8.12.2
 

--- a/qore.spec-multi
+++ b/qore.spec-multi
@@ -31,7 +31,7 @@
 
 Summary: Multithreaded Programming Language
 Name: qore
-Version: 0.8.12.2
+Version: 0.8.12.3
 Release: 1%{dist}
 %if 0%{?suse_version}
 License: LGPL-2.0+ or GPL-2.0+ or MIT
@@ -109,7 +109,7 @@ Provides: qore-module-api-0.6
 Provides: qore-module-api-0.5
 %if %{libname} == "libqore"
 Provides: libqore5 = %{version}
-Obsoletes: libqore5 < 0.8.12.2
+Obsoletes: libqore5 < 0.8.12.3
 %endif
 %if 0%{?sles_version}
 BuildArch: %{_target_cpu}
@@ -255,6 +255,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 
 %changelog
+* Tue Sep 27 2016 David Nichols <david@qore.org> 0.8.12.3
+- updated to 0.8.12.3
+
 * Sat Sep 10 2016 David Nichols <david@qore.org> 0.8.12.2
 - updated to 0.8.12.2
 

--- a/qore.spec-opensuse
+++ b/qore.spec-opensuse
@@ -20,7 +20,7 @@
 
 %define module_dir %{_libdir}/qore-modules
 Name:           qore
-Version:        0.8.12.2
+Version:        0.8.12.3
 Release:        0
 Summary:        Multithreaded Programming Language
 License:        LGPL-2.1+ or GPL-2.0+ or MIT


### PR DESCRIPTION
also refs #1215 call exit() in single-threaded programs to allow buffers to be flushed
