### PR TITLE
Fixed the docs regarding string escaping + added a parse exception in case of escaping octal values in range 400-777

### DIFF
--- a/doxygen/lang/145_basic_data_types.dox.tmpl
+++ b/doxygen/lang/145_basic_data_types.dox.tmpl
@@ -42,7 +42,7 @@
     @section string String
 
     @par Description:
-    String values are specified with text between double or single quotes. Text between double quotes is subject to interpretation of escape characters; text between single quotes is not with the exception of the single quote character, which is the only character that may be escaped (ex: <tt>'hello \'there\''</tt>).\n\n
+    String values are specified with text between double or single quotes. Text between double quotes is subject to interpretation of escape characters; text between single quotes is not.\n\n
     Strings are assumed by default to have the encoding given by the \c QORE_CHARSET or the \c LANG environment variable (see @ref environment_variables). If neither of these variables is set, then all strings will be assumed to have \c UTF-8 encoding.\n\n
     For detailed information on %Qore character encoding handling, please see @ref character_encoding.\n\n
     It is legal to specify a string literal with newline characters like the following:\n

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -12,7 +12,10 @@
     - <a href="https://github.com/qorelanguage/qore/issues/1947">issue 1947</a> added @ref warning-broken-logic-precedence "broken-logic-precedence" warning.
 
     @subsection qore_081211_bug_fixes Bug Fixes in Qore
-    @section qore_081211 Qore 0.8.12.11
+
+    - fixed documentation regarding escaping of characters in strings and added a parse exception in case of trying to escape octal values in range 400-777 (<a href="https://github.com/qorelanguage/qore/issues/50">issue 50</a>)
+
+    @section qore_081210 Qore 0.8.12.10
 
     @par Release Summary
     Bugfix release; see details below

--- a/examples/test/qore/vars/string.qtest
+++ b/examples/test/qore/vars/string.qtest
@@ -23,6 +23,7 @@ class StringTest inherits QUnit::Test {
         addTestCase("Chomp and trim test", \testChompAndTrim());
         addTestCase("Float strings test", \testFloat());
         addTestCase("String conversion test", \testConversions());
+        addTestCase("Octal value escaping test", \testOctalEscaping());
         set_return_value(main());
     }
 
@@ -366,5 +367,15 @@ class StringTest inherits QUnit::Test {
 
     testConversions() {
         assertEq("", string(NULL));
+    }
+
+    testOctalEscaping() {
+        assertEq("\r\n !X| ¥λ", "\15\12 \41\130\174 \302\245\316\273");
+        assertEq("820 95", sprintf("\820 \95"));
+
+        Program p(PO_NEW_STYLE);
+        p.disableParseOptions(PO_NO_TOP_LEVEL_STATEMENTS);
+        assertThrows("PARSE-EXCEPTION", "escape invalid octal value", sub () { p.parse("string abc = \"Number: \\400\";", "test"); });
+        assertThrows("PARSE-EXCEPTION", "escape invalid octal value", sub () { p.parse("string abc = \"Number: \\777\";", "test"); });
     }
 }

--- a/lib/ql_string.qpp
+++ b/lib/ql_string.qpp
@@ -352,6 +352,7 @@ const RE_Global = QRE_GLOBAL;
     |!Character|!Description
     |\c s|string
     |\c d|Integer, output in base 10 format
+    |\c o|Integer, output in base 8 (octal) format
     |\c f|Literal floating point value
     |\c F|Literat floating point value
     |\c a|Hexadecimal floating-point output with lower-case \c "0x" and \c "abcdef"
@@ -367,13 +368,30 @@ const RE_Global = QRE_GLOBAL;
     @anchor string_escape_chars
     <b>String Escape Characters</b>
     |!Escape Characters|!Description
+    |\c \\b|a backspace character
+    |\c \\f|a form-feed character
     |\c \\n|a newline character
     |\c \\r|a carriage-return character
     |\c \\t|a tab character
-    |\c \\b|a backspace character
-    |\c \\f|a form-feed character
+    |\c \\v|a vertical tab character
     |\c \\<em>num</em>|an 8-bit character whose value is the 1, 2, or 3 digit octal number \a num
     |\c \\\"|a double-quote character (\c \")
+    |\c \\\\|a backslash character
+
+    @warning Trying to escape a 3-digit octal number in the range 400-777 will result in a \c PARSE-EXCEPTION being thrown. Trying to parse a number starting with 8 or 9 will result in that number being reproduced literally.
+    @code{.py}
+string abc = "Number: \455"; # will throw a parse error
+    @endcode
+    @code{.py}
+string abc = "Number: \820";
+printf(abc); # will print out "Number: 820"
+    @endcode
+
+    @note Trying to escape any other character will result in that character being reproduced literally:
+    @code{.py}
+string abc = "He\llo\, worl\d!";
+printf(abc); # will print out "Hello, world!"
+    @endcode
  */
 //@{
 

--- a/lib/scanner.lpp
+++ b/lib/scanner.lpp
@@ -1171,6 +1171,8 @@ RTIME           PT(-?[0-9]+[HMSu])+
                                            else { // here token_lenght == 2
                                               val = ascii_to_octal(*(yytext + 1));
                                            }
+                                           if (val >= 0400)
+                                              parse_error("trying to escape invalid octal value (in the range 400-777): %o", val);
                                            yylval->String->concat((char)val);
                                         }
       \\n                               yylval->String->concat('\n');


### PR DESCRIPTION
fixes #50 