### PR TITLE
refs #2643 implemented an error handling callback for schema alignmen…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -11,6 +11,8 @@
     - fixed a crashing bug in the @ref background "background operator" with non-constant hash expressions with local variable references (<a href="https://github.com/qorelanguage/qore/issues/2637">issue 2637</a>)
     - fixed a crashing bug in the @ref plus_equals_operator "+= operator" with objects and hashes when @ref require-types "%require-types" is not in force (<a href="https://github.com/qorelanguage/qore/issues/2634">issue 2634</a>)
     - improved HTTP log masking in the <a href="../../modules/HttpServerUtil/html/index.html">HttpServerUtil</a> module to mask fewer false positives when attempting to mask sensitive data (<a href="https://github.com/qorelanguage/qore/issues/2621">issue 2621</a>)
+    - worked around an Oracle bug in materialized view creation in the <a href="../../modules/OracleSqlUtil/html/index.html">OracleSqlUtil</a> module where when the schema user is missing the <tt>CREATE MATERIALIZED VIEW</tt> grant the table backing the view is created but the materialized view itself is not created causing future creation actions to fail (<a href="https://github.com/qorelanguage/qore/issues/2643">issue 2643</a>)
+    - implemented support for an optional error-handling method in SQL callbacks in the <a href="../../modules/SqlUtil/html/index.html">SqlUtil</a> module to allow SqlUtil to recover from error scenarios in schema creation/alignment (<a href="https://github.com/qorelanguage/qore/issues/2643">issue 2643</a>)
 
     @section qore_08132 Qore 0.8.13.2
 

--- a/qlib/OracleSqlUtil.qm
+++ b/qlib/OracleSqlUtil.qm
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 # @file OracleSqlUtil.qm Qore user module for working with Oracle SQL data
 
-/*  OracleSqlUtil.qm Copyright 2013 - 2017 Qore Technologies, s.r.o.
+/*  OracleSqlUtil.qm Copyright 2013 - 2018 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -46,7 +46,7 @@
 %enable-all-warnings
 
 module OracleSqlUtil {
-    version = "1.2.4";
+    version = "1.2.5";
     desc = "user module for working with Oracle SQL data";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -187,7 +187,7 @@ my *list $rows = $ds.vselectRows("select * from schema.table inner join schema.t
     The \c "materialized_views" key can go in the top level of the @ref schema_desc_hash for Oracle-only schemas, or, for schemas targeting multiple database types, under the \c "driver" and \c "oracle" keys as in the following example:
 
     @code{.py}
-my hash $schema = (
+hash schema = (
     "driver": (
         "oracle": (
             "materialized_views": (
@@ -213,7 +213,7 @@ my hash $schema = (
     The \c "packages" key can go in the top level of the @ref schema_desc_hash for Oracle-only schemas, or, for schemas targeting multiple database types, under the \c "driver" and \c "oracle" keys as in the following example:
 
     @code{.py}
-my hash $schema = (
+hash schema = (
     "driver": (
         "oracle": (
             "packages": (
@@ -239,7 +239,7 @@ MYSTATERROR constant order_status.orderstatus%type := 'E';
     The \c "types" key can go in the top level of the @ref schema_desc_hash for Oracle-only schemas, or, for schemas targeting multiple database types, under the \c "driver" and \c "oracle" keys as in the following example:
 
     @code{.py}
-my hash $schema = (
+hash schema = (
     "driver": (
         "oracle": (
             "types": (
@@ -254,6 +254,9 @@ my hash $schema = (
     @see OracleSqlUtil::OracleDatabase::OracleSchemaDescriptionOptions for a list of Oracle-specific schema description hash keys.
 
     @section ora_relnotes Release Notes
+
+    @subsection v125 OracleSqlUtil v1.2.5
+    - worked around an Oracle bug in materialized view creation where when the schema user is missing the <tt>CREATE MATERIALIZED VIEW</tt> grant the table backing the view is created but the materialized view itself is not created causing future creation actions to fail (<a href="https://github.com/qorelanguage/qore/issues/2643">issue 2643</a>)
 
     @subsection v124 OracleSqlUtil v1.2.4
     - implemented support for custom column operators (<a href="https://github.com/qorelanguage/qore/issues/2314">issue 2314</a>)
@@ -972,6 +975,9 @@ auto v = c.name;
             OracleMaterializedView mv = cast<OracleMaterializedView>(t);
             return mv.logging == logging && mv.use_index == use_index;
         }
+
+        handleError(int ac, *string sql, hash<ExceptionInfo> ex) {
+        }
     }
 
     #! the Oracle specialization for SqlUtil::AbstractDatabase
@@ -1304,6 +1310,9 @@ auto v = c.name;
             if (tl) l += tl;
 
             # create materialized views
+            if (!opt.error_callback) {
+                opt.error_callback = \oracleErrorCallback();
+            }
             tl = alignCodeUnlocked("materialized_view", schema_hash, \getMaterializedView(), \makeMaterializedViewFromDescription(), opt, Type::Hash);
             if (tl) l += tl;
 
@@ -1667,7 +1676,16 @@ auto v = c.name;
             }
         }
 
-    }
+        private oracleErrorCallback(int ac, string type, string name, *string table, *string new_name, *string info, string sql, hash<ExceptionInfo> ex) {
+            # issue #2643: if there is an ORA-01031 "insufficient privileges" error creating a materialized view,
+            # try to drop any table possibly created due to an Oracle bug
+            if (ac == AC_Create && type == "materialized_view" && ex.arg.alterr == "OCI-01031") {
+                # try to drop any table created to back the materialized view, ignoring ORA-00942
+                # "table or view does not exist" errors but rethrowing all others
+                ds.exec("begin execute immediate 'drop table " + name + "'; exception when others then if sqlcode != -942 then raise; end if; end;", name);
+            }
+        }
+   }
 
     #! represents an Oracle table
     /** this is the specialization of SqlUtil::AbstractTable

--- a/qlib/OracleSqlUtil.qm
+++ b/qlib/OracleSqlUtil.qm
@@ -975,9 +975,6 @@ auto v = c.name;
             OracleMaterializedView mv = cast<OracleMaterializedView>(t);
             return mv.logging == logging && mv.use_index == use_index;
         }
-
-        handleError(int ac, *string sql, hash<ExceptionInfo> ex) {
-        }
     }
 
     #! the Oracle specialization for SqlUtil::AbstractDatabase

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -38,7 +38,7 @@
 %enable-all-warnings
 
 module SqlUtil {
-    version = "1.4.2";
+    version = "1.4.3";
     desc = "user module for working with SQL data";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -99,6 +99,9 @@ module SqlUtil {
       - @ref dba_space_management
 
     @section sqlutil_relnotes Release Notes for the SqlUtil Module
+
+   @subsection sqlutilv1_4_3 SqlUtil v1.4.3
+    - implemented support for an optional error-handling method in SQL callbacks to allow SqlUtil to recover from error scenarios in schema creation/alignment (<a href="https://github.com/qorelanguage/qore/issues/2643">issue 2643</a>)
 
     @subsection sqlutilv1_4_2 SqlUtil v1.4.2
     - implemented support for literal values in column operators taking column arguments with @ref SqlUtil::cop_value() "cop_value()" (<a href="https://github.com/qorelanguage/qore/issues/2555">issue 2555</a>)
@@ -1652,6 +1655,18 @@ hash ix_desc = (
     Most of the SqlUtil methods that return SQL strings also accept an option hash where callbacks an be set.  Callbacks can be used
     to display detailed information about long-running operations, such as schema or data alignment for complex schemas or large
     data sets, or as a generic framework for executing and logging SQL operations.
+
+    @subsection error_callback SQL Error Callback
+
+    the \c "error_callback" @ref closure "closure" or @ref call_reference "call reference" is called with information about the current SQL
+    operation if an error occurs in the @ref sql_callback "sql callback" and can be specified as in the following example:
+    @code{.py}
+code error_callback = sub (int ac, string type, string name, *string table, *string new_name, *string info, string sql, hash<ExceptionInfo> ex) {
+    if (ac == AC_Create && type == "materialized_view" && ex.alterr == "ORA-01031") {
+        # try to drop any table create to back the materialized view; ignoring ORA-00942 table or view does not exist errors
+        ds.exec("begin execute immediate 'drop table %s'; exception when others then if sqlcode != 942 then raise; end if; end;", name);
+    }
+};
 
     @subsection info_callback SQL Info CallBack Closure or Call Ceference
 
@@ -7168,24 +7183,37 @@ AbstractDatabase db("pgsql:user/pass@db%host");
             }
         }
 
+        static private runInfoCallback(code info_callback, int ac, string type, string name, *string table, *string new_name, *string info) {
+            bool c = (type == "column");
+            if (c)
+                name = sprintf("%s.%s", table, name);
+            string str = sprintf("%s %s %s", ActionMap{ac}, type, name);
+            if (table && !c)
+                str += sprintf(" %s %s", ac == AC_Drop ? "from" : "on", table);
+            if (new_name)
+                str += sprintf(" to %s", new_name);
+            if (info)
+                str += sprintf(" (%s)", info);
+            info_callback(str, ac, type, name, table, new_name, info);
+        }
+
         static *string doCallback(*hash opt, *string sql, int ac, string type, string name, *string table, *string new_name, *string info) {
             if (!sql)
                 return;
             if (opt.info_callback) {
-                bool c = (type == "column");
-                if (c)
-                    name = sprintf("%s.%s", table, name);
-                string str = sprintf("%s %s %s", ActionMap{ac}, type, name);
-                if (table && !c)
-                    str += sprintf(" %s %s", ac == AC_Drop ? "from" : "on", table);
-                if (new_name)
-                    str += sprintf(" to %s", new_name);
-                if (info)
-                    str += sprintf(" (%s)", info);
-                opt.info_callback(str, ac, type, name, table, new_name, info);
+                AbstractDatabase::runInfoCallback(opt.info_callback, ac, type, name, table, new_name, info);
             }
-            if (opt.sql_callback)
-                opt.sql_callback(sql);
+            if (opt.sql_callback) {
+                try {
+                    opt.sql_callback(sql);
+                }
+                catch (hash<ExceptionInfo> ex) {
+                    if (opt.error_callback) {
+                        opt.error_callback(ac, type, name, table, new_name, info, sql, ex);
+                    }
+                    rethrow;
+                }
+            }
             return sql;
         }
 
@@ -7193,44 +7221,22 @@ AbstractDatabase db("pgsql:user/pass@db%host");
             if (!sql)
                 return sql;
             if (opt.info_callback) {
-                bool c = (type == "column");
-                if (c)
-                    name = sprintf("%s.%s", table, name);
-                string str = sprintf("%s %s %s", ActionMap{ac}, type, name);
-                if (table && !c)
-                    str += sprintf(" %s %s", ac == AC_Drop ? "from" : "on", table);
-                if (new_name)
-                    str += sprintf(" to %s", new_name);
-                if (info)
-                    str += sprintf(" (%s)", info);
-                opt.info_callback(str, ac, type, name, table, new_name, info);
+                AbstractDatabase::runInfoCallback(opt.info_callback, ac, type, name, table, new_name, info);
             }
-            if (opt.sql_callback)
-                map opt.sql_callback($1), sql;
-            return sql;
-        }
-
-/*
-        static *string doCallback(*hash opt, *string sql, string fmt) {
-            if (!sql)
-                return;
-            if (opt.info_callback)
-                opt.info_callback(vsprintf(fmt, argv));
-            if (opt.sql_callback)
-                opt.sql_callback(sql);
-            return sql;
-        }
-
-        static list doCallback(*hash opt, list sql, string fmt) {
-            if (sql) {
-                if (opt.info_callback)
-                    opt.info_callback(vsprintf(fmt, argv));
-                if (opt.sql_callback)
-                    map opt.sql_callback($1), sql;
+            if (opt.sql_callback) {
+                string my_sql;
+                try {
+                    map opt.sql_callback(my_sql = $1), sql;
+                }
+                catch (hash<ExceptionInfo> ex) {
+                    if (opt.error_callback) {
+                        opt.error_callback(ac, type, name, table, new_name, info, my_sql, ex);
+                    }
+                    rethrow;
+                }
             }
             return sql;
         }
-*/
 
         #! executes some SQL with optional arguments so that if an error occurs the current transaction state is not lost
         /** @par Example:


### PR DESCRIPTION
…t/creation to allow the OracleSqlUtil module to work around a bug in older Oracle versions where if materialized view creation fails due to insufficient privileges, the backing table is left in the DB, causing future schema alignments to fail even when the schema user has the appropriate "CREATE MATERIALIZED VIEW" grant

note that I could not write a test for this because this error does not happen in our Oracle DBs as the Oracle bug required is not present in 12c
