### PR TITLE
refs #1835 eliminated a spurious exception thrown in the SQLStatement…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -9,6 +9,8 @@
 
     @subsection qore_081210_bug_fixes Bug Fixes in Qore
 
+    - fixed a bug where connections were not immediately released back to the @ref Qore::SQL::DatasourcePool "DatasourcePool" in case of an \c SQLSTATEMENT-ERROR exception (<a href="https://github.com/qorelanguage/qore/issues/1836">issue 1836</a>)
+    - eliminated a spurious exception in the @ref Qore::SQL::SQLStatement "SQLStatement" class in case of a @ref Qore::SQL::DatasourcePool "DatasourcePool" timeout (<a href="https://github.com/qorelanguage/qore/issues/1832">issue 1832</a>)
     - <a href="../../modules/HttpServerUtil/html/index.html">HttpServerUtil</a>: eliminated excess logging of all HTTP chunks sent and received (<a href="https://github.com/qorelanguage/qore/issues/1832">issue 1832</a>)
     - <a href="../../modules/FixedLengthUtil/html/index.html">FixedLengthUtil</a>: fixes and improvements to errors and exceptions (<a href="https://github.com/qorelanguage/qore/issues/1828">issue 1828</a>)
     - fixed a crash when the incorrect type was passed to a parameter declared @ref reference_or_nothing_type "*reference" (<a href="https://github.com/qorelanguage/qore/issues/1815">issue 1815</a>)

--- a/examples/test/qore/classes/SQLStatement/SQLStatement.qtest
+++ b/examples/test/qore/classes/SQLStatement/SQLStatement.qtest
@@ -106,7 +106,8 @@ class SQLStatementTest inherits QUnit::Test {
             SQLStatement stmt(dsp);
             on_error dsp.rollback();
 
-            stmt.prepare("insert into test (string) values (%v)");
+            stmt.prepare("select * from test");
+            stmt.exec();
             dsp.commit();
 
             # test that an exception is thrown when we try to execute a stmt prepared on another connection

--- a/include/qore/intern/qore_program_private.h
+++ b/include/qore/intern/qore_program_private.h
@@ -531,6 +531,7 @@ public:
       assert(!pendingParseSink);
       assert(pgm_data_map.empty());
       assert(!exec_class_rv);
+      assert(!dc.reference_count());
    }
 
    DLLLOCAL void depRef() {

--- a/lib/DatasourcePool.cpp
+++ b/lib/DatasourcePool.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2016 David Nichols
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -97,7 +97,7 @@ DatasourcePool::~DatasourcePool() {
 // common constructor code
 void DatasourcePool::init(ExceptionSink* xsink) {
    assert(xsink);
-   // ths intiial Datasource creation could throw an exception if there is an error in a driver option, for example
+   // ths initial Datasource creation could throw an exception if there is an error in a driver option, for example
    std::auto_ptr<Datasource> ds(config.get(xsink));
    if (*xsink)
       return;


### PR DESCRIPTION
… class in case of a DatasourcePool timeout

refs #1836 fixed a bug where the SQLStatement class failed to release a connection in case of an SQLSTATEMENT-ERROR