### PR TITLE
refs #1250 ported the lost connection API to 0.8.12; added the Dataso…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -16,6 +16,7 @@
     - fixed a crash when the incorrect type was passed to a parameter declared @ref reference_or_nothing_type "*reference" (<a href="https://github.com/qorelanguage/qore/issues/1815">issue 1815</a>)
     - fixed a crash when the %Qore library exits caused by an error in handling module dependencies with injected modules  (<a href="https://github.com/qorelanguage/qore/issues/1805">issue 1805</a>)
     - fixed segfault crashes caused by calling object methods with null pointers (<a href="https://github.com/qorelanguage/qore/issues/1791">issue 1791</a>)
+    - added internal API support to make it easier for DBI drivers to handle lost connections and to allow DBI drivers that must close all open handles before a connection is closed (such as the oracle driver); due to this change, @ref Qore::SQL::SQLStatement "SQLStatement" objects based on a @ref Qore::SQL::DatasourcePool "DatasourcePool" are closed automatically whenever the datasource is returned to the pool (<a href="https://github.com/qorelanguage/qore/issues/1250">issue 1250</a>)
 
     @section qore_08129 Qore 0.8.12.9
 

--- a/examples/test/qore/classes/SQLStatement/SQLStatement.qtest
+++ b/examples/test/qore/classes/SQLStatement/SQLStatement.qtest
@@ -98,8 +98,8 @@ class SQLStatementTest inherits QUnit::Test {
             assertEq(1, rc);
             dsp.commit();
 
-            # test that an exception is thrown when we try to execute a stmt prepared on another connection
-            assertThrows("SQLSTATEMENT-ERROR", sub () {stmt.exec("hi2");});
+            # test that no exception is thrown when we try to execute a stmt prepared on another connection
+            stmt.exec("hi2");
         }
 
         {
@@ -110,8 +110,8 @@ class SQLStatementTest inherits QUnit::Test {
             stmt.exec();
             dsp.commit();
 
-            # test that an exception is thrown when we try to execute a stmt prepared on another connection
-            assertThrows("SQLSTATEMENT-ERROR", sub () {stmt.exec("hi2");});
+            # test that no exception is thrown when we try to execute a stmt prepared on another connection
+            stmt.exec("hi2");
         }
         {
             SQLStatement stmt(ds);

--- a/include/qore/DBI.h
+++ b/include/qore/DBI.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -92,8 +92,9 @@
 #define QDBI_METHOD_OPT_GET                  30
 #define QDBI_METHOD_STMT_DESCRIBE            31
 #define QDBI_METHOD_DESCRIBE                 32
+#define QDBI_METHOD_STMT_FREE                33
 
-#define QDBI_VALID_CODES 32
+#define QDBI_VALID_CODES 33
 
 /* DBI EVENT Types
    all DBI events must have the following keys:

--- a/include/qore/Datasource.h
+++ b/include/qore/Datasource.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
 
   The Datasource class provides the low-level interface to Qore DBI drivers.
 
@@ -53,6 +53,7 @@ class DBIDriver;
 */
 class Datasource {
    friend class QoreSQLStatement;
+   friend struct qore_ds_private;
 
 private:
    struct qore_ds_private *priv; // private implementation
@@ -433,6 +434,7 @@ public:
 
    //! executes the "get_client_version" function of the driver, if any, and returns the result
    /** the caller owns the AbstractQoreNode pointer's reference count returned (if the pointer is not 0)
+
        @param xsink if an error occurs, the Qore-language exception information will be added here
    */
    DLLEXPORT AbstractQoreNode* getClientVersion(ExceptionSink* xsink) const;
@@ -447,8 +449,42 @@ public:
    /** The DBIDriver should raise its own exception when this call is made, as making this call will
        suppress further Qore exceptions from being raised in the Datasource destructor (at least for
        derived classes)
+
+       @note This call results in all open statements being closed and then the Datasource
+       itself is closed, resulting in the deletion of the driver-specific Datasource local
+       data; if the driver needs to free memory before the Datasource is closed, then the
+       driver should call connectionLost() instead, free its memory, and then call
+       the variant of function taking an ExceptionSink pointer argument.
+
+       @deprecated use connectionAborted(ExceptionSink*) instead
    */
    DLLEXPORT void connectionAborted();
+
+   //! should be called by the DBI driver if the connection to the server has been lost
+   /** The DBIDriver should raise its own exception when this call is made, as making this call will
+       suppress further Qore exceptions from being raised in the Datasource destructor (at least for
+       derived classes)
+
+       @note This call results in all open statements being closed and then the Datasource
+       itself is closed, resulting in the deletion of the driver-specific Datasource local
+       data; if the driver needs to free memory before the Datasource is closed, then the
+       driver should call connectionLost() instead, free its memory, and then call
+       this function.
+
+       @since %Qore 0.8.12.10
+   */
+   DLLEXPORT void connectionAborted(ExceptionSink* xsink);
+
+   //! should be called be the DBI driver to signify that the connection to the server has been lost
+   /** This call does not result in the Datasource being closed, but rather ensures that
+       all open statements are closed while the driver-specific Datasource local data remains
+       in place.
+
+       This flag does not result in the connection aborted flag being set.
+
+       @since %Qore 0.8.12.10
+    */
+   DLLEXPORT void connectionLost(ExceptionSink* xsink);
 
    //! returns the connection aborted status
    /** @return the connection aborted status

--- a/include/qore/Datasource.h
+++ b/include/qore/Datasource.h
@@ -465,6 +465,9 @@ public:
        suppress further Qore exceptions from being raised in the Datasource destructor (at least for
        derived classes)
 
+       This function should be called after a connectionLost() call if the connection is
+       not able to be reopened.
+
        @note This call results in all open statements being closed and then the Datasource
        itself is closed, resulting in the deletion of the driver-specific Datasource local
        data; if the driver needs to free memory before the Datasource is closed, then the
@@ -485,6 +488,18 @@ public:
        @since %Qore 0.8.12.10
     */
    DLLEXPORT void connectionLost(ExceptionSink* xsink);
+
+   //! should be called be the DBI driver to signify that the connection to the server has been recovered
+   /** This call does not result in the Datasource being closed, but rather ensures that
+       all open statements are closed and also that driver-specific Datasource local data
+       is deleted.
+
+       This function should be called after a connectionLost() call if the connection is
+       then reopened.
+
+       @since %Qore 0.8.12.10
+    */
+   DLLEXPORT void connectionRecovered(ExceptionSink* xsink);
 
    //! returns the connection aborted status
    /** @return the connection aborted status

--- a/include/qore/intern/DatasourcePool.h
+++ b/include/qore/intern/DatasourcePool.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2016 David Nichols
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -39,8 +39,8 @@
 #include <qore/QoreString.h>
 #include <qore/AbstractThreadResource.h>
 
-#include <qore/intern/DatasourceStatementHelper.h>
-#include <qore/intern/QoreSQLStatement.h>
+#include "qore/intern/DatasourceStatementHelper.h"
+#include "qore/intern/QoreSQLStatement.h"
 
 #include <map>
 #include <deque>
@@ -198,7 +198,7 @@ protected:
    DLLLOCAL Datasource* getAllocatedDS();
    DLLLOCAL Datasource* getDSIntern(bool& new_ds, int64& wait_total, ExceptionSink* xsink);
    DLLLOCAL Datasource* getDS(bool& new_ds, ExceptionSink* xsink);
-   DLLLOCAL void freeDS();
+   DLLLOCAL void freeDS(ExceptionSink* xsink);
    // share the code for exec() and execRaw()
    DLLLOCAL AbstractQoreNode* exec_internal(bool doBind, const QoreString* sql, const QoreListNode* args, ExceptionSink* xsink);
    DLLLOCAL int checkWait(int64 warn_total, ExceptionSink* xsink);
@@ -278,7 +278,7 @@ public:
    DLLLOCAL virtual Datasource* helperEndAction(char cmd, bool new_transaction, ExceptionSink* xsink) {
       //printd(5, "DatasourcePool::helperEndAction() cmd: %d '%s', nt: %d\n", cmd, DAH_TEXT(cmd), new_transaction);
       if (cmd == DAH_RELEASE) {
-         freeDS();
+         freeDS(xsink);
          return 0;
       }
 
@@ -333,7 +333,7 @@ public:
       if (cmd == DAH_RELEASE
           || ds->wasConnectionAborted()
           || (new_ds && (cmd == DAH_NOCHANGE)))
-	 dsp.freeDS();
+	 dsp.freeDS(xsink);
    }
 
 #if 0

--- a/include/qore/intern/QoreSQLStatement.h
+++ b/include/qore/intern/QoreSQLStatement.h
@@ -120,7 +120,7 @@ public:
    DLLLOCAL bool currentThreadInTransaction(ExceptionSink* xsink);
 
    // called by the datasource object if the connection is lost or the transaction has been committed or rolled back
-   DLLLOCAL void transactionDone(bool clear, ExceptionSink* xsink);
+   DLLLOCAL void transactionDone(bool clear, bool close, ExceptionSink* xsink);
 
    DLLLOCAL QoreStringNode* getSQL(ExceptionSink* xsink);
 };

--- a/include/qore/intern/QoreSQLStatement.h
+++ b/include/qore/intern/QoreSQLStatement.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2006 - 2016 Qore Technologies, sro
+  Copyright (C) 2006 - 2016 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -32,7 +32,7 @@
 #ifndef _QORE_QORESQLSTATEMENT_H
 #define _QORE_QORESQLSTATEMENT_H
 
-#include <qore/intern/sql_statement_private.h>
+#include "qore/intern/sql_statement_private.h"
 
 class DatasourceStatementHelper;
 
@@ -118,6 +118,9 @@ public:
 
    DLLLOCAL bool active() const;
    DLLLOCAL bool currentThreadInTransaction(ExceptionSink* xsink);
+
+   // called by the datasource object if the connection is lost or the transaction has been committed or rolled back
+   DLLLOCAL void transactionDone(bool clear, ExceptionSink* xsink);
 
    DLLLOCAL QoreStringNode* getSQL(ExceptionSink* xsink);
 };

--- a/include/qore/intern/qore_dbi_private.h
+++ b/include/qore/intern/qore_dbi_private.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -59,7 +59,7 @@ struct dbi_driver_stmt {
    q_dbi_stmt_fetch_row_t describe;
    q_dbi_stmt_next_t next;
    q_dbi_stmt_define_t define;
-   q_dbi_stmt_close_t close;
+   q_dbi_stmt_close_t close, free;
    q_dbi_stmt_affected_rows_t affected_rows;
    q_dbi_stmt_get_output_t get_output;
    q_dbi_stmt_get_output_rows_t get_output_rows;
@@ -67,7 +67,7 @@ struct dbi_driver_stmt {
    DLLLOCAL dbi_driver_stmt() : prepare(0), prepare_raw(0), bind(0), bind_placeholders(0),
                                 bind_values(0), exec(0), fetch_row(0), fetch_rows(0),
                                 fetch_columns(0), describe(0), next(0), define(0),
-                                close(0), affected_rows(0), get_output(0), get_output_rows(0) {
+                                close(0), free(0), affected_rows(0), get_output(0), get_output_rows(0) {
    }
 };
 
@@ -341,6 +341,10 @@ struct qore_dbi_private {
 
    DLLLOCAL int stmt_close(SQLStatement* stmt, ExceptionSink* xsink) const {
       return f.stmt.close(stmt, xsink);
+   }
+
+   DLLLOCAL int stmt_free(SQLStatement* stmt, ExceptionSink* xsink) const {
+      return f.stmt.free ? f.stmt.free(stmt, xsink) : 0;
    }
 
    DLLLOCAL int opt_set(Datasource* ds, const char* opt, const AbstractQoreNode* val, ExceptionSink* xsink) {

--- a/lib/DBI.cpp
+++ b/lib/DBI.cpp
@@ -5,7 +5,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -170,7 +170,7 @@ void qore_dbi_method_list::add(int code, q_dbi_stmt_bind_t method) {
 
 // covers stmt exec, close, define, and affectedRows
 void qore_dbi_method_list::add(int code, q_dbi_stmt_exec_t method) {
-   assert(code == QDBI_METHOD_STMT_EXEC || code == QDBI_METHOD_STMT_CLOSE || code == QDBI_METHOD_STMT_DEFINE || code == QDBI_METHOD_STMT_AFFECTED_ROWS);
+   assert(code == QDBI_METHOD_STMT_EXEC || code == QDBI_METHOD_STMT_CLOSE || code == QDBI_METHOD_STMT_DEFINE || code == QDBI_METHOD_STMT_AFFECTED_ROWS || code == QDBI_METHOD_STMT_FREE);
    assert(priv->l.find(code) == priv->l.end());
    priv->l[code] = (void*)method;
 }
@@ -371,6 +371,10 @@ qore_dbi_private::qore_dbi_private(const char* nme, const qore_dbi_mlist_private
          case QDBI_METHOD_STMT_CLOSE:
             assert(!f.stmt.close);
             f.stmt.close = (q_dbi_stmt_close_t)(*i).second;
+            break;
+         case QDBI_METHOD_STMT_FREE:
+            assert(!f.stmt.free);
+            f.stmt.free = (q_dbi_stmt_close_t)(*i).second;
             break;
          case QDBI_METHOD_STMT_AFFECTED_ROWS:
             assert(!f.stmt.affected_rows);

--- a/lib/Datasource.cpp
+++ b/lib/Datasource.cpp
@@ -281,6 +281,10 @@ void Datasource::connectionLost(ExceptionSink* xsink) {
    priv->connectionLost(xsink);
 }
 
+void Datasource::connectionRecovered(ExceptionSink* xsink) {
+   priv->connectionRecovered(xsink);
+}
+
 bool Datasource::wasConnectionAborted() const {
    return priv->connection_aborted;
 }

--- a/lib/Datasource.cpp
+++ b/lib/Datasource.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
 
   NOTE that 2 copies of connection values are kept in case
   the values are changed while a connection is in use
@@ -32,19 +32,23 @@
 */
 
 #include <qore/Qore.h>
-#include <qore/intern/qore_dbi_private.h>
-#include <qore/intern/qore_ds_private.h>
+#include "qore/intern/qore_dbi_private.h"
+#include "qore/intern/qore_ds_private.h"
 
 #include <stdlib.h>
 #include <string.h>
 
-void qore_ds_private::statementExecuted(int rc, ExceptionSink* xsink) {
+void qore_ds_private::statementExecuted(int rc) {
    // we always assume we are in a transaction after executing a transaction-relevant statement
+   // unless the connection was aborted
    if (!in_transaction) {
-      assert(!active_transaction);
-      in_transaction = true;
-      active_transaction = true;
-      return;
+      if (!connection_aborted) {
+         assert(!active_transaction);
+         assert(isopen);
+         in_transaction = true;
+         active_transaction = true;
+         return;
+      }
    }
    else if (!rc && !active_transaction)
       active_transaction = true;
@@ -167,7 +171,7 @@ AbstractQoreNode* Datasource::exec_internal(bool doBind, const QoreString* query
    if (priv->autocommit)
       qore_dbi_private::get(*priv->dsl)->autoCommit(this, xsink);
    else
-      priv->statementExecuted(*xsink, xsink);
+      priv->statementExecuted(*xsink);
 
    return rv;
 }
@@ -227,23 +231,14 @@ int Datasource::commit(ExceptionSink* xsink) {
    if (!priv->in_transaction && beginImplicitTransaction(xsink))
       return -1;
 
-   int rc = qore_dbi_private::get(*priv->dsl)->commit(this, xsink);
-   priv->in_transaction = false;
-   priv->active_transaction = false;
-
-   return rc;
+   return priv->commit(xsink);
 }
 
 int Datasource::rollback(ExceptionSink* xsink) {
    if (!priv->in_transaction && beginImplicitTransaction(xsink))
       return -1;
 
-   //printd(5, "Datasource::rollback() this: %p in_transaction: %d active_transaction: %d\n", this, priv->in_transaction, priv->active_transaction);
-
-   int rc = qore_dbi_private::get(*priv->dsl)->rollback(this, xsink);
-   priv->in_transaction = false;
-   priv->active_transaction = false;
-   return rc;
+   return priv->rollback(xsink);
 }
 
 int Datasource::open(ExceptionSink* xsink) {
@@ -269,20 +264,21 @@ int Datasource::open(ExceptionSink* xsink) {
 }
 
 int Datasource::close() {
-   if (priv->isopen) {
-      qore_dbi_private::get(*priv->dsl)->close(this);
-      priv->isopen = false;
-      priv->in_transaction = false;
-      priv->active_transaction = false;
-      return 0;
-   }
-   return -1;
+   return priv->close();
 }
 
 void Datasource::connectionAborted() {
-   assert(priv->isopen);
-   priv->connection_aborted = true;
-   close();
+   ExceptionSink xsink;
+   priv->connectionAborted(&xsink);
+   xsink.clear();
+}
+
+void Datasource::connectionAborted(ExceptionSink* xsink) {
+   priv->connectionAborted(xsink);
+}
+
+void Datasource::connectionLost(ExceptionSink* xsink) {
+   priv->connectionLost(xsink);
 }
 
 bool Datasource::wasConnectionAborted() const {

--- a/lib/DatasourcePool.cpp
+++ b/lib/DatasourcePool.cpp
@@ -234,7 +234,7 @@ void DatasourcePool::freeDS(ExceptionSink* xsink) {
    free_list.push_back(i->second);
 
    // issue 1250: close any other statements created on this datasource
-   qore_ds_private::get(*pool[i->second])->transactionDone(true, xsink);
+   qore_ds_private::get(*pool[i->second])->transactionDone(true, true, xsink);
 
    tmap.erase(i);
 

--- a/lib/DatasourcePool.cpp
+++ b/lib/DatasourcePool.cpp
@@ -29,8 +29,8 @@
 */
 
 #include <qore/Qore.h>
-#include <qore/intern/DatasourcePool.h>
-
+#include "qore/intern/DatasourcePool.h"
+#include "qore/intern/qore_ds_private.h"
 #include <memory>
 
 DatasourcePool::DatasourcePool(ExceptionSink* xsink, DBIDriver* ndsl, const char* user, const char* pass,
@@ -85,7 +85,7 @@ DatasourcePool::DatasourcePool(const DatasourcePool& old, ExceptionSink* xsink) 
 }
 
 DatasourcePool::~DatasourcePool() {
-   //printd(5, "DatasourcePool::~DatasourcePool() trlist.remove() this: %p\n", this);
+   //printd(5, "DatasourcePool::~DatasourcePool() this: %p\n", this);
    for (unsigned i = 0; i < cmax; ++i)
       delete pool[i];
    delete [] tid_list;
@@ -156,6 +156,7 @@ void DatasourcePool::cleanup(ExceptionSink* xsink) {
 }
 
 void DatasourcePool::destructor(ExceptionSink* xsink) {
+   //printd(5, "DatasourcePool::destructor() this: %p\n", this);
    SafeLocker sl((QoreThreadLock*)this);
 
    // mark object as invalid in case any threads are waiting on a free Datasource
@@ -177,7 +178,7 @@ void DatasourcePool::destructor(ExceptionSink* xsink) {
       // execute rollback on Datasource before releasing to pool
       pool[curr]->rollback(xsink);
 
-      freeDS();
+      freeDS(xsink);
    }
 
    if (warning_callback) {
@@ -218,7 +219,7 @@ QoreString* DatasourcePool::getAndResetSQL() {
 }
 #endif
 
-void DatasourcePool::freeDS() {
+void DatasourcePool::freeDS(ExceptionSink* xsink) {
    // remove from thread resource list
    //printd(5, "DatasourcePool::freeDS() remove_thread_resource(this: %p)\n", this);
 
@@ -231,7 +232,12 @@ void DatasourcePool::freeDS() {
    thread_use_t::iterator i = tmap.find(tid);
    assert(!pool[i->second]->isInTransaction());
    free_list.push_back(i->second);
+
+   // issue 1250: close any other statements created on this datasource
+   qore_ds_private::get(*pool[i->second])->transactionDone(true, xsink);
+
    tmap.erase(i);
+
    if (wait_count)
       signal();
 }
@@ -256,7 +262,7 @@ Datasource* DatasourcePool::getDS(bool &new_ds, ExceptionSink* xsink) {
    if (wait_total && checkWait(wait_total, xsink)) {
       assert(new_ds);
       assert(!ds->isInTransaction());
-      freeDS();
+      freeDS(xsink);
       return 0;
    }
 
@@ -265,7 +271,7 @@ Datasource* DatasourcePool::getDS(bool &new_ds, ExceptionSink* xsink) {
       assert(new_ds);
       if (ds->open(xsink)) {
 	 assert(!ds->isInTransaction());
-	 freeDS();
+	 freeDS(xsink);
 	 return 0;
       }
    }
@@ -600,7 +606,7 @@ void DatasourcePool::clearWarningCallback(ExceptionSink* xsink) {
 
 void DatasourcePool::setWarningCallback(int64 warning_ms, ResolvedCallReferenceNode* cb, AbstractQoreNode* arg, ExceptionSink* xsink) {
    if (warning_ms <= 0) {
-      xsink->raiseException("DATASOURCEPOOL-SETWARNINGCALLBACK-ERROR", "DatasourcePool::setWarningCallback() warning ms argument: "QLLD" must be greater than zero; to clear, call DatasourcePool::clearWarningCallback() with no arguments", warning_ms);
+      xsink->raiseException("DATASOURCEPOOL-SETWARNINGCALLBACK-ERROR", "DatasourcePool::setWarningCallback() warning ms argument: " QLLD " must be greater than zero; to clear, call DatasourcePool::clearWarningCallback() with no arguments", warning_ms);
       return;
    }
    AutoLocker al((QoreThreadLock*)this);

--- a/lib/QoreSQLStatement.cpp
+++ b/lib/QoreSQLStatement.cpp
@@ -30,11 +30,11 @@
 */
 
 #include <qore/Qore.h>
-#include <qore/intern/QC_SQLStatement.h>
-#include <qore/intern/DatasourceStatementHelper.h>
-#include <qore/intern/sql_statement_private.h>
-#include <qore/intern/qore_ds_private.h>
-#include <qore/intern/qore_dbi_private.h>
+#include "qore/intern/QC_SQLStatement.h"
+#include "qore/intern/DatasourceStatementHelper.h"
+#include "qore/intern/sql_statement_private.h"
+#include "qore/intern/qore_ds_private.h"
+#include "qore/intern/qore_dbi_private.h"
 
 const char* QoreSQLStatement::stmt_statuses[] = { "idle", "prepared", "executed", "defined" };
 
@@ -47,47 +47,46 @@ public:
    bool nt; // new transaction flag
 
    DLLLOCAL DBActionHelper(QoreSQLStatement& n_stmt, ExceptionSink* n_xsink, char n_cmd = DAH_NOCHANGE) : stmt(n_stmt), xsink(n_xsink), valid(false), cmd(n_cmd), nt(false) {
-      Datasource* oldds = stmt.priv->ds;
-      //printd(5, "DBActionHelper::DBActionHelper() old ds: %p cmd: %s\n", stmt.priv->ds, DAH_TEXT(cmd));
-      stmt.priv->ds = stmt.dsh->helperStartAction(xsink, nt);
+      Datasource* newds = stmt.dsh->helperStartAction(xsink, nt);
+      assert(!newds || !stmt.priv->ds || (newds == stmt.priv->ds));
+      assert(newds || *xsink);
+      if (newds && !stmt.priv->ds)
+         qore_ds_private::get(*newds)->addStatement(&n_stmt);
+      stmt.priv->ds = newds;
 
-      //printd(5, "DBActionHelper::DBActionHelper() ds: %p cmd: %s nt: %d\n", stmt.priv->ds, DAH_TEXT(cmd), nt);
-
-      // issue #1835: the helperStartAction() call can fail in case of a timeout, therefore we have to check below
-      // that the call succeeded before raising an additional exception
-
-      // if we are trying to start a new transaction on a new Datasource connection, but we have
-      // already prepared the statement on another connection, we have to raise an exception
-      // otherwise the statement will actually be executed on the original connection which is
-      // cached in the driver (https://github.com/qorelanguage/qore/issues/465)
-      if (oldds && stmt.priv->ds && stmt.priv->ds != oldds && cmd == DAH_ACQUIRE) {
-         // issue #1836 we release the connection before marking the object as invalid
-         stmt.priv->ds = stmt.dsh->helperEndAction(DAH_RELEASE, nt, xsink);
-         xsink->raiseException("SQLSTATEMENT-ERROR", "statement was prepared on another Datasource; you must close the statement before executing this action on a new connection");
-      }
-
-      // ensure we either have a datasource or an exception
-      assert((*xsink && !stmt.priv->ds) || (!*xsink && stmt.priv->ds));
-
-      valid = *xsink ? false : true;
+      //printd(5, "DBActionHelper::DBActionHelper() ds: %p new: %p cmd: %s nt: %d xs: %d stmt: %p\n", stmt.priv->ds, newds, DAH_TEXT(cmd), nt, (bool)*xsink, &stmt);
+      valid = (bool)stmt.priv->ds;
    }
 
    DLLLOCAL ~DBActionHelper() {
-      if (!valid)
+      // if no datasource is currently assigned
+      if (!valid || !stmt.priv->ds)
          return;
 
       /* release the Datasource if:
-         1) the connection was lost (exception already raised)
+         1) the transaction was aborted
+         or
          2) the Datasource was acquired for this call, and
               the command was NOCHANGE, meaning, leave the Datasource in the same state it was before the call
        */
-      if (stmt.priv->ds->wasConnectionAborted() || (nt && (cmd == DAH_NOCHANGE)))
+      if (stmt.priv->ds->wasConnectionAborted() || !stmt.priv->ds->isOpen() || (nt && (cmd == DAH_NOCHANGE)))
          cmd = DAH_RELEASE;
 
-      //printd(5, "DBActionHelper::~DBActionHelper() ds: %p cmd: %s nt: %d xsink: %d\n", stmt.priv->ds, DAH_TEXT(cmd), nt, xsink->isEvent());
+      //printd(5, "DBActionHelper::~DBActionHelper() ds: %p cmd: %s nt: %d xsink: %d stmt: %p status: %d data: %p\n", stmt.priv->ds, DAH_TEXT(cmd), nt, xsink->isEvent(), &stmt, stmt.status, stmt.priv->data);
+
+      // remove statement from Datasource if the connection is no longer allocated
+      // must be executed in the Datasource allocation lock
+      if (cmd == DAH_RELEASE) {
+         qore_ds_private* dspriv = qore_ds_private::get(*stmt.priv->ds);
+         //printd(5, "DBActionHelper::~DBActionHelper() old: %p ds: %p removing stmt %p\n", oldds, stmt.priv->ds, &stmt);
+         dspriv->removeStatement(&stmt);
+      }
 
       // call end action with the command
       stmt.priv->ds = stmt.dsh->helperEndAction(cmd, nt, xsink);
+
+      // we have to remove the datasource from the statement immediately if the Datasource is closed or committed
+      assert((cmd == DAH_RELEASE) || stmt.priv->ds);
    }
 
    DLLLOCAL operator bool() const {
@@ -151,13 +150,12 @@ int QoreSQLStatement::checkStatus(ExceptionSink* xsink, DBActionHelper& dba, int
 
 void QoreSQLStatement::deref(ExceptionSink* xsink) {
    if (ROdereference()) {
-      char cmd = DAH_NOCHANGE;
-      //printd(5, "QoreSQLStatement::deref() deleting this=%p cmd=%s\n", this, DAH_TEXT(cmd));
-      {
-         DBActionHelper dba(*this, xsink, cmd);
-         if (dba)
-            closeIntern(xsink);
-      }
+      //char cmd = DAH_NOCHANGE;
+      //printd(5, "QoreSQLStatement::deref() deleting this: %p cmd: %s\n", this, DAH_TEXT(cmd));
+      closeIntern(xsink);
+
+      if (priv->ds)
+         qore_ds_private::get(*priv->ds)->removeStatement(this);
 
       dsh->helperDestructor(this, xsink);
 
@@ -166,6 +164,18 @@ void QoreSQLStatement::deref(ExceptionSink* xsink) {
 
       delete this;
    }
+}
+
+void QoreSQLStatement::transactionDone(bool clear, ExceptionSink* xsink) {
+   //printd(5, "QoreSQLStatement::transactionDone() this: %p data: %p ds: %p clear: %d\n", this, priv->data, priv->ds, clear);
+   if (priv->data) {
+      assert(priv->ds);
+      qore_dbi_private::get(*priv->ds->getDriver())->stmt_close(this, xsink);
+      assert(!priv->data);
+      status = STMT_IDLE;
+   }
+   if (clear && priv->ds)
+      priv->ds = 0;
 }
 
 int QoreSQLStatement::closeIntern(ExceptionSink* xsink) {
@@ -201,7 +211,6 @@ int QoreSQLStatement::prepareIntern(ExceptionSink* xsink) {
    int rc = qore_dbi_private::get(*priv->ds->getDriver())->stmt_prepare(this, str, prepare_args, xsink);
    if (!rc) {
       status = STMT_PREPARED;
-      //stmtds = ds;
    }
    else
       closeIntern(xsink);
@@ -290,7 +299,7 @@ int QoreSQLStatement::execIntern(DBActionHelper& dba, ExceptionSink* xsink) {
 
    //printd(5, "QoreSQLStatement::execIntern() this: %p ds: %p: %s@%s: %s\n", this, priv->ds, priv->ds->getUsername(), priv->ds->getDBName(), str.getBuffer());
 
-   priv->ds->priv->statementExecuted(rc, xsink);
+   priv->ds->priv->statementExecuted(rc);
    return rc;
 }
 
@@ -430,7 +439,7 @@ int QoreSQLStatement::commit(ExceptionSink* xsink) {
       return -1;
 
    int rc = closeIntern(xsink);
-   rc = priv->ds->commit(xsink);
+   rc = qore_ds_private::get(*priv->ds)->commitIntern(xsink);
    //printd(5, "QoreSQLStatement::commit() this: %p ds: %p rc: %d\n", this, priv->ds, rc);
    return rc;
 }
@@ -441,7 +450,7 @@ int QoreSQLStatement::rollback(ExceptionSink* xsink) {
       return -1;
 
    int rc = closeIntern(xsink);
-   rc = priv->ds->rollback(xsink);
+   rc = qore_ds_private::get(*priv->ds)->rollbackIntern(xsink);
    //printd(5, "QoreSQLStatement::rollback() this: %p ds: %p rc: %d\n", this, priv->ds, rc);
    return rc;
 }


### PR DESCRIPTION
…urce::connectionLost() API to allow drivers to ensure that all open statements are closed when a connection is lost to allow drivers such as oracle to close all handles on the current connection object