### PR TITLE
refs #1927 must set parse location for every update in thread-local d…

### DIFF
--- a/command-line.cpp
+++ b/command-line.cpp
@@ -933,7 +933,7 @@ int qore_main_intern(int argc, char* argv[], int other_po) {
 
       // parse immediate argument if any
       if (eval_arg) {
-	 QoreString str("printf(\"%N\n\", (");
+	 QoreString str("printf(\"%N\\n\", (");
 	 str.concat(eval_arg);
 	 str.concat("));");
 	 qpgm->parse(str.getBuffer(), "<command-line>", &xsink, &wsink, warnings);

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -21,6 +21,7 @@
         - fixed a bug that prohibited only columns from the main query to be selected when joins are used (<a href="https://github.com/qorelanguage/qore/issues/1909">issue 1909</a>)
       - <a href="../../modules/TableMapper/html/index.html">TableMapper</a>:
         - fixed a bug in flush messages in the \c InboundTableMapper class (<a href="https://github.com/qorelanguage/qore/issues/1849">issue 1849</a>)
+    - fixed a bug that could cause spurious parse-time exceptions to be thrown when matching call variants with multiple return types for the same callable object (<a href="https://github.com/qorelanguage/qore/issues/1928">issue 1928</a>)
     - fixed the process return code in the output reference in @ref Qore::backquote() "backquote()" on Unix/Linux platforms (<a href="https://github.com/qorelanguage/qore/issues/1884">issue 1884</a>)
     - fixed a bug where connections were not immediately released back to the @ref Qore::SQL::DatasourcePool "DatasourcePool" in case of an \c SQLSTATEMENT-ERROR exception (<a href="https://github.com/qorelanguage/qore/issues/1836">issue 1836</a>)
     - eliminated a spurious exception in the @ref Qore::SQL::SQLStatement "SQLStatement" class in case of a @ref Qore::SQL::DatasourcePool "DatasourcePool" timeout (<a href="https://github.com/qorelanguage/qore/issues/1832">issue 1832</a>)

--- a/examples/test/qore/vars/overload.qtest
+++ b/examples/test/qore/vars/overload.qtest
@@ -5,6 +5,7 @@
 %enable-all-warnings
 %require-types
 %strict-args
+%no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm
 
@@ -27,12 +28,27 @@ string sub f_test(float x) {
 }
 
 public class OverloadTest inherits QUnit::Test {
+    public {
+        const Api = "hash sub p() { return {}; }*hash sub p(string a) {return {};}any sub p(string a, string b) { return 1; }";
+    }
+
     constructor() : Test("Overload test", "1.0") {
-        addTestCase("Values test", \testValues(), NOTHING);
-        addTestCase("Variables test", \testVariables(), NOTHING);
+        addTestCase("Values test", \testValues());
+        addTestCase("Variables test", \testVariables());
+        addTestCase("issue 1928", \issue1928());
 
         # Return for compatibility with test harness that checks return value.
         set_return_value(main());
+    }
+
+    issue1928() {
+        Program p(PO_NEW_STYLE);
+        p.parsePending(Api, "");
+        p.parse("sub t() {}", "");
+        p.parse("int sub t1(){string vstr = ''; string p1 = vstr + ''; any x = ''; int rv = p(x, p1); return rv;}", "");
+        p.parse("hash sub t2(){any a1 = ''; any a2; hash rv = p(a1, a2); return rv;}", "");
+        assertEq(1, p.callFunction("t1"));
+        assertEq({}, p.callFunction("t2"));
     }
 
     testValues() {

--- a/lib/scanner.lpp
+++ b/lib/scanner.lpp
@@ -68,6 +68,7 @@
          yylloc->last_col = col;                                             \
          yylloc->last_line = yylineno;                                       \
       }                                                                      \
+      update_parse_line_location(yylloc->first_line, yylloc->last_line);     \
    }
 
 int yyparse(yyscan_t yyscanner);


### PR DESCRIPTION
…ata still

refs #1928 must ensure that return types are checked for consistency when committing variants at parse time