### PR TITLE
refs #2622 fixed qpp to not flag line comments while parsing a string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -644,7 +644,7 @@ target_link_libraries(qore libqore)
 #target_link_libraries(qr libqore)
 
 #set_target_properties(qore qr PROPERTIES INSTALL_RPATH ${CMAKE_INSTALL_FULL_LIBDIR})
-set_target_properties(qore PROPERTIES INSTALL_RPATH ${CMAKE_INSTALL_FULL_LIBDIR})
+set_target_properties(qore PROPERTIES INSTALL_RPATH_USE_LINK_PATH ${CMAKE_INSTALL_FULL_LIBDIR})
 
 # configuration files
 message(STATUS "Generating unix-config.h")

--- a/lib/qpp.cpp
+++ b/lib/qpp.cpp
@@ -842,11 +842,6 @@ int read_until_close(const char* fileName, unsigned& lineNumber, std::string& st
         if (line_comment)
             continue;
 
-        if (c == '/' && last == '/') {
-            line_comment = true;
-            continue;
-        }
-
         if (c == '"' || c == '\'') {
             log(LL_DEBUG, "found %c on line %d (quote: %c %d)\n", c, lineNumber, quote ? quote : 'x', quote);
             if (quote == c)
@@ -859,6 +854,11 @@ int read_until_close(const char* fileName, unsigned& lineNumber, std::string& st
         if (quote) {
             if (c == '\\')
                 backquote = true;
+            continue;
+        }
+
+        if (c == '/' && last == '/') {
+            line_comment = true;
             continue;
         }
 


### PR DESCRIPTION
refs #2624 do not override rpath when installing qore with cmake builds