### PR TITLE
refs #1511 implemented Program::setThreadInit() modified set_thread_i…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -68,6 +68,8 @@
     - new constants:
       - @ref Qore::PO_STRONG_ENCAPSULATION "PO_STRONG_ENCAPSULATION": disallows out of line class and namespace declarations
     - implemented additional parse-time checks for many @ref operators "operators" to provide feedback for invalid operations detected at parse time
+    - new methods:
+      - @ref Qore::Program::setThreadInit()
     - new pseudo-methods:
       - <int>::format(int, string, string)
       - <float>::format(int, string, string)
@@ -82,6 +84,7 @@
       - @ref Qore::round(int/float/number num, int prec = 0)
       - @ref Qore::floor(int/float/number num, int prec = 0)
       - @ref Qore::ceil(int/float/number num, int prec = 0)
+      - @ref Qore::set_thread_init()
     - new parse options:
       - @ref broken-loop-statement "%broken-loop-statement"
     - new constants:

--- a/examples/test/qore/classes/Program/program.qtest
+++ b/examples/test/qore/classes/Program/program.qtest
@@ -70,6 +70,7 @@ class ProgramTest inherits QUnit::Test {
         addTestCase("type error test", \typeErrorTest());
         addTestCase("broken-operators test", \brokenOperatorsTest());
         addTestCase("class test", \classTest());
+        addTestCase("setThreadInit test", \setThreadInitTest());
 	set_return_value(main());
     }
 
@@ -274,5 +275,25 @@ class ProgramTest inherits QUnit::Test {
             Program p(PO_NEW_STYLE|PO_STRICT_ARGS|PO_REQUIRE_TYPES);
             assertEq(NOTHING, p.parse("class X { static copy(X obj) {}}", ""));
         }
+    }
+
+    setThreadInitTest() {
+        our int i = 0;
+        our Counter cnt(1);
+        Program p(PO_NEW_STYLE);
+        p.importGlobalVariable("i");
+        p.importGlobalVariable("cnt");
+        bool b = p.setThreadInit(sub () { i = 1;});
+        assertEq(False, b);
+        p.parse("background cnt.dec();", "");
+        p.run();
+        cnt.waitForZero();
+        assertEq(1, i);
+        b = p.setThreadInit();
+        assertEq(True, b);
+        i = 0;
+        cnt.inc();
+        p.run();
+        assertEq(0, i);
     }
 }

--- a/examples/test/qore/threads/set_thread_init.qtest
+++ b/examples/test/qore/threads/set_thread_init.qtest
@@ -1,0 +1,38 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class SetThreadInit
+
+
+public class SetThreadInit inherits QUnit::Test {
+    constructor() : Test("set_thread_init", "1.0") {
+        addTestCase("set_thread_init", \setThreadInitTest());
+
+        # Return for compatibility with test harness that checks return value
+        set_return_value(main());
+    }
+
+    setThreadInitTest() {
+        our int i = 0;
+        our Counter cnt(1);
+        bool b = set_thread_init(sub () { i = 1; });
+        assertEq(False, b);
+        background cnt.dec();
+        cnt.waitForZero();
+        assertEq(1, i);
+        i = 0;
+        b = set_thread_init();
+        assertEq(True, b);
+        cnt.inc();
+        background cnt.dec();
+        cnt.waitForZero();
+        assertEq(0, i);
+    }
+}

--- a/lib/QC_Program.qpp
+++ b/lib/QC_Program.qpp
@@ -1518,3 +1518,25 @@ pgm.importSystemApi();
 Program::importSystemApi() {
    qore_program_private::runtimeImportSystemApi(*p, xsink);
 }
+
+//! Sets a @ref call_reference "call reference" or @ref closure "closure" to run every time a new thread is started
+/** This code can be used to initialize @ref threading_and_variables "global thread-local variables", for example.
+
+    @param init a @ref call_reference "call reference" or @ref closure "closure" to run every time a new thread is started or @ref nothing to clear any thread initialization code
+
+    @return @ref True if there was already user initialization code set, @ref False if not
+
+    @par Example:
+    @code{.py}
+pgm.setThreadInit(sub () { var = 123; });
+    @endcode
+
+    @note the code will be run for all new threads, but is not run by this function for the current thread
+
+    @see @ref Qore::set_thread_init()
+
+    @since %Qore 0.8.13
+*/
+bool Program::setThreadInit(*code init) [dom=THREAD_CONTROL] {
+   return qore_program_private::setThreadInit(*p, init, xsink);
+}

--- a/lib/ql_thread.qpp
+++ b/lib/ql_thread.qpp
@@ -513,6 +513,8 @@ nothing mark_thread_resources() [dom=THREAD_CONTROL] {
 //! Sets a @ref call_reference "call reference" or @ref closure "closure" to run every time a new thread is started
 /** This code can be used to initialize @ref threading_and_variables "global thread-local variables", for example.
 
+    @param init a @ref call_reference "call reference" or @ref closure "closure" to run every time a new thread is started or @ref nothing to clear any thread initialization code
+
     @return @ref True if there was already user initialization code set, @ref False if not
 
     @par Example:
@@ -521,8 +523,12 @@ set_thread_init(sub () { var = 123; });
     @endcode
 
     @note the code will be run for all new threads, but is not run by this function for the current thread
+
+    @see @ref Qore::Program::setThreadInit()
+
+    @since %Qore 0.8.13 added the ability to remove the thread initialization code by passing @ref nothing to this function
 */
-bool set_thread_init(code init) [dom=THREAD_CONTROL] {
+bool set_thread_init(*code init) [dom=THREAD_CONTROL] {
    return qore_program_private::setThreadInit(*getProgram(), init, xsink);
 }
 


### PR DESCRIPTION
…nit() to allow the thread initalization code to be removed