### PR TITLE
unload binary modules when rolling back module changes, do not delete…

### DIFF
--- a/include/qore/intern/ModuleInfo.h
+++ b/include/qore/intern/ModuleInfo.h
@@ -602,13 +602,8 @@ public:
    DLLLOCAL virtual ~QoreBuiltinModule() {
       printd(5, "QoreBuiltinModule::~QoreBuiltinModule() '%s': %s calling module_delete: %p\n", name.getBuffer(), filename.getBuffer(), module_delete);
       module_delete();
-      if (dlptr) {
-         printd(5, "calling dlclose(%p)\n", dlptr);
-#ifndef DEBUG
-         // do not close modules when debugging
-         dlclose((void* )dlptr);
-#endif
-      }
+      // we do not close binary modules because we may have thread local data that needs to be
+      // destroyed when exit() is called
    }
 
    DLLLOCAL unsigned getAPIMajor() const {

--- a/lib/ModuleManager.cpp
+++ b/lib/ModuleManager.cpp
@@ -39,14 +39,8 @@
 #include <errno.h>
 #include <string.h>
 
-#ifdef RTLD_NODELETE
-// we use RTLD_NODELETE if possible to avoid removing binary modules from the qore library's address space
-// in case they use c++11 thread-local data which could be destroyed after the module is removed which would
-// cause a crash
-#define QORE_DLOPEN_FLAGS RTLD_LAZY|RTLD_GLOBAL|RTLD_NODELETE
-#else
+// dlopen() flags
 #define QORE_DLOPEN_FLAGS RTLD_LAZY|RTLD_GLOBAL
-#endif
 
 #ifdef HAVE_GLOB_H
 #include <glob.h>
@@ -564,7 +558,6 @@ void QoreModuleManager::loadModuleIntern(ExceptionSink& xsink, const char* name,
    assert(mmi == map.end() || !strcmp(mmi->second->getName(), name));
 
    QoreAbstractModule* mi = (mmi == map.end() ? 0 : mmi->second);
-   //printd(5, "QoreModuleManager::loadModuleIntern() '%s' mi: %p\n", name, mi);
 
    // handle module reloads
    if (load_opt & QMLO_RELOAD) {


### PR DESCRIPTION
… binary modules when closing down the Qore library in case a module uses c++11 thread-local data that needs to be destroyed after has been the module dlclose()ed, if binary modules are not unloaded when rollingback module changes, then it will lead to crashes