### PR TITLE
closes #1303 fixed a bug where a closure created in an object scope c…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -114,6 +114,7 @@
     - fixed a bug where exceptions in base class constructor calls did not reflect the actual source location (<a href="https://github.com/qorelanguage/qore/issues/1230">issue 1230</a>)
     - fixed a bug where runtime function/method variant matching was incorrectly biased towards default matches for missing arguments (<a href="https://github.com/qorelanguage/qore/issues/1231">issue 1231</a>)
     - fixed bugs where calls to @ref Qore::Socket::upgradeClientToSSL() "Socket::upgradeClientToSSL()" and @ref Qore::Socket::upgradeServerToSSL() "Socket::upgradeServerToSSL()" were ignored with no exception thrown if the socket was not connected (<a href="https://github.com/qorelanguage/qore/issues/1258">issue 1258</a>)
+    - fixed a bug where a closure created in an object scope could not be called if the object had been deleted, even if the closure did not refer to the object (<a href="https://github.com/qorelanguage/qore/issues/1258">issue 1303</a>)
 
     @section qore_08124 Qore 0.8.12.4
 

--- a/include/qore/intern/QoreClosureNode.h
+++ b/include/qore/intern/QoreClosureNode.h
@@ -193,6 +193,7 @@ public:
    }
 
    DLLLOCAL ~QoreObjectClosureNode() {
+      assert(!obj);
    }
 
    DLLLOCAL virtual QoreValue execValue(const QoreListNode* args, ExceptionSink* xsink) const;

--- a/lib/Function.cpp
+++ b/lib/Function.cpp
@@ -1798,7 +1798,9 @@ QoreValue UserClosureFunction::evalClosure(const QoreClosureBase& closure_base, 
    const AbstractQoreFunctionVariant* variant = first();
 
    // setup call, save runtime position
-   CodeEvaluationHelper ceh(xsink, this, variant, "<anonymous closure>", args, self, class_ctx, CT_USER);
+   // issue #1303: do not check for object validity here in the call, we already have a weak reference to the object,
+   // so it will stay valid, if the closure code itself refers to the object, it will fail then if the object is invalid
+   CodeEvaluationHelper ceh(xsink, this, variant, "<anonymous closure>", args, 0, class_ctx, CT_USER);
    if (*xsink)
       return QoreValue();
 


### PR DESCRIPTION
…ould not be called if the object had been deleted, even if the closure did not refer to the object
