### PR TITLE
refs #1160 apis for JNI and for Qore

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -275,7 +275,8 @@ include_HEADERS = \
 	include/qore/QoreEvents.h \
 	include/qore/InputStream.h \
 	include/qore/OutputStream.h \
-	include/qore/Transform.h
+	include/qore/Transform.h \
+	include/qore/AbstractException.h
 
 noinst_HEADERS = \
 	include/qore/minitest.hpp \

--- a/include/qore/AbstractException.h
+++ b/include/qore/AbstractException.h
@@ -1,0 +1,63 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+  AbstractException.h
+
+  Qore Programming Language
+
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+
+  Note that the Qore library is released under a choice of three open-source
+  licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+  information.
+*/
+
+#ifndef _QORE_ABSTRACTEXCEPTION_H
+
+#define _QORE_ABSTRACTEXCEPTION_H
+
+/** @file AbstractException.h
+    Defines the abstract base class for c++ exceptions in the %Qore library
+*/
+
+//! abstract base class for c++ Exceptions in the %Qore library
+class AbstractException {
+public:
+   //! Default virtual destructor.
+   DLLEXPORT virtual ~AbstractException() = default;
+
+   //! Raises the corresponding Qore exception in the ExceptionSink.
+   /** @param xsink the exception sink
+    */
+   virtual void convert(ExceptionSink* xsink) = 0;
+
+   DLLEXPORT AbstractException(AbstractException&&) = default;
+   DLLEXPORT AbstractException& operator=(AbstractException&&) = default;
+
+protected:
+   //! Default constructor.
+   DLLEXPORT AbstractException() = default;
+
+private:
+   AbstractException(const AbstractException&) = delete;
+   AbstractException& operator=(const AbstractException&) = delete;
+};
+
+#endif

--- a/include/qore/Qore.h
+++ b/include/qore/Qore.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2016 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -43,6 +43,7 @@
 #endif
 
 #include <qore/common.h>
+#include <qore/AbstractException.h>
 #include <qore/QoreCounter.h>
 
 //! global background thread counter (for threads started explicitly by Qore)

--- a/include/qore/QoreLib.h
+++ b/include/qore/QoreLib.h
@@ -550,4 +550,9 @@ DLLEXPORT int q_env_subst(QoreString& str);
  */
 DLLEXPORT double q_strtod(const char* str);
 
+//! returns true if the Qore library has been shut down
+/** @since %Qore 0.8.13
+ */
+DLLEXPORT bool q_libqore_shutdown();
+
 #endif // _QORE_QORELIB_H

--- a/include/qore/intern/QoreLibIntern.h
+++ b/include/qore/intern/QoreLibIntern.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2016 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -34,6 +34,8 @@
 #define _QORE_QORELIBINTERN_H
 
 #include "qore/intern/config.h"
+
+#include <atomic>
 
 #include <stdarg.h>
 #include <sys/types.h>
@@ -415,6 +417,8 @@ DLLLOCAL int q_fstatvfs(const char* filepath, struct statvfs* buf);
 #include "qore/intern/SwitchStatement.h"
 #include "qore/intern/QorePseudoMethods.h"
 #include "qore/intern/ParseReferenceNode.h"
+
+DLLLOCAL extern std::atomic<bool> qore_shutdown;
 
 DLLLOCAL extern int qore_library_options;
 

--- a/lib/QoreLib.cpp
+++ b/lib/QoreLib.cpp
@@ -2424,3 +2424,7 @@ QoreString* q_fix_decimal(QoreString* str, size_t offset) {
 QoreStringNode* q_fix_decimal(QoreStringNode* str, size_t offset) {
    return q_fix_decimal_tmpl<QoreStringNode>(str, offset);
 }
+
+bool q_libqore_shutdown() {
+   return qore_shutdown.load(std::memory_order_relaxed);
+}


### PR DESCRIPTION
- new AbstractException base class for C++ exception handling in Qore - provides a bridge to ExceptionSink with the abstract "convert" method (ported from the jni module)
- new QPI function q_libqore_shutdown() with a thread-safe implementation - returns true if the Qore library has been shutdown (can be used in modules where threads could still be running that try to make callbacks in Qore - ex: jni)