### PR TITLE
Bugfix/1626 table mapper performance

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -12,6 +12,7 @@
     - fixed bug in internal string generation with \c size_t arguments that could cause invalid data to be output or crashes on 32-bit platforms (<a href="https://github.com/qorelanguage/qore/issues/1640">issue 1640</a>)
     - fixed a runtime memory leak and invalid runtime behavior with undetected recursive lvalue references (<a href="https://github.com/qorelanguage/qore/issues/1617">issue 1617</a>)
     - improved @ref garbage_collection "prompt collection" performance with large graphs of objects by eliminating additional unnecessary graph scans, resulting in further large performance improvements in the garbage collector (<a href="https://github.com/qorelanguage/qore/issues/1363">issue 1363</a>)
+    - improved \c InboundTableMapper::queueData() performance (in the <a href="../../modules/TableMapper/html/index.html">TableMapper</a> module) when used with data in hash of lists format to use bulk DML in input and output without internal data conversions (<a href="https://github.com/qorelanguage/qore/issues/1626">issue 1626</a>)
 
     @section qore_08126 Qore 0.8.12.6
 

--- a/examples/test/qlib/Mapper/mapper.qtest
+++ b/examples/test/qlib/Mapper/mapper.qtest
@@ -8,7 +8,6 @@
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/Mapper.qm
-#%requires /tmp/Mapper.qm
 
 %exec-class MapperTest
 

--- a/examples/test/qlib/Mapper/mapper.qtest
+++ b/examples/test/qlib/Mapper/mapper.qtest
@@ -8,6 +8,7 @@
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/Mapper.qm
+#%requires /tmp/Mapper.qm
 
 %exec-class MapperTest
 
@@ -155,7 +156,7 @@ public class MapperTest inherits QUnit::Test {
     testMapperMapData() {
         Mapper m(DataMap, m_opts);
         list l = map m.mapData($1), MapInput;
-        testAssertion("Verify mapped list", \equalsIterated(), (new ListIterator(l), new ListIterator(MapOutput)));
+        testAssertion("Verify mapped list", \equalsIterated(), (l.iterator(), MapOutput.iterator()));
         testAssertion("Verify item count", \equals(), (m.getCount(), 2));
     }
 

--- a/examples/test/qlib/TableMapper/TableMapperPerformance.qtest
+++ b/examples/test/qlib/TableMapper/TableMapperPerformance.qtest
@@ -219,6 +219,7 @@ public class TableMapperPerformanceTest inherits QUnit::Test {
 
     private usageIntern() {
         TestReporter::usageIntern(OptionColumn);
+        printOption("-b,--block=ARG", sprintf("the row block size for bulk inserts (default: %d)", ENV.TABLEMAPPERPERFORMANCETEST_BLOCK ?? DefaultBlockSize), OptionColumn);
         printOption("-c,--conn=ARG", "set DB connection argument (ex: \"driver:user/pass@db\")", OptionColumn);
         printOption("-r,--rows=ARG", sprintf("the number of rows to insert (default: %d)", ENV.TABLEMAPPERPERFORMANCETEST_ROWS ?? DefaultRows), OptionColumn);
     }

--- a/examples/test/qlib/TableMapper/TableMapperPerformance.qtest
+++ b/examples/test/qlib/TableMapper/TableMapperPerformance.qtest
@@ -1,0 +1,287 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+
+%exec-class TableMapperPerformanceTest
+
+%requires ../../../../qlib/Util.qm
+%requires ../../../../qlib/QUnit.qm
+%requires ../../../../qlib/SqlUtil.qm
+# load all possible SqlUtil driver-specific modules to ensure that our version is used when testing
+%requires ../../../../qlib/OracleSqlUtil.qm
+%requires ../../../../qlib/PgsqlSqlUtil.qm
+%requires ../../../../qlib/MysqlSqlUtil.qm
+%requires ../../../../qlib/FreetdsSqlUtil.qm
+%requires ../../../../qlib/Schema.qm
+%requires ../../../../qlib/Mapper.qm
+%requires ../../../../qlib/TableMapper.qm
+
+public class TableMapperPerformanceTestSchema inherits AbstractSchema {
+    public {
+        const ColumnWidth = 40;
+
+        const T_TableMapperPerformanceTest = (
+            "columns": (
+                "id": c_number(C_NOT_NULL),
+                "var_0": c_varchar(ColumnWidth, C_NOT_NULL),
+                "var_1": c_varchar(ColumnWidth, C_NOT_NULL),
+                "var_2": c_varchar(ColumnWidth, C_NOT_NULL),
+                "var_3": c_varchar(ColumnWidth, C_NOT_NULL),
+                "ncol_0": c_number(C_NOT_NULL),
+                "ncol_1": c_number(C_NOT_NULL),
+                "ncol_2": c_number(C_NOT_NULL),
+                "ncol_3": c_number(C_NOT_NULL),
+                "ncol_4": c_number(C_NOT_NULL),
+                "ncol_5": c_number(C_NOT_NULL),
+                "ncol_6": c_number(C_NOT_NULL),
+                "ncol_7": c_number(C_NOT_NULL),
+                "ncol_8": c_number(C_NOT_NULL),
+                "ncol_9": c_number(C_NOT_NULL),
+                "ncol_10": c_number(C_NOT_NULL),
+                "ncol_11": c_number(C_NOT_NULL),
+                "ncol_12": c_number(C_NOT_NULL),
+                "ncol_13": c_number(C_NOT_NULL),
+                "ncol_14": c_number(C_NOT_NULL),
+                "ncol_15": c_number(C_NOT_NULL),
+                "ncol_16": c_number(C_NOT_NULL),
+                "ncol_17": c_number(C_NOT_NULL),
+                "ncol_18": c_number(C_NOT_NULL),
+                "ncol_19": c_number(C_NOT_NULL),
+                "ncol_20": c_number(C_NOT_NULL),
+                "ncol_21": c_number(C_NOT_NULL),
+                "ncol_22": c_number(C_NOT_NULL),
+                "ncol_23": c_number(C_NOT_NULL),
+                "ncol_24": c_number(C_NOT_NULL),
+                "ncol_25": c_number(C_NOT_NULL),
+                "ncol_26": c_number(C_NOT_NULL),
+                "ncol_27": c_number(C_NOT_NULL),
+                "ncol_28": c_number(C_NOT_NULL),
+                "ncol_29": c_number(C_NOT_NULL),
+                "ncol_30": c_number(C_NOT_NULL),
+                "ncol_31": c_number(C_NOT_NULL),
+                "ncol_32": c_number(C_NOT_NULL),
+                "ncol_33": c_number(C_NOT_NULL),
+                "ncol_34": c_number(C_NOT_NULL),
+                "ncol_35": c_number(C_NOT_NULL),
+                "ncol_36": c_number(C_NOT_NULL),
+                "ncol_37": c_number(C_NOT_NULL),
+                "ncol_38": c_number(C_NOT_NULL),
+                "ncol_39": c_number(C_NOT_NULL),
+                "strcol_0": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_1": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_2": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_3": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_4": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_5": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_6": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_7": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_8": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_9": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_10": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_11": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_12": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_13": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_14": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_15": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_16": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_17": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_18": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_19": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_20": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_21": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_22": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_23": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_24": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_25": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_26": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_27": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_28": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_29": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_30": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_31": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_32": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_33": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_34": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_35": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_36": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_37": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_38": c_varchar(ColumnWidth, C_NOT_NULL),
+                "strcol_39": c_varchar(ColumnWidth, C_NOT_NULL),
+            ),
+            );
+
+        const Tables = (
+            "table_mapper_test": T_TableMapperPerformanceTest,
+            );
+
+        const Sequences = (
+            "seq_table_mapper_test": {},
+            );
+    }
+
+    constructor(AbstractDatasource ds, *string dts, *string its) : AbstractSchema(ds, dts, its) {
+    }
+
+    private *hash getTablesImpl() {
+        return Tables;
+    }
+
+    private *hash getSequencesImpl() {
+        return Sequences;
+    }
+
+    string getNameImpl() {
+        return "TableMapperPerformanceTestSchema";
+    }
+
+    string getVersionImpl() {
+        return "1.0";
+    }
+
+    log(string fmt) {
+        #vprintf(fmt + "\n", argv);
+        delete argv;
+    }
+
+    logpf(string fmt) {
+        #vprintf(fmt + "\n", argv);
+        delete argv;
+    }
+
+    logProgress(string fmt) {
+        #vprintf(fmt + "\n", argv);
+        delete argv;
+    }
+}
+
+public class TableMapperPerformanceTest inherits QUnit::Test {
+    private {
+        AbstractSchema schema;
+        AbstractTable table;
+
+        const Map1 = (
+            "id": ("sequence": "seq_table_mapper_test"),
+            );
+
+        const MyOpts = Opts + (
+            "block": "b,block=i",
+            "connstr": "c,conn=s",
+            "rows": "r,rows=i",
+            );
+
+        const DefaultRows = 100;
+
+        const DefaultBlockSize = 1000;
+
+        const OptionColumn = 22;
+
+        int rows;
+        int block;
+    }
+
+    constructor(any args, *hash mopts) : Test("TableMapperPerformanceTest", "1.0", \args, mopts ?? MyOpts) {
+        Datasource ds;
+        try {
+            ds = getDatasource();
+            # create the test schema
+            schema = new TableMapperPerformanceTestSchema(ds);
+            schema.align(False, m_options.verbose);
+            # get table object
+            table = (new Table(schema.getDatasource(), "table_mapper_test")).getTable();
+        }
+        catch (hash ex) {
+            if (m_options.verbose)
+                printf("%s: %s\n", ex.err, ex.desc);
+        }
+        # add test cases
+        addTestCase("InboundTableMapper", \inboundTableMapperPerformanceTest());
+
+        rows = m_options.rows ?? ENV.TABLEMAPPERPERFORMANCETEST_ROWS ?? DefaultRows;
+        if (rows < 1)
+            throw "ROWS-ERROR", sprintf("rows value: %d must be > 0", rows);
+
+        block = m_options.block ?? ENV.TABLEMAPPERPERFORMANCETEST_BLOCK ?? DefaultBlockSize;
+        if (block < 1)
+            throw "BLOCKSIZE-ERROR", sprintf("block size value: %d must be > 0", block);
+
+        set_return_value(main());
+    }
+
+    globalTearDown() {
+        # drop the test schema
+        if (schema)
+            schema.drop(False, m_options.verbose);
+    }
+
+    private usageIntern() {
+        TestReporter::usageIntern(OptionColumn);
+        printOption("-c,--conn=ARG", "set DB connection argument (ex: \"driver:user/pass@db\")", OptionColumn);
+        printOption("-r,--rows=ARG", sprintf("the number of rows to insert (default: %d)", ENV.TABLEMAPPERPERFORMANCETEST_ROWS ?? DefaultRows), OptionColumn);
+    }
+
+    inboundTableMapperPerformanceTest() {
+        if (!table)
+            testSkip("no DB connection");
+
+        hash cmap = map {
+            "ncol_" + $1: ("constant": rand() % 10000),
+        }, xrange(39);
+
+        cmap += map {
+            "strcol_" + $1: ("constant": get_random_string(TableMapperPerformanceTestSchema::ColumnWidth)),
+        }, xrange(39);
+
+        hash vmap = map {
+            "var_" + $1: True,
+        }, xrange(3);
+
+        # prepare map hash
+        hash map1 = Map1 + cmap + vmap;
+
+        # prepare input data for mapper
+        hash h = map {
+            "var_" + $1: (),
+        }, xrange(3);
+
+        map (map h{$1} += strmul("x", TableMapperPerformanceTestSchema::ColumnWidth), (map "var_" + $1, xrange(3))), xrange(rows - 1);
+
+        #printf("map1: %N\n", map1);
+        #printf("h: %N\n", h);
+
+        InboundTableMapper mapper(table, map1, ("insert_block": block));
+
+        printf("starting test inserting %d rows in %s:%s (block size %d)\n", rows, table.getDatasource().getDriverName(), table.getSqlName(), block);
+
+        date now = now_us();
+
+        {
+            on_error {
+                mapper.discard();
+                mapper.rollback();
+            }
+            on_success {
+                mapper.flush();
+                mapper.commit();
+            }
+
+            mapper.queueData(h);
+        }
+
+        date delta = now_us() - now;
+        float dt = delta.durationSecondsFloat();
+        float rps = dt ? rows / dt : 0;
+        printf("elapsed time: %y rows/s: %s\n", delta, rps);
+    }
+
+    Datasource getDatasource() {
+        if (!m_options.connstr)
+            m_options.connstr = ENV.QORE_DB_CONNSTR_ORACLE ?? ENV.QORE_DB_CONNSTR_PGSQL ?? ENV.QORE_DB_CONNSTR_MYSQL ?? ENV.QORE_DB_CONNSTR_FREETDS ?? ENV.QORE_DB_CONNSTR_SYBASE;
+        Datasource ds(m_options.connstr);
+        ds.open();
+        return ds;
+    }
+}

--- a/qlib/Mapper.qm
+++ b/qlib/Mapper.qm
@@ -916,7 +916,7 @@ Mapper mapv(DataMap);
             map h{$1.key} = m_runtime{$1.value}, rconsth.pairIterator();
 
             # iterate through dynamic target fields
-            map h{$1} = mapFieldIntern($1, rec), mapd.keyIterator();
+            map mapFieldIntern(\h, $1, rec), mapd.keyIterator();
 
             # increment record count
             ++count;
@@ -924,12 +924,14 @@ Mapper mapv(DataMap);
             return h;
         }
 
-        private any mapFieldIntern(string key, hash rec, *bool do_list) {
+        #! maps a single field to the target
+        private nothing mapFieldIntern(reference h, string key, hash rec, *bool do_list) {
             hash m = mapc{key};
 
             # closure to get the current record hash from a hash of lists
-            code getrec = hash sub (int offset) {
-                return map {$1.key: $1.value[offset] ?? $1.value}, rec.pairIterator();
+            # rec is not bound here for performance reasons (so it will remain unlocked)
+            code getrec = hash sub (hash rc, int offset) {
+                return map {$1.key: $1.value[offset] ?? $1.value}, rc.pairIterator();
             };
 
             # get source field name
@@ -940,11 +942,11 @@ Mapper mapv(DataMap);
             if (exists m.constant)
                 v = m.constant;
             else if (exists m.index) {
-                v = do_list ? (map m.index + count + $#, xrange(v.size() - 1)) : m.index + count;
+                v = do_list ? (map m.index + count + $#, v) : m.index + count;
             }
             else if (exists m.runtime) {
                 any rtv = m_runtime{m.runtime};
-                v = do_list ? (map rtv, xrange(v.size() - 1)) : rtv;
+                v = do_list ? (map rtv, v) : rtv;
             }
             else if (m.struct) {
                 # NOTE: hash of lists not supported with struct
@@ -970,7 +972,7 @@ Mapper mapv(DataMap);
             if (m.code) {
                 try {
                     v = do_list
-                        ? (map m.code($1, getrec($#)), v)
+                        ? (map m.code($1, getrec(rec, $#)), v)
                         : m.code(v, rec);
                 }
                 catch (hash ex) {
@@ -989,14 +991,14 @@ Mapper mapv(DataMap);
 
             if (m.type) {
                 if (do_list)
-                    map mapFieldType(key, m, \v[$#], getrec($#)), xrange(v.size() - 1), v[$#].typeCode() != m.typeCode;
+                    map mapFieldType(key, m, \v[$#], getrec(rec, $#)), v, $1.typeCode() != m.typeCode;
                 else
                     mapFieldType(key, m, \v, rec);
             }
 
             if (exists m."default") {
                 if (do_list) {
-                    map v[$#] = m."default", xrange(v.size() - 1), !exists v[$#];
+                    map v[$#] = m."default", v, !exists $1;
                 }
                 else if (!exists v)
                     v = m."default";
@@ -1006,9 +1008,9 @@ Mapper mapv(DataMap);
             if (m.maxlen) {
                 if (do_list) {
                     if (m.trunc)
-                        map v[$1] = truncateField(key, v[$1], $1, v.size(), m.maxlen), xrange(v.size() - 1), v[$#].size() > m.maxlen;
+                        map v[$1] = truncateField(key, $1, $#, v.size(), m.maxlen), v, $1.size() > m.maxlen;
                     else
-                        map fieldLengthError(key, $1, $#, v.size(), m.maxlen, getrec($#)), v, $1.size() > m.maxlen;
+                        map fieldLengthError(key, $1, $#, v.size(), m.maxlen, getrec(rec, $#)), v, $1.size() > m.maxlen;
                 }
                 else {
                     if (v.size() > m.maxlen) {
@@ -1026,7 +1028,7 @@ Mapper mapv(DataMap);
 
             if (m.mand) {
                 if (do_list) {
-                    map error2("MISSING-INPUT", "field %y element %d/%d is marked as mandatory but is missing in the input row: %y", getFieldName(key), $# + 1, v.size(), getrec($#)), v, !exists $1;
+                    map error2("MISSING-INPUT", "field %y element %d/%d is marked as mandatory but is missing in the input row: %y", getFieldName(key), $# + 1, v.size(), getrec(rec, $#)), v, !exists $1;
                 }
                 else if (!exists v)
                     error2("MISSING-INPUT", "field %y is marked as mandatory but is missing in the input row: %y", getFieldName(key), rec);
@@ -1036,18 +1038,19 @@ Mapper mapv(DataMap);
             if (m.ostruct) {
                 # NOTE: ostruct is not supported in list mode
                 # recursive closure for generating structured data
-                code ah = any sub (any ch, int off = 0) {
+                code ah = any sub (*hash ch, any vc, int off = 0) {
                     if (off == m.ostruct.size())
-                        return v;
+                        return vc;
                     string k = m.ostruct[off];
                     any oh = ch{k};
                     if (exists oh && oh.typeCode() != NT_HASH)
                         throw "INVALID-OUTPUT", sprintf("field %y cannot overwrite element %y with type %y", getFieldName(key), k, oh.type());
-                    ch{k} = ah(oh, off + 1);
+                    ch{k} = ah(oh, vc, off + 1);
                     return ch;
                 };
                 try {
-                    return ah((key: v));
+                    h = ah(h, v);
+                    return;
                 }
                 catch (hash ex) {
                     if (ex.err == "INVALID-OUTPUT")
@@ -1057,7 +1060,7 @@ Mapper mapv(DataMap);
                 }
             }
 
-            return v;
+            h{key} = v;
         }
 
         #! called to truncate fields when processing hashes of lists

--- a/qlib/Mapper.qm
+++ b/qlib/Mapper.qm
@@ -35,7 +35,7 @@
 %new-style
 
 module Mapper {
-    version = "1.2";
+    version = "1.3";
     desc = "user module providing basic data mapping infrastructure";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -219,6 +219,9 @@ m.mapData(input2);           # date_begin is still the same as from beginning of
 
     @section mapperrelnotes Release Notes
 
+    @subsection mapperv1_3 Mapper v1.3
+    - internal updates to allow for TableMapper insert performance improvements (<a href="https://github.com/qorelanguage/qore/issues/1626">issue 1626</a>)
+
     @subsection mapperv1_2 Mapper v1.2
     - significantly improved mapper performance with identity (i.e. 1:1) and constant mappings (<a href="https://github.com/qorelanguage/qore/issues/1620">issue 1620</a>)
 
@@ -382,6 +385,9 @@ public namespace Mapper {
 
             #! map of constant fields
             hash consth;
+
+            #! map of constant runtime fields
+            hash rconsth;
         }
 
         #! builds the object based on a hash providing field mappings, data constraints, and optionally custom mapping logic
@@ -516,6 +522,9 @@ Mapper mapv(DataMap);
             }
             if (consth) {
                 mapd -= keys consth;
+            }
+            if (rconsth) {
+                mapd -= keys rconsth;
             }
         }
 
@@ -664,8 +673,26 @@ Mapper mapv(DataMap);
                 fh.type = "number";
                 delete fh.number;
             }
-            else if (exists fh.type && !vt.(fh.type))
-                error("output field %y contains an invalid type value '%s' (valid types: %y)", getFieldName(k), fh.type, vt.keys());
+            else if (exists fh.type) {
+                if (!vt.(fh.type))
+                    error("output field %y contains an invalid type value '%s' (valid types: %y)", getFieldName(k), fh.type, vt.keys());
+                switch (fh.type) {
+                    case "date": {
+                        if (!timezone)
+                            fh.typeCode = NT_DATE;
+                        break;
+                    }
+                    case "string": {
+                        fh.typeCode = NT_STRING;
+                        break;
+                    }
+                    case "integer":
+                    case "int": {
+                        fh.typeCode = NT_INT;
+                        break;
+                    }
+                }
+            }
 
             if (exists fh.code && !fh.code.callp())
                 error("output field %y has a code argument assigned to type '%s'", getFieldName(k), fh.code.type());
@@ -689,6 +716,8 @@ Mapper mapv(DataMap);
                 # add to consth if a constant value is included
                 if (fh.constant)
                     consth{k} = fh.constant;
+                if (fh.runtime)
+                    rconsth{k} = fh.runtime;
                 mapo{k} = NOTHING;
             }
         }
@@ -877,110 +906,170 @@ Mapper mapv(DataMap);
 
             # first copy all 1:1 mappings to the output hash
             if (identl)
-                h = rec{identl};
+                h += rec{identl};
 
             # copy all constant mappings to the output hash
             if (consth)
                 h += consth;
 
+            # copy all runtime constant mappings to the output hash
+            map h{$1.key} = m_runtime{$1.value}, rconsth.pairIterator();
+
             # iterate through dynamic target fields
-            foreach string key in (mapd.keyIterator()) {
-                hash m = mapc{key};
-
-                # get source field name
-                string name = m.name ?? key;
-
-                # get source record value
-                any v;
-                if (exists m.constant)
-                    v = m.constant;
-                else if (exists m.index)
-                    v = m.index + count;
-                else if (m.runtime) {
-                    v = m_runtime{m.runtime}; # TODO/FIXME: throw an exception if it does not exist?
-                }
-                else if (m.struct) {
-                    # get the value
-                    v = rec;
-                    map v = v{m.struct[$1]}, xrange(0, m.struct.size() - 1);
-                }
-                else
-                    v = rec{name} ?? NOTHING;
-
-                # move any XML CDATA into the field value
-                if (v."^cdata^")
-                    v = v."^cdata^";
-
-                # if the internal field was marked as needing processing by a subclass, then call the mapSubclass method
-                if (m.subclass)
-                    v = mapSubclass(m, v);
-
-                # execute any field filter if necessary
-                if (m.code) {
-                    try {
-                        v = m.code(v, rec);
-                    }
-                    catch (hash ex) {
-                        ex.desc = sprintf("field %y closure: %s", key, ex.desc);
-                        throw ex.err, ex.desc, ex.arg;
-                    }
-                }
-
-                if ((m_empty_strings_to_nothing && v === "") || v === NULL)
-                    delete v;
-
-                if (m.type)
-                    mapFieldType(key, m, \v, rec);
-
-                if (exists m."default" && !exists v)
-                    v = m."default";
-
-                # check maximum length
-                if (m.maxlen && v.size() > m.maxlen) {
-                    # truncate the string if necessary
-                    if (m.trunc) {
-                        if (info_log)
-                            info_log("field %y = %y input length %d truncating to %d bytes", getFieldName(key), v, v.size(), m.maxlen);
-                        v = trunc_str(v, m.maxlen, encoding);
-                    }
-                    else
-                        error2("STRING-TOO-LONG", "field %y = %y, input length %d exceeds maximum byte length %d for input row: %y", getFieldName(key), v, strlen(v), m.maxlen, rec);
-                }
-
-                if (m.mand && !exists v)
-                    error2("MISSING-INPUT", "field %y is marked as mandatory but is missing in the input row: %y", getFieldName(key), rec);
-
-                # add value to row list
-                if (m.ostruct) {
-                    # recursive closure for generating structured data
-                    code ah = any sub (any ch, int off = 0) {
-                        if (off == m.ostruct.size())
-                            return v;
-                        string k = m.ostruct[off];
-                        any oh = ch{k};
-                        if (exists oh && oh.typeCode() != NT_HASH)
-                            throw "INVALID-OUTPUT", sprintf("field %y cannot overwrite element %y with type %y", getFieldName(key), k, oh.type());
-                        ch{k} = ah(oh, off + 1);
-                        return ch;
-                    };
-                    try {
-                        h = ah(h);
-                    }
-                    catch (hash ex) {
-                        if (ex.err == "INVALID-OUTPUT")
-                            error2(ex.err, ex.desc);
-                        else
-                            rethrow;
-                    }
-                }
-                else
-                    h{key} = v;
-            }
+            map h{$1} = mapFieldIntern($1, rec), mapd.keyIterator();
 
             # increment record count
             ++count;
 
             return h;
+        }
+
+        private any mapFieldIntern(string key, hash rec, *bool do_list) {
+            hash m = mapc{key};
+
+            # closure to get the current record hash from a hash of lists
+            code getrec = hash sub (int offset) {
+                return map {$1.key: $1.value[offset] ?? $1.value}, rec.pairIterator();
+            };
+
+            # get source field name
+            string name = m.name ?? key;
+
+            # get source record value
+            any v;
+            if (exists m.constant)
+                v = m.constant;
+            else if (exists m.index) {
+                v = do_list ? (map m.index + count + $#, xrange(v.size() - 1)) : m.index + count;
+            }
+            else if (exists m.runtime) {
+                any rtv = m_runtime{m.runtime};
+                v = do_list ? (map rtv, xrange(v.size() - 1)) : rtv;
+            }
+            else if (m.struct) {
+                # NOTE: hash of lists not supported with struct
+                v = rec;
+                map v = v{m.struct[$1]}, xrange(0, m.struct.size() - 1);
+            }
+            else
+                v = rec{name} ?? NOTHING;
+
+            if (do_list && v.typeCode() != NT_LIST)
+                error2("MAPPER-FIELD-LIST-ERROR", "field %y value passed is %y in list mode; expecting \"list\"", key, v.type());
+
+            # move any XML CDATA into the field value
+            # NOTE: cdata not supported with hashes of lists
+            if (v."^cdata^")
+                v = v."^cdata^";
+
+            # if the internal field was marked as needing processing by a subclass, then call the mapSubclass method
+            if (m.subclass)
+                v = do_list ? (map mapSubclass(m, $1), v) : mapSubclass(m, v);
+
+            # execute any field filter if necessary
+            if (m.code) {
+                try {
+                    v = do_list
+                        ? (map m.code($1, getrec($#)), v)
+                        : m.code(v, rec);
+                }
+                catch (hash ex) {
+                    ex.desc = sprintf("field %y closure: %s", key, ex.desc);
+                    throw ex.err, ex.desc, ex.arg;
+                }
+            }
+
+            if (do_list) {
+                map delete v[$#], v, (m_empty_strings_to_nothing && $1 === "" || $1 === NULL);
+            }
+            else {
+                if ((m_empty_strings_to_nothing && v === "") || v === NULL)
+                    delete v;
+            }
+
+            if (m.type) {
+                if (do_list)
+                    map mapFieldType(key, m, \v[$#], getrec($#)), xrange(v.size() - 1), v[$#].typeCode() != m.typeCode;
+                else
+                    mapFieldType(key, m, \v, rec);
+            }
+
+            if (exists m."default") {
+                if (do_list) {
+                    map v[$#] = m."default", xrange(v.size() - 1), !exists v[$#];
+                }
+                else if (!exists v)
+                    v = m."default";
+            }
+
+            # check maximum length
+            if (m.maxlen) {
+                if (do_list) {
+                    if (m.trunc)
+                        map v[$1] = truncateField(key, v[$1], $1, v.size(), m.maxlen), xrange(v.size() - 1), v[$#].size() > m.maxlen;
+                    else
+                        map fieldLengthError(key, $1, $#, v.size(), m.maxlen, getrec($#)), v, $1.size() > m.maxlen;
+                }
+                else {
+                    if (v.size() > m.maxlen) {
+                        # truncate the string if necessary
+                        if (m.trunc) {
+                            if (info_log)
+                                info_log("field %y = %y input length %d truncating to %d bytes", getFieldName(key), v, v.size(), m.maxlen);
+                            v = trunc_str(v, m.maxlen, encoding);
+                        }
+                        else
+                            error2("STRING-TOO-LONG", "field %y = %y, input length %d exceeds maximum byte length %d for input row: %y", getFieldName(key), v, strlen(v), m.maxlen, rec);
+                    }
+                }
+            }
+
+            if (m.mand) {
+                if (do_list) {
+                    map error2("MISSING-INPUT", "field %y element %d/%d is marked as mandatory but is missing in the input row: %y", getFieldName(key), $# + 1, v.size(), getrec($#)), v, !exists $1;
+                }
+                else if (!exists v)
+                    error2("MISSING-INPUT", "field %y is marked as mandatory but is missing in the input row: %y", getFieldName(key), rec);
+            }
+
+            # add value to row list
+            if (m.ostruct) {
+                # NOTE: ostruct is not supported in list mode
+                # recursive closure for generating structured data
+                code ah = any sub (any ch, int off = 0) {
+                    if (off == m.ostruct.size())
+                        return v;
+                    string k = m.ostruct[off];
+                    any oh = ch{k};
+                    if (exists oh && oh.typeCode() != NT_HASH)
+                        throw "INVALID-OUTPUT", sprintf("field %y cannot overwrite element %y with type %y", getFieldName(key), k, oh.type());
+                    ch{k} = ah(oh, off + 1);
+                    return ch;
+                };
+                try {
+                    return ah((key: v));
+                }
+                catch (hash ex) {
+                    if (ex.err == "INVALID-OUTPUT")
+                        error2(ex.err, ex.desc);
+                    else
+                        rethrow;
+                }
+            }
+
+            return v;
+        }
+
+        #! called to truncate fields when processing hashes of lists
+        private string truncateField(string k, string val, int ix, int sze, int maxlen) {
+            if (info_log)
+                info_log("field %y = %y element %d/%d input length %d truncating to %d bytes", getFieldName(k), val, ix + 1, sze, val.size(), maxlen);
+            return trunc_str(val, maxlen, encoding);
+        }
+
+        #! called when a field exceeds its maximum length when processing hashes of lists
+        private fieldLengthError(string k, string val, int ix, int sze, int maxlen, hash rc) {
+            error2("STRING-TOO-LONG", "field %y = %y element %d/%d, input length %d exceeds maximum byte length %d for input row: %y", getFieldName(k), val, ix + 1, val.size(), maxlen, rc);
         }
 
         #! calls the output logging @ref closure "closure" or @ref call_reference "call reference" (if any) to log the output record

--- a/qlib/TableMapper.qm
+++ b/qlib/TableMapper.qm
@@ -40,7 +40,7 @@
 %requires SqlUtil
 
 module TableMapper {
-    version = "1.1.1";
+    version = "1.1.2";
     desc = "user module providing data mapping infrastructure to an SQL Table target";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -198,6 +198,9 @@ on_error table1.rollback();
     Additionally, the value is provided to any row code set with @ref TableMapper::InboundTableMapper::setRowCode(); see @ref tablemapper_bulk_insert_api for more information.
 
     @section tablemapperrelnotes Release Notes
+
+    @subsection tablemapperv1_1_2 TableMapper v1.1.2
+    - performance enhancements for @ref TableMapper::InboundTableMapper::queueData() "InboundTableMapper::queueData()" when called with a hash of lists (<a href="https://github.com/qorelanguage/qore/issues/1626">issue 1626</a>)
 
     @subsection tablemapperv1_1_1 TableMapper v1.1.1
     - fixed runtime option propagation to @ref TableMapper::SqlStatementMapperIterator "SqlStatementMapperIterator" from @ref TableMapper::AbstractSqlStatementOutboundMapper::iterator() "AbstractSqlStatementOutboundMapper::iterator()" (<a href="https://github.com/qorelanguage/qore/issues/1418">issue 1418</a>)
@@ -616,6 +619,7 @@ on_error table_mapper.rollback();
             - this method and batched inserts in general cannot be used when the \c "unstable_input" option is given in the constructor
             - if the \c "insert_block" option is set to 1, then this method simply calls insertRow()
             - if an error occurs flushing data, the count is reset by calling @ref Mapper::Mapper::resetCount() "Mapper::resetCount()"
+            - in case a hash of lists is passed, then the the underlying @ref Mapper::Mapper "Mapper" object does not support structured input or output or XML CDATA in the input; hash of lists data is assumed to come from an SQL query
 
             @see
             - flush()
@@ -630,10 +634,13 @@ on_error table_mapper.rollback();
             if (unstable_input)
                 throw "MAPPER-BATCH-ERROR", sprintf("cannot call %s::queueData() when the unstable_input option is set", self.className());
 
-            if (rec.firstValue().typeCode() == NT_LIST) {
+            if (rec.firstValue().typeCode() != NT_LIST)
+                return queueDataIntern(rec + crec);
+
+            if (insert_block == 1) {
                 hash h;
                 foreach hash row in (rec.contextIterator()) {
-                    *hash th = queueDataIntern(row + crec);
+                    *hash th = insertRow(row);
                     if (th) {
                         if (h)
                             map h.$1 += th.$1, th.keyIterator();
@@ -644,7 +651,46 @@ on_error table_mapper.rollback();
                 return h;
             }
 
-            return queueDataIntern(rec + crec);
+            hash dh;
+
+            # first copy all 1:1 mappings to the output hash
+            if (identl)
+                dh = rec{identl};
+
+            # copy all runtime mappings to the output hash
+            map dh{$1.key} = m_runtime{$1.value}, rconsth.pairIterator();
+
+            map dh.$1 = mapFieldIntern($1, rec, True), mapd.keyIterator();
+
+            # map record data to get the keys for the buffer
+            if (!hbuf) {
+                # copy all constant mappings to the output hash
+                if (consth)
+                    hbuf += consth;
+                if (crec)
+                    hbuf += crec;
+
+                # add mapped data
+                hbuf += dh;
+            }
+            else
+                map hbuf{$1.key} += $1.value, dh.pairIterator();
+
+            # return nothing if nothing needs to be flushed
+            if (hbuf.firstValue().size() < insert_block)
+                return;
+
+            hash h;
+            # return all target data
+            *hash th = flushIntern();
+
+            if (th) {
+                if (h)
+                    map h.$1 += th.$1, th.keyIterator();
+                else
+                    h = th;
+            }
+            return h;
         }
 
         #! inserts a set of rows (list of hashes) into the block buffer based on a mapped input record; the block buffer is flushed to the DB if the buffer size reaches the limit defined by the \c "insert_block" option; does not commit the transaction

--- a/qlib/TableMapper.qm
+++ b/qlib/TableMapper.qm
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! @file TableMapper.qm provides mapping functionality to an SQL Table target
 
-/*  TableMapper.qm Copyright 2014 - 2016 Qore Technologies, s.r.o.
+/*  TableMapper.qm Copyright 2014 - 2017 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -619,7 +619,7 @@ on_error table_mapper.rollback();
             - this method and batched inserts in general cannot be used when the \c "unstable_input" option is given in the constructor
             - if the \c "insert_block" option is set to 1, then this method simply calls insertRow()
             - if an error occurs flushing data, the count is reset by calling @ref Mapper::Mapper::resetCount() "Mapper::resetCount()"
-            - in case a hash of lists is passed, then the the underlying @ref Mapper::Mapper "Mapper" object does not support structured input or output or XML CDATA in the input; hash of lists data is assumed to come from an SQL query
+            - in case a hash of lists is passed in \a rec, then the the underlying @ref Mapper::Mapper "Mapper" object does not support structured input or output or XML CDATA in the input (input data in this format is assumed to come from an SQL query); note that this provides very high performance with SQL drivers that support Bulk DML
 
             @see
             - flush()
@@ -660,7 +660,7 @@ on_error table_mapper.rollback();
             # copy all runtime mappings to the output hash
             map dh{$1.key} = m_runtime{$1.value}, rconsth.pairIterator();
 
-            map dh.$1 = mapFieldIntern($1, rec, True), mapd.keyIterator();
+            map mapFieldIntern(\dh, $1, rec, True), mapd.keyIterator();
 
             # map record data to get the keys for the buffer
             if (!hbuf) {


### PR DESCRIPTION
please see benchmarks here: https://docs.google.com/spreadsheets/d/1pTsV3mXZ6M0EUlszswMUdEdWEtiaEgxrwXmLQ7VM65A/edit#gid=1059708833

`Post5` is the algorithm represented by this pull request, `Pre` is the implementation before the changes - xbox is not reliable for performance testing because the DB performance there varies to a great degree due to all the VMs and other activity on that machine.

The performance test script tests a situation where there are a lot of constant mappings and a few fields that are subject to real mappings - the performance benefit is due to skipping detailed mapping for constant / runtime options that are the same for each row - and passing these as a flat hash so that drivers that support Bulk DML (i.e. oracle - I tested only with oracle) will bind these once when performing Bulk DML binds - then performing mapping transformations in place with hash of lists format - so that the input data is not converted unnecessarily from hash of lists format to a list of hashes (as in the old implementation) and then back again to hash of lists format for Bulk DML binding.

Basically only `TableMapper::queueData()` is affected by this change, however this is the method that is used when making Bulk DML selects and then submitting for mapping and inserting.

The performance benefits reach that of `BulkInsertOperation` while still performing data mappings (ex: what we saw with MIP 70B with Rossini Early Bird for example).