### PR TITLE
Util: add helper function uniq() for branch 0.8.13

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -389,6 +389,7 @@
         - the \c parse_uri_query() function was moved here from the <a href="../../modules/HttpServerUtil/html/index.html">HttpServerUtil</a> module
         - \c parse_uri_query() now handles repeated query arguments as a list
         - added public function \c flatten()
+        - added public function \c uniq()
       - <a href="../../modules/WebSocketClient/html/index.html">WebSocketClient</a> module updates:
         - added the \c WebSocketConnectionObject class to support the <a href="../../ConnectionProvider/html/index.html">ConnectionProvider</a> module
         - updated for complex types

--- a/examples/test/qlib/Util/uniq.qtest
+++ b/examples/test/qlib/Util/uniq.qtest
@@ -1,0 +1,36 @@
+#!/usr/bin/env qore
+
+%requires ../../../../qlib/Util.qm
+%requires ../../../../qlib/QUnit.qm
+
+%new-style
+%require-types
+%enable-all-warnings
+
+%exec-class UniqTest
+
+public class UniqTest inherits QUnit::Test {
+    constructor() : Test ("UniqTest", "1.0") {
+        addTestCase ("Tests for uniq() function", \test_uniq());
+        set_return_value(main());
+    }
+
+    test_uniq() {
+        assertEq ((), uniq ());
+        assertEq ((1,), uniq (1));
+        assertEq ((1,2,3), uniq ((1,2,3)));
+        assertEq ((1,2,3), uniq ((1,2,1,3,2,1)));
+        assertEq (('a','b','c'), uniq (('a','b','c','b','a')));
+
+        # test floats that can get aliased even when they are different
+        # due to the default string conversion having limited precision
+        float f0 = M_PI;
+        float f1 = M_PI + 0.00000001;
+        float f2 = M_PI + 0.000000001;
+        assertTrue (f0 !== f1);
+        assertTrue (f0 !== f2);
+        assertEq ((f0, f1), uniq ((f0, f1)));
+        code kod = sub () { uniq ((f0, f2)); };
+        assertThrows ("UNIQ-ERROR", kod, ());
+    }
+}

--- a/qlib/Util.qm
+++ b/qlib/Util.qm
@@ -81,6 +81,7 @@ module Util {
     - @ref Util::same()
     - @ref Util::slice()
     - @ref Util::tmp_location()
+    - @ref Util::uniq()
     - @ref Util::zip()
 
     @section utilrelnotes Release Notes
@@ -91,6 +92,7 @@ module Util {
     - added the @ref Util::parse_uri_query() "parse_uri_query()" function
     - added the @ref Util::UriQueryInfo "UriQueryInfo" hashdecl
     - added the @ref Util::flatten() "flatten()" function
+    - added the @ref Util::uniq() "uniq()" function
 
     @subsection util_1_2 Util 1.2
     - the following functions are now actually implemented in the %Qore library and only reexported here for backwards-compatibility:
@@ -1304,6 +1306,36 @@ list f = flatten (((1, 2), (3, 4), 5)); # returns (1, 2, 3, 4, 5)
             }
         }
         return r ?? ();
+    }
+
+    #! Returns a duplicate-free version of the list.
+    /**
+        @param  arg a list of values to filter out
+        @return a list of unique values
+
+        @par Example:
+        @code{.py}
+list u = uniq ((1,2,1,3,2,1)); # returns (1,2,3)
+        @endcode
+
+        @note Since implementation of this function uses %hash to keep track of the list values, it cannot safely process values which implicit string representation collide (e.g. %float values that differ outside implicit %toString() precision).
+
+        @throw UNIQ-ERROR if two different values from the list share the same implicit string representation
+
+        @since Util 1.3
+    */
+    public list sub uniq (softlist arg) {
+        hash h;
+        foreach any item in (arg) {
+            string k = item.toString();
+            if (exists h{k}) {
+                if (h{k} !== item)
+                    throw "UNIQ-ERROR", sprintf ("cannot safely handle %s %y -- set already contains %s %y",
+                            item.type(), item, h{k}.type(), h{k});
+            } else
+                h{k} = item;
+        }
+        return h.values();
     }
 
     #! Returns a list of lists, where the i-th list contains the i-th element from each of the argument lists.


### PR DESCRIPTION
Returns a duplicate-free version of the list.

Ported from original feature branch based on develop:
https://github.com/gamato/qore/tree/feature/util_uniq