### PR TITLE
refs #2653 fixed object scope issues with the background operator whe…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -39,7 +39,8 @@
         - added public function \c check_ip_address() (<a href="https://github.com/qorelanguage/qore/issues/2483">issue 2483</a>)
 
     @subsection qore_09_bug_fixes Bug Fixes in Qore
-    WIP
+
+    - fixed bugs handling object scope in @ref background "background" expressions (<a href="https://github.com/qorelanguage/qore/issues/2653">issue 2653</a>)
 
     @section qore_08133 Qore 0.8.13.3
 

--- a/examples/test/qore/threads/thread-object.qtest
+++ b/examples/test/qore/threads/thread-object.qtest
@@ -5,10 +5,51 @@
 %enable-all-warnings
 %require-types
 %strict-args
+%allow-weak-references
 
 %requires ../../../../qlib/QUnit.qm
 
 %exec-class ThreadObjectTest
+
+# this class implements a background thread that does not extend the scope of the object
+# and is shut down cleanly when the object goes out of scope - this allows objects
+# to have a natural scope and also a service thread that's managed with the natural
+# lifecycle of the object
+class TransparentObjectThreadTest {
+    private:internal {
+        Counter end(1);
+        bool stop;
+    }
+
+    constructor() {
+        # we have to let the test method dereference the object before finishing the method
+        # otherwise there is a race condition where the destructor is run in the background
+        # thread and will wait on the end counter before it can be decremented
+        Counter start(1);
+        background test(self, start);
+        start.waitForZero();
+    }
+
+    destructor() {
+        stop = True;
+        end.waitForZero();
+    }
+
+    static test(TransparentObjectThreadTest t, Counter start) {
+        # let the object go out of scope naturally
+        TransparentObjectThreadTest self := t;
+        remove t;
+        # signal the constructor to continue
+        start.dec();
+        # signal the object's end counter when done
+        on_exit self.end.dec();
+
+        # loop until we are signaled to stop
+        while (!self.stop) {
+            usleep(50ms);
+        }
+    }
+}
 
 class ThreadObjectTest inherits QUnit::Test {
     private {
@@ -19,6 +60,7 @@ class ThreadObjectTest inherits QUnit::Test {
         addTestCase("Test Counter", \testCounter());
         addTestCase("Test Queue", \testQueue());
         addTestCase("Test Thread", \testThread());
+        addTestCase("Test TransparentObjectThreadTest", \transparentObjectThreadTest());
         set_return_value(main());
     }
 
@@ -37,6 +79,11 @@ class ThreadObjectTest inherits QUnit::Test {
 
     testThread() {
         new ThreadTest(threads, iters, self);
+    }
+
+    transparentObjectThreadTest() {
+        TransparentObjectThreadTest t();
+        assertTrue(True);
     }
 }
 

--- a/include/qore/intern/Function.h
+++ b/include/qore/intern/Function.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -267,12 +267,18 @@ protected:
    QoreProgram* pgm; // program used when evaluated (to find stacks for references)
    q_rt_flags_t rtflags; // runtime flags
 
+    DLLLOCAL void init(const QoreFunction* func, const AbstractQoreFunctionVariant*& variant, bool is_copy, const qore_class_private* cctx);
+
 public:
    // saves current program location in case there's an exception
    DLLLOCAL CodeEvaluationHelper(ExceptionSink* n_xsink, const QoreFunction* func, const AbstractQoreFunctionVariant*& variant, const char* n_name, const QoreValueList* args = nullptr, QoreObject* self = nullptr, const qore_class_private* n_qc = nullptr, qore_call_t n_ct = CT_UNUSED, bool is_copy = false, const qore_class_private* cctx = nullptr);
 
    // saves current program location in case there's an exception
    DLLLOCAL CodeEvaluationHelper(ExceptionSink* n_xsink, const QoreFunction* func, const AbstractQoreFunctionVariant*& variant, const char* n_name, const QoreListNode* args, QoreObject* self = nullptr, const qore_class_private* n_qc = nullptr, qore_call_t n_ct = CT_UNUSED, bool is_copy = false, const qore_class_private* cctx = nullptr);
+
+   // saves current program location in case there's an exception
+   // performs destructive evaluation of "args"
+   DLLLOCAL CodeEvaluationHelper(ExceptionSink* n_xsink, const QoreFunction* func, const AbstractQoreFunctionVariant*& variant, const char* n_name, QoreListNode* args, QoreObject* self = nullptr, const qore_class_private* n_qc = nullptr, qore_call_t n_ct = CT_UNUSED, bool is_copy = false, const qore_class_private* cctx = nullptr);
 
    DLLLOCAL ~CodeEvaluationHelper();
 
@@ -291,6 +297,10 @@ public:
       assert(!*tmp);
       tmp.assign(true, n_args);
    }
+
+    DLLLOCAL QoreValueListEvalOptionalRefHolder& getArgHolder() {
+        return tmp;
+    }
 
    DLLLOCAL const QoreValueList* getArgs() const {
       return *tmp;
@@ -919,6 +929,10 @@ public:
 
    // if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL then it is identified at run time
    DLLLOCAL virtual QoreValue evalFunction(const AbstractQoreFunctionVariant* variant, const QoreListNode* args, QoreProgram* pgm, ExceptionSink* xsink) const;
+
+   // if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL then it is identified at run time
+   // this function will use destructive evaluation of "args"
+   DLLLOCAL virtual QoreValue evalFunctionTmpArgs(const AbstractQoreFunctionVariant* variant, QoreListNode* args, QoreProgram* pgm, ExceptionSink* xsink) const;
 
    // finds a variant and checks variant capabilities against current program parse options and executes the variant
    DLLLOCAL QoreValue evalDynamic(const QoreListNode* args, ExceptionSink* xsink) const;

--- a/include/qore/intern/FunctionCallNode.h
+++ b/include/qore/intern/FunctionCallNode.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -75,6 +75,10 @@ public:
 
 class AbstractFunctionCallNode : public ParseNode, public FunctionCallBase {
 protected:
+    // set to true if the arg list is a temporary list and can be destroyed when evaluating
+    // such as when the node was created during background operation execution
+    bool tmp_args = false;
+
    DLLLOCAL virtual QoreValue evalValueImpl(bool& needs_deref, ExceptionSink* xsink) const = 0;
 
    DLLLOCAL void doFlags(int64 flags) {
@@ -95,7 +99,8 @@ public:
       has_value_api = true;
    }
 
-   DLLLOCAL AbstractFunctionCallNode(const AbstractFunctionCallNode& old, QoreListNode* n_args) : ParseNode(old), FunctionCallBase(old, n_args) {
+
+   DLLLOCAL AbstractFunctionCallNode(const AbstractFunctionCallNode& old, QoreListNode* n_args) : ParseNode(old), FunctionCallBase(old, n_args), tmp_args(true) {
       has_value_api = true;
    }
 
@@ -438,10 +443,8 @@ public:
    DLLLOCAL StaticMethodCallNode(const StaticMethodCallNode& old, QoreListNode* args) : AbstractFunctionCallNode(old, args), method(old.method) {
    }
 
-      /*
-   DLLLOCAL StaticMethodCallNode(const QoreProgramLocation& loc, const QoreMethod* m, QoreParseListNode* args) : AbstractFunctionCallNode(loc, NT_STATIC_METHOD_CALL, args), scope(0), method(m) {
+   DLLLOCAL StaticMethodCallNode(const QoreProgramLocation& loc, const QoreMethod* m, QoreParseListNode* args) : AbstractFunctionCallNode(loc, NT_STATIC_METHOD_CALL, args), method(m) {
    }
-      */
 
    DLLLOCAL virtual ~StaticMethodCallNode() {
       delete scope;

--- a/include/qore/intern/LocalVar.h
+++ b/include/qore/intern/LocalVar.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -188,6 +188,7 @@ public:
    DLLLOCAL void remove(LValueRemoveHelper& lvrh, const QoreTypeInfo* typeInfo);
 
    DLLLOCAL QoreValue evalValue(bool& needs_deref, ExceptionSink* xsink) const {
+      //printd(5, "LocalVarValue::evalValue() this: %p '%s' type: %d '%s'\n", this, id, val.getType(), val.getTypeName());
       if (val.getType() == NT_REFERENCE) {
          ReferenceNode* ref = reinterpret_cast<ReferenceNode*>(val.v.n);
          LocalRefHelper<LocalVarValue> helper(this, *ref, xsink);

--- a/include/qore/intern/QoreClassIntern.h
+++ b/include/qore/intern/QoreClassIntern.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -800,6 +800,9 @@ public:
    DLLLOCAL QoreValue evalMethod(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, QoreObject* self, const QoreListNode* args, const qore_class_private* cctx = nullptr) const;
 
    // if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL then it is identified at run time
+   DLLLOCAL QoreValue evalMethodTmpArgs(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, QoreObject* self, QoreListNode* args, const qore_class_private* cctx = nullptr) const;
+
+   // if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL then it is identified at run time
    DLLLOCAL QoreValue evalPseudoMethod(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, const QoreValue n, const QoreListNode* args, const qore_class_private* cctx = nullptr) const;
 };
 
@@ -814,8 +817,12 @@ public:
    }
    DLLLOCAL virtual ~StaticMethodFunction() {
    }
+
    // if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL then it is identified at run time
    DLLLOCAL QoreValue evalMethod(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, const QoreListNode* args, const qore_class_private* cctx = nullptr) const;
+
+   // if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL then it is identified at run time
+   DLLLOCAL QoreValue evalMethodTmpArgs(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, QoreListNode* args, const qore_class_private* cctx = nullptr) const;
 };
 
 #define SMETHF(f) (reinterpret_cast<StaticMethodFunction*>(f))
@@ -3297,6 +3304,14 @@ public:
       return SMETHF(func)->evalMethod(xsink, 0, args, cctx);
    }
 
+   DLLLOCAL QoreValue evalTmpArgs(ExceptionSink* xsink, QoreObject* self, QoreListNode* args, const qore_class_private* cctx = nullptr) const {
+      if (!static_flag) {
+         assert(self);
+         return NMETHF(func)->evalMethodTmpArgs(xsink, nullptr, self, args, cctx);
+      }
+      return SMETHF(func)->evalMethodTmpArgs(xsink, nullptr, args, cctx);
+   }
+
    DLLLOCAL QoreValue evalPseudoMethod(const AbstractQoreFunctionVariant* variant, const QoreValue n, const QoreListNode* args, ExceptionSink* xsink) const {
       QORE_TRACE("qore_method_private::evalPseudoMethod()");
 
@@ -3327,6 +3342,10 @@ public:
 
    DLLLOCAL static QoreValue eval(const QoreMethod& m, ExceptionSink* xsink, QoreObject* self, const QoreListNode* args, const qore_class_private* cctx = nullptr) {
       return m.priv->eval(xsink, self, args, cctx);
+   }
+
+   DLLLOCAL static QoreValue evalTmpArgs(const QoreMethod& m, ExceptionSink* xsink, QoreObject* self, QoreListNode* args, const qore_class_private* cctx = nullptr) {
+      return m.priv->evalTmpArgs(xsink, self, args, cctx);
    }
 };
 

--- a/include/qore/intern/QoreObjectIntern.h
+++ b/include/qore/intern/QoreObjectIntern.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -630,8 +630,6 @@ public:
       privateData->insert(key, pd);
       addVirtualPrivateData(key, pd);
    }
-
-   static void breakit() {}
 
    // add virtual IDs for private data to class list
    DLLLOCAL void addVirtualPrivateData(qore_classid_t key, AbstractPrivateData* apd) {

--- a/include/qore/intern/qore_thread_intern.h
+++ b/include/qore/intern/qore_thread_intern.h
@@ -6,7 +6,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -560,7 +560,7 @@ private:
    ExceptionSink* xsink;
 
 public:
-   DLLLOCAL CodeContextHelperBase(const char* code, QoreObject* obj, const qore_class_private* c, ExceptionSink* xsink);
+   DLLLOCAL CodeContextHelperBase(const char* code, QoreObject* obj, const qore_class_private* c, ExceptionSink* xsink, bool ref_obj = true);
    DLLLOCAL ~CodeContextHelperBase();
 };
 
@@ -815,8 +815,8 @@ public:
 
 class CodeContextHelper : public CodeContextHelperBase, public CallStackHelper {
 public:
-   DLLLOCAL CodeContextHelper(ExceptionSink* xs, int t, const char* c, QoreObject* obj = 0, const qore_class_private* cls = 0) :
-      CodeContextHelperBase(c, obj, cls, xs),
+   DLLLOCAL CodeContextHelper(ExceptionSink* xs, int t, const char* c, QoreObject* obj = nullptr, const qore_class_private* cls = nullptr, bool ref_obj = true) :
+      CodeContextHelperBase(c, obj, cls, xs, ref_obj),
       CallStackHelper(c, t, obj, cls, xs) {
    }
 };
@@ -824,8 +824,8 @@ public:
 #else
 class CodeContextHelper : public CodeContextHelperBase {
 public:
-   DLLLOCAL CodeContextHelper(ExceptionSink* xs, int t, const char* c, QoreObject* obj = 0, const qore_class_private* cls = 0) :
-      CodeContextHelperBase(c, obj, cls, xs) {
+   DLLLOCAL CodeContextHelper(ExceptionSink* xs, int t, const char* c, QoreObject* obj = nullptr, const qore_class_private* cls = nullptr, bool ref_obj = true) :
+      CodeContextHelperBase(c, obj, cls, xs, ref_obj) {
    }
 };
 #endif

--- a/include/qore/intern/qore_value_list_private.h
+++ b/include/qore/intern/qore_value_list_private.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -349,6 +349,9 @@ private:
 
    DLLLOCAL void evalIntern(const QoreListNode* exp);
 
+    // destructive evaluation of the list
+   DLLLOCAL void evalIntern(QoreListNode* exp);
+
    //! will create a unique list so the list can be edited
    DLLLOCAL void editIntern() {
       if (!val) {
@@ -402,6 +405,13 @@ public:
       evalIntern(exp);
    }
 
+   //! assigns a new value by executing the given list and dereference flag to this object, dereferences the old object if necessary
+   // exp is evaluated destructively in this function
+   DLLLOCAL void assignEval(QoreListNode* exp) {
+      discardIntern();
+      evalIntern(exp);
+   }
+
    //! assigns a new value and dereference flag to this object, dereferences the old object if necessary
    DLLLOCAL void assign(bool n_needs_deref, QoreValueList* n_val) {
       discardIntern();
@@ -436,6 +446,11 @@ public:
       return val ? val->size() : 0;
    }
 
+    //! returns true if the value being managed can be edited/updated
+    DLLLOCAL bool canEdit() const {
+        return !val || needs_deref || val->is_unique();
+    }
+
    //! returns a pointer to the QoreValueList object being managed
    /**
       if you need a referenced value, use getReferencedValue()
@@ -445,6 +460,16 @@ public:
 
    //! returns a pointer to the QoreValueList object being managed
    DLLLOCAL const QoreValueList* operator*() const { return val; }
+
+   //! returns a pointer to the QoreValueList object being managed
+   /**
+      if you need a referenced value, use getReferencedValue()
+      @return a pointer to the QoreValueList object being managed (or 0 if none)
+   */
+   DLLLOCAL QoreValueList* operator->() { return val; }
+
+   //! returns a pointer to the QoreValueList object being managed
+   DLLLOCAL QoreValueList* operator*() { return val; }
 
    //! returns true if a QoreValueList object pointer is being managed, false if the pointer is 0
    DLLLOCAL operator bool() const { return val != 0; }

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -943,7 +943,7 @@ int qore_class_private::initMembers(QoreObject& o, bool& need_scan, ExceptionSin
 #endif
 
    // make sure the object context is set before evaluating members
-   CodeContextHelperBase cch("constructor", &o, this, xsink);
+   CodeContextHelperBase cch("constructor", &o, this, xsink, false);
    SelfInstantiatorHelper sih(&selfid, &o);
 
    return runtimeInitMembers(o, need_scan, false, xsink);
@@ -4642,7 +4642,7 @@ void UserConstructorVariant::evalConstructor(const QoreClass &thisclass, QoreObj
    if (!uveh)
       return;
 
-   CodeContextHelper cch(xsink, CT_USER, "constructor", self, qore_class_private::get(thisclass));
+   CodeContextHelper cch(xsink, CT_USER, "constructor", self, qore_class_private::get(thisclass), false);
 
    // instantiate "self" before executing base class constructors in case base class constructor arguments reference "self"
    assert(signature.selfid);
@@ -4865,6 +4865,26 @@ QoreValue NormalMethodFunction::evalMethod(ExceptionSink* xsink, const AbstractQ
 }
 
 // if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL then it is identified at run time
+QoreValue NormalMethodFunction::evalMethodTmpArgs(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, QoreObject* self, QoreListNode* args, const qore_class_private* cctx) const {
+   const char* cname = getClassName();
+   const char* mname = getName();
+   //printd(5, "NormalMethodFunction::evalMethod() %s::%s() v: %d\n", cname, mname, self->isValid());
+
+   CodeEvaluationHelper ceh(xsink, this, variant, mname, args, self, qore_class_private::get(*qc), CT_UNUSED, false, cctx);
+   if (*xsink)
+      return QoreValue();
+
+   const MethodVariant* mv = METHV_const(variant);
+   if (mv->isAbstract()) {
+      xsink->raiseException("ABSTRACT-VARIANT-ERROR", "cannot call abstract variant %s::%s(%s) directly", cname, mname, mv->getSignature()->getSignatureText());
+      return QoreValue();
+   }
+   //printd(5, "NormalMethodFunction::evalMethod() %s::%s(%s) (self: %s) variant: %p, mv: %p priv: %d access: %d (%p %s)\n",getClassName(), mname, mv->getSignature()->getSignatureText(), self->getClass()->getName(), variant, mv, mv->isPrivate(), qore_class_private::runtimeCheckPrivateClassAccess(*mv->getClass()), runtime_get_class(), runtime_get_class() ? runtime_get_class()->name.c_str() : "n/a");
+
+   return mv->evalMethod(self, ceh, xsink);
+}
+
+// if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL then it is identified at run time
 QoreValue NormalMethodFunction::evalPseudoMethod(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, const QoreValue n, const QoreListNode* args, const qore_class_private* cctx) const {
    const char* mname = getName();
    CodeEvaluationHelper ceh(xsink, this, variant, mname, args, 0, qore_class_private::get(*qc), CT_UNUSED, false, cctx);
@@ -4876,6 +4896,16 @@ QoreValue NormalMethodFunction::evalPseudoMethod(ExceptionSink* xsink, const Abs
 
 // if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL then it is identified at run time
 QoreValue StaticMethodFunction::evalMethod(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, const QoreListNode* args, const qore_class_private* cctx) const {
+   const char* mname = getName();
+   CodeEvaluationHelper ceh(xsink, this, variant, mname, args, 0, qore_class_private::get(*qc), CT_UNUSED, false, cctx);
+   if (*xsink)
+      return QoreValue();
+
+   return METHV_const(variant)->evalMethod(0, ceh, xsink);
+}
+
+// if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL then it is identified at run time
+QoreValue StaticMethodFunction::evalMethodTmpArgs(ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, QoreListNode* args, const qore_class_private* cctx) const {
    const char* mname = getName();
    CodeEvaluationHelper ceh(xsink, this, variant, mname, args, 0, qore_class_private::get(*qc), CT_UNUSED, false, cctx);
    if (*xsink)

--- a/lib/QoreHashObjectDereferenceOperatorNode.cpp
+++ b/lib/QoreHashObjectDereferenceOperatorNode.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/lib/QoreObject.cpp
+++ b/lib/QoreObject.cpp
@@ -634,119 +634,120 @@ void qore_object_private::unsetRealReference() {
    derefRealIntern();
 }
 
+static void breakit() {}
+
 void qore_object_private::customDeref(bool real, ExceptionSink* xsink) {
+    {
+        //printd(5, "qore_object_private::customDeref() this: %p '%s' references: %d->%d (trefs: %d) status: %d has_delete_blocker: %d delete_blocker_run: %d\n", this, getClassName(), references, references - 1, tRefs.reference_count(), status, theclass->has_delete_blocker(), delete_blocker_run);
 
-   {
-      //printd(5, "qore_object_private::customDeref() this: %p '%s' references: %d->%d (trefs: %d) status: %d has_delete_blocker: %d delete_blocker_run: %d\n", this, getClassName(), references, references - 1, tRefs.reference_count(), status, theclass->has_delete_blocker(), delete_blocker_run);
+        printd(QORE_DEBUG_OBJ_REFS, "qore_object_private::customDeref() this: %p '%s': references %d->%d rrefs %d->%d\n", this, status == OS_OK ? getClassName() : "<deleted>", references.load(), references.load() - 1, rrefs, rrefs - (real ? 1 : 0));
 
-      printd(QORE_DEBUG_OBJ_REFS, "qore_object_private::customDeref() this: %p '%s': references %d->%d rrefs %d->%d\n", this, status == OS_OK ? getClassName() : "<deleted>", references.load(), references.load() - 1, rrefs, rrefs - (real ? 1 : 0));
+        robject_dereference_helper qodh(this, real);
+        int ref_copy = qodh.getRefs();
 
-      robject_dereference_helper qodh(this, real);
-      int ref_copy = qodh.getRefs();
+        // in case this is the last reference (even in recursive cases), ref_copy will remain equal to references throughout this code
+        // in other cases, the references value could change in another thread
 
-      // in case this is the last reference (even in recursive cases), ref_copy will remain equal to references throughout this code
-      // in other cases, the references value could change in another thread
+        bool rrf = false;
+        if (ref_copy) {
+            while (true) {
+                bool recalc = false;
+                {
+                    QoreSafeRSectionReadLocker sl(rml);
 
-      bool rrf = false;
-      if (ref_copy) {
-         while (true) {
-            bool recalc = false;
-            {
-               QoreSafeRSectionReadLocker sl(rml);
-
-               if (in_destructor || status != OS_OK || recursive_ref_found) {
-                  return;
-               }
-
-               // rset can be changed unless the rsection is acquired
-               sl.acquireRSection();
-
-               printd(QRO_LVL, "qore_object_private::customDeref() this: %p '%s' rset: %p (valid: %d) rcount: %d refs: %d/%d rrefs: %d (deferred: %d do_scan: %d)\n", this, getClassName(), rset, RSet::isValid(rset), rcount, ref_copy, references.load(), rrefs, deferred_scan, qodh.doScan());
-
-               int rc;
-               RSet* rs = rset;
-
-               if (!rs) {
-                  if (rcount == ref_copy) {
-                     // this must be true if we really are dealing with an object with no more valid (non-recursive) references
-                     assert(references.load() == ref_copy);
-                     rc = 1;
-                  }
-                  else {
-                     if (qodh.deferredScan()) {
-                        printd(QRO_LVL, "qore_object_private::customDeref() this: %p '%s' deferred scan set; rescanning\n", this, getClassName());
-                        rc = -1;
-                     }
-                     else {
-                        printd(QRO_LVL, "qore_object_private::customDeref() this: %p '%s' no deferred scan\n", this, getClassName());
+                    if (in_destructor || status != OS_OK || recursive_ref_found) {
                         return;
-                     }
-                  }
-               }
-               else
-                  rc = rs->canDelete(ref_copy, rcount);
+                    }
 
-               if (!rc)
-                  return;
+                    // rset can be changed unless the rsection is acquired
+                    sl.acquireRSection();
 
-               if (rc == -1) {
-                  printd(QRO_LVL, "qore_object_private::customDeref() this: %p '%s' invalid rset, recalculating\n", this, getClassName());
-                  recalc = true;
-               }
+                    printd(QRO_LVL, "qore_object_private::customDeref() this: %p '%s' rset: %p (valid: %d) rcount: %d refs: %d/%d rrefs: %d (deferred: %d do_scan: %d)\n", this, getClassName(), rset, RSet::isValid(rset), rcount, ref_copy, references.load(), rrefs, deferred_scan, qodh.doScan());
+
+                    int rc;
+                    RSet* rs = rset;
+
+                    if (!rs) {
+                        if (rcount == ref_copy) {
+                            // this must be true if we really are dealing with an object with no more valid (non-recursive) references
+                            assert(references.load() == ref_copy);
+                            rc = 1;
+                        }
+                        else {
+                            if (qodh.deferredScan()) {
+                                printd(QRO_LVL, "qore_object_private::customDeref() this: %p '%s' deferred scan set; rescanning\n", this, getClassName());
+                                rc = -1;
+                            }
+                            else {
+                                printd(QRO_LVL, "qore_object_private::customDeref() this: %p '%s' no deferred scan\n", this, getClassName());
+                                return;
+                            }
+                        }
+                    }
+                    else
+                        rc = rs->canDelete(ref_copy, rcount);
+
+                    if (!rc)
+                        return;
+
+                    if (rc == -1) {
+                        printd(QRO_LVL, "qore_object_private::customDeref() this: %p '%s' invalid rset, recalculating\n", this, getClassName());
+                        recalc = true;
+                    }
+                }
+                if (recalc) {
+                    if (qodh.doScan()) {
+                        // recalculate rset immediately
+                        RSetHelper rsh(*this);
+                        continue;
+                    }
+                    else {
+                        return;
+                    }
+                }
+
+                printd(QRO_LVL, "qore_object_private::customDeref() this: %p rcount/refs: %d/%d collecting object (%s) with only recursive references\n", this, rcount, ref_copy, getClassName());
+
+                qodh.willDelete();
+                rrf = true;
+                break;
             }
-            if (recalc) {
-               if (qodh.doScan()) {
-                  // recalculate rset immediately
-                  RSetHelper rsh(*this);
-                  continue;
-               }
-               else {
-                  return;
-               }
-            }
+        }
 
-	    printd(QRO_LVL, "qore_object_private::customDeref() this: %p rcount/refs: %d/%d collecting object (%s) with only recursive references\n", this, rcount, ref_copy, getClassName());
+        QoreSafeVarRWWriteLocker sl(rml);
 
-            qodh.willDelete();
-            rrf = true;
-            break;
-         }
-      }
+        if (rrf)
+            recursive_ref_found = true;
 
-      QoreSafeVarRWWriteLocker sl(rml);
-
-      if (rrf)
-         recursive_ref_found = true;
-
-      // if the destructor has already been run, then just run tDeref() which should delete the QoreObject
-      if (in_destructor || status != OS_OK) {
-         sl.unlock();
-         //printd(5, "qore_object_private::customDeref() this: %p obj: %p %s deleting\n", this, obj, getClassName());
-         qodh.finalDeref(this);
-         return;
-      }
-
-      // if the scope deletion is blocked, then do not run the destructor
-      if (!delete_blocker_run && theclass->has_delete_blocker()) {
-         if (theclass->execDeleteBlocker(obj, xsink)) {
-            //printd(5, "qore_object_private::customDeref() this: %p class: %s blocking delete\n", this, getClassName());
-            delete_blocker_run = true;
-            //printd(5, "Object lock %p unlocked (safe)\n", &rml);
+        // if the destructor has already been run, then just run tDeref() which should delete the QoreObject
+        if (in_destructor || status != OS_OK) {
+            sl.unlock();
+            //printd(5, "qore_object_private::customDeref() this: %p obj: %p %s deleting\n", this, obj, getClassName());
+            qodh.finalDeref(this);
             return;
-         }
-      }
+        }
 
-      in_destructor = true;
+        // if the scope deletion is blocked, then do not run the destructor
+        if (!delete_blocker_run && theclass->has_delete_blocker()) {
+            if (theclass->execDeleteBlocker(obj, xsink)) {
+                //printd(5, "qore_object_private::customDeref() this: %p class: %s blocking delete\n", this, getClassName());
+                delete_blocker_run = true;
+                //printd(5, "Object lock %p unlocked (safe)\n", &rml);
+                return;
+            }
+        }
 
-      //printd(5, "qore_object_private::customDeref() class: %s this: %p going out of scope\n", getClassName(), this);
+        in_destructor = true;
 
-      // mark status as in destructor
-      status = gettid();
+        //printd(5, "qore_object_private::customDeref() class: %s this: %p going out of scope\n", getClassName(), this);
 
-      //printd(5, "Object lock %p unlocked (safe)\n", &rml);
-   }
+        // mark status as in destructor
+        status = gettid();
 
-   doDeleteIntern(xsink);
+        //printd(5, "Object lock %p unlocked (safe)\n", &rml);
+    }
+
+    doDeleteIntern(xsink);
 }
 
 int qore_object_private::startCall(const char* mname, ExceptionSink* xsink) {
@@ -1054,6 +1055,7 @@ void QoreObject::doDelete(ExceptionSink* xsink) {
 void qore_object_private::customRefIntern(bool real) {
    if (!references.load())
       tRef();
+
    printd(QORE_DEBUG_OBJ_REFS, "qore_object_private::customRefIntern() this: %p obj: %p '%s' references %d->%d rrefs: %d->%d\n", this, obj, getClassName(), references.load(), references.load() + 1, rrefs, rrefs + (real ? 1 : 0));
    ++references;
    if (real)

--- a/lib/QoreValueList.cpp
+++ b/lib/QoreValueList.cpp
@@ -925,10 +925,37 @@ void QoreValueListEvalOptionalRefHolder::evalIntern(const QoreListNode* exp) {
    ConstListIterator li(exp);
    while (li.next()) {
       const AbstractQoreNode* v = li.getValue();
-      if (!v || v->is_value() || v->getType() == NT_REFERENCE) {
+      if (!v || v->is_value() || !v->needs_eval() || v->getType() == NT_REFERENCE || v->getType() == NT_WEAKREF) {
          QoreValue qv;
          qv.assignAndSanitize(v);
          val->push(qv.refSelf());
+         continue;
+      }
+      val->push(v->evalValue(xsink));
+      if (*xsink)
+         return;
+   }
+   assert(val->size() == exp->size());
+}
+
+// destructive argument evaluation
+void QoreValueListEvalOptionalRefHolder::evalIntern(QoreListNode* exp) {
+    assert(exp->reference_count() == 1);
+
+   if (!exp || exp->empty()) {
+      val = 0;
+      needs_deref = false;
+      return;
+   }
+   val = new QoreValueList;
+   needs_deref = true;
+
+   ListIterator li(exp);
+   while (li.next()) {
+      const AbstractQoreNode* v = li.getValue();
+      if (!v || v->is_value() || !v->needs_eval() || v->getType() == NT_REFERENCE || v->getType() == NT_WEAKREF) {
+         QoreValue qv(li.takeValue());
+         val->push(qv);
          continue;
       }
       val->push(v->evalValue(xsink));

--- a/lib/QoreValueList.cpp
+++ b/lib/QoreValueList.cpp
@@ -940,7 +940,7 @@ void QoreValueListEvalOptionalRefHolder::evalIntern(const QoreListNode* exp) {
 
 // destructive argument evaluation
 void QoreValueListEvalOptionalRefHolder::evalIntern(QoreListNode* exp) {
-    assert(exp->reference_count() == 1);
+    assert(!exp || exp->reference_count() == 1);
 
    if (!exp || exp->empty()) {
       val = 0;


### PR DESCRIPTION
…re objects' scope would be extended to the lifespan of any thread if the object were used in an argument or if a static method of the class was called from within the class itself