### PR TITLE
res #2319 fixed a crashing bug in the background operator when the ob…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -40,6 +40,7 @@
     - made C++ APIs for complex types for modules public (<a href="https://github.com/qorelanguage/qore/issues/2271">issue 2271</a>)
     - fixed inconsistencies in the behavior of the @ref range_operator "range operator (..)" and the @ref list_element_operator "square brackets operator []" with lists and ranges between immediate evaluation and lazy functional evaluation and aligned the behavior of the operators among supported data types with the @ref remove "remove" and @ref delete "delete" operators (<a href="https://github.com/qorelanguage/qore/issues/2260">issue 2260</a>)
     - fixed too-agressive class hierachy checks that disallowed legal hierarchies where the same base class appears more than once in the hierarchy (<a href="https://github.com/qorelanguage/qore/issues/2317">issue 2317</a>)
+    - fixed a crashing bug in the background operator when the object in context goes out of scope with the thread and an exception is thrown (<a href="https://github.com/qorelanguage/qore/issues/2319">issue 2319</a>)
 
     @section qore_0813 Qore 0.8.13
 

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -1452,7 +1452,7 @@ OptionalClassObjSubstitutionHelper::~OptionalClassObjSubstitutionHelper() {
    }
 }
 
-CodeContextHelperBase::CodeContextHelperBase(const char* code, QoreObject* obj, const qore_class_private* c, ExceptionSink* xsink) {
+CodeContextHelperBase::CodeContextHelperBase(const char* code, QoreObject* obj, const qore_class_private* c, ExceptionSink* xsink) : xsink(xsink) {
    ThreadData* td  = thread_data.get();
    old_code = td->current_code;
    td->current_code = code;


### PR DESCRIPTION
…ject in context goes out of scope with the thread and an exception is thrown - due to the nature of this bug, it's not possible to catch the exception that's now generated (instead of a crash) - because it's thrown in the thread cleanup code after all user code has executed when executing the background operator.  For this reason there is no test, but it's been verified by hand.