### PR TITLE
refs #2040 ensure that all assignments of complex types to untyped lv…

### DIFF
--- a/examples/test/qore/misc/hashdecl.qtest
+++ b/examples/test/qore/misc/hashdecl.qtest
@@ -126,13 +126,6 @@ class HashDeclTest inherits QUnit::Test {
         }
 
         {
-            # however otherwise the hashdecl hash keeps its type
-            Program p(PO_NEW_STYLE);
-            p.parse("sub t() {any h = new hash<Container>(); h.b = 'str';}", "");
-            assertThrows("INVALID-MEMBER", \p.callFunction(), "t");
-        }
-
-        {
             Program p(PO_NEW_STYLE);
             assertThrows("PARSE-EXCEPTION", "hashdecl", \p.parse(), ("sub t() {hash<Container> c1; hash<Container2> c2(); c1 = cast<hash<Container>>(c2);}", ""));
         }

--- a/examples/test/qore/misc/types.qtest
+++ b/examples/test/qore/misc/types.qtest
@@ -10,10 +10,72 @@
 
 %exec-class TypeTest
 
+public hashdecl MyHash {
+    int x = 1;
+}
+
 class TypeTest inherits QUnit::Test {
     constructor() : QUnit::Test("TypeTest", "1.0") {
+        addTestCase("complex type compat", \testComplexTypesCompat());
         addTestCase("types", \testTypes());
         set_return_value(main());
+    }
+
+    testComplexTypesCompat() {
+        {
+            hash<MyHash> h();
+            assertEq(True, h.complexType());
+            assertEq(1, h.x);
+            # assigning to an untyped variable strips the type information for backwards-compatibility
+            any h0 = h;
+            assertEq(1, h0.x);
+            assertEq(False, h0.complexType());
+            h0.a = 2;
+            assertEq(2, h0.a);
+            assertThrows("INVALID-MEMBER", sub () { reference r = \h; r.a = "a"; });
+        }
+
+        {
+            hash<string, int> h();
+            assertEq(True, h.complexType());
+            # assigning to an untyped variable strips the type information for backwards-compatibility
+            any h0 = h;
+            assertEq(False, h0.complexType());
+            h0.a = "a";
+            assertEq("a", h0.a);
+            assertThrows("RUNTIME-TYPE-ERROR", sub () { reference r = \h; r.a = "a"; });
+        }
+
+        {
+            list<int> l();
+            assertEq(True, l.complexType());
+            # assigning to an untyped variable strips the type information for backwards-compatibility
+            any l0 = l;
+            assertEq(False, l0.complexType());
+            l0 += "a";
+            assertEq("a", l0[0]);
+            assertThrows("RUNTIME-TYPE-ERROR", sub () { reference r = \l; r += "a"; });
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            assertThrows("PARSE-EXCEPTION", "unknown member", \p.parse(), ("sub t() {hash<MyHash> h(); h.a = 2;}", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            assertThrows("PARSE-TYPE-ERROR", "lvalue for assignment", \p.parse(), ("sub t() {hash<string, int> h(); h.a = 'a';}", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            assertThrows("PARSE-TYPE-ERROR", "lvalue for assignment", \p.parse(), ("sub t() {list<int> l(); l[0] = 'a';}", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            assertThrows("PARSE-TYPE-ERROR", "cannot append", \p.parse(), ("sub t() {list<int> l(); l += 'a';}", ""));
+        }
     }
 
     testTypes() {
@@ -1244,13 +1306,6 @@ class TypeTest inherits QUnit::Test {
             }
 
             {
-                # however otherwise the typed hash keeps its type
-                Program p(PO_NEW_STYLE);
-                p.parse("sub t() { any h = new hash<string, int>(('a': 1)); h.b = 'str'; }", "");
-                assertThrows("RUNTIME-TYPE-ERROR", \p.callFunction(), "t");
-            }
-
-            {
                 # cast to hash from a non-hash must fail at parse time
                 Program p(PO_NEW_STYLE);
                 assertThrows("PARSE-EXCEPTION", \p.parse(), ("sub t() { any h = cast<hash>(1); }", ""));
@@ -1493,16 +1548,6 @@ class TypeTest inherits QUnit::Test {
                 # cast to list from a non-list must fail at parse time
                 Program p(PO_NEW_STYLE);
                 assertThrows("PARSE-EXCEPTION", \p.parse(), ("sub t() { any l = cast<list>(1); }", ""));
-            }
-
-            {
-                # however otherwise the typed list keeps its type
-                Program p(PO_NEW_STYLE);
-                p.parse("sub t() { any l = new list<int>(1); l[0] = 'str'; }", "");
-                assertThrows("RUNTIME-TYPE-ERROR", \p.callFunction(), "t");
-
-                p.parse("sub t1() { any l = new list<int>(1); l += 'str'; }", "");
-                assertThrows("RUNTIME-TYPE-ERROR", \p.callFunction(), "t1");
             }
         }
 

--- a/examples/test/qore/vars/list.qtest
+++ b/examples/test/qore/vars/list.qtest
@@ -28,8 +28,12 @@ public class ListTest inherits QUnit::Test {
     listTest() {
         hash<string, list<hash<T>>> h();
         {
-            list<string> l = h.keys();
-            assertEq(True, l.complexType());
+            list<string> l0 = h.keys();
+            assertEq(True, l0.complexType());
+            any l1 = h.keys();
+            assertEq(False, l1.complexType());
+            l1 += 1;
+            assertEq(1, l1[0]);
         }
         {
             # assigning a complex type to a list lvalue strips the type info
@@ -51,6 +55,11 @@ public class ListTest inherits QUnit::Test {
             assertEq("list<int>", l.fullType());
             assertEq((), l);
             assertEq(1, test(new list<int>(), new list<string>()));
+        }
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("list sub t() {string line = 'a+b,c'; any x; x = (line =~ x/(.)\\+(.*)/); x[1] = split(',', x[1]); return x[1];}", "");
+            assertEq(("b", "c"), p.callFunction("t"));
         }
     }
 

--- a/examples/test/qore/vars/string.qtest
+++ b/examples/test/qore/vars/string.qtest
@@ -443,12 +443,12 @@ class StringTest inherits QUnit::Test {
         assertEq("xmlns-wsdl" =~ x/(\w+):(\w+)/, NOTHING, "negative regex subpattern extraction");
         assertEq(regex_extract("xmlns:wsdl", "(\\w+):(\\w+)"), ("xmlns", "wsdl"), "regex_extract()");
         {
-            *list<string> l = ("xmlns:wsdl" =~ x/(\w+):(\w+)/);
+            *list<*string> l = ("xmlns:wsdl" =~ x/(\w+):(\w+)/);
             assertEq(True, l.complexType());
-            assertEq("list<string>", l.fullType());
+            assertEq("list<*string>", l.fullType());
             l = regex_extract("xmlns:wsdl", "(\\w+):(\\w+)");
             assertEq(True, l.complexType());
-            assertEq("list<string>", l.fullType());
+            assertEq("list<*string>", l.fullType());
         }
 
         # regex operator tests

--- a/include/qore/QoreValue.h
+++ b/include/qore/QoreValue.h
@@ -288,6 +288,11 @@ public:
    //! returns a referenced AbstractQoreNode pointer only if the contained value is an AbstractQoreNode pointer, in which case "this" is left empty (the value is taken from "this"); returns 0 if the object does not contain an AbstractQoreNode pointer (type != QV_Node)
    DLLEXPORT AbstractQoreNode* takeIfNode();
 
+   //! returns the type of the value
+   /** @since %Qore 0.8.13
+   */
+   DLLEXPORT const QoreTypeInfo* getTypeInfo() const;
+
    //! returns the type of value contained
    DLLEXPORT qore_type_t getType() const;
 

--- a/include/qore/intern/QoreTypeInfo.h
+++ b/include/qore/intern/QoreTypeInfo.h
@@ -384,27 +384,35 @@ public:
 
    // static version of method, checking for null pointer
    DLLLOCAL static void acceptInputParam(const QoreTypeInfo* ti, int param_num, const char* param_name, QoreValue& n, ExceptionSink* xsink) {
-      if (ti)
+      if (hasType(ti))
          ti->acceptInputIntern(xsink, false, param_num, param_name, n);
+      else
+         stripTypeInfo(n, xsink);
    }
 
    // static version of method, checking for null pointer
    DLLLOCAL static void acceptInputMember(const QoreTypeInfo* ti, const char* member_name, QoreValue& n, ExceptionSink* xsink) {
-      if (ti)
+      if (hasType(ti))
          ti->acceptInputIntern(xsink, true, -1, member_name, n);
+      else
+         stripTypeInfo(n, xsink);
    }
 
    // static version of method, checking for null pointer
    DLLLOCAL static void acceptInputKey(const QoreTypeInfo* ti, const char* member_name, QoreValue& n, ExceptionSink* xsink) {
-      if (ti)
+      if (hasType(ti))
          ti->acceptInputIntern(xsink, false, -1, member_name, n);
+      else
+         stripTypeInfo(n, xsink);
    }
 
    // static version of method, checking for null pointer
    DLLLOCAL static void acceptAssignment(const QoreTypeInfo* ti, const char* text, QoreValue& n, ExceptionSink* xsink) {
       assert(text && text[0] == '<');
-      if (ti)
+      if (hasType(ti))
          ti->acceptInputIntern(xsink, false, -1, text, n);
+      else
+         stripTypeInfo(n, xsink);
    }
 
    // static version of method, checking for null pointer
@@ -812,6 +820,8 @@ protected:
       else
          str.concat("lvalue ");
    }
+
+   DLLLOCAL static void stripTypeInfo(QoreValue& n, ExceptionSink* xsink);
 };
 
 class QoreParseTypeInfo;

--- a/lib/QorePlusEqualsOperatorNode.cpp
+++ b/lib/QorePlusEqualsOperatorNode.cpp
@@ -43,7 +43,16 @@ AbstractQoreNode* QorePlusEqualsOperatorNode::parseInitImpl(LocalVar* oflag, int
    const QoreTypeInfo* rightTypeInfo = nullptr;
    right = right->parseInit(oflag, pflag, lvids, rightTypeInfo);
 
-   if (!QoreTypeInfo::isType(ti, NT_LIST)
+   if (QoreTypeInfo::isType(ti, NT_LIST)) {
+      if (!QoreTypeInfo::parseReturns(rightTypeInfo, NT_LIST)) {
+         const QoreTypeInfo* eti = QoreTypeInfo::getUniqueReturnComplexList(ti);
+         if (eti && !QoreTypeInfo::parseAccepts(eti, rightTypeInfo)) {
+            parseException(loc, "PARSE-TYPE-ERROR", "cannot append a value with type '%s' to a list with element type '%s'",
+               QoreTypeInfo::getName(rightTypeInfo), QoreTypeInfo::getName(eti));
+         }
+      }
+   }
+   else if (!QoreTypeInfo::isType(ti, NT_LIST)
        && !QoreTypeInfo::isType(ti, NT_HASH)
        && !QoreTypeInfo::isType(ti, NT_OBJECT)
        && !QoreTypeInfo::isType(ti, NT_STRING)

--- a/lib/QoreRegex.cpp
+++ b/lib/QoreRegex.cpp
@@ -181,7 +181,7 @@ QoreListNode* QoreRegex::extractSubstrings(const QoreString* target, ExceptionSi
             int pos = x * 2;
             if (ovector[pos] == -1) {
                if (!l)
-                  l = new QoreListNode(stringTypeInfo);
+                  l = new QoreListNode(stringOrNothingTypeInfo);
                l->push(nothing());
                continue;
             }
@@ -189,7 +189,7 @@ QoreListNode* QoreRegex::extractSubstrings(const QoreString* target, ExceptionSi
             //printd(5, "substring %d: %d - %d (len %d)\n", x, ovector[pos], ovector[pos + 1], ovector[pos + 1] - ovector[pos]);
             tstr->concat(t->getBuffer() + ovector[pos], ovector[pos + 1] - ovector[pos]);
             if (!l)
-               l = new QoreListNode(stringTypeInfo);
+               l = new QoreListNode(stringOrNothingTypeInfo);
             l->push(tstr);
          }
 

--- a/lib/QoreRegexExtractOperatorNode.cpp
+++ b/lib/QoreRegexExtractOperatorNode.cpp
@@ -45,7 +45,7 @@ AbstractQoreNode* QoreRegexExtractOperatorNode::parseInitImpl(LocalVar* oflag, i
    // turn off "reference ok" and "return value ignored" flags
    pflag &= ~(PF_RETURN_VALUE_IGNORED);
 
-   typeInfo = qore_get_complex_list_or_nothing_type(stringTypeInfo);
+   typeInfo = qore_get_complex_list_or_nothing_type(stringOrNothingTypeInfo);
 
    const QoreTypeInfo *lti = 0;
    exp = exp->parseInit(oflag, pflag, lvids, lti);
@@ -61,6 +61,7 @@ AbstractQoreNode* QoreRegexExtractOperatorNode::parseInitImpl(LocalVar* oflag, i
       ParseExceptionSink xsink;
       ValueEvalRefHolder v(this, *xsink);
       assert(!**xsink);
+      typeInfo = v->getTypeInfo();
       return v.getReferencedValue();
    }
 

--- a/lib/QoreTypeInfo.cpp
+++ b/lib/QoreTypeInfo.cpp
@@ -419,6 +419,8 @@ const QoreTypeInfo* getTypeInfoForValue(const AbstractQoreNode* n) {
          return static_cast<const QoreObject*>(n)->getClass()->getTypeInfo();
       case NT_HASH:
          return static_cast<const QoreHashNode*>(n)->getTypeInfo();
+      case NT_LIST:
+         return static_cast<const QoreListNode*>(n)->getTypeInfo();
       default:
          break;
    }
@@ -774,6 +776,20 @@ void QoreTypeInfo::doNonStringWarning(const QoreProgramLocation& loc, const char
    getThisTypeImpl(*desc);
    desc->sprintf(", which cannot be converted to a string, therefore will always evaluate to an empty string at runtime");
    qore_program_private::makeParseWarning(getProgram(), loc, QP_WARN_INVALID_OPERATION, "INVALID-OPERATION", desc);
+}
+
+void QoreTypeInfo::stripTypeInfo(QoreValue& n, ExceptionSink* xsink) {
+   // strips complex typeinfo for an assignment to an untyped lvalue
+   switch (n.getType()) {
+      case NT_HASH: {
+         map_get_plain_hash(n, xsink);
+         break;
+      }
+      case NT_LIST: {
+         map_get_plain_list(n, xsink);
+         break;
+      }
+   }
 }
 
 template <typename T>

--- a/lib/QoreValue.cpp
+++ b/lib/QoreValue.cpp
@@ -390,7 +390,7 @@ const char* QoreValue::getTypeName() const {
       default: assert(false);
          // no break
    }
-   return 0;
+   return nullptr;
 }
 
 const char* QoreValue::getFullTypeName() const {
@@ -402,7 +402,7 @@ const char* QoreValue::getFullTypeName() const {
       default: assert(false);
          // no break
    }
-   return 0;
+   return nullptr;
 }
 
 AbstractQoreNode* QoreValue::takeNodeIntern() {
@@ -426,6 +426,17 @@ bool QoreValue::isNull() const {
 
 bool QoreValue::isNullOrNothing() const {
    return type == QV_Node && (is_nothing(v.n) || is_null(v.n));
+}
+
+const QoreTypeInfo* QoreValue::getTypeInfo() const {
+   switch (type) {
+      case QV_Bool: return boolTypeInfo;
+      case QV_Int: return bigIntTypeInfo;
+      case QV_Float: return floatTypeInfo;
+      case QV_Node: return getTypeInfoForValue(v.n);
+      default: assert(false);
+   }
+   return nullptr;
 }
 
 ValueHolder::~ValueHolder() {

--- a/lib/scanner.lpp
+++ b/lib/scanner.lpp
@@ -1586,7 +1586,7 @@ class{WS}+{WORD}                        { yylval->string = trim(yytext + 6); par
 namespace{WS}+{WORD}                    { const char* ns = trim_inplace(yytext + 10); parse_push_name(ns); return TOK_NAMESPACE; }
 module{WS}+{WORD}                       { const char* mod = trim_inplace(yytext + 7); parse_set_module_def_context_name(mod); return TOK_MODULE; }
 {WORD}                                  yylval->string = strdup(yytext); return IDENTIFIER;
-{WORD}<[a-zA-Z<:_0-9 \t,]+>             {
+{WORD}<[a-zA-Z\*<:_0-9 \t,]+>             {
                                            if (angle_balanced(yytext)) {
                                                yylval->string = strdup(yytext);
                                                return ANGLE_IDENTIFIER;

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -12703,7 +12703,7 @@ int ucnt = table.update(("id": id), ("name": name));
                 any value = i.getValue();
                 string exp = sprintf("%s = ", getColumnSqlName(key));
                 if (value.uop)
-                    exp += getUpdateExpression(key, value);
+                    exp += getUpdateExpression(key, cast<hash<UpdateOperatorInfo>>(value));
                 else {
                     exp += "%v";
                     args += value;


### PR DESCRIPTION
…alues result in the complex type information being lost - this preserves backwards-compatibility with untyped lvalues; fixed parse time type checking for the += operator with lists