### PR TITLE
fixes #2225: cmake builds: binary modules builds are broken when is c…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ option(QORE_RUNTIME_THREAD_STACK_TRACE
        ON)
 
 set(VERSION_MAJOR 0)
-set(VERSION_MINOR 8)
-set(VERSION_SUB 13) # Note: it must be always 2 numeric notation. E.g. 00, 01, ... to follow autotools builds
+set(VERSION_MINOR 9)
+set(VERSION_SUB 00) # Note: it must be always 2 numeric notation. E.g. 00, 01, ... to follow autotools builds
 #set(VERSION_PATCH xxx)
 
 if(DEFINED VERSION_PATCH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ option(QORE_RUNTIME_THREAD_STACK_TRACE
        ON)
 
 set(VERSION_MAJOR 0)
-set(VERSION_MINOR 9)
-set(VERSION_SUB 0)
+set(VERSION_MINOR 8)
+set(VERSION_SUB 13) # Note: it must be always 2 numeric notation. E.g. 00, 01, ... to follow autotools builds
 #set(VERSION_PATCH xxx)
 
 if(DEFINED VERSION_PATCH)


### PR DESCRIPTION
…make built used for qore. QORE_VERSION_CODE check is potentially wrong when using one digit VERSION_SUB