### PR TITLE
refs #2103 ensure that "any" is a lower-priority match than "soft" ty…

### DIFF
--- a/examples/test/qore/vars/overload.qtest
+++ b/examples/test/qore/vars/overload.qtest
@@ -104,6 +104,22 @@ int sub f8(hash<string, int> h) {
     return 2;
 }
 
+int sub f9(any x) {
+    return 0;
+}
+
+int sub f9(softint i) {
+    return 1;
+}
+
+int sub f10(auto x) {
+    return 0;
+}
+
+int sub f10(softint i) {
+    return 1;
+}
+
 public class OverloadTest inherits QUnit::Test {
     public {
         const Api = "hash sub p() { return {}; }*hash sub p(string a) {return {};}any sub p(string a, string b) { return 1; }";
@@ -195,6 +211,11 @@ public class OverloadTest inherits QUnit::Test {
         assertEq(1, f8({}));
         assertEq(2, f8(("a": 1)));
         assertEq(1, f8(("a": "1")));
+        # check overload resolution against "any" and "auto"
+        assertEq(0, f9());
+        assertEq(1, f9("string"));
+        assertEq(0, f10());
+        assertEq(1, f10("string"));
 
         # test runtime matching
         assertEq(0, call_function(\f2_test()));
@@ -214,5 +235,17 @@ public class OverloadTest inherits QUnit::Test {
         assertEq(4, call_function(\f6(), 1, a, a, {}));
         assertEq(4, call_function(\f6(), 1, NOTHING, NOTHING, NOTHING));
         assertEq(4, call_function(\f6(), 1, a, a, a));
+        assertEq(1, call_function(\f7(), {}));
+        assertEq(2, call_function(\f7(), ("a": 1)));
+        assertEq(2, call_function(\f7(), cast<hash<string, int>>(("a": 1))));
+        assertEq(3, call_function(\f7(), new hash<MyHash>()));
+        assertEq(0, call_function(\f8()));
+        assertEq(1, call_function(\f8(), {}));
+        assertEq(2, call_function(\f8(), ("a": 1)));
+        assertEq(1, call_function(\f8(), ("a": "1")));
+        assertEq(0, call_function(\f9()));
+        assertEq(1, call_function(\f9(), "string"));
+        assertEq(0, call_function(\f10()));
+        assertEq(1, call_function(\f10(), "string"));
     }
 }

--- a/include/qore/QoreType.h
+++ b/include/qore/QoreType.h
@@ -174,9 +174,10 @@ enum qore_type_result_e {
    QTI_UNASSIGNED  = -1,  //!< for internal use only
 
    QTI_NOT_EQUAL   =  0,  //!< types do not match
-   QTI_AMBIGUOUS   =  1,  //!< types match, but are not identical
-   QTI_NEAR        =  2,  //!< types nearly match, but are not identical
-   QTI_IDENT       =  3   //!< types match perfectly
+   QTI_WILDCARD    =  1,  //!< types match with a basic wildcard
+   QTI_AMBIGUOUS   =  2,  //!< types match, but are not identical
+   QTI_NEAR        =  3,  //!< types nearly match, but are not identical
+   QTI_IDENT       =  4   //!< types match perfectly
 };
 
 DLLEXPORT int testObjectClassAccess(const QoreObject* obj, const QoreClass* classtoaccess);

--- a/include/qore/intern/QoreTypeInfo.h
+++ b/include/qore/intern/QoreTypeInfo.h
@@ -175,7 +175,7 @@ public:
       else if (typespec == QTS_COMPLEXREF)
          return t == NT_REFERENCE ? QTI_IDENT : QTI_NOT_EQUAL;
       if (u.t == NT_ALL)
-         return QTI_AMBIGUOUS;
+         return QTI_WILDCARD;
       return u.t == t ? QTI_IDENT : QTI_NOT_EQUAL;
    }
 
@@ -302,7 +302,7 @@ public:
 
    // static version of method, checking for null pointer
    DLLLOCAL static qore_type_result_e parseReturns(const QoreTypeInfo* ti, QoreTypeSpec t) {
-      return ti && hasType(ti) ? ti->parseReturns(t) : QTI_AMBIGUOUS;
+      return ti && hasType(ti) ? ti->parseReturns(t) : QTI_WILDCARD;
    }
 
    // static version of method, checking for null pointer
@@ -327,7 +327,7 @@ public:
 
    // static version of method, checking for null pointer
    DLLLOCAL static qore_type_result_e runtimeAcceptsValue(const QoreTypeInfo* ti, const QoreValue n) {
-      return ti && hasType(ti) ? ti->runtimeAcceptsValue(n) : QTI_AMBIGUOUS;
+      return ti && hasType(ti) ? ti->runtimeAcceptsValue(n) : QTI_WILDCARD;
    }
 
    // static version of method, checking for null pointer
@@ -346,12 +346,12 @@ public:
    // static version of method, checking for null pointer
    DLLLOCAL static qore_type_result_e parseAccepts(const QoreTypeInfo* first, const QoreTypeInfo* second, bool& may_not_match, bool& may_need_filter) {
       if (first == autoTypeInfo) {
-         return QTI_AMBIGUOUS;
+         return QTI_WILDCARD;
       }
       if (!hasType(first)) {
          if (!may_need_filter && isComplex(second))
             may_need_filter = true;
-         return QTI_AMBIGUOUS;
+         return QTI_WILDCARD;
       }
       if (!hasType(second)) {
          if (!may_need_filter) {
@@ -828,7 +828,7 @@ protected:
             qore_type_result_e res = parseAcceptsIntern(at, rt, may_not_match, may_need_filter, t_no_match, ok);
             if (res == QTI_IDENT)
                return res;
-            else if (res == QTI_AMBIGUOUS || res == QTI_NEAR) {
+            else if (res == QTI_AMBIGUOUS || res == QTI_NEAR || res == QTI_WILDCARD) {
                assert(ok);
                if (may_not_match)
                   return res;
@@ -883,6 +883,7 @@ protected:
          // fall down to next case
          case QTI_NEAR:
          case QTI_AMBIGUOUS:
+         case QTI_WILDCARD:
             if (at.map && !may_need_filter)
                may_need_filter = true;
             if (t_no_match) {

--- a/lib/Function.cpp
+++ b/lib/Function.cpp
@@ -1523,7 +1523,7 @@ int QoreFunction::parseCheckDuplicateSignatureCommitted(UserSignature* sig) {
    if (rc == QTI_NOT_EQUAL)
       return 0;
 
-   if (rc == QTI_AMBIGUOUS)
+   if (rc == QTI_AMBIGUOUS || rc == QTI_WILDCARD)
       ambiguousDuplicateSignatureException(className(), getName(), vs, sig);
    else
       duplicateSignatureException(className(), getName(), sig);

--- a/lib/QoreAssignmentOperatorNode.cpp
+++ b/lib/QoreAssignmentOperatorNode.cpp
@@ -73,7 +73,8 @@ void QoreAssignmentOperatorNode::parseInitIntern(LocalVar* oflag, int pflag, int
       bool may_not_match = false;
       bool may_need_filter = false;
       res = QoreTypeInfo::parseAccepts(ti, r, may_not_match, may_need_filter);
-      ident = QoreTypeInfo::hasType(r) && ((res == QTI_IDENT || (res == QTI_AMBIGUOUS && !may_not_match)) && !may_need_filter);
+      if (res)
+         ident = QoreTypeInfo::hasType(r) && ((res == QTI_IDENT || !may_not_match) && !may_need_filter);
    }
    else
       res = QTI_AMBIGUOUS;

--- a/lib/QoreHashNode.cpp
+++ b/lib/QoreHashNode.cpp
@@ -171,9 +171,7 @@ void qore_hash_private::parseCheckTypedAssignment(const QoreProgramLocation& loc
                 const QoreTypeInfo* kti = getTypeInfoForValue(i.getValue());
                 bool may_not_match = false;
                 qore_type_result_e res = QoreTypeInfo::parseAccepts(vti, kti, may_not_match);
-                if (res == QTI_IDENT
-                    || ((res == QTI_AMBIGUOUS)
-                        && (!strict_check || !may_not_match)))
+                if (res && (res == QTI_IDENT || (!strict_check || !may_not_match)))
                     continue;
                 parse_error(loc, "cannot %s 'hash<string, %s>' from key '%s' of a hash with incompatible value type '%s'", context_action, QoreTypeInfo::getName(vti), i.getKey(), QoreTypeInfo::getName(kti));
             }
@@ -189,9 +187,7 @@ void qore_hash_private::parseCheckTypedAssignment(const QoreProgramLocation& loc
                 const QoreTypeInfo* vti2 = vtypes[i];
                 bool may_not_match = false;
                 qore_type_result_e res = QoreTypeInfo::parseAccepts(vti, vti2, may_not_match);
-                if (res == QTI_IDENT
-                    || ((res == QTI_AMBIGUOUS)
-                        && (!strict_check || !may_not_match)))
+                if (res && (res == QTI_IDENT || (!strict_check || !may_not_match)))
                     continue;
                 const AbstractQoreNode* kn = keys[i];
                 const QoreStringNode* key = get_node_type(kn) == NT_STRING ? reinterpret_cast<const QoreStringNode*>(kn) : nullptr;

--- a/lib/QoreListNode.cpp
+++ b/lib/QoreListNode.cpp
@@ -163,9 +163,7 @@ void qore_list_private::parseCheckTypedAssignment(const QoreProgramLocation& loc
                 const QoreTypeInfo* vti2 = getTypeInfoForValue(i.getValue());
                 bool may_not_match = false;
                 qore_type_result_e res = QoreTypeInfo::parseAccepts(vti, vti2, may_not_match);
-                if (res == QTI_IDENT
-                    || ((res == QTI_AMBIGUOUS)
-                        && (!strict_check || !may_not_match)))
+                if (res && (res == QTI_IDENT || (!strict_check || !may_not_match)))
                     continue;
                 parse_error(loc, "cannot %s 'list<%s>' from element %d/%d of a list with incompatible value type '%s'", context_action, QoreTypeInfo::getName(vti), (int)i.index() + 1, (int)i.max(), QoreTypeInfo::getName(vti2));
             }
@@ -178,9 +176,7 @@ void qore_list_private::parseCheckTypedAssignment(const QoreProgramLocation& loc
                 const QoreTypeInfo* vti2 = vtypes[i];
                 bool may_not_match = false;
                 qore_type_result_e res = QoreTypeInfo::parseAccepts(vti, vti2, may_not_match);
-                if (res == QTI_IDENT
-                    || ((res == QTI_AMBIGUOUS)
-                        && (!strict_check || !may_not_match)))
+                if (res && (res == QTI_IDENT || (!strict_check || !may_not_match)))
                     continue;
                 parse_error(loc, "cannot %s 'list<%s>' from element %d/%d of a list with incompatible value type '%s'", context_action, QoreTypeInfo::getName(vti), (int)(i + 1), (int)vtypes.size(), QoreTypeInfo::getName(vti2));
             }
@@ -190,9 +186,7 @@ void qore_list_private::parseCheckTypedAssignment(const QoreProgramLocation& loc
             const QoreTypeInfo* vti2 = getTypeInfoForValue(arg);
             bool may_not_match = false;
             qore_type_result_e res = QoreTypeInfo::parseAccepts(vti, vti2, may_not_match);
-            if (res == QTI_IDENT
-                || ((res == QTI_AMBIGUOUS)
-                    && (!strict_check || !may_not_match)))
+            if (res && (res == QTI_IDENT || (!strict_check || !may_not_match)))
                 break;
 
             parse_error(loc, "cannot %s 'list<%s>' from a value with incompatible type '%s'", context_action, QoreTypeInfo::getName(vti), QoreTypeInfo::getName(vti2));

--- a/lib/QoreLogicalEqualsOperatorNode.cpp
+++ b/lib/QoreLogicalEqualsOperatorNode.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2016 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -65,7 +65,7 @@ AbstractQoreNode *QoreLogicalEqualsOperatorNode::parseInitImpl(LocalVar *oflag, 
    }
 
    // check for optimizations based on type, but only assign if neither side is a string or number (highest priority)
-   // and types are known for both operands (if not, QoreTypeInfo::parseReturns(NT_STRING) will return QTI_AMBIGUOUS
+   // and types are known for both operands (if not, QoreTypeInfo::parseReturns(type, NT_STRING) will return a non-zero value
    if (!QoreTypeInfo::parseReturns(lti, NT_STRING) && !QoreTypeInfo::parseReturns(rti, NT_STRING)
       && !QoreTypeInfo::parseReturns(lti, NT_NUMBER) && !QoreTypeInfo::parseReturns(rti, NT_NUMBER)) {
       if (QoreTypeInfo::isType(lti, NT_FLOAT) || QoreTypeInfo::isType(rti, NT_FLOAT))

--- a/lib/QoreTypeInfo.cpp
+++ b/lib/QoreTypeInfo.cpp
@@ -650,7 +650,7 @@ qore_type_result_e QoreTypeSpec::match(const QoreTypeSpec& t, bool& may_not_matc
       case QTS_TYPE: {
          qore_type_t ot = t.getType();
          if (u.t == NT_ALL) {
-            return QTI_AMBIGUOUS;
+            return QTI_WILDCARD;
          }
          // NOTE: with %strict-types, anything with may_not_match = true must return QTI_NOT_EQUAL
          if (ot == NT_ALL) {

--- a/lib/TypedHashDecl.cpp
+++ b/lib/TypedHashDecl.cpp
@@ -109,12 +109,10 @@ void typed_hash_decl_private::parseCheckHashDeclAssignment(const QoreProgramLoca
             bool may_not_match = false;
             qore_type_result_e res = QoreTypeInfo::parseAccepts(m->getTypeInfo(), i->second->getTypeInfo(), may_not_match);
 
-            if (res == QTI_IDENT
-                || ((res == QTI_AMBIGUOUS)
-                    && (!strict_check || !may_not_match)))
+            if (res && (res == QTI_IDENT || (!strict_check || !may_not_match)))
                 continue;
 
-            if (res == QTI_AMBIGUOUS && may_not_match)
+            if ((res == QTI_WILDCARD || res == QTI_AMBIGUOUS || res == QTI_NEAR) && may_not_match)
                 parse_error(loc, "hashdecl '%s' initializer value for key '%s' from hashdecl '%s' from %s has incompatible type '%s'; expecting '%s'; types may not be compatible at runtime; use cast<hash<%s>>() to force a runtime check", name.c_str(), i->first, hd.name.c_str(), context, QoreTypeInfo::getName(i->second->getTypeInfo()), QoreTypeInfo::getName(m->getTypeInfo()), name.c_str());
             else
                 parse_error(loc, "hashdecl '%s' initializer value for key '%s' from hashdecl '%s' from %s has incompatible type '%s'; expecting '%s'", name.c_str(), i->first, hd.name.c_str(), context, QoreTypeInfo::getName(i->second->getTypeInfo()), QoreTypeInfo::getName(m->getTypeInfo()));
@@ -139,9 +137,7 @@ void typed_hash_decl_private::parseCheckHashDeclAssignment(const QoreProgramLoca
                     qore_type_result_e res = QoreTypeInfo::parseAccepts(m->getTypeInfo(), kti, may_not_match);
                     if (may_not_match && !runtime_check)
                         runtime_check = true;
-                    if (res == QTI_IDENT
-                        || ((res == QTI_AMBIGUOUS)
-                            && (!strict_check || !may_not_match)))
+                    if (res && (res == QTI_IDENT || (!strict_check || !may_not_match)))
                         continue;
                     parse_error(loc, "hashdecl '%s' initializer value from %s cannot be assigned from key '%s' with incompatible value type '%s'; expecting '%s'", name.c_str(), context, i.getKey(), QoreTypeInfo::getName(kti), QoreTypeInfo::getName(m->getTypeInfo()));
                 }
@@ -170,12 +166,10 @@ void typed_hash_decl_private::parseCheckHashDeclAssignment(const QoreProgramLoca
                     qore_type_result_e res = QoreTypeInfo::parseAccepts(m->getTypeInfo(), vti, may_not_match);
                     if (may_not_match && !runtime_check)
                         runtime_check = true;
-                    if (res == QTI_IDENT
-                        || ((res == QTI_AMBIGUOUS)
-                            && (!strict_check || !may_not_match)))
+                    if (res && (res == QTI_IDENT || (!strict_check || !may_not_match)))
                         continue;
 
-                    if (res == QTI_AMBIGUOUS && may_not_match)
+                    if ((res == QTI_WILDCARD || res == QTI_AMBIGUOUS || res == QTI_NEAR) && may_not_match)
                         parse_error(loc, "hashdecl '%s' initializer value for key '%s' from %s has incompatible type '%s'; expecting '%s'; types may not be compatible at runtime; use cast<hash<%s>>() to force a runtime check", name.c_str(), key->c_str(), context, QoreTypeInfo::getName(vti), QoreTypeInfo::getName(m->getTypeInfo()), name.c_str());
                     else
                         parse_error(loc, "hashdecl '%s' initializer value for key '%s' from %s has incompatible type '%s'; expecting '%s'; types may not be compatible at runtime", name.c_str(), key->c_str(), context, QoreTypeInfo::getName(vti), QoreTypeInfo::getName(m->getTypeInfo()), name.c_str());


### PR DESCRIPTION
…pes or other non-wildcard ambiguous matches; ensure that QTI_NEAR is treated the same as QTI_AMBIGUOUS (and now also QTI_WILDCARD), added tests