### PR TITLE
added C++ API support for external stack traces in Qore exceptions (e…

### DIFF
--- a/include/qore/ExceptionSink.h
+++ b/include/qore/ExceptionSink.h
@@ -36,8 +36,12 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <string>
+#include <vector>
+
 class QoreException;
 struct QoreProgramLocation;
+struct QoreCallStack;
 
 //! container for holding Qore-language exception information and also for registering a "thread_exit" call
 class ExceptionSink {
@@ -90,7 +94,7 @@ public:
        @param fmt the format string for the description for the exception
        @return always returns 0
    */
-   DLLEXPORT AbstractQoreNode *raiseException(const char *err, const char *fmt, ...);
+   DLLEXPORT AbstractQoreNode* raiseException(const char *err, const char *fmt, ...);
 
    //! appends a Qore-language exception to the list and appends the result of strerror(errno) to the description
    /** The AbstractQoreNode pointer returned is always 0; used to simplify error handling code.
@@ -117,7 +121,7 @@ public:
        @param fmt the format string for the description for the exception
        @return always returns 0
    */
-   DLLEXPORT AbstractQoreNode *raiseExceptionArg(const char* err, AbstractQoreNode* arg, const char* fmt, ...);
+   DLLEXPORT AbstractQoreNode* raiseExceptionArg(const char* err, AbstractQoreNode* arg, const char* fmt, ...);
 
    //! appends a Qore-language exception to the list, and sets the 'arg' member (this object takes over the reference counts of 'arg' and 'desc')
    /** The AbstractQoreNode pointer returned is always 0; used to simplify error handling code.
@@ -126,7 +130,20 @@ public:
        @param desc the description string for the exception; the ExceptionSink object takes ownership of the reference count
        @return always returns 0
    */
-   DLLEXPORT AbstractQoreNode *raiseExceptionArg(const char* err, AbstractQoreNode* arg, QoreStringNode *desc);
+   DLLEXPORT AbstractQoreNode* raiseExceptionArg(const char* err, AbstractQoreNode* arg, QoreStringNode* desc);
+
+   //! appends a Qore-language exception to the list, and sets the 'arg' member (this object takes over the reference counts of 'arg' and 'desc')
+   /** The AbstractQoreNode pointer returned is always 0; used to simplify error handling code.
+       @param err the exception code string
+       @param arg the 'arg' member of the Qore-language exception object; will be dereferenced when the QoreException object is destroyed
+       @param desc the description string for the exception; the ExceptionSink object takes ownership of the reference count
+       @param stack a call stack to prepend to the Qore call stack
+
+       @return always returns 0
+
+       @since %Qore 0.8.13
+   */
+   DLLEXPORT AbstractQoreNode* raiseExceptionArg(const char* err, AbstractQoreNode* arg, QoreStringNode* desc, const QoreCallStack& stack);
 
    //! appends a Qore-language exception to the list; takes owenership of the "desc" argument reference
    /** The AbstractQoreNode pointer returned is always 0; used to simplify error handling code.
@@ -134,7 +151,7 @@ public:
        @param desc the description string for the exception; the ExceptionSink object takes ownership of the reference count
        @return always returns 0
    */
-   DLLEXPORT AbstractQoreNode *raiseException(const char *err, QoreStringNode *desc);
+   DLLEXPORT AbstractQoreNode* raiseException(const char *err, QoreStringNode* desc);
 
    //! sets the "thread_exit" flag; will cause the current thread to terminate
    DLLEXPORT void raiseThreadExit();
@@ -170,6 +187,66 @@ public:
 
    DLLLOCAL static void defaultExceptionHandler(QoreException* e);
    DLLLOCAL static void defaultWarningHandler(QoreException* e);
+};
+
+//! call stack element type
+enum qore_call_t {
+   CT_UNUSED     = -1,
+   CT_USER       =  0,
+   CT_BUILTIN    =  1,
+   CT_NEWTHREAD  =  2,
+   CT_RETHROW    =  3
+};
+
+//! Qore source location; strings must be in the default encoding for the Qore process
+/** @since %Qore 0.8.13
+ */
+struct QoreSourceLocation {
+   std::string label;     //!< the code label name (source file if source not present)
+   int start_line,        //!< the start line
+      end_line;           //!< the end line
+   std::string source;    //!< optional additional source file
+   unsigned offset = 0;   //!< offset in source file (only used if source is not empty)
+   std::string code;      //!< the function or method call name; method calls in format class::name
+
+   DLLLOCAL QoreSourceLocation(const char* n_label, int start, int end, const char* n_code) :
+      label(n_label), start_line(start), end_line(end), code(n_code) {
+   }
+
+   DLLLOCAL QoreSourceLocation(const char* n_label, int start, int end, const char* n_source, unsigned n_offset, const char* n_code) :
+      label(n_label), start_line(start), end_line(end), source(n_source), offset(n_offset), code(n_code) {
+   }
+
+};
+
+//! call stack element; strings must be in the default encoding for the Qore process
+/** @since %Qore 0.8.13
+ */
+struct QoreCallStackElement : QoreSourceLocation {
+   qore_call_t type;        //!< the call stack element type
+
+   DLLLOCAL QoreCallStackElement(qore_call_t n_type, const char* n_label, int start, int end, const char* n_code) :
+      QoreSourceLocation(n_label, start, end, n_code), type(n_type) {
+   }
+
+   DLLLOCAL QoreCallStackElement(qore_call_t n_type, const char* n_label, int start, int end, const char* n_source, unsigned n_offset, const char* n_code) :
+      QoreSourceLocation(n_label, start, end, n_source, n_offset, n_code), type(n_type) {
+   }
+};
+
+typedef std::vector<QoreCallStackElement> callstack_vec_t;
+
+//! Qore call stack
+/** @since %Qore 0.8.13
+ */
+struct QoreCallStack : public callstack_vec_t {
+   DLLLOCAL void add(qore_call_t n_type, const char* n_label, int start, int end, const char* n_code) {
+      push_back(QoreCallStackElement(n_type, n_label, start, end, n_code));
+   }
+
+   DLLLOCAL void add(qore_call_t n_type, const char* n_label, int start, int end, const char* n_source, unsigned n_offset, const char* n_code) {
+      push_back(QoreCallStackElement(n_type, n_label, start, end, n_source, n_offset, n_code));
+   }
 };
 
 static inline void alreadyDeleted(ExceptionSink *xsink, const char *cmeth) {

--- a/include/qore/intern/BufferedStreamReader.h
+++ b/include/qore/intern/BufferedStreamReader.h
@@ -305,7 +305,7 @@ public:
       return i;
    }
 
-   DLLLOCAL virtual const char* getName() const { return "BufferedStreamReader"; }
+   DLLLOCAL virtual const char* getName() const override { return "BufferedStreamReader"; }
 
 private:
    DLLLOCAL int64 fillBuffer(qore_size_t bytes, ExceptionSink* xsink) {

--- a/include/qore/intern/QoreException.h
+++ b/include/qore/intern/QoreException.h
@@ -4,7 +4,7 @@
 
   Qore programming language exception handling support
 
-  Copyright (C) 2003 - 2016 David Nichols
+  Copyright (C) 2003 - 2016 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -43,14 +43,14 @@
 
 struct QoreExceptionBase {
    int type;
-   QoreListNode *callStack;
-   AbstractQoreNode *err, *desc, *arg;
+   QoreListNode* callStack = new QoreListNode;
+   AbstractQoreNode* err, *desc, *arg;
 
-   DLLLOCAL QoreExceptionBase(AbstractQoreNode *n_err, AbstractQoreNode *n_desc, AbstractQoreNode *n_arg = 0, int n_type = ET_SYSTEM)
-      : type(n_type), callStack(new QoreListNode), err(n_err), desc(n_desc), arg(n_arg) {
+   DLLLOCAL QoreExceptionBase(AbstractQoreNode* n_err, AbstractQoreNode* n_desc, AbstractQoreNode* n_arg = 0, int n_type = ET_SYSTEM)
+      : type(n_type), err(n_err), desc(n_desc), arg(n_arg) {
    }
 
-   DLLLOCAL QoreExceptionBase(const QoreExceptionBase &old) :
+   DLLLOCAL QoreExceptionBase(const QoreExceptionBase& old) :
                type(old.type), callStack(old.callStack->copy()),
                err(old.err ? old.err->refSelf() : 0), desc(old.desc ? old.desc->refSelf() : 0),
                arg(old.arg ? old.arg->refSelf() : 0) {
@@ -62,7 +62,7 @@ struct QoreExceptionLocation : QoreProgramLineLocation {
    std::string source;
    int offset;
 
-   DLLLOCAL QoreExceptionLocation(const QoreProgramLocation &loc) : QoreProgramLineLocation(loc),
+   DLLLOCAL QoreExceptionLocation(const QoreProgramLocation& loc) : QoreProgramLineLocation(loc),
          file(loc.file ? loc.file : ""), source(loc.source ? loc.source : ""), offset(loc.offset) {
    }
 
@@ -95,25 +95,30 @@ protected:
       assert(!arg);
    }
 
-   DLLLOCAL void addStackInfo(AbstractQoreNode *n);
-   DLLLOCAL static QoreHashNode *getStackHash(int type, const char *class_name, const char *code, const QoreProgramLocation& loc);
+   DLLLOCAL void addStackInfo(AbstractQoreNode* n);
+
+   DLLLOCAL static const char* getType(qore_call_t type);
+
+   DLLLOCAL static QoreHashNode* getStackHash(int type, const char *class_name, const char *code, const QoreProgramLocation& loc);
+
+   DLLLOCAL static QoreHashNode* getStackHash(const QoreCallStackElement& cse);
 
 public:
    QoreException *next;
 
    // called for generic exceptions
-   DLLLOCAL QoreHashNode *makeExceptionObjectAndDelete(ExceptionSink *xsink);
-   DLLLOCAL QoreHashNode *makeExceptionObject();
+   DLLLOCAL QoreHashNode* makeExceptionObjectAndDelete(ExceptionSink *xsink);
+   DLLLOCAL QoreHashNode* makeExceptionObject();
 
    // called for runtime exceptions
-   DLLLOCAL QoreException(const char *n_err, AbstractQoreNode *n_desc, AbstractQoreNode *n_arg = 0) : QoreExceptionBase(new QoreStringNode(n_err), n_desc, n_arg), QoreExceptionLocation(QoreProgramLocation(RunTimeLocation)), next(0) {
+   DLLLOCAL QoreException(const char *n_err, AbstractQoreNode* n_desc, AbstractQoreNode* n_arg = 0) : QoreExceptionBase(new QoreStringNode(n_err), n_desc, n_arg), QoreExceptionLocation(QoreProgramLocation(RunTimeLocation)), next(0) {
    }
 
-   DLLLOCAL QoreException(const QoreException &old) : QoreExceptionBase(old), QoreExceptionLocation(old), next(old.next ? new QoreException(*old.next) : 0) {
+   DLLLOCAL QoreException(const QoreException& old) : QoreExceptionBase(old), QoreExceptionLocation(old), next(old.next ? new QoreException(*old.next) : 0) {
    }
 
    // called for user exceptions
-   DLLLOCAL QoreException(const QoreListNode *n) : QoreExceptionBase(0, 0, 0, ET_USER), QoreExceptionLocation(QoreProgramLocation(RunTimeLocation)), next(0) {
+   DLLLOCAL QoreException(const QoreListNode* n) : QoreExceptionBase(0, 0, 0, ET_USER), QoreExceptionLocation(QoreProgramLocation(RunTimeLocation)), next(0) {
       if (n) {
          err = n->get_referenced_entry(0);
          desc = n->get_referenced_entry(1);
@@ -122,7 +127,7 @@ public:
    }
 ;
 
-   DLLLOCAL QoreException(const QoreProgramLocation &n_loc, const char *n_err, AbstractQoreNode *n_desc, AbstractQoreNode *n_arg = 0, int n_type = ET_SYSTEM) : QoreExceptionBase(new QoreStringNode(n_err), n_desc, n_arg, n_type), QoreExceptionLocation(n_loc), next(0) {
+   DLLLOCAL QoreException(const QoreProgramLocation& n_loc, const char *n_err, AbstractQoreNode* n_desc, AbstractQoreNode* n_arg = 0, int n_type = ET_SYSTEM) : QoreExceptionBase(new QoreStringNode(n_err), n_desc, n_arg, n_type), QoreExceptionLocation(n_loc), next(0) {
    }
 
    DLLLOCAL void del(ExceptionSink *xsink);
@@ -131,18 +136,18 @@ public:
       QoreException *e = new QoreException(*this);
 
       // insert current position as a rethrow entry in the new callstack
-      QoreListNode *l = e->callStack;
+      QoreListNode* l = e->callStack;
       const char *fn = 0;
-      QoreHashNode *n = reinterpret_cast<QoreHashNode *>(l->retrieve_entry(0));
+      QoreHashNode* n = reinterpret_cast<QoreHashNode* >(l->retrieve_entry(0));
       // get function name
       if (n) {
-         QoreStringNode *func = reinterpret_cast<QoreStringNode *>(n->getKeyValue("function"));
+         QoreStringNode* func = reinterpret_cast<QoreStringNode* >(n->getKeyValue("function"));
          fn = func->getBuffer();
       }
       if (!fn)
          fn = "<unknown>";
 
-      QoreHashNode *h = getStackHash(CT_RETHROW, 0, fn, get_runtime_location());
+      QoreHashNode* h = getStackHash(CT_RETHROW, 0, fn, get_runtime_location());
       l->insert(h);
 
       return e;
@@ -161,12 +166,10 @@ public:
 };
 
 struct qore_es_private {
-   bool thread_exit;
-   QoreException* head, * tail;
+   bool thread_exit = false;
+   QoreException* head = 0, * tail = 0;
 
    DLLLOCAL qore_es_private() {
-      thread_exit = false;
-      head = tail = 0;
    }
 
    DLLLOCAL ~qore_es_private() {
@@ -225,6 +228,24 @@ struct qore_es_private {
          if (w)
             n->ref();
       }
+   }
+
+   DLLLOCAL void addStackInfo(const QoreCallStackElement& cse) {
+      assert(head);
+      QoreHashNode* n = QoreException::getStackHash(cse);
+
+      QoreException *w = head;
+      while (w) {
+         w->addStackInfo(n);
+         w = w->next;
+         if (w)
+            n->ref();
+      }
+   }
+
+   DLLLOCAL void addStackInfo(const QoreCallStack& stack) {
+      for (auto& i : stack)
+         addStackInfo(i);
    }
 
    DLLLOCAL static void addStackInfo(ExceptionSink& xsink, int type, const char* class_name, const char* code, const QoreProgramLocation& loc = QoreProgramLocation(ParseLocation)) {

--- a/include/qore/intern/QoreLibIntern.h
+++ b/include/qore/intern/QoreLibIntern.h
@@ -314,14 +314,6 @@ typedef std::map<QoreCondition*, int> cond_map_t;
 #define QORE_MANAGE_STACK
 #endif
 
-enum qore_call_t {
-   CT_UNUSED     = -1,
-   CT_USER       =  0,
-   CT_BUILTIN    =  1,
-   CT_NEWTHREAD  =  2,
-   CT_RETHROW    =  3
-};
-
 // Datasource Access Helper codes
 #define DAH_NOCHANGE  0 // acquire lock temporarily
 #define DAH_ACQUIRE   1 // acquire lock and hold

--- a/include/qore/qore_thread.h
+++ b/include/qore/qore_thread.h
@@ -6,7 +6,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/lib/ExceptionSink.cpp
+++ b/lib/ExceptionSink.cpp
@@ -169,6 +169,15 @@ AbstractQoreNode* ExceptionSink::raiseExceptionArg(const char* err, AbstractQore
    return 0;
 }
 
+AbstractQoreNode* ExceptionSink::raiseExceptionArg(const char* err, AbstractQoreNode* arg, QoreStringNode *desc, const QoreCallStack& stack) {
+   printd(5, "ExceptionSink::raiseExceptionArg(%s, %s, %p)\n", err, desc->getBuffer(), &stack);
+   QoreException* exc = new QoreException(err, desc);
+   exc->arg = arg;
+   priv->insert(exc);
+   priv->addStackInfo(stack);
+   return 0;
+}
+
 AbstractQoreNode* ExceptionSink::raiseExceptionArg(const char* err, AbstractQoreNode* arg, const char* fmt, ...) {
    QoreStringNode *desc = new QoreStringNode;
 

--- a/lib/QoreException.cpp
+++ b/lib/QoreException.cpp
@@ -3,7 +3,7 @@
 
   Qore programming language exception handling support
 
-  Copyright (C) 2003 - 2016 David Nichols
+  Copyright (C) 2003 - 2016 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -68,7 +68,7 @@ void QoreException::del(ExceptionSink *xsink) {
    delete this;
 }
 
-QoreHashNode *QoreException::makeExceptionObject() {
+QoreHashNode* QoreException::makeExceptionObject() {
    QORE_TRACE("makeExceptionObject()");
 
    QoreHashNode *h = new QoreHashNode;
@@ -372,6 +372,38 @@ void ExceptionSink::defaultWarningHandler(QoreException *e) {
    }
 }
 
+const char* QoreException::getType(qore_call_t type) {
+   switch (type) {
+      case CT_USER:
+	 return "user";
+      case CT_BUILTIN:
+	 return "builtin";
+      case CT_RETHROW:
+	 return "rethrow";
+      default:
+	 break;
+   }
+   assert(false);
+   return 0;
+}
+
+// static function
+QoreHashNode* QoreException::getStackHash(const QoreCallStackElement& cse) {
+   QoreHashNode* h = new QoreHashNode;
+
+   assert(!cse.code.empty());
+   h->setKeyValue("function", new QoreStringNode(cse.code), 0);
+   h->setKeyValue("line",     new QoreBigIntNode(cse.start_line), 0);
+   h->setKeyValue("endline",  new QoreBigIntNode(cse.end_line), 0);
+   h->setKeyValue("file",     !cse.label.empty() ? new QoreStringNode(cse.label) : 0, 0);
+   h->setKeyValue("source",   !cse.source.empty() ? new QoreStringNode(cse.source) : 0, 0);
+   h->setKeyValue("offset",   new QoreBigIntNode(cse.offset), 0);
+   h->setKeyValue("typecode", new QoreBigIntNode(cse.type), 0);
+   h->setKeyValue("type",     new QoreStringNode(getType(cse.type)), 0);
+
+   return h;
+}
+
 // static function
 QoreHashNode *QoreException::getStackHash(int type, const char *class_name, const char *code, const QoreProgramLocation& loc) {
    QoreHashNode *h = new QoreHashNode;
@@ -390,26 +422,8 @@ QoreHashNode *QoreException::getStackHash(int type, const char *class_name, cons
    h->setKeyValue("source",   loc.source ? new QoreStringNode(loc.source) : 0, 0);
    h->setKeyValue("offset",   new QoreBigIntNode(loc.offset), 0);
    h->setKeyValue("typecode", new QoreBigIntNode(type), 0);
-   const char *tstr = 0;
-   switch (type) {
-      case CT_USER:
-	 tstr = "user";
-         break;
-      case CT_BUILTIN:
-	 tstr = "builtin";
-         break;
-      case CT_RETHROW:
-	 tstr = "rethrow";
-         break;
-/*
-      case CT_NEWTHREAD:
-	 tstr = "new-thread";
-         break;
-*/
-      default:
-	 assert(false);
-   }
-   h->setKeyValue("type",  new QoreStringNode(tstr), 0);
+   h->setKeyValue("type",     new QoreStringNode(getType((qore_call_t)type)), 0);
+
    return h;
 }
 


### PR DESCRIPTION
…x: jni)

use RTLD_NODELETE when calling dlclose() in case external modules are using C++ thread-local variables and they are destroyed after the dlclose() (ex: jni)
fixed a warning in BufferedStreamReader when compiled with clang++
