### PR TITLE
refs #1972 qpp unittest files are generated in src dir, not in the bu…

### DIFF
--- a/cmake/QoreMacros.cmake
+++ b/cmake/QoreMacros.cmake
@@ -26,10 +26,11 @@ MACRO (QORE_WRAP_QPP _cpp_files)
         GET_FILENAME_COMPONENT(_infile ${it} ABSOLUTE)
         SET(_cppfile ${CMAKE_CURRENT_BINARY_DIR}/${_outfile}.cpp)
         SET(_doxfile ${CMAKE_CURRENT_BINARY_DIR}/${_outfile}.dox.h)
+        SET(_unitfile ${CMAKE_CURRENT_BINARY_DIR}/${_outfile}.qunit)
 
         ADD_CUSTOM_COMMAND(OUTPUT ${_cppfile} ${_doxfile}
                            COMMAND ${QORE_QPP_EXECUTABLE}
-                           ARGS --output=${_cppfile} --dox-output=${_doxfile} ${_infile}
+                           ARGS --output=${_cppfile} --dox-output=${_doxfile} --unit=${_unitfile} ${_infile}
                            MAIN_DEPENDENCY ${_infile}
                            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                            VERBATIM
@@ -61,10 +62,11 @@ MACRO (QORE_WRAP_QPP_VALUE _cpp_files)
         GET_FILENAME_COMPONENT(_infile ${it} ABSOLUTE)
         SET(_cppfile ${CMAKE_CURRENT_BINARY_DIR}/${_outfile}.cpp)
         SET(_doxfile ${CMAKE_CURRENT_BINARY_DIR}/${_outfile}.dox.h)
+        SET(_unitfile ${CMAKE_CURRENT_BINARY_DIR}/${_outfile}.qunit)
 
         ADD_CUSTOM_COMMAND(OUTPUT ${_cppfile} ${_doxfile}
                            COMMAND ${QORE_QPP_EXECUTABLE}
-                           ARGS -V --output=${_cppfile} --dox-output=${_doxfile} ${_infile}
+                           ARGS -V --output=${_cppfile} --dox-output=${_doxfile} --unit=${_unitfile} ${_infile}
                            MAIN_DEPENDENCY ${_infile}
                            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                            VERBATIM

--- a/cmake/QoreMacros.cmake
+++ b/cmake/QoreMacros.cmake
@@ -26,7 +26,7 @@ MACRO (QORE_WRAP_QPP _cpp_files)
         GET_FILENAME_COMPONENT(_infile ${it} ABSOLUTE)
         SET(_cppfile ${CMAKE_CURRENT_BINARY_DIR}/${_outfile}.cpp)
         SET(_doxfile ${CMAKE_CURRENT_BINARY_DIR}/${_outfile}.dox.h)
-        SET(_unitfile ${CMAKE_CURRENT_BINARY_DIR}/${_outfile}.qunit)
+        SET(_unitfile ${CMAKE_CURRENT_BINARY_DIR}/${_outfile}.qtest)
 
         ADD_CUSTOM_COMMAND(OUTPUT ${_cppfile} ${_doxfile}
                            COMMAND ${QORE_QPP_EXECUTABLE}
@@ -62,7 +62,7 @@ MACRO (QORE_WRAP_QPP_VALUE _cpp_files)
         GET_FILENAME_COMPONENT(_infile ${it} ABSOLUTE)
         SET(_cppfile ${CMAKE_CURRENT_BINARY_DIR}/${_outfile}.cpp)
         SET(_doxfile ${CMAKE_CURRENT_BINARY_DIR}/${_outfile}.dox.h)
-        SET(_unitfile ${CMAKE_CURRENT_BINARY_DIR}/${_outfile}.qunit)
+        SET(_unitfile ${CMAKE_CURRENT_BINARY_DIR}/${_outfile}.qtest)
 
         ADD_CUSTOM_COMMAND(OUTPUT ${_cppfile} ${_doxfile}
                            COMMAND ${QORE_QPP_EXECUTABLE}


### PR DESCRIPTION
…ild "out of source" location

@davidnich why do we have 2 very similar versions of qore_wrap_qpp... macros, please? What must be done to use "qpp -V " everywhere?