### PR TITLE
refs #1771 reverted the change to ARGV and QORE_ARGV to make them "li…

### DIFF
--- a/include/qore/intern/qore_program_private.h
+++ b/include/qore/intern/qore_program_private.h
@@ -377,12 +377,11 @@ public:
       }
 
       // initialize global vars
-      const QoreTypeInfo* losti = qore_get_complex_list_type(stringTypeInfo);
-      Var *var = qore_root_ns_private::runtimeCreateVar(*RootNS, *QoreNS, "ARGV", losti);
+      Var *var = qore_root_ns_private::runtimeCreateVar(*RootNS, *QoreNS, "ARGV", listTypeInfo);
       if (var && ARGV)
          var->setInitial(ARGV->copy());
 
-      var = qore_root_ns_private::runtimeCreateVar(*RootNS, *QoreNS, "QORE_ARGV", losti);
+      var = qore_root_ns_private::runtimeCreateVar(*RootNS, *QoreNS, "QORE_ARGV", listTypeInfo);
       if (var && QORE_ARGV)
          var->setInitial(QORE_ARGV->copy());
 

--- a/qlib/QUnit.qm
+++ b/qlib/QUnit.qm
@@ -645,7 +645,7 @@ public class QUnit::TestReporter {
         m_name = name;
         m_version = version;
         if (!p_argv)
-            p_argv = ARGV;
+            p_argv = cast<list<string>>(ARGV);
         m_options = new GetOpt(opts).parse2(\p_argv);
         processOptions(\p_argv);
 


### PR DESCRIPTION
…st<string>"; now they are "list" again because the change broke working code in modules and most likely elsewhere