### PR TITLE
Bugfix/1774 ref leak fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,7 @@ set(LIBQORE_CPP_SRC
         lib/SelfVarrefNode.cpp
         lib/StaticClassVarRefNode.cpp
         lib/ReferenceNode.cpp
+        lib/lvalue_ref.cpp
         lib/BackquoteNode.cpp
         lib/ContextrefNode.cpp
         lib/ComplexContextrefNode.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -265,6 +265,7 @@ noinst_HEADERS = \
 	include/qore/intern/ReferenceHelper.h \
 	include/qore/intern/ThreadResourceList.h \
 	include/qore/intern/ssl_constants.h \
+	include/qore/intern/lvalue_ref.h \
 	include/qore/intern/qore_thread_intern.h \
 	include/qore/intern/qore_list_private.h \
 	include/qore/intern/qore_value_list_private.h \

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -9,6 +9,7 @@
 
     @subsection qore_08129_bug_fixes Bug Fixes in Qore
 
+    - fixed a memory leak where references participate in recursive references (<a href="https://github.com/qorelanguage/qore/issues/1774">issue 1774</a>)
     - fixed a build issue with clang++ (<a href="https://github.com/qorelanguage/qore/issues/1768">issue 1768</a>)
     - fixed a memory leak in the @ref Qore::Thread::Queue "Queue" copy constructor when the @ref Qore::Thread::Queue "Queue" was used in other objects (such as an event queue, etc; <a href="https://github.com/qorelanguage/qore/issues/1749">issue 1749</a>)
     - <a href="../../modules/Mapper/html/index.html">Mapper</a> module fixes:

--- a/examples/test/qore/misc/gc.qtest
+++ b/examples/test/qore/misc/gc.qtest
@@ -16,6 +16,7 @@ class GcTest {
         any a;
         *GcTest b;
         *GcTest c;
+        any d;
     }
 
     private {
@@ -353,11 +354,27 @@ class DgcTest inherits QUnit::Test {
             # issue #1774 leak in closure-bound/reference local var handling
             GcTest o1(inc);
             GcTest o2(inc, o1);
-            o1.a = \o2;
-            hash h = ("a": \o2,);
-            o1.a."a" = \h.a;
+            o1.a = ("a": \o2);
         }
         assertEq(10, cnt);
+
+        {
+            # issue #1774 leak in closure-bound/reference local var handling
+            GcTest o1(inc);
+            GcTest o2(inc, o1);
+            o1.a = \o2;
+            o1.d = ("a": \o2);
+        }
+        assertEq(12, cnt);
+
+        {
+            # issue #1774 leak in closure-bound/reference local var handling
+            GcTest o1(inc);
+            GcTest o2(inc, o1);
+            o1.a = \o2;
+            o1.d = \o2;
+        }
+        assertEq(14, cnt);
 
         {
             # issue #1774 leak in closure-bound/reference local var handling
@@ -366,7 +383,7 @@ class DgcTest inherits QUnit::Test {
             list l = (\o2, \o2);
             o1.a = \l[0];
         }
-        assertEq(12, cnt);
+        assertEq(16, cnt);
 
         {
             # issue #1774 leak in closure-bound/reference local var handling
@@ -375,6 +392,6 @@ class DgcTest inherits QUnit::Test {
             hash h = ("a": \o2, "b": \o2);
             o1.a."a" = \h.a;
         }
-        assertEq(14, cnt);
+        assertEq(18, cnt);
     }
 }

--- a/examples/test/qore/misc/gc.qtest
+++ b/examples/test/qore/misc/gc.qtest
@@ -35,6 +35,10 @@ class GcTest {
     set(*GcTest obj) {
         o = obj;
     }
+
+    reference getRef() {
+        return \a;
+    }
 }
 
 class GcTest1 {
@@ -108,6 +112,7 @@ class DgcTest inherits QUnit::Test {
         addTestCase("ClosureTests", \closureTests());
         addTestCase("Destructor order", \dtorOrder());
         addTestCase("MiscGcTests", \miscGcTests());
+        addTestCase("refLeak", \refLeakTest());
 
         # Return for compatibility with test harness that checks the return value
         set_return_value(main());
@@ -304,5 +309,72 @@ class DgcTest inherits QUnit::Test {
             delete obj2;
         }
         assertEq(2, cnt);
+    }
+
+    refLeakTest() {
+        int cnt = 0;
+        code inc = sub () { ++cnt; };
+
+        {
+            # issue #1774 leak in closure-bound/reference local var handling
+            GcTest o1(inc);
+            GcTest o2(inc, o1);
+            o1.a = \o2;
+        }
+        assertEq(2, cnt);
+
+        {
+            # issue #1774 leak in closure-bound/reference local var handling
+            GcTest o1(inc);
+            GcTest o2(inc, o1);
+            o1.a = o2.getRef();
+        }
+        assertEq(4, cnt);
+
+        {
+            # issue #1774 leak in closure-bound/reference local var handling
+            GcTest o1(inc);
+            GcTest o2(inc, o1);
+            list l = (\o2,);
+            o1.a = \l[0];
+        }
+        assertEq(6, cnt);
+
+        {
+            # issue #1774 leak in closure-bound/reference local var handling
+            GcTest o1(inc);
+            GcTest o2(inc, o1);
+            hash h = ("a": \o2,);
+            o1.a."a" = \h.a;
+        }
+        assertEq(8, cnt);
+
+        {
+            # issue #1774 leak in closure-bound/reference local var handling
+            GcTest o1(inc);
+            GcTest o2(inc, o1);
+            o1.a = \o2;
+            hash h = ("a": \o2,);
+            o1.a."a" = \h.a;
+        }
+        assertEq(10, cnt);
+
+        {
+            # issue #1774 leak in closure-bound/reference local var handling
+            GcTest o1(inc);
+            GcTest o2(inc, o1);
+            list l = (\o2, \o2);
+            o1.a = \l[0];
+        }
+        assertEq(12, cnt);
+
+        {
+            # issue #1774 leak in closure-bound/reference local var handling
+            GcTest o1(inc);
+            GcTest o2(inc, o1);
+            hash h = ("a": \o2, "b": \o2);
+            o1.a."a" = \h.a;
+        }
+        assertEq(14, cnt);
     }
 }

--- a/include/qore/ReferenceNode.h
+++ b/include/qore/ReferenceNode.h
@@ -111,7 +111,14 @@ public:
    //! returns the type name as a c string
    DLLEXPORT virtual const char* getTypeName() const;
 
+   //! called when the object is deleted
    DLLEXPORT virtual bool derefImpl(ExceptionSink* xsink);
+
+   //! increments the reference count
+   DLLEXPORT virtual void customRef() const;
+
+   //! decrements the reference count
+   DLLEXPORT virtual void customDeref(ExceptionSink* xsink);
 };
 
 #endif

--- a/include/qore/ReferenceNode.h
+++ b/include/qore/ReferenceNode.h
@@ -50,8 +50,6 @@ private:
    //! private implementation
    class lvalue_ref* priv;
 
-   DLLLOCAL ReferenceNode(lvalue_ref* p);
-
 protected:
    //! returns the value of the reference; caller owns any reference count returned for non-NULL return values
    DLLEXPORT virtual AbstractQoreNode* evalImpl(ExceptionSink* xsink) const;
@@ -77,6 +75,11 @@ protected:
 public:
    //! creates the ReferenceNode object - internal function, not exported, not part of the Qore API
    DLLLOCAL ReferenceNode(AbstractQoreNode* exp, QoreObject* self, const void* lvalue_id);
+
+   //! creates a copy of the object
+   /** @since %Qore 0.8.12.9
+    */
+   DLLLOCAL ReferenceNode(const ReferenceNode& old);
 
    //! concatenate the verbose string representation of the value to an existing QoreString
    /** used for %n and %N printf formatting

--- a/include/qore/ReferenceNode.h
+++ b/include/qore/ReferenceNode.h
@@ -113,12 +113,6 @@ public:
 
    //! called when the object is deleted
    DLLEXPORT virtual bool derefImpl(ExceptionSink* xsink);
-
-   //! increments the reference count
-   DLLEXPORT virtual void customRef() const;
-
-   //! decrements the reference count
-   DLLEXPORT virtual void customDeref(ExceptionSink* xsink);
 };
 
 #endif

--- a/include/qore/intern/LocalVar.h
+++ b/include/qore/intern/LocalVar.h
@@ -185,6 +185,8 @@ public:
 
       return val.getReferencedValue(needs_deref);
    }
+
+   DLLLOCAL bool scanMembers(RSetHelper& rsh);
 };
 
 struct ClosureVarValue : public VarValueBase, public RObject {
@@ -387,6 +389,12 @@ public:
          return get_var()->remove(lvrh, typeInfo);
 
       return thread_find_closure_var(name.c_str())->remove(lvrh);
+   }
+
+   DLLLOCAL bool scanMembers(RSetHelper& rsh) {
+      return !closure_use
+         ? get_var()->scanMembers(rsh)
+         : thread_find_closure_var(name.c_str())->scanMembers(rsh);
    }
 
    DLLLOCAL const QoreTypeInfo* getTypeInfo() const {

--- a/include/qore/intern/LocalVar.h
+++ b/include/qore/intern/LocalVar.h
@@ -185,8 +185,6 @@ public:
 
       return val.getReferencedValue(needs_deref);
    }
-
-   DLLLOCAL bool scanMembers(RSetHelper& rsh);
 };
 
 struct ClosureVarValue : public VarValueBase, public RObject {
@@ -389,12 +387,6 @@ public:
          return get_var()->remove(lvrh, typeInfo);
 
       return thread_find_closure_var(name.c_str())->remove(lvrh);
-   }
-
-   DLLLOCAL bool scanMembers(RSetHelper& rsh) {
-      return !closure_use
-         ? get_var()->scanMembers(rsh)
-         : thread_find_closure_var(name.c_str())->scanMembers(rsh);
    }
 
    DLLLOCAL const QoreTypeInfo* getTypeInfo() const {

--- a/include/qore/intern/QoreLibIntern.h
+++ b/include/qore/intern/QoreLibIntern.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2016 David Nichols
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -380,6 +380,7 @@ DLLLOCAL int q_fstatvfs(const char* filepath, struct statvfs* buf);
 #include <qore/intern/QoreTypeInfo.h>
 #include <qore/intern/ParseNode.h>
 #include <qore/intern/QoreThreadList.h>
+#include <qore/intern/lvalue_ref.h>
 #include <qore/intern/qore_thread_intern.h>
 #include <qore/intern/Function.h>
 #include <qore/intern/CallReferenceCallNode.h>

--- a/include/qore/intern/QoreObjectIntern.h
+++ b/include/qore/intern/QoreObjectIntern.h
@@ -40,7 +40,7 @@
 #include <set>
 #include <vector>
 
-#define _QORE_CYCLE_CHECK 1
+//#define _QORE_CYCLE_CHECK 1
 #ifdef _QORE_CYCLE_CHECK
 #define QORE_DEBUG_OBJ_REFS 0
 #define QRO_LVL 0

--- a/include/qore/intern/QoreObjectIntern.h
+++ b/include/qore/intern/QoreObjectIntern.h
@@ -40,7 +40,7 @@
 #include <set>
 #include <vector>
 
-//#define _QORE_CYCLE_CHECK 1
+#define _QORE_CYCLE_CHECK 1
 #ifdef _QORE_CYCLE_CHECK
 #define QORE_DEBUG_OBJ_REFS 0
 #define QRO_LVL 0

--- a/include/qore/intern/RSet.h
+++ b/include/qore/intern/RSet.h
@@ -324,6 +324,8 @@ struct RSetStat {
    }
 };
 
+class QoreClosureBase;
+
 class RSetHelper {
    friend class RSectionScanHelper;
    friend class RObject;
@@ -406,6 +408,11 @@ public:
       rset_t::iterator i = tr_out.lower_bound(ro);
       if (i == tr_out.end() || *i != ro)
          tr_out.insert(i, ro);
+   }
+
+   // returns true if a lock error has occurred, false if otherwise
+   DLLLOCAL bool checkNode(AbstractQoreNode* n) {
+      return checkIntern(n);
    }
 };
 

--- a/include/qore/intern/RSet.h
+++ b/include/qore/intern/RSet.h
@@ -414,6 +414,11 @@ public:
    DLLLOCAL bool checkNode(AbstractQoreNode* n) {
       return checkIntern(n);
    }
+
+   // returns true if a lock error has occurred, false if otherwise
+   DLLLOCAL bool checkNode(RObject& robj) {
+      return checkIntern(robj);
+   }
 };
 
 class qore_object_private;

--- a/include/qore/intern/VarRefNode.h
+++ b/include/qore/intern/VarRefNode.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -223,6 +223,8 @@ public:
       if (type == VT_LOCAL || type == VT_CLOSURE || type == VT_LOCAL_TS)
          ref.id->parseAssigned();
    }
+
+   DLLLOCAL bool scanMembers(RSetHelper& rsh);
 };
 
 class GlobalVarRefNode : public VarRefNode {
@@ -237,6 +239,8 @@ public:
 
    DLLLOCAL void reg();
 };
+
+class RSetHelper;
 
 class VarRefDeclNode : public VarRefNode {
 protected:
@@ -309,7 +313,7 @@ public:
    }
    DLLLOCAL virtual void makeGlobal();
 
-   void parseInitCommon(LocalVar* oflag, int pflag, int& lvids, bool is_new = false);
+   DLLLOCAL void parseInitCommon(LocalVar* oflag, int pflag, int& lvids, bool is_new = false);
 };
 
 class VarRefImmediateNode : public VarRefDeclNode {

--- a/include/qore/intern/Variable.h
+++ b/include/qore/intern/Variable.h
@@ -95,6 +95,7 @@ union qore_gvar_ref_u {
 
 class LValueHelper;
 class LValueRemoveHelper;
+class RSetHelper;
 
 // structure for global variables
 class Var : protected QoreReferenceCounter {

--- a/include/qore/intern/lvalue_ref.h
+++ b/include/qore/intern/lvalue_ref.h
@@ -1,0 +1,92 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+  lvalue_ref.h
+
+  POSIX thread library for Qore
+
+  Qore Programming Language
+
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+
+  Note that the Qore library is released under a choice of three open-source
+  licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+  information.
+*/
+
+#ifndef _QORE_INTERN_LVALUE_REF_H
+#define _QORE_INTERN_LVALUE_REF_H
+
+#include <qore/intern/RSection.h>
+#include <qore/intern/RSet.h>
+
+class lvalue_ref : public RObject {
+public:
+   ReferenceNode* ref;
+   AbstractQoreNode* vexp;
+   QoreObject* self;
+   QoreProgram* pgm;
+   const void* lvalue_id;
+
+   DLLLOCAL lvalue_ref(ReferenceNode* ref, AbstractQoreNode* n_lvexp, QoreObject* n_self, const void* lvid);
+
+   DLLLOCAL lvalue_ref(const lvalue_ref& old, ReferenceNode* ref);
+
+   DLLLOCAL ~lvalue_ref() {
+      //printd(5, "lvalue_ref::~lvalue_ref() this: %p vexp: %p self: %p pgm: %p\n", this, vexp, self, pgm);
+      if (self)
+         self->tDeref();
+      if (vexp)
+         vexp->deref(0);
+   }
+
+   DLLLOCAL void del(ExceptionSink* xsink) {
+      //printd(5, "lvalue_ref::del() this: %p vexp: %p self: %p pgm: %p\n", this, vexp, self, pgm);
+
+      removeInvalidateRSet();
+
+      if (vexp) {
+         vexp->deref(xsink);
+         vexp = 0;
+      }
+   }
+
+   DLLLOCAL static lvalue_ref* get(const ReferenceNode* r) {
+      return r->priv;
+   }
+
+   // returns true if a lock error has occurred and the transaction should be aborted or restarted; the rsection lock is held when this function is called
+   DLLLOCAL virtual bool scanMembers(RSetHelper& rsh);
+
+   // returns true if the object needs to be scanned for recursive references (ie could contain an object or closure or a container containing one of those)
+   /** @param scan_now scan will be made now
+    */
+   DLLLOCAL virtual bool needsScan(bool scan_now);
+
+   // deletes the object itself
+   DLLLOCAL virtual void deleteObject();
+
+   // returns the name of the object
+   DLLLOCAL virtual const char* getName() const;
+
+   DLLLOCAL static bool scanNode(RSetHelper& rsh, AbstractQoreNode* vexp);
+};
+
+#endif

--- a/include/qore/intern/lvalue_ref.h
+++ b/include/qore/intern/lvalue_ref.h
@@ -68,9 +68,9 @@ public:
       }
    }
 
-   DLLLOCAL static lvalue_ref* get(const ReferenceNode* r) {
-      return r->priv;
-   }
+   DLLLOCAL void doRef() const;
+
+   DLLLOCAL void doDeref(ExceptionSink* xsink);
 
    // returns true if a lock error has occurred and the transaction should be aborted or restarted; the rsection lock is held when this function is called
    DLLLOCAL virtual bool scanMembers(RSetHelper& rsh);
@@ -85,6 +85,10 @@ public:
 
    // returns the name of the object
    DLLLOCAL virtual const char* getName() const;
+
+   DLLLOCAL static lvalue_ref* get(const ReferenceNode* r) {
+      return r->priv;
+   }
 
    DLLLOCAL static bool scanNode(RSetHelper& rsh, AbstractQoreNode* vexp);
 };

--- a/include/qore/intern/lvalue_ref.h
+++ b/include/qore/intern/lvalue_ref.h
@@ -34,10 +34,9 @@
 #ifndef _QORE_INTERN_LVALUE_REF_H
 #define _QORE_INTERN_LVALUE_REF_H
 
-#include <qore/intern/RSection.h>
-#include <qore/intern/RSet.h>
+class RSetHelper;
 
-class lvalue_ref : public RObject {
+class lvalue_ref {
 public:
    ReferenceNode* ref;
    AbstractQoreNode* vexp;
@@ -45,9 +44,9 @@ public:
    QoreProgram* pgm;
    const void* lvalue_id;
 
-   DLLLOCAL lvalue_ref(ReferenceNode* ref, AbstractQoreNode* n_lvexp, QoreObject* n_self, const void* lvid);
+   DLLLOCAL lvalue_ref(AbstractQoreNode* n_lvexp, QoreObject* n_self, const void* lvid);
 
-   DLLLOCAL lvalue_ref(const lvalue_ref& old, ReferenceNode* ref);
+   DLLLOCAL lvalue_ref(const lvalue_ref& old);
 
    DLLLOCAL ~lvalue_ref() {
       //printd(5, "lvalue_ref::~lvalue_ref() this: %p vexp: %p self: %p pgm: %p\n", this, vexp, self, pgm);
@@ -59,32 +58,17 @@ public:
 
    DLLLOCAL void del(ExceptionSink* xsink) {
       //printd(5, "lvalue_ref::del() this: %p vexp: %p self: %p pgm: %p\n", this, vexp, self, pgm);
-
-      removeInvalidateRSet();
-
       if (vexp) {
          vexp->deref(xsink);
          vexp = 0;
       }
    }
 
-   DLLLOCAL void doRef() const;
-
-   DLLLOCAL void doDeref(ExceptionSink* xsink);
-
    // returns true if a lock error has occurred and the transaction should be aborted or restarted; the rsection lock is held when this function is called
-   DLLLOCAL virtual bool scanMembers(RSetHelper& rsh);
+   DLLLOCAL bool scanReference(RSetHelper& rsh);
 
    // returns true if the object needs to be scanned for recursive references (ie could contain an object or closure or a container containing one of those)
-   /** @param scan_now scan will be made now
-    */
-   DLLLOCAL virtual bool needsScan(bool scan_now);
-
-   // deletes the object itself
-   DLLLOCAL virtual void deleteObject();
-
-   // returns the name of the object
-   DLLLOCAL virtual const char* getName() const;
+   DLLLOCAL bool needsScan();
 
    DLLLOCAL static lvalue_ref* get(const ReferenceNode* r) {
       return r->priv;

--- a/include/qore/intern/qore_thread_intern.h
+++ b/include/qore/intern/qore_thread_intern.h
@@ -551,46 +551,6 @@ public:
    DLLLOCAL const qore_class_private* getClass() const;
 };
 
-class lvalue_ref {
-public:
-   AbstractQoreNode* vexp;
-   QoreObject* self;
-   QoreProgram* pgm;
-   const void* lvalue_id;
-
-   DLLLOCAL lvalue_ref(AbstractQoreNode* n_lvexp, QoreObject* n_self, const void* lvid) : vexp(n_lvexp), self(n_self), pgm(getProgram()), lvalue_id(lvid) {
-      //printd(5, "lvalue_ref::lvalue_ref() this: %p vexp: %p self: %p pgm: %p\n", this, vexp, self, pgm);
-      if (self)
-         self->tRef();
-   }
-
-   DLLLOCAL lvalue_ref(const lvalue_ref& old) : vexp(old.vexp->refSelf()), self(old.self), pgm(old.pgm), lvalue_id(old.lvalue_id) {
-      //printd(5, "lvalue_ref::lvalue_ref() this: %p vexp: %p self: %p pgm: %p\n", this, vexp, self, pgm);
-      if (self)
-         self->tRef();
-   }
-
-   DLLLOCAL ~lvalue_ref() {
-      //printd(5, "lvalue_ref::~lvalue_ref() this: %p vexp: %p self: %p pgm: %p\n", this, vexp, self, pgm);
-      if (self)
-         self->tDeref();
-      if (vexp)
-         vexp->deref(0);
-   }
-
-   DLLLOCAL void del(ExceptionSink* xsink) {
-      //printd(5, "lvalue_ref::del() this: %p vexp: %p self: %p pgm: %p\n", this, vexp, self, pgm);
-      if (vexp) {
-         vexp->deref(xsink);
-         vexp = 0;
-      }
-   }
-
-   static lvalue_ref* get(const ReferenceNode* r) {
-      return r->priv;
-   }
-};
-
 class CodeContextHelper {
 private:
    const char* old_code;
@@ -715,9 +675,6 @@ public:
    DLLLOCAL ProgramRuntimeParseAccessHelper(ExceptionSink* xsink, QoreProgram* pgm);
    DLLLOCAL ~ProgramRuntimeParseAccessHelper();
 };
-
-//int thread_ref_set(const lvalue_ref* r);
-//void thread_ref_remove(const lvalue_ref* r);
 
 class RuntimeReferenceHelperBase {
 protected:

--- a/lib/AbstractQoreNode.cpp
+++ b/lib/AbstractQoreNode.cpp
@@ -637,6 +637,7 @@ bool needs_scan(const AbstractQoreNode* n) {
       case NT_OBJECT: return true;
       case NT_VALUE_LIST: assert(false); return qore_value_list_private::getScanCount(*static_cast<const QoreValueList*>(n)) ? true : false;
       case NT_RUNTIME_CLOSURE: return static_cast<const QoreClosureBase*>(n)->needsScan();
+      case NT_REFERENCE: return lvalue_ref::get(static_cast<const ReferenceNode*>(n))->needsScan(false);
    }
 
    return false;

--- a/lib/AbstractQoreNode.cpp
+++ b/lib/AbstractQoreNode.cpp
@@ -637,7 +637,7 @@ bool needs_scan(const AbstractQoreNode* n) {
       case NT_OBJECT: return true;
       case NT_VALUE_LIST: assert(false); return qore_value_list_private::getScanCount(*static_cast<const QoreValueList*>(n)) ? true : false;
       case NT_RUNTIME_CLOSURE: return static_cast<const QoreClosureBase*>(n)->needsScan();
-      case NT_REFERENCE: return lvalue_ref::get(static_cast<const ReferenceNode*>(n))->needsScan(false);
+      case NT_REFERENCE: return lvalue_ref::get(static_cast<const ReferenceNode*>(n))->needsScan();
    }
 
    return false;

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -116,6 +116,7 @@ libqore_la_SOURCES = \
 	VarRefNode.cpp \
 	FunctionCallNode.cpp \
 	ReferenceNode.cpp \
+	lvalue_ref.cpp \
 	ScopedRefNode.cpp \
 	ClassRefNode.cpp \
 	AbstractQoreNode.cpp \

--- a/lib/QoreObject.cpp
+++ b/lib/QoreObject.cpp
@@ -6,7 +6,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2016 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/lib/RSet.cpp
+++ b/lib/RSet.cpp
@@ -284,7 +284,7 @@ bool RSetHelper::checkIntern(AbstractQoreNode* n) {
    if (!needs_scan(n))
       return false;
 
-   printd(0, "RSetHelper::checkIntern() checking %p %s\n", n, get_type_name(n));
+   //printd(5, "RSetHelper::checkIntern() checking %p %s\n", n, get_type_name(n));
 
    switch (get_node_type(n)) {
       case NT_OBJECT:
@@ -361,7 +361,7 @@ bool RSetHelper::checkIntern(AbstractQoreNode* n) {
       }
 
       case NT_REFERENCE:
-         return checkIntern(*lvalue_ref::get(static_cast<ReferenceNode*>(n)));
+         return lvalue_ref::get(static_cast<ReferenceNode*>(n))->scanReference(*this);
 
       case NT_VALUE_LIST:
          assert(false);

--- a/lib/RSet.cpp
+++ b/lib/RSet.cpp
@@ -49,6 +49,11 @@ void RObject::setRSet(RSet* rs, int rcnt) {
    }
    rset = rs;
    rcount = rcnt;
+#ifdef DEBUG
+   if (rcount > references)
+      printd(0, "RObject::setRSet() this: %p '%s' cannot set rcount %d > references %d\n", this, getName(), rcount, references);
+   assert(rcount <= references);
+#endif
    if (rs) {
       rs->ref();
       // we make a weak reference from the rset to the object to ensure that it does not disappear while the rset is valid
@@ -279,7 +284,7 @@ bool RSetHelper::checkIntern(AbstractQoreNode* n) {
    if (!needs_scan(n))
       return false;
 
-   //printd(5, "RSetHelper::checkIntern() checking %p %s\n", n, get_type_name(n));
+   printd(0, "RSetHelper::checkIntern() checking %p %s\n", n, get_type_name(n));
 
    switch (get_node_type(n)) {
       case NT_OBJECT:
@@ -501,6 +506,8 @@ bool RSetHelper::makeChain(int i, omap_t::iterator fi, int tid) {
          if (i == (int)(ovec.size() - 1)) {
             printd(QRO_LVL, " + %p '%s': parent object %p '%s' was not in cycle (rcount: %d -> %d)\n", fi->first, fi->first->getName(), ovec[i]->first, ovec[i]->first->getName(), fi->second.rcount, fi->second.rcount + 1);
             ++fi->second.rcount;
+            // rcount can never be more than real references for the target object
+            assert(fi->first->references >= fi->second.rcount);
          }
       }
       else
@@ -552,12 +559,16 @@ bool RSetHelper::checkIntern(RObject& obj) {
          if (inCurrentSet(fi)) {
             printd(QRO_LVL, " + recursive obj %p '%s' already finalized and in current cycle (rcount: %d -> %d)\n", &obj, obj.getName(), fi->second.rcount, fi->second.rcount + 1);
             ++fi->second.rcount;
+            // rcount can never be more than real references for the target object
+            assert(fi->first->references >= fi->second.rcount);
          }
          else if (!ovec.empty()) {
             // FIXME: use this optimization in the loop below
             if (ovec.back()->second.rset == fi->second.rset) {
                printd(QRO_LVL, " + %p '%s': parent object %p '%s' in same cycle (rcount: %d -> %d)\n", &obj, obj.getName(), ovec.back()->first, ovec.back()->first->getName(), fi->second.rcount, fi->second.rcount + 1);
                ++fi->second.rcount;
+               // rcount can never be more than real references for the target object
+               assert(fi->first->references >= fi->second.rcount);
                return false;
             }
 

--- a/lib/RSet.cpp
+++ b/lib/RSet.cpp
@@ -279,6 +279,8 @@ bool RSetHelper::checkIntern(AbstractQoreNode* n) {
    if (!needs_scan(n))
       return false;
 
+   //printd(5, "RSetHelper::checkIntern() checking %p %s\n", n, get_type_name(n));
+
    switch (get_node_type(n)) {
       case NT_OBJECT:
          return checkIntern(*qore_object_private::get(*reinterpret_cast<QoreObject*>(n)));
@@ -352,6 +354,9 @@ bool RSetHelper::checkIntern(AbstractQoreNode* n) {
 
          return false;
       }
+
+      case NT_REFERENCE:
+         return checkIntern(*lvalue_ref::get(static_cast<ReferenceNode*>(n)));
 
       case NT_VALUE_LIST:
          assert(false);

--- a/lib/ReferenceNode.cpp
+++ b/lib/ReferenceNode.cpp
@@ -123,7 +123,6 @@ AbstractQoreNode* ParseReferenceNode::parseInitImpl(LocalVar* oflag, int pflag, 
       parse_error("the reference operator was expecting an lvalue, got '%s' instead", lvexp->getTypeName());
       return this;
    }
-
    // check lvalue, and convert "normal" local vars to thread-safe local vars
    AbstractQoreNode* n = lvexp;
    while (true) {
@@ -148,10 +147,11 @@ AbstractQoreNode* ParseReferenceNode::parseInitImpl(LocalVar* oflag, int pflag, 
    return this;
 }
 
-ReferenceNode::ReferenceNode(AbstractQoreNode* exp, QoreObject* self, const void* lvalue_id) : AbstractQoreNode(NT_REFERENCE, false, true), priv(new lvalue_ref(exp, self, lvalue_id)) {
+ReferenceNode::ReferenceNode(AbstractQoreNode* exp, QoreObject* self, const void* lvalue_id) : AbstractQoreNode(NT_REFERENCE, false, true), priv(new lvalue_ref(this, exp, self, lvalue_id)) {
+   priv->ref = this;
 }
 
-ReferenceNode::ReferenceNode(lvalue_ref* p) : AbstractQoreNode(NT_REFERENCE, false, true), priv(p) {
+ReferenceNode::ReferenceNode(const ReferenceNode& old) : AbstractQoreNode(NT_REFERENCE, false, true), priv(new lvalue_ref(*old.priv, this)) {
 }
 
 ReferenceNode::~ReferenceNode() {
@@ -184,7 +184,7 @@ QoreValue ReferenceNode::evalValue(bool& needs_deref, ExceptionSink* xsink) cons
 */
 
 AbstractQoreNode* ReferenceNode::realCopy() const {
-   return new ReferenceNode(new lvalue_ref(*priv));
+   return new ReferenceNode(*this);
 }
 
 // the type passed must always be equal to the current type

--- a/lib/ReferenceNode.cpp
+++ b/lib/ReferenceNode.cpp
@@ -147,11 +147,11 @@ AbstractQoreNode* ParseReferenceNode::parseInitImpl(LocalVar* oflag, int pflag, 
    return this;
 }
 
-ReferenceNode::ReferenceNode(AbstractQoreNode* exp, QoreObject* self, const void* lvalue_id) : AbstractQoreNode(NT_REFERENCE, false, true), priv(new lvalue_ref(this, exp, self, lvalue_id)) {
+ReferenceNode::ReferenceNode(AbstractQoreNode* exp, QoreObject* self, const void* lvalue_id) : AbstractQoreNode(NT_REFERENCE, false, true, false, true), priv(new lvalue_ref(this, exp, self, lvalue_id)) {
    priv->ref = this;
 }
 
-ReferenceNode::ReferenceNode(const ReferenceNode& old) : AbstractQoreNode(NT_REFERENCE, false, true), priv(new lvalue_ref(*old.priv, this)) {
+ReferenceNode::ReferenceNode(const ReferenceNode& old) : AbstractQoreNode(NT_REFERENCE, false, true, false, true), priv(new lvalue_ref(*old.priv, this)) {
 }
 
 ReferenceNode::~ReferenceNode() {
@@ -244,4 +244,12 @@ bool ReferenceNode::boolEvalImpl(ExceptionSink *xsink) const {
 double ReferenceNode::floatEvalImpl(ExceptionSink *xsink) const {
    LValueHelper lvh(this, xsink);
    return lvh ? lvh.getAsFloat() : 0.0;
+}
+
+void ReferenceNode::customRef() const {
+   priv->doRef();
+}
+
+void ReferenceNode::customDeref(ExceptionSink* xsink) {
+   priv->doDeref(xsink);
 }

--- a/lib/ReferenceNode.cpp
+++ b/lib/ReferenceNode.cpp
@@ -147,11 +147,10 @@ AbstractQoreNode* ParseReferenceNode::parseInitImpl(LocalVar* oflag, int pflag, 
    return this;
 }
 
-ReferenceNode::ReferenceNode(AbstractQoreNode* exp, QoreObject* self, const void* lvalue_id) : AbstractQoreNode(NT_REFERENCE, false, true, false, true), priv(new lvalue_ref(this, exp, self, lvalue_id)) {
-   priv->ref = this;
+ReferenceNode::ReferenceNode(AbstractQoreNode* exp, QoreObject* self, const void* lvalue_id) : AbstractQoreNode(NT_REFERENCE, false, true), priv(new lvalue_ref(exp, self, lvalue_id)) {
 }
 
-ReferenceNode::ReferenceNode(const ReferenceNode& old) : AbstractQoreNode(NT_REFERENCE, false, true, false, true), priv(new lvalue_ref(*old.priv, this)) {
+ReferenceNode::ReferenceNode(const ReferenceNode& old) : AbstractQoreNode(NT_REFERENCE, false, true), priv(new lvalue_ref(*old.priv)) {
 }
 
 ReferenceNode::~ReferenceNode() {
@@ -244,12 +243,4 @@ bool ReferenceNode::boolEvalImpl(ExceptionSink *xsink) const {
 double ReferenceNode::floatEvalImpl(ExceptionSink *xsink) const {
    LValueHelper lvh(this, xsink);
    return lvh ? lvh.getAsFloat() : 0.0;
-}
-
-void ReferenceNode::customRef() const {
-   priv->doRef();
-}
-
-void ReferenceNode::customDeref(ExceptionSink* xsink) {
-   priv->doDeref(xsink);
 }

--- a/lib/VarRefNode.cpp
+++ b/lib/VarRefNode.cpp
@@ -213,9 +213,8 @@ void VarRefNode::remove(LValueRemoveHelper& lvrh) {
 }
 
 bool VarRefNode::scanMembers(RSetHelper& rsh) {
-   if (type == VT_LOCAL) {
+   if (type == VT_LOCAL)
       return ref.id->scanMembers(rsh);
-   }
    if (type == VT_CLOSURE)
       return thread_get_runtime_closure_var(ref.id)->scanMembers(rsh);
    if (type == VT_LOCAL_TS)

--- a/lib/VarRefNode.cpp
+++ b/lib/VarRefNode.cpp
@@ -213,14 +213,22 @@ void VarRefNode::remove(LValueRemoveHelper& lvrh) {
 }
 
 bool VarRefNode::scanMembers(RSetHelper& rsh) {
-   if (type == VT_LOCAL)
-      return ref.id->scanMembers(rsh);
+   if (type == VT_CLOSURE)
+      return rsh.checkNode(*thread_get_runtime_closure_var(ref.id));
+   if (type == VT_LOCAL_TS)
+      return rsh.checkNode(*thread_find_closure_var(ref.id->getName()));
+   if (type == VT_IMMEDIATE)
+      return rsh.checkNode(*ref.cvv);
+
+   /*
    if (type == VT_CLOSURE)
       return thread_get_runtime_closure_var(ref.id)->scanMembers(rsh);
    if (type == VT_LOCAL_TS)
       return thread_find_closure_var(ref.id->getName())->scanMembers(rsh);
    if (type == VT_IMMEDIATE)
       return ref.cvv->scanMembers(rsh);
+   */
+   // never called with type == VT_LOCAL
    // we don't scan global vars; they are deleted explicitly when the program goes out of scope
    assert(type == VT_GLOBAL);
    return false;

--- a/lib/VarRefNode.cpp
+++ b/lib/VarRefNode.cpp
@@ -219,15 +219,6 @@ bool VarRefNode::scanMembers(RSetHelper& rsh) {
       return rsh.checkNode(*thread_find_closure_var(ref.id->getName()));
    if (type == VT_IMMEDIATE)
       return rsh.checkNode(*ref.cvv);
-
-   /*
-   if (type == VT_CLOSURE)
-      return thread_get_runtime_closure_var(ref.id)->scanMembers(rsh);
-   if (type == VT_LOCAL_TS)
-      return thread_find_closure_var(ref.id->getName())->scanMembers(rsh);
-   if (type == VT_IMMEDIATE)
-      return ref.cvv->scanMembers(rsh);
-   */
    // never called with type == VT_LOCAL
    // we don't scan global vars; they are deleted explicitly when the program goes out of scope
    assert(type == VT_GLOBAL);

--- a/lib/VarRefNode.cpp
+++ b/lib/VarRefNode.cpp
@@ -199,7 +199,7 @@ int VarRefNode::getLValue(LValueHelper& lvh, bool for_remove) const {
    return ref.var->getLValue(lvh, for_remove);
 }
 
-DLLLOCAL void VarRefNode::remove(LValueRemoveHelper& lvrh) {
+void VarRefNode::remove(LValueRemoveHelper& lvrh) {
    if (type == VT_LOCAL)
       return ref.id->remove(lvrh);
    if (type == VT_CLOSURE)
@@ -210,6 +210,21 @@ DLLLOCAL void VarRefNode::remove(LValueRemoveHelper& lvrh) {
       return ref.cvv->remove(lvrh);
    assert(type == VT_GLOBAL);
    return ref.var->remove(lvrh);
+}
+
+bool VarRefNode::scanMembers(RSetHelper& rsh) {
+   if (type == VT_LOCAL) {
+      return ref.id->scanMembers(rsh);
+   }
+   if (type == VT_CLOSURE)
+      return thread_get_runtime_closure_var(ref.id)->scanMembers(rsh);
+   if (type == VT_LOCAL_TS)
+      return thread_find_closure_var(ref.id->getName())->scanMembers(rsh);
+   if (type == VT_IMMEDIATE)
+      return ref.cvv->scanMembers(rsh);
+   // we don't scan global vars; they are deleted explicitly when the program goes out of scope
+   assert(type == VT_GLOBAL);
+   return false;
 }
 
 GlobalVarRefNode::GlobalVarRefNode(char *n, const QoreTypeInfo* typeInfo) : VarRefNode(n, 0, false, true) {

--- a/lib/Variable.cpp
+++ b/lib/Variable.cpp
@@ -1246,6 +1246,10 @@ void LocalVarValue::remove(LValueRemoveHelper& lvrh, const QoreTypeInfo* typeInf
    lvrh.doRemove((QoreLValueGeneric&)val, typeInfo);
 }
 
+bool LocalVarValue::scanMembers(RSetHelper& rsh) {
+   return rsh.checkNode(val.getInternalNode());
+}
+
 const void* ClosureVarValue::getLValueId() const {
    QoreSafeVarRWWriteLocker sl(rml);
    if (val.getType() == NT_REFERENCE) {

--- a/lib/Variable.cpp
+++ b/lib/Variable.cpp
@@ -432,7 +432,6 @@ int LValueHelper::doLValue(const ReferenceNode* ref, bool for_remove) {
    // a reference to a reference, however it's safe to insert it multiple times;
    // the reference count for the lvalue_id object is handled elsewhere
    lvid_set->insert(r->lvalue_id);
-   robj = const_cast<lvalue_ref*>(r);
    return doLValue(r->vexp, for_remove);
 }
 
@@ -1247,11 +1246,6 @@ void LocalVarValue::remove(LValueRemoveHelper& lvrh, const QoreTypeInfo* typeInf
    lvrh.doRemove((QoreLValueGeneric&)val, typeInfo);
 }
 
-bool LocalVarValue::scanMembers(RSetHelper& rsh) {
-   printd(0, "LocalVarValue::scanMembers() scanning %p %s\n", val.getInternalNode(), get_type_name(val.getInternalNode()));
-   return rsh.checkNode(val.getInternalNode());
-}
-
 const void* ClosureVarValue::getLValueId() const {
    QoreSafeVarRWWriteLocker sl(rml);
    if (val.getType() == NT_REFERENCE) {
@@ -1363,6 +1357,6 @@ void ClosureVarValue::deref(ExceptionSink* xsink) {
 }
 
 bool ClosureVarValue::scanMembers(RSetHelper& rsh) {
-   printd(0, "ClosureVarValue::scanMembers() scanning %p %s\n", val.getInternalNode(), get_type_name(val.getInternalNode()));
+   //printd(5, "ClosureVarValue::scanMembers() scanning %p %s\n", val.getInternalNode(), get_type_name(val.getInternalNode()));
    return scanCheck(rsh, val.getInternalNode());
 }

--- a/lib/Variable.cpp
+++ b/lib/Variable.cpp
@@ -432,6 +432,7 @@ int LValueHelper::doLValue(const ReferenceNode* ref, bool for_remove) {
    // a reference to a reference, however it's safe to insert it multiple times;
    // the reference count for the lvalue_id object is handled elsewhere
    lvid_set->insert(r->lvalue_id);
+   robj = const_cast<lvalue_ref*>(r);
    return doLValue(r->vexp, for_remove);
 }
 
@@ -1247,6 +1248,7 @@ void LocalVarValue::remove(LValueRemoveHelper& lvrh, const QoreTypeInfo* typeInf
 }
 
 bool LocalVarValue::scanMembers(RSetHelper& rsh) {
+   printd(0, "LocalVarValue::scanMembers() scanning %p %s\n", val.getInternalNode(), get_type_name(val.getInternalNode()));
    return rsh.checkNode(val.getInternalNode());
 }
 
@@ -1361,5 +1363,6 @@ void ClosureVarValue::deref(ExceptionSink* xsink) {
 }
 
 bool ClosureVarValue::scanMembers(RSetHelper& rsh) {
+   printd(0, "ClosureVarValue::scanMembers() scanning %p %s\n", val.getInternalNode(), get_type_name(val.getInternalNode()));
    return scanCheck(rsh, val.getInternalNode());
 }

--- a/lib/lvalue_ref.cpp
+++ b/lib/lvalue_ref.cpp
@@ -1,0 +1,100 @@
+/* -*- indent-tabs-mode: nil -*- */
+/*
+  lvalue_ref.cpp
+
+  POSIX thread library for Qore
+
+  Qore Programming Language
+
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+
+  Note that the Qore library is released under a choice of three open-source
+  licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+  information.
+*/
+
+lvalue_ref::lvalue_ref(ReferenceNode* ref, AbstractQoreNode* n_lvexp, QoreObject* n_self, const void* lvid) : RObject(ref->references), ref(ref), vexp(n_lvexp), self(n_self), pgm(getProgram()), lvalue_id(lvid) {
+   //printd(5, "lvalue_ref::lvalue_ref() this: %p vexp: %p self: %p pgm: %p\n", this, vexp, self, pgm);
+   if (self)
+      self->tRef();
+}
+
+lvalue_ref::lvalue_ref(const lvalue_ref& old, ReferenceNode* ref) : RObject(ref->references), ref(ref), vexp(old.vexp->refSelf()), self(old.self), pgm(old.pgm), lvalue_id(old.lvalue_id) {
+   //printd(5, "lvalue_ref::lvalue_ref() this: %p vexp: %p self: %p pgm: %p\n", this, vexp, self, pgm);
+   if (self)
+      self->tRef();
+}
+
+bool lvalue_ref::scanMembers(RSetHelper& rsh) {
+   assert(rml.checkRSectionExclusive());
+
+   return scanNode(rsh, vexp);
+}
+
+bool lvalue_ref::scanNode(RSetHelper& rsh, AbstractQoreNode* vexp) {
+   //printd(5, "lvalue_ref::scanNode() vexp: %p %s\n", vexp, get_type_name(vexp));
+   qore_type_t ntype = vexp->getType();
+   if (ntype == NT_VARREF) {
+      return reinterpret_cast<VarRefNode*>(vexp)->scanMembers(rsh);
+   }
+   else if (ntype == NT_SELF_VARREF) {
+      //printd(5, "lvalue_ref::scanMembers() self ref %p\n", vexp);
+      // here we scan the whole object instead of just the key since effectively we have a link to the object
+      // note that getStackObject() is guaranteed to return a value here (self varref is only valid in a method)
+      QoreObject* obj = runtime_get_stack_object();
+      return rsh.checkNode(obj);
+   }
+   else if (ntype == NT_OPERATOR) {
+      QoreSquareBracketsOperatorNode* op = dynamic_cast<QoreSquareBracketsOperatorNode*>(vexp);
+      assert(op);
+      assert(op->getRight()->getType() == NT_INT);
+      // we scan the whole list here because we have a reference to the list
+      return scanNode(rsh, op->getLeft());
+   }
+   else if (ntype == NT_TREE) {
+      // it must be a tree
+      QoreTreeNode* tree = reinterpret_cast<QoreTreeNode*>(vexp);
+      assert(tree->getOp() == OP_OBJECT_REF);
+      // we scan the whole hash here because we have a reference to the hash
+      return scanNode(rsh, tree->left);
+   }
+   else if (ntype == NT_REFERENCE) {
+      return rsh.checkNode(vexp);
+   }
+   /* other possibility:
+      - NT_CLASS_VARREF - does not need a scan - values are deleted when the Program is deleted
+   */
+
+   return false;
+}
+
+bool lvalue_ref::needsScan(bool scan_now) {
+   // we always perform the scan
+   return true;
+}
+
+void lvalue_ref::deleteObject() {
+   delete ref;
+}
+
+const char* lvalue_ref::getName() const {
+   return "lvalue reference";
+}

--- a/lib/single-compilation-unit.cpp
+++ b/lib/single-compilation-unit.cpp
@@ -35,6 +35,7 @@
 #include "SelfVarrefNode.cpp"
 #include "StaticClassVarRefNode.cpp"
 #include "ReferenceNode.cpp"
+#include "lvalue_ref.cpp"
 #include "BackquoteNode.cpp"
 #include "ContextrefNode.cpp"
 #include "ComplexContextrefNode.cpp"


### PR DESCRIPTION
@pavelkveton it turns out that I fixed the leak, and it turned out much simpler than I thought, because the only thing I needed to do was ensure that ClosureVarValue (which already was in the scan) is followed through ReferenceNode - all other paths are not relevant for cycles - so the code closes the memory leak and also was fairly simple in the end

please approve or make a note if we should postpone to 0.8.12.10 - I would like to include this in 0.9.12.9 because I don't believe it's a dangerous change and fixes important memory leaks in the GC