### PR TITLE
Feature/1428 sqlutil default values

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -10,6 +10,7 @@
     @subsection qore_08125_new_features New Features in Qore
 
     - added the <a href="../../modules/SalesforceRestClient/html/index.html">SalesforceRestClient</a> module for communicating with Salesforce.com using the REST APIs
+    - module <a href="../../modules/SqlUtil/html/index.html">SqlUtil</a> has support for native default values in tables. See: <a href="https://github.com/qorelanguage/qore/issues/1428">issue 1428</a>
 
     @subsection qore_08125_bug_fixes Bug Fixes in Qore
 

--- a/examples/test/qlib/SqlUtil/OracleSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/OracleSqlUtil.qtest
@@ -43,6 +43,15 @@ class OracleTestSchema inherits SqlUtilTestSchema {
                 "id": c_number(14, True),
                 "id_": c_number(14, True),
                 "null_f": c_varchar(69),
+                # data for test of driver specific opts merged into tolevel hash
+                "drv_test" : ( "qore_type" : SqlUtil::VARCHAR,
+                               "size" : 1,
+                               "driver" : (
+                                   "oracle" : (
+                                      "qore_type" : SqlUtil::NUMERIC,
+                                   ),
+                               ),
+                             ),
             ),
             "primary_key": ("name": "pk_oracle_test", "columns": ("id")),
             );
@@ -158,6 +167,7 @@ class OracleTest inherits SqlTestBase {
             addTestCase("sequence operators", \testSequenceOperators());
             addTestCase("pseudo-columns", \testPseudoColumns());
             addTestCase("character semantics", \testCharacterSemantics());
+            addTestCase("driver specific opts for columns", \testDriverSpecificColumns());
         }
 
         set_return_value(main());
@@ -216,6 +226,15 @@ class OracleTest inherits SqlTestBase {
             );
 
         assertEq(Type::String, table.selectRow(sh).rowid.type());
+    }
+
+    testDriverSpecificColumns() {
+        if (!table)
+            testSkip("no DB connection");
+
+        AbstractDatasource ds = table.getDatasource();
+        hash c = ds.selectRow("select * from user_tab_columns where table_name = %v and column_name = %v", "ORACLE_TEST", "DRV_TEST");
+        assertEq("NUMBER", c.data_type);
     }
 
     private usageIntern() {

--- a/examples/test/qlib/SqlUtil/OracleSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/OracleSqlUtil.qtest
@@ -52,6 +52,10 @@ class OracleTestSchema inherits SqlUtilTestSchema {
                                    ),
                                ),
                              ),
+                # default value test for
+                # SqlUtil: schema alignment: default values can be complex statement instead of simple value only #1428
+                "def_test1" : c_date(C_NOT_NULL) + ("driver" : ("oracle" : ("default_value" : "to_date('1.1.2000', 'dd.mm.yyyy')", "default_value_native" : True))),
+                "def_test2" : c_number(C_NOT_NULL) + ( "default_value" : 0 ),
             ),
             "primary_key": ("name": "pk_oracle_test", "columns": ("id")),
             );
@@ -168,6 +172,7 @@ class OracleTest inherits SqlTestBase {
             addTestCase("pseudo-columns", \testPseudoColumns());
             addTestCase("character semantics", \testCharacterSemantics());
             addTestCase("driver specific opts for columns", \testDriverSpecificColumns());
+            addTestCase("default values", \testDefaultValues());
         }
 
         set_return_value(main());
@@ -235,6 +240,18 @@ class OracleTest inherits SqlTestBase {
         AbstractDatasource ds = table.getDatasource();
         hash c = ds.selectRow("select * from user_tab_columns where table_name = %v and column_name = %v", "ORACLE_TEST", "DRV_TEST");
         assertEq("NUMBER", c.data_type);
+    }
+
+    testDefaultValues() {
+        if (!table)
+            testSkip("no DB connection");
+
+        AbstractDatasource ds = table.getDatasource();
+        hash c = ds.selectRow("select * from user_tab_columns where table_name = %v and column_name = %v", "ORACLE_TEST", "DEF_TEST1");
+        assertEq("to_date('1.1.2000', 'dd.mm.yyyy') ", c.data_default);
+
+        c = ds.selectRow("select * from user_tab_columns where table_name = %v and column_name = %v", "ORACLE_TEST", "DEF_TEST2");
+        assertEq("0 ", c.data_default);
     }
 
     private usageIntern() {

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -1466,7 +1466,7 @@ hash table_desc = (
     - \c size: for data types requiring a size component, the size; for numeric columns this represents the precision for example
     - \c scale: for numeric data types, this value gives the scale
     - \c default_value: the default value for the column
-    - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is stronlgy recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
+    - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is strongly recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
     - \c comment: an optional comment for the column
     - \c notnull: if the column should have a "not null" constraint on it; if missing the default value is @ref Qore::False "False"
     - \c driver: this key can optionally contain a hash keyed by driver name which contains a hash of values that will be added to the column description hash before processing; this way a column description hash can contain all the information required for the column including driver-specific options; any driver-specific options will overwrite values in the top level of the hash if there are duplicate hash keys, see below for an example
@@ -7886,7 +7886,7 @@ Table table("pgsql:user/pass@db%host", "table");
                 - \c size: (@ref int_type) for data types requiring a size component, the size; for numeric columns this represents the precision for example
                 - \c scale: (@ref int_type) for numeric data types, this value gives the scale
                 - \c default_value: the default value for the column
-                - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is stronlgy recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
+                - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is strongly recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
                 - \c comment: (@ref string_type) an optional comment for the column
                 - \c notnull: if the column should have a "not null" constraint on it; if missing the default value is @ref Qore::False "False"
                 - \c driver: this key can optionally contain a hash keyed by driver name which contains a hash of values that will be added to the column description hash before processing; this way a column description hash can contain all the information required for the column including driver-specific options; any driver-specific options will overwrite values in the top level of the hash if there are duplicate hash keys, see below for an example
@@ -8656,7 +8656,7 @@ table.addColumn("name", ("qore_type": Type::String, "size": 50), False);
             - \c size: for data types requiring a size component, the size; for numeric columns this represents the precision for example
             - \c scale: for numeric data types, this value gives the scale
             - \c default_value: the default value for the column
-            - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is stronlgy recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
+            - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is strongly recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
             @param nullable if @ref Qore::True "True" then the column can hold NULL values; note that primary key columns cannot be nullable
             @param lsql an optional reference to a list of strings to retrieve the SQL used to modify the table (only executed if the table is already in the database)
 
@@ -8688,7 +8688,7 @@ list l = table.getAddColumnSql("name", ("qore_type": Type::String, "size": 50), 
             - \c size: for data types requiring a size component, the size; for numeric columns this represents the precision for example
             - \c scale: for numeric data types, this value gives the scale
             - \c default_value: the default value for the column
-            - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is stronlgy recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
+            - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is strongly recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
             @param nullable if @ref Qore::True "True" then the column can hold NULL values; note that primary key columns cannot be nullable
             @param opt a hash of options for the SQL string; see @ref SqlUtil::AbstractTable::AlignTableOptions for common options; each driver can support additional driver-specific options
 
@@ -8762,7 +8762,7 @@ table.modifyColumn("name", ("qore_type": Type::String, "size": 240), False);
             - \c size: for data types requiring a size component, the size; for numeric columns this represents the precision for example
             - \c scale: for numeric data types, this value gives the scale
             - \c default_value: the default value for the column
-            - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is stronlgy recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
+            - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is strongly recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
             @param lsql an optional reference to a list of strings to retrieve the SQL used to modify the table (only executed if the table is already in the database)
 
             @param nullable if @ref Qore::True "True" then the column can hold NULL values; note that primary key columns cannot be nullable
@@ -8809,7 +8809,7 @@ list l = table.getModifyColumnSql("name", ("qore_type": Type::String, "size": 24
             - \c size: for data types requiring a size component, the size; for numeric columns this represents the precision for example
             - \c scale: for numeric data types, this value gives the scale
             - \c default_value: the default value for the column
-            - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is stronlgy recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
+            - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is strongly recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
             @param nullable if @ref Qore::True "True" then the column can hold NULL values; note that primary key columns cannot be nullable
             @param opt a hash of options for the SQL string; see @ref SqlUtil::AbstractTable::AlignTableOptions for common options; each driver can support additional driver-specific options
 

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -6093,9 +6093,7 @@ AbstractDatabase db("pgsql:user/pass@db%host");
         private validateOptionsIntern(string err, hash ropt, reference opt, string tag) {
             # make sure driver-specific options take precedence over generic options
             string dn = getDriverName();
-            if (opt.driver{dn})
-                opt += remove opt.driver{dn};
-            delete opt.driver;
+            AbstractDatabase::checkDriverOptions(\opt, dn);
 
             # check valid options and option value types
             foreach string k in (opt.keyIterator()) {
@@ -8551,10 +8549,7 @@ bool b = table.empty();
             foreach string cn in (desc.columns.keyIterator()) {
                 if (desc.columns{cn}.typeCode() != NT_HASH)
                     throw "DESCRIPTION-ERROR", sprintf("%s: value assigned to column key %y is not a hash, got type %y instead (%y)", getDesc(), cn, desc.columns{cn}.type(), desc.columns{cn});
-                if (desc.columns{cn}.driver) {
-                    desc.columns{cn} += desc.columns{cn}.driver{drv};
-                    delete desc.columns{cn}.driver;
-                }
+                AbstractDatabase::checkDriverOptions(\desc.columns{cn}, drv);
             }
 
             preSetupTableImpl(\desc, opt);
@@ -14018,9 +14013,7 @@ string sql = table.getAlignSqlString(table2);
             # make sure driver options take precedence over generic options
             if (opt) {
                 string dn = getDriverName();
-                if (opt.driver{dn})
-                    opt += remove opt.driver{dn};
-                delete opt.driver;
+                AbstractDatabase::checkDriverOptions(\opt, dn);
             }
 
             # mark in options that the entire table is being created

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -1466,6 +1466,7 @@ hash table_desc = (
     - \c size: for data types requiring a size component, the size; for numeric columns this represents the precision for example
     - \c scale: for numeric data types, this value gives the scale
     - \c default_value: the default value for the column
+    - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is stronlgy recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
     - \c comment: an optional comment for the column
     - \c notnull: if the column should have a "not null" constraint on it; if missing the default value is @ref Qore::False "False"
     - \c driver: this key can optionally contain a hash keyed by driver name which contains a hash of values that will be added to the column description hash before processing; this way a column description hash can contain all the information required for the column including driver-specific options; any driver-specific options will overwrite values in the top level of the hash if there are duplicate hash keys, see below for an example
@@ -7885,6 +7886,7 @@ Table table("pgsql:user/pass@db%host", "table");
                 - \c size: (@ref int_type) for data types requiring a size component, the size; for numeric columns this represents the precision for example
                 - \c scale: (@ref int_type) for numeric data types, this value gives the scale
                 - \c default_value: the default value for the column
+                - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is stronlgy recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
                 - \c comment: (@ref string_type) an optional comment for the column
                 - \c notnull: if the column should have a "not null" constraint on it; if missing the default value is @ref Qore::False "False"
                 - \c driver: this key can optionally contain a hash keyed by driver name which contains a hash of values that will be added to the column description hash before processing; this way a column description hash can contain all the information required for the column including driver-specific options; any driver-specific options will overwrite values in the top level of the hash if there are duplicate hash keys, see below for an example
@@ -7896,6 +7898,7 @@ Table table("pgsql:user/pass@db%host", "table");
                 "size": Type::Int,
                 "scale": Type::Int,
                 "default_value": Type::NothingType,
+                "default_value_native" : Type::Boolean,
                 "comment": Type::String,
                 );
 
@@ -8653,6 +8656,7 @@ table.addColumn("name", ("qore_type": Type::String, "size": 50), False);
             - \c size: for data types requiring a size component, the size; for numeric columns this represents the precision for example
             - \c scale: for numeric data types, this value gives the scale
             - \c default_value: the default value for the column
+            - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is stronlgy recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
             @param nullable if @ref Qore::True "True" then the column can hold NULL values; note that primary key columns cannot be nullable
             @param lsql an optional reference to a list of strings to retrieve the SQL used to modify the table (only executed if the table is already in the database)
 
@@ -8684,6 +8688,7 @@ list l = table.getAddColumnSql("name", ("qore_type": Type::String, "size": 50), 
             - \c size: for data types requiring a size component, the size; for numeric columns this represents the precision for example
             - \c scale: for numeric data types, this value gives the scale
             - \c default_value: the default value for the column
+            - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is stronlgy recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
             @param nullable if @ref Qore::True "True" then the column can hold NULL values; note that primary key columns cannot be nullable
             @param opt a hash of options for the SQL string; see @ref SqlUtil::AbstractTable::AlignTableOptions for common options; each driver can support additional driver-specific options
 
@@ -8757,6 +8762,7 @@ table.modifyColumn("name", ("qore_type": Type::String, "size": 240), False);
             - \c size: for data types requiring a size component, the size; for numeric columns this represents the precision for example
             - \c scale: for numeric data types, this value gives the scale
             - \c default_value: the default value for the column
+            - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is stronlgy recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
             @param lsql an optional reference to a list of strings to retrieve the SQL used to modify the table (only executed if the table is already in the database)
 
             @param nullable if @ref Qore::True "True" then the column can hold NULL values; note that primary key columns cannot be nullable
@@ -8803,6 +8809,7 @@ list l = table.getModifyColumnSql("name", ("qore_type": Type::String, "size": 24
             - \c size: for data types requiring a size component, the size; for numeric columns this represents the precision for example
             - \c scale: for numeric data types, this value gives the scale
             - \c default_value: the default value for the column
+            - \c default_value_native: a boolean flag to say if a \c default_value should be validated against table column type (False) or used as it is (True) to allow to use DBMS native functions or features. Defaults to False. It is stronlgy recommended to use \c default_value_native for \c default_value in \c driver specific sub-hash to avoid non-portable schema hashes
             @param nullable if @ref Qore::True "True" then the column can hold NULL values; note that primary key columns cannot be nullable
             @param opt a hash of options for the SQL string; see @ref SqlUtil::AbstractTable::AlignTableOptions for common options; each driver can support additional driver-specific options
 
@@ -10361,7 +10368,7 @@ string sql = table.getDropTriggerSql("trig_mytable");
                 opt.size = th.default_size;
 
             # check type of default value (must match column type)
-            if (exists opt.default_value) {
+            if (exists opt.default_value && !opt.default_value_native) {
                 checkValue(cname, "default_value", \opt.default_value, th.qore);
                 opt.default_value = getSqlValue(opt.default_value);
             }


### PR DESCRIPTION
this patch allows us to use native functions in default values like eg.:

```
create table t (
   dt date default to_date('1.1.2000', 'dd.mm.yyyy') not null
);
```

in different DBMS dialects.

It also reduces copypasted option-for-drivers mergers

Refs: #1428