### PR TITLE
refs #2077 added the "auto" subtype to maintain complex type info wit…

### DIFF
--- a/doxygen/lang/150_container_data_types.dox.tmpl
+++ b/doxygen/lang/150_container_data_types.dox.tmpl
@@ -65,6 +65,17 @@ element3 = list[2];
     @par Type Name:
     \c "list"
 
+    The list type supports a complex element type specification as well, however "list" lvalues without a
+    complex element type specification will strip the complex type when assigned as in the following example:
+    @code{.py}
+list l0 = (2, 3);
+# prints "list"
+printf("%y\n", l0.fullType());
+list<auto> l1 = (2, 3);
+# prints "list<int>"
+printf("%y\n", l1.fullType());
+    @endcode
+
     @see
     - @ref list_type, @ref softlist_type
     - @ref list_functions
@@ -72,10 +83,20 @@ element3 = list[2];
     @par Complex Type Support for Lists
     The \c "list" type also supports an optional type argument which allows the value type of list elements to be declared; the following example demonstrates a list declaration with a specific value type:\n
     @code{.py}
-list<int> h(2, 3);
+list<int> l(2, 3);
     @endcode \n
     This type is supported at parse-time and at runtime; to convert such values to an untyped list, assign it
     to a @ref list_type "list" lvalue, use @ref cast "cast<list>(...)" on the value, or call the @ref Qore::list() "list()" function on the value.  Each of these options can be used to convert a type-safe list to an untyped list.
+
+    A special type argument, \c "auto", allows for the lvalue to maintain the complex list type as in the following example:
+    @code{.py}
+list l0 = (2, 3);
+# prints "list"
+printf("%y\n", l0.fullType());
+list<auto> l1 = (2, 3);
+# prints "list<int>"
+printf("%y\n", l1.fullType());
+    @endcode
 
     @see @ref list_complex_type
 
@@ -200,6 +221,18 @@ hash<Container> h2(("i": 10, "str": "other"));
     @endcode \n
     This type is supported at parse-time and at runtime; to convert such values to an untyped hash, assign it
     to a @ref hash_type "hash" lvalue, use @ref cast "cast<hash>(...)" on the value, or call the @ref Qore::hash() "hash()" function on the value.  Each of these options can be used to convert a type-safe hash to an untyped hash.
+
+    A special single argument, \c "auto", allows for the lvalue to maintain the complex hash type as in the following example:
+    @code{.py}
+hash h0 = ("a": 2, "b": 3);
+# prints "hash"
+printf("%y\n", h0.fullType());
+hash<auto> h1 = ("a": 2, "b": 3);
+# prints "hash<string, int>"
+printf("%y\n", h1.fullType());
+    @endcode
+
+    @note a \c hashdecl may not have the name \c "auto", this name has a special meaning in complex types
 
     @see
     - @ref hashdecl

--- a/doxygen/lang/155_data_type_declarations.dox.tmpl
+++ b/doxygen/lang/155_data_type_declarations.dox.tmpl
@@ -35,6 +35,7 @@
     |@ref softstring_type "softstring"|@ref integer, @ref float, @ref number, @ref boolean, @ref string, @ref null|@ref string|Accepts @ref integer, @ref float, @ref boolean, @ref string, @ref null and converts non-string values to a string and returns the new value
     |@ref softdate_type "softdate"|@ref integer, @ref float, @ref number, @ref boolean, @ref string, @ref date, @ref null|@ref date|Accepts @ref integer, @ref float, @ref boolean, @ref string, @ref date, and @ref null and converts non-date values to a date and returns the new value
     |@ref softlist_type "softlist"|all types|@ref list|Accepts all types; @ref nothing is returned as an empty list; a list is returned unchanged, and any other type is returned as the first element of a new list
+    |@ref softlist_complex_type "softlist<...>"|all types|@ref list|Accepts all data types; @ref nothing is returned as an empty list; a list is returned with its elements processed by the subtype declaration, and any other type is returned as the first element of a new list, also processed by the subtype declaration
     |@ref data_type "data"|@ref string or @ref binary|same as received|Restricts input to @ref string and @ref binary and returns the same type
     |@ref code_type "code"|@ref closure, @ref call_reference|same as received|Restricts values to @ref closure "closures" and @ref call_reference "call references"
     |@ref reference_type "reference"|@ref lvalue_references|the type the reference points to|Restricts values to references to lvalues
@@ -66,6 +67,7 @@
     |@ref softstring_or_nothing_type "*softstring"|@ref integer, @ref float, @ref number, @ref boolean, @ref string, @ref null or @ref nothing|@ref string or @ref nothing|Accepts @ref integer, @ref float, @ref number, @ref boolean, @ref string, @ref null and converts non-string values to a string and returns the new value. If no value or @ref null is passed, then @ref nothing is returned
     |@ref softdate_or_nothing_type "*softdate"|@ref integer, @ref float, @ref number, @ref boolean, @ref string, @ref date, @ref null or @ref nothing|@ref date or @ref nothing|Accepts @ref integer, @ref float, @ref number, @ref boolean, @ref string, @ref date, and @ref null and converts non-date values to a date and returns the new value. If no value or @ref null is passed, then @ref nothing is returned
     |@ref softlist_or_nothing_type "*softlist"|all types|@ref list or @ref nothing|Accepts all types; @ref nothing and list values are returned as the same value; @ref null is returned as @ref nothing, any other type is returned as the first element of a new list
+    |@ref softlist_complex_or_nothing_type "*softlist<...>"|all types|@ref list or @ref nothing|Accepts all data types; @ref nothing and @ref null are returned as @ref nothing; a list is returned with its elements processed by the declared subtype, and any other type is returned as the first element of a new list with its element processed by the declared subtype
     |@ref any_type "any"|any|same as received|Provides no restrictions on the type of value it receives and returns the same value
 
     <hr>
@@ -225,9 +227,19 @@ hash<MyHash> sub foo(int x) {
     function on the value, or assign it to an untyped lvalue.  Each of these options can be used to convert a type-safe
     hash to an untyped hash.
 
-    @note complex type information is lost when assigning to an lvalue with a compatible but more generic type or by
+    Complex type information is lost when assigning to an lvalue with a compatible but more generic type or by
     assigning to an untyped lvalue; this was necessary to allow complex types to be introduced in %Qore without
     breaking backwards compatibility.
+
+    However, a special single argument, \c "auto", allows for the lvalue to maintain the complex hash type as in the following example:
+    @code{.py}
+hash h0 = ("a": 2, "b": 3);
+# prints "hash"
+printf("%y\n", h0.fullType());
+hash<auto> h1 = new hash<MyHash>();
+# prints "hash<MyHash>"
+printf("%y\n", h1.fullType());
+    @endcode
 
     @see
     - @ref hashdecl
@@ -277,9 +289,19 @@ hash<string, int> h4 = cast<hash<string, int>>(get_hash());
     function on the value, or assign it to an untyped lvalue.  Each of these options can be used to convert a type-safe
     hash to an untyped hash.
 
-    @note complex type information is lost when assigning to an lvalue with a compatible but more generic type or by
+    Complex type information is lost when assigning to an lvalue with a compatible but more generic type or by
     assigning to an untyped lvalue; this was necessary to allow complex types to be introduced in %Qore without
     breaking backwards compatibility.
+
+    However, a special single argument, \c "auto", allows for the lvalue to maintain the complex hash type as in the following example:
+    @code{.py}
+hash h0 = ("a": 2, "b": 3);
+# prints "hash"
+printf("%y\n", h0.fullType());
+hash<auto> h1 = ("a": 2, "b": 3);
+# prints "hash<string, int>"
+printf("%y\n", h1.fullType());
+    @endcode
 
     @see
     - @ref hashdecl
@@ -330,9 +352,19 @@ list<int> l4 = cast<list<int>>(get_list());
     function on the value, or assign it to an untyped lvalue.  Each of these options can be used to convert a type-safe
     list to an untyped list.
 
-    @note complex type information is lost when assigning to an lvalue with a compatible but more generic type or by
+    Complex type information is lost when assigning to an lvalue with a compatible but more generic type or by
     assigning to an untyped lvalue; this was necessary to allow complex types to be introduced in %Qore without
     breaking backwards compatibility.
+
+    However, a special single argument, \c "auto", allows for the lvalue to maintain the complex list type as in the following example:
+    @code{.py}
+list l0 = (2, 3);
+# prints "list"
+printf("%y\n", l0.fullType());
+list<auto> l1 = (2, 3);
+# prints "list<int>"
+printf("%y\n", l1.fullType());
+    @endcode
 
     @see
     - @ref new
@@ -524,6 +556,54 @@ softlist sub foo(softlist l) {
     return l;
 }
     @endcode
+
+    @subsection softlist_complex_type Softlist With Declared Value Type
+
+    <b>Complex list Type Restriction</b>
+    |!Name|!Accepts %Qore Type(s)|!Returns %Qore Type(s)|!Description
+    |\c softlist|all data types|@ref list|Accepts all data types; @ref nothing is returned as an empty list; a list is returned with its elements processed by the subtype declaration, and any other type is returned as the first element of a new list, also processed by the subtype declaration
+
+    The softlist type supports one type argument in angle brackets to specify the value
+    type.  This results in a list where the values must always be of the declared type.  See the
+    following example for more information.
+
+    @par Examples
+    @code{.py}
+# 1: declaration and initialization (identical to 2 and 3)
+softlist<int> l1(500, 300, 0);
+
+# 2: declaration and initialization with the assignment operator (identical to 1 and 3)
+softlist<int> l2 = (500, 300, 0);
+
+# 3: declaration and initialization with the new operator (identical to 1 and 2)
+softlist<int> l3 = new list<int>(500, 300, 0);
+
+# assignment from an untyped list with the cast<> operator (can result in runtime type errors)
+softlist<int> l4 = cast<list<int>>(get_list());
+    @endcode
+
+    This type is supported at parse-time and at runtime; to convert such values to an untyped list, assign it
+    to a @ref list_type "list" lvalue, use @ref cast "cast<list>(...)" on the value, call the @ref Qore::list() "list()"
+    function on the value, or assign it to an untyped lvalue.  Each of these options can be used to convert a type-safe
+    list to an untyped list.
+
+    Complex type information is lost when assigning to an lvalue with a compatible but more generic type or by
+    assigning to an untyped lvalue; this was necessary to allow complex types to be introduced in %Qore without
+    breaking backwards compatibility.
+
+    However, a special single argument, \c "auto", allows for the lvalue to maintain the complex list type as in the following example:
+    @code{.py}
+softlist l0 = 1;
+# prints "list"
+printf("%y\n", l0.fullType());
+softlist<auto> l1 = (1, );
+# prints "list<int>"
+printf("%y\n", l1.fullType());
+    @endcode
+
+    @see
+    - @ref new
+    - @ref cast
 
     @since %Qore 0.8.3 introduced the softlist type
 
@@ -947,6 +1027,19 @@ sub foo(*softdate d) {
 *softlist d = v;
     @endcode
 
+    @subsection softlist_complex_or_nothing_type *softlist<...>
+
+    <b>Complex Softlist or Nothing Type Restriction</b>
+    |!Name|!Accepts %Qore Type(s)|!Returns %Qore Type(s)|!Description
+    |\c *softlist|all data types|@ref list or @ref nothing|Accepts all data types; @ref nothing and @ref null are returned as @ref nothing; a list is returned with its elements processed by the declared subtype, and any other type is returned as the first element of a new list with its element processed by the declared subtype
+
+    @par Example
+    @code{.py}
+*softlist<int> sub foo() {
+    return 1list_;
+}
+    @endcode
+
     @since %Qore 0.8.3 introduced the *softlist type
 
     <hr>
@@ -960,6 +1053,4 @@ sub foo(*softdate d) {
     @code{.py}
 any v = bar;
     @endcode
-
-    @note Complex types (hash of lists, reference to string, etc) are currently not possible to declare but support may be added in future versions of %Qore for this.
 */

--- a/doxygen/lang/155_data_type_declarations.dox.tmpl
+++ b/doxygen/lang/155_data_type_declarations.dox.tmpl
@@ -1035,8 +1035,9 @@ sub foo(*softdate d) {
 
     @par Example
     @code{.py}
-*softlist<int> sub foo() {
-    return 1list_;
+*softlist<softint> sub foo() {
+    # returns a list with 2 as the first element
+    return "2";
 }
     @endcode
 

--- a/doxygen/lang/217_hashdecl.dox.tmpl
+++ b/doxygen/lang/217_hashdecl.dox.tmpl
@@ -23,7 +23,9 @@ hashdecl MyHash {
 }
     @endcode
 
-    @note Each %Qore type has a "pseudo-class" associated with it; for hashes the type is @ref Qore::zzz8hashzzz9 "<hash>"; methods from the data type's "pseudo-class" can be run on any value of that type.
+    @note
+    - a \c hashdecl may not have the name \c "auto", this name has a special meaning in complex types
+    - Each %Qore type has a "pseudo-class" associated with it; for hashes the type is @ref Qore::zzz8hashzzz9 "<hash>"; methods from the data type's "pseudo-class" can be run on any value of that type.
 
     @section hashdecl_creation Type-Safe Hash Creation
     When type-safe hashes are created, the hash is automatically populated with the values given by

--- a/examples/test/qore/misc/types.qtest
+++ b/examples/test/qore/misc/types.qtest
@@ -16,9 +16,40 @@ public hashdecl MyHash {
 
 class TypeTest inherits QUnit::Test {
     constructor() : QUnit::Test("TypeTest", "1.0") {
+        addTestCase("complex auto", \testComplexAutoTypes());
         addTestCase("complex type compat", \testComplexTypesCompat());
-        addTestCase("types", \testTypes());
+        #addTestCase("types", \testTypes());
         set_return_value(main());
+    }
+
+    testComplexAutoTypes() {
+        list<auto> l0 = ("str0", "str1");
+        assertEq("list<string>", l0.fullType());
+        softlist<auto> l1 = ("str0", "str1");
+        assertEq("list<string>", l1.fullType());
+        *list<auto> l2 = ("str0", "str1");
+        assertEq("list<string>", l2.fullType());
+        *softlist<auto> l3 = ("str0", "str1");
+        assertEq("list<string>", l3.fullType());
+
+        hash<auto> h0 = ("a": 1, "b": 2);
+        assertEq("hash<string, int>", h0.fullType());
+        hash<string, auto> h1 = ("a": 1, "b": 2);
+        assertEq("hash<string, int>", h1.fullType());
+        hash<auto> h2 = new hash<MyHash>();
+        assertEq("hash<MyHash>", h2.fullType());
+
+        # reference<auto> == reference<any>
+        reference<auto> r = \h0;
+        assertEq("hash<string, int>", r.fullType());
+
+        {
+            hash h = {};
+            *hash h9 = ("a": ());
+            h += ("a": ("a": ("a": 1), "b": h9));
+            assertEq("hash", h.fullType());
+            assertEq("hash", h.a.b.fullType());
+        }
     }
 
     testComplexTypesCompat() {
@@ -69,6 +100,36 @@ class TypeTest inherits QUnit::Test {
             hash ih = testAnyArg(l);
             assertEq(False, ih.complex);
             assertEq("list", ih.type);
+        }
+
+        {
+            softlist<int> l();
+            assertEq(True, l.complexType());
+            # assigning to an untyped variable strips the type information for backwards-compatibility
+            any l0 = l;
+            assertEq(False, l0.complexType());
+            l0 += "a";
+            assertEq("a", l0[0]);
+            assertThrows("RUNTIME-TYPE-ERROR", sub () { reference r = \l; r += "a"; });
+            hash ih = testAnyArg(l);
+            assertEq(False, ih.complex);
+            assertEq("list", ih.type);
+        }
+
+        {
+            softlist<softint> l = "1";
+            assertEq(1, l[0]);
+            assertEq(True, l.complexType());
+            # assigning to an untyped variable strips the type information for backwards-compatibility
+            any l0 = l;
+            assertEq(False, l0.complexType());
+            l0 += "a";
+            assertEq("a", l0[1]);
+            hash ih = testAnyArg(l);
+            assertEq(False, ih.complex);
+            assertEq("list", ih.type);
+            l += "2";
+            assertEq(2, l[1]);
         }
 
         {

--- a/examples/test/qore/misc/types.qtest
+++ b/examples/test/qore/misc/types.qtest
@@ -18,7 +18,7 @@ class TypeTest inherits QUnit::Test {
     constructor() : QUnit::Test("TypeTest", "1.0") {
         addTestCase("complex auto", \testComplexAutoTypes());
         addTestCase("complex type compat", \testComplexTypesCompat());
-        #addTestCase("types", \testTypes());
+        addTestCase("types", \testTypes());
         set_return_value(main());
     }
 

--- a/include/qore/QoreType.h
+++ b/include/qore/QoreType.h
@@ -59,7 +59,9 @@ DLLEXPORT extern const QoreTypeInfo* anyTypeInfo,
    *dateTypeInfo,
    *objectTypeInfo,
    *hashTypeInfo,
+   *autoHashTypeInfo,
    *listTypeInfo,
+   *autoListTypeInfo,
    *nothingTypeInfo,
    *nullTypeInfo,
    *numberTypeInfo,
@@ -74,6 +76,7 @@ DLLEXPORT extern const QoreTypeInfo* anyTypeInfo,
    *softStringTypeInfo,           // converts to string from int, float, bool, number, and null
    *softDateTypeInfo,             // converts to date from int, float, bool, string, number, and null
    *softListTypeInfo,             // converts NOTHING -> empty list, list -> the same list, and everything else: list(arg)
+   *softAutoListTypeInfo,
    *dataTypeInfo,                 // either string or binary
    *timeoutTypeInfo,              // accepts int or date and returns int giving timeout in milliseconds
    *bigIntOrFloatTypeInfo,        // accepts int or float and returns the same
@@ -89,7 +92,9 @@ DLLEXPORT extern const QoreTypeInfo* anyTypeInfo,
    *objectOrNothingTypeInfo,
    *dateOrNothingTypeInfo,
    *hashOrNothingTypeInfo,
+   *autoHashOrNothingTypeInfo,
    *listOrNothingTypeInfo,
+   *autoListOrNothingTypeInfo,
    *nullOrNothingTypeInfo,
    *codeOrNothingTypeInfo,
    *dataOrNothingTypeInfo,
@@ -102,6 +107,7 @@ DLLEXPORT extern const QoreTypeInfo* anyTypeInfo,
    *softStringOrNothingTypeInfo,
    *softDateOrNothingTypeInfo,
    *softListOrNothingTypeInfo,
+   *softAutoListOrNothingTypeInfo,
    *timeoutOrNothingTypeInfo;
 
 DLLEXPORT qore_type_t get_next_type_id();

--- a/include/qore/intern/ConstantList.h
+++ b/include/qore/intern/ConstantList.h
@@ -236,9 +236,9 @@ public:
    DLLLOCAL ConstantList(const ConstantList& old, int64 po, ClassNs p);
 
    // do not delete the object returned by this function
-   DLLLOCAL cnemap_t::iterator add(const char* name, AbstractQoreNode* val, const QoreTypeInfo* typeInfo = 0, ClassAccess access = Public);
+   DLLLOCAL cnemap_t::iterator add(const char* name, AbstractQoreNode* val, const QoreTypeInfo* typeInfo = nullptr, ClassAccess access = Public);
 
-   DLLLOCAL cnemap_t::iterator parseAdd(const QoreProgramLocation& loc, const char* name, AbstractQoreNode* val, const QoreTypeInfo* typeInfo = 0, bool pub = false, ClassAccess access = Public);
+   DLLLOCAL cnemap_t::iterator parseAdd(const QoreProgramLocation& loc, const char* name, AbstractQoreNode* val, const QoreTypeInfo* typeInfo = nullptr, bool pub = false, ClassAccess access = Public);
 
    DLLLOCAL ConstantEntry* findEntry(const char* name);
 

--- a/include/qore/intern/QoreLibIntern.h
+++ b/include/qore/intern/QoreLibIntern.h
@@ -933,4 +933,6 @@ DLLLOCAL qore_offset_t q_UTF16LE_get_char_len(const char* p, qore_size_t len);
 
 DLLLOCAL int64 get_ms_zero(const QoreValue& v);
 
+DLLLOCAL AbstractQoreNode* copy_strip_complex_types(const AbstractQoreNode* n);
+
 #endif

--- a/include/qore/intern/QoreTypeInfo.h
+++ b/include/qore/intern/QoreTypeInfo.h
@@ -106,7 +106,7 @@ public:
             return NT_HASH;
          case QTS_COMPLEXLIST:
          case QTS_COMPLEXSOFTLIST:
-         return NT_LIST;
+            return NT_LIST;
          case QTS_COMPLEXREF:
             return NT_REFERENCE;
       }

--- a/include/qore/intern/qore_list_private.h
+++ b/include/qore/intern/qore_list_private.h
@@ -113,6 +113,20 @@ struct qore_list_private {
           holder = v.takeNode();
           return *xsink ? -1 : 0;
        }
+       else {
+           switch (get_node_type(*holder)) {
+               case NT_LIST:
+               case NT_HASH: {
+                   {
+                       ReferenceHolder<> h2(holder.release(), xsink);
+                       holder = copy_strip_complex_types(*h2);
+                   }
+                   return *xsink ? -1 : 0;
+               }
+               default:
+                  break;
+           }
+       }
        return 0;
    }
 

--- a/include/qore/intern/qore_program_private.h
+++ b/include/qore/intern/qore_program_private.h
@@ -187,7 +187,9 @@ public:
       cll,                  // complex list lock
       clonl,                // complex list or nothing lock
       crl,                  // complex reference lock
-      cronl;                // complex reference or nothing lock
+      cronl,                // complex reference or nothing lock
+      csll,                 // complex softlist lock
+      cslonl;               // complex softlist or nothing lock
 
    typedef std::map<const QoreTypeInfo*, QoreTypeInfo*> tmap_t;
    tmap_t ch_map,          // complex hash map
@@ -195,7 +197,9 @@ public:
       cl_map,              // complex list map
       clon_map,            // complex list or nothing map
       cr_map,              // complex reference map
-      cron_map;            // complex reference or nothing map
+      cron_map,            // complex reference or nothing map
+      csl_map,             // complex softlist map
+      cslon_map;           // complex softlist or nothing map
 
    // set of signals being handled by code in this Program (to be deleted on exit)
    int_set_t sigset;
@@ -1464,6 +1468,8 @@ public:
    DLLLOCAL const QoreTypeInfo* getComplexListOrNothingType(const QoreTypeInfo* vti);
    DLLLOCAL const QoreTypeInfo* getComplexReferenceType(const QoreTypeInfo* vti);
    DLLLOCAL const QoreTypeInfo* getComplexReferenceOrNothingType(const QoreTypeInfo* vti);
+   DLLLOCAL const QoreTypeInfo* getComplexSoftListType(const QoreTypeInfo* vti);
+   DLLLOCAL const QoreTypeInfo* getComplexSoftListOrNothingType(const QoreTypeInfo* vti);
 
    DLLLOCAL static QoreClass* runtimeFindClass(const QoreProgram& pgm, const char* class_name, ExceptionSink* xsink) {
       return pgm.priv->runtimeFindClass(class_name, xsink);

--- a/lib/ConstantList.cpp
+++ b/lib/ConstantList.cpp
@@ -187,7 +187,7 @@ int ConstantEntry::parseInit(ClassNs ptr) {
 
       // push parse class context
       qore_class_private* p = ptr.getClass();
-      QoreParseClassHelper qpch(p ? p->cls : 0);
+      QoreParseClassHelper qpch(p ? p->cls : nullptr);
 
       // ensure that there is no accessible local variable state
       VariableBlockHelper vbh;
@@ -197,12 +197,12 @@ int ConstantEntry::parseInit(ClassNs ptr) {
 
       //printd(5, "ConstantEntry::parseInit() this: %p '%s' about to init node: %p '%s' class: %p '%s'\n", this, name.c_str(), node, get_type_name(node), p, p ? p->name.c_str() : "n/a");
       if (typeInfo)
-         typeInfo = 0;
+         typeInfo = nullptr;
 
       node = node->parseInit((LocalVar*)0, PF_CONST_EXPRESSION, lvids, typeInfo);
    }
 
-   //printd(5, "ConstantEntry::parseInit() this: %p %s initialized to node: %p (%s) value: %d\n", this, name.c_str(), node, get_type_name(node), node->is_value());
+   //printd(5, "ConstantEntry::parseInit() this: %p %s initialized to node: %p (%s) value: %d type: '%s'\n", this, name.c_str(), node, get_type_name(node), node->is_value(), QoreTypeInfo::getName(typeInfo));
 
    if (node->is_value())
       return 0;
@@ -210,8 +210,8 @@ int ConstantEntry::parseInit(ClassNs ptr) {
    // do not evaluate expression if any parse exceptions have been thrown
    QoreProgram* pgm = getProgram();
    if (pgm->parseExceptionRaised()) {
-      discard(node, 0);
-      node = 0;
+      discard(node, nullptr);
+      node = nullptr;
       typeInfo = nothingTypeInfo;
       return -1;
    }
@@ -232,12 +232,11 @@ int ConstantEntry::parseInit(ClassNs ptr) {
          }
          else {
             typeInfo = getTypeInfoForValue(node);
-            //check_constant_cycle(pgm, node); // address circular refs: pgm->const->pgm
          }
       }
       else {
          node->deref(&xsink);
-         node = 0;
+         node = nullptr;
          typeInfo = nothingTypeInfo;
       }
    }
@@ -369,7 +368,7 @@ AbstractQoreNode* ConstantList::parseFind(const char* name, const QoreTypeInfo*&
       return &Nothing;
    }
 
-   constantTypeInfo = 0;
+   constantTypeInfo = nullptr;
    return 0;
 }
 
@@ -381,8 +380,8 @@ AbstractQoreNode* ConstantList::find(const char* name, const QoreTypeInfo*& cons
       return i->second->node;
    }
 
-   constantTypeInfo = 0;
-   return 0;
+   constantTypeInfo = nullptr;
+   return nullptr;
 }
 
 bool ConstantList::inList(const char* name) const {

--- a/lib/Pseudo_QC_String.qpp
+++ b/lib/Pseudo_QC_String.qpp
@@ -409,7 +409,7 @@ string <string>::substr(softint start, softint len) [flags=RET_VALUE_ONLY] {
     @par Example:
     @code{.py}
 string str = "some:text:here";
-list list = str.split(":"); # returns ("some", "text", "here")
+list<string> list = str.split(":"); # returns ("some", "text", "here")
     @endcode
 
     @throw ENCODING-CONVERSION-ERROR this exception could be thrown if the string arguments have different @ref character_encoding "character encodings" and an error occurs during encoding conversion
@@ -418,7 +418,7 @@ list list = str.split(":"); # returns ("some", "text", "here")
 
     @since %Qore 0.8.5
  */
-list <string>::split(string sep, bool with_separator = False) [flags=RET_VALUE_ONLY] {
+list<string> <string>::split(string sep, bool with_separator = False) [flags=RET_VALUE_ONLY] {
    // convert pattern encoding to string if necessary
    TempEncodingHelper temp(sep, str->getEncoding(), xsink);
    if (*xsink)
@@ -440,7 +440,7 @@ list <string>::split(string sep, bool with_separator = False) [flags=RET_VALUE_O
 
     @par Example:
     @code{.py}
-list list = "some,'text with spaces, and commas, here is another one! ,',here".split(",", "'"); # returns ("some", ", and commas, here is another one! ,", "here")
+list<string> list = "some,'text with spaces, and commas, here is another one! ,',here".split(",", "'"); # returns ("some", ", and commas, here is another one! ,", "here")
     @endcode
 
     @throw ENCODING-CONVERSION-ERROR this exception could be thrown if the string arguments have different @ref character_encoding "character encodings" and an error occurs during encoding conversion
@@ -452,7 +452,7 @@ list list = "some,'text with spaces, and commas, here is another one! ,',here".s
     - %Qore 0.8.5 added this pseudo-method
     - %Qore 0.8.6 added the \c trim_unquoted parameter
  */
-list <string>::split(string sep, string quote, bool trim_unquoted = False) [flags=RET_VALUE_ONLY] {
+list<string> <string>::split(string sep, string quote, bool trim_unquoted = False) [flags=RET_VALUE_ONLY] {
    return split_with_quote(sep, str, quote, trim_unquoted, xsink);
 }
 
@@ -498,7 +498,7 @@ bool <string>::regex(string regex, int options = 0) [flags=RET_VALUE_ONLY] {
     @par Example:
     @code{.py}
 string str = "ns:element";
-*list rv = str.regexExtract("(\\w+):(\\w+)");
+*list<string> rv = str.regexExtract("(\\w+):(\\w+)");
     @endcode
 
     @throw REGEX-COMPILATION-ERROR There was an error compiling the regular expression

--- a/lib/QoreAssignmentOperatorNode.cpp
+++ b/lib/QoreAssignmentOperatorNode.cpp
@@ -51,7 +51,7 @@ void QoreAssignmentOperatorNode::parseInitIntern(LocalVar* oflag, int pflag, int
        && (getProgram()->getParseOptions64() & PO_BROKEN_INT_ASSIGNMENTS))
       broken_int = true;
 
-   const QoreTypeInfo* r = 0;
+   const QoreTypeInfo* r = nullptr;
    right = right->parseInit(oflag, pflag, lvids, r);
 
    // check for illegal assignment to $self

--- a/lib/QoreHashNode.cpp
+++ b/lib/QoreHashNode.cpp
@@ -833,7 +833,7 @@ QoreHashNode* QoreHashNode::getSlice(const QoreListNode* value_list, ExceptionSi
 }
 
 AbstractQoreNode* QoreHashNode::parseInit(LocalVar* oflag, int pflag, int &lvids, const QoreTypeInfo *&typeInfo) {
-   typeInfo = hashTypeInfo;
+   typeInfo = priv->getTypeInfo();
    return this;
 }
 

--- a/lib/QoreListNode.cpp
+++ b/lib/QoreListNode.cpp
@@ -1336,7 +1336,7 @@ QoreListNode* QoreListNode::listRefSelf() const {
 }
 
 QoreListNode* QoreListNode::parseInitList(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo) {
-   typeInfo = listTypeInfo;
+   typeInfo = priv->getTypeInfo();
 
    QoreListNodeParseInitHelper li(this, oflag, pflag, lvids);
    while (li.next()) {

--- a/lib/QoreParseListNode.cpp
+++ b/lib/QoreParseListNode.cpp
@@ -94,7 +94,7 @@ AbstractQoreNode* QoreParseListNode::parseInitImpl(LocalVar* oflag, int pflag, i
 
 QoreValue QoreParseListNode::evalValueImpl(bool& needs_deref, ExceptionSink* xsink) const {
     assert(needs_deref);
-    ReferenceHolder<QoreListNode> l(new QoreListNode, xsink);
+    ReferenceHolder<QoreListNode> l(new QoreListNode(vtype), xsink);
     qore_list_private::get(**l)->reserve(values.size());
 
     for (size_t i = 0; i < values.size(); ++i) {

--- a/lib/QoreProgram.cpp
+++ b/lib/QoreProgram.cpp
@@ -740,6 +740,10 @@ void qore_program_private::del(ExceptionSink* xsink) {
       delete i.second;
    for (auto& i : cron_map)
       delete i.second;
+   for (auto& i : csl_map)
+      delete i.second;
+   for (auto& i : cslon_map)
+      delete i.second;
 
    //printd(5, "QoreProgram::~QoreProgram() this: %p deleting root ns %p\n", this, RootNS);
 }
@@ -828,6 +832,30 @@ const QoreTypeInfo* qore_program_private::getComplexListOrNothingType(const Qore
 
    QoreComplexListOrNothingTypeInfo* ti = new QoreComplexListOrNothingTypeInfo(vti);
    clon_map.insert(i, tmap_t::value_type(vti, ti));
+   return ti;
+}
+
+const QoreTypeInfo* qore_program_private::getComplexSoftListType(const QoreTypeInfo* vti) {
+   AutoLocker al(csll);
+
+   tmap_t::iterator i = csl_map.lower_bound(vti);
+   if (i != csl_map.end() && i->first == vti)
+      return i->second;
+
+   QoreComplexSoftListTypeInfo* ti = new QoreComplexSoftListTypeInfo(vti);
+   csl_map.insert(i, tmap_t::value_type(vti, ti));
+   return ti;
+}
+
+const QoreTypeInfo* qore_program_private::getComplexSoftListOrNothingType(const QoreTypeInfo* vti) {
+   AutoLocker al(cslonl);
+
+   tmap_t::iterator i = cslon_map.lower_bound(vti);
+   if (i != cslon_map.end() && i->first == vti)
+      return i->second;
+
+   QoreComplexSoftListOrNothingTypeInfo* ti = new QoreComplexSoftListOrNothingTypeInfo(vti);
+   cslon_map.insert(i, tmap_t::value_type(vti, ti));
    return ti;
 }
 

--- a/lib/QorePushOperatorNode.cpp
+++ b/lib/QorePushOperatorNode.cpp
@@ -62,7 +62,7 @@ QoreValue QorePushOperatorNode::evalValueImpl(bool& needs_deref, ExceptionSink* 
 
    QoreListNode* l = reinterpret_cast<QoreListNode*>(val.getValue());
 
-   l->push(res.getReferencedValue());
+   l->push(res.getReferencedValue(), xsink);
 
    // reference for return value
    return ref_rv ? l->refSelf() : QoreValue();

--- a/lib/QoreTypeInfo.cpp
+++ b/lib/QoreTypeInfo.cpp
@@ -62,8 +62,14 @@ const QoreDateOrNothingTypeInfo staticDateOrNothingTypeInfo;
 const QoreHashTypeInfo staticHashTypeInfo;
 const QoreHashOrNothingTypeInfo staticHashOrNothingTypeInfo;
 
+const QoreAutoHashTypeInfo staticAutoHashTypeInfo;
+const QoreAutoHashOrNothingTypeInfo staticAutoHashOrNothingTypeInfo;
+
 const QoreListTypeInfo staticListTypeInfo;
 const QoreListOrNothingTypeInfo staticListOrNothingTypeInfo;
+
+const QoreAutoListTypeInfo staticAutoListTypeInfo;
+const QoreAutoListOrNothingTypeInfo staticAutoListOrNothingTypeInfo;
 
 const QoreNothingTypeInfo staticNothingTypeInfo;
 
@@ -112,6 +118,9 @@ const QoreSoftDateOrNothingTypeInfo staticSoftDateOrNothingTypeInfo;
 const QoreSoftListTypeInfo staticSoftListTypeInfo;
 const QoreSoftListOrNothingTypeInfo staticSoftListOrNothingTypeInfo;
 
+const QoreSoftAutoListTypeInfo staticSoftAutoListTypeInfo;
+const QoreSoftAutoListOrNothingTypeInfo staticSoftAutoListOrNothingTypeInfo;
+
 const QoreTimeoutTypeInfo staticTimeoutTypeInfo;
 const QoreTimeoutOrNothingTypeInfo staticTimeoutOrNothingTypeInfo;
 
@@ -130,7 +139,9 @@ const QoreTypeInfo* anyTypeInfo = &staticAnyTypeInfo,
    *dateTypeInfo = &staticDateTypeInfo,
    *objectTypeInfo = &staticObjectTypeInfo,
    *hashTypeInfo = &staticHashTypeInfo,
+   *autoHashTypeInfo = &staticAutoHashTypeInfo,
    *listTypeInfo = &staticListTypeInfo,
+   *autoListTypeInfo = &staticAutoListTypeInfo,
    *nothingTypeInfo = &staticNothingTypeInfo,
    *nullTypeInfo = &staticNullTypeInfo,
    *numberTypeInfo = &staticNumberTypeInfo,
@@ -145,6 +156,7 @@ const QoreTypeInfo* anyTypeInfo = &staticAnyTypeInfo,
    *softStringTypeInfo = &staticSoftStringTypeInfo,
    *softDateTypeInfo = &staticSoftDateTypeInfo,
    *softListTypeInfo = &staticSoftListTypeInfo,
+   *softAutoListTypeInfo = &staticSoftAutoListTypeInfo,
    *dataTypeInfo = &staticDataTypeInfo,
    *timeoutTypeInfo = &staticTimeoutTypeInfo,
    *bigIntOrFloatTypeInfo = &staticIntOrFloatTypeInfo,
@@ -160,7 +172,9 @@ const QoreTypeInfo* anyTypeInfo = &staticAnyTypeInfo,
    *objectOrNothingTypeInfo = &staticObjectOrNothingTypeInfo,
    *dateOrNothingTypeInfo = &staticDateOrNothingTypeInfo,
    *hashOrNothingTypeInfo = &staticHashOrNothingTypeInfo,
+   *autoHashOrNothingTypeInfo = &staticAutoHashOrNothingTypeInfo,
    *listOrNothingTypeInfo = &staticListOrNothingTypeInfo,
+   *autoListOrNothingTypeInfo = &staticAutoListOrNothingTypeInfo,
    *nullOrNothingTypeInfo = &staticNullOrNothingTypeInfo,
    *codeOrNothingTypeInfo = &staticCodeOrNothingTypeInfo,
    *dataOrNothingTypeInfo = &staticDataOrNothingTypeInfo,
@@ -173,6 +187,7 @@ const QoreTypeInfo* anyTypeInfo = &staticAnyTypeInfo,
    *softStringOrNothingTypeInfo = &staticSoftStringOrNothingTypeInfo,
    *softDateOrNothingTypeInfo = &staticSoftDateOrNothingTypeInfo,
    *softListOrNothingTypeInfo = &staticSoftListOrNothingTypeInfo,
+   *softAutoListOrNothingTypeInfo = &staticSoftAutoListOrNothingTypeInfo,
    *timeoutOrNothingTypeInfo = &staticTimeoutOrNothingTypeInfo;
 
 QoreListNode* emptyList;
@@ -216,7 +231,9 @@ tmap_t ch_map,          // complex hash map
    cl_map,              // complex list map
    clon_map,            // complex list or nothing map
    cr_map,              // complex reference map
-   cron_map;            // complex reference or nothing map
+   cron_map,            // complex reference or nothing map
+   csl_map,             // complex softlist map
+   cslon_map;           // complex softlist or nothing map
 
 // rwlock for global type map
 static QoreRWLock extern_type_info_map_lock;
@@ -322,6 +339,10 @@ void delete_qore_types() {
       delete i.second;
    for (auto& i : cron_map)
       delete i.second;
+   for (auto& i : csl_map)
+      delete i.second;
+   for (auto& i : cslon_map)
+      delete i.second;
 }
 
 void add_to_type_map(qore_type_t t, const QoreTypeInfo* typeInfo) {
@@ -348,6 +369,12 @@ const QoreTypeInfo* get_or_nothing_type(const QoreTypeInfo* typeInfo) {
       const QoreTypeInfo* ti = QoreTypeInfo::getUniqueReturnComplexHash(typeInfo);
       if (ti)
          return qore_program_private::get(*getProgram())->getComplexHashOrNothingType(ti);
+   }
+
+   {
+      const QoreTypeInfo* ti = QoreTypeInfo::getUniqueReturnComplexSoftList(typeInfo);
+      if (ti)
+         return qore_program_private::get(*getProgram())->getComplexSoftListOrNothingType(ti);
    }
 
    {
@@ -410,6 +437,30 @@ const QoreTypeInfo* qore_get_complex_list_or_nothing_type(const QoreTypeInfo* vt
 
    QoreComplexListOrNothingTypeInfo* ti = new QoreComplexListOrNothingTypeInfo(vti);
    clon_map.insert(i, tmap_t::value_type(vti, ti));
+   return ti;
+}
+
+const QoreTypeInfo* qore_get_complex_softlist_type(const QoreTypeInfo* vti) {
+   AutoLocker al(ctl);
+
+   tmap_t::iterator i = csl_map.lower_bound(vti);
+   if (i != csl_map.end() && i->first == vti)
+      return i->second;
+
+   QoreComplexSoftListTypeInfo* ti = new QoreComplexSoftListTypeInfo(vti);
+   csl_map.insert(i, tmap_t::value_type(vti, ti));
+   return ti;
+}
+
+const QoreTypeInfo* qore_get_complex_softlist_or_nothing_type(const QoreTypeInfo* vti) {
+   AutoLocker al(ctl);
+
+   tmap_t::iterator i = cslon_map.lower_bound(vti);
+   if (i != cslon_map.end() && i->first == vti)
+      return i->second;
+
+   QoreComplexSoftListOrNothingTypeInfo* ti = new QoreComplexSoftListOrNothingTypeInfo(vti);
+   cslon_map.insert(i, tmap_t::value_type(vti, ti));
    return ti;
 }
 
@@ -564,9 +615,11 @@ qore_type_result_e QoreTypeSpec::match(const QoreTypeSpec& t, bool& may_not_matc
          }
          return QTI_NOT_EQUAL;
       }
+      case QTS_COMPLEXSOFTLIST:
       case QTS_COMPLEXLIST: {
          //printd(5, "QoreTypeSpec::match() t.typespec: %d '%s'\n", (int)t.typespec, QoreTypeInfo::getName(u.ti));
          switch (t.typespec) {
+            case QTS_COMPLEXSOFTLIST:
             case QTS_COMPLEXLIST:
                return match_type(u.ti, t.u.ti, may_not_match, may_need_filter);
             default: {
@@ -680,6 +733,7 @@ bool QoreTypeSpec::acceptInput(ExceptionSink* xsink, const QoreTypeInfo& typeInf
          }
          break;
       }
+      case QTS_COMPLEXSOFTLIST:
       case QTS_COMPLEXLIST: {
          if (n.getType() == NT_LIST) {
             QoreListNode* l = n.get<QoreListNode>();
@@ -690,7 +744,7 @@ bool QoreTypeSpec::acceptInput(ExceptionSink* xsink, const QoreTypeInfo& typeInf
             }
 
             // try to fold values into our type; value types are not identical;
-            // we have to get a new hash
+            // we have to get a new list
             qore_list_private* lp;
             if (!l->is_unique()) {
                discard(n.assign(l = qore_list_private::get(*l)->copy(&typeInfo)), xsink);
@@ -712,6 +766,12 @@ bool QoreTypeSpec::acceptInput(ExceptionSink* xsink, const QoreTypeInfo& typeInf
                   return true;
             }
 
+            ok = true;
+         }
+         else if (typespec == QTS_COMPLEXSOFTLIST) {
+            QoreValue val = n;
+            n.swap(val);
+            n.assign(qore_list_private::newComplexListFromValue(&typeInfo, val, xsink));
             ok = true;
          }
          break;
@@ -771,6 +831,7 @@ bool QoreTypeSpec::operator==(const QoreTypeSpec& other) const {
          return typed_hash_decl_private::get(*u.hd)->equal(*typed_hash_decl_private::get(*other.u.hd));
       case QTS_COMPLEXHASH:
       case QTS_COMPLEXLIST:
+      case QTS_COMPLEXSOFTLIST:
       case QTS_COMPLEXREF:
          return QoreTypeInfo::equal(u.ti, other.u.ti);
    }
@@ -799,10 +860,13 @@ qore_type_result_e QoreTypeSpec::runtimeAcceptsValue(const QoreValue& n, bool ex
       if (ti && QoreTypeInfo::equal(u.ti, ti))
          return exact ? QTI_IDENT : QTI_AMBIGUOUS;
    }
-   else if (ot == NT_LIST && typespec == QTS_COMPLEXLIST) {
+   else if (ot == NT_LIST && (typespec == QTS_COMPLEXLIST || typespec == QTS_COMPLEXSOFTLIST)) {
       const QoreTypeInfo* ti = n.get<const QoreListNode>()->getValueTypeInfo();
       if (ti && QoreTypeInfo::equal(u.ti, ti))
          return exact ? QTI_IDENT : QTI_AMBIGUOUS;
+   }
+   else if (typespec == QTS_COMPLEXSOFTLIST) {
+      return QTI_AMBIGUOUS;
    }
    else if (ot == NT_REFERENCE && typespec == QTS_COMPLEXREF) {
       const QoreTypeInfo* ti = n.get<const ReferenceNode>()->getLValueTypeInfo();
@@ -893,6 +957,8 @@ bool return_vec_compare(const q_return_vec_t& a, const q_return_vec_t& b) {
 const QoreTypeInfo* QoreParseTypeInfo::resolveSubtype(const QoreProgramLocation& loc) const {
    if (!strcmp(cscope->ostr, "hash")) {
       if (subtypes.size() == 1) {
+         if (!strcmp(subtypes[0]->cscope->ostr, "auto"))
+            return or_nothing ? autoHashOrNothingTypeInfo : autoHashTypeInfo;
          // resolve hashdecl
          const TypedHashDecl* hd = qore_root_ns_private::get(*getRootNS())->parseFindHashDecl(loc, *subtypes[0]->cscope);
          //printd(5, "QoreParseTypeInfo::resolveSubtype() this: %p '%s' hd: %p '%s' type: %p (pgm: %p)\n", this, getName(), hd, hd ? hd->getName() : "n/a", hd ? hd->getTypeInfo(false) : nullptr, getProgram());
@@ -903,6 +969,9 @@ const QoreTypeInfo* QoreParseTypeInfo::resolveSubtype(const QoreProgramLocation&
             parseException(loc, "PARSE-TYPE-ERROR", "invalid complex hash type '%s'; hash key type must be 'string'; cannot declare a hash with key type '%s'", getName(), subtypes[0]->cscope->ostr);
          }
          else {
+            if (!strcmp(subtypes[1]->cscope->ostr, "auto"))
+              return or_nothing ? autoHashOrNothingTypeInfo : autoHashTypeInfo;
+
             // resolve value type
             const QoreTypeInfo* valueType = QoreParseTypeInfo::resolveAny(subtypes[1], loc);
             if (QoreTypeInfo::hasType(valueType)) {
@@ -919,6 +988,8 @@ const QoreTypeInfo* QoreParseTypeInfo::resolveSubtype(const QoreProgramLocation&
    }
    if (!strcmp(cscope->ostr, "list")) {
       if (subtypes.size() == 1) {
+         if (!strcmp(subtypes[0]->cscope->ostr, "auto"))
+            return or_nothing ? autoListOrNothingTypeInfo : autoListTypeInfo;
          // resolve value type
          const QoreTypeInfo* valueType = QoreParseTypeInfo::resolveAny(subtypes[0], loc);
          if (QoreTypeInfo::hasType(valueType)) {
@@ -932,8 +1003,27 @@ const QoreTypeInfo* QoreParseTypeInfo::resolveSubtype(const QoreProgramLocation&
       }
       return or_nothing ? listOrNothingTypeInfo : listTypeInfo;
    }
+   if (!strcmp(cscope->ostr, "softlist")) {
+      if (subtypes.size() == 1) {
+         if (!strcmp(subtypes[0]->cscope->ostr, "auto"))
+            return or_nothing ? softAutoListOrNothingTypeInfo : softAutoListTypeInfo;
+         // resolve value type
+         const QoreTypeInfo* valueType = QoreParseTypeInfo::resolveAny(subtypes[0], loc);
+         if (QoreTypeInfo::hasType(valueType)) {
+            return !or_nothing
+            ? qore_program_private::get(*getProgram())->getComplexSoftListType(valueType)
+            : qore_program_private::get(*getProgram())->getComplexSoftListOrNothingType(valueType);
+         }
+      }
+      else {
+         parseException(loc, "PARSE-TYPE-ERROR", "cannot resolve '%s' with %d type arguments; base type 'softlist' takes a single type name giving list element value type", getName(), (int)subtypes.size());
+      }
+      return or_nothing ? softListOrNothingTypeInfo : softListTypeInfo;
+   }
    if (!strcmp(cscope->ostr, "reference")) {
       if (subtypes.size() == 1) {
+         if (!strcmp(subtypes[0]->cscope->ostr, "auto"))
+            return or_nothing ? referenceOrNothingTypeInfo : referenceTypeInfo;
          // resolve value type
          const QoreTypeInfo* valueType = QoreParseTypeInfo::resolveAny(subtypes[0], loc);
          if (QoreTypeInfo::hasType(valueType)) {
@@ -952,6 +1042,9 @@ const QoreTypeInfo* QoreParseTypeInfo::resolveSubtype(const QoreProgramLocation&
          parseException(loc, "PARSE-TYPE-ERROR", "cannot resolve '%s'; base type 'object' takes a single class name as a subtype argument", getName());
          return or_nothing ? objectOrNothingTypeInfo : objectTypeInfo;
       }
+
+      if (!strcmp(subtypes[0]->cscope->ostr, "auto"))
+         return or_nothing ? objectOrNothingTypeInfo : objectTypeInfo;
 
       // resolve class
       return resolveClass(loc, *subtypes[0]->cscope, or_nothing);
@@ -1003,7 +1096,56 @@ QoreValue QoreHashDeclTypeInfo::getDefaultQoreValueImpl() const {
    //return new QoreHashNode(accept_vec[0].spec.getHashDecl(), xsink);
 }
 
+QoreComplexSoftListTypeInfo::QoreComplexSoftListTypeInfo(const QoreTypeInfo* vti) : QoreComplexListTypeInfo(q_accept_vec_t {
+      {QoreComplexListTypeSpec(vti), nullptr, true},
+      {NT_LIST, [vti] (QoreValue& n, ExceptionSink* xsink) {
+            QoreValue val;
+            n.swap(val);
+            n.assign(qore_list_private::newComplexListFromValue(qore_program_private::get(*getProgram())->getComplexListType(vti), val, xsink));
+         }
+      },
+      {NT_NOTHING, [vti] (QoreValue& n, ExceptionSink* xsink) {
+            QoreListNode* l = new QoreListNode(vti);
+            n.assign(l);
+         }
+      },
+      {NT_ALL, [vti] (QoreValue& n, ExceptionSink* xsink) {
+            QoreValue val;
+            n.swap(val);
+            n.assign(qore_list_private::newComplexListFromValue(qore_program_private::get(*getProgram())->getComplexListType(vti), val, xsink));
+         }
+      },
+   }, q_return_vec_t {{QoreComplexListTypeSpec(vti), true}}) {
+   assert(vti);
+   tname.sprintf("softlist<%s>", QoreTypeInfo::getName(vti));
+}
+
+QoreComplexSoftListOrNothingTypeInfo::QoreComplexSoftListOrNothingTypeInfo(const QoreTypeInfo* vti) : QoreComplexListOrNothingTypeInfo(q_accept_vec_t {
+      {QoreComplexListTypeSpec(vti), nullptr},
+      {NT_LIST, [vti] (QoreValue& n, ExceptionSink* xsink) {
+            QoreValue val;
+            n.swap(val);
+            n.assign(qore_list_private::newComplexListFromValue(qore_program_private::get(*getProgram())->getComplexListType(vti), val, xsink));
+         }
+      },
+      {NT_NOTHING, nullptr},
+      {NT_NULL, [] (QoreValue& n, ExceptionSink* xsink) { n.assignNothing(); }},
+      {NT_ALL, [vti] (QoreValue& n, ExceptionSink* xsink) {
+            QoreValue val;
+            n.swap(val);
+            n.assign(qore_list_private::newComplexListFromValue(qore_program_private::get(*getProgram())->getComplexListType(vti), val, xsink));
+         }
+      },
+      }, q_return_vec_t {{QoreComplexListTypeSpec(vti)}, {NT_NOTHING}}) {
+   assert(vti);
+   tname.sprintf("*softlist<%s>", QoreTypeInfo::getName(vti));
+}
+
 void map_get_plain_hash(QoreValue& n, ExceptionSink* xsink) {
+   ReferenceHolder<QoreHashNode> h(n.get<QoreHashNode>(), xsink);
+   n.assign(copy_strip_complex_types(*h));
+
+   /*
    QoreHashNode* h = n.get<QoreHashNode>();
    qore_hash_private* ph = qore_hash_private::get(*h);
    //printd(5, "map_get_plain_hash ph: %p hd: %p c: %p refs: %d\n", ph, ph->hashdecl, ph->complexTypeInfo, h->reference_count());
@@ -1016,9 +1158,14 @@ void map_get_plain_hash(QoreValue& n, ExceptionSink* xsink) {
    }
    ph->hashdecl = nullptr;
    ph->complexTypeInfo = nullptr;
+   */
 }
 
 void map_get_plain_list(QoreValue& n, ExceptionSink* xsink) {
+   ReferenceHolder<QoreListNode> l(n.get<QoreListNode>(), xsink);
+   n.assign(copy_strip_complex_types(*l));
+
+   /*
    QoreListNode* l = n.get<QoreListNode>();
    qore_list_private* pl = qore_list_private::get(*l);
    //printd(5, "map_get_plain_list pl: %p c: %p refs: %d\n", ph, pl->complexTypeInfo, l->reference_count());
@@ -1030,4 +1177,5 @@ void map_get_plain_list(QoreValue& n, ExceptionSink* xsink) {
       return;
    }
    pl->complexTypeInfo = nullptr;
+   */
 }

--- a/lib/parser.ypp
+++ b/lib/parser.ypp
@@ -172,16 +172,23 @@ public:
 
    DLLLOCAL HashDeclDef(const QoreProgramLocation& loc, NamedScope *n, typed_hash_decl_private* hp) :
         loc(loc), name(n), hashdecl(hp->newTypedHashDecl(name->getIdentifier())) {
+      checkName();
    }
 
    DLLLOCAL HashDeclDef(const QoreProgramLocation& loc, char* n, typed_hash_decl_private* hp) :
         loc(loc), name(new NamedScope(n)), hashdecl(hp->newTypedHashDecl(name->getIdentifier())) {
+      checkName();
    }
 
    DLLLOCAL ~HashDeclDef() {
       delete name;
       if (hashdecl)
          typed_hash_decl_private::get(*hashdecl)->deref();
+   }
+
+   DLLLOCAL void checkName() {
+     if (!strcmp(name->getIdentifier(), "auto"))
+        parse_error(loc, "a hashdecl may not have the name 'auto'; this name has a special meaning in complex types; please choose another name for your hashdecl");
    }
 
    DLLLOCAL TypedHashDecl* takeHashDecl() {

--- a/lib/parser.ypp
+++ b/lib/parser.ypp
@@ -129,7 +129,7 @@ public:
    AbstractQoreNode* value;
    bool pub;
 
-  DLLLOCAL ConstNode(const QoreProgramLocation& loc, char* n, AbstractQoreNode* v, bool p = false) : loc(loc), name(n), value(v), pub(p) {
+   DLLLOCAL ConstNode(const QoreProgramLocation& loc, char* n, AbstractQoreNode* v, bool p = false) : loc(loc), name(n), value(v), pub(p) {
       // see if constant definitions are allowed
       if (parse_check_parse_option(PO_NO_CONSTANT_DEFS))
          parse_error(loc, "illegal constant definition \"%s\" (conflicts with parse option PO_NO_CONSTANT_DEFS)", n);
@@ -187,8 +187,8 @@ public:
    }
 
    DLLLOCAL void checkName() {
-     if (!strcmp(name->getIdentifier(), "auto"))
-        parse_error(loc, "a hashdecl may not have the name 'auto'; this name has a special meaning in complex types; please choose another name for your hashdecl");
+      if (!strcmp(name->getIdentifier(), "auto"))
+         parse_error(loc, "a hashdecl may not have the name 'auto'; this name has a special meaning in complex types; please choose another name for your hashdecl");
    }
 
    DLLLOCAL TypedHashDecl* takeHashDecl() {

--- a/lib/ql_misc.qpp
+++ b/lib/ql_misc.qpp
@@ -602,7 +602,7 @@ any result = call_function_args("func_name", (arg1, arg2));
 
     @note The function called could also throw other exceptions
 */
-any call_function_args(string name, *softlist vargs) {
+any call_function_args(string name, *softlist<auto> vargs) {
    return getProgram()->callFunction(name->getBuffer(), vargs, xsink);
 }
 
@@ -618,7 +618,7 @@ any result = call_function_args(call_ref, (arg1, arg2));
 
     @note The @ref call_reference "call reference" or @ref closure "closure" called could also throw other exceptions
 */
-any call_function_args(code f, *softlist vargs) {
+any call_function_args(code f, *softlist<auto> vargs) {
    return f->execValue(vargs, xsink).takeNode();
 }
 
@@ -673,7 +673,7 @@ any result = call_builtin_function_args("func_name", (arg1, arg2));
 
     @since 0.8.4 this function no longer restricts its search to builtin functions as as of Qore 0.8.4 builtin and user functions are stored identically internally; there is only one function implementation which can contain both builtin and user variants
 */
-any call_builtin_function_args(string name, *softlist vargs) {
+any call_builtin_function_args(string name, *softlist<auto> vargs) {
    const QoreFunction* f = get_builtin_func(name, xsink);
    if (!f)
       return QoreValue();

--- a/lib/ql_object.qpp
+++ b/lib/ql_object.qpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2016 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -197,7 +197,7 @@ any call_object_method(object obj, string method, ...) {
 
     @deprecated use call_object_method_args(); camel-case function names were deprecated in %Qore 0.8.12
  */
-any callObjectMethodArgs(object obj, string method, *softlist varg) [flags=DEPRECATED] {
+any callObjectMethodArgs(object obj, string method, *softlist<auto> varg) [flags=DEPRECATED] {
    return obj->evalMethod(method, varg, xsink);
 }
 
@@ -229,7 +229,7 @@ any result = call_object_method_args(obj, "method", arglist);
 
     @since %Qore 0.8.12 as a replacement for deprecated camel-case callObjectMethodArgs()
 */
-any call_object_method_args(object obj, string method, *softlist varg) {
+any call_object_method_args(object obj, string method, *softlist<auto> varg) {
    return obj->evalMethod(method, varg, xsink);
 }
 
@@ -268,7 +268,7 @@ any call_pseudo(any val, string meth, ...) {
 
     @since %Qore 0.8.8
  */
-any call_pseudo_args(any val, string meth, *softlist argv) {
+any call_pseudo_args(any val, string meth, *softlist<auto> argv) {
    return pseudo_classes_eval(val, meth->getBuffer(), argv, xsink).takeNode();
 }
 
@@ -316,7 +316,7 @@ object obj = create_object_args(class_name, arg_list);
 
     @since %Qore 0.8.12
  */
-object create_object_args(string class_name, *softlist argv) {
+object create_object_args(string class_name, *softlist<auto> argv) {
    ReferenceHolder<QoreValueList> arg_list(xsink);
    if (argv)
       arg_list = new QoreValueList(argv);

--- a/lib/qpp.cpp
+++ b/lib/qpp.cpp
@@ -712,6 +712,25 @@ static int get_qore_type(const std::string& qt, std::string& cppt) {
                 qc = "qore_get_complex_list_type(" + subtype_qt + ")";
             log(LL_DEBUG, "registering complex list return type '%s': '%s'\n", qt.c_str(), qc.c_str());
         }
+        else if (!qt.compare(on ? 1 : 0, 5, "softlist<")) {
+            // extract subtype name
+            std::string subtype = qt.substr((on ? 10 : 9), qt.size() - (on ? 11 : 10));
+
+            if (subtype.find(',') != std::string::npos) {
+                log(LL_CRITICAL, "unsupported complex softlist type found: '%s'\n", qt.c_str());
+                assert(false);
+            }
+
+            std::string subtype_qt;
+            get_qore_type(subtype, subtype_qt);
+
+            // generate type name
+            if (on)
+                qc = "qore_get_complex_softlist_or_nothing_type(" + subtype_qt + ")";
+            else
+                qc = "qore_get_complex_softlist_type(" + subtype_qt + ")";
+            log(LL_DEBUG, "registering complex softlist return type '%s': '%s'\n", qt.c_str(), qc.c_str());
+        }
         else if (!qt.compare(on ? 1 : 0, 10, "reference<")) {
             // extract subtype name
             std::string subtype = qt.substr((on ? 11 : 10), qt.size() - (on ? 12 : 11));

--- a/lib/qpp.cpp
+++ b/lib/qpp.cpp
@@ -688,9 +688,13 @@ static int get_qore_type(const std::string& qt, std::string& cppt) {
                 }
             }
             else {
-                // generate type name
-                qc = "hashdecl" + subtype + "->getTypeInfo(" + (on ? "true" : "false") + ")";
-                log(LL_DEBUG, "registering hashdecl return type '%s': '%s'\n", qt.c_str(), qc.c_str());
+                if (subtype == "auto")
+                    qc = on ? "autoHashOrNothingTypeInfo" : "autoHashTypeInfo";
+                else {
+                    // generate type name
+                    qc = "hashdecl" + subtype + "->getTypeInfo(" + (on ? "true" : "false") + ")";
+                    log(LL_DEBUG, "registering hashdecl return type '%s': '%s'\n", qt.c_str(), qc.c_str());
+                }
             }
         }
         else if (!qt.compare(on ? 1 : 0, 5, "list<")) {
@@ -706,13 +710,17 @@ static int get_qore_type(const std::string& qt, std::string& cppt) {
             get_qore_type(subtype, subtype_qt);
 
             // generate type name
-            if (on)
-                qc = "qore_get_complex_list_or_nothing_type(" + subtype_qt + ")";
-            else
-                qc = "qore_get_complex_list_type(" + subtype_qt + ")";
+            if (subtype == "auto")
+                qc = on ? "autoListOrNothingTypeInfo" : "autoListTypeInfo";
+            else {
+                if (on)
+                    qc = "qore_get_complex_list_or_nothing_type(" + subtype_qt + ")";
+                else
+                    qc = "qore_get_complex_list_type(" + subtype_qt + ")";
+            }
             log(LL_DEBUG, "registering complex list return type '%s': '%s'\n", qt.c_str(), qc.c_str());
         }
-        else if (!qt.compare(on ? 1 : 0, 5, "softlist<")) {
+        else if (!qt.compare(on ? 1 : 0, 9, "softlist<")) {
             // extract subtype name
             std::string subtype = qt.substr((on ? 10 : 9), qt.size() - (on ? 11 : 10));
 
@@ -725,10 +733,15 @@ static int get_qore_type(const std::string& qt, std::string& cppt) {
             get_qore_type(subtype, subtype_qt);
 
             // generate type name
-            if (on)
-                qc = "qore_get_complex_softlist_or_nothing_type(" + subtype_qt + ")";
-            else
-                qc = "qore_get_complex_softlist_type(" + subtype_qt + ")";
+            // generate type name
+            if (subtype == "auto")
+                qc = on ? "softAutoListOrNothingTypeInfo" : "softAutoListTypeInfo";
+            else {
+                if (on)
+                    qc = "qore_get_complex_softlist_or_nothing_type(" + subtype_qt + ")";
+                else
+                    qc = "qore_get_complex_softlist_type(" + subtype_qt + ")";
+            }
             log(LL_DEBUG, "registering complex softlist return type '%s': '%s'\n", qt.c_str(), qc.c_str());
         }
         else if (!qt.compare(on ? 1 : 0, 10, "reference<")) {
@@ -757,7 +770,7 @@ static int get_qore_type(const std::string& qt, std::string& cppt) {
             qc = "QC_" + qc;
             qc += on ? "->getOrNothingTypeInfo()" : "->getTypeInfo()";
         }
-        log(LL_DEBUG, "registering object return type '%s': '%s'\n", qt.c_str(), qc.c_str());
+        log(LL_DEBUG, "registering reference return type '%s': '%s'\n", qt.c_str(), qc.c_str());
         oset.insert(qt);
         tmap[qt] = qc;
         cppt = tmap[qt];


### PR DESCRIPTION
…hout a specific lvalue type; ensure that list and hash complex types are always propagated at runtime; when stripping complex types, do it recursively, other general fixes