### PR TITLE
refs #2145 fixed a bug where a call reference to an object method tha…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -348,6 +348,7 @@
     - @ref Qore::RangeIterator::constructor(int) and @ref Qore::xrange(int) were updated; the second arguments were removed to avoid ambiguity with the other overloaded variants (<a href="https://github.com/qorelanguage/qore/issues/2016">issue 2016</a>)
     - fixed a bug where @ref Qore::replace() could get in an infinite loop with arguments with embededed nulls (<a href="https://github.com/qorelanguage/qore/issues/2098">issue 2098</a>)
     - fixed a bug in regular expression extraction where an infinite loop could occur (<a href="https://github.com/qorelanguage/qore/issues/2083">issue 2083</a>)
+    - fixed a bug where a call reference to an object method that crosses @ref Qore::Program "Program" boundaries could result in a core dump when called due to an error managing thread-local data (<a href="https://github.com/qorelanguage/qore/issues/2145">issue 2145</a>)
 
     @section qore_081212 Qore 0.8.12.12
 

--- a/examples/test/qore/functions/digests.qtest
+++ b/examples/test/qore/functions/digests.qtest
@@ -19,7 +19,6 @@ public class DigestTest inherits QUnit::Test {
         addTestCase("Test MD2 Digest", \md2Test());
         addTestCase("Test MD4 Digest", \md4Test());
         addTestCase("Test MD5 Digest", \md5Test());
-        addTestCase("Test SHA Digest", \shaTest());
         addTestCase("Test SHA1 Digest", \sha1Test());
         addTestCase("Test RIPEMD160 Digest", \ripemd160Test());
 
@@ -40,10 +39,6 @@ public class DigestTest inherits QUnit::Test {
 
     md5Test() {
         testAssertion("MD5 digest", \MD5(), (str,), new TestResultValue("bcbece19c1fe41d8c9e2e6134665ba5b"));
-    }
-
-    shaTest() {
-        testAssertion("SHA digest", \SHA(), (str,), new TestResultValue("99910d63f10286e8dda3c4a57801996f48f25b4b"));
     }
 
     sha1Test() {

--- a/examples/test/qore/functions/hmac.qtest
+++ b/examples/test/qore/functions/hmac.qtest
@@ -20,7 +20,6 @@ public class HmacTest inherits QUnit::Test {
         addTestCase("Basic MD2 test", \md2Test());
         addTestCase("Basic MD4 test", \md4Test());
         addTestCase("Basic MD5 test", \md5Test());
-        addTestCase("Basic SHA test", \shaTest());
         addTestCase("Basic SHA1 test", \sha1Test());
         addTestCase("Basic RIPEMD160 test", \ripemd160Test());
         addTestCase("Basic MDC2 test", \mdc2Test());
@@ -46,10 +45,6 @@ public class HmacTest inherits QUnit::Test {
 
     md5Test() {
         testAssertion("MD5 hmac", \MD5_hmac(), (str, key), new TestResultValue("87505c6164aaf6ca6315233902a01ef4"));
-    }
-
-    shaTest() {
-        testAssertion("SHA hmac", \SHA_hmac(), (str, key), new TestResultValue("0ad47c8d36dc4606d52f7e4cbd144ef2fda492a0"));
     }
 
     sha1Test() {

--- a/examples/test/qore/misc/callref.qtest
+++ b/examples/test/qore/misc/callref.qtest
@@ -10,11 +10,12 @@
 
 %exec-class CallRefTest
 
-class C { m() { print("ERROR!\n");} }
+class C { m() {print("ERROR!\n");} int get(int x = 0) {return 1 + x;}}
 
 class CallRefTest inherits QUnit::Test {
     constructor() : QUnit::Test("CallRef Test", "1.0") {
         addTestCase("Test", \test());
+        addTestCase("issue 2145", \issue2145());
         set_return_value(main());
     }
 
@@ -38,6 +39,25 @@ class CallRefTest inherits QUnit::Test {
             code c = \obj.m();
             delete p;
             assertThrows("PROGRAM-ERROR", c);
+        }
+    }
+
+    issue2145() {
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("int sub get(code c) { return c(); }", "1");
+
+            C c();
+            int i = p.callFunction("get", \c.get());
+            assertEq(1, i);
+        }
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("class C1 { private {code c; int x = 1;} constructor(code c) {self.c = c;} int get() {return c(x);}} int sub get(code c) { C1 c1(c); return c1.get(); }", "2");
+
+            C c();
+            int i = p.callFunction("get", \c.get());
+            assertEq(2, i);
         }
     }
 }

--- a/include/qore/intern/Function.h
+++ b/include/qore/intern/Function.h
@@ -193,7 +193,7 @@ public:
 
    DLLLOCAL virtual ~UserSignature() {
       for (ptype_vec_t::iterator i = parseTypeList.begin(), e = parseTypeList.end(); i != e; ++i)
-	 delete* i;
+         delete* i;
       delete parseReturnTypeInfo;
    }
 
@@ -266,10 +266,10 @@ protected:
 
 public:
    // saves current program location in case there's an exception
-   DLLLOCAL CodeEvaluationHelper(ExceptionSink* n_xsink, const QoreFunction* func, const AbstractQoreFunctionVariant*& variant, const char* n_name, const QoreValueList* args = 0, QoreObject* self = 0, const qore_class_private* n_qc = 0, qore_call_t n_ct = CT_UNUSED, bool is_copy = false);
+   DLLLOCAL CodeEvaluationHelper(ExceptionSink* n_xsink, const QoreFunction* func, const AbstractQoreFunctionVariant*& variant, const char* n_name, const QoreValueList* args = nullptr, QoreObject* self = nullptr, const qore_class_private* n_qc = nullptr, qore_call_t n_ct = CT_UNUSED, bool is_copy = false, const qore_class_private* cctx = nullptr);
 
    // saves current program location in case there's an exception
-   DLLLOCAL CodeEvaluationHelper(ExceptionSink* n_xsink, const QoreFunction* func, const AbstractQoreFunctionVariant*& variant, const char* n_name, const QoreListNode* args, QoreObject* self = 0, const qore_class_private* n_qc = 0, qore_call_t n_ct = CT_UNUSED, bool is_copy = false);
+   DLLLOCAL CodeEvaluationHelper(ExceptionSink* n_xsink, const QoreFunction* func, const AbstractQoreFunctionVariant*& variant, const char* n_name, const QoreListNode* args, QoreObject* self = nullptr, const qore_class_private* n_qc = nullptr, qore_call_t n_ct = CT_UNUSED, bool is_copy = false, const qore_class_private* cctx = nullptr);
 
    DLLLOCAL ~CodeEvaluationHelper();
 
@@ -486,7 +486,7 @@ public:
    DLLLOCAL UserVariantExecHelper(const UserVariantBase* n_uvb, CodeEvaluationHelper* ceh, ExceptionSink* n_xsink) : ProgramThreadCountContextHelper(n_xsink, n_uvb->pgm, true), uvb(n_uvb), argv(n_xsink), xsink(n_xsink) {
       assert(xsink);
       if (*xsink || uvb->setupCall(ceh, argv, xsink))
-	 uvb = 0;
+         uvb = nullptr;
    }
 
    DLLLOCAL ~UserVariantExecHelper();
@@ -546,7 +546,7 @@ public:
    DLLLOCAL void del() {
       // dereference all variants
       for (vlist_t::iterator i = begin(), e = end(); i != e; ++i)
-	 (*i)->deref();
+         (*i)->deref();
       clear();
    }
 };
@@ -658,7 +658,7 @@ protected:
    DLLLOCAL void addVariant(AbstractQoreFunctionVariant* variant) {
       const QoreTypeInfo* rti = variant->getReturnTypeInfo();
       if (same_return_type && !vlist.empty() && !QoreTypeInfo::isOutputIdentical(rti, first()->getReturnTypeInfo()))
-	 same_return_type = false;
+         same_return_type = false;
 
       int64 vf = variant->getFunctionality();
       int64 vflags = variant->getFlags();
@@ -666,7 +666,7 @@ protected:
       bool rtn = (bool)(vflags & QC_RUNTIME_NOOP);
 
       if (vlist.empty()) {
-	 unique_functionality = vf;
+         unique_functionality = vf;
          unique_flags = vflags;
       }
       else {
@@ -824,7 +824,7 @@ public:
 
    DLLLOCAL void deref() {
       if (ROdereference())
-	 delete this;
+         delete this;
    }
 
    DLLLOCAL const char* className() const {

--- a/include/qore/intern/QoreClassIntern.h
+++ b/include/qore/intern/QoreClassIntern.h
@@ -797,10 +797,10 @@ public:
    }
 
    // if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL then it is identified at run time
-   DLLLOCAL QoreValue evalMethod(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, QoreObject* self, const QoreListNode* args) const;
+   DLLLOCAL QoreValue evalMethod(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, QoreObject* self, const QoreListNode* args, const qore_class_private* cctx = nullptr) const;
 
    // if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL then it is identified at run time
-   DLLLOCAL QoreValue evalPseudoMethod(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, const QoreValue n, const QoreListNode* args) const;
+   DLLLOCAL QoreValue evalPseudoMethod(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, const QoreValue n, const QoreListNode* args, const qore_class_private* cctx = nullptr) const;
 };
 
 #define NMETHF(f) (reinterpret_cast<NormalMethodFunction*>(f))
@@ -815,7 +815,7 @@ public:
    DLLLOCAL virtual ~StaticMethodFunction() {
    }
    // if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL then it is identified at run time
-   DLLLOCAL QoreValue evalMethod(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, const QoreListNode* args) const;
+   DLLLOCAL QoreValue evalMethod(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, const QoreListNode* args, const qore_class_private* cctx = nullptr) const;
 };
 
 #define SMETHF(f) (reinterpret_cast<StaticMethodFunction*>(f))
@@ -3256,12 +3256,12 @@ public:
       BSYSCONB(func)->eval(*parent_class, self, code, args);
    }
 
-   DLLLOCAL QoreValue eval(ExceptionSink* xsink, QoreObject* self, const QoreListNode* args) const {
+   DLLLOCAL QoreValue eval(ExceptionSink* xsink, QoreObject* self, const QoreListNode* args, const qore_class_private* cctx = nullptr) const {
       if (!static_flag) {
          assert(self);
-         return NMETHF(func)->evalMethod(xsink, 0, self, args);
+         return NMETHF(func)->evalMethod(xsink, 0, self, args, cctx);
       }
-      return SMETHF(func)->evalMethod(xsink, 0, args);
+      return SMETHF(func)->evalMethod(xsink, 0, args, cctx);
    }
 
    DLLLOCAL QoreValue evalPseudoMethod(const AbstractQoreFunctionVariant* variant, const QoreValue n, const QoreListNode* args, ExceptionSink* xsink) const {
@@ -3292,8 +3292,8 @@ public:
       return m.priv->evalPseudoMethod(variant, n, args, xsink);
    }
 
-   DLLLOCAL static QoreValue eval(const QoreMethod& m, ExceptionSink* xsink, QoreObject* self, const QoreListNode* args) {
-      return m.priv->eval(xsink, self, args);
+   DLLLOCAL static QoreValue eval(const QoreMethod& m, ExceptionSink* xsink, QoreObject* self, const QoreListNode* args, const qore_class_private* cctx = nullptr) {
+      return m.priv->eval(xsink, self, args, cctx);
    }
 };
 

--- a/lib/CallReferenceNode.cpp
+++ b/lib/CallReferenceNode.cpp
@@ -359,8 +359,9 @@ RunTimeResolvedMethodReferenceNode::~RunTimeResolvedMethodReferenceNode() {
 }
 
 QoreValue RunTimeResolvedMethodReferenceNode::execValue(const QoreListNode* args, ExceptionSink* xsink) const {
-   OptionalClassObjSubstitutionHelper osh(qc);
-   return qore_method_private::eval(*method, xsink, obj, args);
+   //printd(5, "RunTimeResolvedMethodReferenceNode::execValue() cpgm: %p opgm: %p\n", getProgram(), obj->getProgram());
+   // issue #2145: do not set the call reference class context before arguments are evaluted
+   return qore_method_private::eval(*method, xsink, obj, args, qc);
 }
 
 QoreProgram* RunTimeResolvedMethodReferenceNode::getProgram() const {

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -4811,13 +4811,14 @@ void DestructorMethodFunction::evalDestructor(const QoreClass& thisclass, QoreOb
 }
 
 // if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL then it is identified at run time
-QoreValue NormalMethodFunction::evalMethod(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, QoreObject* self, const QoreListNode* args) const {
+QoreValue NormalMethodFunction::evalMethod(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, QoreObject* self, const QoreListNode* args, const qore_class_private* cctx) const {
    const char* cname = getClassName();
    const char* mname = getName();
    //printd(5, "NormalMethodFunction::evalMethod() %s::%s() v: %d\n", cname, mname, self->isValid());
 
-   CodeEvaluationHelper ceh(xsink, this, variant, mname, args, self, qore_class_private::get(*qc), CT_UNUSED, false);
-   if (*xsink) return QoreValue();
+   CodeEvaluationHelper ceh(xsink, this, variant, mname, args, self, qore_class_private::get(*qc), CT_UNUSED, false, cctx);
+   if (*xsink)
+      return QoreValue();
 
    const MethodVariant* mv = METHV_const(variant);
    if (mv->isAbstract()) {
@@ -4830,9 +4831,9 @@ QoreValue NormalMethodFunction::evalMethod(ExceptionSink* xsink, const AbstractQ
 }
 
 // if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL then it is identified at run time
-QoreValue NormalMethodFunction::evalPseudoMethod(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, const QoreValue n, const QoreListNode* args) const {
+QoreValue NormalMethodFunction::evalPseudoMethod(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, const QoreValue n, const QoreListNode* args, const qore_class_private* cctx) const {
    const char* mname = getName();
-   CodeEvaluationHelper ceh(xsink, this, variant, mname, args, 0, qore_class_private::get(*qc));
+   CodeEvaluationHelper ceh(xsink, this, variant, mname, args, 0, qore_class_private::get(*qc), CT_UNUSED, false, cctx);
    if (*xsink)
       return QoreValue();
 
@@ -4840,10 +4841,11 @@ QoreValue NormalMethodFunction::evalPseudoMethod(ExceptionSink* xsink, const Abs
 }
 
 // if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL then it is identified at run time
-QoreValue StaticMethodFunction::evalMethod(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, const QoreListNode* args) const {
+QoreValue StaticMethodFunction::evalMethod(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, const QoreListNode* args, const qore_class_private* cctx) const {
    const char* mname = getName();
-   CodeEvaluationHelper ceh(xsink, this, variant, mname, args, 0, qore_class_private::get(*qc), CT_UNUSED, false);
-   if (*xsink) return QoreValue();
+   CodeEvaluationHelper ceh(xsink, this, variant, mname, args, 0, qore_class_private::get(*qc), CT_UNUSED, false, cctx);
+   if (*xsink)
+      return QoreValue();
 
    return METHV_const(variant)->evalMethod(0, ceh, xsink);
 }

--- a/lib/SelfVarrefNode.cpp
+++ b/lib/SelfVarrefNode.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2016 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
…t crosses Program boundaries could result in a core dump when called due to an error managing thread-local data