### PR TITLE
Fixed autotools build regarding wrong install folder for modules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1883,22 +1883,6 @@ else
    QORE_LIB_CFLAGS="$QORE_LIB_CPPFLAGS"
 fi
 
-# if compiling for mingw32, we have to add qore ldflags to the module's ldflags
-if test "$mingw" = yes; then
-    MODULE_LDFLAGS="$MODULE_LDFLAGS $QORE_LDFLAGS"
-    AC_SUBST(MODULE_LDFLAGS)
-fi
-
-# save more version information in config.h
-MODULE_VERSION_MAJOR=`echo $PACKAGE_VERSION | cut -f3 -d\  | sed s/\"//g | cut -f1 -d.`
-MODULE_VERSION_MINOR=`echo $PACKAGE_VERSION | cut -f3 -d\  | sed s/\"//g | cut -f2 -d.`
-MODULE_VERSION_SUB=`echo $PACKAGE_VERSION | cut -f3 -d\  | sed s/\"//g | cut -f3 -d.`
-QORE_MODULE_PACKAGE_VERSION="$PACKAGE_VERSION"
-
-# set user module directory
-mymodverdir=${qore_version}
-AC_SUBST([mymodverdir])
-
 # save compiler settings in config file
 AC_DEFINE_UNQUOTED([QORE_LIB_CXX], "$CXX", [c++ compiler used])
 AC_DEFINE_UNQUOTED([QORE_LIB_CPPFLAGS], "$QORE_LIB_CPPFLAGS", [preprocessor flags])
@@ -1906,15 +1890,6 @@ AC_DEFINE_UNQUOTED([QORE_LIB_CXXFLAGS], "$QORE_LIB_CXXFLAGS", [c++ compiler flag
 AC_DEFINE_UNQUOTED([QORE_LIB_CFLAGS],   "$QORE_LIB_CFLAGS", [c++ compiler flags])
 AC_DEFINE_UNQUOTED([QORE_LIB_LDFLAGS],  "$QORE_LIB_LDFLAGS", [linker flags])
 AC_DEFINE_UNQUOTED([QORE_BUILD_HOST],   "`uname -a`", [Qore build host info])
-
-# set version information
-AC_DEFINE_UNQUOTED([MODULE_VERSION_MAJOR], $MODULE_VERSION_MAJOR, [major version number])
-AC_DEFINE_UNQUOTED([MODULE_VERSION_MINOR], $MODULE_VERSION_MINOR, [minor version number])
-AC_DEFINE_UNQUOTED([MODULE_VERSION_SUB], $MODULE_VERSION_SUB, [sub version number])
-AC_DEFINE_UNQUOTED([MODULE_TARGET_ARCH], "$ARCH", [host type])
-AC_DEFINE_UNQUOTED([MODULE_TARGET_OS], "$OS", [host type])
-AC_DEFINE_UNQUOTED([MODULE_TARGET_BITS], $bits, [32 or 64 bit build])
-AC_DEFINE_UNQUOTED([QORE_MODULE_PACKAGE_VERSION], "$QORE_MODULE_PACKAGE_VERSION", [qore module package version])
 
 AC_CONFIG_FILES([Makefile lib/Makefile])
 AC_CONFIG_FILES([modules/astparser/Makefile modules/astparser/src/Makefile])


### PR DESCRIPTION
Turns out it was possible to remove pretty much all the added variables without affecting the astparser module build, and also fixing the other module installations by doing that.