### PR TITLE
fixed #1688: sqlutil: oracle: character_semantics can be different fo…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -11,6 +11,8 @@
 
     - fixed a memory leak in @ref try-module "%try-module" error handling (<a href="https://github.com/qorelanguage/qore/issues/1690">issue 1690</a>)
     - fixed a bug in @ref Qore::trunc_str() "trunc_str()" when the string has an invalid multi-byte character at the end of the string and the string is exactly the byte width requested (<a href="https://github.com/qorelanguage/qore/issues/1693">issue 1693</a>)
+    - <a href="../../modules/OracleSqlUtil/html/index.html">OracleSqlUtil</a> module fixes:
+      - fixed a bug in \c character_semantics for standalone column (<a href="https://github.com/qorelanguage/qore/issues/1688">issue 1688</a>)
 
     @section qore_08127 Qore 0.8.12.7
 
@@ -26,7 +28,6 @@
     - <a href="../../modules/OracleSqlUtil/html/index.html">OracleSqlUtil</a> module fixes:
       - worked around \c ORA-22165 from \c op_in() caused by Oracle's limit on number of collection elements (<a href="https://github.com/qorelanguage/qore/issues/1660">issue 1660</a>)
       - fixed a bug in the \a force option (i.e. cascade) for dropping types (<a href="https://github.com/qorelanguage/qore/issues/1683">issue 1683</a>)
-      - fixed a bug in \c character_semantics for standalone column (<a href="https://github.com/qorelanguage/qore/issues/1688">issue 1688</a>)
     - improved @ref try-module "%try-module" error reporting and documentation (<a href="https://github.com/qorelanguage/qore/issues/1648">issue 1648</a>)
 
     @section qore_08126 Qore 0.8.12.6

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -16,6 +16,7 @@
     - <a href="../../modules/OracleSqlUtil/html/index.html">OracleSqlUtil</a> module fixes:
       - worked around \c ORA-22165 from \c op_in() caused by Oracle's limit on number of collection elements (<a href="https://github.com/qorelanguage/qore/issues/1660">issue 1660</a>)
       - fixed a bug in the \a force option (i.e. cascade) for dropping types (<a href="https://github.com/qorelanguage/qore/issues/1683">issue 1683</a>)
+      - fixed a bug in \c character_semantics for standalone column (<a href="https://github.com/qorelanguage/qore/issues/1688">issue 1688</a>)
     - improved @ref try-module "%try-module" error reporting and documentation (<a href="https://github.com/qorelanguage/qore/issues/1648">issue 1648</a>)
 
     @section qore_08126 Qore 0.8.12.6

--- a/examples/test/qlib/SqlUtil/OracleSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/OracleSqlUtil.qtest
@@ -63,8 +63,19 @@ class OracleTestSchema inherits SqlUtilTestSchema {
             "primary_key": ("name": "pk_oracle_test", "columns": ("id")),
             );
 
+        # bug #1688: sqlutil: oracle: character_semantics can be
+        # different for each column, not only for the whole schema
+        # BYTE semantics is forced here because global character_semantics = True
+        const T_OracleTestSemantics = (
+            "columns" : (
+                    "c_char" : c_varchar(1) + ( "character_semantics" : True ),
+                    "c_byte" : c_varchar(1) + ( "character_semantics" : False ),
+                ),
+            );
+
         const Tables = (
             "oracle_test": T_OracleTest,
+            "oracle_test_semantics" : T_OracleTestSemantics,
             );
 
         const Sequences = (
@@ -233,6 +244,16 @@ class OracleTest inherits SqlTestBase {
         c = ds.selectRow("select * from user_tab_columns where table_name = %v and column_name = %v", "ORACLE_TEST", "VARCHAR2_F");
         # it must be C (CHAR) in case of character_semantics=True, B is for BYTE
         assertEq("C", c.char_used, "character_semantics after alignment");
+
+        # bug #1688: sqlutil: oracle: character_semantics can be
+        # different for each column, not only for the whole schema
+        # BYTE semantics is forced here because global character_semantics = True
+        c = ds.selectRow("select * from user_tab_columns where table_name = %v and column_name = %v",
+                         "ORACLE_TEST_SEMANTICS", "C_CHAR");
+        assertEq("C", c.char_used, "character_semantics CHAR enforced");
+        c = ds.selectRow("select * from user_tab_columns where table_name = %v and column_name = %v",
+                         "ORACLE_TEST_SEMANTICS", "C_BYTE");
+        assertEq("B", c.char_used, "character_semantics BYTE enforced");
     }
 
     testSequenceOperators() {

--- a/qlib/OracleSqlUtil.qm
+++ b/qlib/OracleSqlUtil.qm
@@ -46,7 +46,7 @@
 %enable-all-warnings
 
 module OracleSqlUtil {
-    version = "1.2.2";
+    version = "1.2.3";
     desc = "user module for working with Oracle SQL data";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -254,6 +254,9 @@ my hash $schema = (
     @see OracleSqlUtil::OracleDatabase::OracleSchemaDescriptionOptions for a list of Oracle-specific schema description hash keys.
 
     @section ora_relnotes Release Notes
+
+    @subsection v123 OracleSqlUtil v1.2.3
+    - fixed a bug in \c character_semantics for standalone column (<a href="https://github.com/qorelanguage/qore/issues/1688">issue 1688</a>)
 
     @subsection v122 OracleSqlUtil v1.2.2
     - fixed a bug in the \a force option (i.e. cascade) for dropping types (<a href="https://github.com/qorelanguage/qore/issues/1683">issue 1683</a>)

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -8565,7 +8565,10 @@ bool b = table.empty();
             foreach string cn in (desc.columns.keyIterator()) {
                 hash ch = desc.columns{cn};
                 softbool nullable = !exists ch.notnull ? True : !(remove ch.notnull);
-                addColumnUnlocked(cn, ch + oc, nullable ? True : False);
+                # bug #1688: sqlutil: oracle: character_semantics can be
+                # different for each column. So the global options (oc)
+                # are overwriten with column options (ch).
+                addColumnUnlocked(cn, oc + ch, nullable ? True : False);
             }
 
             # add indexes to table


### PR DESCRIPTION
…r each column, not only for the whole schema

@omusil24 please propagate to develop after merging