### PR TITLE
Fix need_icon_translit_check so it works with C++11.

### DIFF
--- a/cmake/QoreMacrosIntern.cmake
+++ b/cmake/QoreMacrosIntern.cmake
@@ -608,7 +608,7 @@ else()
       int main(void){
       iconv_t cd;
       cd = iconv_open(\"ISO8859-1//TRANSLIT\",\"ISO8859-1\");
-      if(cd == -1)
+      if(cd == (iconv_t)-1)
         return 1;
       iconv_close(cd);
       return 0; }


### PR DESCRIPTION
Iconv_translit_check fails with a message that C++11 does not allow
implicit casts form * to int.
Add an explicit cast to make it compile under C++11.