### PR TITLE
refs #2418: allow to use DBA_* views instead of ALL_* if possible

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -27,8 +27,10 @@
       - <a href="../../modules/RestSchemaValidator/html/index.html">RestSchemaValidator</a> module fixes:
         - updated docs for @ref RestSchemaValidator::AbstractRestSchemaValidator::parseRequest() "AbstractRestSchemaValidator::parseRequest()" to reflect how validation exceptions should be raised for proper error reporting (<a href="https://github.com/qorelanguage/qore/issues/2344">issue 2344</a>)
         - fixed handling of messages with non-object (i.e. non-hash) bodies (<a href="https://github.com/qorelanguage/qore/issues/2366">issue 2366</a>)
-      - <q href="../../modules/SqlUtil/html.indexhtml">SqlUtil</a> module changes
+      - <a href="../../modules/SqlUtil/html/index.html">SqlUtil</a> module changes
         - implemented support for custom column operators (<a href="https://github.com/qorelanguage/qore/issues/2314">issue 2314</a>)
+      - <a href="../../modules/OracleSqlUtil/html/index.html">OracleSqlUtil</a> module changes
+        - allow to use DBA_* views instead of ALL_* if possible (<a href="https://github.com/qorelanguage/qore/issues/2418">issue 2418</a>)
       - <a href="../../modules/Swagger/html/index.html">Swagger</a> module fixes:
         - fixed handling of string type date and date-time formats (<a href="https://github.com/qorelanguage/qore/issues/2341">issue 2341</a>)
         - fixed example value for binary type (<a href="https://github.com/qorelanguage/qore/issues/2342">issue 2342</a>)

--- a/qlib/OracleSqlUtil.qm
+++ b/qlib/OracleSqlUtil.qm
@@ -257,6 +257,7 @@ my hash $schema = (
 
     @subsection v124 OracleSqlUtil v1.2.4
     - implemented support for custom column operators (<a href="https://github.com/qorelanguage/qore/issues/2314">issue 2314</a>)
+    - allow to use DBA_* views instead of ALL_* if possible (<a href="https://github.com/qorelanguage/qore/issues/2418">issue 2418</a>)
 
     @subsection v123 OracleSqlUtil v1.2.3
     - fixed a bug in \c character_semantics for standalone column (<a href="https://github.com/qorelanguage/qore/issues/1688">issue 1688</a>)
@@ -2073,6 +2074,26 @@ auto v = c.name;
 
             # helper flag to indicate if is the OracleTable real table or a view
             bool m_isView = False;
+
+            # oraclesqlutil: allow to use DBA_* views instead of ALL_* if possible #2418
+            # An internal cache to find the highest priority available
+            # system dictionary object. Priority: DBA > ALL
+            hash m_sys_views = (
+                    "dba_col_comments"      : "all_col_comments",
+                    "dba_cons_columns"      : "all_cons_columns",
+                    "dba_constraints"       : "all_constraints",
+                    "dba_db_links"          : "all_db_links",
+                    "dba_ind_columns"       : "all_ind_columns",
+                    "dba_ind_expressions"   : "all_ind_expressions",
+                    "dba_indexes"           : "all_indexes",
+                    "dba_sequences"         : "all_sequences",
+                    "dba_synonyms"          : "all_synonyms",
+                    "dba_tab_columns"       : "all_tab_columns",
+                    "dba_tab_comments"      : "all_tab_comments",
+                    "dba_tables"            : "all_tables",
+                    "dba_triggers"          : "all_triggers",
+                    "dba_views"             : "all_views",
+                );
         }
 
         constructor(AbstractDatasource nds, string nname, *hash opts) : AbstractTable(nds, nname, opts) {
@@ -2101,6 +2122,30 @@ auto v = c.name;
                 throw "ORACLE-DRIVER-ERROR", sprintf("OracleSqlUtil requires oracle module 3.0+ to query system catalogs since LONG support was added in oracle module version 3.0; current module version: %s; upgrade your oracle module to at least 3.0 to use OracleSqlUtil", get_module_hash().oracle.version);
 
             ora_major = (nds.getServerVersion() =~ x/([0-9]+)/)[0].toInt();
+
+            # validate presence of DBA_* views for this connection/user
+            hash dba_in = bindOracleCollection("SYS.ODCIVARCHAR2LIST", map $1.upr(), m_sys_views.keys());
+            hash dba_sys = nds.select("select /* OracleSqlUtil::OracleTable::constructor */
+                                            object_name
+                                        from all_objects
+                                        where owner = %v
+                                            and object_name in (select column_value from table(%v))
+                                            and object_type = %v",
+                                      "SYS", dba_in, "VIEW");
+            context (dba_sys) {
+                string n = %object_name.lwr();
+                m_sys_views{n} = n;
+            }
+        }
+
+        # oraclesqlutil: allow to use DBA_* views instead of ALL_* if possible #2418
+        # get the most appropriate system catalogue/dictinary view available
+        private string systemView(string name) {
+            name = name.lwr();
+            if (!m_sys_views.hasKey(name)) {
+                throw "TABLE-ERROR", sprintf("Unknown system view %s, known: %y", name, m_sys_views.keys());
+            }
+            return m_sys_views{name};
         }
 
         private bool checkExistenceImpl() {
@@ -2125,7 +2170,7 @@ auto v = c.name;
 
             # get any comment
             if (!m_isView) {
-                auto cm = ds.selectRow("select * from all_tab_comments" + (dblink ? "@" + dblink : "") + " where owner = %v and table_name = %v", schema.upr(), name.upr()).comments;
+                auto cm = ds.selectRow("select * from " + systemView("dba_tab_comments") + (dblink ? "@" + dblink : "") + " where owner = %v and table_name = %v", schema.upr(), name.upr()).comments;
                 comment = cm ? cm : NOTHING;
             }
 
@@ -2144,11 +2189,11 @@ auto v = c.name;
 
         private hash setSchemaTable() {
             # get the table information if possible
-            *hash row = ds.selectRow("select * from all_tables" + (dblink ? "@" + dblink : "") + " where owner = %v and table_name = %v", schema.upr(), name.upr());
+            *hash row = ds.selectRow("select * from " + systemView("dba_tables") + (dblink ? "@" + dblink : "") + " where owner = %v and table_name = %v", schema.upr(), name.upr());
             if (row)
                 return row;
 
-            row = ds.selectRow("select * from all_views" + (dblink ? "@" + dblink : "") + " where owner = %v and view_name = %v", schema.upr(), name.upr());
+            row = ds.selectRow("select * from " + systemView("dba_views") + (dblink ? "@" + dblink : "") + " where owner = %v and view_name = %v", schema.upr(), name.upr());
             if (row) {
                 m_isView = True;
                 return row;
@@ -2158,7 +2203,7 @@ auto v = c.name;
         }
 
         private setDblinkSchema() {
-            *hash dblr = ds.selectRow("select * from all_db_links where owner in ('PUBLIC', %v) and db_link = %v and rownum = 1", ds.getUserName().upr(), dblink);
+            *hash dblr = ds.selectRow("select * from " + systemView("dba_db_links") + " where owner in ('PUBLIC', %v) and db_link = %v and rownum = 1", ds.getUserName().upr(), dblink);
             if (!dblr)
                 throw "TABLE-ERROR", sprintf("dblink %y is unknown", dblink);
             schema = dblr.username;
@@ -2186,7 +2231,7 @@ auto v = c.name;
             row = ds.selectRow("select * from user_synonyms where synonym_name = %v", name.upr());
             if (!row) {
                 # see if there is a public synonym with this name
-                row = ds.selectRow("select * from all_synonyms where owner = 'PUBLIC' and synonym_name = %v", name.upr());
+                row = ds.selectRow("select * from " + systemView("dba_synonyms") + " where owner = 'PUBLIC' and synonym_name = %v", name.upr());
                 if (!row)
                     throw "TABLE-ERROR", sprintf("table %y or synonym %y does not exist or is not accessible to this user (%s)", name, name, getDBString());
                 pub = True;
@@ -2216,11 +2261,11 @@ auto v = c.name;
             }
 
             # get the table information if possible
-            row = ds.selectRow("select * from all_tables" + (dblink ? "@" + dblink : "") + " where owner = %v and table_name = %v", schema.upr(), name.upr());
+            row = ds.selectRow("select * from " + systemView("dba_tables") + (dblink ? "@" + dblink : "") + " where owner = %v and table_name = %v", schema.upr(), name.upr());
             if (row)
                 return row;
 
-            row = ds.selectRow("select * from all_views" + (dblink ? "@" + dblink : "") + " where owner = %v and view_name = %v", schema.upr(), name.upr());
+            row = ds.selectRow("select * from " + systemView("dba_views") + (dblink ? "@" + dblink : "") + " where owner = %v and view_name = %v", schema.upr(), name.upr());
             if (row) {
                 m_isView = True;
                 return row;
@@ -2344,13 +2389,13 @@ auto v = c.name;
                 setTableInfoIntern();
 
             # get column descriptions
-            *hash qh = ds.select("select col.column_name, data_type, data_length, data_precision, data_scale, nullable, data_default, char_length, char_used, comments from all_tab_columns" + (dblink ? "@" + dblink : "") + " col, all_col_comments" + (dblink ? "@" + dblink : "") + " com where col.owner = %v and col.table_name = %v and com.owner = col.owner and com.table_name = col.table_name and com.column_name = col.column_name order by column_id", schema.upr(), name.upr());
+            *hash qh = ds.select("select col.column_name, data_type, data_length, data_precision, data_scale, nullable, data_default, char_length, char_used, comments from " + systemView("dba_tab_columns") + (dblink ? "@" + dblink : "") + " col, " + systemView("dba_col_comments") + (dblink ? "@" + dblink : "") + " com where col.owner = %v and col.table_name = %v and com.owner = col.owner and com.table_name = col.table_name and com.column_name = col.column_name order by column_id", schema.upr(), name.upr());
             if (!qh.column_name)
                 throw "TABLE-ERROR", sprintf("cannot retrieve table information for table %y.%y in %y", schema, name, dsdesc);
 
             # now we have to find unvalidated but enabled not null constraints - because these cause the column to appear to be "nullable" when it really isn't
             # also we can't filter by search_condition, because it's a LONG, otherwise we could make a left join above :(
-            *hash nnq = ds.select("select * from all_constraints" + (dblink ? "@" + dblink : "") + " where owner = %v and table_name = %v and generated = 'GENERATED NAME' and constraint_type = 'C' and status = 'ENABLED' and validated != 'VALIDATED'", schema.upr(), name.upr());
+            *hash nnq = ds.select("select * from " + systemView("dba_constraints") + (dblink ? "@" + dblink : "") + " where owner = %v and table_name = %v and generated = 'GENERATED NAME' and constraint_type = 'C' and status = 'ENABLED' and validated != 'VALIDATED'", schema.upr(), name.upr());
             hash cnh;
             context (nnq) {
                 *string cn = (%search_condition =~ x/"([^"]+)" IS NOT NULL$/)[0];
@@ -2421,7 +2466,7 @@ auto v = c.name;
             hash rv;
 
             # get primary key description
-            *hash qh = ds.select("select cons.constraint_name, cols.column_name, cols.position, cons.status, cons.index_name from all_constraints" + (dblink ? "@" + dblink : "") + " cons, all_cons_columns" + (dblink ? "@" + dblink : "") + " cols where cols.owner = %v and cols.table_name = %v and cons.constraint_type = 'P' and cons.owner = cols.owner and cons.constraint_name = cols.constraint_name order by cols.position", schema.upr(), name.upr());
+            *hash qh = ds.select("select cons.constraint_name, cols.column_name, cols.position, cons.status, cons.index_name from " + systemView("dba_constraints") + (dblink ? "@" + dblink : "") + " cons, " + systemView("dba_cons_columns") + (dblink ? "@" + dblink : "") + " cols where cols.owner = %v and cols.table_name = %v and cons.constraint_type = 'P' and cons.owner = cols.owner and cons.constraint_name = cols.constraint_name order by cols.position", schema.upr(), name.upr());
             if (!qh.constraint_name)
                 return new OraclePrimaryKey();
 
@@ -2452,13 +2497,13 @@ auto v = c.name;
 
             # get index description
             *hash qh = ds.select("select i.index_name, index_type, uniqueness, tablespace_name, constraint_name
- from all_indexes" + (dblink ? "@" + dblink : "") + " i left join all_constraints" + (dblink ? "@" + dblink : "") + " c on (i.index_name = c.index_name and i.owner = c.owner and i.table_name = c.table_name)
+ from " + systemView("dba_indexes") + (dblink ? "@" + dblink : "") + " i left join " + systemView("dba_constraints") + (dblink ? "@" + dblink : "") + " c on (i.index_name = c.index_name and i.owner = c.owner and i.table_name = c.table_name)
  where i.owner = %v and i.table_name = %v", schema.upr(), name.upr());
             if (qh.index_name) {
                 hash ih;
 
                 # get column info for all indexes in 1 query
-                *hash iqh = ds.select("select c.index_name, c.column_name, e.column_expression from all_ind_columns" + (dblink ? "@" + dblink : "") + " c left join all_ind_expressions" + (dblink ? "@" + dblink : "") + " e on (c.table_owner = e.index_owner and c.index_name = e.index_name and c.table_name = e.table_name) where c.table_owner = %v and c.table_name = %v order by c.index_name, c.column_position", schema.upr(), name.upr());
+                *hash iqh = ds.select("select c.index_name, c.column_name, e.column_expression from " + systemView("dba_ind_columns") + (dblink ? "@" + dblink : "") + " c left join " + systemView("dba_ind_expressions") + (dblink ? "@" + dblink : "") + " e on (c.table_owner = e.index_owner and c.index_name = e.index_name and c.table_name = e.table_name) where c.table_owner = %v and c.table_name = %v order by c.index_name, c.column_position", schema.upr(), name.upr());
                 foreach hash row in (iqh.contextIterator()) {
                     if (!native_case)
                         map row.$1 = row.$1.lwr(), ("index_name", "column_name", "column_expression"), row.$1;
@@ -2510,7 +2555,7 @@ auto v = c.name;
                         "enabled": row.status == "ENABLED",
                         );
                 }
-                qh = ds.select("select c.constraint_name, status, cols1.column_name source_column, cols1.position, cols2.table_name target_table, cols2.column_name target_column from all_constraints" + (dblink ? "@" + dblink : "") + " c, all_cons_columns" + (dblink ? "@" + dblink : "") + " cols1, all_cons_columns" + (dblink ? "@" + dblink : "") + " cols2 where c.owner = %v and c.table_name = %v and c.constraint_name = cols1.constraint_name and constraint_type = 'R' and c.r_constraint_name = cols2.constraint_name and cols1.position = cols2.position and cols1.owner = c.owner and cols2.owner = c.owner order by cols1.position", schema.upr(), name.upr());
+                qh = ds.select("select c.constraint_name, status, cols1.column_name source_column, cols1.position, cols2.table_name target_table, cols2.column_name target_column from " + systemView("dba_constraints") + (dblink ? "@" + dblink : "") + " c, " + systemView("dba_cons_columns") + (dblink ? "@" + dblink : "") + " cols1, " + systemView("dba_cons_columns") + (dblink ? "@" + dblink : "") + " cols2 where c.owner = %v and c.table_name = %v and c.constraint_name = cols1.constraint_name and constraint_type = 'R' and c.r_constraint_name = cols2.constraint_name and cols1.position = cols2.position and cols1.owner = c.owner and cols2.owner = c.owner order by cols1.position", schema.upr(), name.upr());
                 foreach hash row in (qh.contextIterator()) {
                     if (!native_case) {
                         row.constraint_name = row.constraint_name.lwr();
@@ -2542,7 +2587,7 @@ auto v = c.name;
                 setTableInfoIntern();
 
             # get only user check constraints
-            *hash qh = ds.select("select constraint_name, search_condition, status from all_constraints" + (dblink ? "@" + dblink : "") + " where owner = %v and table_name = %v and constraint_type = 'C' and generated != 'GENERATED NAME'", schema.upr(), name.upr());
+            *hash qh = ds.select("select constraint_name, search_condition, status from " + systemView("dba_constraints") + (dblink ? "@" + dblink : "") + " where owner = %v and table_name = %v and constraint_type = 'C' and generated != 'GENERATED NAME'", schema.upr(), name.upr());
             hash rv;
             foreach hash row in (qh.contextIterator()) {
                 if (!native_case)
@@ -2553,7 +2598,7 @@ auto v = c.name;
             Constraints c(rv);
 
             # now get unique constraints
-            qh = ds.select("select c.constraint_name, status, cols.column_name, cols.position, status, c.index_name from all_constraints" + (dblink ? "@" + dblink : "") + " c, all_cons_columns cols where c.owner = %v and c.table_name = %v and c.constraint_name = cols.constraint_name and constraint_type = 'U' and cols.owner = c.owner and generated != 'GENERATED NAME' order by cols.position", schema.upr(), name.upr());
+            qh = ds.select("select c.constraint_name, status, cols.column_name, cols.position, status, c.index_name from " + systemView("dba_constraints") + (dblink ? "@" + dblink : "") + " c, " + systemView("dba_cons_columns") + (dblink ? "@" + dblink : "") + " cols where c.owner = %v and c.table_name = %v and c.constraint_name = cols.constraint_name and constraint_type = 'U' and cols.owner = c.owner and generated != 'GENERATED NAME' order by cols.position", schema.upr(), name.upr());
             delete rv;
             foreach hash row in (qh.contextIterator()) {
                 if (!native_case)
@@ -2586,7 +2631,7 @@ auto v = c.name;
             hash rv;
 
             # get trigger description
-            *hash qh = ds.select("select * from all_triggers" + (dblink ? "@" + dblink : "") + " where owner = %v and table_name = %v", schema.upr(), name.upr());
+            *hash qh = ds.select("select * from " + systemView("dba_triggers") + (dblink ? "@" + dblink : "") + " where owner = %v and table_name = %v", schema.upr(), name.upr());
             foreach hash row in (qh.contextIterator()) {
                 if (!native_case)
                     map row.$1 = row.$1.lwr(), ("trigger_name", "trigger_type", "triggering_event", "referencing_names");


### PR DESCRIPTION
the functionality remains exactly the same as before. It just checks if there are DBA_* views available in OracleTable constructor, then the DBA or ALL vies is used on demand. DBA and ALL views have exatcly the same structure and indexes, so there is no performance penalty accessing DBA instead of ALL. The only (minor) slowdown is in OracleTable::constructor() where it tests presence of DBA objects for given connection.