### PR TITLE
refs #1768 fixed compilation issues with clang++; use c++11 move cons…

### DIFF
--- a/include/qore/AutoVLock.h
+++ b/include/qore/AutoVLock.h
@@ -1,11 +1,11 @@
 /* -*- mode: c++; indent-tabs-mode: nil -*- */
 /*
   AutoVLock.h
-  
+
   Qore Programming Language
- 
-  Copyright (C) 2003 - 2015 David Nichols
- 
+
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
   to deal in the Software without restriction, including without limitation
@@ -94,17 +94,20 @@ private:
    struct qore_avl_private* priv;
 
    //! this function is not implemented; it is here as a private function in order to prohibit it from being used
-   DLLLOCAL AutoVLock(const AutoVLock&);
+   DLLLOCAL AutoVLock(const AutoVLock&) = delete;
    //! this function is not implemented; it is here as a private function in order to prohibit it from being used
-   DLLLOCAL AutoVLock& operator=(const AutoVLock&);
+   DLLLOCAL AutoVLock& operator=(const AutoVLock&) = delete;
    //! this function is not implemented; it is here as a private function in order to prohibit it from being used
-   DLLLOCAL void* operator new(size_t);
-   
+   DLLLOCAL void* operator new(size_t) = delete;
+
 public:
    //! creates an empty lock container
    /** @param n_xsink pointer to ExceptionSink object for use with object notifications
     */
    DLLEXPORT AutoVLock(ExceptionSink* n_xsink);
+
+   //! default move constructor
+   DLLEXPORT AutoVLock(AutoVLock&& o) = default;
 
    //! releases all locks held and destroys the container
    DLLEXPORT ~AutoVLock();

--- a/include/qore/intern/LocalVar.h
+++ b/include/qore/intern/LocalVar.h
@@ -73,7 +73,7 @@ protected:
    LValueHelper valp;
 
 public:
-   DLLLOCAL LValueRefHelper(T* val, ExceptionSink* xsink) : LocalRefHelper<T>(val, xsink), valp(this->valid ? *((ReferenceNode*)val->v.n) : 0, xsink) {
+   DLLLOCAL LValueRefHelper(T* val, ExceptionSink* xsink) : LocalRefHelper<T>(val, xsink), valp(this->valid ? LValueHelper(*reinterpret_cast<const ReferenceNode*>(val->v.n), xsink, false) : LValueHelper(reinterpret_cast<AbstractQoreNode*>(0), xsink)) {
    }
 
    DLLLOCAL operator bool() const {

--- a/include/qore/intern/QoreTypeInfo.h
+++ b/include/qore/intern/QoreTypeInfo.h
@@ -619,13 +619,13 @@ public:
    // must be reimplemented in subclasses if returns_mult is true
    DLLLOCAL virtual const type_vec_t& getReturnTypeList() const {
       assert(false);
-      return *((type_vec_t*)0);
+      throw;
    }
 
    // must be reimplemented in subclasses if accepts_mult is true
    DLLLOCAL virtual const type_vec_t& getAcceptTypeList() const {
       assert(false);
-      return *((type_vec_t*)0);
+      throw;
    }
 
    // FIXME: eliminate

--- a/include/qore/intern/Variable.h
+++ b/include/qore/intern/Variable.h
@@ -344,8 +344,8 @@ class LValueHelper {
 
 private:
    // not implemented
-   DLLLOCAL LValueHelper(const LValueHelper&);
-   DLLLOCAL LValueHelper& operator=(const LValueHelper&);
+   DLLLOCAL LValueHelper(const LValueHelper&) = delete;
+   DLLLOCAL LValueHelper& operator=(const LValueHelper&) = delete;
 
 protected:
    template <class T, typename t, int nt>
@@ -419,6 +419,8 @@ public:
 
    DLLLOCAL LValueHelper(const ReferenceNode& ref, ExceptionSink* xsink, bool for_remove = false);
    DLLLOCAL LValueHelper(const AbstractQoreNode* exp, ExceptionSink* xsink, bool for_remove = false);
+
+   DLLLOCAL LValueHelper(LValueHelper&& o);
 
    // to scan objects after initialization
    DLLLOCAL LValueHelper(QoreObject& obj, ExceptionSink* xsink);

--- a/lib/Variable.cpp
+++ b/lib/Variable.cpp
@@ -47,6 +47,7 @@
 #include "qore/intern/QoreHashNodeIntern.h"
 
 #include <memory>
+#include <utility>
 
 // global environment hash
 QoreHashNode* ENV;
@@ -204,6 +205,9 @@ LValueHelper::LValueHelper(const AbstractQoreNode* exp, ExceptionSink* xsink, bo
 // this constructor function is used to scan objects after initialization
 LValueHelper::LValueHelper(QoreObject& self, ExceptionSink* xsink) : vl(xsink), v(0), lvid_set(0), before(true), rdt(0), robj(qore_object_private::get(self)), val(0), typeInfo(0) {
    ocvec.push_back(ObjCountRec(&self));
+}
+
+LValueHelper::LValueHelper(LValueHelper&& o) : vl(std::move(o.vl)), v(o.v), tvec(std::move(o.tvec)), lvid_set(o.lvid_set), ocvec(std::move(o.ocvec)), before(o.before), rdt(o.rdt), robj(o.robj), val(o.val), typeInfo(o.typeInfo) {
 }
 
 LValueHelper::~LValueHelper() {


### PR DESCRIPTION
…tructors for efficiency and to work around issues with the ternary operator and constructor functions chosen by subclass constructor arguments