### PR TITLE
refs #1160 added a new object API to try to get a referenced private …

### DIFF
--- a/include/qore/QoreObject.h
+++ b/include/qore/QoreObject.h
@@ -329,6 +329,15 @@ public:
    */
    DLLEXPORT AbstractPrivateData* getReferencedPrivateData(qore_classid_t key, ExceptionSink* xsink) const;
 
+   //! returns the private data corresponding to the class ID passed with an incremented reference count if it exists, caller owns the reference
+   /**
+      @param key the class ID of the class to get the private data for
+      @param xsink if an error occurs (the object has already been deleted), the Qore-language exception information will be added here
+
+      @since %Qore 0.8.13
+   */
+   DLLEXPORT AbstractPrivateData* tryGetReferencedPrivateData(qore_classid_t key, ExceptionSink* xsink) const;
+
    //! evaluates the given method with the arguments passed and returns the return value, caller owns the AbstractQoreNode (reference) returned
    /**
       @param name the name of the method to evaluate
@@ -660,17 +669,15 @@ public:
    }
 };
 
+//! convenience class for holding AbstractPrivateData references
+template <class T>
+class TryPrivateDataRefHolder : public ReferenceHolder<T> {
+public:
+   DLLLOCAL TryPrivateDataRefHolder(const QoreObject* o, qore_classid_t cid, ExceptionSink* xsink) : ReferenceHolder<T>(reinterpret_cast<T*>(o->tryGetReferencedPrivateData(cid, xsink)), xsink) {
+   }
+};
+
 class QorePrivateObjectAccessHelper {
-private:
-   // not implemented
-   DLLLOCAL QorePrivateObjectAccessHelper(const QorePrivateObjectAccessHelper&);
-   DLLLOCAL QorePrivateObjectAccessHelper& operator=(const QorePrivateObjectAccessHelper&);
-   DLLLOCAL void* operator new(size_t);
-
-protected:
-   ExceptionSink* xsink;
-   void* ptr;
-
 public:
    DLLLOCAL QorePrivateObjectAccessHelper(ExceptionSink* xs) : xsink(xs), ptr(0) {
    }
@@ -678,6 +685,15 @@ public:
    DLLLOCAL operator bool() const {
       return (bool)ptr;
    }
+
+private:
+   DLLLOCAL QorePrivateObjectAccessHelper(const QorePrivateObjectAccessHelper&) = delete;
+   DLLLOCAL QorePrivateObjectAccessHelper& operator=(const QorePrivateObjectAccessHelper&) = delete;
+   DLLLOCAL void* operator new(size_t) = delete;
+
+protected:
+   ExceptionSink* xsink;
+   void* ptr;
 };
 
 #endif

--- a/include/qore/intern/QoreObjectIntern.h
+++ b/include/qore/intern/QoreObjectIntern.h
@@ -640,6 +640,8 @@ public:
 
    DLLLOCAL AbstractPrivateData* getReferencedPrivateData(qore_classid_t key, ExceptionSink* xsink) const;
 
+   DLLLOCAL AbstractPrivateData* tryGetReferencedPrivateData(qore_classid_t key, ExceptionSink* xsink) const;
+
    DLLLOCAL QoreValue evalBuiltinMethodWithPrivateData(const QoreMethod& method, const BuiltinNormalMethodVariantBase* meth, const QoreValueList* args, q_rt_flags_t rtflags, ExceptionSink* xsink);
 
    // no locking necessary; if class_ctx is non-null, an internal member is being initialized

--- a/lib/QoreObject.cpp
+++ b/lib/QoreObject.cpp
@@ -585,6 +585,24 @@ AbstractPrivateData* qore_object_private::getReferencedPrivateData(qore_classid_
       return 0;
    }
 
+   AbstractPrivateData* d = privateData->getReferencedPrivateData(key);
+   if (!d)
+      makeAccessDeletedObjectException(xsink, theclass->getName());
+
+   return d;
+}
+
+AbstractPrivateData* qore_object_private::tryGetReferencedPrivateData(qore_classid_t key, ExceptionSink* xsink) const {
+   QoreSafeVarRWReadLocker sl(rml);
+
+   if (status == OS_DELETED) {
+      makeAccessDeletedObjectException(xsink, theclass->getName());
+      return 0;
+   }
+
+   if (!privateData)
+      return 0;
+
    return privateData->getReferencedPrivateData(key);
 }
 
@@ -1247,6 +1265,10 @@ AbstractQoreNode** QoreObject::getExistingValuePtr(const char* mem, AutoVLock *v
 
 AbstractPrivateData* QoreObject::getReferencedPrivateData(qore_classid_t key, ExceptionSink* xsink) const {
    return priv->getReferencedPrivateData(key, xsink);
+}
+
+AbstractPrivateData* QoreObject::tryGetReferencedPrivateData(qore_classid_t key, ExceptionSink* xsink) const {
+   return priv->tryGetReferencedPrivateData(key, xsink);
 }
 
 AbstractPrivateData* QoreObject::getAndClearPrivateData(qore_classid_t key, ExceptionSink* xsink) {


### PR DESCRIPTION
…data object so that two calls are not necessary - otherwise a QoreObject::getClass() has to be run first, which is O(n) where n is the number of classes in the hierarchy, and then if successful QoreObject::getReferencedPrivateData() can be called - with this change only a single call is necessary
