### PR TITLE
Bugfix/1952 gethostbyname

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,7 +297,7 @@ qore_search_libs(LIBQORE_LIBS gethostbyname nsl)
 qore_search_libs(LIBQORE_LIBS clock_gettime rt)
 
 set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${LIBQORE_LIBS})
-qore_check_funcs(access alarm atoll bzero chown clock_gettime doprnt exp2 floor fork fsync getegid geteuid getgid getgrgid_r getgrnam_r getgroups gethostbyaddr gethostbyname gethostname getppid getpwnam_r getpwuid_r getsockopt gettimeofday getuid glob gmtime_r inet_ntop inet_pton isblank kill lchown localtime_r lstat memmem memmove memset mkfifo mkfifo nanosleep poll pthread_attr_getstacksize putenv random readlink realloc realpath regcomp round select setegid setegid setenv seteuid seteuid setgid setgroups setsid setsockopt setuid setuid sleep socket strcasecmp strcasestr strchr strdup strerror strncasecmp strspn strstr strtoll strtol symlink system tbbmalloc timegm unsetenv usleep vfork vprintf)
+qore_check_funcs(access alarm atoll bzero chown clock_gettime doprnt exp2 floor fork fsync getaddrinfo getegid geteuid getgid getgrgid_r getgrnam_r getgroups gethostbyaddr gethostbyname gethostname getnameinfo getppid getpwnam_r getpwuid_r getsockopt gettimeofday getuid glob gmtime_r inet_ntop inet_pton isblank kill lchown localtime_r lstat memmem memmove memset mkfifo mkfifo nanosleep poll pthread_attr_getstacksize putenv random readlink realloc realpath regcomp round select setegid setegid setenv seteuid seteuid setgid setgroups setsid setsockopt setuid setuid sleep socket strcasecmp strcasestr strchr strdup strerror strncasecmp strspn strstr strtoll strtol symlink system tbbmalloc timegm unsetenv usleep vfork vprintf)
 qore_func_strerror_r()
 qore_gethost_checks()
 unset(CMAKE_REQUIRED_LIBRARIES)

--- a/configure.ac
+++ b/configure.ac
@@ -1456,7 +1456,7 @@ AC_FUNC_STAT
 AC_FUNC_STRERROR_R
 AC_FUNC_STRTOD
 AC_FUNC_VPRINTF
-AC_CHECK_FUNCS([bzero floor gethostbyaddr gethostbyname gethostname gettimeofday memmove memset mkfifo putenv regcomp select socket setsockopt getsockopt strcasecmp strchr strdup strerror strspn strstr atoll strtol strtoll isblank localtime_r gmtime_r exp2 clock_gettime realloc timegm seteuid setegid setenv unsetenv round pthread_attr_getstacksize getpwuid_r getpwnam_r getgrgid_r getgrnam_r backtrace glob system inet_ntop inet_pton lstat fsync lchown chown setsid setuid mkfifo random kill getppid getgid getegid getuid geteuid setuid seteuid setgid setegid sleep usleep nanosleep readlink symlink access strcasestr strncasecmp setgroups getgroups poll realpath memmem])
+AC_CHECK_FUNCS([bzero floor getaddrinfo gethostbyaddr gethostbyname gethostname getnameinfo gettimeofday memmove memset mkfifo putenv regcomp select socket setsockopt getsockopt strcasecmp strchr strdup strerror strspn strstr atoll strtol strtoll isblank localtime_r gmtime_r exp2 clock_gettime realloc timegm seteuid setegid setenv unsetenv round pthread_attr_getstacksize getpwuid_r getpwnam_r getgrgid_r getgrnam_r backtrace glob system inet_ntop inet_pton lstat fsync lchown chown setsid setuid mkfifo random kill getppid getgid getegid getuid geteuid setuid seteuid setgid setegid sleep usleep nanosleep readlink symlink access strcasestr strncasecmp setgroups getgroups poll realpath memmem])
 
 # some systems have internal gethostby*_r in libc but don't hide the
 # symbols, so we look if they are declared before checking in the libraries

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -253,6 +253,7 @@
     - fixed a bug in overloaded call variant matching where missing arguments were counted towards the match (<a href="https://github.com/qorelanguage/qore/issues/1897">issue 1897</a>)
     - fixed many bugs where parse-time errors could be reported at an incorrect source location; parse-time error location reporting has been completely overhauled and reimplemented for correctness (<a href="https://github.com/qorelanguage/qore/issues/1930">issue 1930</a>)
     - fixed a bug where code signatures would accept parameter variables without \c "$" signs even when @ref allow-bare-refs "%allow-bare-refs" was not in effect (<a href="https://github.com/qorelanguage/qore/issues/1941">issue 1941</a>)
+    - rewritten the Qore functions \ref gethostbyname(), \ref gethostbyname_long() and \ref gethostbyaddr() to use standard C functions \c getaddrinfo(3) and \c getnameinfo(3) internally instead of the deprecated \c gethostbyname(3) and \c gethostbyaddr(3) (<a href="https://github.com/qorelanguage/qore/issues/1952">issue 1952</a>)
 
     @section qore_081210 Qore 0.8.12.10
 

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -253,7 +253,7 @@
     - fixed a bug in overloaded call variant matching where missing arguments were counted towards the match (<a href="https://github.com/qorelanguage/qore/issues/1897">issue 1897</a>)
     - fixed many bugs where parse-time errors could be reported at an incorrect source location; parse-time error location reporting has been completely overhauled and reimplemented for correctness (<a href="https://github.com/qorelanguage/qore/issues/1930">issue 1930</a>)
     - fixed a bug where code signatures would accept parameter variables without \c "$" signs even when @ref allow-bare-refs "%allow-bare-refs" was not in effect (<a href="https://github.com/qorelanguage/qore/issues/1941">issue 1941</a>)
-    - rewritten the Qore functions \ref gethostbyname(), \ref gethostbyname_long() and \ref gethostbyaddr() to use standard C functions \c getaddrinfo(3) and \c getnameinfo(3) internally instead of the deprecated \c gethostbyname(3) and \c gethostbyaddr(3) (<a href="https://github.com/qorelanguage/qore/issues/1952">issue 1952</a>)
+    - rewrote %Qore functions @ref gethostbyname(), @ref gethostbyname_long() and @ref gethostbyaddr() to use standard C functions \c getaddrinfo(3) and \c getnameinfo(3) internally instead of the deprecated \c gethostbyname(3) and \c gethostbyaddr(3) (<a href="https://github.com/qorelanguage/qore/issues/1952">issue 1952</a>)
 
     @section qore_081211 Qore 0.8.12.11
 

--- a/examples/test/qore/functions/gethost.qtest
+++ b/examples/test/qore/functions/gethost.qtest
@@ -1,0 +1,45 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class GetHostTest
+
+public class GetHostTest inherits QUnit::Test {
+    constructor() : Test("GetHostBy*Test", "1.0") {
+        addTestCase("gethostbyname test", \gethostbynameTest());
+        addTestCase("gethostbyaddr test", \gethostbyaddrTest());
+
+        # Return for compatibility with test harness that checks return value.
+        set_return_value(main());
+    }
+
+    gethostbynameTest() {
+        assertTrue(gethostbyname("8.8.8.8") =~ /8.8.8.8/);
+        *hash result = gethostbyname_long("8.8.8.8");
+        assertTrue(result.name =~ /8.8.8.8/);
+        assertTrue(result.hasKey("aliases"));
+        assertEq("ipv4", result.typename);
+        assertEq(2, result.type);
+        assertEq(4, result.len);
+
+        string ipValRgx = "([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))";
+        string ipRegex = ipValRgx + "\\." + ipValRgx + "\\." + ipValRgx + "\\." + ipValRgx;
+        assertTrue(gethostbyname("google.com").regex(ipRegex));
+    }
+
+    gethostbyaddrTest() {
+        assertTrue(gethostbyaddr("8.8.8.8") =~ /google.com/);
+        *hash result = gethostbyaddr_long("8.8.8.8");
+        assertTrue(result.name =~ /google.com/);
+        assertTrue(result.hasKey("aliases"));
+        assertEq("ipv4", result.typename);
+        assertEq(2, result.type);
+        assertEq(4, result.len);
+    }
+}

--- a/examples/test/qore/functions/gethost.qtest
+++ b/examples/test/qore/functions/gethost.qtest
@@ -30,7 +30,9 @@ public class GetHostTest inherits QUnit::Test {
 
         string ipValRgx = "([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))";
         string ipRegex = ipValRgx + "\\." + ipValRgx + "\\." + ipValRgx + "\\." + ipValRgx;
-        assertTrue(gethostbyname("google.com").regex(ipRegex));
+        string simpleIp6Regex = "((([0-9]|[abcdef]){1,4}):|:)+(([0-9]|[abcdef]){1,4})";
+        string ip = gethostbyname("google.com");
+        assertTrue(ip.regex(ipRegex) || ip.regex(simpleIp6Regex));
     }
 
     gethostbyaddrTest() {

--- a/include/qore/QoreNet.h
+++ b/include/qore/QoreNet.h
@@ -37,30 +37,63 @@
 
 #include <sys/types.h>
 
-//! thread-safe gethostbyname (0 = success, !0 = error)
-/** FIXME: should be const struct in_addr
+//! Get host's IP address (struct in_addr*) from name.
+/**
+    @param host host's name
+    @param sin_addr host's IP address will be saved here
+    @return 0 in case of success, non-zero in case of error
+
+    @note utilizes \c getaddrinfo(3) internally instead of \c gethostbyname(3)
  */
-DLLEXPORT int q_gethostbyname(const char *host, struct in_addr *sin_addr);
+DLLEXPORT int q_gethostbyname(const char* host, struct in_addr* sin_addr);
 
-//! thread-safe gethostbyname (0/NULL = error)
-DLLEXPORT QoreHashNode *q_gethostbyname_to_hash(const char *host);
+//! Get host's IP addresses and info from name.
+/**
+    @param host host's name
+    @return hash containing info about host; nullptr in case of error
 
-//! thread-safe gethostbyname (0/NULL = error)
-DLLEXPORT QoreStringNode *q_gethostbyname_to_string(const char *host);
+    @note utilizes \c getaddrinfo(3) internally instead of \c gethostbyname(3)
+ */
+DLLEXPORT QoreHashNode* q_gethostbyname_to_hash(const char* host);
 
-//! thread-safe gethostbyaddr (string returned must be freed)
-DLLEXPORT char *q_gethostbyaddr(const char *addr, int len, int type);
+//! Get host's IP address from name.
+/**
+    @param host host's name
+    @return host's IP address; nullptr in case of error
+
+    @note utilizes \c getaddrinfo(3) internally instead of \c gethostbyname(3)
+ */
+DLLEXPORT QoreStringNode* q_gethostbyname_to_string(const char* host);
+
+//! Get host's name from IP address.
+/**
+    @param addr in_addr structure (in the form of char*)
+    @param len length of addr
+    @param type IP address type
+    @return host's name (string returned must be freed); nullptr in case of error
+
+    @note utilizes \c getnameinfo(3) internally instead of \c gethostbyaddr(3)
+ */
+DLLEXPORT char* q_gethostbyaddr(const char* addr, int len, int type);
 
 //! thread-safe gethostbyaddr (0/NULL = error)
-DLLEXPORT QoreHashNode *q_gethostbyaddr_to_hash(ExceptionSink *xsink, const char *addr, int type = Q_AF_INET);
+DLLEXPORT QoreHashNode* q_gethostbyaddr_to_hash(ExceptionSink* xsink, const char* addr, int type = Q_AF_INET);
 
-//! thread-safe gethostbyaddr (0/NULL = error)
-DLLEXPORT QoreStringNode *q_gethostbyaddr_to_string(ExceptionSink *xsink, const char *addr, int type = Q_AF_INET);
+//! Get host's name from IP address.
+/**
+    @param xsink exception sink
+    @param addr host's name
+    @param type IP address type
+    @return host's name; nullptr in case of error
+
+    @note utilizes \c getnameinfo(3) internally instead of \c gethostbyaddr(3)
+ */
+DLLEXPORT QoreStringNode* q_gethostbyaddr_to_string(ExceptionSink* xsink, const char* addr, int type = Q_AF_INET);
 
 //! converts a network address in network byte order to a string (address_family = AF_INET or AF_INET6), returns 0 on error
 /** @see q_addr_to_string2()
  */
-DLLEXPORT QoreStringNode *q_addr_to_string(int address_family, const char *addr);
+DLLEXPORT QoreStringNode* q_addr_to_string(int address_family, const char* addr);
 
 //! converts a network address in network byte order to a string (address_family = AF_INET or AF_INET6), returns -1 on error
 /** @param address_family the address family
@@ -74,7 +107,7 @@ DLLEXPORT QoreStringNode *q_addr_to_string(int address_family, const char *addr)
 DLLEXPORT int q_addr_to_string(int address_family, const char* addr, QoreString& str);
 
 //! converts a network address in network byte order to a string (address_family = AF_INET or AF_INET6), returns 0 on error
-DLLEXPORT QoreStringNode *q_addr_to_string2(const struct sockaddr *ai_addr);
+DLLEXPORT QoreStringNode* q_addr_to_string2(const struct sockaddr* ai_addr);
 
 //! converts a network address in network byte order to a string (address_family = AF_INET or AF_INET6), returns -1 on error
 /** @param ai_addr the address
@@ -84,13 +117,13 @@ DLLEXPORT QoreStringNode *q_addr_to_string2(const struct sockaddr *ai_addr);
 
     @see q_addr_to_string2()
  */
-DLLEXPORT int q_addr_to_string2(const struct sockaddr *ai_addr, QoreString& str);
+DLLEXPORT int q_addr_to_string2(const struct sockaddr* ai_addr, QoreString& str);
 
 //! get port from struct sockaddr, returns -1 if port cannot be determined
-DLLEXPORT int q_get_port_from_addr(const struct sockaddr *ai_addr);
+DLLEXPORT int q_get_port_from_addr(const struct sockaddr* ai_addr);
 
 //! returns address info as a hash
-DLLEXPORT QoreListNode *q_getaddrinfo_to_list(ExceptionSink *xsink, const char *node, const char *service, int family = Q_AF_UNSPEC, int flags = 0, int socktype = Q_SOCK_STREAM);
+DLLEXPORT QoreListNode* q_getaddrinfo_to_list(ExceptionSink* xsink, const char* node, const char* service, int family = Q_AF_UNSPEC, int flags = 0, int socktype = Q_SOCK_STREAM);
 
 //! adds the address family as "type" and a descriptive name as "typename" to the hash; writes "unknown" if the address family is unknown
 DLLEXPORT void q_af_to_hash(int af, QoreHashNode& h, ExceptionSink* xsink);
@@ -98,7 +131,7 @@ DLLEXPORT void q_af_to_hash(int af, QoreHashNode& h, ExceptionSink* xsink);
 //! provides an interface to getaddrinfo
 class QoreAddrInfo {
 protected:
-   struct addrinfo *ai;
+   struct addrinfo* ai;
    bool has_svc;
 
 public:
@@ -120,21 +153,21 @@ public:
        @param socktype a hint for the type of socket; 0 = any socket type
        @param protocol a hint for the protocol number; 0 = the default protocol
     */
-   DLLEXPORT int getInfo(ExceptionSink *xsink, const char *node, const char *service, int family = Q_AF_UNSPEC, int flags = 0, int socktype = Q_SOCK_STREAM, int protocol = 0);
+   DLLEXPORT int getInfo(ExceptionSink* xsink, const char* node, const char* service, int family = Q_AF_UNSPEC, int flags = 0, int socktype = Q_SOCK_STREAM, int protocol = 0);
 
    //! returns the struct addrinfo * being managed (may by 0)
-   DLLLOCAL struct addrinfo *getAddrInfo() const {
+   DLLLOCAL struct addrinfo* getAddrInfo() const {
       return ai;
    }
    
    //! returns a list of hashes of address info, if an addrinfo structure is being managed
-   DLLEXPORT QoreListNode *getList() const;   
+   DLLEXPORT QoreListNode* getList() const;
 
    //! returns the name of the address family as a string (ie AF_INET = "ipv4", etc)
-   DLLEXPORT static const char *getFamilyName(int address_family);
+   DLLEXPORT static const char* getFamilyName(int address_family);
 
    //! returns a descriptive string for the address family and an address string (ie AF_INET6, "::1" = "ipv6[::1]")
-   DLLEXPORT static QoreStringNode *getAddressDesc(int address_family, const char *addr);
+   DLLEXPORT static QoreStringNode* getAddressDesc(int address_family, const char* addr);
 };
 
 #endif // _QORE_QORENET_H

--- a/include/qore/intern/QoreLibIntern.h
+++ b/include/qore/intern/QoreLibIntern.h
@@ -416,9 +416,6 @@ DLLLOCAL extern std::atomic<bool> qore_shutdown;
 
 DLLLOCAL extern int qore_library_options;
 
-#ifndef HAVE_GETHOSTBYNAME_R
-DLLLOCAL extern QoreThreadLock lck_gethostbyname;
-#endif
 #ifndef HAVE_GETHOSTBYADDR_R
 DLLLOCAL extern QoreThreadLock lck_gethostbyaddr;
 #endif

--- a/lib/QoreNet.cpp
+++ b/lib/QoreNet.cpp
@@ -59,7 +59,7 @@ int q_get_sock_type(int t) {
    return SOCK_STREAM;
 }
 
-int q_addr_to_string(int family, const char *addr, QoreString& str) {
+int q_addr_to_string(int family, const char* addr, QoreString& str) {
    family = q_get_af(family);
 
    char buf[QORE_NET_ADDR_BUF_LEN];
@@ -69,7 +69,7 @@ int q_addr_to_string(int family, const char *addr, QoreString& str) {
    return 0;
 }
 
-QoreStringNode *q_addr_to_string(int family, const char *addr) {
+QoreStringNode* q_addr_to_string(int family, const char* addr) {
    family = q_get_af(family);
 
    char buf[QORE_NET_ADDR_BUF_LEN];
@@ -79,14 +79,14 @@ QoreStringNode *q_addr_to_string(int family, const char *addr) {
 int q_addr_to_string2(const struct sockaddr* ai_addr, QoreString& str) {
    size_t slen = str.strlen();
 
-   const void *addr;
+   const void* addr;
    if (ai_addr->sa_family == AF_INET) {
-      struct sockaddr_in *ipv4 = (struct sockaddr_in *)ai_addr;
+      struct sockaddr_in* ipv4 = (struct sockaddr_in*)ai_addr;
       addr = &(ipv4->sin_addr);
       str.reserve(slen + INET_ADDRSTRLEN + 1);
    }
    else if (ai_addr->sa_family == AF_INET6) {
-      struct sockaddr_in6 *ipv6 = (struct sockaddr_in6 *)ai_addr;
+      struct sockaddr_in6* ipv6 = (struct sockaddr_in6*)ai_addr;
       addr = &(ipv6->sin6_addr);
       str.reserve(slen + INET6_ADDRSTRLEN + 1);
    }
@@ -101,7 +101,7 @@ int q_addr_to_string2(const struct sockaddr* ai_addr, QoreString& str) {
    else
       return -1;
 
-   if (!inet_ntop(ai_addr->sa_family, addr, (char *)(str.getBuffer() + slen), str.capacity() - slen))
+   if (!inet_ntop(ai_addr->sa_family, addr, (char*)(str.getBuffer() + slen), str.capacity() - slen))
       return -1;
 
    str.terminate(slen + strlen(str.getBuffer() + slen));
@@ -109,19 +109,19 @@ int q_addr_to_string2(const struct sockaddr* ai_addr, QoreString& str) {
 }
 
 
-QoreStringNode *q_addr_to_string2(const struct sockaddr *ai_addr) {
+QoreStringNode* q_addr_to_string2(const struct sockaddr* ai_addr) {
    SimpleRefHolder<QoreStringNode> str(new QoreStringNode);
 
    return q_addr_to_string2(ai_addr, **str) ? 0 : str.release();
 }
 
-int q_get_port_from_addr(const struct sockaddr *ai_addr) {
+int q_get_port_from_addr(const struct sockaddr* ai_addr) {
    if (ai_addr->sa_family == AF_INET) {
-      const struct sockaddr_in *ipv4 = (struct sockaddr_in *)ai_addr;
+      const struct sockaddr_in* ipv4 = (struct sockaddr_in*)ai_addr;
       return ntohs(ipv4->sin_port);
    }
    else if (ai_addr->sa_family == AF_INET6) {
-      const struct sockaddr_in6 *ipv6 = (struct sockaddr_in6 *)ai_addr;
+      const struct sockaddr_in6* ipv6 = (struct sockaddr_in6*)ai_addr;
       return ntohs(ipv6->sin6_port);
    }
 
@@ -129,13 +129,6 @@ int q_get_port_from_addr(const struct sockaddr *ai_addr) {
 }
 
 //! Get host's IP address (struct in_addr*) from name.
-/**
-    @param host host's name
-    @param sin_addr host's IP address will be saved here
-    @return 0 in case of success, non-zero in case of error
-
-    @note utilizes \c getaddrinfo(3) internally instead of \c gethostbyname(3)
- */
 int q_gethostbyname(const char* host, struct in_addr* sin_addr) {
    QORE_TRACE("q_gethostbyname()");
 
@@ -175,14 +168,14 @@ void q_af_to_hash(int af, QoreHashNode& h, ExceptionSink* xsink) {
    h.setKeyValue("typename", new QoreStringNode(q_af_to_str(af)), xsink);
 }
 
-static QoreHashNode *he_to_hash(struct hostent &he) {
-   QoreHashNode *h = new QoreHashNode;
+static QoreHashNode* he_to_hash(struct hostent& he) {
+   QoreHashNode* h = new QoreHashNode;
 
    if (he.h_name && he.h_name[0])
       h->setKeyValue("name", new QoreStringNode(he.h_name), 0); // official host name
    if (he.h_aliases) {
-      QoreListNode *l = new QoreListNode;
-      char **a = he.h_aliases;
+      QoreListNode* l = new QoreListNode;
+      char** a = he.h_aliases;
       while (*a)
 	 l->push(new QoreStringNode(*(a++)));
       h->setKeyValue("aliases", l, 0);
@@ -207,8 +200,8 @@ static QoreHashNode *he_to_hash(struct hostent &he) {
    if (he.h_addr_list) {
       char buf[QORE_NET_ADDR_BUF_LEN];
 
-      QoreListNode *l = new QoreListNode();
-      char **a = he.h_addr_list;
+      QoreListNode* l = new QoreListNode();
+      char** a = he.h_addr_list;
       while (*a) {
 	 if (inet_ntop(he.h_addrtype, *(a++), buf, QORE_NET_ADDR_BUF_LEN))
 	    l->push(new QoreStringNode(buf));
@@ -219,30 +212,7 @@ static QoreHashNode *he_to_hash(struct hostent &he) {
    return h;
 }
 
-static QoreStringNode *hename_string(struct hostent &he) {
-   if (he.h_name && he.h_name[0])
-      return new QoreStringNode(he.h_name);
-
-   return new QoreStringNode;
-}
-
-static QoreStringNode *headdr_string(struct hostent &he) {
-   if (he.h_addr_list && he.h_addr_list[0]) {
-      char buf[QORE_NET_ADDR_BUF_LEN];
-      if (inet_ntop(he.h_addrtype, he.h_addr_list[0], buf, QORE_NET_ADDR_BUF_LEN))
-	 return new QoreStringNode(buf);
-   }
-
-   return new QoreStringNode;
-}
-
 //! Get host's IP addresses and info from name.
-/**
-    @param host host's name
-    @return hash containing info about host
-
-    @note utilizes \c getaddrinfo(3) internally instead of \c gethostbyname(3)
- */
 QoreHashNode* q_gethostbyname_to_hash(const char* host) {
    ExceptionSink xsink;
    QoreAddrInfo qai;
@@ -293,12 +263,6 @@ QoreHashNode* q_gethostbyname_to_hash(const char* host) {
 }
 
 //! Get host's IP address from name.
-/**
-    @param host host's name
-    @return host's IP address
-
-    @note utilizes \c getaddrinfo(3) internally instead of \c gethostbyname(3)
- */
 QoreStringNode* q_gethostbyname_to_string(const char* host) {
    ExceptionSink xsink;
    QoreAddrInfo qai;
@@ -315,56 +279,49 @@ QoreStringNode* q_gethostbyname_to_string(const char* host) {
    return addr.release();
 }
 
-// thread-safe gethostbyaddr (string returned must be freed)
-// FIXME: check err?
-char *q_gethostbyaddr(const char *addr, int len, int type) {
-   char *host;
+//! Get host's name from IP address.
+char* q_gethostbyaddr(const char* addr, int len, int type) {
+   sockaddr_in in;
+   sockaddr_in6 in6;
+   char buf[512];
+   int rc;
 
    type = q_get_af(type);
+   if (type == AF_INET) {
+      memset(&in, 0, sizeof(sockaddr_in));
+      in.sin_family = AF_INET;
+      in.sin_addr = *((struct in_addr*)addr);
+      rc = getnameinfo(reinterpret_cast<sockaddr*>(&in), sizeof(sockaddr_in), buf, sizeof buf, nullptr, 0, NI_NAMEREQD);
+   }
+   else if (type == AF_INET6) {
+      memset(&in6, 0, sizeof(sockaddr_in6));
+      in6.sin6_family = AF_INET6;
+      in6.sin6_addr = *((struct in6_addr*)addr);
+      rc = getnameinfo(reinterpret_cast<sockaddr*>(&in6), sizeof(sockaddr_in6), buf, sizeof buf, nullptr, 0, NI_NAMEREQD);
+   }
+   else {
+      return nullptr;
+   }
 
-#ifdef HAVE_GETHOSTBYADDR_R
-   struct hostent he;
-   char buf[NET_BUFSIZE];
-   int err;
-# ifdef HAVE_SOLARIS_STYLE_GETHOST
-   if (gethostbyaddr_r(addr, len, type, &he, buf, NET_BUFSIZE, &err))
-      host = strdup(he.h_name);
-   else
-      host = 0;
-# else // assume glibc2-style gethostbyaddr_r
-   struct hostent *p;
-
-   int rc = gethostbyaddr_r(addr, len, type, &he, buf, NET_BUFSIZE, &p, &err);
-   host = !rc && p ? strdup(he.h_name) : 0;
-# endif // HAVE_SOLARIS_STYLE_GETHOST
-#else  // else if !HAVE_GETHOSTBYADDR_R
-   lck_gethostbyaddr.lock();
-   struct hostent *he;
-   if ((he = gethostbyaddr(addr, len, type)))
-      host = strdup(he->h_name);
-   else
-      host = 0;
-   lck_gethostbyaddr.unlock();
-#endif // HAVE_GETHOSTBYADDR_R
-   return host;
+   return rc ? nullptr : strdup(buf);
 }
 
 // thread-safe gethostbyaddr
 // FIXME: check err?
-QoreHashNode *q_gethostbyaddr_to_hash(ExceptionSink *xsink, const char *addr, int type) {
+QoreHashNode* q_gethostbyaddr_to_hash(ExceptionSink* xsink, const char* addr, int type) {
    in_addr sin_addr;
    in6_addr sin6_addr;
-   void *dst;
+   void* dst;
    int len;
 
    type = q_get_af(type);
 
    if (type == AF_INET) {
-      dst = (void *)&sin_addr;
+      dst = (void*)&sin_addr;
       len = sizeof(sin_addr);
    }
    else if (type == AF_INET6) {
-      dst = (void *)&sin6_addr;
+      dst = (void*)&sin6_addr;
       len = sizeof(sin6_addr);
    }
    else {
@@ -385,10 +342,10 @@ QoreHashNode *q_gethostbyaddr_to_hash(ExceptionSink *xsink, const char *addr, in
    char buf[NET_BUFSIZE];
    int err;
 # ifdef HAVE_SOLARIS_STYLE_GETHOST
-   if (!gethostbyaddr_r((char *)dst, len, type, &he, buf, NET_BUFSIZE, &err))
+   if (!gethostbyaddr_r((char*)dst, len, type, &he, buf, NET_BUFSIZE, &err))
       return 0;
 # else // assume glibc2-style gethostbyaddr_r
-   struct hostent *p;
+   struct hostent* p;
 
    rc = gethostbyaddr_r(dst, len, type, &he, buf, NET_BUFSIZE, &p, &err);
    if (rc || !p)
@@ -399,73 +356,59 @@ QoreHashNode *q_gethostbyaddr_to_hash(ExceptionSink *xsink, const char *addr, in
 
 #else  // else if !HAVE_GETHOSTBYADDR_R
    AutoLocker al(&lck_gethostbyaddr);
-   struct hostent *he;
-   if (!(he = gethostbyaddr((char *)dst, len, type)))
+   struct hostent* he;
+   if (!(he = gethostbyaddr((char*)dst, len, type)))
       return 0;
 
    return he_to_hash(*he);
 #endif // HAVE_GETHOSTBYADDR_R
 }
 
-// thread-safe gethostbyaddr
-// FIXME: check err?
-QoreStringNode *q_gethostbyaddr_to_string(ExceptionSink *xsink, const char *addr, int type) {
-   in_addr sin_addr;
-   in6_addr sin6_addr;
-   void *dst;
-   int len;
+//! Get host's name from IP address.
+QoreStringNode* q_gethostbyaddr_to_string(ExceptionSink* xsink, const char* addr, int type) {
+   sockaddr_in in;
+   sockaddr_in6 in6;
+   char buf[512];
+   void* dst;
 
    type = q_get_af(type);
-
    if (type == AF_INET) {
-      dst = (void *)&sin_addr;
-      len = sizeof(sin_addr);
+      memset(&in, 0, sizeof(sockaddr_in));
+      in.sin_family = AF_INET;
+      dst = (void*)&in.sin_addr;
    }
    else if (type == AF_INET6) {
-      dst = (void *)&sin6_addr;
-      len = sizeof(sin6_addr);
+      memset(&in6, 0, sizeof(sockaddr_in6));
+      in6.sin6_family = AF_INET6;
+      dst = (void*)&in6.sin6_addr;
    }
    else {
       xsink->raiseException("GETHOSTBYADDR-ERROR", "%d is an invalid address type (valid types are AF_INET=%d, AF_INET6=%d", type, AF_INET, AF_INET6);
-      return 0;
+      return nullptr;
    }
 
    int rc = inet_pton(type, addr, dst);
    if (rc == 0) {
       xsink->raiseException("GETHOSTBYADDR-ERROR", "'%s' is not a valid address for %s addresses", addr, type == AF_INET ? "AF_INET (IPv4)" : "AF_INET6 (IPv6)");
-      return 0;
+      return nullptr;
    }
    if (rc < 0)
-      return 0;
+      return nullptr;
 
-#ifdef HAVE_GETHOSTBYADDR_R
-   struct hostent he;
-   char buf[NET_BUFSIZE];
-   int err;
-# ifdef HAVE_SOLARIS_STYLE_GETHOST
-   if (!gethostbyaddr_r((char *)dst, len, type, &he, buf, NET_BUFSIZE, &err))
-      return 0;
-# else // assume glibc2-style gethostbyaddr_r
-   struct hostent *p;
+   if (type == AF_INET) {
+      rc = getnameinfo(reinterpret_cast<sockaddr*>(&in), sizeof(sockaddr_in), buf, sizeof buf, nullptr, 0, NI_NAMEREQD);
+   }
+   else {
+      rc = getnameinfo(reinterpret_cast<sockaddr*>(&in6), sizeof(sockaddr_in6), buf, sizeof buf, nullptr, 0, NI_NAMEREQD);
+   }
 
-   rc = gethostbyaddr_r(dst, len, type, &he, buf, NET_BUFSIZE, &p, &err);
-   if (rc || !p)
-      return 0;
-# endif // HAVE_SOLARIS_STYLE_GETHOST
+   if (rc)
+      return nullptr;
 
-   return hename_string(he);
-
-#else  // else if !HAVE_GETHOSTBYADDR_R
-   AutoLocker al(&lck_gethostbyaddr);
-   struct hostent *he;
-   if (!(he = gethostbyaddr((char *)dst, len, type)))
-      return 0;
-
-   return hename_string(*he);
-#endif // HAVE_GETHOSTBYADDR_R
+   return new QoreStringNode(buf);
 }
 
-QoreListNode *q_getaddrinfo_to_list(ExceptionSink *xsink, const char *node, const char *service, int family, int flags, int socktype) {
+QoreListNode* q_getaddrinfo_to_list(ExceptionSink* xsink, const char* node, const char* service, int family, int flags, int socktype) {
    QoreAddrInfo ai;
    if (ai.getInfo(xsink, node, service, family, flags, socktype))
       return 0;
@@ -488,7 +431,7 @@ void QoreAddrInfo::clear() {
    }
 }
 
-int QoreAddrInfo::getInfo(ExceptionSink *xsink, const char *node, const char *service, int family, int flags, int socktype, int protocol) {
+int QoreAddrInfo::getInfo(ExceptionSink* xsink, const char* node, const char* service, int family, int flags, int socktype, int protocol) {
    family = q_get_af(family);
    socktype = q_get_sock_type(socktype);
 
@@ -515,21 +458,21 @@ int QoreAddrInfo::getInfo(ExceptionSink *xsink, const char *node, const char *se
    return 0;
 }
 
-QoreListNode *QoreAddrInfo::getList() const {
+QoreListNode* QoreAddrInfo::getList() const {
    if (!ai)
       return 0;
 
-   QoreListNode *l = new QoreListNode;
+   QoreListNode* l = new QoreListNode;
 
-   for (struct addrinfo *p = ai; p; p = p->ai_next) {
-      QoreHashNode *h = new QoreHashNode;
+   for (struct addrinfo* p = ai; p; p = p->ai_next) {
+      QoreHashNode* h = new QoreHashNode;
 
-      const char *family = q_af_to_str(p->ai_family);
+      const char* family = q_af_to_str(p->ai_family);
 
       if (p->ai_canonname && *p->ai_canonname)
 	 h->setKeyValue("canonname", new QoreStringNode(p->ai_canonname), 0);
 
-      QoreStringNode *addr = q_addr_to_string2(p->ai_addr);
+      QoreStringNode* addr = q_addr_to_string2(p->ai_addr);
       if (addr) {
 	 h->setKeyValue("address", addr, 0);
 	 h->setKeyValue("address_desc", getAddressDesc(p->ai_family, addr->getBuffer()), 0);
@@ -550,14 +493,14 @@ QoreListNode *QoreAddrInfo::getList() const {
    return l;
 }
 
-const char *QoreAddrInfo::getFamilyName(int family) {
+const char* QoreAddrInfo::getFamilyName(int family) {
    return q_af_to_str(q_get_af(family));
 }
 
-QoreStringNode *QoreAddrInfo::getAddressDesc(int family, const char *addr) {
+QoreStringNode* QoreAddrInfo::getAddressDesc(int family, const char* addr) {
    family = q_get_af(family);
 
-   QoreStringNode *str = new QoreStringNode;
+   QoreStringNode* str = new QoreStringNode;
    switch (family) {
       case AF_INET:
 	 str->sprintf("ipv4(%s)", addr);

--- a/lib/QoreNet.cpp
+++ b/lib/QoreNet.cpp
@@ -44,9 +44,9 @@ int q_get_af(int type) {
 
    switch (type) {
       case Q_AF_UNSPEC:
-	 return AF_UNSPEC;
+         return AF_UNSPEC;
       case Q_AF_INET6:
-	 return AF_INET6;
+         return AF_INET6;
    }
 
    return AF_INET;
@@ -177,23 +177,21 @@ static QoreHashNode* he_to_hash(struct hostent& he) {
       QoreListNode* l = new QoreListNode;
       char** a = he.h_aliases;
       while (*a)
-	 l->push(new QoreStringNode(*(a++)));
+         l->push(new QoreStringNode(*(a++)));
       h->setKeyValue("aliases", l, 0);
    }
    switch (he.h_addrtype) {
       case AF_INET:
-	 h->setKeyValue("typename", new QoreStringNode("ipv4"), 0);
-	 h->setKeyValue("type", new QoreBigIntNode(AF_INET), 0);
-	 break;
-
+         h->setKeyValue("typename", new QoreStringNode("ipv4"), 0);
+         h->setKeyValue("type", new QoreBigIntNode(AF_INET), 0);
+         break;
       case AF_INET6:
-	 h->setKeyValue("typename", new QoreStringNode("ipv6"), 0);
-	 h->setKeyValue("type", new QoreBigIntNode(AF_INET6), 0);
-	 break;
-
+         h->setKeyValue("typename", new QoreStringNode("ipv6"), 0);
+         h->setKeyValue("type", new QoreBigIntNode(AF_INET6), 0);
+         break;
       default:
-	 h->setKeyValue("typename", new QoreStringNode("unknown"), 0);
-	 // no break
+         h->setKeyValue("typename", new QoreStringNode("unknown"), 0);
+         break;
    }
    h->setKeyValue("len", new QoreBigIntNode(he.h_length), 0);
 
@@ -203,8 +201,8 @@ static QoreHashNode* he_to_hash(struct hostent& he) {
       QoreListNode* l = new QoreListNode();
       char** a = he.h_addr_list;
       while (*a) {
-	 if (inet_ntop(he.h_addrtype, *(a++), buf, QORE_NET_ADDR_BUF_LEN))
-	    l->push(new QoreStringNode(buf));
+         if (inet_ntop(he.h_addrtype, *(a++), buf, QORE_NET_ADDR_BUF_LEN))
+            l->push(new QoreStringNode(buf));
       }
       h->setKeyValue("addresses", l, 0);
    }
@@ -449,7 +447,7 @@ int QoreAddrInfo::getInfo(ExceptionSink* xsink, const char* node, const char* se
    int status = getaddrinfo(node, service, &hints, &ai);
    if (status) {
       if (xsink)
-	 xsink->raiseException("QOREADDRINFO-GETINFO-ERROR", "getaddrinfo(node: '%s', service: '%s', address_family: %d='%s', flags: %d) error: %s", node ? node : "", service ? service : "", family, q_af_to_str(family), flags, gai_strerror(status));
+         xsink->raiseException("QOREADDRINFO-GETINFO-ERROR", "getaddrinfo(node: '%s', service: '%s', address_family: %d='%s', flags: %d) error: %s", node ? node : "", service ? service : "", family, q_af_to_str(family), flags, gai_strerror(status));
       return -1;
    }
 
@@ -470,21 +468,21 @@ QoreListNode* QoreAddrInfo::getList() const {
       const char* family = q_af_to_str(p->ai_family);
 
       if (p->ai_canonname && *p->ai_canonname)
-	 h->setKeyValue("canonname", new QoreStringNode(p->ai_canonname), 0);
+         h->setKeyValue("canonname", new QoreStringNode(p->ai_canonname), 0);
 
       QoreStringNode* addr = q_addr_to_string2(p->ai_addr);
       if (addr) {
-	 h->setKeyValue("address", addr, 0);
-	 h->setKeyValue("address_desc", getAddressDesc(p->ai_family, addr->getBuffer()), 0);
+         h->setKeyValue("address", addr, 0);
+         h->setKeyValue("address_desc", getAddressDesc(p->ai_family, addr->getBuffer()), 0);
       }
 
       h->setKeyValue("family", new QoreBigIntNode(p->ai_family), 0);
       h->setKeyValue("familystr", new QoreStringNode(family), 0);
       h->setKeyValue("addrlen", new QoreBigIntNode(p->ai_addrlen), 0);
       if (has_svc) {
-	 int port = q_get_port_from_addr(p->ai_addr);
-	 if (port != -1)
-	    h->setKeyValue("port", new QoreBigIntNode(port), 0);
+         int port = q_get_port_from_addr(p->ai_addr);
+         if (port != -1)
+            h->setKeyValue("port", new QoreBigIntNode(port), 0);
       }
 
       l->push(h);
@@ -503,14 +501,14 @@ QoreStringNode* QoreAddrInfo::getAddressDesc(int family, const char* addr) {
    QoreStringNode* str = new QoreStringNode;
    switch (family) {
       case AF_INET:
-	 str->sprintf("ipv4(%s)", addr);
-	 break;
+         str->sprintf("ipv4(%s)", addr);
+         break;
       case AF_INET6:
-	 str->sprintf("ipv6[%s]", addr);
-	 break;
+         str->sprintf("ipv6[%s]", addr);
+         break;
       default:
-	 str->sprintf("%s:%s", getFamilyName(family), addr);
-	 break;
+         str->sprintf("%s:%s", getFamilyName(family), addr);
+         break;
    }
    return str;
 }

--- a/lib/ql_lib.qpp
+++ b/lib/ql_lib.qpp
@@ -858,7 +858,7 @@ if (!exists host)
 nothing gethostbyname() [flags=RUNTIME_NOOP] {
 }
 
-//! Returns the official hostname corresponding to the network addressed passed as an argument
+//! Returns the official hostname corresponding to the network address passed as an argument
 /** If the address family is invalid or the address string is not a valid address for the given family a \c GETHOSTBYADDR-ERROR exception will be thrown.
 
     @param addr the address to look up

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -78,10 +78,6 @@ DLLLOCAL bool threads_initialized = false;
 // recursive mutex attribute
 DLLLOCAL pthread_mutexattr_t ma_recursive;
 
-#ifndef HAVE_GETHOSTBYNAME_R
-DLLLOCAL QoreThreadLock lck_gethostbyname;
-#endif
-
 #ifndef HAVE_GETHOSTBYADDR_R
 DLLLOCAL QoreThreadLock lck_gethostbyaddr;
 #endif


### PR DESCRIPTION
Rewritten all `q_gethostbyname` functions to use `QoreAddrInfo` internally and
rewritten `q_gethostbyaddr` and `q_gethostbyaddr_string` using `getnameinfo(3)`.
`q_gethostbyaddr_to_hash` was left as it is as it's not possible to easily rewrite it using `getnameinfo` - this is because `q_gethostbyaddr_to_hash` is supposed to return the hostname + all aliases but `getnameinfo` returns only the hostname.

@pvanek @davidnich is this okay?