### PR TITLE
refs #1759 fixed an invalid assert()ion by skipping the RSetHelper::c…

### DIFF
--- a/lib/RSet.cpp
+++ b/lib/RSet.cpp
@@ -721,7 +721,8 @@ RSetHelper::RSetHelper(RObject& obj) {
       break;
    }
 
-   commit(obj);
+   if (obj.isValid())
+      commit(obj);
 
    printd(QRO_LVL, "RSetHelper::RSetHelper() this: %p (%p) EXIT\n", this, &obj);
 }


### PR DESCRIPTION
…ommit() call when the object is invalid

@omusil24 please propagate to develop after merging