### PR TITLE
refs #2040 ensure that type folding with untyped lvalues is always r…

### DIFF
--- a/doxygen/lang/155_data_type_declarations.dox.tmpl
+++ b/doxygen/lang/155_data_type_declarations.dox.tmpl
@@ -215,7 +215,13 @@ hash<MyHash> sub foo(int x) {
     @endcode
 
     This type is supported at parse-time and at runtime; to convert such values to an untyped hash, assign it
-    to a @ref hash_type "hash" lvalue, use @ref cast "cast<hash>(...)" on the value, or call the @ref Qore::hash() "hash()" function on the value.  Each of these options can be used to convert a type-safe hash to an untyped hash.
+    to a @ref hash_type "hash" lvalue, use @ref cast "cast<hash>(...)" on the value, call the @ref Qore::hash() "hash()"
+    function on the value, or assign it to an untyped lvalue.  Each of these options can be used to convert a type-safe
+    hash to an untyped hash.
+
+    @note complex type information is lost when assigning to an lvalue with a compatible but more generic type or by
+    assigning to an untyped lvalue; this was necessary to allow complex types to be introduced in %Qore without
+    breaking backwards compatibility.
 
     @see
     - @ref hashdecl
@@ -261,7 +267,13 @@ hash<string, int> h4 = cast<hash<string, int>>(get_hash());
     @endcode
 
     This type is supported at parse-time and at runtime; to convert such values to an untyped hash, assign it
-    to a @ref hash_type "hash" lvalue, use @ref cast "cast<hash>(...)" on the value, or call the @ref Qore::hash() "hash()" function on the value.  Each of these options can be used to convert a type-safe hash to an untyped hash.
+    to a @ref hash_type "hash" lvalue, use @ref cast "cast<hash>(...)" on the value, call the @ref Qore::hash() "hash()"
+    function on the value, or assign it to an untyped lvalue.  Each of these options can be used to convert a type-safe
+    hash to an untyped hash.
+
+    @note complex type information is lost when assigning to an lvalue with a compatible but more generic type or by
+    assigning to an untyped lvalue; this was necessary to allow complex types to be introduced in %Qore without
+    breaking backwards compatibility.
 
     @see
     - @ref hashdecl
@@ -308,7 +320,13 @@ list<int> l4 = cast<list<int>>(get_list());
     @endcode
 
     This type is supported at parse-time and at runtime; to convert such values to an untyped list, assign it
-    to a @ref list_type "list" lvalue, use @ref cast "cast<list>(...)" on the value, or call the @ref Qore::list() "list()" function on the value.  Each of these options can be used to convert a type-safe list to an untyped list.
+    to a @ref list_type "list" lvalue, use @ref cast "cast<list>(...)" on the value, call the @ref Qore::list() "list()"
+    function on the value, or assign it to an untyped lvalue.  Each of these options can be used to convert a type-safe
+    list to an untyped list.
+
+    @note complex type information is lost when assigning to an lvalue with a compatible but more generic type or by
+    assigning to an untyped lvalue; this was necessary to allow complex types to be introduced in %Qore without
+    breaking backwards compatibility.
 
     @see
     - @ref new

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -28,6 +28,7 @@
       - @ref list_complex_type "list with type-safe values"; ex: @code{.py} list<int> l = (1); @endcode
       - improved @ref new "new", @ref cast "cast<>", and @ref instanceof "instanceof" operators
       - the @ref instanceof "instanceof" operator now works with any type; ex: @code{.py} bool b = v instanceof hash<string, int>; @endcode
+      - note that complex type information is lost when assigning to an lvalue with a compatible but more generic type or by assigning to an untyped lvalue; this was necessary to allow complex types to be introduced in %Qore without breaking backwards compatibility.
     - support for input and output streams for the efficient piecewise processing of small or large amounts of data with a low memory overhead; includes the following classes:
       - @ref Qore::BinaryInputStream "BinaryInputStream"
       - @ref Qore::BinaryOutputStream "BinaryOutputStream"

--- a/examples/test/qore/misc/types.qtest
+++ b/examples/test/qore/misc/types.qtest
@@ -17,7 +17,7 @@ public hashdecl MyHash {
 class TypeTest inherits QUnit::Test {
     constructor() : QUnit::Test("TypeTest", "1.0") {
         addTestCase("complex type compat", \testComplexTypesCompat());
-        #addTestCase("types", \testTypes());
+        addTestCase("types", \testTypes());
         set_return_value(main());
     }
 

--- a/examples/test/qore/misc/types.qtest
+++ b/examples/test/qore/misc/types.qtest
@@ -17,7 +17,7 @@ public hashdecl MyHash {
 class TypeTest inherits QUnit::Test {
     constructor() : QUnit::Test("TypeTest", "1.0") {
         addTestCase("complex type compat", \testComplexTypesCompat());
-        addTestCase("types", \testTypes());
+        #addTestCase("types", \testTypes());
         set_return_value(main());
     }
 
@@ -33,6 +33,9 @@ class TypeTest inherits QUnit::Test {
             h0.a = 2;
             assertEq(2, h0.a);
             assertThrows("INVALID-MEMBER", sub () { reference r = \h; r.a = "a"; });
+            hash ih = testAnyArg(h);
+            assertEq(False, ih.complex);
+            assertEq("hash", ih.type);
         }
 
         {
@@ -44,6 +47,9 @@ class TypeTest inherits QUnit::Test {
             h0.a = "a";
             assertEq("a", h0.a);
             assertThrows("RUNTIME-TYPE-ERROR", sub () { reference r = \h; r.a = "a"; });
+            hash ih = testAnyArg(h);
+            assertEq(False, ih.complex);
+            assertEq("hash", ih.type);
         }
 
         {
@@ -55,6 +61,9 @@ class TypeTest inherits QUnit::Test {
             l0 += "a";
             assertEq("a", l0[0]);
             assertThrows("RUNTIME-TYPE-ERROR", sub () { reference r = \l; r += "a"; });
+            hash ih = testAnyArg(l);
+            assertEq(False, ih.complex);
+            assertEq("list", ih.type);
         }
 
         {
@@ -4938,5 +4947,12 @@ class TypeTest inherits QUnit::Test {
             i = NOTHING;
             assertEq(NOTHING, i);
         }
+    }
+
+    static hash testAnyArg(any v) {
+        return (
+            "type": v.fullType(),
+            "complex": v.complexType(),
+        );
     }
 }


### PR DESCRIPTION
…eported internally; updated docs regarding the fact that assigning complex types to an untyped lvalue results in the complex type information being lost