### PR TITLE
Bugfix/1603 tree map fix

### DIFF
--- a/include/qore/intern/QC_TreeMap.h
+++ b/include/qore/intern/QC_TreeMap.h
@@ -39,22 +39,22 @@
 DLLEXPORT extern qore_classid_t CID_TREEMAP;
 DLLLOCAL extern QoreClass* QC_TREEMAP;
 
-DLLLOCAL QoreClass *initTreeMapClass(QoreNamespace& ns);
+DLLLOCAL QoreClass* initTreeMapClass(QoreNamespace& ns);
 
 static inline bool isPathEnd(char c) {
    return c == '/' || c == '?';
 }
 
-static inline size_t getFirstPathSegmentLength(const std::string &path) {
+static inline size_t getFirstPathSegmentLength(const std::string& path) {
    size_t prefixLen = path.find_first_of("/?");
    return prefixLen == std::string::npos ? path.length() : prefixLen;
 }
 
-static inline bool isPrefix(const std::string &prefix, const std::string &str) {
+static inline bool isPrefix(const std::string& prefix, const std::string& str) {
    return str.length() >= prefix.length() && !str.compare(0, prefix.length(), prefix);
 }
 
-static inline bool isPathPrefix(const std::string &prefix, const std::string &path) {
+static inline bool isPathPrefix(const std::string& prefix, const std::string& path) {
    return isPrefix(prefix, path) && (path.length() == prefix.length() || isPathEnd(path[prefix.length()]));
 }
 
@@ -91,7 +91,7 @@ public:
 
       QoreAutoRWReadLocker al(rwl);
       if (!data.empty()) {
-         std::string path(keyStr->getBuffer());
+         std::string path(keyStr->c_str());
 
          Map::const_iterator b = data.begin();
          Map::const_iterator it = data.upper_bound(path);

--- a/lib/QC_TreeMap.qpp
+++ b/lib/QC_TreeMap.qpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -88,15 +88,8 @@ nothing TreeMap::put(string path, any value) {
    tm->put(path, value, xsink);
 }
 
-//! Retrieves a value from the TreeMap and returns optionally unmatched path suffix
-/** Looks for an entry whose key is the longest prefix of \c path.
-    @param path the path to lookup
-    @param unmatched path suffix, reference to a @ref string_or_nothing_type "*string" compatible type is needed, if \c path not found then returns @ref nothing
-    @since %Qore 0.8.13
-
-    @return the value pointed to by the longest prefix of \c path or @ref nothing if no such mapping exists
-
-    @par Example:
+//! Retrieves a value from the TreeMap and optionally returns the unmatched path suffix
+/** @par Example:
     @code{.py}
 TreeMap tm();
 tm.put("abc", "1");
@@ -104,21 +97,31 @@ tm.put("def/g/hi", "5");
 
 any v;
 *string unmatched;
-v = tm.get("abc");   # returns "1"
-v = tm.get("abc", \unmatched);   # returns "1" and unmatched is ""
-v = tm.get("abc/cde/", \unmatched);   # returns "1" and unmatched is "cde/"
+# returns "1"
+v = tm.get("abc");
+# returns "1" and unmatched is ""
+v = tm.get("abc", \unmatched);
+# returns "1" and unmatched is "cde/"
+v = tm.get("abc/cde/", \unmatched);
 *hash h;
 v = tm.get("def/g/hi/five", \h.unmatched);  # returns "5" and h.unmatched is "five"
-
     @endcode
 
+    Looks for an entry whose key is the longest prefix of \c path.
+
+    @param path the path to lookup
+    @param unmatched path suffix, reference to a @ref string_or_nothing_type "*string" compatible type is needed, if \c path is not found, then @ref nothing is returned
+
+    @return the value pointed to by the longest prefix of \c path or @ref nothing if no such mapping exists
+
+    @since %Qore 0.8.13
  */
 any TreeMap::get(string path, *reference unmatched) [flags=RET_VALUE_ONLY] {
    return tm->get(path, unmatched, xsink);
 }
 
 //! Removes a value from the TreeMap and returns the value removed
-/** The \c path must be an exact match
+/** \c path must be an exact match
 
     @param path the path to remove
 
@@ -131,7 +134,7 @@ any TreeMap::take(string path) {
 }
 
 //! Retrieves the entire TreeMap as a hash; returns @ref nothing if the TreeMap is empty
-/** @return the entire TreeMap as a hash or returns @ref nothing if the TreeMap is empty
+/** @return the entire TreeMap as a hash; returns @ref nothing if the TreeMap is empty
  */
 *hash TreeMap::getAll() [flags=CONSTANT] {
    return tm->getAll();


### PR DESCRIPTION
the TreeMap internal implementation turned out to be OK.  The main change is that this branch avoids the conversion of `QoreValue` -> `AbstractQoreNode*` -> `QoreValue` (avoids unnecessary memory and reference counts)
