### PR TITLE
refs #2016 fixed ambiguous signatures in RangeIterator::constructor()…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -165,12 +165,14 @@
       - @ref Qore::Socket::getSslVerifyMode()
       - @ref Qore::Socket::setSslVerifyMode()
     - updated methods:
-      - @ref Qore::TreeMap::get() new parameter to return also unmatched part suffix
+      - @ref Qore::Thread::Counter::dec() "Counter::dec()": now returns the current value of the counter
       - @ref Qore::HTTPClient::constructor() added support for the following options:
         - \c ssl_cert_path: allows an X.509 client certificate to be set in the constructor
         - \c ssl_key_path: allows a private key for an X.509 client certificate to be set in the constructor
         - \c ssl_key_password: allows a password-protected private key to be used wih an X.509 client certificate
         - \c ssl_verify_cert: enforces server certificate validation with HTTPS connections
+      - @ref Qore::RangeIterator::constructor(int) was updated; the second argument was removed to avoid ambiguity with the other overloaded constructor
+      - @ref Qore::TreeMap::get() "TreeMap::get()": added a new optional argument to return the unmatched part of the search string
       - the following read-only static methods were moved from the @ref Qore::File "File" class to the @ref Qore::ReadOnlyFile "ReadOnlyFile" class:
         - @ref Qore::ReadOnlyFile::hstat() "ReadOnlyFile::hstat()"
         - @ref Qore::ReadOnlyFile::hlstat() "ReadOnlyFile::hlstat()"
@@ -203,14 +205,14 @@
       - @ref Qore::parse_int()
       - @ref Qore::set_global_var_value()
       - @ref Qore::set_local_var_value()
-    - updated functions/methods:
-      - @ref Qore::Thread::Counter::dec() "Counter::dec()": now returns the current value of the counter
+    - updated functions:
       - @ref Qore::ceil() "ceil()": now allows the precision to be specified
       - @ref Qore::floor() "floor()": now allows the precision to be specified
       - @ref Qore::hash() "hash()": now returns an untyped hash stripped of any key type information
       - @ref Qore::mkdir() "mkdir()": now allows parent directories to be created in the same call
       - @ref Qore::round() "round()": now allows the precision to be specified
       - @ref Qore::set_thread_init() "set_thread_init()": now allows for thread init code to be removed
+      - @ref Qore::xrange(int) was updated; the second argument was removed to avoid ambiguity with the other overloaded variant
     - module updates:
       - <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module updates:
         - added a minimal substring of string bodies received to the log message when logging HTTP requests
@@ -310,6 +312,7 @@
     - fixed cmake builds on Darwin (<a href="https://github.com/qorelanguage/qore/issues/1980">issue 1980</a>)
     - fixed a bug where immediate date-time values were not marked with their type at parse time (<a href="https://github.com/qorelanguage/qore/issues/2001">issue 2001</a>)
     - fixed a bug where the @ref data_or_nothing_type "*data" type restriction would allow all types to be assigned at runtime (<a href="https://github.com/qorelanguage/qore/issues/2002">issue 2002</a>)
+    - @ref Qore::RangeIterator::constructor(int) and @ref Qore::xrange(int) were updated; the second arguments were removed to avoid ambiguity with the other overloaded variants (<a href="https://github.com/qorelanguage/qore/issues/2016">issue 2016</a>)
 
     @section qore_081212 Qore 0.8.12.12
 

--- a/examples/test/qore/functions/xrange.qtest
+++ b/examples/test/qore/functions/xrange.qtest
@@ -17,12 +17,9 @@ public class XrangeTest inherits QUnit::Test {
         # Return for compatibility with test harness that checks return value.
         set_return_value(main());
     }
-    
-    test_xrange(list correct, RangeIterator testing, string message) {
-        list lst;
-        foreach int i in (testing)
-            push lst, i;
 
+    test_xrange(list correct, RangeIterator testing, string message) {
+        list lst = map $1, testing;
         assertEq(correct, lst, message);
     }
 

--- a/lib/QC_RangeIterator.qpp
+++ b/lib/QC_RangeIterator.qpp
@@ -94,8 +94,8 @@ RangeIterator i(5);
 
     @since %Qore 0.8.11.1
  */
-RangeIterator::constructor(int stop, auto val) {
-   ReferenceHolder<RangeIterator> r(new RangeIterator(0, stop, 1, val, xsink), xsink);
+RangeIterator::constructor(int stop) {
+   ReferenceHolder<RangeIterator> r(new RangeIterator(0, stop, 1, QoreValue(), xsink), xsink);
    if (*xsink)
       return;
    self->setPrivate(CID_RANGEITERATOR, r.release());
@@ -273,8 +273,8 @@ xrange(-3); # 0, -1, -2, -3
     @since %Qore 0.8.6
     @since %Qore 0.8.11.1 this function takes the optional \a val argument
  */
-RangeIterator xrange(int stop, auto val) [flags=CONSTANT] {
-   ReferenceHolder<RangeIterator> r(new RangeIterator(0, stop, 1, val, xsink), xsink);
+RangeIterator xrange(int stop) [flags=CONSTANT] {
+   ReferenceHolder<RangeIterator> r(new RangeIterator(0, stop, 1, QoreValue(), xsink), xsink);
    if (*xsink)
       return QoreValue();
 


### PR DESCRIPTION
… and xrange(); tests reveal no breakage; a static code analysis also found no instances of usage of the variant that was modified; in any case it would have resulted in the first variant being executed due to the ambiguity