### PR TITLE
refs #1327 backported the fix for trunc_str() to 0.8.11.1

### DIFF
--- a/include/qore/QoreEncoding.h
+++ b/include/qore/QoreEncoding.h
@@ -62,7 +62,7 @@ typedef qore_size_t (*mbcs_pos_t)(const char* str, const char* ptr, bool &invali
     @param len the number of valid bytes at the start of the character pointer
     @return 0=invalid, positive = number of characters needed, negative numbers = number of additional bytes needed to perform the check
  */
-typedef qore_size_t (*mbcs_charlen_t)(const char* str, qore_size_t valid_len);
+typedef qore_offset_t (*mbcs_charlen_t)(const char* str, qore_size_t valid_len);
 
 class ExceptionSink;
 
@@ -73,7 +73,7 @@ class ExceptionSink;
     have functions implemented.
     @note only encodings that are backwards compatible with ASCII are supported
     by Qore; currently the only multi-byte encoding supported by qore is UTF-8
-    @note the default encoding is represented by QCS_DEFAULT; unless another 
+    @note the default encoding is represented by QCS_DEFAULT; unless another
     encoding is explicitly given, all strings will be tagged with QCS_DEFAULT
     @see QCS_DEFAULT
 */
@@ -97,7 +97,7 @@ public:
    //! gives the length of the string in characters
    /** @param p a pointer to the character data
        @param end a pointer to the next byte after the end of the character data
-       @param invalid if true after executing the function, invalid input was given and the return value should be ignored 
+       @param invalid if true after executing the function, invalid input was given and the return value should be ignored
        @return the number of characters in the string
    */
    DLLLOCAL qore_size_t getLength(const char* p, const char* end, bool &invalid) const {
@@ -116,7 +116,7 @@ public:
    /** @param p a pointer to the character data
        @param end a pointer to the next byte after the end of the character data
        @param c the number of characters to check
-       @param invalid if true after executing the function, invalid input was given and the return value should be ignored 
+       @param invalid if true after executing the function, invalid input was given and the return value should be ignored
        @return the number of bytes for the given number of characters in the string or up to the end of the string
    */
    DLLLOCAL qore_size_t getByteLen(const char* p, const char* end, qore_size_t c, bool& invalid) const {
@@ -135,7 +135,7 @@ public:
    //! gives the character position (number of characters) starting from the first pointer to the second
    /** @param p a pointer to the character data
        @param end a pointer to the next byte after the end of the character data
-       @param invalid if true after executing the function, invalid input was given and the return value should be ignored 
+       @param invalid if true after executing the function, invalid input was given and the return value should be ignored
        @return the number of bytes for the given number of characters in the string
    */
    DLLLOCAL qore_size_t getCharPos(const char* p, const char* end, bool& invalid) const {
@@ -156,10 +156,10 @@ public:
        @param valid_len the number of valid bytes at the start of the character pointer
        @return 0=invalid, positive = number of characters needed, negative numbers = number of additional bytes needed to perform the check
    */
-   DLLLOCAL qore_size_t getCharLen(const char* p, qore_size_t valid_len) const {
+   DLLLOCAL qore_offset_t getCharLen(const char* p, qore_size_t valid_len) const {
       return fcharlen ? fcharlen(p, valid_len) : 1;
    }
-      
+
    //! returns true if the encoding is a multi-byte encoding
    DLLLOCAL bool isMultiByte() const {
       return (bool)flength;
@@ -195,7 +195,7 @@ private:
    DLLLOCAL static encoding_map_t emap;
    DLLLOCAL static const_encoding_map_t amap;
    DLLLOCAL static class QoreThreadLock mutex;
-   
+
    DLLLOCAL static const QoreEncoding* addUnlocked(const char* code, const char* desc, unsigned char maxwidth = 1, mbcs_length_t l = 0, mbcs_end_t e = 0, mbcs_pos_t p = 0, mbcs_charlen_t = 0);
    DLLLOCAL static const QoreEncoding* findUnlocked(const char* name);
 
@@ -224,13 +224,13 @@ public:
 };
 
 DLLEXPORT qore_size_t q_get_byte_len(const QoreEncoding* enc, const char* p, const char* end, qore_size_t c, ExceptionSink* xsink);
-DLLEXPORT qore_size_t q_get_char_len(const QoreEncoding* enc, const char* p, qore_size_t valid_len, ExceptionSink* xsink);
+DLLEXPORT qore_offset_t q_get_char_len(const QoreEncoding* enc, const char* p, qore_size_t valid_len, ExceptionSink* xsink);
 
 //! the QoreEncodingManager object
 DLLEXPORT extern QoreEncodingManager QEM;
 
 // builtin character encodings
-DLLEXPORT extern const QoreEncoding* QCS_DEFAULT, //!< the default encoding for the Qore library 
+DLLEXPORT extern const QoreEncoding* QCS_DEFAULT, //!< the default encoding for the Qore library
    *QCS_USASCII,                                  //!< ascii encoding
    *QCS_UTF8,                                     //!< UTF-8 multi-byte encoding (the only multi-byte encoding, all others are single-byte encodings)
    *QCS_ISO_8859_1,                               //!< latin-1, Western European encoding
@@ -253,6 +253,6 @@ DLLEXPORT extern const QoreEncoding* QCS_DEFAULT, //!< the default encoding for 
    *QCS_KOI7;                                     //!< Russian: Kod Obmena Informatsiey, 7 bit characters
 
 //! returns the length of the next UTF-8 character or 0 for an encoding error or a negative number if the string is too short to represent the character
-DLLEXPORT qore_size_t q_UTF8_get_char_len(const char* p, qore_size_t valid_len);
+DLLEXPORT qore_offset_t q_UTF8_get_char_len(const char* p, qore_size_t valid_len);
 
 #endif // _QORE_CHARSET_H

--- a/lib/QoreFile.cpp
+++ b/lib/QoreFile.cpp
@@ -973,7 +973,7 @@ QoreStringNode *QoreFile::getchar(ExceptionSink *xsink) {
 
       // read in more characters for multi-byte chars if needed
       qore_offset_t rc = priv->charset->getCharLen(str->getBuffer(), 1);
-      // rc < 0: invalid character; but we can't throw an exception here
+      // rc < 0: invalid character
       if (rc <= 0) {
 	 xsink->raiseException("FILE-GETCHAR-ERROR", "invalid multi-byte character received: initial byte 0x%x is an invalid initial character for '%s' character encoding", c, priv->charset->getCode());
 	 return 0;

--- a/lib/QoreFile.cpp
+++ b/lib/QoreFile.cpp
@@ -972,10 +972,9 @@ QoreStringNode *QoreFile::getchar(ExceptionSink *xsink) {
 	 return str.release();
 
       // read in more characters for multi-byte chars if needed
-      qore_size_t rc = priv->charset->getCharLen(str->getBuffer(), 1);
-      // rc == 0: invalid character; but we can't throw an exception here - anyway I think this can't happen with UTF-8 currently
-      //          which is the only multi-byte encoding we currently support
-      if (!rc) {
+      qore_offset_t rc = priv->charset->getCharLen(str->getBuffer(), 1);
+      // rc < 0: invalid character; but we can't throw an exception here
+      if (rc <= 0) {
 	 xsink->raiseException("FILE-GETCHAR-ERROR", "invalid multi-byte character received: initial byte 0x%x is an invalid initial character for '%s' character encoding", c, priv->charset->getCode());
 	 return 0;
       }

--- a/lib/charset.cpp
+++ b/lib/charset.cpp
@@ -104,7 +104,7 @@ const QoreEncoding *QoreEncodingManager::add(const char *code, const char *desc,
 
 QoreEncodingManager::QoreEncodingManager() {
    // add character sets and setup aliases
-   
+
    QCS_USASCII     = addUnlocked("US-ASCII",    "7-bit ASCII character set");
    addAlias(QCS_USASCII, "ASCII");
    addAlias(QCS_USASCII, "USASCII");
@@ -261,7 +261,7 @@ QoreEncodingManager::QoreEncodingManager() {
    addAlias(QCS_KOI8_U, "KOI8U");
 
    QCS_KOI7        = addUnlocked("KOI7",        "Russian: Kod Obmena Informatsiey, 7 bit characters");
-   
+
    QCS_DEFAULT = QCS_UTF8;
 };
 
@@ -347,12 +347,12 @@ const QoreEncoding *QoreEncodingManager::findCreate(const QoreString *str) {
    return findCreate(str->getBuffer());
 }
 
-qore_size_t q_UTF8_get_char_len(const char* p, qore_size_t len) {
+qore_offset_t q_UTF8_get_char_len(const char* p, qore_size_t len) {
    // see if a multi-byte char is starting
    if ((*p & 0xc0) == 0xc0) {
       //printd(5, "MULTIBYTE *p = %hhx\n", *p);
       // check for a 3-byte sequence
-      if ((*p) & 0x20) { 
+      if ((*p) & 0x20) {
 	 // check for a 4-byte sequence
 	 if ((*p) & 0x10) {
 	    if (len >= 4) {
@@ -389,7 +389,7 @@ qore_size_t q_UTF8_get_char_len(const char* p, qore_size_t len) {
 static qore_size_t UTF8_getLength(const char *p, const char *end, bool &invalid) {
    qore_size_t i = 0;
    while (*p) {
-      qore_size_t l = q_UTF8_get_char_len(p, end - p);
+      qore_offset_t l = q_UTF8_get_char_len(p, end - p);
       if (l <= 0) {
 	 invalid = true;
 	 return i;
@@ -405,7 +405,7 @@ static qore_size_t UTF8_getLength(const char *p, const char *end, bool &invalid)
 static qore_size_t UTF8_getByteLen(const char *p, const char *end, qore_size_t l, bool &invalid) {
    qore_size_t b = 0;
    while (*p && l) {
-      qore_size_t bl = q_UTF8_get_char_len(p, end - p);
+      qore_offset_t bl = q_UTF8_get_char_len(p, end - p);
       if (bl <= 0) {
 	 invalid = true;
 	 return b;
@@ -421,7 +421,7 @@ static qore_size_t UTF8_getByteLen(const char *p, const char *end, qore_size_t l
 static qore_size_t UTF8_getCharPos(const char *p, const char *end, bool &invalid) {
    qore_size_t i = 0;
    while (p < end) {
-      qore_size_t l = q_UTF8_get_char_len(p, end - p);
+      qore_offset_t l = q_UTF8_get_char_len(p, end - p);
       if (l <= 0) {
 	 invalid = true;
 	 return i;
@@ -481,12 +481,11 @@ qore_size_t q_get_byte_len(const QoreEncoding* enc, const char *p, const char *e
    return enc->getByteLen(p, end, c, xsink);
 }
 
-qore_size_t q_get_char_len(const QoreEncoding* enc, const char *p, qore_size_t valid_len, ExceptionSink* xsink) {
-   qore_size_t rc = enc->getCharLen(p, valid_len);
+qore_offset_t q_get_char_len(const QoreEncoding* enc, const char *p, qore_size_t valid_len, ExceptionSink* xsink) {
+   qore_offset_t rc = enc->getCharLen(p, valid_len);
    if (rc <= 0) {
       xsink->raiseException("INVALID-ENCODING", "invalid %s encoding encountered in string", enc->getCode());
       return -1;
    }
    return rc;
 }
-

--- a/lib/ql_string.qpp
+++ b/lib/ql_string.qpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2014 David Nichols
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -1419,7 +1419,7 @@ string trunc_str(softstring str, softint len, *string encoding) [flags=RET_VALUE
    if (!tmp)
       return 0;
 
-   if (tmp->strlen() <= (qore_size_t)len) {
+   if (tmp->strlen() < (qore_size_t)len) {
       len = tmp->strlen();
       return new QoreStringNode(tmp.giveBuffer(), len, len + 1, enc);
    }
@@ -1431,8 +1431,8 @@ string trunc_str(softstring str, softint len, *string encoding) [flags=RET_VALUE
    const char *p = tmp->getBuffer();
    int64 sl = 0;
    while (true) {
-      qore_size_t size = enc->getCharLen(p, len - sl);
-      if ((sl + size) > (qore_size_t)len)
+      qore_offset_t size = enc->getCharLen(p, len - sl);
+      if (size <= 0 || ((sl + size) > (qore_size_t)len))
 	 break;
       sl += size;
       p += size;


### PR DESCRIPTION
refs #1693 fixed the case when an invalid multi-byte character begins at exactly the requested byte length for the string

@omusil24 please note that we will not release 0.8.11.1, so we don't need relnotes (can be included in upstream projects i.e. Qorus) - also we can't merge to 0.8.12 before Pavel gives the OK