### PR TITLE
added an API to the QoreProgram class to allow binary modules to supp…

### DIFF
--- a/include/qore/QoreClass.h
+++ b/include/qore/QoreClass.h
@@ -1018,7 +1018,7 @@ public:
    DLLEXPORT void addPrivateMember(const char* mem, const QoreTypeInfo* n_typeInfo, AbstractQoreNode* initial_value = 0);
 
    //! sets a pointer to user-specific data in the class
-   /** @deprecated use setUserData(AbstractQoreClassUserData*) instead
+   /** @deprecated use setManagedUserData(AbstractQoreClassUserData*) instead
     */
    DLLEXPORT void setUserData(const void* ptr);
 

--- a/include/qore/intern/ModuleInfo.h
+++ b/include/qore/intern/ModuleInfo.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2016 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/include/qore/intern/QoreClassIntern.h
+++ b/include/qore/intern/QoreClassIntern.h
@@ -2030,6 +2030,8 @@ public:
       return checkAssignSpecialIntern(m);
    }
 
+   DLLLOCAL void mergeAbstract(QoreString& csig);
+
    // returns -1 if a recursive inheritance list was found, 0 if not
    DLLLOCAL int initializeIntern(qcp_set_t& qcp_set);
    DLLLOCAL void initialize();

--- a/include/qore/intern/qore_program_private.h
+++ b/include/qore/intern/qore_program_private.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2016 David Nichols
+  Copyright (C) 2003 - 2016 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -350,6 +350,9 @@ class qore_program_private_base {
 
 protected:
    DLLLOCAL void setDefines();
+
+   typedef std::map<const char*, AbstractQoreProgramExternalData*, ltstr> extmap_t;
+   extmap_t extmap;
 
 public:
    LocalVariableList local_var_list;
@@ -1544,6 +1547,18 @@ public:
    DLLLOCAL void doThreadInit(ExceptionSink* xsink);
 
    DLLLOCAL QoreClass* runtimeFindClass(const char* class_name, ExceptionSink* xsink) const;
+
+   DLLLOCAL void setExternalData(const char* owner, AbstractQoreProgramExternalData* pud) {
+      AutoLocker al(plock);
+      assert(extmap.find(owner) == extmap.end());
+      extmap.insert(extmap_t::value_type(owner, pud));
+   }
+
+   DLLLOCAL AbstractQoreProgramExternalData* getExternalData(const char* owner) const {
+      AutoLocker al(plock);
+      extmap_t::const_iterator i = extmap.find(owner);
+      return i == extmap.end() ? nullptr : i->second;
+   }
 
    DLLLOCAL static QoreClass* runtimeFindClass(const QoreProgram& pgm, const char* class_name, ExceptionSink* xsink) {
       return pgm.priv->runtimeFindClass(class_name, xsink);

--- a/include/qore/intern/qore_thread_intern.h
+++ b/include/qore/intern/qore_thread_intern.h
@@ -400,15 +400,6 @@ public:
    }
 };
 
-class QoreProgramContextHelper {
-protected:
-   QoreProgram *old_pgm;
-
-public:
-   DLLLOCAL QoreProgramContextHelper(QoreProgram* pgm);
-   DLLLOCAL ~QoreProgramContextHelper();
-};
-
 class QoreProgramOptionalLocationHelper {
 protected:
    QoreProgramLocation loc;
@@ -664,12 +655,6 @@ protected:
 public:
    DLLLOCAL ProgramRuntimeParseCommitContextHelper(ExceptionSink* xsink, QoreProgram* pgm);
    DLLLOCAL ~ProgramRuntimeParseCommitContextHelper();
-};
-
-class CurrentProgramRuntimeParseContextHelper {
-public:
-   DLLLOCAL CurrentProgramRuntimeParseContextHelper();
-   DLLLOCAL ~CurrentProgramRuntimeParseContextHelper();
 };
 
 class ProgramRuntimeParseAccessHelper {

--- a/lib/ModuleManager.cpp
+++ b/lib/ModuleManager.cpp
@@ -264,6 +264,9 @@ static QoreStringNode* loadModuleError(const char* name, ExceptionSink& xsink) {
 void QoreBuiltinModule::addToProgramImpl(QoreProgram* pgm, ExceptionSink& xsink) const {
    QoreModuleContextHelper qmc(name.getBuffer(), pgm, xsink);
 
+   // make sure getProgram() returns this Program when module_ns_init() is called
+   QoreProgramContextHelper pch(pgm);
+
    RootQoreNamespace* rns = pgm->getRootNS();
    QoreNamespace* qns = pgm->getQoreNS();
 
@@ -1211,7 +1214,7 @@ QoreAbstractModule* QoreModuleManager::loadBinaryModuleFromPath(ExceptionSink& x
 
    printd(5, "QoreModuleManager::loadBinaryModuleFromPath(%s) %s: calling module_init@%p\n", path, name, *module_init);
 
-   // this is needed for backwards-compatibility for modules that add builtin functions in the module initilization code
+   // this is needed for backwards-compatibility for modules that add builtin functions in the module initialization code
    QoreModuleContextHelper qmc(name, pgm, xsink);
    QoreStringNode* str = (*module_init)();
    if (str) {

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -1494,7 +1494,7 @@ ProgramThreadCountContextHelper::~ProgramThreadCountContextHelper() {
    QoreProgram* pgm = td->current_pgm;
    //printd(5, "ProgramThreadCountContextHelper::~ProgramThreadCountContextHelper() current_pgm: %p restoring old pgm: %p old tlpd: %p\n", td->current_pgm, old_pgm, old_tlpd);
    td->current_pgm = old_pgm;
-   td->tlpd        = old_tlpd;
+   td->tlpd = old_tlpd;
 
    qore_program_private::decThreadCount(*pgm, td->tid);
 }


### PR DESCRIPTION
…ort custom data in each QoreProgram object (ex: jni object to store the custom classloader and java -> QoreClass maps)

made QoreProgramContextHelper part of the public API/ABI for use in modules (ex: jni)
made CurrentProgramRuntimeParseContextHelper part of the public API/ABI for use in modules (ex: jni)
fixed internal scan of builtin classes to process abstract methods properly in parent classes