### PR TITLE
refs #1160 added PO_NO_UNCONTROLLED_APIS to cover the jni module sinc…

### DIFF
--- a/doxygen/lang/120_modules.dox.tmpl
+++ b/doxygen/lang/120_modules.dox.tmpl
@@ -48,7 +48,7 @@
     |user|<a href="../../modules/Pop3Client/html/index.html">Pop3Client</a>|Provides POP3 client functionality; provides an API to retrieve email messages from a POP3 server
     |user|<a href="../../modules/PgsqlSqlUtil/html/index.html">PgsqlSqlUtil</a>|Provides a high-level DB-independent API for working with PostgreSQL database objects; loaded automatically by the <a href="../../modules/SqlUtil/html/index.html">SqlUtil</a> module when working with PostgreSQL databases for automated schema management, programmatic DB access, schema and data synchronization, and more
     |user|<a href="../../modules/Qdx/html/index.html">Qdx</a>|Provides support for documentation generation with doxygen from %Qore sources
-    |user|<a href="../../modules/Qorize/html/index.html">Qorize</a>|Provides basic support for automatically-generating Qore code from data
+    |user|<a href="../../modules/Qorize/html/index.html">Qorize</a>|Provides basic support for automatically-generating %Qore code from data
     |user|<a href="../../modules/QUnit/html/index.html">QUnit</a>|Provides an API for defining and executing tests and reporting results in various formats
     |user|<a href="../../modules/RestClient/html/index.html">RestClient</a>|Provides a simple API for communicating with HTTP servers implementing <a href="http://en.wikipedia.org/wiki/Representational_state_transfer">REST</a> services
     |user|<a href="../../modules/RestHandler/html/index.html">RestHandler</a>|Provides an easy to use interface to the %Qore <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module for implementing server-side <a href="http://en.wikipedia.org/wiki/Representational_state_transfer">REST</a> services
@@ -67,13 +67,12 @@
     <b>Modules Provided Separately</b>
     |!Type|!Module|!Description
     |binary|<a href="https://github.com/qorelanguage/module-sybase">freetds</a>|Provides a FreeTDS-based DBI driver for communicating with Sybase and MS SQL Server databases
-    |binary|<a href="https://github.com/qorelanguage/module-fsevent">fsevent</a>|Provides an event-driven filesystem event API
-    |binary|<a href="https://github.com/qorelanguage/module-glut">glut</a>|Provides GLUT functionality
+    |binary|<a href="https://github.com/qorelanguage/module-jni">jni</a>|Provides access to Java APIs in %Qore
     |binary|<a href="https://github.com/qorelanguage/module-json">json</a>|Provides JSON and JSON-RPC client functionality, also provides the following user modules:\n- <a href="http://www.qore.org/manual/modules/json/current/JsonRpcHandler/html/index.html">JsonRpcHandler</a>: provides infrastructure for implementing JSON-RPC server-side services using the <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module
-    |binary|<a href="https://github.com/qorelanguage/module-linenoise">linenoise</a>|Provides a readline-like API to Qore under a permissive license
+    |binary|<a href="https://github.com/qorelanguage/module-linenoise">linenoise</a>|Provides a readline-like API to %Qore under a permissive license
     |binary|<a href="https://github.com/qorelanguage/module-mysql">mysql</a>|Provides a MySQL / MariaDB / Percona DBI driver
+    |binary|<a href="https://github.com/qorelanguage/module-odbc">odbc</a>|Provides an ODBC DBI driver to %Qore
     |binary|<a href="https://github.com/qorelanguage/module-oracle">oracle</a>|Provides an Oracle DBI driver, providing many advanced features such as support for named types and collections, advanced queuing, etc, also provides the following user modules:\n- <a href="http://www.qore.org/manual/modules/oracle/current/OracleExtensions/html/index.html">OracleExtensions</a>: provides infrastructure for SQL tracing
-    |binary|<a href="https://github.com/qorelanguage/module-opengl">opengl</a>|Provides an OpenGL API to %Qore
     |binary|<a href="https://github.com/qorelanguage/module-openldap">openldap</a>|Provides an OpenLDAP API to %Qore
     |binary|<a href="https://github.com/qorelanguage/module-pgsql">pgsql</a>|Provides a PostgreSQL DBI driver
     |binary|<a href="https://github.com/qorelanguage/module-sqlite3">sqlite3</a>|Provides an SQLite3 DBI driver
@@ -86,14 +85,6 @@
     |binary|<a href="https://github.com/qorelanguage/module-xml">xml</a>|Provides XML (SAX and DOM parsers), XPath, XML-RPC, SOAP client and server, etc functionality, also provides the following user modules:\n- <a href="http://www.qore.org/manual/modules/xml/current/SoapClient/html/index.html">SoapClient</a>: provides an easy to use API for making requests to SOAP servers\n- <a href="http://www.qore.org/manual/modules/xml/current/SalesforceSoapClient/html/index.html">SalesforceSoapClient</a>: provides an easy to use API for making requests to Salesforce.com SOAP servers\n- <a href="http://www.qore.org/manual/modules/xml/current/SoapHandler/html/index.html">SoapHandler</a>: provides infrastructure for implementing SOAP server-side services using the <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module\n- <a href="http://www.qore.org/manual/modules/xml/current/WSDL/html/index.html">WSDL</a>: provides underlying web service/WSDL support for the <a href="http://www.qore.org/manual/modules/xml/current/SoapClient/html/index.html">SoapClient</a> and <a href="http://www.qore.org/manual/modules/xml/current/SoapHandler/html/index.html">SoapHandler</a> modules\n- <a href="http://www.qore.org/manual/modules/xml/current/XmlRpcHandler/html/index.html">XmlRpcHandler</a>: provides infrastructure for implementing XML-RPC server-side services using the <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module
     |binary|<a href="https://github.com/qorelanguage/module-xmlsec">xmlsec</a>|Provides xmldsig and xmlenc functionality
     |binary|<a href="https://github.com/qorelanguage/module-yaml">yaml</a>|Provides YAML functionality, also provides the following user modules:\n- <a href="http://www.qore.org/manual/modules/yaml/current/DataStreamClient/html/index.html">DataStreamClient</a>: provides a DataStream client API extending the RestClient\n- <a href="http://www.qore.org/manual/modules/yaml/current/DataStreamRequestHandler/html/index.html">DataStreamRequestHandler</a>: provides a DataStream server-side handler API extending the RestHandler\n- <a href="http://www.qore.org/manual/modules/yaml/current/DataStreamUtil/html/index.html">DataStreamUtil</a>: provides underlying DataStream client and server protocol support\n- <a href="http://www.qore.org/manual/modules/yaml/current/YamlRpcClient/html/index.html">YamlRpcClient</a>: provides an API for easily making YAML-RPC calls over the network\n- <a href="http://www.qore.org/manual/modules/yaml/current/YamlRpcHandler/html/index.html">YamlRpcHandler</a>: provides infrastructure for implementing YAML-RPC server-side services using the <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module
-
-    <b>Other Modules Provided Separately</b>
-    |!Type|!Module|!Description
-    |binary|<a href="https://github.com/qorelanguage/module-asn1">asn1</a>|Provides some ASN.1 functionality; stable but only partial ASN.1 functionality is provided, uses very old APIs
-    |binary|<a href="https://github.com/qorelanguage/module-db2">db2</a>|Provides an IBM DB2 driver; stuck in protype phase due to lack of development
-    |binary|<a href="https://github.com/qorelanguage/module-ncurses">ncurses</a>|Provides curses APIs; stable and works, but uses old APIs, needs updating
-    |binary|<a href="https://github.com/qorelanguage/module-qt4">qt4</a>|Provides Nokia (formerly Trolltech) QT4 APIs for GUI development; this module works for a subset of the QT API, but due to the need for complete object lifecycle control, it's not recommended for use until we can implement a new garbage collector for %Qore objects created from external modules
-    |binary|<a href="https://github.com/qorelanguage/module-tuxedo">tuxedo</a>|Provides Oracle (ex Bea) Tuxedo functionality; this module has not been updated for some time, uses old APIs
 
     @section binary_modules Binary Modules
 

--- a/doxygen/lang/245_parse_directives.dox.tmpl
+++ b/doxygen/lang/245_parse_directives.dox.tmpl
@@ -66,6 +66,7 @@
     |@ref no-thread-info "%no-thread-info"|Disallows any access to functionality that provides threading information (see @ref no-thread-info "%no-thread-info" for a list of features not available with this parse option); equivalent to parse option @ref Qore::PO_NO_THREAD_INFO and the <tt>-</tt><tt>-no-thread-info</tt> command line option
     |@ref no-threads "%no-threads"|Disallows access to all thread control operations and thread classes (equivalent to <tt>-</tt><tt>-no-thread-control</tt> and <tt>-</tt><tt>-no-thread-classes</tt> together); equivalent to parse option @ref Qore::PO_NO_THREADS and the <tt>-</tt><tt>-no-threads</tt> command line option
     |@ref no-top-level "%no-top-level"|Disallows any further top level code; equivalent to parse option @ref Qore::PO_NO_TOP_LEVEL_STATEMENTS and the <tt>-</tt><tt>-no-top-level</tt> command line option
+    |@ref no-uncontrolled-apis "%no-uncontrolled-apis"|Disallows access to uncontrolled APIs such as external language bindings or direct generic system call APIs that could bypass %Qore's sandboxing controls
     |@ref perl-bool-eval "%perl-bool-eval"|Set to mimic perl's boolean evaluation; this is the default with qore >= 0.8.6; prior to this version, by default qore used strict mathematic boolean evaluation, where any value converted to 0 is @ref Qore::False "False" and otherwise it's is @ref Qore::True "True". <br><br>As of %Qore 0.8.6+, this parse option is only needed if @ref strict-bool-eval "%strict-bool-eval" is set. <br><br>When this option is set, boolean evaluation follows the same rules as <value>::val(); see also @ref strict-bool-eval "%strict-bool-eval"<br><br>Since %Qore 0.8.6
     |@ref push-parse-options "%push-parse-options"|Stores parse options so that they will be restored when the current file is done parsing; use in include files to ensure parse options are set appropriately for the file being parsed
     |@ref require-dollar "%require-dollar"|Resets the default %Qore behavior where the use of the \c "$" character in variable names, method calls, and object member references is required; use after @ref allow-bare-refs "%allow-bare-refs" to reset the default parsing behavior <br><br>Since %Qore 0.8.4
@@ -677,7 +678,7 @@ i+ =4;
     @ref Qore::PO_NO_EXTERNAL_ACCESS
 
     @par Description:
-    This option is made up of @ref no-process-control "%no-process-control", @ref no-network "%no-network", @ref no-filesystem "%no-filesystem", @ref no-database "%no-database", @ref no-external-info "%no-external-info", and @ref no-modules "%no-modules"
+    This option is made up of @ref no-process-control "%no-process-control", @ref no-network "%no-network", @ref no-filesystem "%no-filesystem", @ref no-database "%no-database", @ref no-external-info "%no-external-info", @ref no-modules "%no-modules", and @ref no-uncontrolled-apis "%no-uncontrolled-apis"
 
     @see @ref lockdown "%lockdown"
 
@@ -836,7 +837,7 @@ i+ =4;
     @ref Qore::PO_NO_IO
 
     @par Description:
-    Made up of @ref no-gui "%no-gui" | @ref no-terminal-io "%no-terminal-io" | @ref no-filesystem "%no-filesystem" | @ref no-network "%no-network" | @ref no-database "%no-database"
+    Made up of @ref no-gui "%no-gui" | @ref no-terminal-io "%no-terminal-io" | @ref no-filesystem "%no-filesystem" | @ref no-network "%no-network" | @ref no-database "%no-database" | @ref no-uncontrolled-apis "%no-uncontrolled-apis"
 
     <hr>
     @section no-locale-control %no-locale-control
@@ -1104,6 +1105,21 @@ i+ =4;
 
     @par Description:
     Disallows top level code from this point on, any top level statements before this directive are still allowed and become part of the @ref Qore::Program "Program" context.
+
+    <hr>
+    @section no-uncontrolled-apis %no-uncontrolled-apis
+
+    @par Parse Directive:
+    <tt>%no-uncontrolled-apis</tt>
+
+    @par Command Line:
+    <tt>-p=no-uncontrolled-apis</tt>
+
+    @par Parse Option Constant:
+    @ref Qore::PO_NO_UNCONTROLLED_APIS
+
+    @par Description:
+    Disallows access to uncontrolled APIs such as external language bindings or direct generic system call APIs that could bypass %Qore's sandboxing controls.
 
     <hr>
     @section perl-bool-eval %perl-bool-eval

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -66,9 +66,11 @@
       - added \c InboundTableMapper::queueData(list)
     - new access modifiers: <tt><b>private:internal</b></tt> (providing strong encapsulation of the following declaration(s)) and <tt><b>private:hierarchy</b></tt> (which is equivalent to <tt><b>private</b></tt>; <a href="https://github.com/qorelanguage/qore/issues/1197">issue 1197</a>)
     - new parse options:
+      - @ref no-uncontrolled-apis "no-uncontrolled-apis": disallow access to uncontrolled APIs such as external language bindings or direct generic system call APIs that could bypass %Qore's sandboxing controls
       - @ref strong-encapsulation "%strong-encapsulation": disallows out of line class and namespace declarations
     - new constants:
       - @ref Qore::PathSep "PathSep": defines the platform-specific path separator character
+      - @ref Qore::PO_NO_UNCONTROLLED_APIS "PO_NO_UNCONTROLLED_APIS": disallow access to uncontrolled APIs such as external language bindings or direct generic system call APIs that could bypass %Qore's sandboxing controls; note that this parse option was also added to @ref Qore::PO_NO_IO and @ref Qore::PO_NO_EXTERNAL_ACCESS
       - @ref Qore::PO_STRONG_ENCAPSULATION "PO_STRONG_ENCAPSULATION": disallows out of line class and namespace declarations
     - implemented additional parse-time checks for many @ref operators "operators" to provide feedback for invalid operations detected at parse time
     - new methods:

--- a/include/qore/Restrictions.h
+++ b/include/qore/Restrictions.h
@@ -82,6 +82,7 @@
 #define PO_BROKEN_OPERATORS                 (1LL << 42)  //!< allow for old pre-%Qore 0.8.12 parsing of multi-character operators with spaces
 #define PO_BROKEN_LOOP_STATEMENT            (1LL << 43)  //!< allow for old pre-%Qore 0.8.13 handling of break and continue
 #define PO_STRONG_ENCAPSULATION             (1LL << 44)  //!< disallow out-of-line class and namespace declarations
+#define PO_NO_UNCONTROLLED_APIS             (1LL << 45)  //!< disallow access to "uncontrolled APIs" like external language bindings or direct generic system call APIs that could bypass sandboxing controls
 
 // aliases for old defines
 #define PO_NO_SYSTEM_FUNC_VARIANTS          PO_NO_INHERIT_SYSTEM_FUNC_VARIANTS
@@ -101,10 +102,10 @@
 #define PO_NO_THREADS                 (PO_NO_THREAD_CONTROL|PO_NO_THREAD_CLASSES|PO_NO_THREAD_INFO)
 
 //! prohibits any external access
-#define PO_NO_EXTERNAL_ACCESS         (PO_NO_PROCESS_CONTROL|PO_NO_NETWORK|PO_NO_FILESYSTEM|PO_NO_DATABASE|PO_NO_EXTERNAL_INFO|PO_NO_EXTERNAL_PROCESS|PO_NO_MODULES)
+#define PO_NO_EXTERNAL_ACCESS         (PO_NO_PROCESS_CONTROL|PO_NO_NETWORK|PO_NO_FILESYSTEM|PO_NO_DATABASE|PO_NO_EXTERNAL_INFO|PO_NO_EXTERNAL_PROCESS|PO_NO_MODULES|PO_NO_UNCONTROLLED_APIS)
 
 //! prohibits all terminal and file I/O and GUI operations
-#define PO_NO_IO                      (PO_NO_GUI|PO_NO_TERMINAL_IO|PO_NO_FILESYSTEM|PO_NO_NETWORK|PO_NO_DATABASE)
+#define PO_NO_IO                      (PO_NO_GUI|PO_NO_TERMINAL_IO|PO_NO_FILESYSTEM|PO_NO_NETWORK|PO_NO_DATABASE|PO_NO_UNCONTROLLED_APIS)
 
 //! most restrictive access - can just execute logic, no I/O, no threading, no external access
 #define PO_LOCKDOWN                   (PO_NO_EXTERNAL_ACCESS|PO_NO_THREADS|PO_NO_IO)
@@ -153,5 +154,6 @@
 #define QDOM_IN_MODULE          PO_IN_MODULE              //!< tagged with code that is restricted in user modules
 #define QDOM_EMBEDDED_LOGIC     PO_NO_EMBEDDED_LOGIC      //!< provides dynamic parsing functionality
 #define QDOM_INJECTION          PO_ALLOW_INJECTION        //!< provides functionality related to code / dependency injection
+#define QDOM_UNCONTROLLED_API   PO_NO_UNCONTROLLED_APIS   //!< provides unchecked access to system functionality that could bypass Qore's sandboxing controls
 
 #endif //_QORE_DOMAIN_H

--- a/lib/ModuleManager.cpp
+++ b/lib/ModuleManager.cpp
@@ -173,7 +173,7 @@ void QoreModuleDefContext::initClosure(AbstractQoreNode*& c, const char* n) {
    int lvids = 0;
    const QoreTypeInfo* typeInfo = 0;
    // check for local variables at the top level - this can only happen if the expresion is not a closure
-   c = c->parseInit(0, PO_LOCKDOWN, lvids, typeInfo);
+   c = c->parseInit(0, 0, lvids, typeInfo);
    if (lvids) {
       parseException("ILLEGAL-LOCAL-VAR", "local variables may not be declared in module '%s' code", n);
       // discard variables immediately

--- a/lib/ParseOptionMap.cpp
+++ b/lib/ParseOptionMap.cpp
@@ -86,6 +86,7 @@ void ParseOptionMap::static_init() {
    DO_MAP("broken-operators",         PO_BROKEN_OPERATORS);
    DO_MAP("broken-loop-statement",    PO_BROKEN_LOOP_STATEMENT);
    DO_MAP("strong-encapsulation",     PO_STRONG_ENCAPSULATION);
+   DO_MAP("no-uncontrolled-apis",     PO_NO_UNCONTROLLED_APIS);
 }
 
 int ParseOptionMap::find_code(const char *name) {

--- a/lib/QC_Program.qpp
+++ b/lib/QC_Program.qpp
@@ -144,7 +144,7 @@ const PO_NO_DATABASE = PO_NO_DATABASE;
 const PO_NO_EMBEDDED_LOGIC = PO_NO_EMBEDDED_LOGIC;
 
 //! Prohibits any external access
-/** made up of @ref PO_NO_PROCESS_CONTROL | @ref PO_NO_NETWORK | @ref PO_NO_FILESYSTEM | @ref PO_NO_DATABASE | @ref PO_NO_EXTERNAL_INFO | @ref PO_NO_EXTERNAL_PROCESS
+/** made up of @ref PO_NO_PROCESS_CONTROL | @ref PO_NO_NETWORK | @ref PO_NO_FILESYSTEM | @ref PO_NO_DATABASE | @ref PO_NO_EXTERNAL_INFO | @ref PO_NO_EXTERNAL_PROCESS | @ref PO_NO_UNCONTROLLED_APIS
 
     @see @ref no-external-access "%no-external-access"
  */
@@ -181,7 +181,7 @@ const PO_NO_GLOBAL_VARS = PO_NO_GLOBAL_VARS;
 const PO_NO_GUI = PO_NO_GUI;
 
 //! Prohibits all terminal and file I/O and GUI operations
-/** made up of @ref PO_NO_GUI | @ref PO_NO_TERMINAL_IO | @ref PO_NO_FILESYSTEM | @ref PO_NO_NETWORK | @ref PO_NO_DATABASE
+/** made up of @ref PO_NO_GUI | @ref PO_NO_TERMINAL_IO | @ref PO_NO_FILESYSTEM | @ref PO_NO_NETWORK | @ref PO_NO_DATABASE | @ref PO_NO_UNCONTROLLED_APIS
 
     @see @ref no-io "%no-io"
  */
@@ -446,6 +446,13 @@ const PO_BROKEN_LOOP_STATEMENT = PO_BROKEN_LOOP_STATEMENT;
     @since %Qore 0.8.13
 */
 const PO_STRONG_ENCAPSULATION = PO_STRONG_ENCAPSULATION;
+
+//! disallow access to "uncontrolled APIs" like external language bindings or direct generic system call APIs that could bypass %Qore's sandboxing controls
+/** @see @ref no-uncontrolled-apis "%no-uncontrolled-apis"
+
+    @since %Qore 0.8.13
+*/
+const PO_NO_UNCONTROLLED_APIS = PO_NO_UNCONTROLLED_APIS;
 //@}
 
 /** @defgroup warning_constants Warning Constants

--- a/lib/scanner.lpp
+++ b/lib/scanner.lpp
@@ -747,6 +747,7 @@ RTIME           PT(-?[0-9]+[HMSu])+
 ^%perl-bool-eval{WS}*$                  getProgram()->parseDisableParseOptions(PO_STRICT_BOOLEAN_EVAL);
 ^%strict-bool-eval{WS}*$                getProgram()->parseSetParseOptions(PO_STRICT_BOOLEAN_EVAL);
 ^%strong-encapsulation{WS}*$            getProgram()->parseSetParseOptions(PO_STRONG_ENCAPSULATION);
+^%no-uncontrolled-apis{WS}*$            getProgram()->parseSetParseOptions(PO_NO_UNCONTROLLED_APIS);
 ^%broken-list-parsing{WS}*$             getProgram()->parseSetParseOptions(PO_BROKEN_LIST_PARSING);
 ^%broken-logic-precedence{WS}*$         getProgram()->parseSetParseOptions(PO_BROKEN_LOGIC_PRECEDENCE);
 ^%broken-loop-statement{WS}*$           getProgram()->parseSetParseOptions(PO_BROKEN_LOOP_STATEMENT);


### PR DESCRIPTION
…e it could be used to bypass Qore's sandboxing controls

refs #1534 removed references to out of date, incomplete, and unstable binary modules