### PR TITLE
refs #2317 fixed too-aggressive hierachy checking that disallowed leg…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -33,6 +33,7 @@
     - fixed a bug in \c qpp generating hashdecl code in a specific namespace (<a href="https://github.com/qorelanguage/qore/issues/2255">issue 2255</a>)
     - made C++ APIs for complex types for modules public (<a href="https://github.com/qorelanguage/qore/issues/2271">issue 2271</a>)
     - fixed inconsistencies in the behavior of the @ref range_operator "range operator (..)" and the @ref list_element_operator "square brackets operator []" with lists and ranges between immediate evaluation and lazy functional evaluation and aligned the behavior of the operators among supported data types with the @ref remove "remove" and @ref delete "delete" operators (<a href="https://github.com/qorelanguage/qore/issues/2260">issue 2260</a>)
+    - fixed too-agressive class hierachy checks that disallowed legal hierarchies where the same base class appears more than once in the hierarchy (<a href="https://github.com/qorelanguage/qore/issues/2317">issue 2317</a>)
 
     @section qore_0813 Qore 0.8.13
 

--- a/examples/test/qore/misc/classes.qtest
+++ b/examples/test/qore/misc/classes.qtest
@@ -420,6 +420,17 @@ public class ClassesTest inherits QUnit::Test {
             assertThrows("INVALID-METHOD", \p.parse(), ("class B{}class C inherits B{code t(){return \\B::copy();}}", ""));
             # ensure that call references cannot be taken of copy methods
             assertThrows("PARSE-EXCEPTION", \p.parse(), ("class B{copy(){}}class C inherits B{copy(){}}sub t(){C c();code cd=\\c.copy();cd();}", ""));
+
+            # ensure that circular references in class hierarchies are found
+            assertThrows("PARSE-EXCEPTION", \p.parse(), ("class B inherits A; class C inherits B; class A inherits C;", ""));
+            assertThrows("PARSE-EXCEPTION", \p.parse(), ("class B inherits A; class C inherits B, A; class A inherits C;", ""));
+        }
+
+        {
+            # ensure that multiple inheritance allows the case when a single class is inherited more than once
+            Program p(PO_NEW_STYLE|PO_REQUIRE_TYPES);
+            p.parse("class A; class B inherits A; class E inherits A, B;", "");
+            assertTrue(True);
         }
     }
 

--- a/examples/test/qore/stack/exception-location.qtest
+++ b/examples/test/qore/stack/exception-location.qtest
@@ -84,8 +84,8 @@ class ExceptionLocationTest inherits QUnit::Test {
             assertEq("<run-time-loaded: K>", ex.file);
 
             ex = getEx(\p.parse(), "class B1 {\n} class B inherits\nB1, private B1 {}\n", "L");
-            assertEq(1, ex.line);
-            assertEq(2, ex.endline);
+            assertEq(2, ex.line);
+            assertEq(3, ex.endline);
             assertEq("<run-time-loaded: L>", ex.file);
 
             ex = getEx(\p.parse(), "class B1 {\n} class B inherits\nB1 {constructor() : B1(int i = \n2) {}}\n", "M");

--- a/include/qore/intern/QoreClassIntern.h
+++ b/include/qore/intern/QoreClassIntern.h
@@ -1483,6 +1483,8 @@ public:
    DLLLOCAL const QoreMemberInfo* parseFindMember(const char* mem, const qore_class_private*& qc, ClassAccess& n_access, bool toplevel) const;
    DLLLOCAL const QoreVarInfo* parseFindVar(const char* name, const qore_class_private*& qc, ClassAccess& n_access, bool toplevel) const;
 
+   DLLLOCAL const QoreClass* findInHierarchy(const qore_class_private& qc);
+
    DLLLOCAL const QoreClass* getClass(qore_classid_t cid, ClassAccess& n_access, bool toplevel) const;
    DLLLOCAL const QoreClass* getClass(const qore_class_private& qc, ClassAccess& n_access, bool toplevel) const;
    DLLLOCAL const QoreClass* parseGetClass(const qore_class_private& qc, ClassAccess& n_access, bool toplevel) const;
@@ -1573,6 +1575,8 @@ public:
    DLLLOCAL const QoreVarInfo* parseFindVar(const char* vname, const qore_class_private*& qc, ClassAccess& access, bool toplevel) const;
 
    DLLLOCAL bool parseHasPublicMembersInHierarchy() const;
+
+   DLLLOCAL const QoreClass* findInHierarchy(const qore_class_private& qc);
 
    DLLLOCAL const QoreClass* getClass(qore_classid_t cid, ClassAccess& n_access, bool toplevel) const;
    DLLLOCAL const QoreClass* getClass(const qore_class_private& qc, ClassAccess& n_access, bool toplevel) const;
@@ -2758,10 +2762,17 @@ public:
    DLLLOCAL qore_type_result_e runtimeCheckCompatibleClass(const qore_class_private& oc) const;
    DLLLOCAL qore_type_result_e runtimeCheckCompatibleClassIntern(const qore_class_private& oc) const;
 
+   // find the given class anywhere in the hierarchy regardless of access permissions or location
+   DLLLOCAL const QoreClass* findInHierarchy(const qore_class_private& qc) {
+      if (equal(qc))
+          return cls;
+      return scl ? scl->findInHierarchy(qc) : nullptr;
+   }
+
    DLLLOCAL const QoreClass* getClassIntern(qore_classid_t cid, ClassAccess& n_access, bool toplevel) const {
       if (cid == classID)
          return cls;
-      return scl ? scl->getClass(cid, n_access, toplevel) : 0;
+      return scl ? scl->getClass(cid, n_access, toplevel) : nullptr;
    }
 
    DLLLOCAL const QoreClass* getClass(const qore_class_private& qc, ClassAccess& n_access) const {

--- a/lib/Variable.cpp
+++ b/lib/Variable.cpp
@@ -1674,7 +1674,7 @@ void LValueRemoveHelper::doRemove(const QoreSquareBracketsRangeOperatorNode* op)
            QoreListNode* nl = l->extract(start, stop - start + 1, xsink);
            // add additional elements if necessary
            //printd(5, "l->size: %d start: %d stop: %d\n", (int)orig_size, (int)start, (int)stop);
-           if (stop >= orig_size)
+           if (stop >= (int64)orig_size)
               qore_list_private::get(*nl)->resize(nl->size() + stop - orig_size + 1);
            v = nl;
            if (*xsink)


### PR DESCRIPTION
…al hierarchies (ex: the same abstract base class appears more than once as an ancestor in the hierarchy)