### PR TITLE
refs #1671 fixed pdox script to use /bin/bash instead of /bin/sh that…

### DIFF
--- a/doxygen/pdox
+++ b/doxygen/pdox
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # updates codes for characters that confuse doxygen back to the original characters
 


### PR DESCRIPTION
… does not support double square bracket