### PR TITLE
updated rest (major updates) and sfrest, allow the data serialization…

### DIFF
--- a/bin/rest
+++ b/bin/rest
@@ -3,7 +3,7 @@
 
 # @file rest example program for the RestClient module
 
-/*  Copyright 2013 - 2015 David Nichols
+/*  Copyright 2013 - 2016 David Nichols
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -30,119 +30,260 @@
 %strict-args
 
 %requires RestClient
+%requires Util
+%requires Mime
 
-#! program options
-const opts = (
-    "proxy": "proxy-url,p=s",
-    "to": "timeout,t=i",
-    "verbose": "verbose,v:i+",
-    "help": "h,help",
-    );
+%try-module yaml >= 0.5
+%define NoYaml
+%endtry
 
-#! recognized HTTP methods
-const Methods = (
-    "GET": True,
-    "PUT": True,
-    "POST": True,
-    "DELETE": True,
-    );
+%try-module xml >= 1.3
+%define NoXml
+%endtry
 
-main();
+%try-module json >= 1.5
+%define NoJson
+%endtry
 
-sub usage() {
-    printf("usage: %s [options] get|put|post|delete URL ['qore msg body']
- -p,--proxy-url=ARG  set the proxy URL (ex: http://proxy:port)
- -t,--timeout=ARG    set HTTP timeout in seconds
- -v,--verbose        show more info (-v = response headers, -vv = msgs,
-                     -vvv = all info)
- -h,--help           this help text
-", get_script_name());
-    exit(1);
-}
+%exec-class RestCmd
 
-any sub parse_arg(string arg) {
-    # try to evaluate as a Qore expression
-    string str = sprintf("any sub get() { return %s; }", arg);
-    Program prog();
-    try {
-        prog.parse(str, "main");
-        return prog.callFunction("get");
-    }
-    catch (hash ex) {
-        return arg;
-    }
-}
-
-sub main() {
-    GetOpt g(opts);
-    hash opt = g.parse3(\ARGV);
-
-    if (opt.help || !ARGV[0])
-        usage();
-
-    *string meth = shift ARGV;
-    if (!meth)
-        usage();
-    meth = meth.upr();
-    if (!Methods{meth}) {
-        printf("ERROR: unrecognized HTTP method %y; allowed methods: %y\n", meth, Methods.keys());
-        usage();
-    }
-
-    *string url = shift ARGV;
-    if (!url) {
-        printf("ERROR: missing URL for REST server\n");
-        usage();
-    }
-
-    hash opts.url = url;
-
-    if (opt.proxy)
-        opts.proxy = opt.proxy;
-
-    if (opt.to) {
-        int to = opt.to * 1000;
-        opts += (
-            "timeout": to,
-            "connect_timeout": to,
+class RestCmd {
+    public {
+        #! program options
+        const opts = (
+            "sendenc":   "e,send-encoding:s",
+            "header":    "H,header=s@",
+            "proxy":     "P,proxy-url=s",
+            "to":        "t,timeout=i",
+            "lit":       "l,literal:i+",
+            "reformat":  "R,reformat",
+            "fullex":    "E,full-exception",
+            "data":      "S,serialization=s",
+            "help":      "h,help",
             );
+
+        #! recognized HTTP methods
+        const Methods = (
+            "GET": True,
+            "PUT": True,
+            "POST": True,
+            "DELETE": True,
+            );
+    }
+
+    constructor() {
+        GetOpt g(opts);
+        hash opt = g.parse3(\ARGV);
+
+        if (opt.help || !ARGV[0])
+            usage();
+
+        *string meth = shift ARGV;
+        if (!exists meth)
+            usage();
+
+        *string url = shift ARGV;
+        any body;
+        if (!Methods{meth.upr()}) {
+            body = url;
+            url = meth;
+            meth = "GET";
+        }
+        else {
+            meth = meth.upr();
+            body = shift ARGV;
         }
 
-    RestClient rest(opts);
+        if (!url) {
+            printf("ERROR: missing URL for REST server\n");
+            usage();
+        }
 
-    hash info;
-    any body = shift ARGV;
-    if (exists body)
-        body = parse_arg(body);
-    #printf("body: %y\n", body);
-    try {
-        any ans = rest.doRequest(meth, "", body, \info);
-        switch (opt.verbose) {
-            case NOTHING:
-            case 0: printf("%N\n", ans.body); break;
-            case 1: printf("response headers: %N\nresponse body:\n%N\n", info."response-headers" - "body", ans.body); break;
-          default: {
-              printf("request URI: %s\n", info."request-uri");
-              printf("request headers: %N\n", info.headers);
-              if (info."request-body")
-                  printf("request body: %s\n", info."request-body");
-              printf("response URI: %s\n", info."response-uri");
-              printf("response headers: %N\n", info."response-headers" - "body");
-              if (info."response-body")
-                  printf("response body: %s\n", info."response-body");
-              break;
+        hash opts.url = url;
+
+        if (opt.proxy)
+            opts.proxy = opt.proxy;
+
+        if (opt.to) {
+            int to = opt.to * 1000;
+            opts += (
+                "timeout": to,
+                "connect_timeout": to,
+                );
+        }
+
+        RestClient rest(opts);
+
+        foreach string h in (opt.header) {
+            (*string k, *string v) = (h =~ x/([^:]+):(.+)$/); #/);
+            trim k;
+            trim v;
+            if (!k || !v) {
+                stderr.printf("invalid header %y; expecting \"key: value\" format\n", h);
+                exit(1);
+            }
+            rest.addDefaultHeaders((k: v));
+        }
+
+        if (exists body)
+            body = parse_to_qore_value(body);
+
+        if (opt.data) {
+            if (!RestClient::DataSerializationOptions{opt.data})
+                error("data serialization option %y is unknown; valid options: %y", opt.data, RestClient::DataSerializationOptions.keys());
+            rest.setSerialization(opt.data);
+        }
+
+        if (opt.sendenc) {
+            if (opt.sendenc === True)
+                opt.sendenc = "deflate";
+            else if (!RestClient::EncodingSupport{opt.sendenc})
+                error("send encoding option %y is unknown; valid options: %y", opt.sendenc, RestClient::EncodingSupport.keys());
+            rest.setSendEncoding(opt.sendenc);
+        }
+
+        hash info;
+        #printf("body: %y\n", body);
+        try {
+            hash h;
+            on_exit if (opt.lit) {
+                showRestRequest(info, body, opt);
+                showRestResponse(info, h.body, opt);
+            }
+
+            h = rest.doRequest(meth, "", body, \info);
+            if (!opt.lit)
+                printf("%N\n", h.body);
+        }
+        catch (hash ex) {
+            if (opt.fullex)
+                printf("%s\n", get_exception_string(ex));
+            else {
+                if (ex.err == "DESERIALIZATION-ERROR" && info."response-headers"."content-type" == "text/html")
+                    printf("%s\n%s\n", info."response-uri", html_decode(info."response-body"));
+                else {
+                    printf("%s: %s: %s", rest.getURL(), ex.err, ex.desc);
+                    if (ex.arg) {
+                        print(": ");
+                        if (ex.arg.body.typeCode() == NT_STRING) {
+                            trim ex.arg.body;
+                            print(ex.arg.body);
+                        }
+                        else {
+                            if (ex.arg.typeCode() == NT_STRING) {
+                                trim ex.arg;
+                                printf("%y", ex.arg);
+                            }
+                            else
+                                printf("%y", ex.arg);
+                        }
+                    }
+                    print("\n");
+                }
             }
         }
     }
-    catch (hash ex) {
-        printf("%s: %s: %s", get_ex_pos(ex), ex.err, ex.desc);
-        if (ex.arg) {
-            print(": ");
-            if (ex.arg.body.typeCode() == NT_STRING)
-                print(ex.arg.body);
+
+    private showRestRequest(hash info, any args, *hash opt) {
+        printf("> %s\n", info."request-uri");
+        if (opt.lit > 1)
+            printf("> %N\n", info.headers);
+        if (info."request-body") {
+            *string str;
+            if (opt.reformat) {
+                switch (info."request-serialization") {
+%ifndef NoXml
+                    case "xml": str = make_xmlrpc_value(args, XGF_ADD_FORMATTING); break;
+                    case "rawxml": str = make_xml(args, XGF_ADD_FORMATTING); break;
+%endif
+%ifndef NoJson
+                    case "json": str = make_json(args, JGF_ADD_FORMATTING); break;
+%endif
+%ifndef NoYaml
+                    case "yaml": str = trim(make_yaml(args, YAML::BlockStyle)); break;
+%endif
+                    case "url": str = mime_get_form_urlencoded_string(args); break;
+                    default: str = getBody(info); break;
+                }
+            }
             else
-                printf(ex.arg.typeCode() == NT_STRING ? "%s" : "%y", ex.arg);
+                str = getBody(info);
+            printf("> %s\n", str);
         }
-        print("\n");
+    }
+
+    private showRestResponse(hash info, any rv, *hash opt) {
+        if (!info."response-uri")
+            return;
+        printf("< %s\n", info."response-uri");
+        if (opt.lit > 1)
+            printf("< %N\n", info."response-headers" - "body");
+        if (info."response-body") {
+            if (!exists rv)
+                rv = info."response-body";
+            string str;
+            switch (info."response-serialization") {
+%ifndef NoXml
+                case "xml": str = make_xmlrpc_value(rv, opt.reformat ? XGF_ADD_FORMATTING : NOTHING); break;
+                case "rawxml": str = make_xml(rv, opt.reformat ? XGF_ADD_FORMATTING : NOTHING); break;
+%endif
+%ifndef NoJson
+                case "json": str = make_json(rv, opt.reformat ? JGF_ADD_FORMATTING : NOTHING); break;
+%endif
+%ifndef NoYaml
+                case "yaml": str = trim(make_yaml(rv, opt.reformat ? YAML::BlockStyle : NOTHING)); break;
+%endif
+                case "url": str = mime_get_form_urlencoded_string(rv); break;
+                default: str = trim(info."response-body"); break;
+            }
+            printf("< %s\n", str);
+        }
+    }
+
+    private string getBody(hash info) {
+        switch (info.headers."Content-Encoding") {
+            case "deflate":
+            case "x-deflate":
+                info."request-body" = uncompress_to_string(info."request-body");
+                break;
+            case "gzip":
+            case "x-gzip":
+                info."request-body" = gunzip_to_string(info."request-body");
+                break;
+            case "bzip2":
+            case "x-bzip2":
+                info."request-body" = bunzip2_to_string(info."request-body");
+                break;
+            case "identity":
+                info."request-body" = binary_to_string(info."request-body");
+                break;
+            case NOTHING:
+                break;
+            default:
+                throw "UNKNOWN-CONTENT-ENCODING", sprintf("unknown Content-Encoding %y used to send message", info.headers."Content-Encoding");
+        }
+        return trim(info."request-body");
+    }
+
+    static usage() {
+        printf("usage: %s [options] get|put|post|delete URL ['qore msg body']
+ -e,--send-encoding[=ARG]  set compression in outgoing request
+                           [ARG=gzip,deflate,bzip2,identity]
+ -E,--full-exception       show full exception output
+ -H,--header=ARG           send header with request
+ -l,--literal              show literal API calls (more l's, more info)
+ -P,--proxy-url=ARG        set the proxy URL (ex: http://proxy:port)
+ -R,--reformat             reformat data with -l+ for better readability
+ -S,--serialization=ARG    set REST data serialization type:
+                           auto, json, yaml, xml, rawxml, url
+ -t,--timeout=ARG          set HTTP timeout in seconds
+ -h,--help                 this help text
+", get_script_name());
+        exit(1);
+    }
+
+    static error(string fmt) {
+        stderr.printf("%s: ERROR: %s\n", get_script_name(), vsprintf(fmt, argv));
+        exit(1);
     }
 }

--- a/bin/sfrest
+++ b/bin/sfrest
@@ -9,6 +9,9 @@
 %require-types
 %enable-all-warnings
 
+%requires SalesforceRestClient
+%requires Util
+
 %try-module yaml >= 0.5
 %define NoYaml
 %endtry
@@ -21,15 +24,15 @@
 %define NoJson
 %endtry
 
-%requires SalesforceRestClient
-%requires Util
-
 %exec-class SfRestClient
 
 class SfRestClient {
     public {
         #! program options
         const Opts = (
+            "sendenc":        "e,send-encoding:s",
+            "data":           "S,serialization=s",
+            "examples":       "x,show-examples",
             "proxy":          "P,proxy-url=s",
             "show":           "W,show-url",
             "timeout":        "t,timeout=i",
@@ -40,6 +43,7 @@ class SfRestClient {
             "oath_url_token": "U,oauth-token-url=s",
             "verbose":        "v,verbose:i+",
 
+            "job":            "j,job-command",
             "bulk":           "b,bulk-api",
             "mod":            "m,if-modified-since=d",
             "unmod":          "n,if-unmodified-since=d",
@@ -95,8 +99,13 @@ class SfRestClient {
             exit(0);
         }
 
+        if (opt.examples) {
+            showExamples();
+            exit(0);
+        }
+
         *string meth = shift ARGV;
-        if (!meth)
+        if (!exists meth)
             usage();
 
         *string path = shift ARGV;
@@ -130,6 +139,20 @@ class SfRestClient {
         if (exists body)
             body = parse_to_qore_value(body);
 
+        if (opt.data) {
+            if (!RestClient::DataSerializationOptions{opt.data})
+                error("data serialization option %y is unknown; valid options: %y", opt.data, RestClient::DataSerializationOptions.keys());
+            rc.setSerialization(opt.data);
+        }
+
+        if (opt.sendenc) {
+            if (opt.sendenc === True)
+                opt.sendenc = "deflate";
+            else if (!RestClient::EncodingSupport{opt.sendenc})
+                error("send encoding option %y is unknown; valid options: %y", opt.sendenc, RestClient::EncodingSupport.keys());
+            rc.setSendEncoding(opt.sendenc);
+        }
+
         rc.login();
 
         if (opt.verbose)
@@ -158,6 +181,21 @@ class SfRestClient {
                 showRestRequest(info, body, opt);
                 showRestResponse(info, h.body, opt);
             }
+
+            if (opt.job) {
+                opt.bulk = True;
+                if (body) {
+                    if (body.typeCode() != NT_HASH)
+                        throw "ERR", "option -j requires a hash message body";
+                    body = (opt.job: (
+                                "^attributes": (
+                                    "xmlns": SalesforceRestClient::AsyncDataloadNs,
+                                ),
+                            ) + body,
+                        );
+                }
+            }
+
             h = opt.bulk
                 ? rc.doBulkRequest(meth, "", body, \info, NOTHING, hdr)
                 : rc.doRequest(meth, "", body, \info, NOTHING, hdr);
@@ -193,9 +231,26 @@ class SfRestClient {
         }
     }
 
-    error(string fmt) {
+    static error(string fmt) {
         stderr.printf("%s: ERROR: %s\n", get_script_name(), vsprintf(fmt, argv));
         exit(1);
+    }
+
+    showExamples() {
+        printf("* REST API EXAMPLES\n");
+        printf("** return information about an object\n");
+        printf("     sfrest sobjects/Account/0012A000022K3zxQAC\n\n");
+        printf("** execute a SOQL query\n");
+        printf("     sfrest query?q=\"select id from account where name like 'acc_%'\"\n\n");
+        printf("* BULK REST API EXAMPLES\n");
+        printf("** create a bulk job\n");
+        printf("     sfrest -j=jobInfo post job 'operation=delete,object=Account,contentType=XML'\n\n");
+        printf("** add a batch to a bulk job\n");
+        printf("     sfrest -j=sObjects post job/7502A000008lo8fQAA/batch 'sObject=(Id=0012A000022K3ypQAC)'\n\n");
+        printf("** show job info\n");
+        printf("     sfrest -j job/7502A000008lo8fQAA\n\n");
+        printf("** close a bulk job\n");
+        printf("     sfrest -j=jobInfo post job/7502A000008lo8fQAA state=Closed\n\n");
     }
 
     private showRestRequest(hash info, any args, *hash opt) {
@@ -233,25 +288,23 @@ class SfRestClient {
         if (opt.lit > 1)
             printf("< %N\n", info."response-headers" - "body");
         if (info."response-body") {
+            if (!exists rv)
+                rv = info."response-body";
             string str;
-            if (opt.reformat) {
-                switch (info."response-serialization") {
+            switch (info."response-serialization") {
 %ifndef NoXml
-                    case "xml": str = make_xmlrpc_value(rv, XGF_ADD_FORMATTING); break;
-                    case "rawxml": str = make_xml(rv, XGF_ADD_FORMATTING); break;
+                case "xml": str = make_xmlrpc_value(rv, opt.reformat ? XGF_ADD_FORMATTING : NOTHING); break;
+                case "rawxml": str = make_xml(rv, opt.reformat ? XGF_ADD_FORMATTING : NOTHING); break;
 %endif
 %ifndef NoJson
-                    case "json": str = make_json(rv, JGF_ADD_FORMATTING); break;
+                case "json": str = make_json(rv, opt.reformat ? JGF_ADD_FORMATTING : NOTHING); break;
 %endif
 %ifndef NoYaml
-                    case "yaml": str = trim(make_yaml(rv, YAML::BlockStyle)); break;
+                case "yaml": str = trim(make_yaml(rv, opt.reformat ? YAML::BlockStyle : NOTHING)); break;
 %endif
-                    case "url": str = mime_get_form_urlencoded_string(rv); break;
-                    default: str = trim(info."response-body"); break;
-                }
+                case "url": str = mime_get_form_urlencoded_string(rv); break;
+                default: str = trim(info."response-body"); break;
             }
-            else
-                str = trim(info."response-body");
             printf("< %s\n", str);
         }
     }
@@ -290,23 +343,32 @@ class SfRestClient {
  -p,--password=ARG             the account password (or from $SALESFORCE_PASS)
 
 ** Data Options
- -b,--bulk-api                 use the Bulk REST API
+ -b,--bulk-api                 use the Bulk REST API (uses \"rawxml\" encoding)
+ -j,--job-command=ARG          use the Bulk REST API and serialize for a batch job request
+                               ARG=top-level XML element (ex: jobInfo, sObjects, etc)
+                               uses \"rawxml\" encoding by default
+                               includes xmlns=%y
  -m,--if-modified-since=ARG    set the If-Modified-Since header
  -n,--if-unmodified-since=ARG  set the If-Unmodified-Since header
 
 ** Other Options
+ -e,--send-encoding[=ARG]      set compression in outgoing request
+                               [ARG=gzip,deflate,bzip2,identity]
  -E,--full-exception           show full exception output
  -H,--header=ARG               send header with request
  -P,--proxy-url=ARG            set the proxy URL (ex: http://user:pass@proxy:port)
  -l,--literal                  show literal API calls (more l's, more info)
  -R,--reformat                 reformat data with -l+ for better readability
+ -S,--serialization=ARG        set REST data serialization type:
+                               auto, json, yaml, xml, rawxml, url
  -t,--timeout=ARG              set HTTP timeout in seconds
  -U,--oauth-token-url=ARG      the URL for the OAuth2 token request
                                default: %y
  -v,--verbose                  show more information
  -W,--show-url                 show default REST API URL and exit
+ -x,--show-examples            show usage examples and exit
  -h,--help                     this help text
-", get_script_name(), (SalesforceRestClient::Defaults).oauth_url_token);
+", get_script_name(), SalesforceRestClient::AsyncDataloadNs, (SalesforceRestClient::Defaults).oauth_url_token);
         exit(1);
     }
 

--- a/examples/test/qlib/RestHandler/RestHandler.qtest
+++ b/examples/test/qlib/RestHandler/RestHandler.qtest
@@ -1,0 +1,129 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+
+%requires ../../../../qlib/QUnit.qm
+%requires ../../../../qlib/Mime.qm
+%requires ../../../../qlib/HttpServerUtil.qm
+%requires ../../../../qlib/HttpServer.qm
+%requires ../../../../qlib/RestHandler.qm
+%requires ../../../../qlib/RestClient.qm
+
+%exec-class RestHandlerTest
+
+class TestRestClass inherits AbstractRestClass {
+    string name() {
+        return "test";
+    }
+
+    hash getEcho(hash cx, *hash ah) {
+        return RestHandler::makeResponse(200, cx.body);
+    }
+
+    hash putEcho(hash cx, *hash ah) {
+        return RestHandler::makeResponse(200, cx.body);
+    }
+}
+
+class MyRestHandler inherits RestHandler {
+    constructor() {
+        addClass(new TestRestClass());
+    }
+}
+
+public class RestHandlerTest inherits QUnit::Test {
+    private {
+        HttpServer mServer;
+        RestClient mClient;
+        MyRestHandler mHandler();
+        int port;
+
+        const SimpleHashValue = ("a": "1");
+        const LargerHashValue = ("a": "1", "b": "2");
+        const HashValue = ("a": ("1", "2"));
+
+        const ListValue = ("1", "two", "3");
+
+        const AllValues = ("1", "one", ListValue, SimpleHashValue, LargerHashValue, HashValue);
+
+        const DataValues = (
+            "xml": AllValues,
+            "auto": AllValues,
+            "yaml": AllValues,
+            "json": AllValues,
+            "rawxml": SimpleHashValue,
+            "url": (SimpleHashValue, LargerHashValue),
+            );
+    }
+
+    public {
+    }
+
+    constructor() : Test("RestHandlerTest", "1.0") {
+        addTestCase("Test basics", \basicTest());
+
+        mServer = new HttpServer(\log(), \log());
+        mServer.setHandler("rest-handler", "", MimeTypeHtml, mHandler);
+        mServer.setDefaultHandler("rest-handler", mHandler);
+        port = mServer.addListener(0).port;
+
+        mClient = new RestClient(("url": "http://localhost:" + port));
+
+        # Return for compatibility with test harness that checks return value.
+        set_return_value(main());
+
+        mServer.stop();
+        delete mServer;
+    }
+
+    basicTest() {
+        map testSerialization($1.key, $1.value), DataValues.pairIterator();
+
+        # special tests for rawxml (typeless / raw XML encoding)
+        mClient.setSerialization("rawxml");
+
+        hash info;
+        on_error printf("info: %N\n", info);
+
+        hash h = mClient.get("test?action=echo", LargerHashValue, \info);
+        assertEq(("value": LargerHashValue), h.body);
+        h = mClient.put("test?action=echo", LargerHashValue, \info);
+        assertEq(("value": LargerHashValue), h.body);
+        h = mClient.get("test?action=echo", HashValue, \info);
+        assertEq(("value": HashValue), h.body);
+        h = mClient.put("test?action=echo", HashValue, \info);
+        assertEq(("value": HashValue), h.body);
+        h = mClient.put("test?action=echo", "1", \info);
+        assertEq(("value": "1"), h.body);
+        h = mClient.put("test?action=echo", ListValue, \info);
+        assertEq(("list": ("element": ListValue)), h.body);
+
+        # special tests for "url" (form URL encoding)
+        mClient.setSerialization("url");
+
+        assertThrows("FORMURLENCODING-ERROR", \mClient.put(), ("test?action=echo", "1", \info));
+        assertThrows("FORMURLENCODING-ERROR", \mClient.put(), ("test?action=echo", ListValue, \info));
+        assertThrows("INVALID-VALUE", \mClient.put(), ("test?action=echo", HashValue, \info));
+    }
+
+    testSerialization(string data, softlist values) {
+        mClient.setSerialization(data);
+
+        foreach any val in (values) {
+            hash info;
+            on_error printf("info: %N\n", info);
+            hash h = mClient.get("test?action=echo", val, \info);
+            assertEq(val, h.body, sprintf("GET %s: %s", data, val.type()));
+            h = mClient.put("test?action=echo", val, \info);
+            assertEq(val, h.body, sprintf("PUT %s: %s", data, val.type()));
+        }
+    }
+
+    log(string str) {
+        delete argv;
+    }
+}

--- a/examples/test/qlib/RestHandler/RestHandler.qtest
+++ b/examples/test/qlib/RestHandler/RestHandler.qtest
@@ -66,16 +66,20 @@ public class RestHandlerTest inherits QUnit::Test {
     constructor() : Test("RestHandlerTest", "1.0") {
         addTestCase("Test basics", \basicTest());
 
+        # Return for compatibility with test harness that checks return value.
+        set_return_value(main());
+    }
+
+    globalSetUp() {
         mServer = new HttpServer(\log(), \log());
         mServer.setHandler("rest-handler", "", MimeTypeHtml, mHandler);
         mServer.setDefaultHandler("rest-handler", mHandler);
         port = mServer.addListener(0).port;
 
         mClient = new RestClient(("url": "http://localhost:" + port));
+    }
 
-        # Return for compatibility with test harness that checks return value.
-        set_return_value(main());
-
+    globalTearDown() {
         mServer.stop();
         delete mServer;
     }

--- a/qlib/Mime.qm
+++ b/qlib/Mime.qm
@@ -803,10 +803,10 @@ public namespace Mime {
      */
     public hash sub mime_parse_form_urlencoded_string(string str) {
         hash rv = {};
-        foreach string str in (str.split("&")) {
-            (*string key, *string value) = (str =~ x/([^=]+)=(.+)$/);
+        foreach string ustr in (str.split("&")) {
+            (*string key, *string value) = (ustr =~ x/([^=]+)=(.+)$/);
             if (!key || !value)
-                throw "URLENCODED-PARSE-ERROR", sprintf("urlencoded parameter element not in key=value format: %y", str);
+                throw "URLENCODED-PARSE-ERROR", sprintf("urlencoded parameter element not in key=value format: %y", ustr);
             rv{mime_decode_urlencoded_string(key)} = mime_decode_urlencoded_string(value);
         }
 

--- a/qlib/RestClient.qm
+++ b/qlib/RestClient.qm
@@ -105,7 +105,8 @@ hash ans = rest.get("orders/1?option=full");
 printf("%N\n", ans.body);
     @endcode
 
-    See example file \c "rest" in the examples directory for a more detailed example using this module
+    @see \c "rest" in the bin directory for a user-friendly command-line interface to REST
+    functionality and a more detailed example of code using this module.
 
     @section restclientrelnotes Release Notes
 
@@ -256,7 +257,7 @@ public namespace RestClient {
             const Accept = AcceptList.join(",");
 
             #! RestClient Version
-            const Version = "1.3";
+            const Version = "1.3.1";
 
             #! RestClient Version String
             const VersionString = sprintf("Qore-RestClient/%s", RestClient::Version);

--- a/qlib/RestClient.qm
+++ b/qlib/RestClient.qm
@@ -110,7 +110,7 @@ printf("%N\n", ans.body);
     @section restclientrelnotes Release Notes
 
     @subsection restclientv1_3_1 RestClient v1.3.1
-    - added support for the \c "url" encoding for URL form encodeded message bodies (<a href="https://github.com/qorelanguage/qore/issues/1436">issue 1436</a>)
+    - added support for the \c "url" encoding for URL form encoded message bodies (<a href="https://github.com/qorelanguage/qore/issues/1436">issue 1436</a>)
     - added support for the \c "rawxml" data type; when parsing XML responses, if the XML cannot be parsed as XML-RPC data, then it's attempted to be parsed as untyped XML data (<a href="https://github.com/qorelanguage/qore/issues/1437">issue 1437</a>)
     - fixed a bug where an empty chunked response would cause a spurious exception to be thrown (<a href="https://github.com/qorelanguage/qore/issues/1448">issue 1448</a>)
 
@@ -331,13 +331,13 @@ RestClient rest(("url": "http://localhost:8001/rest"));
             @endcode
 
             @param opts valid options are:
-            - \c additional_methods: Optional hash with more but not-HTTP-standardized methods to handle. It allows to create various HTTP extensions like e.g. WebDAV. The hash takes the method name as a key, and the value is a boolean @ref Qore::True "True" or @ref Qore::False "False": indicating if the method required a message body as well. Example:
+            - \c additional_methods: Optional hash with more but not-HTTP-standardized methods to handle. It allows to create various HTTP extensions like e.g. WebDAV. The hash takes the method name as a key, and the value is a boolean @ref Qore::True "True" or @ref Qore::False "False": indicating if the method requires a message body as well. Example:
                 @code{.py}
 # add new HTTP methods for WebDAV. Both of them require body posting to the server
 ("additional_methods": ("PROPFIND": True, "MKCOL": True ));
                 @endcode
             - \c connect_timeout: The timeout value in milliseconds for establishing a new socket connection (also can be a relative date-time value for clarity, ex: \c 20s)
-            - \c content_encoding: for possible values, see @ref EncodingSupport; this sets the send encoding (if the \c "send_encoding" option is not set) and the requested response encoding
+            - \c content_encoding: for possible values, see @ref EncodingSupport; this sets the send encoding (if the \c "send_encoding" option is not set) and the requested response encoding (note that the @ref RestClient::RestClient "RestClient" class will only compress outgoing message bodies over @ref RestClient::RestClient::CompressionThreshold "CompressionThreshold" bytes in size)
             - \c data: a @ref DataSerializationOptions "data serialization option"; if not present defaults to \c "auto"
             - \c default_path: The default path to use for new connections if a path is not otherwise specified in the connection URL
             - \c default_port: The default port number to connect to if none is given in the URL
@@ -345,7 +345,7 @@ RestClient rest(("url": "http://localhost:8001/rest"));
             - \c http_version: Either '1.0' or '1.1' for the claimed HTTP protocol version compliancy in outgoing message headers
             - \c max_redirects: The maximum number of redirects before throwing an exception (the default is 5)
             - \c proxy: The proxy URL for connecting through a proxy
-            - \c send_encoding: a @ref EncodingSupport "send data encoding option" or the value \c "auto" which means to use automatic encoding; if not present defaults to no content-encoding on sent message bodies
+            - \c send_encoding: a @ref EncodingSupport "send data encoding option" or the value \c "auto" which means to use automatic encoding; if not present defaults to no content-encoding on sent message bodies (note that the @ref RestClient::RestClient "RestClient" class will only compress outgoing message bodies over @ref RestClient::RestClient::CompressionThreshold "CompressionThreshold" bytes in size)
             - \c timeout: The timeout value in milliseconds (also can be a relative date-time value for clarity, ex: \c 30s)
             - \c url: A string giving the URL to connect to
             @param do_not_connect if \c False (the default), then a connection will be immediately established to the remote server
@@ -521,7 +521,7 @@ string ser = rest.getSerialization();
             return ds;
         }
 
-        #! sends an HTTP GET request to the REST server and returns the response
+        #! sends an HTTP \c GET request to the REST server and returns the response
         /** @par Example:
             @code{.py}
 hash ans = rest.get("/orders/1?info=verbose");
@@ -560,7 +560,7 @@ hash ans = rest.get("/orders/1?info=verbose");
             return doRequest("GET", path, body, \info, NOTHING, hdr);
         }
 
-        #! sends an HTTP PUT request to the REST server and returns the response
+        #! sends an HTTP \c PUT request to the REST server and returns the response
         /** @par Example:
             @code{.py}
 hash ans = rest.put("/orders/1", ("action": "cancel"));
@@ -599,7 +599,7 @@ hash ans = rest.put("/orders/1", ("action": "cancel"));
             return doRequest("PUT", path, body, \info, NOTHING, hdr);
         }
 
-        #! sends an HTTP POST request to the REST server and returns the response
+        #! sends an HTTP \c POST request to the REST server and returns the response
         /** @par Example:
             @code{.py}
 hash ans = rest.post("/orders", ("product": "xyz123", "options": 500));
@@ -638,7 +638,7 @@ hash ans = rest.post("/orders", ("product": "xyz123", "options": 500));
             return doRequest("POST", path, body, \info, NOTHING, hdr);
         }
 
-        #! sends an HTTP DELETE request to the REST server and returns the response
+        #! sends an HTTP \c DELETE request to the REST server and returns the response
         /** @par Example:
             @code{.py}
 hash ans = rest.del("/orders/1");

--- a/qlib/RestClient.qm
+++ b/qlib/RestClient.qm
@@ -168,12 +168,22 @@ public namespace RestClient {
                 ),
                 "rawxml": (
                     "ct": MimeTypeXmlApp,
-                    "out": \make_xml(),
+                    "out": string sub (any v) {
+                        switch (v.typeCode()) {
+                            case NT_LIST: return make_xml(("list": ("element": v)));
+                            case NT_HASH: return v.size() == 1 && v.firstValue().lsize() == 1 ? make_xml(v) : make_xml(("value": v));
+                        }
+                        return make_xml(("value": v));
+                    },
                 ),
 %endif
                 "url": (
                     "ct": MimeTypeFormUrlEncoded,
-                    "out": \mime_get_form_urlencoded_string(),
+                    "out": string sub (any v) {
+                        if (v.typeCode() == NT_HASH)
+                            return mime_get_form_urlencoded_string(v);
+                        throw "FORMURLENCODING-ERROR", sprintf("form URL encoding can only encode hashes; type %y requested", v.type());
+                    },
                 ),
                 };
 

--- a/qlib/RestHandler.qm
+++ b/qlib/RestHandler.qm
@@ -750,7 +750,13 @@ public namespace RestHandler {
                     "deserialize": \parse_xmlrpc_value(),
                 ),
                 MimeTypeXmlApp: (
-                    "serialize": \make_xml(),
+                    "serialize": string sub (any v) {
+                        switch (v.typeCode()) {
+                            case NT_LIST: return make_xml(("list": ("element": v)));
+                            case NT_HASH: return v.size() == 1 && v.firstValue().lsize() == 1 ? make_xml(v) : make_xml(("value": v));
+                        }
+                        return make_xml(("value": v));
+                    },
                     "deserialize": hash sub (string xml) {
                         try {
                             return parse_xmlrpc_value(xml);

--- a/qlib/SalesforceRestClient.qm
+++ b/qlib/SalesforceRestClient.qm
@@ -121,6 +121,9 @@ rc.bulkJobAddBatch(h.id, data, BulkJobJson, \info);
 rc.bulkJobClose(h.id);
     @endcode
 
+    @see \c "sfrest" in the bin directory for a user-friendly command-line interface to Salesforce.com REST API
+    functionality and a more detailed example of code using this module.
+
     @section salesforcerestclientrelnotes Release Notes
 
     @subsection salesforcerestclientv1_0 SalesforceRestClient v1.0

--- a/qlib/SalesforceRestClient.qm
+++ b/qlib/SalesforceRestClient.qm
@@ -258,6 +258,7 @@ If-Modified-Since: Thu, 24 Nov 2016 23:00:00 GMT
                 "oauth_url_token": "https://login.salesforce.com/services/oauth2/token",
                 "oauth_url_revoke": "https://login.salesforce.com/services/oauth2/revoke",
                 "api": "auto",
+                "send_encoding": "gzip",
                 );
 
             #! required options
@@ -329,7 +330,7 @@ SalesforceRestClient rest(("url": "http://localhost:8001/rest"));
             @endcode
 
             @param opts valid options are:
-            - \c additional_methods: Optional hash with more but not-HTTP-standardized methods to handle. It allows to create various HTTP extensions like e.g. WebDAV. The hash takes the method name as a key, and the value is a boolean @ref Qore::True "True" or @ref Qore::False "False": indicating if the method required a message body as well. Example:
+            - \c additional_methods: Optional hash with more but not-HTTP-standardized methods to handle. It allows to create various HTTP extensions like e.g. WebDAV. The hash takes the method name as a key, and the value is a boolean @ref Qore::True "True" or @ref Qore::False "False": indicating if the method requires a message body as well. Example:
                 @code{.py}
 # add new HTTP methods for WebDAV. Both of them require body posting to the server
 ("additional_methods": ("PROPFIND": True, "MKCOL": True ));
@@ -338,7 +339,7 @@ SalesforceRestClient rest(("url": "http://localhost:8001/rest"));
             - \c client_id: (required) the Salesforce.com "consumer key" for the Connected App
             - \c client_secret: (required) the Salesforce.com "consumer secret" for the Connected App
             - \c connect_timeout: The timeout value in milliseconds for establishing a new socket connection (also can be a relative date-time value for clarity, ex: \c 20s)
-            - \c content_encoding: for possible values, see @ref EncodingSupport; this sets the send encoding (if the \c "send_encoding" option is not set) and the requested response encoding
+            - \c content_encoding: for possible values, see @ref EncodingSupport; this sets the send encoding (if the \c "send_encoding" option is not set) and the requested response encoding (note that the @ref RestClient::RestClient "RestClient" class will only compress outgoing message bodies over @ref RestClient::RestClient::CompressionThreshold "CompressionThreshold" bytes in size); additionally please note that Salesforce.com does not support \c "bzip2" compression
             - \c data: a @ref DataSerializationOptions "data serialization option"; if not present defaults to \c "json"
             - \c default_path: The default path to use for new connections if a path is not otherwise specified in the connection URL
             - \c default_port: The default port number to connect to if none is given in the URL
@@ -347,7 +348,7 @@ SalesforceRestClient rest(("url": "http://localhost:8001/rest"));
             - \c max_redirects: The maximum number of redirects before throwing an exception (the default is 5)
             - \c password: (required) the Salesforce.com account password for the Connected App
             - \c proxy: The proxy URL for connecting through a proxy
-            - \c send_encoding: a @ref EncodingSupport "send data encoding option" or the value \c "auto" which means to use automatic encoding; if not present defaults to no content-encoding on sent message bodies
+            - \c send_encoding: a @ref EncodingSupport "send data encoding option" or the value \c "auto" which means to use automatic encoding; if not present defaults to \c "gzip" content encoding on sent message bodies (note that the @ref RestClient::RestClient "RestClient" class will only compress outgoing message bodies over @ref RestClient::RestClient::CompressionThreshold "CompressionThreshold" bytes in size); additionally please note that Salesforce.com does not support \c "bzip2" compression
             - \c timeout: The timeout value in milliseconds (also can be a relative date-time value for clarity, ex: \c 30s)
             - \c username: (required) the Salesforce.com account username for the Connected App
             @param do_not_connect if \c False (the default), then a connection will be immediately established to the remote server and a token will be received
@@ -374,7 +375,7 @@ SalesforceRestClient rest(("url": "http://localhost:8001/rest"));
                 loginIntern();
         }
 
-        #! sends an HTTP PATCH request to the Salesforce.com REST server and returns the response; performs an implicit login to Salesforce.com if necessary
+        #! sends an HTTP \c PATCH request to the Salesforce.com REST server and returns the response; performs an implicit login to Salesforce.com if necessary
         /** @par Example:
             @code{.py}
 hash ans = rest.patch("/orders/1", ("action": "cancel"));
@@ -539,7 +540,7 @@ hash ans = rest.doBulkRequest("POST", "job", job);
             return RestClient::doRequest(m, path, body, \info, decode_errors, hdr);
         }
 
-        #! sends an HTTP GET request to the REST server using the Salesforce.com Bulk REST API and returns the response
+        #! sends an HTTP \c GET request to the REST server using the Salesforce.com Bulk REST API and returns the response
         /** @par Example:
             @code{.py}
 hash ans = rest.bulkGet("/orders/1?info=verbose");
@@ -580,7 +581,7 @@ hash ans = rest.bulkGet("/orders/1?info=verbose");
             return doBulkRequest("GET", path, body, \info, NOTHING, hdr);
         }
 
-        #! sends an HTTP POST request to the REST server using the Salesforce.com Bulk REST API and returns the response
+        #! sends an HTTP \c POST request to the REST server using the Salesforce.com Bulk REST API and returns the response
         /** @par Example:
             @code{.py}
 hash ans = rest.bulkPost("/orders", ("product": "xyz123", "options": 500));
@@ -747,7 +748,7 @@ printf("batch ID: %y batch state: %y\n", h.id, h.state);
             return sendAndDecodeResponse(batch_data, "POST", path, hdr, \info, True);
         }
 
-        #! sends a Bulk REST API job close POST request to the server and returns the deserialized result message body
+        #! sends a Bulk REST API job close \c POST request to the server and returns the deserialized result message body
         /** @par Example:
             @code{.py}
 sfrest.bulkJobClose(jh.id);

--- a/qlib/SalesforceRestClient.qm
+++ b/qlib/SalesforceRestClient.qm
@@ -891,6 +891,13 @@ sfrest.logout();
             else
                 delete headers.Accept;
 
+            # save send encoding and retore on error
+            *hash old_seh = seh;
+            # turn off compression for the login request (is not currently supported in Salesforce.com)
+            setSendEncoding("identity");
+            # restore the encoding on exit
+            on_exit seh = old_seh;
+
             # create login hash
             hash lh = self.("client_id", "client_secret", "username", "password") + (
                 "grant_type": "password",


### PR DESCRIPTION
… type and send compression to be set

sfrest: added the -x option to show usage examples
SalesforceRestClient.qm: disable send compression in the login because it will cause the Salesforce.com login to fail
RestClient.qm: fixed several bugs in recent commits related to new data serialization type support (esp "rawxml")
Mime.qm: fixed a bug in the new / unreleased form url encoded functions
added tests for RestHandler and RestClient for all data serialization types