### PR TITLE
fix int(number)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,7 @@ set(QMOD
     qlib/RestClient.qm
     qlib/RestHandler.qm
     qlib/Schema.qm
+    qlib/SchemaReverse.qm
     qlib/SmtpClient.qm
     qlib/SqlUtil.qm
     qlib/TableMapper.qm

--- a/Makefile.am
+++ b/Makefile.am
@@ -40,6 +40,7 @@ DOX_MODULES = qlib/SmtpClient.qm \
 	qlib/WebUtil.qm \
 	qlib/TableMapper.qm \
 	qlib/Schema.qm \
+	qlib/SchemaReverse.qm \
 	qlib/QUnit.qm \
 	qlib/Diff.qm \
 	qlib/BulkSqlUtil.qm \

--- a/bin/schema-reverse
+++ b/bin/schema-reverse
@@ -1,0 +1,154 @@
+#!/usr/bin/env qore
+%new-style
+%exec-class Main
+%requires SchemaReverse
+%requires SqlUtil
+
+const VERSION = "0.1";
+
+const OBJECT_OPTIONS = (
+        "sequences"     : "seq,q:s",
+        "tables"        : "table,t:s",
+        "types"         : "type,y:s",
+        "views"         : "view,v:s",
+        "mviews"        : "mview,m:s",
+        "procedures"    : "proc,p:s",
+        "functions"     : "func,f:s",
+        "packages"      : "pkg,g:s",
+    );
+
+const OPTIONS = (
+        "help" : "help,h",
+        "version" : "version,V",
+        "verbose" : "verbose",
+        "schema" : "schema,s=s",
+    ) + OBJECT_OPTIONS;
+
+sub help(int exitCode) {
+    printf("Usage:
+%s <options> <connection_string>
+
+Options:
+ -h --help          Display help and exits
+ -V --version       Show version of this script
+    --verbose       Show additional verbose info
+ -s --schema=<name> Export full (supported objects) DB schema.
+                    The class of the qsm output will be named <name>
+ -t --table=<val>   Export specified table(s). See <val> section below.
+ -q --seq=<val>     Export specified sequence(s). See <val> section below.
+ -y --type=<val>    Export specified type(s). See <val> section below.
+ -v --view=<val>    Export specified view(s). See <val> section below.
+ -m --mview=<val>   Export specified materialized view(s). See <val> section below.
+ -p --proc=<val>    Export specified procedure(s). See <val> section below.
+ -f --func=<val>    Export specified function(s). See <val> section below.
+ -g --pkg=<val>     Export specified package(s). See <val> section below.
+
+Object <val> filtering:
+    Any <val> can be exact name of the object, a list (separated by ','),
+    or a regular expression to match object name.
+
+Note:
+    --schema and (--tables or --sequences or --types) cannot be
+    used together
+
+Example:
+    %s -s=OmqXbox oracle:omq/omq@xbox
+        export full OMQ schema
+
+    %s -t=\"workflows,.*step.*\" oracle:omq/omq@xbox
+        export only tables whch matches exact table name 'workflows',
+        and any of tables with 'step' in name
+
+",
+    get_script_name(), get_script_name(), get_script_name()
+    );
+    exit(exitCode);
+}
+
+class Main {
+    private {
+        hash m_opts;
+        Datasource m_ds;
+    }
+
+    constructor() {
+        GetOpt go(OPTIONS);
+        m_opts = go.parse2(\ARGV);
+
+        if (m_opts.help) {
+            help(0);
+        }
+
+        if (m_opts.version) {
+            printf(VERSION + "\n");
+            exit(0);
+        }
+
+        bool userObjects = False;
+        foreach string i in (OBJECT_OPTIONS.keyIterator()) {
+            if (m_opts{i}.typeCode() == NT_BOOLEAN && m_opts{i}) {
+                m_opts{i} = ".*";
+            }
+            if (m_opts{i}.size()) {
+                userObjects = True;
+            }
+        }
+
+        if (!m_opts.schema && !userObjects) {
+            error("NOT-ALLOWED-OPTS", sprintf("At least one option must be set: \"schema\" or %y", OBJECT_OPTIONS.keys()));
+        }
+
+        if (m_opts.schema && userObjects) {
+            error("NOT-ALLOWED-OPTS", sprintf("Cannot combine \"schema\" and %y together", OBJECT_OPTIONS.keys()));
+        }
+
+        *string connstr = shift ARGV;
+        if (!connstr) {
+            error("NO-CONNECTION-STRING", "Please specify qore DB connection string");
+        }
+
+        m_ds = new Datasource(connstr);
+
+        if (m_opts.schema) {
+            cout("Exporting full schema: %s", m_opts.schema);
+            SchemaReverse sr(m_ds, m_opts.schema);
+            printf("%s\n", sr.toString());
+        }
+        else {
+            HashIterator it(OBJECT_OPTIONS);
+            while (it.next()) {
+                string key = it.getKey();
+                if (exists m_opts{key}) {
+                    exportObjects(m_opts{key}, key);
+                }
+            }
+        }
+    } # constructor
+
+    private string makeRxString(string val) {
+        list ret = val.split(",");
+        ret = map trim($1), ret;
+        return ret.join("|");
+    }
+
+    private exportObjects(string input, string objectType) {
+        cout("Exporting objects: %s, for: %s", objectType, input);
+        string rx = makeRxString(input);
+        AbstractReverseObject o = SchemaReverse::get_object(objectType, m_ds, input);
+        printf("%s\n", o.toString());
+    }
+
+    private cout(string msg) {
+        if (!m_opts.verbose) {
+            return;
+        }
+
+        printf("# %s\n", vsprintf(msg, argv));
+    }
+    
+    static error(string errcode, string msg) {
+        stderr.printf("%s: %s\n", errcode, msg);
+        exit(1);
+    }
+
+} # class Main

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -126,6 +126,7 @@
     - fixed bugs where calls to @ref Qore::Socket::upgradeClientToSSL() "Socket::upgradeClientToSSL()" and @ref Qore::Socket::upgradeServerToSSL() "Socket::upgradeServerToSSL()" were ignored with no exception thrown if the socket was not connected (<a href="https://github.com/qorelanguage/qore/issues/1258">issue 1258</a>)
     - fixed a bug where a closure created in an object scope could not be called if the object had been deleted, even if the closure did not refer to the object (<a href="https://github.com/qorelanguage/qore/issues/1258">issue 1303</a>)
     - fixed a bug where @ref Qore::ord() "ord()" would return negative numbers for bytes with the high bit set with compilers where <tt>char</tt> is the same as <tt>signed char</tt> (<a href="https://github.com/qorelanguage/qore/issues/1385">issue 1385</a>)
+    - fixed a bug where @ref Qore::int(softint) "int(number)" returned rounded value instead of the integer part (while @ref Qore::int(softint) "int(float)" behaved correctly; also cf. initializing a softint value from a number vs. from a float) (<a href="https://github.com/qorelanguage/qore/issues/1463">issue 1463</a>)
 
     @section qore_08125 Qore 0.8.12.5
 

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -73,6 +73,8 @@
       - <float>::format(int, string, string)
       - <number>::format(int, string, string)
       - <string>::toInt(int)
+      - <int>::toBase(int)
+      - <number>::toBase(int)
     - new functions:
       - @ref Qore::parse_int()
     - updated functions:

--- a/examples/test/qlib/SchemaReverse/schema-reverse.qtest
+++ b/examples/test/qlib/SchemaReverse/schema-reverse.qtest
@@ -1,0 +1,113 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+
+%requires ../../../../qlib/QUnit.qm
+%requires ../../../../qlib/Qorize.qm
+%requires ../../../../qlib/SqlUtil.qm
+%requires ../../../../qlib/Schema.qm
+%requires ../../../../qlib/SchemaReverse.qm
+
+%exec-class Main
+
+#
+# NOTE: the SchemaReverse is automatic hash/string creator. So the reference
+#       (REF_...) constants must be more strict than in user code.
+#       Example: if there is something like string or list, list should be used:
+#       ("columns" : ("id",), "unique" : True))...
+#
+
+const REF_TABLE = (
+        "columns" : (
+                "id" : c_number(C_NOT_NULL, "comment for id"),
+                "foo" : c_varchar(10, C_NULL, "comment for foo"),
+                "bar" : c_date(C_NOT_NULL, "comment for bar"),
+            ),
+        "indexes" : ( "schema_reverse_ix1" : ("columns" : ("id",), "unique" : True)),
+    );
+
+const REF_SCHEMA = (
+        "sequences" : (
+                "schema_reverse_seq" : hash(),
+            ),
+        "tables" : (
+                "schema_reverse_t1" : REF_TABLE,
+            ),
+        #"views" : (
+        #        "schema_reverse_v" : ( "src" : "select * from schema_reverse_t1"),
+        #    ),
+    );
+
+class Main inherits QUnit::Test {
+
+    private {
+        const LOCAL_OPTS = Opts + (
+            "connstr": "c,conn=s",
+            );
+
+        Datasource m_ds;
+        Database m_db;
+    }
+
+    constructor() : QUnit::Test("SchemaReverseTest", "1.0", \ARGV, LOCAL_OPTS) {
+        if (!m_options.connstr)
+            m_options.connstr = ENV.QORE_DB_CONNSTR_ORACLE;
+
+        m_ds = new Datasource(m_options.connstr);
+        m_db = new Database(m_ds);
+
+        addTestCase("schema reverse - table", \testSchemaReverseTable());
+        addTestCase("schema reverse - tables", \testSchemaReverseTables());
+        addTestCase("schema reverse - sequence", \testSchemaReverseSequence());
+        addTestCase("schema reverse - sequences", \testSchemaReverseSequences());
+
+        set_return_value(main());
+    }
+
+    testSchemaReverseTable() {
+        TableReverse r(m_ds, "schema_reverse_t1");
+        hash q = r.toQore();
+        assertEq(REF_TABLE, q, "TableReverse::toQore()");
+    }
+
+    testSchemaReverseTables() {
+        TablesReverse r(m_ds, "schema_reverse_t1");
+        hash q = r.toQore();
+        assertEq(REF_SCHEMA.tables, q, "TableReverse::toQore()");
+    }
+
+    testSchemaReverseSequence() {
+        SequenceReverse r(m_ds, "schema_reverse_seq");
+        hash q = r.toQore();
+        assertEq(REF_SCHEMA.sequences.schema_reverse_seq, q, "SequenceReverse::toQore()");
+    }
+
+    testSchemaReverseSequences() {
+        SequencesReverse r(m_ds, "schema_reverse_seq");
+        hash q = r.toQore();
+        assertEq(REF_SCHEMA.sequences, q, "SequencesReverse::toQore()");
+    }
+
+
+    private globalMakeSchema(string method) {
+        on_exit m_ds.commit();
+        list sql = call_object_method(m_db, method, REF_SCHEMA);
+        ListIterator it(sql);
+        while (it.next()) {
+            m_ds.exec(it.getValue());
+        }
+    }
+
+    globalSetUp() {
+        globalMakeSchema("getAlignSql");
+    }
+
+    globalTearDown() {
+        globalMakeSchema("getDropSchemaSql");
+    }
+
+} # class Main

--- a/examples/test/qlib/SchemaReverse/schema-reverse.qtest
+++ b/examples/test/qlib/SchemaReverse/schema-reverse.qtest
@@ -54,18 +54,35 @@ class Main inherits QUnit::Test {
     }
 
     constructor() : QUnit::Test("SchemaReverseTest", "1.0", \ARGV, LOCAL_OPTS) {
-        if (!m_options.connstr)
-            m_options.connstr = ENV.QORE_DB_CONNSTR_ORACLE;
-
-        m_ds = new Datasource(m_options.connstr);
-        m_db = new Database(m_ds);
-
         addTestCase("schema reverse - table", \testSchemaReverseTable());
         addTestCase("schema reverse - tables", \testSchemaReverseTables());
         addTestCase("schema reverse - sequence", \testSchemaReverseSequence());
         addTestCase("schema reverse - sequences", \testSchemaReverseSequences());
 
         set_return_value(main());
+    }
+
+    private globalMakeSchema(string method) {
+        on_exit m_ds.commit();
+        list sql = call_object_method(m_db, method, REF_SCHEMA);
+        ListIterator it(sql);
+        while (it.next()) {
+            m_ds.exec(it.getValue());
+        }
+    }
+
+    globalSetUp() {
+        if (!m_options.connstr)
+            m_options.connstr = ENV.QORE_DB_CONNSTR ? ENV.QORE_DB_CONNSTR : (ENV.QORE_DB_CONNSTR_ORACLE ? ENV.QORE_DB_CONNSTR_ORACLE : ENV.QORE_DB_CONNSTR_PGSQL);
+
+        m_ds = new Datasource(m_options.connstr);
+        m_db = new Database(m_ds);
+
+        globalMakeSchema("getAlignSql");
+    }
+
+    globalTearDown() {
+        globalMakeSchema("getDropSchemaSql");
     }
 
     testSchemaReverseTable() {
@@ -91,23 +108,4 @@ class Main inherits QUnit::Test {
         hash q = r.toQore();
         assertEq(REF_SCHEMA.sequences, q, "SequencesReverse::toQore()");
     }
-
-
-    private globalMakeSchema(string method) {
-        on_exit m_ds.commit();
-        list sql = call_object_method(m_db, method, REF_SCHEMA);
-        ListIterator it(sql);
-        while (it.next()) {
-            m_ds.exec(it.getValue());
-        }
-    }
-
-    globalSetUp() {
-        globalMakeSchema("getAlignSql");
-    }
-
-    globalTearDown() {
-        globalMakeSchema("getDropSchemaSql");
-    }
-
 } # class Main

--- a/examples/test/qore/functions/to_base.qtest
+++ b/examples/test/qore/functions/to_base.qtest
@@ -11,7 +11,7 @@
 %exec-class ToBaseTest
 
 public class ToBaseTest inherits QUnit::Test {
-    constructor() : Test("FloorTest", "1.1") {
+    constructor() : Test("ToBaseTest", "1.1") {
         addTestCase("Test <int>::toBase()", \testIntToBase(), NOTHING);
         addTestCase("Test <number>::toBase()", \testNumberToBase(), NOTHING);
         set_return_value(main());

--- a/examples/test/qore/functions/to_base.qtest
+++ b/examples/test/qore/functions/to_base.qtest
@@ -1,0 +1,50 @@
+#! /usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class ToBaseTest
+
+public class ToBaseTest inherits QUnit::Test {
+    constructor() : Test("FloorTest", "1.1") {
+        addTestCase("Test <int>::toBase()", \testIntToBase(), NOTHING);
+        addTestCase("Test <number>::toBase()", \testNumberToBase(), NOTHING);
+        set_return_value(main());
+    }
+
+    testIntToBase() {
+        assertEq("11011", 27.toBase(2));
+        assertEq("11011", 033.toBase(2));
+        assertEq("11011", 0x1B.toBase(2));
+
+        assertEq("-102", (-27).toBase(5));
+        assertEq("-102", (-0x1B).toBase(5));
+
+        assertEq("33", 27.toBase(8));
+        assertEq("33", 033.toBase(8));
+        assertEq("33", 0x1B.toBase(8));
+
+        assertEq("27", 033.toBase());
+        assertEq("27", 0x1B.toBase());
+
+        assertEq("-21", (-27).toBase(13));
+
+        assertEq("1B", 27.toBase(16));
+        assertEq("1B", 0x1B.toBase(16));
+
+        assertEq("10", 27.toBase(27));
+        assertEq("-R", (-27).toBase(28));
+        assertEq("R", 27.toBase(36));
+        assertEq("Z", 35.toBase(36));
+    }
+
+    testNumberToBase() {
+        assertEq("1111010110011101001100000011011011010110000000110000100111", 276536798792387623n.toBase(2));
+        assertEq("-MJ934KRG1O3R", (-276536798792387623n).toBase(29));
+    }
+}

--- a/examples/test/qore/vars/cast_to_int.qtest
+++ b/examples/test/qore/vars/cast_to_int.qtest
@@ -1,0 +1,28 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class CastToIntTest
+
+class CastToIntTest inherits QUnit::Test {
+
+    constructor() : QUnit::Test("IntTest", "1.0") {
+        addTestCase("castToIntTests", \castToIntTests());
+        set_return_value(main());
+    }
+
+    castToIntTests() {
+        assertEq(int(7.8), 7);
+        assertEq(int(7.8n), 7);
+        softint f = 7.8;
+        softint n = 7.8n;
+        assertEq(f, 7);
+        assertEq(n, 7);
+    }
+}

--- a/include/qore/intern/qore_number_private.h
+++ b/include/qore/intern/qore_number_private.h
@@ -52,6 +52,8 @@ using namespace std;
 #endif
 // round to nearest (roundTiesToEven in IEEE 754-2008)
 #define QORE_MPFR_RND MPFR_RNDN
+// round toward zero
+#define QORE_MPFR_RNDZ MPFR_RNDZ
 // MPFR_RNDA
 
 #ifndef HAVE_MPFR_EXP_T
@@ -182,7 +184,7 @@ struct qore_number_private : public qore_number_private_intern {
    }
 
    DLLLOCAL int64 getAsBigInt() const {
-      return mpfr_get_sj(num, QORE_MPFR_RND);
+      return mpfr_get_sj(num, QORE_MPFR_RNDZ);
    }
 
    DLLLOCAL bool getAsBool() const {

--- a/lib/Pseudo_QC_Int.qpp
+++ b/lib/Pseudo_QC_Int.qpp
@@ -32,7 +32,7 @@
 #include <qore/Qore.h>
 #include "qore/intern/qore_number_private.h"
 
-string to_base_intern(long long i, int base, ExceptionSink* xsink);
+string to_base_intern(int64 i, int base, ExceptionSink* xsink);
 
 //! Methods in this pseudo-class can be executed on @ref integer "integer values"
 /**
@@ -358,7 +358,7 @@ string <int>::toBase(int base = 10) [flags=RET_VALUE_ONLY] {
     return *xsink ? QoreValue() : ((SimpleRefHolder<QoreStringNode>)new QoreStringNode(s)).release();
 }
 
-string to_base_intern(long long i, int base, ExceptionSink* xsink) {
+string to_base_intern(int64 i, int base, ExceptionSink* xsink) {
     if (base < 2 || base > 36) {
         xsink -> raiseException("INVALID-BASE", "base " QLLD " is invalid; base must be 2 - 36 inclusive", base);
         return "";

--- a/lib/Pseudo_QC_Int.qpp
+++ b/lib/Pseudo_QC_Int.qpp
@@ -32,6 +32,8 @@
 #include <qore/Qore.h>
 #include "qore/intern/qore_number_private.h"
 
+string to_base_intern(long long i, int base, ExceptionSink* xsink);
+
 //! Methods in this pseudo-class can be executed on @ref integer "integer values"
 /**
  */
@@ -317,4 +319,60 @@ string <int>::toUnicode() [flags=RET_VALUE_ONLY] {
    SimpleRefHolder<QoreStringNode> str(new QoreStringNode(QCS_UTF8));
    str->concatUnicode(i);
    return *xsink ? 0 : str.release();
+}
+
+//! Converts the integer to a different <b>base</b> (and returns it as a string).
+/** @param base the base to convert the integer to; this value must be 2 - 36 inclusive or an \c INVALID-BASE exception will be thrown
+
+    @return the converted value as a string
+
+    @par Example:
+    @code{.py}
+        27.toBase(2));       // returns "11011"
+        033.toBase(2));      // returns "11011"
+        0x1B.toBase(2));     // returns "11011"
+        (-27).toBase(5));    // returns  "-102"
+        (-0x1B).toBase(5));  // returns  "-102"
+        27.toBase(8));       // returns    "33"
+        033.toBase(8));      // returns    "33"
+        27.toBase());        // returns    "27"
+        033.toBase());       // returns    "27"
+        0x1B.toBase());      // returns    "27"
+        (-27).toBase(13));   // returns   "-21"
+        27.toBase(16));      // returns    "1B"
+        0x1B.toBase(16));    // returns    "1B"
+        27.toBase(27));      // returns    "10"
+        27.toBase(28));      // returns     "R"
+        (-27).toBase(36));   // returns    "-R"
+        35.toBase(36));      // returns     "Z"
+    @endcode
+
+    @throw INVALID-BASE the base is invalid; must be 2 - 36 inclusive
+
+    @see \link <number>::toBase(int base) \endlink
+
+    @since %Qore 0.8.13
+*/
+string <int>::toBase(int base = 10) [flags=RET_VALUE_ONLY] {
+    string s = to_base_intern(i, base, xsink);
+    return *xsink ? NULL : ((SimpleRefHolder<QoreStringNode>)new QoreStringNode(s)).release();
+}
+
+string to_base_intern(long long i, int base, ExceptionSink* xsink) {
+    if (base < 2 || base > 36) {
+        xsink -> raiseException("INVALID-BASE", "base " QLLD " is invalid; base must be 2 - 36 inclusive", base);
+        return "";
+    }
+
+    if (i < 0)
+        return '-' + to_base_intern(-i, base, xsink);
+
+    string s;
+    while (true) {
+        int rem = i % base;
+        s = char((rem < 10 ? 48 : 55) + rem) + s;
+        if ((i /= base) == 0)
+            break;
+    }
+    return s;
 }

--- a/lib/Pseudo_QC_Int.qpp
+++ b/lib/Pseudo_QC_Int.qpp
@@ -355,7 +355,7 @@ string <int>::toUnicode() [flags=RET_VALUE_ONLY] {
 */
 string <int>::toBase(int base = 10) [flags=RET_VALUE_ONLY] {
     string s = to_base_intern(i, base, xsink);
-    return *xsink ? NULL : ((SimpleRefHolder<QoreStringNode>)new QoreStringNode(s)).release();
+    return *xsink ? QoreValue() : ((SimpleRefHolder<QoreStringNode>)new QoreStringNode(s)).release();
 }
 
 string to_base_intern(long long i, int base, ExceptionSink* xsink) {

--- a/lib/Pseudo_QC_Number.qpp
+++ b/lib/Pseudo_QC_Number.qpp
@@ -302,5 +302,5 @@ number <number>::abs() [flags=CONSTANT] {
 */
 string <number>::toBase(int base = 10) [flags=RET_VALUE_ONLY] {
     string s = to_base_intern(n -> getAsBigInt(), base, xsink);
-    return *xsink ? NULL : ((SimpleRefHolder<QoreStringNode>)new QoreStringNode(s)).release();
+    return *xsink ? QoreValue() : ((SimpleRefHolder<QoreStringNode>)new QoreStringNode(s)).release();
 }

--- a/lib/Pseudo_QC_Number.qpp
+++ b/lib/Pseudo_QC_Number.qpp
@@ -282,3 +282,25 @@ n = n.abs();
 number <number>::abs() [flags=CONSTANT] {
    return qore_number_private::doUnary(*n, mpfr_abs);
 }
+
+//! Converts the integer to a different <b>base</b> (and returns it as a string).
+/** @param base the base to convert the integer to; this value must be 2 - 36 inclusive or an \c INVALID-BASE exception will be thrown
+
+    @return the converted value as a string
+
+    @par Example:
+    @code{.py}
+        (-276536798792387623n).toBase(29)); // returns "-MJ934KRG1O3R"
+          276536798792387623n.toBase(2));   // returns "1111010110011101001100000011011011010110000000110000100111"
+    @endcode
+
+    @throw INVALID-BASE the base is invalid; must be 2 - 36 inclusive
+
+    @see \link <int>::toBase(int base) \endlink
+
+    @since %Qore 0.8.13
+*/
+string <number>::toBase(int base = 10) [flags=RET_VALUE_ONLY] {
+    string s = to_base_intern(n -> getAsBigInt(), base, xsink);
+    return *xsink ? NULL : ((SimpleRefHolder<QoreStringNode>)new QoreStringNode(s)).release();
+}

--- a/qlib/SchemaReverse.qm
+++ b/qlib/SchemaReverse.qm
@@ -485,6 +485,7 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
                     ret = c_timestamp(!c.nullable, c.comment);
                     break;
                 case "number":
+                case "numeric":
                     ret = c_number(c.size, /* c.scale */ 0, !c.nullable, c.comment); # TODO/FIXME: scale
                     break;
                 case "clob":
@@ -498,10 +499,8 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
                 #case "raw":
                 #    # TODO/FIXME ret =  ("qore_type": SQL::RAW, "comment": c.comment, "notnull" : !c.nullable);
                 #    break;
-                #default:
-                #    printf("%N\n", c);
-                #    throw "REVERSE-DB-ERROR", sprintf("Unimplemented column describe: %n", ("name" : c.name, "type" : c.native_type));
-                    #ret = ( "todo" : "fixme");
+                default:
+                    ret = ( "unknown_column_type" : sprintf("%n", c) );
             }
 
             if (exists c.def_val) {

--- a/qlib/SchemaReverse.qm
+++ b/qlib/SchemaReverse.qm
@@ -274,7 +274,7 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
     /*! It provides basic shared functionality for all specialized
         object related classes.
 
-        All inherited classe must implement abstract method AbstractReverseObject::toQore()
+        All inherited classes must implement abstract method AbstractReverseObject::toQore()
         for object related functionality.
      */
     public class AbstractReverseObject {
@@ -312,8 +312,8 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
         }
 
         #! Dedicated functionlity to get DB object info into the internal structure is done here.
-        /*! All inerited classe must implement this method to get
-            all required DB metadata n proper format
+        /*! All inherited classes must implement this method to get
+            all required DB metadata in proper format
          */
         abstract any toQore();
 
@@ -803,7 +803,7 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
                 string key = regex_extract(it.getValue(), "<SCHEMA_(.*)>")[0];
                 AbstractReverseObject o = get_object(key.lwr(), m_ds);
                 string out = o.toString();
-                # HACK: let's guess that SchemaDescriptionOptions constains
+                # HACK: let's guess that SchemaDescriptionOptions contains
                 #       objects supported in all DB servers/dialects.
                 #       All other objects must go to the driver specific sub-hash.
                 if (!SqlUtil::AbstractDatabase::SchemaDescriptionOptions.hasKey(key.lwr())) {
@@ -823,7 +823,7 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
         @param name a string with exact object name or a regex mask
 
         Parameters \c ds and \c name are passed as \c argv into class constructor.
-        See apropritate class for constructor reference.
+        See appropriate class for constructor reference.
      */
     public AbstractReverseObject sub get_object(string object_type) {
         *string className = TYPE_TO_CLASS{object_type} ?? MULTI_TO_CLASS{object_type};

--- a/qlib/SchemaReverse.qm
+++ b/qlib/SchemaReverse.qm
@@ -1,0 +1,837 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+# @file SchemaReverse.qm Qore user module for reverse engineering of database SQL schemas
+
+/*  SchemaReverse.qm Copyright 2016 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FORANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+# this module requires Qore 0.8.12 or better
+%requires qore >= 0.8.12
+
+# requires the SqlUtil module
+%requires SqlUtil >= 1.2
+
+# requires the Util module
+%requires Util >= 1.1
+
+# requires the Qorize module
+%requires Qorize >= 0.1.1
+
+%requires Schema
+
+%new-style
+%require-types
+%enable-all-warnings
+%strict-args
+
+module SchemaReverse {
+    version = "1.0";
+    desc = "user module for reverse engineering of database SQL schemas";
+    author = "Petr Vanek <petr@yarpen.cz>";
+    url = "http://qore.org";
+    license = "MIT";
+}
+
+/** @mainpage SchemaReverse Module
+
+SchemaReverse module provides functionality to create Qore source code usable
+as an input for Schema::AbstractSchema (Schema.qm user module).
+
+To use this module, use "%requires SchemaReverse" in your code.
+
+All the public symbols in the module are defined in the @ref SchemaReverse namespace.
+
+Currently it can handle only database object types.
+
+    - sequences
+    - tables
+    - types
+    - views
+    - materialized views
+    - functions
+    - procedures
+    - packages
+
+Not all database object types are available in all DBMS.
+
+Simple example (to get one table definition):
+
+@code{.py}
+%new-style
+%requires SchemaReverse
+
+Datasource ds("oracle:omq/omq@xbpx");
+on_exit ds.commit();
+
+TableReverse t = SchemaReverse::get_object("table", ds, "schema_reverse_t1");
+string str = t.toString();
+
+printf("%N\n", str);
+@endcode
+
+The output will be:
+
+@code
+        (
+        "columns" :
+            (
+            "id" :
+                (
+                "qore_type" : "number",
+                "comment" : "comment for id",
+                "notnull" : True,
+                ),
+            "foo" :
+                (
+                "qore_type" : "string",
+                "size" : 10,
+                "comment" : "comment for foo",
+                ),
+            "bar" :
+                (
+                "qore_type" : "date",
+                "driver" :
+                    (
+                    "oracle" :
+                        (
+                        "native_type" : "date",
+                        ),
+                    "pgsql" :
+                        (
+                        "native_type" : "date",
+                        ),
+                    ),
+                "comment" : "comment for bar",
+                "notnull" : True,
+                ),
+            ),
+        "indexes" :
+            (
+            "schema_reverse_ix1" :
+                (
+                "columns" :
+                    ("id",),
+                "unique" : True,
+                ),
+            ),
+        )
+@endcode
+
+*/
+
+#! this namespace contains all public definitions in the %SchemaReverse module
+public namespace SchemaReverse {
+
+    #! A map translating simple DB object name into its class
+    const TYPE_TO_CLASS = (
+            "sequence" : "SequenceReverse",
+            "table" : "TableReverse",
+            "type" : "TypeReverse",
+            "view" : "ViewReverse",
+            "mview" : "MViewReverse",
+            "function" : "FunctionReverse",
+            "procedure" : "ProcedureReverse",
+            "package" : "PackageReverse",
+        );
+
+    #! A map translating multi DB objects name into its class
+    const MULTI_TO_CLASS = (
+            "sequences" : "SequencesReverse",
+            "tables" : "TablesReverse",
+            "types" : "TypesReverse",
+            "views" : "ViewsReverse",
+            "mviews" : "MViewsReverse",
+            "functions" : "FunctionsReverse",
+            "procedures" : "ProceduresReverse",
+            "packages" : "PackagesReverse",
+        );
+
+    #! A template string for full schema used in SchemaReverse::SchemaReverse class
+    const TEMPLATE = '
+%requires Schema
+%requires SqlUtil
+
+%new-style
+%require-types
+%enable-all-warnings
+
+
+const GenericOptions = (
+        "replace": True,
+    );
+
+const IndexOptions = (
+        "driver": (
+                "oracle": ("compute_statistics": False,),
+            ),
+    );
+
+const ColumnOptions = (
+        "driver": (
+                "oracle": ("character_semantics": True,),
+            ),
+    );
+
+const SEQUENCES = <SCHEMA_SEQUENCES>;
+
+const TABLES = <SCHEMA_TABLES>;
+
+const TYPES = <SCHEMA_TYPES>;
+
+const VIEWS = <SCHEMA_VIEWS>;
+
+const MATERIALIZED_VIEWS = <SCHEMA_MVIEWS>;
+
+const FUNCTIONS = <SCHEMA_FUNCTIONS>;
+
+const PROCEDURES = <SCHEMA_PROCEDURES>;
+
+const PACKAGES = <SCHEMA_PACKAGES>;
+
+
+class <X_SCHEMA_NAME> inherits AbstractSchema {
+    public {
+        const SchemaName = "<X_SCHEMA_NAME>";
+        const SchemaVersion = "1.0";
+    }
+
+    constructor(AbstractDatasource ds, *string dts, *string its) :  AbstractSchema(ds, dts, its) {
+    }
+
+    private string getNameImpl() {
+        return SchemaName;
+    }
+
+    private string getVersionImpl() {
+        return SchemaVersion;
+    }
+
+    private *hash getTablesImpl() {
+        return TABLES;
+    }
+
+    private *hash getSequencesImpl() {
+        return SEQUENCES;
+    }
+
+    private *hash getTypesImpl() {
+        return TYPES;
+    }
+
+    private *hash getViewsImpl() {
+        return VIEWS;
+    }
+
+    private *hash getMaterializedViewsImpl() {
+        return MATERIALIZED_VIEWS;
+    }
+
+    private *hash getFunctionsImpl() {
+        return FUNCTIONS;
+    }
+
+    private *hash getProceduresImpl() {
+        return PROCEDURES;
+    }
+
+    private *hash getPackagesImpl() {
+        return PACKAGES;
+    }
+
+    private *hash getIndexOptionsImpl() {
+        return IndexOptions;
+    }
+
+    private *hash getGenericOptionsImpl() {
+        return GenericOptions;
+    }
+
+    private *hash getColumnOptionsImpl() {
+        return ColumnOptions;
+    }
+
+} # class <X_SCHEMA_NAME>
+';
+
+    #! A basic class for all SchemaReverse DB object related classes
+    /*! It provides basic shared functionality for all specialized
+        object related classes.
+
+        All inherited classe must implement abstract method AbstractReverseObject::toQore()
+        for object related functionality.
+     */
+    public class AbstractReverseObject {
+        private {
+            AbstractDatasource m_ds;
+            Database m_db;
+            string m_name;
+        }
+
+        /*! Setup basic shared attributes.
+            @param ds a AbstractDatasource with DB connection
+            @param name a string with exact name or regex to match names of DB objects
+         */
+        constructor(AbstractDatasource ds, string name) {
+            m_ds = ds;
+            m_name = name;
+        }
+
+        #! @return current AbstractDatasource
+        AbstractDatasource datasource() {
+            return m_ds;
+        }
+
+        #! @return current SqlUtil::database object when required
+        Database database() {
+            if (!m_db) {
+                m_db = new SqlUtil::Database(m_ds);
+            }
+            return m_db;
+        }
+
+        #! @return a string with exact name or regex to match names
+        string name() {
+            return m_name;
+        }
+
+        #! Dedicated functionlity to get DB object info into the internal structure is done here.
+        /*! All inerited classe must implement this method to get
+            all required DB metadata n proper format
+         */
+        abstract any toQore();
+
+        #! Make a string with Qore code from a structure prepared by AbstractReverseObject::toQore().
+        /*! @return string with final Qore source code
+         */
+        string toString() {
+            string ret = qorize_val(toQore());
+            if (ret.regex(".*\,$")) {
+                ret = ret.substr(0, -1);
+            }
+            return ret;
+        }
+    } # class AbstractReverseObject
+
+    #! Structure dump of a sequence
+    public class SequenceReverse inherits AbstractReverseObject {
+        /*! @param ds an AbstractDatasource object
+            @param name a string with exact object name
+         */
+        constructor(AbstractDatasource ds, string name)
+            : AbstractReverseObject(ds, name)
+        {
+        }
+
+        hash toQore() {
+            return hash();
+        }
+    } # class SequenceReverse
+
+    #! Structure dump of sequences
+    /** This class uses SchemaReverse::SeqenceReverse internally.
+     */
+    public class SequencesReverse inherits AbstractReverseObject {
+        /*! @param ds an AbstractDatasource object
+            @param mask a regexp mask used to specify what objects of this type are fetched
+         */
+        constructor(AbstractDatasource ds, string mask = ".*")
+            : AbstractReverseObject(ds, mask)
+        {
+        }
+
+        hash toQore() {
+            ListIterator it = database().sequenceIterator();
+            hash ret = hash();
+            while (it.next()) {
+                string s = it.getValue();
+                if (s.regex(name())) {
+                    ret{s} = hash();
+                }
+            }
+            return ret;
+        }
+    } # class SequencesReverse
+
+    #! Structure dump of a 'type' or 'named type'
+    public class TypeReverse inherits AbstractReverseObject {
+        /*! @param ds an AbstractDatasource object
+            @param name a string with exact object name
+         */
+        constructor(AbstractDatasource ds, string name)
+            : AbstractReverseObject(ds, name)
+        {
+        }
+
+        hash toQore() {
+            if (database().supportsTypes()) {
+                return ( name() : database().getType(name()).src );
+            }
+            return hash();
+        }
+    } # class TypeReverse
+
+    #! Structure dump of 'types' or 'named types'
+    public class TypesReverse inherits AbstractReverseObject {
+        /*! @param ds an AbstractDatasource object
+            @param mask a regexp mask used to specify what objects of this type are fetched
+         */
+        constructor(AbstractDatasource ds, string mask = ".*")
+            : AbstractReverseObject(ds, mask)
+        {
+        }
+
+        hash toQore() {
+            if (!database().supportsTypes()) {
+                return hash();
+            }
+
+            ListIterator it = database().typeIterator();
+            hash ret = hash();
+            while (it.next()) {
+                string s = it.getValue();
+                if (s.regex(name())) {
+                    ret += new TypeReverse(datasource(), s).toQore();
+                }
+            }
+            return ret;
+        }
+    } # class TypesReverse
+
+    #! Structure dump of a table
+    public class TableReverse inherits AbstractReverseObject {
+        /*! @param ds an AbstractDatasource object
+            @param name a string with exact object name
+         */
+        constructor(AbstractDatasource ds, string name)
+            : AbstractReverseObject(ds, name)
+        {
+        }
+
+        hash toQore() {
+            Table t(datasource(), name());
+            hash ret;
+
+            # columns
+            HashIterator cit = t.describe().iterator();
+            while (cit.next()) {
+                #printf("%n\n", cit.getValue());
+                AbstractColumn c = cit.getValue();
+                ret.columns{c.name} = columnToQore(c);
+            }
+
+            # indexes
+            if (!t.getIndexes().empty()) {
+                my HashIterator it = t.getIndexes().iterator();
+                while (it.next()) {
+                    ret.indexes{it.getValue().name} = ( "columns" : it.getValue().columns.keys(),
+                                                        "unique" : it.getValue().unique,
+                                                    );
+                }
+            }
+
+            # PK
+            AbstractPrimaryKey pk = t.getPrimaryKey();
+            #printf("PK: %N\n", pk);
+            if (!pk.empty()) {
+                ret.primary_key = ( "name" : pk.getName(),
+                                    "columns" : pk.keys(),
+                                );
+            }
+
+            # Triggers
+            if (!t.getTriggers().empty()) {
+                HashIterator it = t.getTriggers().iterator();
+                while (it.next()) {
+                    ret.triggers = ( it.getValue().name : it.getValue().src);
+                }
+            }
+
+            return ret;
+        }
+
+        static any columnToQore(AbstractColumn c) {
+            hash ret = hash();
+            #printf("%N\n", c);
+            switch (c.native_type) {
+                case "varchar":
+                case "varchar2":
+                    ret = c_varchar(c.size, !c.nullable, c.comment);
+                    break;
+                case "char":
+                    ret = c_char(c.size, !c.nullable, c.comment);
+                    break;
+                case "date":
+                    ret = c_date(!c.nullable, c.comment);
+                    break;
+                case "timestamp":
+                case /^timestamp.*/:
+                    ret = c_timestamp(!c.nullable, c.comment);
+                    break;
+                case "number":
+                    ret = c_number(c.size, /* c.scale */ 0, !c.nullable, c.comment); # TODO/FIXME: scale
+                    break;
+                case "clob":
+                    ret =  ("qore_type": SQL::CLOB, "comment": c.comment, "notnull" : !c.nullable);
+                    break;
+                case "blob":
+                    ret =  ("qore_type": SQL::BLOB, "comment": c.comment, "notnull" : !c.nullable);
+                    break;
+                #case "rowid":
+                #case "sdo_geometry":
+                #case "raw":
+                #    # TODO/FIXME ret =  ("qore_type": SQL::RAW, "comment": c.comment, "notnull" : !c.nullable);
+                #    break;
+                #default:
+                #    printf("%N\n", c);
+                #    throw "REVERSE-DB-ERROR", sprintf("Unimplemented column describe: %n", ("name" : c.name, "type" : c.native_type));
+                    #ret = ( "todo" : "fixme");
+            }
+
+            if (exists c.def_val) {
+                ret.default_value = c.def_val;
+            }
+            if (!ret.size) {
+                delete ret.size;
+            }
+            if (!ret.scale) {
+                delete ret.scale;
+            }
+            if (!ret.comment) {
+                delete ret.comment;
+            }
+
+            return ret;
+        }
+
+    } # class TableReverse
+
+    #! Structure dump of tables
+    public class TablesReverse inherits AbstractReverseObject {
+        /*! @param ds an AbstractDatasource object
+            @param mask a regexp mask used to specify what objects of this type are fetched
+         */
+        constructor(AbstractDatasource ds, string mask = ".*")
+            : AbstractReverseObject(ds, mask)
+        {
+        }
+
+        hash toQore() {
+            ListIterator it = database().tableIterator();
+            hash ret = hash();
+            while (it.next()) {
+                string s = it.getValue();
+                if (s.regex(name())) {
+                    ret{s} = new TableReverse(datasource(), s).toQore();
+                }
+            }
+            return ret;
+        }
+    } # class TablesReverse
+
+    #! A basic class for all DB object classes which use SQL code as base of its content
+    /*! For example VIEW or PROCEDURE etc.
+        This class is not primarily used for direct usage in user code,
+        but only as a base for real implementations.
+     */
+    public class CodeBaseReverse inherits AbstractReverseObject {
+        private {
+            string m_object_type;
+            string m_function_name;
+            list m_ignored_keys;
+        }
+
+        /*! @param object_type a string with DB type name see TYPE_TO_CLASS map
+            @param ds a datasource
+            @param name a string with DB object name
+            @param function_name to get the DB object info, as eg 'getView'
+            @param ignored_keys an optional list with keys to ignore from result of meta call of \c function_name
+         */
+        constructor(string object_type,
+                    AbstractDatasource ds,
+                    string name,
+                    string function_name,
+                    softlist ignored_keys
+                   )
+            : AbstractReverseObject(ds, name)
+        {
+            m_object_type = object_type;
+            m_function_name = function_name;
+            m_ignored_keys = ignored_keys;
+        }
+
+        hash toQore() {
+            if (database().hasCallableMethod(m_function_name)) {
+                return hash();
+            }
+
+            object o = call_object_method(database(), m_function_name, name());
+            ObjectIterator it = o.iterator();
+            hash ret = hash();
+            while (it.next()) {
+                if (inlist(it.getKey(), m_ignored_keys)) {
+                    continue;
+                }
+                if (exists it.getValue()) {
+                    ret{it.getKey()} = it.getValue();
+                }
+            }
+            return ret;
+        }
+    } # class CodeBaseReverse
+
+    #! A basic class for all DB object classes which use SQL code as base of its content
+    /*! For example multiple VIEWs or PROCEDUREs etc.
+        This class is not primarily used for direct usage in user code,
+        but only as a base for real implementations.
+     */
+    public class CodesBaseReverse inherits AbstractReverseObject {
+        private {
+            string m_object_type;
+            string m_function_name;
+        }
+
+        /*! @param object_type a string with DB type name see TYPE_TO_CLASS map
+            @param ds a datasource
+            @param mask a string with DB object name or regex to match names
+            @param function_name to get the DB object info, as eg 'getView'
+         */
+        constructor(string object_type,
+                    AbstractDatasource ds,
+                    string mask,
+                    string function_name,
+                   )
+            : AbstractReverseObject(ds, mask)
+        {
+            if (!exists TYPE_TO_CLASS{object_type}) {
+                throw "CODES-BASE-REVERSE-ERROR", sprintf("Unknown object type: %s; available: %y", object_type, TYPE_TO_CLASS.keys());
+            }
+            m_object_type = object_type;
+            m_function_name = function_name;
+        }
+
+        hash toQore() {
+            if (database().hasCallableMethod(m_function_name)) {
+                return hash();
+            }
+
+            ListIterator it = call_object_method(database(), m_function_name);
+            hash ret = hash();
+            while (it.next()) {
+                string s = it.getValue();
+                if (s.regex(name())) {
+                    AbstractReverseObject o = create_object(TYPE_TO_CLASS{m_object_type}, datasource(), s);
+                    ret{s} = o.toQore();
+                }
+            }
+            return ret;
+        }
+    } # class CodeBaseReverse
+
+    #! Structure dump of a view
+    public class ViewReverse inherits CodeBaseReverse {
+        /*! @param ds an AbstractDatasource object
+            @param name a string with exact object name
+         */
+        constructor(AbstractDatasource ds, string name)
+            : CodeBaseReverse("view", ds, name, "getView", ("schema", "name", ))
+        {
+        }
+    } # class ViewReverse
+
+    #! Structure dump of views
+    public class ViewsReverse inherits CodesBaseReverse {
+        /*! @param ds an AbstractDatasource object
+            @param mask a regexp mask used to specify what objects of this type are fetched
+         */
+        constructor(AbstractDatasource ds, string mask = ".*")
+            : CodesBaseReverse("view", ds, mask, "viewIterator")
+        {
+        }
+    } # class ViewsReverse
+
+    #! Structure dump of a materialized view or snapshot
+    public class MViewReverse inherits CodeBaseReverse {
+        /*! @param ds an AbstractDatasource object
+            @param name a string with exact object name
+         */
+        constructor(AbstractDatasource ds, string name)
+            : CodeBaseReverse("mview", ds, name, "getMaterializedView", ("schema", "name", "type"))
+        {
+        }
+    } # class MViewReverse
+
+    #! Structure dump of materialized views or snapshots
+    public class MViewsReverse inherits CodesBaseReverse {
+        /*! @param ds an AbstractDatasource object
+            @param mask a regexp mask used to specify what objects of this type are fetched
+         */
+        constructor(AbstractDatasource ds, string mask = ".*")
+            : CodesBaseReverse("mview", ds, mask, "materializedViewIterator")
+        {
+        }
+    } # class MViewsReverse
+
+    #! Structure dump of a function
+    public class FunctionReverse inherits AbstractReverseObject {
+        /*! @param ds an AbstractDatasource object
+            @param name a string with exact object name
+         */
+        constructor(AbstractDatasource ds, string name)
+            : AbstractReverseObject(ds, name)
+        {
+        }
+
+        string toQore() {
+            if (database().hasCallableMethod("getFunction")) {
+                return "";
+            }
+            object o = database().getFunction(name());
+            return o.src;
+        }
+    } # class FunctionReverse
+
+    #! Structure dump of functions
+    public class FunctionsReverse inherits CodesBaseReverse {
+        /*! @param ds an AbstractDatasource object
+            @param mask a regexp mask used to specify what objects of this type are fetched
+         */
+        constructor(AbstractDatasource ds, string mask = ".*")
+            : CodesBaseReverse("function", ds, mask, "functionIterator")
+        {
+        }
+    } # class FunctionsReverse
+
+    #! Structure dump of a procedure
+    public class ProcedureReverse inherits AbstractReverseObject {
+        /*! @param ds an AbstractDatasource object
+            @param name a string with exact object name
+         */
+        constructor(AbstractDatasource ds, string name)
+            : AbstractReverseObject(ds, name)
+        {
+        }
+
+        string toQore() {
+            if (database().hasCallableMethod("getProcedure")) {
+                return "";
+            }
+            object o = database().getProcedure(name());
+            return o.src;
+        }
+    } # class ProcedureReverse
+
+    #! Structure dump of procedures
+    public class ProceduresReverse inherits CodesBaseReverse {
+        /*! @param ds an AbstractDatasource object
+            @param mask a regexp mask used to specify what objects of this type are fetched
+         */
+        constructor(AbstractDatasource ds, string mask = ".*")
+            : CodesBaseReverse("procedure", ds, mask, "procedureIterator")
+        {
+        }
+    } # class ProceduresReverse
+
+    #! Structure dump of a package
+    public class PackageReverse inherits AbstractReverseObject {
+        /*! @param ds an AbstractDatasource object
+            @param name a string with exact object name
+         */
+        constructor(AbstractDatasource ds, string name)
+            : AbstractReverseObject(ds, name)
+        {
+        }
+
+        hash toQore() {
+            if (database().hasCallableMethod("getPackage")) {
+                return hash();
+            }
+            object o = database().getPackage(name());
+            return ( "src" : o.src, "body" : o.body_src );
+        }
+    } # class ProcedureReverse
+
+    #! Structure dump of packages
+    public class PackagesReverse inherits CodesBaseReverse {
+        /*! @param ds an AbstractDatasource object
+            @param mask a regexp mask used to specify what objects of this type are fetched
+         */
+        constructor(AbstractDatasource ds, string mask = ".*")
+            : CodesBaseReverse("package", ds, mask, "packageIterator")
+        {
+        }
+    } # class ProceduresReverse
+
+    #! Structure dump of all objects in given schema/connection
+    public class SchemaReverse {
+        private {
+            AbstractDatasource m_ds;
+            string m_class_name;
+        }
+
+        /*! @param ds an AbstractDatasource object
+            @param class_name a string with name of the resulting schema class
+         */
+        constructor(AbstractDatasource ds, string class_name) {
+            m_ds = ds;
+            m_class_name = class_name;
+        }
+
+        string toString() {
+            string ret = TEMPLATE;
+            ret = replace(ret, "<X_SCHEMA_NAME>", m_class_name);
+
+            softlist toReplace = regex_extract(TEMPLATE, "(<SCHEMA_.*>)", Qore::RE_MultiLine|Qore::RE_Global);
+            ListIterator it(toReplace);
+            while (it.next()) {
+                string key = regex_extract(it.getValue(), "<SCHEMA_(.*)>")[0];
+                AbstractReverseObject o = get_object(key.lwr(), m_ds);
+                string out = o.toString();
+                # HACK: let's guess that SchemaDescriptionOptions constains
+                #       objects supported in all DB servers/dialects.
+                #       All other objects must go to the driver specific sub-hash.
+                if (!SqlUtil::AbstractDatabase::SchemaDescriptionOptions.hasKey(key.lwr())) {
+                    out = sprintf("(\"driver\" : (\"%s\" :\n%s\n ), ); # end of driver/%s", m_ds.getDriverName(), out, m_ds.getDriverName());
+                }
+                ret = replace(ret, it.getValue(), out);
+            }
+
+            return ret;
+        }
+
+    } # class SchemaReverse
+
+    #! An universal wrapper to get any of SchemaReverse::AbstractReverseObject instance
+    /** @param object_type a string with object type. See keys in SchemaReverse::TYPE_TO_CLASS and SchemaReverse::MULTI_TO_MULTI
+        @param ds an Qore::AbstractDatasource instance
+        @param name a string with exact object name or a regex mask
+
+        Parameters \c ds and \c name are passed as \c argv into class constructor.
+        See apropritate class for constructor reference.
+     */
+    public AbstractReverseObject sub get_object(string object_type) {
+        *string className = TYPE_TO_CLASS{object_type} ?? MULTI_TO_CLASS{object_type};
+        if (!exists className) {
+            throw "SCHEMA-REVERSE-ERROR", sprintf("Unknown object type: %s; available: %y", object_type, TYPE_TO_CLASS.keys()+MULTI_TO_CLASS.keys());
+        }
+        object o = create_object_args(className, argv);
+        return o;
+    }
+
+} # namespace SchemaReverse


### PR DESCRIPTION
Fixes different behaviour of `int(float)` and `int(number)`:
`int(float)` returned the whole part - e.g. `int(3.8)` returned `3`
but
`int(number)` did rounding - e.g. `int(3.8n)` returned `4`
Now `int(3.8n)` returns `3 `as well.

This also fixes issue #1464, since `int(number)` is implemented by the implementation of  `QoreNumberNode::getAsBigInt()`.
