### PR TITLE
refs #2030 do not evaluate base class constructor argument twice; only…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ option(QORE_RUNTIME_THREAD_STACK_TRACE
 set(VERSION_MAJOR 0)
 set(VERSION_MINOR 8)
 set(VERSION_SUB 12)
-set(VERSION_PATCH 10)
+set(VERSION_PATCH 12)
 
 # If changing the module API numbers, make sure to change the appropriate
 # defines in include/qore/ModuleManager.h too.

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # Process this file with autoconf to produce a configure script.
 
 # AC_PREREQ(2.59)
-AC_INIT([qore], [0.8.12.11],
+AC_INIT([qore], [0.8.12.12],
         [David Nichols <david@qore.org>],
         [qore])
 AM_INIT_AUTOMAKE([no-dist-gzip dist-bzip2 tar-ustar])

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -2,6 +2,15 @@
 
     @tableofcontents
 
+    @section qore_081212 Qore 0.8.12.12
+
+    @par Release Summary
+    Bugfix release; see details below
+
+    @subsection qore_081212_bug_fixes Bug Fixes in Qore
+
+    - fixed a bug handling \c argv in base class constructor execution (<a href="https://github.com/qorelanguage/qore/issues/2030">issue 2030</a>)
+
     @section qore_081211 Qore 0.8.12.11
 
     @par Release Summary

--- a/examples/test/qore/misc/classes.qtest
+++ b/examples/test/qore/misc/classes.qtest
@@ -74,8 +74,20 @@ class Test2 {
 }
 
 # issue #2030
-class B2030 { constructor() {} }
-class C2030 inherits B2030 { constructor() : B2030(argv) {}}
+class B2030 {
+    public {
+        *list l;
+    }
+
+    constructor() {
+        l = argv[0];
+    }
+}
+
+class C2030 inherits B2030 {
+    constructor() : B2030(argv) {
+    }
+}
 
 %exec-class ClassesTest
 
@@ -156,8 +168,9 @@ public class ClassesTest inherits QUnit::Test {
         Program p(PO_NEW_STYLE | PO_REQUIRE_TYPES);
         assertThrows("ILLEGAL-ABSTRACT-METHOD", \p.parse(), ("class X{static abstract m();}", ""));
         {
-            C2030 c();
+            C2030 c(1, 2, 3);
             assertEq(Type::Object, c.type());
+            assertEq((1, 2, 3), c.l);
         }
     }
 }

--- a/examples/test/qore/misc/classes.qtest
+++ b/examples/test/qore/misc/classes.qtest
@@ -74,18 +74,28 @@ class Test2 {
 }
 
 # issue #2030
-class B2030 {
+class B2030_1 {
     public {
-        *list l;
+        *list l0;
     }
 
     constructor() {
-        l = argv[0];
+        l0 = argv[0];
     }
 }
 
-class C2030 inherits B2030 {
-    constructor() : B2030(argv) {
+class B2030_2 {
+    public {
+        *list l1;
+    }
+
+    constructor() {
+        l1 = argv[0];
+    }
+}
+
+class C2030 inherits B2030_1, B2030_2 {
+    constructor() : B2030_1(argv), B2030_2(argv) {
     }
 }
 
@@ -170,7 +180,8 @@ public class ClassesTest inherits QUnit::Test {
         {
             C2030 c(1, 2, 3);
             assertEq(Type::Object, c.type());
-            assertEq((1, 2, 3), c.l);
+            assertEq((1, 2, 3), c.l0);
+            assertEq((1, 2, 3), c.l1);
         }
     }
 }

--- a/examples/test/qore/misc/classes.qtest
+++ b/examples/test/qore/misc/classes.qtest
@@ -73,6 +73,10 @@ class Test2 {
     }
 }
 
+# issue #2030
+class B2030 { constructor() {} }
+class C2030 inherits B2030 { constructor() : B2030(argv) {}}
+
 %exec-class ClassesTest
 
 public class ClassesTest inherits QUnit::Test {
@@ -151,5 +155,9 @@ public class ClassesTest inherits QUnit::Test {
     miscTest() {
         Program p(PO_NEW_STYLE | PO_REQUIRE_TYPES);
         assertThrows("ILLEGAL-ABSTRACT-METHOD", \p.parse(), ("class X{static abstract m();}", ""));
+        {
+            C2030 c();
+            assertEq(Type::Object, c.type());
+        }
     }
 }

--- a/include/qore/intern/QoreClassIntern.h
+++ b/include/qore/intern/QoreClassIntern.h
@@ -380,8 +380,16 @@ public:
       assert(signature.selfid);
       signature.selfid->instantiateSelf(self);
 
+      // instantiate argv and push id on stack
+      ReferenceHolder<QoreListNode>& argv = uveh.getArgv();
+      signature.argvid->instantiate(argv ? argv->refSelf() : 0);
+      ArgvContextHelper argv_helper(argv.release(), xsink);
+
       if (!constructorPrelude(thisclass, ceh, self, bcl, bceal, xsink))
          evalIntern(uveh.getArgv(), 0, xsink).discard(xsink);
+
+      // uninstantiate argv
+      signature.argvid->uninstantiate(xsink);
 
       // if self then uninstantiate
       signature.selfid->uninstantiateSelf();

--- a/include/qore/intern/QoreClassIntern.h
+++ b/include/qore/intern/QoreClassIntern.h
@@ -380,16 +380,20 @@ public:
       assert(signature.selfid);
       signature.selfid->instantiateSelf(self);
 
-      // instantiate argv and push id on stack
-      ReferenceHolder<QoreListNode>& argv = uveh.getArgv();
-      signature.argvid->instantiate(argv ? argv->refSelf() : 0);
-      ArgvContextHelper argv_helper(argv.release(), xsink);
+      // instantiate argv and push id on stack for base class constructors
+      if (bcl) {
+         ReferenceHolder<QoreListNode>& argv = uveh.getArgv();
+         //printd(5, "UserConstructorVariant::evalConstructor() argv: %p len: %d\n", *argv, argv ? argv->size() : 0);
+         signature.argvid->instantiate(argv ? argv->refSelf() : 0);
+         ArgvContextHelper argv_helper(argv ? argv->listRefSelf() : 0, xsink);
+      }
 
       if (!constructorPrelude(thisclass, ceh, self, bcl, bceal, xsink))
          evalIntern(uveh.getArgv(), 0, xsink).discard(xsink);
 
       // uninstantiate argv
-      signature.argvid->uninstantiate(xsink);
+      if (bcl)
+         signature.argvid->uninstantiate(xsink);
 
       // if self then uninstantiate
       signature.selfid->uninstantiateSelf();

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -1370,19 +1370,14 @@ int BCEAList::add(qore_classid_t classid, const QoreListNode* arg, const Abstrac
    if (!n && i->second->execed)
       return 0;
 
-   // evaluate arguments
-   ReferenceHolder<QoreListNode> nargs(arg ? arg->evalList(xsink) : 0, xsink);
-   if (*xsink)
-      return -1;
-
-   // save arguments
+   // save arguments for evaluation in the constructor
    if (n)
-      insert(i, bceamap_t::value_type(classid, new BCEANode(nargs.release(), variant)));
+      insert(i, bceamap_t::value_type(classid, new BCEANode(arg ? arg->listRefSelf() : 0, variant)));
    else {
       assert(!i->second->args);
       assert(!i->second->variant);
       assert(!i->second->execed);
-      i->second->args = nargs.release();
+      i->second->args = arg ? arg->listRefSelf() : 0;
       i->second->variant = variant;
    }
    return 0;

--- a/qore.spec-fedora
+++ b/qore.spec-fedora
@@ -3,7 +3,7 @@
 
 Summary: Multithreaded Programming Language
 Name: qore
-Version: 0.8.12.11
+Version: 0.8.12.12
 Release: 1%{?dist}
 License: LGPLv2+ or GPLv2+ or MIT
 Group: Development/Languages
@@ -32,7 +32,7 @@ Group: System Environment/Libraries
 Provides: qore-module(abi)%{?_isa} = 0.19
 Provides: qore-module(abi)%{?_isa} = 0.18
 Provides: libqore5 = %{version}
-Obsoletes: libqore5 < 0.8.12.11
+Obsoletes: libqore5 < 0.8.12.12
 # provided for backwards-compatibility with unversioned capabilities and will be removed when the ABI drops backwards-compatibility
 Provides: qore-module-api-0.18
 Provides: qore-module-api-0.17
@@ -165,6 +165,9 @@ make check
 %{_mandir}/man1/qore.1.*
 
 %changelog
+* Thu Aug 3 2017 David Nichols <david@qore.org> 0.8.12.12-1
+- updated to 0.8.12.12
+
 * Thu Jun 15 2017 David Nichols <david@qore.org> 0.8.12.11-1
 - updated to 0.8.12.11
 

--- a/qore.spec-multi
+++ b/qore.spec-multi
@@ -31,7 +31,7 @@
 
 Summary: Multithreaded Programming Language
 Name: qore
-Version: 0.8.12.11
+Version: 0.8.12.12
 Release: 1%{dist}
 %if 0%{?suse_version}
 License: LGPL-2.0+ or GPL-2.0+ or MIT
@@ -109,7 +109,7 @@ Provides: qore-module-api-0.6
 Provides: qore-module-api-0.5
 %if %{libname} == "libqore"
 Provides: libqore5 = %{version}
-Obsoletes: libqore5 < 0.8.12.11
+Obsoletes: libqore5 < 0.8.12.12
 %endif
 %if 0%{?sles_version}
 BuildArch: %{_target_cpu}
@@ -260,6 +260,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 
 %changelog
+* Thu Aug 3 2017 David Nichols <david@qore.org> 0.8.12.12
+- updated to 0.8.12.12
+
 * Thu Jun 15 2017 David Nichols <david@qore.org> 0.8.12.11
 - updated to 0.8.12.11
 

--- a/qore.spec-opensuse
+++ b/qore.spec-opensuse
@@ -20,7 +20,7 @@
 
 %define module_dir %{_libdir}/qore-modules
 Name:           qore
-Version:        0.8.12.11
+Version:        0.8.12.12
 Release:        0
 Summary:        Multithreaded Programming Language
 License:        LGPL-2.1+ or GPL-2.0+ or MIT


### PR DESCRIPTION
… evalute once when the constructor is executed; in this case for user constructors also handle argv lvar instantiation, added test + relnote