### PR TITLE
refs #1513 allow for binary modules attempt to acquire the current pr…

### DIFF
--- a/include/qore/QoreProgram.h
+++ b/include/qore/QoreProgram.h
@@ -686,16 +686,22 @@ public:
 //! allows for the parse lock for the current program to be acquired by binary modules
 /** @since %Qore 0.8.13
  */
-class CurrentProgramRuntimeParseContextHelper {
+class CurrentProgramRuntimeExternalParseContextHelper {
 public:
    //! acquires the parse lock; if already acquired by another thread, then this call blocks until the lock can be acquired
-   DLLEXPORT CurrentProgramRuntimeParseContextHelper();
+   DLLEXPORT CurrentProgramRuntimeExternalParseContextHelper();
+
    //! releases the parse lock for the current program
-   DLLEXPORT ~CurrentProgramRuntimeParseContextHelper();
+   DLLEXPORT ~CurrentProgramRuntimeExternalParseContextHelper();
+
+   //! returns true if the object is valid (lock acquired), false if not (program already deleted)
+   DLLEXPORT operator bool() const;
 
 private:
+   bool valid = true;
+
    // not implemented
-   CurrentProgramRuntimeParseContextHelper(const CurrentProgramRuntimeParseContextHelper&) = delete;
+   CurrentProgramRuntimeExternalParseContextHelper(const CurrentProgramRuntimeExternalParseContextHelper&) = delete;
    void* operator new(size_t) = delete;
 };
 

--- a/include/qore/intern/qore_program_private.h
+++ b/include/qore/intern/qore_program_private.h
@@ -668,8 +668,8 @@ public:
       }
 
       if (ptid && ptid != gettid()) {
-         assert(xsink);
-         xsink->raiseException("PROGRAM-ERROR", "the Program accessed has already been deleted and therefore cannot be accessed");
+         if (xsink)
+            xsink->raiseException("PROGRAM-ERROR", "the Program accessed has already been deleted and therefore cannot be accessed");
          return -1;
       }
 

--- a/include/qore/intern/qore_thread_intern.h
+++ b/include/qore/intern/qore_thread_intern.h
@@ -417,6 +417,20 @@ public:
    }
 };
 
+// allows for the parse lock for the current program to be acquired by binary modules
+class CurrentProgramRuntimeParseContextHelper {
+public:
+   // acquires the parse lock; if already acquired by another thread, then this call blocks until the lock can be acquired
+   DLLEXPORT CurrentProgramRuntimeParseContextHelper();
+   // releases the parse lock for the current program
+   DLLEXPORT ~CurrentProgramRuntimeParseContextHelper();
+
+private:
+   // not implemented
+   CurrentProgramRuntimeParseContextHelper(const CurrentProgramRuntimeParseContextHelper&) = delete;
+   void* operator new(size_t) = delete;
+};
+
 // acquires a TID and thread entry, returns -1 if not successful
 DLLLOCAL int get_thread_entry();
 // acquires TID 0 and sets up the signal thread entry, always returns 0

--- a/lib/QoreProgram.cpp
+++ b/lib/QoreProgram.cpp
@@ -653,6 +653,7 @@ void qore_program_private::del(ExceptionSink* xsink) {
    for (auto& i : extmap) {
       i.second->doDeref();
    }
+   extmap.clear();
 
    if (thr_init)
       thr_init->deref(xsink);

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -1578,6 +1578,27 @@ CurrentProgramRuntimeParseContextHelper::~CurrentProgramRuntimeParseContextHelpe
       qore_program_private::unlockParsing(*td->current_pgm);
 }
 
+CurrentProgramRuntimeExternalParseContextHelper::CurrentProgramRuntimeExternalParseContextHelper() {
+   ThreadData* td = thread_data.get();
+   // attach to and lock current program for parsing - cannot fail with a running program
+   // but current_pgm can be null when loading binary modules
+   if (!td->current_pgm || qore_program_private::lockParsing(*td->current_pgm, 0))
+      valid = false;
+}
+
+CurrentProgramRuntimeExternalParseContextHelper::~CurrentProgramRuntimeExternalParseContextHelper() {
+   if (valid) {
+      ThreadData* td = thread_data.get();
+      // current_pgm can be null when loading binary modules
+      if (td->current_pgm)
+         qore_program_private::unlockParsing(*td->current_pgm);
+   }
+}
+
+CurrentProgramRuntimeExternalParseContextHelper::operator bool() const {
+   return valid;
+}
+
 ProgramRuntimeParseAccessHelper::ProgramRuntimeParseAccessHelper(ExceptionSink* xsink, QoreProgram* pgm) : restore(false) {
    ThreadData* td = thread_data.get();
    if (pgm != td->current_pgm) {


### PR DESCRIPTION
…ogram's parse lock to fail (ex: the module has a weak ref to the Program but the Program has been deleted); also when dereferencing Program external data, clear the data structure after the dereference