### PR TITLE
Bugfix/1660 sql util op in fixes

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -12,6 +12,8 @@
     - fixed bug in internal string generation with \c size_t arguments that could cause invalid data to be output or crashes on 32-bit platforms (<a href="https://github.com/qorelanguage/qore/issues/1640">issue 1640</a>)
     - fixed a runtime memory leak and invalid runtime behavior with undetected recursive lvalue references (<a href="https://github.com/qorelanguage/qore/issues/1617">issue 1617</a>)
     - improved @ref garbage_collection "prompt collection" performance with large graphs of objects by eliminating additional unnecessary graph scans, resulting in further large performance improvements in the garbage collector (<a href="https://github.com/qorelanguage/qore/issues/1363">issue 1363</a>)
+    - <a href="../../modules/OracleSqlUtil/html/index.html">OracleSqlUtil</a> module fixes:
+      - worked around ORA-22165 from op_in() caused by Oracle's limit on number of collection elements (<a href="https://github.com/qorelanguage/qore/issues/1660">issue 1660</a>)
 
     @section qore_08126 Qore 0.8.12.6
 

--- a/examples/test/qlib/SqlUtil/SqlUtilTestBase.qm
+++ b/examples/test/qlib/SqlUtil/SqlUtilTestBase.qm
@@ -514,6 +514,25 @@ public class SqlTestBase inherits QUnit::Test {
                         "data": (("id": 1),),
                         ),
                     ),
+                "op_in_empty": (
+                    "in": (
+                        "where": ("id": op_in(list())),
+                        ),
+                    "out": (
+                        "count": 0,
+                        "data": (),
+                        ),
+                    ),
+                "op_in_large": (
+                    "in": (
+                        "where": ("id": op_in(range(32767))), # value 32767 is enough to trigger Oracle's ORA-22165
+                        "orderby": ("id",)
+                        ),
+                    "out": (
+                        "count": 2,
+                        "data": (("id": 1), ("id": 2)),
+                        ),
+                    ),
                 "op_not": (
                     "in": (
                         "where": ("id": op_not (op_in((0,1,3)))),

--- a/examples/test/qlib/SqlUtil/SqlUtilTestBase.qm
+++ b/examples/test/qlib/SqlUtil/SqlUtilTestBase.qm
@@ -532,6 +532,7 @@ public class SqlTestBase inherits QUnit::Test {
                         "count": 2,
                         "data": (("id": 1), ("id": 2)),
                         ),
+                    "skip_for": ("FreetdsTest"), # TODO: remove once support is implemented in FreetdsSqlUtil
                     ),
                 "op_not": (
                     "in": (
@@ -638,6 +639,10 @@ public class SqlTestBase inherits QUnit::Test {
                 );
 
         foreach hash t in (test_set.pairIterator()) {
+            if (inlist (self.className(), t.value.skip_for)) {
+                assertSkip (t.value.skip_for + " might fail this test");
+                continue;
+            }
             *list rows = table.selectRows (t.value.in, \sql);
             hash out = t.value.out;
             assertEq (out.count, rows.size(), "checking where operator " + t.key);

--- a/qlib/FreetdsSqlUtil.qm
+++ b/qlib/FreetdsSqlUtil.qm
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 # @file FreetdsSqlUtil.qm Qore user module for working with PostgreSQL SQL data
 
-/*  FreetdsSqlUtil.qm Copyright (C) 2015 - 2016 Qore Technologies, s.r.o.
+/*  FreetdsSqlUtil.qm Copyright (C) 2015 - 2017 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -63,6 +63,9 @@ module FreetdsSqlUtil {
     @note This module requires the <a href="https://github.com/qorelanguage/module-sybase">freetds</a> binary module for communication with MS SQL Server and Sybase databases
 
     @section freetds_sql_operations SQL Operations with the FreeTDS Driver
+
+    Queries are limited in the number of arguments in the \c "in" operator depending on the database server; use a join with a temporary table
+    to select a large number of values known at runtime instead of using the \c "in" operator (see @ref SqlUtil::op_in()).
 
     %FreetdsSqlUtil supports the following additional @ref select_option_hash "select option" when working with MS SQL Server databases:
     - \c "tablehint": A single string or a list of strings with the following possible values:
@@ -941,7 +944,7 @@ my any $v = $c.name;
             #! where operator specializations for FreeTDS
             const FreetdsOpMap = DefaultOpMap + (
                 OP_SUBSTR: (
-                    "code": string sub (object t, string cn, any arg, reference args, *hash jch, bool join = False, *hash ch, *hash psch) {
+                    "code": string sub (object t, string cn, softlist arg, reference args, *hash jch, bool join = False, *hash ch, *hash psch) {
                         args += arg[0]; # start
                         if (!exists arg[1]) {
                             args += arg[2]; # text

--- a/qlib/OracleSqlUtil.qm
+++ b/qlib/OracleSqlUtil.qm
@@ -1837,8 +1837,8 @@ my any $v = $c.name;
                                 case NT_NOTHING:
                                     continue;
                                 case NT_DATE:
-                                case NT_FLOAT:
                                 case NT_INT:
+                                case NT_FLOAT:
                                 case NT_NUMBER:
                                 case NT_STRING:
                                     ltype = it.getValue().typeCode();
@@ -1849,21 +1849,32 @@ my any $v = $c.name;
                             if (ltype) break;
                         }
 
-                        # Bind to oracle by expected type
-                        switch (ltype) {
-                            case NT_DATE:
-                                args += bindOracleCollection("SYS.ODCIDATELIST", arg);
-                                break;
-                            case NT_FLOAT:
-                            case NT_NUMBER:
-                            case NT_INT:
-                                args += bindOracleCollection("SYS.ODCINUMBERLIST", arg);
-                                break;
-                            default:
-                                args += bindOracleCollection("SYS.ODCIVARCHAR2LIST", arg);
+                        # Split long array to chunks of no more than 32767 elements due to Oracle limitation
+                        # "ORA-22165: OCI-22165: given index [32767] must be in the range of [0] to [32766]"
+                        int count;
+                        while (arg.size()) {
+                            ++count;
+                            list chunk = extract arg, 0, 32767;
+
+                            # Bind to Oracle by expected type
+                            switch (ltype) {
+                                case NT_DATE:
+                                    args += bindOracleCollection("SYS.ODCIDATELIST", chunk);
+                                    break;
+                                case NT_INT:
+                                case NT_FLOAT:
+                                case NT_NUMBER:
+                                    args += bindOracleCollection("SYS.ODCINUMBERLIST", chunk);
+                                    break;
+                                default:
+                                    args += bindOracleCollection("SYS.ODCIVARCHAR2LIST", chunk);
+                            }
                         }
 
-                        return cn + " in (select column_value from table(%v))";
+                        if (count)
+                            return cn + " in (" + (map "select column_value from table(%v)", range(1,count)).join(" union all ") + ")";
+                        else
+                            return "1 != 1";
 %endif
 %ifdef NO_ORACLE
                         throw "MISSING-ORACLE-DRIVER", "op_in requires oracle driver";

--- a/qlib/OracleSqlUtil.qm
+++ b/qlib/OracleSqlUtil.qm
@@ -257,6 +257,7 @@ my hash $schema = (
 
     @subsection v121 OracleSqlUtil v1.2.1
     - implemented the \a force option (i.e. cascade) for dropping code objects (<a href="https://github.com/qorelanguage/qore/issues/1314">issue 1314</a>)
+    - worked around ORA-22165 from op_in() caused by Oracle's limit on number of collection elements (<a href="https://github.com/qorelanguage/qore/issues/1660">issue 1660</a>)
 
     @subsection v12 OracleSqlUtil v1.2
     - implemented support for the \c "returning" clause as an insert option
@@ -1872,7 +1873,7 @@ my any $v = $c.name;
                         }
 
                         if (count)
-                            return cn + " in (" + (map "select column_value from table(%v)", range(1,count)).join(" union all ") + ")";
+                            return cn + " in (" + (map "select column_value from table(%v)", xrange(1,count)).join(" union all ") + ")";
                         else
                             return "1 != 1";
 %endif

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -3827,7 +3827,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @return a where operation description hash for use in @ref where_clauses "where clauses"
 
-        @note Number of arguments may be constrained depending on the database server / driver used. Too many arguments may be a sign of an improper application design.
+        @note The argument list size may be constrained depending on the database server / driver used; passing a large number of arguments to this function may be a sign of an improper application or query design; consider using a join with a temporary table instead of passing a large number of arguments to this function
     */
     public hash sub op_in() {
         return make_op(OP_IN, argv);
@@ -3843,7 +3843,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @return a where operation description hash for use in @ref where_clauses "where clauses"
 
-        @note The argument list size may be constrained depending on the database server / driver used. Too long list may be a sign of an improper application design.
+        @note The argument list size may be constrained depending on the database server / driver used; passing a large number of arguments to this function may be a sign of an improper application or query design; consider using a join with a temporary table instead of passing a large number of arguments to this function
     */
     public hash sub op_in(list args) {
         return make_op(OP_IN, args);

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -3826,6 +3826,8 @@ int rows_updated = t.update(("counter": uop_divide(2)));
         @endcode
 
         @return a where operation description hash for use in @ref where_clauses "where clauses"
+
+        @note Number of arguments may be constrained depending on the database server / driver used. Too many arguments may be a sign of an improper application design.
     */
     public hash sub op_in() {
         return make_op(OP_IN, argv);
@@ -3840,6 +3842,8 @@ int rows_updated = t.update(("counter": uop_divide(2)));
         @param args a list of values for the \c "in" operator
 
         @return a where operation description hash for use in @ref where_clauses "where clauses"
+
+        @note The argument list size may be constrained depending on the database server / driver used. Too long list may be a sign of an improper application design.
     */
     public hash sub op_in(list args) {
         return make_op(OP_IN, args);


### PR DESCRIPTION
@gamato I agree with your assessment; I don't see any way to work around the query limitations with FreeTDS; for 0.8.13 we can consider redesigning SqlUtil (and child modules) to allow for transaction-based temporary tables to be created on demand and joined to better implement this kind of functionality...