### PR TITLE
refs #2679 fixed a bug where a crash would result when evaluting cert…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -8,6 +8,7 @@
     Bugfix release; see details below
 
     @subsection qore_08133_bug_fixes Bug Fixes in Qore
+    - fixed a bug where a crash would result when evaluting certain expressions in the @ref background "brackground operator" due to a memory error (<a href="https://github.com/qorelanguage/qore/issues/2679">issue 2679</a>)
     - fixed a bug affecting class initialization with out of order initialization (<a href="https://github.com/qorelanguage/qore/issues/2657">issue 2657</a>)
     - fixed a bug where implicitly-declared values of complex "or nothing" types would not be declared with the correct runtime type information (<a href="https://github.com/qorelanguage/qore/issues/2652">issue 2652</a>)
     - fixed a bug in the @ref map "map operator" with complex types and empty list expressions (<a href="https://github.com/qorelanguage/qore/issues/2651">issue 2651</a>)

--- a/examples/test/qore/threads/background.qtest
+++ b/examples/test/qore/threads/background.qtest
@@ -27,6 +27,7 @@ class T {
         addTestCase("background operator tests", \basicTests());
         addTestCase("issue 1467", \issue1467());
         addTestCase("issue 2637", \issue2637());
+        addTestCase("issue 2679", \issue2679());
         set_return_value(main());
     }
 
@@ -49,6 +50,12 @@ class T {
 
     private auto issue2637_2(Counter c, hash<auto> h) {
         c.dec();
+    }
+
+    issue2679() {
+        # causes a crash with #2279
+        background (sprintf("A"),sprintf("B"));
+        assertTrue(True);
     }
 
     basicTests() {

--- a/include/qore/intern/ParseNode.h
+++ b/include/qore/intern/ParseNode.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -92,6 +92,7 @@ public:
       has_value_api = true;
    }
    DLLLOCAL ParseNode(const ParseNode& old) : SimpleQoreNode(old.type, false, old.needs_eval_flag), loc(old.loc), effect(old.effect), ref_rv(old.ref_rv), parse_init(false) {
+      has_value_api = true;
    }
    // parse types should never be copied
    DLLLOCAL virtual AbstractQoreNode* realCopy() const {


### PR DESCRIPTION
…ain expressions in the brackground operator due to a memory error