### PR TITLE
refs #2576 fixed a bug handling condition variable timeouts on macOS …

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -13,6 +13,7 @@
     @subsection qore_08132_bug_fixes Bug Fixes in Qore
     - <a href="../../modules/WebSocketHandler/html/index.html">WebSocketHandler</a>: fixed a bug where unsolicited \c PONG messages caused the connection to be prematurely closed (<a href="https://github.com/qorelanguage/qore/issues/2566">issue 2566</a>)
     - <a href="../../modules/WebSocketClient/html/index.html">WebSocketClient</a>: added \c WebSocketClient::pong() to allow unsolicited \c PONG messages to be sent (<a href="https://github.com/qorelanguage/qore/issues/2566">issue 2566</a>)
+    - fixed a bug with @ref Qore::Thread::Condition "Condition" variable handling on macOS High Sierra due to an internal undocumented API change (<a href="https://github.com/qorelanguage/qore/issues/2576">issue 2576</a>)
 
     @section qore_08131 Qore 0.8.13.1
 


### PR DESCRIPTION
…by eliminating the use of a non-portable API that either is not supported or has new undocumented semantics (I suspect the former) - the man page has disappeared in High Sierra, and a Google search indicates a lot of bugs in other applications related to the use of this non-portable API.  Darwin's implementation is now the same as all other platforms (i.e. pure pthreads)