### PR TITLE
refs #2397 Swagger.qm: return a 400 error with invalid parameters

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -22,6 +22,7 @@
         - fixed a bug in documentation post-processing for @ref hashdecl "hashdecl" declarations (<a href="https://github.com/qorelanguage/qore/issues/2298">issue 2298</a>)
       - <a href="../../modules/RestHandler/html/index.html">RestHandler</a> module fixes:
         - updated to return a 400 Bad Request error when REST schema validation fails on messages received <a href="https://github.com/qorelanguage/qore/issues/2344">issue 2344</a>)
+        - updated to return a 400 Bad Request error when there are string encoding errors with messages received (<a href="https://github.com/qorelanguage/qore/issues/2398">issue 2398</a>)
       - <a href="../../modules/RestSchemaValidator/html/index.html">RestSchemaValidator</a> module fixes:
         - updated docs for @ref RestSchemaValidator::AbstractRestSchemaValidator::parseRequest() "AbstractRestSchemaValidator::parseRequest()" to reflect how validation exceptions should be raised for proper error reporting (<a href="https://github.com/qorelanguage/qore/issues/2344">issue 2344</a>)
         - fixed handling of messages with non-object (i.e. non-hash) bodies (<a href="https://github.com/qorelanguage/qore/issues/2366">issue 2366</a>)
@@ -37,6 +38,7 @@
         - fixed handling of messages with non-object (i.e. non-hash) bodies (<a href="https://github.com/qorelanguage/qore/issues/2366">issue 2366</a>)
         - fixed handling of optional parameters (<a href="https://github.com/qorelanguage/qore/issues/2369">issue 2369</a>)
         - fixed handling of non-string query parameters (<a href="https://github.com/qorelanguage/qore/issues/2388">issue 2388</a>)
+        - fixed a bug where invalid date, binary, and byte values would cause a <tt>500 Internal Server Error</tt> response to be returned instead of a <tt>400 Bad Request</tt> error (<a href="https://github.com/qorelanguage/qore/issues/2397">issue 2397</a>)
     - added missing comparison methods in the <a href="../../modules/QUnit/html/index.html">QUnit</a> module (<a href="https://github.com/qorelanguage/qore/issues/1588">issue 1588</a>):
       - \c Test::assertRegex()
       - \c Test::assertNRegex()

--- a/examples/test/qlib/RestHandler/RestHandler.qtest
+++ b/examples/test/qlib/RestHandler/RestHandler.qtest
@@ -153,6 +153,7 @@ public class RestHandlerTest inherits QUnit::Test {
         addTestCase("Test external serialization", \serializationTest());
         addTestCase("Test xml", \xmlTest());
         addTestCase("Test swagger", \swaggerTest());
+        addTestCase("issue 2398", \issue2398());
 
         # Return for compatibility with test harness that checks return value.
         set_return_value(main());
@@ -177,7 +178,7 @@ public class RestHandlerTest inherits QUnit::Test {
 
     directTest() {
         # test direct interface
-        any val = mHandler.handleExternalRequest("GET", "test?action=echo", LargerHashValue);
+        auto val = mHandler.handleExternalRequest("GET", "test?action=echo", LargerHashValue);
         assertEq(LargerHashValue, val);
         val = mHandler.handleExternalRequest("PUT", "test?action=echo", LargerHashValue);
         assertEq(LargerHashValue, val);
@@ -285,6 +286,26 @@ public class RestHandlerTest inherits QUnit::Test {
         assertThrows("FORMURLENCODING-ERROR", \mClient.put(), ("test?action=echo", "1", \info));
         assertThrows("FORMURLENCODING-ERROR", \mClient.put(), ("test?action=echo", ListValue, \info));
         assertThrows("INVALID-VALUE", \mClient.put(), ("test?action=echo", HashValue, \info));
+
+        auto rv = mClient.put("test?action=echo", ("a": "1"), \info);
+        assertEq(("a": "1"), rv.body);
+    }
+
+    issue2398() {
+        hash info;
+        on_error printf("info: %N\n", info);
+
+        HTTPClient hc(("url": "http://localhost:" + port));
+
+        hash<ExceptionInfo> ex;
+        try {
+            hc.send(<01ff008001020304>, "PUT", "test?action=echo", ("Content-Type": MimeTypeFormUrlEncoded + ";charset=UTF-8"), False, \info);
+        }
+        catch (hash<ExceptionInfo> ex1) {
+            ex = ex1;
+        }
+        assertRegex("invalid.*encoding", ex.arg.body);
+        assertEq(400, ex.arg.status_code);
     }
 
     testSerialization(string data, softlist values) {

--- a/examples/test/qlib/Swagger/Swagger.qtest
+++ b/examples/test/qlib/Swagger/Swagger.qtest
@@ -1745,7 +1745,7 @@ public class SwaggerTest inherits QUnit::Test {
                 ),
             );
             b.paths."/api/smtg" += (
-                "get": (
+                "post": (
                     "parameters": ((
                         "$ref": "#/parameters/a",
                     ),),
@@ -1794,28 +1794,28 @@ public class SwaggerTest inherits QUnit::Test {
 
             SwaggerSchema so(b);
 
-            assertThrows("SCHEMA-VALIDATION-ERROR", \so.processRequest(), ("get", "/api/smtg", ("a": "a")));
+            assertThrows("SCHEMA-VALIDATION-ERROR", \so.processRequest(), ("post", "/api/smtg", ("a": "a")));
 
             b.definitions.a.properties.a.readOnly = False;
             so = new SwaggerSchema(b);
 
             # issue #2369
-            assertThrows("SCHEMA-VALIDATION-ERROR", \so.processRequest(), ("get", "/api/smtg"));
+            assertThrows("SCHEMA-VALIDATION-ERROR", \so.processRequest(), ("post", "/api/smtg"));
 
             b.parameters.a.required = False;
             so = new SwaggerSchema(b);
-            hash<RestRequestClientInfo> h = so.processRequest("get", "/api/smtg");
+            hash<RestRequestClientInfo> h = so.processRequest("post", "/api/smtg");
             assertEq("/api/smtg", h.uri_path);
             assertNothing(h.body);
 
             # by default, parameters are optional
             remove b.parameters.a.required;
             so = new SwaggerSchema(b);
-            h = so.processRequest("get", "/api/smtg");
+            h = so.processRequest("post", "/api/smtg");
             assertEq("/api/smtg", h.uri_path);
             assertNothing(h.body);
 
-            h = so.processRequest("get", "/api/smtg", ("a": "a"), NOTHING, MimeTypeFormUrlEncoded);
+            h = so.processRequest("post", "/api/smtg", ("a": "a"), NOTHING, MimeTypeFormUrlEncoded);
             assertEq("/api/smtg", h.uri_path);
             assertEq("a=a", h.body);
             assertEq(MimeTypeFormUrlEncoded, h.content);
@@ -1823,7 +1823,7 @@ public class SwaggerTest inherits QUnit::Test {
 
             {
                 hash hdr = ("content-type": h.content);
-                hash<RestRequestServerInfo> sh = so.parseRequest("get", h.uri_path, h.body, \hdr);
+                hash<RestRequestServerInfo> sh = so.parseRequest("post", h.uri_path, h.body, \hdr);
                 assertEq("/api/smtg", sh.path);
                 assertEq("a", sh.body.a);
                 #printf("sh: %N\n", sh);
@@ -1832,15 +1832,15 @@ public class SwaggerTest inherits QUnit::Test {
             {
                 hash hdr = ("content-type": h.content);
                 h.body = "b=a";
-                assertThrows("SCHEMA-VALIDATION-ERROR", \so.parseRequest(), ("get", h.uri_path, h.body, \hdr));
+                assertThrows("SCHEMA-VALIDATION-ERROR", \so.parseRequest(), ("post", h.uri_path, h.body, \hdr));
             }
 
             # test for issue #2365
-            assertThrows("SCHEMA-VALIDATION-ERROR", "Parameter \"a\".*invalid type", \so.processRequest(), ("get", "/api/smtg", ("a": 1)));
+            assertThrows("SCHEMA-VALIDATION-ERROR", "Parameter \"a\".*invalid type", \so.processRequest(), ("post", "/api/smtg", ("a": 1)));
 
-            assertThrows("SERIALIZATION-ERROR", "application/octet-stream", \so.processRequest(), ("get", "/api/smtg", ("a": "a"), NOTHING, MimeTypeOctetStream));
+            assertThrows("SERIALIZATION-ERROR", "application/octet-stream", \so.processRequest(), ("post", "/api/smtg", ("a": "a"), NOTHING, MimeTypeOctetStream));
 
-            h = so.processRequest("get", "/api/smtg", ("a": "a"), NOTHING, MimeTypeMultipartFormData);
+            h = so.processRequest("post", "/api/smtg", ("a": "a"), NOTHING, MimeTypeMultipartFormData);
             assertEq("/api/smtg", h.uri_path);
             assertEq(True, h.content =~ /^multipart\/form-data;boundary=/);
             assertEq(Type::Binary, h.body.type());
@@ -1848,7 +1848,7 @@ public class SwaggerTest inherits QUnit::Test {
 
             {
                 hash hdr = ("content-type": h.content);
-                hash<RestRequestServerInfo> sh = so.parseRequest("get", h.uri_path, h.body, \hdr);
+                hash<RestRequestServerInfo> sh = so.parseRequest("post", h.uri_path, h.body, \hdr);
                 assertEq("/api/smtg", sh.path);
                 assertEq("a", sh.body.a);
             }
@@ -1905,6 +1905,12 @@ public class SwaggerTest inherits QUnit::Test {
                 assertEq(2, sh.body);
             }
 
+            {
+                # issue #2397 400 Bad Request response to invalid date params
+                hash hdr."content-type" = "application/json";
+                assertThrows("SCHEMA-VALIDATION-ERROR", "date.*invalid", \so.parseRequest(), ("put", "/api/smtg?date=2017-01-x1", h.body, \hdr));
+            }
+
             # issue #2388 bin parameter check
             h = so.processRequest("put", "/api/smtg?bin=abcd", 3);
             #printf("h: %y\n", h);
@@ -1937,6 +1943,54 @@ public class SwaggerTest inherits QUnit::Test {
                 assertEq("/api/smtg", sh.path);
                 assertEq(<616263>, sh.query.byte);
                 assertEq(3, sh.body);
+            }
+
+            # issue #2397 400 Bad Request response to invalid date params
+            b.definitions.a = (
+                "type": "string",
+                "format": "date",
+            );
+
+            so = new SwaggerSchema(b);
+
+            {
+                hash hdr = ("content-type": h.content);
+                hash<RestRequestServerInfo> sh = so.parseRequest("post", "/api/smtg", "\"2017-01-01\"", \hdr);
+                assertEq("/api/smtg", sh.path);
+                assertEq(2017-01-01, sh.body);
+
+                assertThrows("SCHEMA-VALIDATION-ERROR", \so.parseRequest(), ("post", "/api/smtg", "\"2017-01-0x\"", \hdr));
+                #printf("sh: %N\n", sh);
+            }
+
+            # issue #2397 400 Bad Request response to invalid binary params
+            b.definitions.a.format = "binary";
+
+            so = new SwaggerSchema(b);
+
+            {
+                hash hdr = ("content-type": h.content);
+                hash<RestRequestServerInfo> sh = so.parseRequest("post", "/api/smtg", "\"abcd\"", \hdr);
+                assertEq("/api/smtg", sh.path);
+                assertEq(<abcd>, sh.body);
+
+                assertThrows("SCHEMA-VALIDATION-ERROR", \so.parseRequest(), ("post", "/api/smtg", "\"abcx\"", \hdr));
+                #printf("sh: %N\n", sh);
+            }
+
+            # issue #2397 400 Bad Request response to invalid byte params
+            b.definitions.a.format = "byte";
+
+            so = new SwaggerSchema(b);
+
+            {
+                hash hdr = ("content-type": h.content);
+                hash<RestRequestServerInfo> sh = so.parseRequest("post", "/api/smtg", "\"YWJjZA==\"", \hdr);
+                assertEq("/api/smtg", sh.path);
+                assertEq("abcd", sh.body.toString());
+
+                assertThrows("SCHEMA-VALIDATION-ERROR", \so.parseRequest(), ("post", "/api/smtg", "\"YWJjZZZ\"", \hdr));
+                #printf("sh: %N\n", sh);
             }
         }
 

--- a/qlib/RestHandler.qm
+++ b/qlib/RestHandler.qm
@@ -312,6 +312,7 @@ Content-Length: 36
 
     @subsection rh_1_2_1 RestHandler v1.2.1
     - updated to return a 400 Bad Request error when REST schema validation fails on messages received (<a href="https://github.com/qorelanguage/qore/issues/2344">issue 2344</a>)
+    - updated to return a 400 Bad Request error when there are string encoding errors with messages received (<a href="https://github.com/qorelanguage/qore/issues/2398">issue 2398</a>)
 
     @subsection rh_1_2 RestHandler v1.2
     - added logic to allow sensitive data to be masked in log messages (<a href="https://github.com/qorelanguage/qore/issues/1086">issue 1086</a>)
@@ -990,10 +991,6 @@ public namespace RestHandler {
         hash<HttpResponseInfo> handleRequest(HttpListenerInterface listener, Socket s, hash cx, hash hdr, *data b) {
             #logDebug("REST DBG: cx: %N", cx);
             #logDebug("REST DBG: hdr: %N", hdr);
-            if (b) {
-                string bstr = maskData(b.typeCode() == NT_STRING ? trim(b) : sprintf("%y", b));
-                logDebug("REST DBG: body: %s", bstr);
-            }
 
             auto body = b;
 
@@ -1004,10 +1001,18 @@ public namespace RestHandler {
 
             hash<RestRequestServerInfo> req;
             try {
+                if (b) {
+                    string bstr = maskData(b.typeCode() == NT_STRING ? trim(b) : sprintf("%y", b));
+                    logDebug("REST DBG: body: %s", bstr);
+                }
+
                 req = validator.parseRequest(hdr.method, path, body, \hdr);
             }
             catch (hash<ExceptionInfo> ex) {
-                if (ex.err == "DESERIALIZATION-ERROR" || ex.err == "SCHEMA-VALIDATION-ERROR")
+                # return a 400 Bad Request response to encoding, serialization, or validation errors
+                if (ex.err == "INVALID-ENCODING"
+                    || ex.err == "DESERIALIZATION-ERROR"
+                    || ex.err == "SCHEMA-VALIDATION-ERROR")
                     return AbstractHttpRequestHandler::make400("%s: %s", ex.err, ex.desc);
                 if (ex.err == "INVALID-METHOD") {
                     string ml = (foldl $1 + "," + $2, ex.arg) ?? "";

--- a/qlib/Swagger.qm
+++ b/qlib/Swagger.qm
@@ -161,6 +161,7 @@ RestHandler handler(NOTHING, swagger);
     - fixed handling of messages with non-object (i.e. non-hash) bodies (<a href="https://github.com/qorelanguage/qore/issues/2366">issue 2366</a>)
     - fixed handling of optional parameters (<a href="https://github.com/qorelanguage/qore/issues/2369">issue 2369</a>)
     - fixed handling of non-string query parameters (<a href="https://github.com/qorelanguage/qore/issues/2388">issue 2388</a>)
+    - fixed a bug where invalid date, binary, and byte values would cause a <tt>500 Internal Server Error</tt> response to be returned instead of a <tt>400 Bad Request</tt> error
 
     @subsection swagger_1_0 Swagger v1.0
 
@@ -548,17 +549,32 @@ class SchemaBase {
             switch (format) {
                 # NOTE: deserializes to a binary object
                 case "byte":
-                    value = parse_base64_string(v);
+                    try {
+                        value = parse_base64_string(v);
+                    }
+                    catch (hash<ExceptionInfo> ex) {
+                        throw "SCHEMA-VALIDATION-ERROR", sprintf("Parameter %y for path %y and method %y of type %y is invalid; value provided: %y (%s)", name, path, method, format, v, ex.desc);
+                    }
                     break;
                 # NOTE: deserializes to a binary object
                 case "binary":
-                    value = parse_hex_string(v);
+                    try {
+                        value = parse_hex_string(v);
+                    }
+                    catch (hash<ExceptionInfo> ex) {
+                        throw "SCHEMA-VALIDATION-ERROR", sprintf("Parameter %y for path %y and method %y of type %y is invalid; value provided: %y (%s)", name, path, method, format, v, ex.desc);
+                    }
                     break;
                 # NOTE: deserializes to a date/time value
                 case "date":
                 case "date-time":
-                    # https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14
-                    value = date(v);
+                    try {
+                        # https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14
+                        value = date(v);
+                    }
+                    catch (hash<ExceptionInfo> ex) {
+                        throw "SCHEMA-VALIDATION-ERROR", sprintf("Parameter %y for path %y and method %y of type %y is invalid; value provided: %y (%s)", name, path, method, format, v, ex.desc);
+                    }
                     break;
             }
         }


### PR DESCRIPTION
refs #2398 RestHandler.qm: return a 400 error with enoding errors in requests