### PR TITLE
refs #1525 reexporting modules works, added the %try-reexport-module …

### DIFF
--- a/doxygen/lang/245_parse_directives.dox.tmpl
+++ b/doxygen/lang/245_parse_directives.dox.tmpl
@@ -40,7 +40,7 @@
     |@ref enable-all-warnings "%enable-all-warnings"|Turns on all @ref warnings "warnings"
     |@ref enable-warning "%enable-warning" <em>@ref warnings "warning-code"</em>|Enables the named @ref warnings "warning"
     |@ref endif "%endif"|Closes a @ref conditional_parsing "conditionally-parsed" block started by the @ref ifdef "%ifdef" or @ref ifndef "%ifndef" parse directives <br><br>Since %Qore 0.8.3
-    |@ref endtry "%endtry"|Closes a @ref try-module "%try-module" block <br><br>Since %Qore 0.8.6
+    |@ref endtry "%endtry"|Closes a @ref try-module "%try-module" or @ref try-reexport-module "%try-reexport-module" block <br><br>Since %Qore 0.8.6
     |@ref exec-class "%exec-class" <em>@ref qore_classes "class_name"</em>|Instantiates the named class as the application class; also turns on @ref no-top-level "%no-top-level". If the program is read from stdin or from the command line, an argument must be given specifying the class name. Any top level statements before this directive are silently ignored
     |@ref ifdef "%ifdef"|Opens a @ref conditional_parsing "conditionally-parsed" block; if the given @ref conditional_parsing "parse define" is defined, then the block after the @ref ifdef "%ifdef" is parsed until either an @ref else "%else" or an @ref endif "%endif" <br><br>Since %Qore 0.8.3
     |@ref ifndef "%ifndef"|Opens a @ref conditional_parsing "conditionally-parsed" block; if the given @ref conditional_parsing "parse define" is not defined, then the block after the @ref ifdef "%ifdef" is parsed until either an @ref else "%else" or an @ref endif "%endif" <br><br>Since %Qore 0.8.3
@@ -63,7 +63,7 @@
     |@ref no-gui "%no-gui"|Disallows functionality that draws graphics to the display; equivalent to parse option @ref Qore::PO_NO_GUI and the <tt>-pno-gui</tt> command line option
     |@ref no-io "%no-io"|Made up of @ref no-gui "%no-gui" \| @ref no-terminal-io "%no-terminal-io" \| @ref no-filesystem "%no-filesystem" \| @ref no-network "%no-network" \| @ref no-database "%no-database"; equivalent to parse option @ref Qore::PO_NO_IO and the \c --no-io command line option
     |@ref no-locale-control "%no-locale-control"|Disallows access to functionality that changes locale information (see %no-locale-control for a list of features not available with this parse option); equivalent to parse option @ref Qore::PO_NO_LOCALE_CONTROL and the <tt>-</tt><tt>-no-locale-control</tt> command line option
-    |@ref no-modules "%no-modules"|Disallows loading @ref qore_modules "modules" with the @ref requires "%requires" or @ref try-module "%try-module" parse directive or at runtime with load_module(); equivalent to @ref Qore::PO_NO_MODULES and the <tt>-pno-modules</tt> command line option <br><br>Since %Qore 0.8.4
+    |@ref no-modules "%no-modules"|Disallows loading @ref qore_modules "modules" with the @ref requires "%requires", @ref try-module "%try-module", and @ref try-reexport-module "%try-reexport-module" parse directive or at runtime with load_module(); equivalent to @ref Qore::PO_NO_MODULES and the <tt>-pno-modules</tt> command line option <br><br>Since %Qore 0.8.4
     |@ref no-namespace-defs "%no-namespace-defs"|Disallows new @ref qore_namespaces "namespace definitions"; equivalent to @ref Qore::PO_NO_NAMESPACE_DEFS and the <tt>-</tt><tt>-no-namespace-defs</tt> command line option
     |@ref no-network "%no-network"|Disallows access to the network; equivalent to parse option @ref Qore::PO_NO_NETWORK and the <tt>-</tt><tt>-no-network</tt> command line option
     |@ref no-new "%no-new"|Disallows use of the @ref new "new operator"; equivalent to parse option @ref Qore::PO_NO_NEW and the <tt>-</tt><tt>-no-new</tt> command line option
@@ -82,13 +82,13 @@
     |@ref require-our "%require-our"|Requires global variables to be declared with @ref our "our" prior to use (like perl's <tt>use strict vars</tt> pragma); equivalent to parse option @ref Qore::PO_REQUIRE_OUR and the <tt>-</tt><tt>-require-our</tt> command line option
     |@ref require-prototypes "%require-prototypes"|Requires type declarations for all function and method parameters and return types. Variables and object members do not need to have type declarations; equivalent to parse option @ref Qore::PO_REQUIRE_PROTOTYPES and the <tt>-</tt><tt>-require-prototypes</tt> command line option <br><br>Since %Qore 0.8.0
     |@ref require-types "%require-types"|Requires type declarations for all function and method parameters, return types, variables, and object members; equivalent to parse option @ref Qore::PO_REQUIRE_TYPES and the <tt>-</tt><tt>-require-types</tt> command line option; also implies @ref strict-args "%strict-args" <br><br>Since %Qore 0.8.0
-    |@ref requires "%requires"<tt>[(reexport)] <em>feature</em> [\<\|\<=\|=\|\>=\|\> <em>version</em>]</tt>|If the named feature is not already present in %Qore, then the \c QORE_MODULE_DIR environment variable is used to provide a list of directories to seach for a module with the same name (<em>feature</em><tt>[-api-</tt><em>x</em><tt>.</tt><em>y</em><tt>].qmod</tt> for binary modules or <em>feature</em><tt>.qm</tt> for user modules). If the module is not found, then the qore default module directory is checked.<br><br>This directive must be used to load modules providing parse support (i.e. modules providing classes, constants, functions, etc that are resolved at parse time).<br><br>If version information is provided, then it is compared with the module's version information, and if it does not match a parse exception is raised. <br><br>See also @ref Qore::load_module() for a function providing run-time module loading and @ref try-module "%try-module" for a similar parse directive that allows module loading errors to be handled at runtime
+    |@ref requires "%requires"<tt>[(reexport)] <em>feature</em> [\<\|\<=\|=\|\>=\|\> <em>version</em>]</tt>|If the named feature is not already present in %Qore, then the \c QORE_MODULE_DIR environment variable is used to provide a list of directories to seach for a module with the same name (<em>feature</em><tt>[-api-</tt><em>x</em><tt>.</tt><em>y</em><tt>].qmod</tt> for binary modules or <em>feature</em><tt>.qm</tt> for user modules). If the module is not found, then the qore default module directory is checked.<br><br>This directive must be used to load modules providing parse support (i.e. modules providing classes, constants, functions, etc that are resolved at parse time).<br><br>If version information is provided, then it is compared with the module's version information, and if it does not match a parse exception is raised. <br><br>See also @ref Qore::load_module() for a function providing run-time module loading and @ref try-module "%try-module" and @ref try-reexport-module "%try-reexport-module" for a similar parse directive that allows module loading errors to be handled at runtime
     |@ref set-time-zone "%set-time-zone"|Sets the time zone for the current program from a UTC offset (with format \c "+/-[00[:00[:00]]"; \c ":" characters are optional) or a time zone region name (ex: \c "Europe/Prague") <br><br>Since %Qore 0.8.3
     |@ref strict-args "%strict-args"|Prohibits access to builtin functions and methods flagged with @ref RUNTIME_NOOP and also causes errors to be raised if excess arguments are given to functions that do not access excess arguments and if a non-list lvalue is passed to the @ref push, @ref pop, or @ref shift <br><br>Since %Qore 0.8.0
     |@ref strict-bool-eval "%strict-bool-eval"|Sets qore's default strict mathematic boolean evaluation mode, where any value converted to 0 is @ref Qore::False "False" and otherwise it's is @ref Qore::True "True"; this was how qore behaved by default prior to v0.8.6. <br><br>Equivalent to parse option @ref Qore::PO_STRICT_BOOLEAN_EVAL and the <tt>-pstrict-bool-eval</tt> command line option. <br><br>See also @ref perl-bool-eval "%perl-bool-eval"<br><br>Since %Qore 0.8.6
     |@ref strong-encapsulation "%strong-encapsulation"|Disallows out-of-line class and namespace declarations. <br><br>Since %Qore 0.8.13
-    |@ref try-module "%try-module" (@ref variable_declarations "var_decl") <em>feature</em> <tt>[\<\|\<=\|=\|\>=\|\></tt> <em>version</em><tt>]</tt>|If the named feature is not already present in %Qore, then the \c QORE_MODULE_DIR environment variable is used to provide a list of directories to seach for a module with the same name (<em>feature</em><tt>[-api-</tt><em>x</em><tt>.</tt><em>y</em><tt>].qmod</tt> for binary modules or <em>feature</em><tt>.qm</tt> for user modules). If the module is not found, then the qore default module directory is checked.<br><br>If an error occurs loading the module, then the @ref variable_declarations "variable" declared after <tt>%%try-module</tt> is instantiated with the exception information, and the code up to the @ref endtry "%endtry" parse declaration is parsed into the program, allowing for the qore script/program to handle module loading errors at parse time for modules that must be loaded at parse time.<br><br>If version information is provided, then it is compared with the module's version information, and if it does not match a parse exception is raised that is handled like any other load error.<br><br>See also @ref Qore::load_module() for a function providing run-time module loading and @ref requires "%requires" for a similar declaration that does not allow for parse-time module loading error handling.<br><br>Since %Qore 0.8.6
-
+    |@ref try-module "%try-module" [(@ref variable_declarations "var_decl")] <em>feature</em> <tt>[\<\|\<=\|=\|\>=\|\></tt> <em>version</em><tt>]</tt>|If the named feature is not already present in %Qore, then the \c QORE_MODULE_DIR environment variable is used to provide a list of directories to seach for a module with the same name (<em>feature</em><tt>[-api-</tt><em>x</em><tt>.</tt><em>y</em><tt>].qmod</tt> for binary modules or <em>feature</em><tt>.qm</tt> for user modules). If the module is not found, then the qore default module directory is checked.<br><br>If an error occurs loading the module, then the @ref variable_declarations "variable" declared after <tt>%%try-module</tt> is instantiated with the exception information, and the code up to the @ref endtry "%endtry" parse declaration is parsed into the program, allowing for the qore script/program to handle module loading errors at parse time for modules that must be loaded at parse time.<br><br>If version information is provided, then it is compared with the module's version information, and if it does not match a parse exception is raised that is handled like any other load error.<br><br>See also @ref Qore::load_module() for a function providing run-time module loading and @ref requires "%requires" for a similar declaration that does not allow for parse-time module loading error handling.<br><br>Since %Qore 0.8.6
+    |@ref try-reexport-module "%try-reexport-module" [(@ref variable_declarations "var_decl")] <em>feature</em> <tt>[\<\|\<=\|=\|\>=\|\></tt> <em>version</em><tt>]</tt>|The same as @ref try-module "%try-module" except that if used in a @ref user_modules "user module", the module is reexported to the importing code<br><br>Since %Qore 0.8.13
     <hr>
     @section allow-bare-refs %allow-bare-refs
 
@@ -615,7 +615,7 @@ i+ =4;
     n/a
 
     @par Description:
-    Closes a @ref try-module "%try-module" block
+    Closes a @ref try-module "%try-module" or @ref try-reexport-module "%try-reexport-module" block
 
     @since %Qore 0.8.6
 
@@ -1060,7 +1060,7 @@ i+ =4;
     @ref Qore::PO_NO_MODULES
 
     @par Description:
-    Disallows loading @ref qore_modules "modules" with the @ref requires "%requires" or @ref try-module "%try-module" directives or at runtime with load_module()
+    Disallows loading @ref qore_modules "modules" with the @ref requires "%requires", @ref try-module "%try-module", or @ref try-reexport-module "%try-reexport-module" directives or at runtime with load_module()
 
     @since %Qore 0.8.4
 
@@ -1457,7 +1457,7 @@ if (str)
     If this form is used in a @ref user_modules "user module", all public definitions from the <a href="../../modules/Mime/html/index.html">Mime</a> module would also be loaded into any @ref Qore::Program "Program" that requires the user module.\n\n
     Note that there is one special feature name: \c "qore". This pseudo-feature can be used to check the minimum %Qore version; if this feature is requested with version information, then the %Qore library's version information is used for the version number comparison.
 
-    @see @ref try-module "%try-module" for a similar parse directive that allows module loading errors to be caught and handled at parse-time
+    @see @ref try-module "%try-module" and @ref try-reexport-module "%try-reexport-module" for similar parse directives that allows module loading errors to be caught and handled at parse-time
 
     <hr>
     @section set-time-zone %set-time-zone
@@ -1587,4 +1587,53 @@ if (str)
     @see @ref requires "%requires" for a similar parse directive where errors are handled with the default parse exception handler
 
     @since %Qore 0.8.6; the variant without the @ref variable_declarations "variable declaration" was introduced in %Qore 0.8.6.1
+
+    <hr>
+    @section try-reexport-module %try-reexport-module
+
+    @par Parse Directive:
+    <tt>%%try-reexport-module</tt> [(@ref variable_declarations "var_decl")] <em>feature</em> <tt>[\<\|\<=\|=\|\>=\|\></tt> <em>version</em><tt>]</tt>
+
+    @par Command Line:
+    n/a
+
+    @par Parse Option Constant:
+    n/a
+
+    @par Description:
+    Loads a %Qore module immediately; if an error occurs loading the module, then the @ref variable_declarations "variable" declared in parentheses after <tt>%%try-module</tt> is instantiated with the exception information, and the code up to the @ref endtry "%endtry" parse declaration is parsed into the program, allowing for the qore script/program to handle module loading errors at parse time for modules that must be loaded at parse time.\n\n
+    A comparison operator (one of <tt>\<, \<=, =, \>=, or \></tt>) and version information can be optionally given after the module name as well. Version numbers are compared via integer comparisons of each element, where elements are separated by a \c ".". If one of the versions does not have as many elements as another, the missing elements are assumed to be \c "0" (i.e. version \c "1.0" compared with version \c "1.0.1" will be extended to \c "1.0.0").  Version errors are handled in the same was as any other module loading error.\n\n
+    If the module is successfully loaded in a @ref user_modules "user module", then the module is also reexported to any
+    code that requires the importing module.\n\n
+    For example:\n
+    @code{.py}
+%new-style
+%try-reexport-module (ex) some_module > 2.0
+%define DontHaveSomeModule
+    printf("error loading module %y: %s: %s\n", ex.arg, ex.err, ex.desc);
+    exit(1);
+%endtry
+
+%ifndef DontHaveSomeModule
+    some_module_api();
+%endif
+    @endcode \n
+    This will load the \c "some_module" module if it is at least version 2.0, and print an error message and exit gracefully if it cannot be loaded.   Note that in order for the Qore script to be executable and exit gracefully in case the given module cannot be loaded, a parse define must be set in the \c %%try-module block and any code that accesses definitions provided by that module must be wrapped in \c %%ifndef blocks as in the above example.\n\n
+    The @ref variable_declarations "variable declaration" in parentheses is optional; use the variant without the exception variable in code where parse option @ref Qore::PO_NO_TOP_LEVEL_STATEMENTS "PO_NO_TOP_LEVEL_STATEMENTS" is set, for example.  In this case, for example, other parse options can be set before the @ref endtry "%endtry" directive.\n\n
+    Here is an example without a @ref variable_declarations "variable declaration" in parentheses:\n
+    @code{.py}
+%new-style
+%try-reexport-module some_module > 2.0
+%define DontHaveSomeModule
+%endtry
+    @endcode \n
+    @note
+    - There is one special feature name: \c "qore". This pseudo-feature can be used to check the minimum %Qore version; if this feature is requested with version information, then the %Qore library's version information is used for the version number comparison.
+    - No type can be given with the \c %%try-module variable declaration; the value assigned to the variable will be a @ref hash_type "hash".
+
+    @see
+    - @ref try-module "%try-module"
+    - @ref requires "%requires" for a similar parse directive where errors are handled with the default parse exception handler
+
+    @since %Qore 0.8.13
 */

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -106,7 +106,7 @@
       - added support for upserts in \c InboundTableMapper (<a href="https://github.com/qorelanguage/qore/issues/1067">issue 1067</a>)
       - added \c InboundTableMapper::queueData(list)
     - new access modifiers: <tt><b>private:internal</b></tt> (providing strong encapsulation of the following declaration(s)) and <tt><b>private:hierarchy</b></tt> (which is equivalent to <tt><b>private</b></tt>; <a href="https://github.com/qorelanguage/qore/issues/1197">issue 1197</a>)
-    - new parse options:
+    - new parse options and directives:
       - @ref allow-debugging "%allow-debugging": allows debugging actions that could be insecure such as reading the thread local variable stack
       - @ref broken-loop-statement "%broken-loop-statement": allows @ref continue "continue" and @ref break "break" statements to be accepted anywhere in the source and behave like a @ref return "return" statement
       - @ref broken-references "%broken-references": allows @ref reference_type "reference" and @ref reference_or_nothing_type "*reference" type restrictions to accept any type contrary to the documented design and intention of these type restrictions
@@ -114,6 +114,7 @@
       - @ref correct-references "%correct-references": to revert the effect of @ref broken-references "%broken-references"
       - @ref no-uncontrolled-apis "%no-uncontrolled-apis": disallow access to uncontrolled APIs such as external language bindings or direct generic system call APIs that could bypass %Qore's sandboxing controls
       - @ref strong-encapsulation "%strong-encapsulation": disallows out of line class and namespace declarations
+      - @ref try-reexport-module "%try-reexport-module": conditionally loads a module in a @ref user_modules "user module" and allows for that module to be reexported as well
     - new constants:
       - @ref Qore::PathSep "PathSep": defines the platform-specific path separator character
       - @ref Qore::PO_ALLOW_DEBUGGING "PO_ALLOW_DEBUGGING": allows debugging actions that could be insecure such as reading the thread local variable stack

--- a/examples/test/qore/misc/module-loader/A.qm
+++ b/examples/test/qore/misc/module-loader/A.qm
@@ -2,6 +2,10 @@
 
 %new-style
 
+%try-reexport-module xml
+%define NoXml
+%endtry
+
 module A {
     version = "1.0";
     desc = "Test Module A";
@@ -15,4 +19,10 @@ public namespace Common {
     public our int AV;
     public const AC = 1;
     public class A;
+
+%ifdef NoXml
+    public const Xml = False;
+%else
+    public const Xml = True;
+%endif
 }

--- a/examples/test/qore/misc/module-loader/ReExportSub.qm
+++ b/examples/test/qore/misc/module-loader/ReExportSub.qm
@@ -3,7 +3,7 @@
 %new-style
 
 %requires(reexport) ./A.qm
-#/;
+%requires(reexport) ./B.qm
 
 module ReExportSub {
     version = "1.0";

--- a/examples/test/qore/misc/module-loader/ReExportTest.qm
+++ b/examples/test/qore/misc/module-loader/ReExportTest.qm
@@ -3,8 +3,6 @@
 %new-style
 
 %requires(reexport) ./ReExportSub.qm
-%requires(reexport) A
-#/;
 
 module ReExportTest {
     version = "1.0";

--- a/examples/test/qore/misc/module-loader/reexport.qtest
+++ b/examples/test/qore/misc/module-loader/reexport.qtest
@@ -9,7 +9,6 @@
 %requires ../../../../../qlib/QUnit.qm
 
 %requires ./ReExportTest.qm
-#/;
 
 %exec-class ReExportTest
 
@@ -21,7 +20,11 @@ class ReExportTest inherits QUnit::Test {
     }
 
     test() {
-        testAssertion("ReExport Test-A", bool sub() { return AV.typeCode() == NT_INT; });
-        #testAssertion("ReExport Test-B", bool sub() { return BV.typeCode() == NT_INT; });
+        assertEq(Type::Int, AV.type());
+        assertEq(Type::Int, BV.type());
+
+        if (Xml) {
+            assertEq("<?xml version=\"1.0\" encoding=\"UTF-8\"?><a>1</a>", call_function("make_xml", ("a": 1)));
+        }
     }
 }

--- a/include/qore/intern/qore_thread_intern.h
+++ b/include/qore/intern/qore_thread_intern.h
@@ -291,6 +291,9 @@ DLLLOCAL void parse_set_module_def_context_name(const char* name);
 DLLLOCAL const char* set_user_module_context_name(const char* n);
 DLLLOCAL const char* get_user_module_context_name();
 
+DLLLOCAL void parse_set_try_reexport(bool tr);
+DLLLOCAL bool parse_get_try_reexport();
+
 DLLLOCAL void set_thread_tz(const AbstractQoreZoneInfo* tz);
 DLLLOCAL const AbstractQoreZoneInfo* get_thread_tz(bool& set);
 DLLLOCAL void clear_thread_tz();

--- a/lib/scanner.lpp
+++ b/lib/scanner.lpp
@@ -815,11 +815,22 @@ RTIME           PT(-?[0-9]+[HMSu])+
                                         }
 ^%exec-class{WS}*$                      { parse_error("missing argument to %%exec-class"); }
 ^%exec-class{WS}+                       BEGIN(exec_class_state);
+^%try-reexport-module{WS}*$             {
+                                           parse_error("missing argument to %%try-reexport-module");
+                                           BEGIN(p_skip_to_endtry);
+                                        }
+^%try-reexport-module                   {
+                                           parse_set_try_reexport(true);
+                                           BEGIN(try_module);
+                                        }
 ^%try-module{WS}*$                      {
                                            parse_error("missing argument to %%try-module");
                                            BEGIN(p_skip_to_endtry);
                                         }
-^%try-module                            BEGIN(try_module);
+^%try-module                            {
+                                           parse_set_try_reexport(false);
+                                           BEGIN(try_module);
+                                        }
 <try_module>[^\n\r]+                    {
                                            parse_try_module_inc();
                                            QoreString str(yytext);
@@ -892,7 +903,7 @@ RTIME           PT(-?[0-9]+[HMSu])+
                                                     //printd(5, "scanner requesting feature: '%s'\n", cn);
                                                     QoreProgram* pgm = getProgram();
                                                     ExceptionSink xsink;
-                                                    QMM.parseLoadModule(xsink, str.getBuffer(), pgm);
+                                                    QMM.parseLoadModule(xsink, str.getBuffer(), pgm, parse_get_try_reexport());
                                                     if (!xsink) {
                                                        BEGIN(p_skip_to_endtry);
                                                     }

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -346,8 +346,8 @@ public:
    uintptr_t qmi;
 
    bool
-   foreign : 1,
-   try_reexport : 1; // true if the thread is a foreign thread
+      foreign : 1, // true if the thread is a foreign thread
+      try_reexport : 1;
 
    DLLLOCAL ThreadData(int ptid, QoreProgram* p, bool n_foreign = false) :
       tid(ptid),


### PR DESCRIPTION
…parse directive to allow for tests to be written covering this functionality (and thereby also closing a functional gap in Qore related to conditionally loading modules; previously it was not possible for a user module to reexport a conditionally-loaded module)