### PR TITLE
refs #2701 updated the default thread stack size to 512 KB on linux (…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -11,6 +11,8 @@
     WIP
 
     @subsection qore_09_new_features New Features in Qore
+    - the default thread stack size was changed from 8MB to 512KB resulting in a large reduction in the total
+      memory used in programs with many threads (<a href="https://github.com/qorelanguage/qore/issues/2701">issue 2701</a>)
     - new classes:
       - @ref Qore::SQL::AbstractSQLStatement "AbstractSQLStatement": has been added as the parent class defining an abstract API for @ref Qore::SQL::SQLStatement "SQLStatement"
       - @ref Qore::StreamBase "StreamBase": a base class for stream classes allowing for a controlled handoff of the stream to another thread


### PR DESCRIPTION
…from 8 MB) resulting in a large improvement in the amount of memory used for programs with many threads