### PR TITLE
refs #1250 removed unnecessary code; statements are closed properly i…

### DIFF
--- a/lib/ManagedDatasource.cpp
+++ b/lib/ManagedDatasource.cpp
@@ -47,10 +47,6 @@ void ManagedDatasource::cleanup(ExceptionSink *xsink) {
 
 void ManagedDatasource::destructor(ExceptionSink *xsink) {
    AutoLocker al(&ds_lock);
-   // issue 1250: close all statements created on this datasource
-   // must be performed before the datasource is closed
-   qore_ds_private::get(*this)->transactionDone(true, true, xsink);
-
    if (tid == gettid() || tid == -1)
       // closeUnlocked will throw an exception if a transaction is in progress (and release the transaction lock if held)
       closeUnlocked(xsink);


### PR DESCRIPTION
…n lower-level functions; it's not necessary to duplicate this call here

@omusil24 sorry for the back-and-forth, but after further review and comparing with `develop`, the change added here was unnecessary; statements are always closed before closing in lower-level functions