### PR TITLE
Bugfix/2706 program memory

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -8,6 +8,9 @@
     WIP
 
     @subsection qore_09_compatibility Changes That Can Affect Backwards-Compatibility
+    - Qore classes and functions can no longer be modified after creation; any attempt to add a new user
+      variant to an existing function or to add new declarations to an existing class will result in a
+      parse error.
     WIP
 
     @subsection qore_09_new_features New Features in Qore

--- a/examples/test/qore/classes/Datasource/Datasource.qtest
+++ b/examples/test/qore/classes/Datasource/Datasource.qtest
@@ -13,9 +13,9 @@
 
 public class DatasourceTest inherits QUnit::Test {
     public {
-        const MyOpts = Opts + (
+        const MyOpts = Opts + {
             "connstr": "c,conn=s",
-            );
+        };
 
         const OptionColumn = 22;
     }

--- a/examples/test/qore/misc/rwlock.qtest
+++ b/examples/test/qore/misc/rwlock.qtest
@@ -10,8 +10,10 @@
 
 %requires ../../../../qlib/QUnit.qm
 
-int RWLock::methodGate(any m) {
-    return 0;
+class MyRWLock inherits RWLock {
+    int methodGate(any m) {
+        return 0;
+    }
 }
 
 %exec-class RwlockTest
@@ -22,10 +24,15 @@ public class RwlockTest inherits QUnit::Test {
         int writers = 10;
         int readers = 10;
 
-        RWLock rwl;
+        MyRWLock rwl();
         Counter readc;
         Counter writec;
-        hash o;
+        hash<auto> o = {
+            "key1": "key1",
+            "key2": "key2",
+            "key3": "key3",
+            "key4": "key4",
+        };
     }
 
     constructor() : Test("Rwlock test", "1.0") {
@@ -36,15 +43,8 @@ public class RwlockTest inherits QUnit::Test {
     }
 
     globalSetUp() {
-        rwl = new RWLock();
         readc = new Counter(readers);
         writec = new Counter(writers);
-        o = (
-            "key1" : "key1",
-            "key2" : "key2",
-            "key3" : "key3",
-            "key4" : "key4",
-        );
     }
 
     testRwlock() {

--- a/include/qore/CallReferenceNode.h
+++ b/include/qore/CallReferenceNode.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/include/qore/ModuleManager.h
+++ b/include/qore/ModuleManager.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/include/qore/QoreClass.h
+++ b/include/qore/QoreClass.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -1137,7 +1137,7 @@ private:
    class qore_class_private* priv;
 
    // private constructor only called when the class is copied
-   DLLLOCAL QoreClass(qore_classid_t id, const char* nme);
+   DLLLOCAL QoreClass(qore_class_private* priv);
 
    DLLLOCAL void insertMethod(QoreMethod* o);
    DLLLOCAL void insertStaticMethod(QoreMethod* o);

--- a/include/qore/QoreClass.h
+++ b/include/qore/QoreClass.h
@@ -94,104 +94,105 @@ class MethodVariantBase;
     @see QoreClass
  */
 class QoreMethod {
-   friend class StaticMethodCallNode;
-   friend class QoreObject;
-   friend class qore_class_private;
-   friend class qore_method_private;
-   friend class BCList;
+    friend class StaticMethodCallNode;
+    friend class QoreObject;
+    friend class qore_class_private;
+    friend class qore_method_private;
+    friend class BCList;
 
 private:
-   //! private implementation of the method
-   class qore_method_private* priv;
+    //! private implementation of the method
+    class qore_method_private* priv;
 
-   //! this function is not implemented; it is here as a private function in order to prohibit it from being used
-   DLLLOCAL QoreMethod(const QoreMethod&);
+    //! this function is not implemented; it is here as a private function in order to prohibit it from being used
+    DLLLOCAL QoreMethod(const QoreMethod&);
 
-   //! this function is not implemented; it is here as a private function in order to prohibit it from being used
-   DLLLOCAL QoreMethod& operator=(const QoreMethod&);
+    //! this function is not implemented; it is here as a private function in order to prohibit it from being used
+    DLLLOCAL QoreMethod& operator=(const QoreMethod&);
 
 public:
-   //! DEPRECATED: always returns false, do not use
-   /** this method no longer returns useful information due to method overloading
-       @return always returns false, do not use
+    //! DEPRECATED: always returns false, do not use
+    /** this method no longer returns useful information due to method overloading
+         @return always returns false, do not use
 
-       @deprecated always returns false, do not use
-   */
-   DLLEXPORT bool isSynchronized() const;
-
-   //! DEPRECATED: always returns false, do not use
-   /** this method no longer returns useful information due to method overloading
-       @return always returns false
-
-       @deprecated always returns false, do not use
-   */
-   DLLEXPORT bool newCallingConvention() const;
-
-   //! returns true if all variants of the method are user variants
-   /** @return true if all variants of the method are user variants
+        @deprecated always returns false, do not use
     */
-   DLLEXPORT bool isUser() const;
+    DLLEXPORT bool isSynchronized() const;
 
-   //! returns true if all variants of the method are builtin variants
-   /** @return true if all variants of the method are builtin variants
+    //! DEPRECATED: always returns false, do not use
+    /** this method no longer returns useful information due to method overloading
+         @return always returns false
+
+        @deprecated always returns false, do not use
     */
-   DLLEXPORT bool isBuiltin() const;
+    DLLEXPORT bool newCallingConvention() const;
 
-   //! returns true if all overloaded variants of a methods are private or class internal, false if at least one variant is public
-   /** @return true if all overloaded variants of a methods are private or class internal, false if at least one variant is public
+    //! returns true if all variants of the method are user variants
+    /** @return true if all variants of the method are user variants
+        */
+    DLLEXPORT bool isUser() const;
+
+    //! returns true if all variants of the method are builtin variants
+    /** @return true if all variants of the method are builtin variants
+        */
+    DLLEXPORT bool isBuiltin() const;
+
+    //! returns true if all overloaded variants of a methods are private or class internal, false if at least one variant is public
+    /** @return true if all overloaded variants of a methods are private or class internal, false if at least one variant is public
+        */
+    DLLEXPORT bool isPrivate() const;
+
+    //! returns the lowest access code of all variants in the method
+    DLLEXPORT ClassAccess getAccess() const;
+
+    //! returns true if the method is static
+    /**
+         @return true if the method is static
     */
-   DLLEXPORT bool isPrivate() const;
+    DLLEXPORT bool isStatic() const;
 
-   //! returns the lowest access code of all variants in the method
-   DLLEXPORT ClassAccess getAccess() const;
-
-   //! returns true if the method is static
-   /**
-      @return true if the method is static
-   */
-   DLLEXPORT bool isStatic() const;
-
-   //! returns the method's name
-   /**
-      @return the method's name
-   */
-   DLLEXPORT const char* getName() const;
-
-   //! returns the method's name
-   /**
-      @return the method's name
-   */
-   DLLEXPORT const std::string& getNameStr() const;
-
-   //! returns a pointer to the parent class
-   DLLEXPORT const QoreClass* getClass() const;
-
-   //! returns the class name for the method
-   DLLEXPORT const char* getClassName() const;
-
-   //! returns true if a variant with the given parameter signature already exists in the method
-   DLLEXPORT bool existsVariant(const type_vec_t& paramTypeInfo) const;
-
-   /* returns the return type information for the method if it is available and if
-      there is only one return type (there can be more return types if the method is
-      overloaded)
-   */
-   DLLEXPORT const QoreTypeInfo* getUniqueReturnTypeInfo() const;
-
-   //! evaluates the method and returns the value, does not reference the object for the call
-   /** @note this method should only be used when the caller can guarantee that the object will not go out of scope during the call
-
-       @since %Qore 0.8.12
+    //! returns the method's name
+    /**
+         @return the method's name
     */
-   DLLEXPORT QoreValue execManaged(QoreObject* self, const QoreListNode* args, ExceptionSink* xsink) const;
+    DLLEXPORT const char* getName() const;
 
-   DLLLOCAL QoreMethod(const QoreClass* p_class, MethodFunctionBase* n_func, bool n_static = false);
+    //! returns the method's name
+    /**
+         @return the method's name
+    */
+    DLLEXPORT const std::string& getNameStr() const;
 
-   DLLLOCAL ~QoreMethod();
-   DLLLOCAL bool inMethod(const QoreObject* self) const;
-   DLLLOCAL QoreMethod* copy(const QoreClass* p_class) const;
-   DLLLOCAL void assign_class(const QoreClass* p_class);
-   DLLLOCAL MethodFunctionBase* getFunction() const;
+    //! returns a pointer to the parent class
+    DLLEXPORT const QoreClass* getClass() const;
+
+    //! returns the class name for the method
+    DLLEXPORT const char* getClassName() const;
+
+    //! returns true if a variant with the given parameter signature already exists in the method
+    DLLEXPORT bool existsVariant(const type_vec_t& paramTypeInfo) const;
+
+    /* returns the return type information for the method if it is available and if
+        there is only one return type (there can be more return types if the method is
+        overloaded)
+    */
+    DLLEXPORT const QoreTypeInfo* getUniqueReturnTypeInfo() const;
+
+    //! evaluates the method and returns the value, does not reference the object for the call
+    /** @note this method should only be used when the caller can guarantee that the object will not go out of scope during the call
+
+        @since %Qore 0.8.12
+        */
+    DLLEXPORT QoreValue execManaged(QoreObject* self, const QoreListNode* args, ExceptionSink* xsink) const;
+
+    DLLLOCAL QoreMethod(const QoreClass* p_class, MethodFunctionBase* n_func, bool n_static = false);
+
+    DLLLOCAL bool inMethod(const QoreObject* self) const;
+    DLLLOCAL QoreMethod* copy(const QoreClass* p_class) const;
+    DLLLOCAL void assign_class(const QoreClass* p_class);
+    DLLLOCAL MethodFunctionBase* getFunction() const;
+    // non-exported destructor
+    DLLLOCAL ~QoreMethod();
 };
 
 //! an abstract class for class-specific external user data

--- a/include/qore/QoreHashNode.h
+++ b/include/qore/QoreHashNode.h
@@ -640,7 +640,7 @@ class qhi_priv;
    @code
    HashIterator hi(h);
    while (hi.next()) {
-      QoreStringValueHelper str(hi.getValue());
+      QoreStringValueHelper str(hi.get());
       printf("key: '%s', value: '%s'\n", hi.getKey(), str->getBuffer());
    }
    @endcode
@@ -736,13 +736,13 @@ public:
 
 //! reverse iterator class for QoreHashNode, to be only created on the stack
 /**
-   @code
-   ReverseHashIterator hi(h);
-   while (hi.next()) {
-   QoreStringValueHelper str(hi.getValue());
-   printf("key: '%s', value: '%s'\n", hi.getKey(), str->getBuffer());
-   }
-   @endcode
+    @code
+    ReverseHashIterator hi(h);
+    while (hi.next()) {
+        QoreStringValueHelper str(hi.get());
+        printf("key: '%s', value: '%s'\n", hi.getKey(), str->getBuffer());
+    }
+    @endcode
 */
 class ReverseHashIterator : public HashIterator {
 public:
@@ -776,13 +776,13 @@ public:
 
 //! constant iterator class for QoreHashNode, to be only created on the stack
 /**
-   @code
-   ConstHashIterator hi(h);
-   while (hi.next()) {
-   QoreStringValueHelper str(hi.getValue());
-   printf("key: '%s', value: '%s'\n", hi.getKey(), str->getBuffer());
-   }
-   @endcode
+    @code
+    ConstHashIterator hi(h);
+    while (hi.next()) {
+        QoreStringValueHelper str(hi.get());
+        printf("key: '%s', value: '%s'\n", hi.getKey(), str->getBuffer());
+    }
+    @endcode
 */
 class ConstHashIterator {
 protected:
@@ -856,13 +856,13 @@ public:
 
 //! reverse constant iterator class for QoreHashNode, to be only created on the stack
 /**
-   @code
-   ReverseConstHashIterator hi(h);
-   while (hi.next()) {
-   QoreStringValueHelper str(hi.getValue());
-   printf("key: '%s', value: '%s'\n", hi.getKey(), str->getBuffer());
-   }
-   @endcode
+    @code
+    ReverseConstHashIterator hi(h);
+    while (hi.next()) {
+        QoreStringValueHelper str(hi.get());
+        printf("key: '%s', value: '%s'\n", hi.getKey(), str->getBuffer());
+    }
+    @endcode
 */
 class ReverseConstHashIterator : public ConstHashIterator {
 public:

--- a/include/qore/QoreHashNode.h
+++ b/include/qore/QoreHashNode.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -374,6 +374,15 @@ public:
    */
    DLLEXPORT AbstractQoreNode** getKeyValuePtr(const char* key);
 
+    //! returns a reference to the value of the key (assumed to be in QCS_DEFAULT) so the value may be set or changed externally
+    /** The key hash entry is created if it does not already exist.
+         @param key the key to return the pointer to the value pointer for
+        @return a reference to the value of the key (assumed to be in QCS_DEFAULT)
+
+        @since %Qore 0.9.0
+    */
+    DLLEXPORT QoreValue& getValueRef(const char* key);
+
    //! returns a pointer to a pointer of the value of the key only if the key already exists
    /** Converts "key" to the default character encoding (QCS_DEFAULT) if necessary.
        An exception could be thrown if the character encoding conversion fails.
@@ -691,6 +700,9 @@ public:
    DLLEXPORT QoreString* getKeyString() const;
 
    //! returns the value of the current key
+   DLLEXPORT QoreValue get() const;
+
+   //! returns the value of the current key
    DLLEXPORT AbstractQoreNode* getValue() const;
 
    //! deletes the key from the hash and returns the value, caller owns the reference
@@ -711,6 +723,9 @@ public:
 
    //! returns the value of the current key with an incremented reference count
    DLLEXPORT AbstractQoreNode* getReferencedValue() const;
+
+   //! returns the value of the current key with an incremented reference count
+   DLLEXPORT QoreValue getReferenced() const;
 
    //! returns the hash
    DLLEXPORT QoreHashNode* getHash() const;
@@ -818,10 +833,16 @@ public:
    DLLEXPORT QoreString* getKeyString() const;
 
    //! returns the value of the current key
+   DLLEXPORT const QoreValue get() const;
+
+   //! returns the value of the current key
    DLLEXPORT const AbstractQoreNode* getValue() const;
 
    //! returns the value of the current key with an incremented reference count
    DLLEXPORT AbstractQoreNode* getReferencedValue() const;
+
+   //! returns the value of the current key with an incremented reference count
+   DLLEXPORT QoreValue getReferenced() const;
 
    //! returns the hash
    DLLEXPORT const QoreHashNode* getHash() const;
@@ -956,11 +977,24 @@ public:
     */
    DLLEXPORT void assign(AbstractQoreNode* v, ExceptionSink* xsink);
 
+   //! assigns a value to the hash key, dereferences any old value, assumes that the value is already referenced for the assignment
+   /** a Qore-language exception could be raised when the existing value is dereferenced
+       (i.e. if it's an object that goes out of scope and the destructor raises an
+       exception, for example)
+    */
+   DLLEXPORT void assign(QoreValue v, ExceptionSink* xsink);
+
    //! swaps the current value with the new value of the hash key, assumes that the new value is already referenced for the assignment; returns the old value
    /** could throw a Qore-language exception if there is a type error; in this case 0 is returned and the value passed for the assignment is dereferenced
 @return the old value of the hash key including its reference count (the old value is not dereferenced); the caller owns the value returned
     */
    DLLEXPORT AbstractQoreNode* swap(AbstractQoreNode* v, ExceptionSink* xsink);
+
+   //! swaps the current value with the new value of the hash key, assumes that the new value is already referenced for the assignment; returns the old value
+   /** could throw a Qore-language exception if there is a type error; in this case 0 is returned and the value passed for the assignment is dereferenced
+@return the old value of the hash key including its reference count (the old value is not dereferenced); the caller owns the value returned
+    */
+   DLLEXPORT QoreValue swap(QoreValue v, ExceptionSink* xsink);
 
    //! returns the current value of the hash key; the pointer returned is still owned by the hash
    /** @return the current value of the hash key

--- a/include/qore/QoreHashNode.h
+++ b/include/qore/QoreHashNode.h
@@ -374,15 +374,6 @@ public:
    */
    DLLEXPORT AbstractQoreNode** getKeyValuePtr(const char* key);
 
-    //! returns a reference to the value of the key (assumed to be in QCS_DEFAULT) so the value may be set or changed externally
-    /** The key hash entry is created if it does not already exist.
-         @param key the key to return the pointer to the value pointer for
-        @return a reference to the value of the key (assumed to be in QCS_DEFAULT)
-
-        @since %Qore 0.9.0
-    */
-    DLLEXPORT QoreValue& getValueRef(const char* key);
-
    //! returns a pointer to a pointer of the value of the key only if the key already exists
    /** Converts "key" to the default character encoding (QCS_DEFAULT) if necessary.
        An exception could be thrown if the character encoding conversion fails.

--- a/include/qore/QoreObject.h
+++ b/include/qore/QoreObject.h
@@ -6,7 +6,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2016 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -289,6 +289,14 @@ public:
       @return the value of the given member with the reference count incremented, the caller owns the AbstractQoreNode (reference) returned
    */
    DLLEXPORT AbstractQoreNode* getReferencedMemberNoMethod(const char* mem, ExceptionSink* xsink) const;
+
+   //! returns the value of the given member with the reference count incremented, the caller owns the AbstractQoreNode (reference) returned
+   /**
+      @param mem the name member to retrieve the value for
+      @param xsink if an error occurs, the Qore-language exception information will be added here
+      @return the value of the given member with the reference count incremented, the caller owns any reference returned
+   */
+   DLLEXPORT QoreValue getReferencedMemberValueNoMethod(const char* mem, ExceptionSink* xsink) const;
 
    //! returns the value of the given member as an int64
    /**

--- a/include/qore/QoreValue.h
+++ b/include/qore/QoreValue.h
@@ -53,454 +53,456 @@ class QoreString;
 
 //! this is the union that stores values in QoreValue
 union qore_value_u {
-   bool b;               //!< for boolean values
-   int64 i;              //!< for integer values
-   double f;             //!< for double values
-   AbstractQoreNode* n;  //!< for all heap-allocated values
+    bool b;               //!< for boolean values
+    int64 i;              //!< for integer values
+    double f;             //!< for double values
+    AbstractQoreNode* n;  //!< for all heap-allocated values
 };
 
 //! namespace for implementation details of QoreValue functions
 namespace detail {
-   //! used in QoreValue::get()
-   template<typename Type>
-   struct QoreValueCastHelper {
-      typedef Type * Result;
+    //! used in QoreValue::get()
+    template<typename Type>
+    struct QoreValueCastHelper {
+        typedef Type * Result;
 
-      template<typename QV>
-      static Result cast(QV *qv, valtype_t type) {
-         assert(type == QV_Node);
-         assert(!qv->v.n || dynamic_cast<Result>(qv->v.n));
-         return reinterpret_cast<Result>(qv->v.n);
-      }
-   };
+        template<typename QV>
+        static Result cast(QV *qv, valtype_t type) {
+            assert(type == QV_Node);
+            assert(!qv->v.n || dynamic_cast<Result>(qv->v.n));
+            return reinterpret_cast<Result>(qv->v.n);
+        }
+    };
 
-   //! used in QoreValue::get()
-   template<>
-   struct QoreValueCastHelper<bool> {
-      typedef bool Result;
+    //! used in QoreValue::get()
+    template<>
+    struct QoreValueCastHelper<bool> {
+        typedef bool Result;
 
-      template<typename QV>
-      static bool cast(QV *qv, valtype_t type) {
-         return qv->getAsBool();
-      }
-   };
+        template<typename QV>
+        static bool cast(QV *qv, valtype_t type) {
+            return qv->getAsBool();
+        }
+    };
 
-   //! used in QoreValue::get()
-   template<>
-   struct QoreValueCastHelper<double> {
-      typedef double Result;
+    //! used in QoreValue::get()
+    template<>
+    struct QoreValueCastHelper<double> {
+        typedef double Result;
 
-      template<typename QV>
-      static double cast(QV *qv, valtype_t type) {
-         return qv->getAsFloat();
-      }
-   };
+        template<typename QV>
+        static double cast(QV *qv, valtype_t type) {
+            return qv->getAsFloat();
+        }
+    };
 
-   //! used in QoreValue::get()
-   template<>
-   struct QoreValueCastHelper<int64> {
-      typedef int64 Result;
+    //! used in QoreValue::get()
+    template<>
+    struct QoreValueCastHelper<int64> {
+        typedef int64 Result;
 
-      template<typename QV>
-      static int64 cast(QV *qv, valtype_t type) {
-         return qv->getAsBigInt();
-      }
-   };
+        template<typename QV>
+        static int64 cast(QV *qv, valtype_t type) {
+            return qv->getAsBigInt();
+        }
+    };
 } // namespace detail
 
 //! The main value class in Qore, designed to be passed by value
 struct QoreValue {
-   friend class ValueHolder;
-   friend class ValueOptionalRefHolder;
-   template<typename> friend struct detail::QoreValueCastHelper;
+    friend class ValueHolder;
+    friend class ValueOptionalRefHolder;
+    template<typename> friend struct detail::QoreValueCastHelper;
 
 protected:
-   //! returns the internal AbstractQoreNode pointer, does not check that type == QV_Node, leaves the object empty
-   DLLEXPORT AbstractQoreNode* takeNodeIntern();
+    //! returns the internal AbstractQoreNode pointer, does not check that type == QV_Node, leaves the object empty
+    DLLEXPORT AbstractQoreNode* takeNodeIntern();
 
 public:
-   //! the actual value is stored here
-   qore_value_u v;
-   //! indicates the value that the union is holding
-   valtype_t type;
+    //! the actual value is stored here
+    qore_value_u v;
+    //! indicates the value that the union is holding
+    valtype_t type;
 
-   //! creates with no value (i.e. @ref QoreNothingNode)
-   DLLEXPORT QoreValue();
+    //! creates with no value (i.e. @ref QoreNothingNode)
+    DLLEXPORT QoreValue();
 
-   //! creates as a bool
-   DLLEXPORT QoreValue(bool b);
+    //! creates as a bool
+    DLLEXPORT QoreValue(bool b);
 
-   //! creates as an int
-   DLLEXPORT QoreValue(int i);
+    //! creates as an int
+    DLLEXPORT QoreValue(int i);
 
-   //! creates as an int
-   DLLEXPORT QoreValue(unsigned int i);
+    //! creates as an int
+    DLLEXPORT QoreValue(unsigned int i);
 
-   //! creates as an int
-   DLLEXPORT QoreValue(long i);
+    //! creates as an int
+    DLLEXPORT QoreValue(long i);
 
-   //! creates as an int
-   DLLEXPORT QoreValue(unsigned long i);
+    //! creates as an int
+    DLLEXPORT QoreValue(unsigned long i);
 
-   //! creates as an int
-   DLLEXPORT QoreValue(unsigned long long i);
+    //! creates as an int
+    DLLEXPORT QoreValue(unsigned long long i);
 
-   //! creates as an int
-   DLLEXPORT QoreValue(int64 i);
+    //! creates as an int
+    DLLEXPORT QoreValue(int64 i);
 
-   //! creates as a double
-   DLLEXPORT QoreValue(double f);
+    //! creates as a double
+    DLLEXPORT QoreValue(double f);
 
-   //! the QoreValue object takes the reference of the argument passed
-   DLLEXPORT QoreValue(AbstractQoreNode* n);
+    //! the QoreValue object takes the reference of the argument passed
+    DLLEXPORT QoreValue(AbstractQoreNode* n);
 
-   //! creates as the given object; does not reference n for the assignment to this object
-   /** sanitizes n (increases the reference of n if necessary), meaning that
-       if possible, the value is converted to an immediate value in place
-       (int, float, or bool)
+    //! creates as the given object; does not reference n for the assignment to this object
+    /** sanitizes n (increases the reference of n if necessary), meaning that
+         if possible, the value is converted to an immediate value in place
+        (int, float, or bool)
 
-       if getType() == QV_Node after this assignment, then the node must be referenced for the assignment
-   */
-   DLLEXPORT QoreValue(const AbstractQoreNode* n);
-
-   //! copies the value, in case type == QV_Node, no additional references are made in this function
-   DLLEXPORT QoreValue(const QoreValue& old);
-
-   //! exchanges the values
-   DLLEXPORT void swap(QoreValue& val);
-
-   //! returns the value as a bool
-   DLLEXPORT bool getAsBool() const;
-
-   //! returns the value as an int
-   DLLEXPORT int64 getAsBigInt() const;
-
-   //! returns the value as a float
-   DLLEXPORT double getAsFloat() const;
-
-   //! references the contained value if type == QV_Node
-   DLLEXPORT void ref() const;
-
-   //! references the contained value if type == QV_Node, returns itself
-   DLLEXPORT QoreValue refSelf() const;
-
-   //! returns any AbstractQoreNode value held; if type != QV_Node, returns NULL
-   DLLEXPORT AbstractQoreNode* getInternalNode();
-
-   //! returns any AbstractQoreNode value held; if type != QV_Node, returns NULL
-   DLLEXPORT const AbstractQoreNode* getInternalNode() const;
-
-   //! the QoreValue object takes the reference of the argument
-   /** @param n the new node value of the object, sets type to QV_Node
-       @return any node value held before; if type != QV_Node before the assignment, returns NULL
+        if getType() == QV_Node after this assignment, then the node must be referenced for the assignment
     */
-   DLLEXPORT AbstractQoreNode* assign(AbstractQoreNode* n);
+    DLLEXPORT QoreValue(const AbstractQoreNode* n);
 
-   //! sets the value of the object and returns any node value held previously
-   /** @param n the new value of the object
-       @return any node value held before; if type != QV_Node before the assignment, returns NULL
+    //! copies the value, in case type == QV_Node, no additional references are made in this function
+    DLLEXPORT QoreValue(const QoreValue& old);
+
+    //! exchanges the values
+    DLLEXPORT void swap(QoreValue& val);
+
+    //! returns the value as a bool
+    DLLEXPORT bool getAsBool() const;
+
+    //! returns the value as an int
+    DLLEXPORT int64 getAsBigInt() const;
+
+    //! returns the value as a float
+    DLLEXPORT double getAsFloat() const;
+
+    //! references the contained value if type == QV_Node
+    DLLEXPORT void ref() const;
+
+    //! references the contained value if type == QV_Node, returns itself
+    DLLEXPORT QoreValue refSelf() const;
+
+    //! returns any AbstractQoreNode value held; if type != QV_Node, returns NULL
+    DLLEXPORT AbstractQoreNode* getInternalNode();
+
+    //! returns any AbstractQoreNode value held; if type != QV_Node, returns NULL
+    DLLEXPORT const AbstractQoreNode* getInternalNode() const;
+
+    //! the QoreValue object takes the reference of the argument
+    /** @param n the new node value of the object, sets type to QV_Node
+         @return any node value held before; if type != QV_Node before the assignment, returns NULL
+        */
+    DLLEXPORT AbstractQoreNode* assign(AbstractQoreNode* n);
+
+    //! sets the value of the object and returns any node value held previously
+    /** @param n the new value of the object
+         @return any node value held before; if type != QV_Node before the assignment, returns NULL
     */
-   DLLEXPORT AbstractQoreNode* assignAndSanitize(const QoreValue n);
+    DLLEXPORT AbstractQoreNode* assignAndSanitize(const QoreValue n);
 
-   //! sets the value of the object and returns any node value held previously
-   /** @param n the new value of the object; sets type to QV_Int
-       @return any node value held before; if type != QV_Node before the assignment, returns NULL
+    //! sets the value of the object and returns any node value held previously
+    /** @param n the new value of the object; sets type to QV_Int
+         @return any node value held before; if type != QV_Node before the assignment, returns NULL
     */
-   DLLEXPORT AbstractQoreNode* assign(int64 n);
+    DLLEXPORT AbstractQoreNode* assign(int64 n);
 
-   //! sets the value of the object and returns any node value held previously
-   /** @param n the new value of the object; sets type to QV_Float
-       @return any node value held before; if type != QV_Node before the assignment, returns NULL
+    //! sets the value of the object and returns any node value held previously
+    /** @param n the new value of the object; sets type to QV_Float
+        @return any node value held before; if type != QV_Node before the assignment, returns NULL
     */
-   DLLEXPORT AbstractQoreNode* assign(double n);
+    DLLEXPORT AbstractQoreNode* assign(double n);
 
-   //! sets the value of the object and returns any node value held previously
-   /** @param n the new value of the object; sets type to QV_Bool
-       @return any node value held before; if type != QV_Node before the assignment, returns NULL
+    //! sets the value of the object and returns any node value held previously
+    /** @param n the new value of the object; sets type to QV_Bool
+        @return any node value held before; if type != QV_Node before the assignment, returns NULL
     */
-   DLLEXPORT AbstractQoreNode* assign(bool n);
+    DLLEXPORT AbstractQoreNode* assign(bool n);
 
-   //! sets the value of the object to @ref QoreNothingNode and returns any node value held previously
-   /** sets type to QV_Node
+    //! sets the value of the object to @ref QoreNothingNode and returns any node value held previously
+    /** sets type to QV_Node
 
-       @return any node value held before; if type != QV_Node before the assignment, returns NULL
+        @return any node value held before; if type != QV_Node before the assignment, returns NULL
     */
-   DLLEXPORT AbstractQoreNode* assignNothing();
+    DLLEXPORT AbstractQoreNode* assignNothing();
 
-   //! returns trus if the argument value is equal to the current value with type conversions
-   DLLEXPORT bool isEqualSoft(const QoreValue v, ExceptionSink* xsink) const;
+    //! returns trus if the argument value is equal to the current value with type conversions
+    DLLEXPORT bool isEqualSoft(const QoreValue v, ExceptionSink* xsink) const;
 
-   //! returns trus if the argument value is equal to the current value without any type conversions
-   DLLEXPORT bool isEqualHard(const QoreValue v) const;
+    //! returns trus if the argument value is equal to the current value without any type conversions
+    DLLEXPORT bool isEqualHard(const QoreValue v) const;
 
-   //! converts any node pointers to efficient representations if possible and dereferences the node value contained
-   DLLEXPORT void sanitize();
+    //! converts any node pointers to efficient representations if possible and dereferences the node value contained
+    DLLEXPORT void sanitize();
 
-   //! assigns a new value
-   DLLEXPORT QoreValue& operator=(const QoreValue& n);
+    //! assigns a new value
+    DLLEXPORT QoreValue& operator=(const QoreValue& n);
 
-   //! dereferences any contained AbstractQoreNode pointer and sets to 0; does not modify other values
-   DLLEXPORT void discard(ExceptionSink* xsink);
+    //! dereferences any contained AbstractQoreNode pointer and sets to 0; does not modify other values
+    DLLEXPORT void discard(ExceptionSink* xsink);
 
-   //! unconditionally set the QoreValue to @ref QoreNothingNode (does not dereference any possible contained AbstractQoreNode ptr)
-   DLLEXPORT void clear();
+    //! unconditionally set the QoreValue to @ref QoreNothingNode (does not dereference any possible contained AbstractQoreNode ptr)
+    DLLEXPORT void clear();
 
-   //! appends the string value of the contained node to the string argument with optional formatting
-   DLLEXPORT int getAsString(QoreString& str, int format_offset, ExceptionSink *xsink) const;
+    //! appends the string value of the contained node to the string argument with optional formatting
+    DLLEXPORT int getAsString(QoreString& str, int format_offset, ExceptionSink *xsink) const;
 
-   //! returns the string value with optional formatting of the contained node
-   DLLEXPORT QoreString* getAsString(bool& del, int foff, ExceptionSink* xsink) const;
+    //! returns the string value with optional formatting of the contained node
+    DLLEXPORT QoreString* getAsString(bool& del, int foff, ExceptionSink* xsink) const;
 
-   //! returns a pointer to an object of the given class; takes the pointer from the object; the caller owns the reference returned
-   /** will assert() in debug mode if the object does not contain a value of the requested type or if type != QV_Node
+    //! returns a pointer to an object of the given class; takes the pointer from the object; the caller owns the reference returned
+    /** will assert() in debug mode if the object does not contain a value of the requested type or if type != QV_Node
     */
-   template<typename T>
-   DLLLOCAL T* take() {
-      assert(type == QV_Node);
-      assert(dynamic_cast<T*>(v.n));
-      T* rv = reinterpret_cast<T*>(v.n);
-      v.n = 0;
-      return rv;
-   }
+    template<typename T>
+    DLLLOCAL T* take() {
+        assert(type == QV_Node);
+        assert(dynamic_cast<T*>(v.n));
+        T* rv = reinterpret_cast<T*>(v.n);
+        v.n = 0;
+        return rv;
+    }
 
-   //! returns the value as the given type
-   /** @note that if a pointer type is given and the object does not contain a node (i.e. type != QV_Node), then this call will cause a segfault, however it is always legal to cast to simple types (int64, bool, float), in which case type conversions are performed
+    //! returns the value as the given type
+    /** @note that if a pointer type is given and the object does not contain a node (i.e. type != QV_Node), then
+        this call will cause a segfault, however it is always legal to cast to simple types (int64, bool, float), in which case type conversions are performed
     */
-   template<typename T>
-   DLLLOCAL typename detail::QoreValueCastHelper<T>::Result get() {
-      return detail::QoreValueCastHelper<T>::cast(this, type);
-   }
+    template<typename T>
+    DLLLOCAL typename detail::QoreValueCastHelper<T>::Result get() {
+        return detail::QoreValueCastHelper<T>::cast(this, type);
+    }
 
-   //! returns the value as the given type
-   /** @note that if a pointer type is given and the object does not contain a node (i.e. type != QV_Node), then this call will cause a segfault, however it is always legal to cast to simple types (int64, bool, float), in which case type conversions are performed
+    //! returns the value as the given type
+    /** @note that if a pointer type is given and the object does not contain a node (i.e. type != QV_Node), then
+        this call will cause a segfault, however it is always legal to cast to simple types (int64, bool, float), in which case type conversions are performed
     */
-   template<typename T>
-   DLLLOCAL typename detail::QoreValueCastHelper<const T>::Result get() const {
-      return detail::QoreValueCastHelper<const T>::cast(this, type);
-   }
+    template<typename T>
+    DLLLOCAL typename detail::QoreValueCastHelper<const T>::Result get() const {
+        return detail::QoreValueCastHelper<const T>::cast(this, type);
+    }
 
-   //! returns a referenced AbstractQoreNode pointer; leaving the "this" untouched; the caller owns the reference returned
-   DLLEXPORT AbstractQoreNode* getReferencedValue() const;
+    //! returns a referenced AbstractQoreNode pointer; leaving the "this" untouched; the caller owns the reference returned
+    DLLEXPORT AbstractQoreNode* getReferencedValue() const;
 
-   //! returns a referenced AbstractQoreNode pointer leaving "this" empty (value is taken from "this"); the caller owns the reference returned
-   DLLEXPORT AbstractQoreNode* takeNode();
+    //! returns a referenced AbstractQoreNode pointer leaving "this" empty (value is taken from "this"); the caller owns the reference returned
+    DLLEXPORT AbstractQoreNode* takeNode();
 
-   //! returns a referenced AbstractQoreNode pointer only if the contained value is an AbstractQoreNode pointer, in which case "this" is left empty (the value is taken from "this"); returns 0 if the object does not contain an AbstractQoreNode pointer (type != QV_Node)
-   DLLEXPORT AbstractQoreNode* takeIfNode();
+    //! returns a referenced AbstractQoreNode pointer only if the contained value is an AbstractQoreNode pointer, in which case "this" is left empty (the value is taken from "this"); returns 0 if the object does not contain an AbstractQoreNode pointer (type != QV_Node)
+    DLLEXPORT AbstractQoreNode* takeIfNode();
 
-   //! returns the type of the value
-   /** @since %Qore 0.8.13
-   */
-   DLLEXPORT const QoreTypeInfo* getTypeInfo() const;
+    //! returns the type of the value
+    /** @since %Qore 0.8.13
+    */
+    DLLEXPORT const QoreTypeInfo* getTypeInfo() const;
 
-   //! returns the type of value contained
-   DLLEXPORT qore_type_t getType() const;
+    //! returns the type of value contained
+    DLLEXPORT qore_type_t getType() const;
 
-   //! returns a string type description of the value contained (ex: \c "nothing" for a null AbstractQoreNode pointer)
-   DLLEXPORT const char* getTypeName() const;
+    //! returns a string type description of the value contained (ex: \c "nothing" for a null AbstractQoreNode pointer)
+    DLLEXPORT const char* getTypeName() const;
 
-   //! returns a string type description of the full type of the value contained (ex: \c "nothing" for a null AbstractQoreNode pointer); differs from the return value of getTypeName() for complex types (ex: \c "hash<string, int>")
-   DLLEXPORT const char* getFullTypeName() const;
+    //! returns a string type description of the full type of the value contained (ex: \c "nothing" for a null AbstractQoreNode pointer); differs from the return value of getTypeName() for complex types (ex: \c "hash<string, int>")
+    DLLEXPORT const char* getFullTypeName() const;
 
-   //! returns true if the object contains a non-null AbstractQoreNode pointer (ie type == QV_Node && v.n is not 0)
-   DLLEXPORT bool hasNode() const;
+    //! returns true if the object contains a non-null AbstractQoreNode pointer (ie type == QV_Node && v.n is not 0)
+    DLLEXPORT bool hasNode() const;
 
-   //! returns true if the object contains NOTHING
-   DLLEXPORT bool isNothing() const;
+    //! returns true if the object contains NOTHING
+    DLLEXPORT bool isNothing() const;
 
-   //! returns true if the object contains NULL
-   DLLEXPORT bool isNull() const;
+    //! returns true if the object contains NULL
+    DLLEXPORT bool isNull() const;
 
-   //! returns true if the object contains NOTHING or NULL
-   DLLEXPORT bool isNullOrNothing() const;
+    //! returns true if the object contains NOTHING or NULL
+    DLLEXPORT bool isNullOrNothing() const;
 };
 
 //! base class for holding a QoreValue object
 class ValueHolderBase {
 protected:
-   //! the vlaue held
-   QoreValue v;
-   //! for possible Qore-language exceptions
-   ExceptionSink* xsink;
+    //! the vlaue held
+    QoreValue v;
+    //! for possible Qore-language exceptions
+    ExceptionSink* xsink;
 
 public:
-   //! creates an ampty object
-   DLLLOCAL ValueHolderBase(ExceptionSink* xs) : xsink(xs) {
-   }
+    //! creates an ampty object
+    DLLLOCAL ValueHolderBase(ExceptionSink* xs) : xsink(xs) {
+    }
 
-   //! creates the object with the given value
-   DLLLOCAL ValueHolderBase(QoreValue n_v, ExceptionSink* xs) : v(n_v), xsink(xs) {
-   }
+    //! creates the object with the given value
+    DLLLOCAL ValueHolderBase(QoreValue n_v, ExceptionSink* xs) : v(n_v), xsink(xs) {
+    }
 
-   //! returns the value being managed
-   DLLLOCAL QoreValue* operator->() { return &v; }
+    //! returns the value being managed
+    DLLLOCAL QoreValue* operator->() { return &v; }
 
-   //! returns the value being managed
-   DLLLOCAL QoreValue& operator*() { return v; }
+    //! returns the value being managed
+    DLLLOCAL QoreValue& operator*() { return v; }
 };
 
 //! holds an object and dereferences it in the destructor
 class ValueHolder : public ValueHolderBase {
 public:
-   //! creates an empty object
-   DLLLOCAL ValueHolder(ExceptionSink* xs) : ValueHolderBase(xs) {
-   }
+    //! creates an empty object
+    DLLLOCAL ValueHolder(ExceptionSink* xs) : ValueHolderBase(xs) {
+    }
 
-   //! creates the object with the given value
-   DLLLOCAL ValueHolder(QoreValue n_v, ExceptionSink* xs) : ValueHolderBase(n_v, xs) {
-   }
+    //! creates the object with the given value
+    DLLLOCAL ValueHolder(QoreValue n_v, ExceptionSink* xs) : ValueHolderBase(n_v, xs) {
+    }
 
-   //! dereferences any contained node
-   DLLEXPORT ~ValueHolder();
+    //! dereferences any contained node
+    DLLEXPORT ~ValueHolder();
 
-   //! returns a referenced AbstractQoreNode ptr; caller owns the reference; the current object is left empty
-   DLLEXPORT AbstractQoreNode* getReferencedValue();
+    //! returns a referenced AbstractQoreNode ptr; caller owns the reference; the current object is left empty
+    DLLEXPORT AbstractQoreNode* getReferencedValue();
 
-   //! returns a QoreValue object and leaves the current object empty; the caller owns any reference contained in the return value
-   DLLEXPORT QoreValue release();
+    //! returns a QoreValue object and leaves the current object empty; the caller owns any reference contained in the return value
+    DLLEXPORT QoreValue release();
 
-   //! assigns the object, any currently-held value is dereferenced before the assignment
-   DLLLOCAL QoreValue& operator=(QoreValue nv) {
-      v.discard(xsink);
-      v = nv;
-      return v;
-   }
+    //! assigns the object, any currently-held value is dereferenced before the assignment
+    DLLLOCAL QoreValue& operator=(QoreValue nv) {
+        v.discard(xsink);
+        v = nv;
+        return v;
+    }
 
-   //! returns true if holding an AbstractQoreNode reference
-   DLLLOCAL operator bool() const {
-      return v.type == QV_Node && v.v.n;
-   }
+    //! returns true if holding an AbstractQoreNode reference
+    DLLLOCAL operator bool() const {
+        return v.type == QV_Node && v.v.n;
+    }
 };
 
 //! allows storing a value and setting a boolean flag that indicates if the value should be dereference in the destructor or not
 class ValueOptionalRefHolder : public ValueHolderBase {
 private:
-   // not implemented
-   DLLLOCAL QoreValue& operator=(QoreValue& nv);
+    // not implemented
+    DLLLOCAL QoreValue& operator=(QoreValue& nv);
 
 protected:
-   //! flag indicating if the value should be dereferenced in the destructor or not
-   bool needs_deref;
+    //! flag indicating if the value should be dereferenced in the destructor or not
+    bool needs_deref;
 
 public:
-   //! creates the object with the given values
-   DLLLOCAL ValueOptionalRefHolder(QoreValue n_v, bool nd, ExceptionSink* xs) : ValueHolderBase(n_v, xs), needs_deref(nd) {
-   }
+    //! creates the object with the given values
+    DLLLOCAL ValueOptionalRefHolder(QoreValue n_v, bool nd, ExceptionSink* xs) : ValueHolderBase(n_v, xs), needs_deref(nd) {
+    }
 
-   //! creates an empty object
-   DLLLOCAL ValueOptionalRefHolder(ExceptionSink* xs) : ValueHolderBase(xs), needs_deref(false) {
-   }
+    //! creates an empty object
+    DLLLOCAL ValueOptionalRefHolder(ExceptionSink* xs) : ValueHolderBase(xs), needs_deref(false) {
+    }
 
-   DLLEXPORT ~ValueOptionalRefHolder();
+    DLLEXPORT ~ValueOptionalRefHolder();
 
-   //! returns true if the value is temporary (needs dereferencing)
-   DLLLOCAL bool isTemp() const { return needs_deref; }
+    //! returns true if the value is temporary (needs dereferencing)
+    DLLLOCAL bool isTemp() const { return needs_deref; }
 
-   //! sets needs_deref = false
-   DLLLOCAL void clearTemp() {
-      if (needs_deref)
-         needs_deref = false;
-   }
+    //! sets needs_deref = false
+    DLLLOCAL void clearTemp() {
+        if (needs_deref)
+            needs_deref = false;
+    }
 
-   //! returns true if holding an AbstractQoreNode reference
-   DLLLOCAL operator bool() const {
-      return v.type == QV_Node && v.v.n;
-   }
+    //! returns true if holding an AbstractQoreNode reference
+    DLLLOCAL operator bool() const {
+        return v.type == QV_Node && v.v.n;
+    }
 
-   //! assigns a new non-temporary value
-   DLLLOCAL void setValue(QoreValue nv) {
-      if (needs_deref) {
-         v.discard(xsink);
-         needs_deref = false;
-      }
-      v = nv;
-   }
+    //! assigns a new non-temporary value
+    DLLLOCAL void setValue(QoreValue nv) {
+        if (needs_deref) {
+            v.discard(xsink);
+            needs_deref = false;
+        }
+        v = nv;
+    }
 
-   //! assigns a new value
-   DLLLOCAL void setValue(QoreValue nv, bool temp) {
-      if (needs_deref)
-         v.discard(xsink);
-      if (needs_deref != temp)
-         needs_deref = temp;
-      v = nv;
-   }
+    //! assigns a new value
+    DLLLOCAL void setValue(QoreValue nv, bool temp) {
+        if (needs_deref)
+            v.discard(xsink);
+        if (needs_deref != temp)
+            needs_deref = temp;
+        v = nv;
+    }
 
-   // ensures that the held value is referenced
-   /** if needs_deref is false and an AbstractQoreNode* is contained, then the value is referenced and needs_deref is set to true
+    // ensures that the held value is referenced
+    /** if needs_deref is false and an AbstractQoreNode* is contained, then the value is referenced and needs_deref is set to true
     */
-   DLLEXPORT void ensureReferencedValue();
+    DLLEXPORT void ensureReferencedValue();
 
-   //! returns the stored node value and leaves the current object empty
-   template<typename T>
-   DLLLOCAL T* takeReferencedNode() {
-      T* rv = v.take<T>();
-      if (needs_deref)
-         needs_deref = false;
-      else
-         rv->ref();
+    //! returns the stored node value and leaves the current object empty
+    template<typename T>
+    DLLLOCAL T* takeReferencedNode() {
+        T* rv = v.take<T>();
+        if (needs_deref)
+            needs_deref = false;
+        else
+            rv->ref();
 
-      return rv;
-   }
+        return rv;
+    }
 
-   //! returns a referenced AbstractQoreNode ptr; caller owns the reference; the current object is left empty
-   DLLEXPORT AbstractQoreNode* getReferencedValue();
+    //! returns a referenced AbstractQoreNode ptr; caller owns the reference; the current object is left empty
+    DLLEXPORT AbstractQoreNode* getReferencedValue();
 
-   //! returns the stored AbstractQoreNode pointer and sets the dereference flag as an output variable
-   DLLLOCAL AbstractQoreNode* takeNode(bool& nd) {
-      if (v.type == QV_Node) {
-         nd = needs_deref;
-         return v.takeNodeIntern();
-      }
-      nd = true;
-      return v.takeNode();
-   }
+    //! returns the stored AbstractQoreNode pointer and sets the dereference flag as an output variable
+    DLLLOCAL AbstractQoreNode* takeNode(bool& nd) {
+        if (v.type == QV_Node) {
+            nd = needs_deref;
+            return v.takeNodeIntern();
+        }
+        nd = true;
+        return v.takeNode();
+    }
 
-   //! returns the stored value and sets the dereference flag as an output variable
-   DLLLOCAL QoreValue takeValue(bool& nd) {
-      if (v.type == QV_Node) {
-         nd = needs_deref;
-	 return v.takeNodeIntern();
-      }
-      nd = false;
-      return v;
-   }
+    //! returns the stored value and sets the dereference flag as an output variable
+    DLLLOCAL QoreValue takeValue(bool& nd) {
+        if (v.type == QV_Node) {
+            nd = needs_deref;
+            return v.takeNodeIntern();
+        }
+        nd = false;
+        return v;
+    }
 
-   //! returns the stored value which must be dereferenced if it is a node object (i.e. type == QV_Node)
-   DLLLOCAL void takeValueFrom(ValueOptionalRefHolder& val) {
-      if (needs_deref)
-         v.discard(xsink);
-      v = val.takeValue(needs_deref);
-   }
+    //! returns the stored value which must be dereferenced if it is a node object (i.e. type == QV_Node)
+    DLLLOCAL void takeValueFrom(ValueOptionalRefHolder& val) {
+        if (needs_deref)
+            v.discard(xsink);
+        v = val.takeValue(needs_deref);
+    }
 
-   //! returns a QoreValue after incrementing the reference count of any node value stored
-   DLLEXPORT QoreValue takeReferencedValue();
+    //! returns a QoreValue after incrementing the reference count of any node value stored
+    DLLEXPORT QoreValue takeReferencedValue();
 
-   // FIXME: remove with new API/ABI
-   //! converts pointers to efficient representations and manages the reference count
-   DLLEXPORT void sanitize();
+    // FIXME: remove with new API/ABI
+    //! converts pointers to efficient representations and manages the reference count
+    DLLEXPORT void sanitize();
 };
 
 //! evaluates an AbstractQoreNode and dereferences the stored value in the destructor
 class ValueEvalRefHolder : public ValueOptionalRefHolder {
 public:
-   //! evaluates the AbstractQoreNode argument
-   DLLEXPORT ValueEvalRefHolder(const AbstractQoreNode* exp, ExceptionSink* xs);
+    //! evaluates the AbstractQoreNode argument
+    DLLEXPORT ValueEvalRefHolder(const AbstractQoreNode* exp, ExceptionSink* xs);
 
-   //! creates the object with with no evaluation
-   /** @since %Qore 0.8.13.1
-   */
-   DLLEXPORT ValueEvalRefHolder(ExceptionSink* xs);
+    //! creates the object with with no evaluation
+    /** @since %Qore 0.8.13.1
+     */
+    DLLEXPORT ValueEvalRefHolder(ExceptionSink* xs);
 
-   //! evaluates the argument, returns -1 for error, 0 = OK
-   /** @since %Qore 0.8.13.1
-   */
-   DLLEXPORT int eval(const AbstractQoreNode* exp);
+    //! evaluates the argument, returns -1 for error, 0 = OK
+    /** @since %Qore 0.8.13.1
+     */
+    DLLEXPORT int eval(const AbstractQoreNode* exp);
 
 protected:
-   //! evaluates the argument, returns -1 for error, 0 = OK
-   /** @since %Qore 0.8.13.1
-   */
-   DLLLOCAL void evalIntern(const AbstractQoreNode* exp);
+    //! evaluates the argument, returns -1 for error, 0 = OK
+    /** @since %Qore 0.8.13.1
+     */
+    DLLLOCAL void evalIntern(const AbstractQoreNode* exp);
 };
 
 #endif

--- a/include/qore/intern/CallReferenceNode.h
+++ b/include/qore/intern/CallReferenceNode.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/include/qore/intern/ConstantList.h
+++ b/include/qore/intern/ConstantList.h
@@ -176,7 +176,7 @@ public:
     }
 
 protected:
-    AbstractQoreNode* saved_node;
+    AbstractQoreNode* saved_node = nullptr;
     ClassAccess access;
 
     DLLLOCAL int scanValue(const QoreValue& n) const;

--- a/include/qore/intern/ConstantList.h
+++ b/include/qore/intern/ConstantList.h
@@ -242,13 +242,6 @@ public:
 
     DLLLOCAL ConstantEntry* findEntry(const char* name);
 
-    DLLLOCAL AbstractQoreNode* parseFind(const char* name, const QoreTypeInfo*& constantTypeInfo, ClassAccess& access);
-
-    DLLLOCAL AbstractQoreNode* parseFind(const char* name, const QoreTypeInfo*& constantTypeInfo) {
-        ClassAccess access;
-        return parseFind(name, constantTypeInfo, access);
-    }
-
     DLLLOCAL AbstractQoreNode* find(const char* name, const QoreTypeInfo*& constantTypeInfo, ClassAccess& access);
 
     DLLLOCAL AbstractQoreNode* find(const char* name, const QoreTypeInfo*& constantTypeInfo) {

--- a/include/qore/intern/ConstantList.h
+++ b/include/qore/intern/ConstantList.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   constants can only be defined when parsing
   constants values will be substituted during the 2nd parse phase
@@ -211,214 +211,214 @@ typedef std::map<const char*, ConstantEntry*, ltstr> cnemap_t;
 #endif
 
 class ConstantList {
-   friend class ConstantListIterator;
-   friend class ConstConstantListIterator;
+    friend class ConstantListIterator;
+    friend class ConstConstantListIterator;
 
 private:
-   // not implemented
-   DLLLOCAL ConstantList& operator=(const ConstantList&);
+    // not implemented
+    DLLLOCAL ConstantList& operator=(const ConstantList&);
 
-   DLLLOCAL void clearIntern(ExceptionSink* xsink);
+    DLLLOCAL void clearIntern(ExceptionSink* xsink);
 
 protected:
-   // the object that owns the list (either a class or a namespace)
-   ClassNs ptr;
+    // the object that owns the list (either a class or a namespace)
+    ClassNs ptr;
 
 public:
-   cnemap_t cnemap;
+    cnemap_t cnemap;
 
-   DLLLOCAL ~ConstantList();
+    DLLLOCAL ~ConstantList();
 
-   DLLLOCAL ConstantList(ClassNs p) : ptr(p) {
-      //printd(5, "ConstantList::ConstantList() this: %p cls: %p ns: %p\n", this, ptr.getClass(), ptr.getNs());
-   }
+    DLLLOCAL ConstantList(ClassNs p) : ptr(p) {
+        //printd(5, "ConstantList::ConstantList() this: %p cls: %p ns: %p\n", this, ptr.getClass(), ptr.getNs());
+    }
 
-   DLLLOCAL ConstantList(const ConstantList& old, int64 po, ClassNs p);
+    DLLLOCAL ConstantList(const ConstantList& old, int64 po, ClassNs p);
 
-   // do not delete the object returned by this function
-   DLLLOCAL cnemap_t::iterator add(const char* name, AbstractQoreNode* val, const QoreTypeInfo* typeInfo = nullptr, ClassAccess access = Public);
+    // do not delete the object returned by this function
+    DLLLOCAL cnemap_t::iterator add(const char* name, AbstractQoreNode* val, const QoreTypeInfo* typeInfo = nullptr, ClassAccess access = Public);
 
-   DLLLOCAL cnemap_t::iterator parseAdd(const QoreProgramLocation& loc, const char* name, AbstractQoreNode* val, const QoreTypeInfo* typeInfo = nullptr, bool pub = false, ClassAccess access = Public);
+    DLLLOCAL cnemap_t::iterator parseAdd(const QoreProgramLocation& loc, const char* name, AbstractQoreNode* val, const QoreTypeInfo* typeInfo = nullptr, bool pub = false, ClassAccess access = Public);
 
-   DLLLOCAL ConstantEntry* findEntry(const char* name);
+    DLLLOCAL ConstantEntry* findEntry(const char* name);
 
-   DLLLOCAL AbstractQoreNode* parseFind(const char* name, const QoreTypeInfo*& constantTypeInfo, ClassAccess& access);
+    DLLLOCAL AbstractQoreNode* parseFind(const char* name, const QoreTypeInfo*& constantTypeInfo, ClassAccess& access);
 
-   DLLLOCAL AbstractQoreNode* parseFind(const char* name, const QoreTypeInfo*& constantTypeInfo) {
-      ClassAccess access;
-      return parseFind(name, constantTypeInfo, access);
-   }
+    DLLLOCAL AbstractQoreNode* parseFind(const char* name, const QoreTypeInfo*& constantTypeInfo) {
+        ClassAccess access;
+        return parseFind(name, constantTypeInfo, access);
+    }
 
-   DLLLOCAL AbstractQoreNode* find(const char* name, const QoreTypeInfo*& constantTypeInfo, ClassAccess& access);
+    DLLLOCAL AbstractQoreNode* find(const char* name, const QoreTypeInfo*& constantTypeInfo, ClassAccess& access);
 
-   DLLLOCAL AbstractQoreNode* find(const char* name, const QoreTypeInfo*& constantTypeInfo) {
-      ClassAccess access;
-      return find(name, constantTypeInfo, access);
-   }
+    DLLLOCAL AbstractQoreNode* find(const char* name, const QoreTypeInfo*& constantTypeInfo) {
+        ClassAccess access;
+        return find(name, constantTypeInfo, access);
+    }
 
-   DLLLOCAL bool inList(const char* name) const;
-   DLLLOCAL bool inList(const std::string& name) const;
-   //DLLLOCAL ConstantList *copy();
+    DLLLOCAL bool inList(const char* name) const;
+    DLLLOCAL bool inList(const std::string& name) const;
+    //DLLLOCAL ConstantList *copy();
 
-   // assimilate the list without any duplicate checking
-   DLLLOCAL void assimilate(ConstantList& n);
+    // assimilate the list without any duplicate checking
+    DLLLOCAL void assimilate(ConstantList& n);
 
-   // assimilate a constant list in a namespace with duplicate checking (also in pending list)
-   DLLLOCAL void assimilate(ConstantList& n, ConstantList& otherlist, const char* type, const char* name);
+    // assimilate a constant list in a namespace with duplicate checking (also in pending list)
+    DLLLOCAL void assimilate(ConstantList& n, const char* type, const char* name, const ConstantList* other = nullptr);
 
-   // copy all user/public elements of the source list to the target, assuming no duplicates
-   DLLLOCAL void mergeUserPublic(const ConstantList& src);
+    // copy all user/public elements of the source list to the target, assuming no duplicates
+    DLLLOCAL void mergeUserPublic(const ConstantList& src);
 
-   DLLLOCAL int importSystemConstants(const ConstantList& src, ExceptionSink* xsink);
+    DLLLOCAL int importSystemConstants(const ConstantList& src, ExceptionSink* xsink);
 
-   // add a constant to a list with duplicate checking (pub & priv + pending)
-   DLLLOCAL void parseAdd(const QoreProgramLocation& loc, const std::string& name, AbstractQoreNode* val, ConstantList& committed, ClassAccess access, const char* cname);
+    // add a constant to a list with duplicate checking (pub & priv + pending)
+    DLLLOCAL void parseAdd(const QoreProgramLocation& loc, const std::string& name, AbstractQoreNode* val, ClassAccess access, const char* cname);
 
-   DLLLOCAL void parseInit();
-   DLLLOCAL QoreHashNode* getInfo();
-   DLLLOCAL void parseDeleteAll();
-   DLLLOCAL void clear(QoreListNode& l);
-   DLLLOCAL void deleteAll(ExceptionSink* xsink);
-   DLLLOCAL void reset();
+    DLLLOCAL void parseInit();
+    DLLLOCAL QoreHashNode* getInfo();
+    DLLLOCAL void parseDeleteAll();
+    DLLLOCAL void clear(QoreListNode& l);
+    DLLLOCAL void deleteAll(ExceptionSink* xsink);
+    DLLLOCAL void reset();
 
-   DLLLOCAL bool empty() const {
-      return cnemap.empty();
-   }
+    DLLLOCAL bool empty() const {
+        return cnemap.empty();
+    }
 
-   DLLLOCAL cnemap_t::iterator end() {
-      return cnemap.end();
-   }
+    DLLLOCAL cnemap_t::iterator end() {
+        return cnemap.end();
+    }
 
-   DLLLOCAL cnemap_t::const_iterator end() const {
-      return cnemap.end();
-   }
+    DLLLOCAL cnemap_t::const_iterator end() const {
+        return cnemap.end();
+    }
 
-   DLLLOCAL void setAccess(ClassAccess access) {
-      for (auto& i : cnemap)
-         i.second->access = access;
-   }
+    DLLLOCAL void setAccess(ClassAccess access) {
+        for (auto& i : cnemap)
+            i.second->access = access;
+    }
 };
 
 class ConstantListIterator {
 protected:
-   cnemap_t& cl;
-   cnemap_t::iterator i;
+    cnemap_t& cl;
+    cnemap_t::iterator i;
 
 public:
-   DLLLOCAL ConstantListIterator(ConstantList& n_cl) : cl(n_cl.cnemap), i(cl.end()) {
-   }
+    DLLLOCAL ConstantListIterator(ConstantList& n_cl) : cl(n_cl.cnemap), i(cl.end()) {
+    }
 
-   DLLLOCAL bool next() {
-      if (i == cl.end())
-         i = cl.begin();
-      else
-         ++i;
-      return i != cl.end();
-   }
+    DLLLOCAL bool next() {
+        if (i == cl.end())
+            i = cl.begin();
+        else
+            ++i;
+        return i != cl.end();
+    }
 
-   DLLLOCAL const std::string& getName() const {
-      return i->second->getNameStr();
-   }
+    DLLLOCAL const std::string& getName() const {
+        return i->second->getNameStr();
+    }
 
-   DLLLOCAL AbstractQoreNode* getValue() const {
-      return i->second->node;
-   }
+    DLLLOCAL AbstractQoreNode* getValue() const {
+        return i->second->node;
+    }
 
-   DLLLOCAL ConstantEntry* getEntry() const {
-      return i->second;
-   }
+    DLLLOCAL ConstantEntry* getEntry() const {
+        return i->second;
+    }
 
-   DLLLOCAL ClassAccess getAccess() const {
-      return i->second->getAccess();
-   }
+    DLLLOCAL ClassAccess getAccess() const {
+        return i->second->getAccess();
+    }
 
-   DLLLOCAL const bool isPublic() const {
-      return i->second->isPublic();
-   }
+    DLLLOCAL const bool isPublic() const {
+        return i->second->isPublic();
+    }
 
-   DLLLOCAL const bool isUserPublic() const {
-      return i->second->isUserPublic();
-   }
+    DLLLOCAL const bool isUserPublic() const {
+        return i->second->isUserPublic();
+    }
 };
 
 class ConstConstantListIterator {
 protected:
-   const cnemap_t& cl;
-   cnemap_t::const_iterator i;
+    const cnemap_t& cl;
+    cnemap_t::const_iterator i;
 
 public:
-   DLLLOCAL ConstConstantListIterator(const ConstantList& n_cl) : cl(n_cl.cnemap), i(cl.end()) {
-   }
+    DLLLOCAL ConstConstantListIterator(const ConstantList& n_cl) : cl(n_cl.cnemap), i(cl.end()) {
+    }
 
-   DLLLOCAL bool next() {
-      if (i == cl.end())
-         i = cl.begin();
-      else
-         ++i;
-      return i != cl.end();
-   }
+    DLLLOCAL bool next() {
+        if (i == cl.end())
+            i = cl.begin();
+        else
+            ++i;
+        return i != cl.end();
+    }
 
-   DLLLOCAL const std::string& getName() const {
-      return i->second->getNameStr();
-   }
+    DLLLOCAL const std::string& getName() const {
+        return i->second->getNameStr();
+    }
 
-   DLLLOCAL const AbstractQoreNode* getValue() const {
-      return i->second->node;
-   }
+    DLLLOCAL const AbstractQoreNode* getValue() const {
+        return i->second->node;
+    }
 
-   DLLLOCAL const ConstantEntry* getEntry() const {
-      return i->second;
-   }
+    DLLLOCAL const ConstantEntry* getEntry() const {
+        return i->second;
+    }
 
-   DLLLOCAL const bool isPublic() const {
-      return i->second->isPublic();
-   }
+    DLLLOCAL const bool isPublic() const {
+        return i->second->isPublic();
+    }
 
-   DLLLOCAL const bool isUserPublic() const {
-      return i->second->isUserPublic();
-   }
+    DLLLOCAL const bool isUserPublic() const {
+        return i->second->isUserPublic();
+    }
 };
 
 class RuntimeConstantRefNode : public ParseNode {
 protected:
-   ConstantEntry* ce;
+    ConstantEntry* ce;
 
-   virtual AbstractQoreNode* parseInitImpl(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo) {
-      return this;
-   }
+    virtual AbstractQoreNode* parseInitImpl(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo) {
+        return this;
+    }
 
-   virtual const QoreTypeInfo* getTypeInfo() const {
-      assert(ce->saved_node);
-      return getTypeInfoForValue(ce->saved_node);
-   }
+    virtual const QoreTypeInfo* getTypeInfo() const {
+        assert(ce->saved_node);
+        return getTypeInfoForValue(ce->saved_node);
+    }
 
-   DLLLOCAL virtual QoreValue evalValueImpl(bool& needs_deref, ExceptionSink* xsink) const {
-      assert(ce->saved_node);
-      return ce->saved_node->evalValue(needs_deref, xsink);
-   }
+    DLLLOCAL virtual QoreValue evalValueImpl(bool& needs_deref, ExceptionSink* xsink) const {
+        assert(ce->saved_node);
+        return ce->saved_node->evalValue(needs_deref, xsink);
+    }
 
-   DLLLOCAL ~RuntimeConstantRefNode() {
-      ce->deref();
-   }
+    DLLLOCAL ~RuntimeConstantRefNode() {
+        ce->deref();
+    }
 
 public:
-   DLLLOCAL RuntimeConstantRefNode(const QoreProgramLocation& loc, ConstantEntry* n_ce) : ParseNode(loc, NT_RTCONSTREF, true, false), ce(n_ce) {
-      assert(ce->saved_node);
-   }
+    DLLLOCAL RuntimeConstantRefNode(const QoreProgramLocation& loc, ConstantEntry* n_ce) : ParseNode(loc, NT_RTCONSTREF, true, false), ce(n_ce) {
+        assert(ce->saved_node);
+    }
 
-   DLLLOCAL virtual int getAsString(QoreString& str, int foff, ExceptionSink* xsink) const {
-      assert(ce->saved_node);
-      return ce->saved_node->getAsString(str, foff, xsink);
-   }
+    DLLLOCAL virtual int getAsString(QoreString& str, int foff, ExceptionSink* xsink) const {
+        assert(ce->saved_node);
+        return ce->saved_node->getAsString(str, foff, xsink);
+    }
 
-   DLLLOCAL virtual QoreString* getAsString(bool& del, int foff, ExceptionSink* xsink) const {
-      assert(ce->saved_node);
-      return ce->saved_node->getAsString(del, foff, xsink);
-   }
+    DLLLOCAL virtual QoreString* getAsString(bool& del, int foff, ExceptionSink* xsink) const {
+        assert(ce->saved_node);
+        return ce->saved_node->getAsString(del, foff, xsink);
+    }
 
-   DLLLOCAL virtual const char* getTypeName() const {
-      return ce->saved_node ? ce->saved_node->getTypeName() : "nothing";
-   }
+    DLLLOCAL virtual const char* getTypeName() const {
+        return ce->saved_node ? ce->saved_node->getTypeName() : "nothing";
+    }
 };
 
 #endif // _QORE_CONSTANTLIST_H

--- a/include/qore/intern/ConstantList.h
+++ b/include/qore/intern/ConstantList.h
@@ -86,8 +86,6 @@ struct ClassNs {
 
 class RuntimeConstantRefNode;
 
-static void breakit() {}
-
 class ConstantEntry : public QoreReferenceCounter {
     friend class ConstantEntryInitHelper;
     friend class RuntimeConstantRefNode;
@@ -109,8 +107,6 @@ public:
     DLLLOCAL ConstantEntry(const ConstantEntry& old);
 
     DLLLOCAL void deref(ExceptionSink* xsink) {
-        if (name == "closure")
-        printd(0, "CE::d(e) this: %p %d -> %d\n", this, reference_count(), reference_count() - 1);
         if (ROdereference()) {
             del(xsink);
             delete this;
@@ -118,8 +114,6 @@ public:
     }
 
     DLLLOCAL void deref(QoreListNode& l) {
-        if (name == "closure")
-        printd(0, "CE::d(l) this: %p %d -> %d\n", this, reference_count(), reference_count() - 1);
         if (ROdereference()) {
             del(l);
             delete this;
@@ -127,10 +121,6 @@ public:
     }
 
     DLLLOCAL void ref() {
-        if (name == "closure") {
-            printd(0, "CE::r() this: %p %d -> %d\n", this, reference_count(), reference_count() + 1);
-            breakit();
-        }
         ROreference();
     }
 
@@ -195,8 +185,6 @@ protected:
     DLLLOCAL void del(QoreListNode& l);
 
     DLLLOCAL ~ConstantEntry() {
-        if (name == "closure")
-           printd(0, "ConstantEntry::~ConstantEntry() this: %p\n", this);
         assert(!saved_node);
         assert(val.isNothing());
     }

--- a/include/qore/intern/ConstantList.h
+++ b/include/qore/intern/ConstantList.h
@@ -179,7 +179,7 @@ protected:
     AbstractQoreNode* saved_node;
     ClassAccess access;
 
-    DLLLOCAL int scanValue(const AbstractQoreNode* n) const;
+    DLLLOCAL int scanValue(const QoreValue& n) const;
 
     DLLLOCAL void del(ExceptionSink* xsink);
     DLLLOCAL void del(QoreListNode& l);

--- a/include/qore/intern/Function.h
+++ b/include/qore/intern/Function.h
@@ -326,8 +326,6 @@ public:
 
 class UserVariantBase;
 
-static void breakit() {}
-
 // describes the details of the function variant
 class AbstractQoreFunctionVariant : protected QoreReferenceCounter {
 private:
@@ -346,8 +344,7 @@ protected:
 
 public:
     DLLLOCAL AbstractQoreFunctionVariant(int64 n_flags, bool n_is_user = false) : flags(n_flags), is_user(n_is_user) {
-        printd(0, "AbstractQoreFunctionVariant::AbstractQoreFunctionVariant() this: %p cntr: %d\n", this, ++cntr);
-        if (cntr == 3261) breakit();
+        //printd(5, "AbstractQoreFunctionVariant::AbstractQoreFunctionVariant() this: %p cntr: %d\n", this, ++cntr);
     }
 
     DLLLOCAL virtual AbstractFunctionSignature* getSignature() const = 0;

--- a/include/qore/intern/Function.h
+++ b/include/qore/intern/Function.h
@@ -745,12 +745,12 @@ public:
         for (vlist_t::const_iterator i = old.vlist.begin(), e = old.vlist.end(); i != e; ++i) {
             if (!copy_all) {
                 if ((*i)->isUser()) {
-                if (no_user || !(*i)->isModulePublic())
-                    continue;
+                    if (no_user || !(*i)->isModulePublic())
+                        continue;
                 }
                 else
-                if (no_builtin)
-                    continue;
+                    if (no_builtin)
+                        continue;
             }
 
             vlist.push_back((*i)->ref());
@@ -1024,7 +1024,7 @@ public:
 
    // copy constructor, only copies committed variants
    DLLLOCAL MethodFunctionBase(const MethodFunctionBase& old, const QoreClass* n_qc)
-      : QoreFunction(old, 0, 0, true),
+      : QoreFunction(old, 0, true),
         qc(n_qc),
         is_static(old.is_static),
         has_final(old.has_final),

--- a/include/qore/intern/Function.h
+++ b/include/qore/intern/Function.h
@@ -326,111 +326,118 @@ public:
 
 class UserVariantBase;
 
+static void breakit() {}
+
 // describes the details of the function variant
 class AbstractQoreFunctionVariant : protected QoreReferenceCounter {
 private:
-   // not implemented
-   DLLLOCAL AbstractQoreFunctionVariant(const AbstractQoreFunctionVariant& old);
-   DLLLOCAL AbstractQoreFunctionVariant& operator=(AbstractQoreFunctionVariant& orig);
+    // not implemented
+    DLLLOCAL AbstractQoreFunctionVariant(const AbstractQoreFunctionVariant& old);
+    DLLLOCAL AbstractQoreFunctionVariant& operator=(AbstractQoreFunctionVariant& orig);
 
 protected:
-   // code flags
-   int64 flags;
-   bool is_user;
+    // code flags
+    int64 flags;
+    bool is_user;
 
-   DLLLOCAL virtual ~AbstractQoreFunctionVariant() {}
+    static unsigned cntr;
+
+    DLLLOCAL virtual ~AbstractQoreFunctionVariant() {}
 
 public:
-   DLLLOCAL AbstractQoreFunctionVariant(int64 n_flags, bool n_is_user = false) : flags(n_flags), is_user(n_is_user) {}
-
-   DLLLOCAL virtual AbstractFunctionSignature* getSignature() const = 0;
-   DLLLOCAL virtual const QoreTypeInfo* parseGetReturnTypeInfo() const = 0;
-
-   DLLLOCAL const QoreTypeInfo* getReturnTypeInfo() const {
-      return getSignature()->getReturnTypeInfo();
-   }
-
-   DLLLOCAL unsigned numParams() const {
-      AbstractFunctionSignature* sig = getSignature();
-      return sig ? sig->numParams() : 0;
-   }
-
-   DLLLOCAL qore_call_t getCallType() const {
-      return is_user ? CT_USER : CT_BUILTIN;
-   }
-
-   DLLLOCAL int64 getParseOptions(int64 po) const;
-
-   DLLLOCAL int64 getFlags() const {
-      return flags;
-   }
-
-   DLLLOCAL virtual int64 getFunctionality() const = 0;
-
-   // set flag to recheck params against committed variants in stage 2 parsing after type resolution (only for user variants); should never be called with builtin variants
-   DLLLOCAL virtual void setRecheck() {
-      assert(false);
-   }
-
-   DLLLOCAL void parseResolveUserSignature();
-
-   DLLLOCAL virtual UserVariantBase* getUserVariantBase() {
-      return 0;
+    DLLLOCAL AbstractQoreFunctionVariant(int64 n_flags, bool n_is_user = false) : flags(n_flags), is_user(n_is_user) {
+        printd(0, "AbstractQoreFunctionVariant::AbstractQoreFunctionVariant() this: %p cntr: %d\n", this, ++cntr);
+        if (cntr == 3261) breakit();
     }
 
-   DLLLOCAL const UserVariantBase* getUserVariantBase() const {
-      // avoid the virtual function call if possible
-      return is_user ? const_cast<AbstractQoreFunctionVariant*>(this)->getUserVariantBase() : nullptr;
-   }
+    DLLLOCAL virtual AbstractFunctionSignature* getSignature() const = 0;
+    DLLLOCAL virtual const QoreTypeInfo* parseGetReturnTypeInfo() const = 0;
 
-   DLLLOCAL virtual QoreValue evalFunction(const char* name, CodeEvaluationHelper& ceh, ExceptionSink* xsink) const {
-      assert(false);
-      return QoreValue();
-   }
+    DLLLOCAL const QoreTypeInfo* getReturnTypeInfo() const {
+        return getSignature()->getReturnTypeInfo();
+    }
 
-   DLLLOCAL virtual const QoreClass* getClass() const {
-      return 0;
-   }
+    DLLLOCAL unsigned numParams() const {
+        AbstractFunctionSignature* sig = getSignature();
+        return sig ? sig->numParams() : 0;
+    }
 
-   DLLLOCAL const char* className() const {
-      const QoreClass* qc = getClass();
-      return qc ? qc->getName() : 0;
-   }
+    DLLLOCAL qore_call_t getCallType() const {
+        return is_user ? CT_USER : CT_BUILTIN;
+    }
 
-   DLLLOCAL bool isSignatureIdentical(const AbstractFunctionSignature& sig) const {
-      //printd(5, "AbstractQoreFunctionVariant::isSignatureIdentical() this: %p '%s' == '%s': %d\n", this, getSignature()->getSignatureText(), sig.getSignatureText(), *(getSignature()) == sig);
-      return *(getSignature()) == sig;
-   }
+    DLLLOCAL int64 getParseOptions(int64 po) const;
 
-   DLLLOCAL AbstractQoreFunctionVariant* ref() {
-      ROreference();
-      return this;
-   }
+    DLLLOCAL int64 getFlags() const {
+        return flags;
+    }
 
-   DLLLOCAL void deref() {
-      if (ROdereference()) {
-         delete this;
-      }
-   }
+    DLLLOCAL virtual int64 getFunctionality() const = 0;
 
-   DLLLOCAL bool isUser() const {
-      return is_user;
-   }
+    // set flag to recheck params against committed variants in stage 2 parsing after type resolution (only for user variants); should never be called with builtin variants
+    DLLLOCAL virtual void setRecheck() {
+        assert(false);
+    }
 
-   DLLLOCAL bool hasBody() const;
+    DLLLOCAL void parseResolveUserSignature();
 
-   DLLLOCAL virtual bool isModulePublic() const {
-      return false;
-   }
+    DLLLOCAL virtual UserVariantBase* getUserVariantBase() {
+        return 0;
+        }
 
-   // the default implementation of this function does nothing
-   DLLLOCAL virtual void parseInit(QoreFunction* f) {
-   }
+    DLLLOCAL const UserVariantBase* getUserVariantBase() const {
+        // avoid the virtual function call if possible
+        return is_user ? const_cast<AbstractQoreFunctionVariant*>(this)->getUserVariantBase() : nullptr;
+    }
 
-   // the default implementation of this function does nothing
-   DLLLOCAL virtual void parseCommit() {
-   }
- };
+    DLLLOCAL virtual QoreValue evalFunction(const char* name, CodeEvaluationHelper& ceh, ExceptionSink* xsink) const {
+        assert(false);
+        return QoreValue();
+    }
+
+    DLLLOCAL virtual const QoreClass* getClass() const {
+        return nullptr;
+    }
+
+    DLLLOCAL const char* className() const {
+        const QoreClass* qc = getClass();
+        return qc ? qc->getName() : nullptr;
+    }
+
+    DLLLOCAL bool isSignatureIdentical(const AbstractFunctionSignature& sig) const {
+        //printd(5, "AbstractQoreFunctionVariant::isSignatureIdentical() this: %p '%s' == '%s': %d\n", this, getSignature()->getSignatureText(), sig.getSignatureText(), *(getSignature()) == sig);
+        return *(getSignature()) == sig;
+    }
+
+    DLLLOCAL AbstractQoreFunctionVariant* ref() {
+        ROreference();
+        return this;
+    }
+
+    DLLLOCAL void deref() {
+        if (ROdereference()) {
+            delete this;
+        }
+    }
+
+    DLLLOCAL bool isUser() const {
+        return is_user;
+    }
+
+    DLLLOCAL bool hasBody() const;
+
+    DLLLOCAL virtual bool isModulePublic() const {
+        return false;
+    }
+
+    // the default implementation of this function does nothing
+    DLLLOCAL virtual void parseInit(QoreFunction* f) {
+    }
+
+    // the default implementation of this function does nothing
+    DLLLOCAL virtual void parseCommit() {
+    }
+};
 
 class VRMutex;
 class UserVariantExecHelper;
@@ -592,59 +599,59 @@ struct IList : public ilist_t {
 
 class QoreFunction : protected QoreReferenceCounter {
 protected:
-   std::string name;
-   qore_ns_private* ns;
+    std::string name;
+    qore_ns_private* ns;
 
-   // list of function variants
-   VList vlist;
+    // list of function variants
+    VList vlist;
 
-   // list of inherited methods for variant matching; the first pointer is always a pointer to "this"
-   IList ilist;
+    // list of inherited methods for variant matching; the first pointer is always a pointer to "this"
+    IList ilist;
 
-   // if true means all variants have the same return value
-   bool same_return_type, parse_same_return_type;
-   int64 unique_functionality;
-   int64 unique_flags;
+    // if true means all variants have the same return value
+    bool same_return_type;
+    int64 unique_functionality;
+    int64 unique_flags;
 
-   // same as above but for variants without QC_RUNTIME_NOOP
-   bool nn_same_return_type;
-   int64 nn_unique_functionality;
-   int64 nn_unique_flags;
-   int nn_count;
-   bool parse_rt_done;
-   bool parse_init_done;
-   bool has_user;                   // has at least 1 committed user variant
-   bool has_builtin;                // has at least 1 committed builtin variant
-   bool has_mod_pub;                // has at least 1 committed user variant with public visibility
-   bool inject;
-   bool check_parse = false;
+    // same as above but for variants without QC_RUNTIME_NOOP
+    bool nn_same_return_type;
+    int64 nn_unique_functionality;
+    int64 nn_unique_flags;
+    int nn_count;
+    bool parse_rt_done;
+    bool parse_init_done;
+    bool has_user;                   // has at least 1 committed user variant
+    bool has_builtin;                // has at least 1 committed builtin variant
+    bool has_mod_pub;                // has at least 1 committed user variant with public visibility
+    bool inject;
+    bool check_parse = false;
 
-   const QoreTypeInfo* nn_uniqueReturnType;
+    const QoreTypeInfo* nn_uniqueReturnType;
 
-   DLLLOCAL void parseCheckReturnType() {
-      if (parse_rt_done)
-         return;
+    DLLLOCAL void parseCheckReturnType() {
+        if (parse_rt_done)
+            return;
 
-      parse_rt_done = true;
+        parse_rt_done = true;
 
-      if (!same_return_type || !check_parse)
-         return;
+        if (!same_return_type)
+            return;
 
-      for (vlist_t::iterator i = vlist.begin(), e = vlist.end(); i != e; ++i) {
-         reinterpret_cast<UserSignature*>((*i)->getUserVariantBase()->getUserSignature())->resolve();
-         const QoreTypeInfo* rti = (*i)->getReturnTypeInfo();
+        for (vlist_t::iterator i = vlist.begin(), e = vlist.end(); i != e; ++i) {
+            reinterpret_cast<UserSignature*>((*i)->getUserVariantBase()->getUserSignature())->resolve();
+            const QoreTypeInfo* rti = (*i)->getReturnTypeInfo();
 
-         if (i == vlist.begin()) {
-            if (!vlist.empty()) {
-               if (!QoreTypeInfo::isOutputIdentical(rti, first()->getReturnTypeInfo())) {
-                  parse_same_return_type = false;
-                  break;
-               }
+            if (i == vlist.begin()) {
+                continue;
             }
-            continue;
-         }
-      }
-   }
+
+            if (!QoreTypeInfo::isOutputIdentical(rti, first()->getReturnTypeInfo())) {
+                same_return_type = false;
+                break;
+            }
+        }
+       //printd(5, "QoreFunction::parseCheckReturnType() '%s' srt: %d\n", name.c_str(), same_return_type);
+    }
 
    // returns QTI_NOT_EQUAL, QTI_AMBIGUOUS, or QTI_IDENT
    DLLLOCAL static int parseCompareResolvedSignature(const VList& vlist, const AbstractFunctionSignature* sig, const AbstractFunctionSignature*& vs);
@@ -697,7 +704,7 @@ protected:
 
 public:
    DLLLOCAL QoreFunction(const char* n_name, qore_ns_private* n = 0)
-      : name(n_name), ns(n), same_return_type(true), parse_same_return_type(true),
+      : name(n_name), ns(n), same_return_type(true),
         unique_functionality(QDOM_DEFAULT), unique_flags(QC_NO_FLAGS),
         nn_same_return_type(true), nn_unique_functionality(QDOM_DEFAULT),
         nn_unique_flags(QC_NO_FLAGS), nn_count(0), parse_rt_done(true),
@@ -710,7 +717,6 @@ public:
    // copy constructor (used by method functions when copied)
    DLLLOCAL QoreFunction(const QoreFunction& old, int64 po = 0, qore_ns_private* n = 0, bool copy_all = false, bool n_inject = false)
       : name(old.name), ns(n), same_return_type(old.same_return_type),
-        parse_same_return_type(true),
         unique_functionality(old.unique_functionality),
         unique_flags(old.unique_flags),
         nn_same_return_type(old.nn_same_return_type),
@@ -761,7 +767,6 @@ public:
    // copy constructor when importing public user variants from user modules into Program objects
    DLLLOCAL QoreFunction(bool ignore, const QoreFunction& old, qore_ns_private* nns)
       : name(old.name), ns(nns), same_return_type(old.same_return_type),
-        parse_same_return_type(true),
         unique_functionality(old.unique_functionality),
         unique_flags(old.unique_flags),
         nn_same_return_type(old.nn_same_return_type),
@@ -895,17 +900,17 @@ public:
     DLLLOCAL const QoreTypeInfo* parseGetUniqueReturnTypeInfo() {
         parseCheckReturnType();
 
-        //printd(5, "QoreFunction::parseGetUniqueReturnTypeInfo() this: %p '%s' rt: %d srt: %d psrt: %d vs: %d\n", this, name.c_str(), parse_get_parse_options() & PO_REQUIRE_TYPES, same_return_type, parse_same_return_type, vlist.size());
+        //printd(5, "QoreFunction::parseGetUniqueReturnTypeInfo() this: %p '%s' rt: %d srt: %d vs: %d\n", this, name.c_str(), parse_get_parse_options() & PO_REQUIRE_TYPES, same_return_type, vlist.size());
+
+        if (!same_return_type)
+            return nullptr;
 
         if (parse_get_parse_options() & PO_REQUIRE_TYPES) {
-            if (!nn_same_return_type || !parse_same_return_type)
+            if (!nn_same_return_type)
                 return nullptr;
 
             return nn_count ? nn_uniqueReturnType : (!vlist.empty() ? first()->getReturnTypeInfo() : nullptr);
         }
-
-        if (!same_return_type || !parse_same_return_type)
-            return nullptr;
 
         if (!vlist.empty())
             return first()->getReturnTypeInfo();

--- a/include/qore/intern/FunctionCallNode.h
+++ b/include/qore/intern/FunctionCallNode.h
@@ -79,49 +79,48 @@ protected:
     // such as when the node was created during background operation execution
     bool tmp_args = false;
 
-   DLLLOCAL virtual QoreValue evalValueImpl(bool& needs_deref, ExceptionSink* xsink) const = 0;
+    DLLLOCAL virtual QoreValue evalValueImpl(bool& needs_deref, ExceptionSink* xsink) const = 0;
 
-   DLLLOCAL void doFlags(int64 flags) {
-      if (flags & QC_RET_VALUE_ONLY)
-         set_effect(false);
-   }
+    DLLLOCAL void doFlags(int64 flags) {
+        if (flags & QC_RET_VALUE_ONLY)
+            set_effect(false);
+    }
 
 public:
-   DLLLOCAL AbstractFunctionCallNode(const QoreProgramLocation& loc, qore_type_t t, QoreParseListNode* n_args, bool needs_eval = true) : ParseNode(loc, t, needs_eval), FunctionCallBase(n_args) {
-      has_value_api = true;
-   }
+    DLLLOCAL AbstractFunctionCallNode(const QoreProgramLocation& loc, qore_type_t t, QoreParseListNode* n_args, bool needs_eval = true) : ParseNode(loc, t, needs_eval), FunctionCallBase(n_args) {
+        has_value_api = true;
+    }
 
-   DLLLOCAL AbstractFunctionCallNode(const QoreProgramLocation& loc, qore_type_t t, QoreParseListNode* parse_args, QoreListNode* args, bool needs_eval = true) : ParseNode(loc, t, needs_eval), FunctionCallBase(parse_args, args) {
-      has_value_api = true;
-   }
+    DLLLOCAL AbstractFunctionCallNode(const QoreProgramLocation& loc, qore_type_t t, QoreParseListNode* parse_args, QoreListNode* args, bool needs_eval = true) : ParseNode(loc, t, needs_eval), FunctionCallBase(parse_args, args) {
+        has_value_api = true;
+    }
 
-   DLLLOCAL AbstractFunctionCallNode(const AbstractFunctionCallNode& old) : ParseNode(old), FunctionCallBase(old) {
-      has_value_api = true;
-   }
+    DLLLOCAL AbstractFunctionCallNode(const AbstractFunctionCallNode& old) : ParseNode(old), FunctionCallBase(old) {
+        has_value_api = true;
+    }
 
+    DLLLOCAL AbstractFunctionCallNode(const AbstractFunctionCallNode& old, QoreListNode* n_args) : ParseNode(old), FunctionCallBase(old, n_args), tmp_args(true) {
+        has_value_api = true;
+    }
 
-   DLLLOCAL AbstractFunctionCallNode(const AbstractFunctionCallNode& old, QoreListNode* n_args) : ParseNode(old), FunctionCallBase(old, n_args), tmp_args(true) {
-      has_value_api = true;
-   }
+    DLLLOCAL virtual ~AbstractFunctionCallNode() {
+        // there could be an object here in the case of a background expression
+        if (args) {
+            ExceptionSink xsink;
+            args->deref(&xsink);
+            args = nullptr;
+        }
+    }
 
-   DLLLOCAL virtual ~AbstractFunctionCallNode() {
-      // there could be an object here in the case of a background expression
-      if (args) {
-         ExceptionSink xsink;
-         args->deref(&xsink);
-         args = 0;
-      }
-   }
-
-   DLLLOCAL int parseArgs(LocalVar* oflag, int pflag, QoreFunction* func, const QoreTypeInfo*& returnTypeInfo) {
-      int lvids = parseArgsVariant(loc, oflag, pflag, func, returnTypeInfo);
-      // clear "effect" flag if possible, only if QC_CONSTANT is set on the variant or function
-      if (variant)
-         doFlags(variant->getFlags());
-      else if (func)
-         doFlags(func->parseGetUniqueFlags());
-      return lvids;
-   }
+    DLLLOCAL int parseArgs(LocalVar* oflag, int pflag, QoreFunction* func, const QoreTypeInfo*& returnTypeInfo) {
+        int lvids = parseArgsVariant(loc, oflag, pflag, func, returnTypeInfo);
+        // clear "effect" flag if possible, only if QC_CONSTANT is set on the variant or function
+        if (variant)
+            doFlags(variant->getFlags());
+        else if (func)
+            doFlags(func->parseGetUniqueFlags());
+        return lvids;
+    }
 
    DLLLOCAL virtual const char* getName() const = 0;
 };

--- a/include/qore/intern/FunctionCallNode.h
+++ b/include/qore/intern/FunctionCallNode.h
@@ -35,42 +35,44 @@
 
 #include <qore/Qore.h>
 #include "qore/intern/QoreParseListNode.h"
+#include "qore/intern/FunctionList.h"
 
 class FunctionCallBase {
 protected:
-   QoreParseListNode* parse_args = nullptr;
-   QoreListNode* args = nullptr;
-   const AbstractQoreFunctionVariant* variant = nullptr;
+    QoreParseListNode* parse_args = nullptr;
+    QoreListNode* args = nullptr;
+    const AbstractQoreFunctionVariant* variant = nullptr;
 
 public:
-   DLLLOCAL FunctionCallBase(QoreParseListNode* parse_args, QoreListNode* args = nullptr) : parse_args(parse_args), args(args) {
-   }
+    DLLLOCAL FunctionCallBase(QoreParseListNode* parse_args, QoreListNode* args = nullptr) : parse_args(parse_args), args(args) {
+    }
 
-   DLLLOCAL FunctionCallBase(const FunctionCallBase& old) :
-      parse_args(old.parse_args ? old.parse_args->listRefSelf() : nullptr),
-      args(old.args ? old.args->listRefSelf() : nullptr),
-      variant(old.variant) {
-   }
+    DLLLOCAL FunctionCallBase(const FunctionCallBase& old) :
+        parse_args(old.parse_args ? old.parse_args->listRefSelf() : nullptr),
+        args(old.args ? old.args->listRefSelf() : nullptr),
+        variant(old.variant) {
+    }
 
-   DLLLOCAL FunctionCallBase(const FunctionCallBase& old, QoreListNode* n_args) : args(n_args), variant(old.variant) {
-   }
+    DLLLOCAL FunctionCallBase(const FunctionCallBase& old, QoreListNode* n_args) : args(n_args), variant(old.variant) {
+    }
 
-   DLLLOCAL ~FunctionCallBase() {
-      if (parse_args)
-         parse_args->deref();
-      if (args)
-         args->deref(nullptr);
-   }
+    DLLLOCAL ~FunctionCallBase() {
+        if (parse_args)
+            parse_args->deref();
+        if (args)
+            args->deref(nullptr);
+    }
 
-   DLLLOCAL const QoreParseListNode* getParseArgs() const { return parse_args; }
+    DLLLOCAL const QoreParseListNode* getParseArgs() const { return parse_args; }
 
-   DLLLOCAL const QoreListNode* getArgs() const { return args; }
+    DLLLOCAL const QoreListNode* getArgs() const { return args; }
 
-   DLLLOCAL int parseArgsVariant(const QoreProgramLocation& loc, LocalVar* oflag, int pflag, QoreFunction* func, const QoreTypeInfo*& returnTypeInfo);
+    // ns can be nullptr if the function is a method
+    DLLLOCAL int parseArgsVariant(const QoreProgramLocation& loc, LocalVar* oflag, int pflag, QoreFunction* func, qore_ns_private* ns, const QoreTypeInfo*& returnTypeInfo);
 
-   DLLLOCAL const AbstractQoreFunctionVariant* getVariant() const {
-      return variant;
-   }
+    DLLLOCAL const AbstractQoreFunctionVariant* getVariant() const {
+        return variant;
+    }
 };
 
 class AbstractFunctionCallNode : public ParseNode, public FunctionCallBase {
@@ -112,8 +114,9 @@ public:
         }
     }
 
-    DLLLOCAL int parseArgs(LocalVar* oflag, int pflag, QoreFunction* func, const QoreTypeInfo*& returnTypeInfo) {
-        int lvids = parseArgsVariant(loc, oflag, pflag, func, returnTypeInfo);
+    // ns can be nullptr if the function is a method
+    DLLLOCAL int parseArgs(LocalVar* oflag, int pflag, QoreFunction* func, qore_ns_private* ns, const QoreTypeInfo*& returnTypeInfo) {
+        int lvids = parseArgsVariant(loc, oflag, pflag, func, ns, returnTypeInfo);
         // clear "effect" flag if possible, only if QC_CONSTANT is set on the variant or function
         if (variant)
             doFlags(variant->getFlags());
@@ -127,121 +130,121 @@ public:
 
 class FunctionCallNode : public AbstractFunctionCallNode {
 protected:
-   const QoreFunction* func = nullptr;
-   QoreProgram* pgm = nullptr;
-   char* c_str = nullptr;
-   // was this call enclosed in parentheses (in which case it will not be converted to a method call)
-   bool finalized = false;
+    const FunctionEntry* fe = nullptr;
+    QoreProgram* pgm = nullptr;
+    char* c_str = nullptr;
+    // was this call enclosed in parentheses (in which case it will not be converted to a method call)
+    bool finalized = false;
 
-   using AbstractFunctionCallNode::evalImpl;
-   DLLLOCAL virtual QoreValue evalValueImpl(bool& needs_deref, ExceptionSink* xsink) const;
+    using AbstractFunctionCallNode::evalImpl;
+    DLLLOCAL virtual QoreValue evalValueImpl(bool& needs_deref, ExceptionSink* xsink) const;
 
-   DLLLOCAL FunctionCallNode(const QoreProgramLocation& loc, char* name, QoreParseListNode* a, qore_type_t n_type) : AbstractFunctionCallNode(loc, n_type, a), c_str(name), finalized(false) {
-   }
+    DLLLOCAL FunctionCallNode(const QoreProgramLocation& loc, char* name, QoreParseListNode* a, qore_type_t n_type) : AbstractFunctionCallNode(loc, n_type, a), c_str(name), finalized(false) {
+    }
 
-   DLLLOCAL virtual AbstractQoreNode* parseInitImpl(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo);
+    DLLLOCAL virtual AbstractQoreNode* parseInitImpl(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo);
 
-   DLLLOCAL virtual const QoreTypeInfo* getTypeInfo() const {
-      return variant ? variant->parseGetReturnTypeInfo() : (func ? const_cast<QoreFunction*>(func)->parseGetUniqueReturnTypeInfo() : nullptr);
-   }
+    DLLLOCAL virtual const QoreTypeInfo* getTypeInfo() const {
+        return variant ? variant->parseGetReturnTypeInfo() : (fe ? fe->getFunction()->parseGetUniqueReturnTypeInfo() : nullptr);
+    }
 
 public:
-   DLLLOCAL FunctionCallNode(const FunctionCallNode& old, QoreListNode* args) : AbstractFunctionCallNode(old, args), func(old.func), pgm(old.pgm), finalized(old.finalized) {
-   }
+    DLLLOCAL FunctionCallNode(const FunctionCallNode& old, QoreListNode* args) : AbstractFunctionCallNode(old, args), fe(old.fe), pgm(old.pgm), finalized(old.finalized) {
+    }
 
-   DLLLOCAL FunctionCallNode(const QoreProgramLocation& loc, const QoreFunction* f, QoreParseListNode* a) : AbstractFunctionCallNode(loc, NT_FUNCTION_CALL, a), func(f) {
-   }
+    DLLLOCAL FunctionCallNode(const QoreProgramLocation& loc, const FunctionEntry* f, QoreParseListNode* a) : AbstractFunctionCallNode(loc, NT_FUNCTION_CALL, a), fe(f) {
+    }
 
-   DLLLOCAL FunctionCallNode(const QoreProgramLocation& loc, const QoreFunction* f, QoreListNode* a, QoreProgram* n_pgm) : AbstractFunctionCallNode(loc, NT_FUNCTION_CALL, nullptr, a), func(f), pgm(n_pgm) {
-   }
+    DLLLOCAL FunctionCallNode(const QoreProgramLocation& loc, const FunctionEntry* f, QoreListNode* a, QoreProgram* n_pgm) : AbstractFunctionCallNode(loc, NT_FUNCTION_CALL, nullptr, a), fe(f), pgm(n_pgm) {
+    }
 
-   // normal function call constructor
-   DLLLOCAL FunctionCallNode(const QoreProgramLocation& loc, char* name, QoreParseListNode* a) : AbstractFunctionCallNode(loc, NT_FUNCTION_CALL, a), c_str(name) {
-   }
+    // normal function call constructor
+    DLLLOCAL FunctionCallNode(const QoreProgramLocation& loc, char* name, QoreParseListNode* a) : AbstractFunctionCallNode(loc, NT_FUNCTION_CALL, a), c_str(name) {
+    }
 
-   DLLLOCAL virtual ~FunctionCallNode() {
-      printd(5, "FunctionCallNode::~FunctionCallNode(): func=%p c_str=%p (%s) args=%p\n", func, c_str, c_str ? c_str : "n/a", args);
-      if (c_str)
-         free(c_str);
-   }
+    DLLLOCAL virtual ~FunctionCallNode() {
+        printd(5, "FunctionCallNode::~FunctionCallNode(): fe: %p c_str: %p (%s) args: %p\n", fe, c_str, c_str ? c_str : "n/a", args);
+        if (c_str)
+            free(c_str);
+    }
 
-   DLLLOCAL virtual int getAsString(QoreString &str, int foff, ExceptionSink* xsink) const;
-   DLLLOCAL virtual QoreString* getAsString(bool& del, int foff, ExceptionSink* xsink) const;
+    DLLLOCAL virtual int getAsString(QoreString &str, int foff, ExceptionSink* xsink) const;
+    DLLLOCAL virtual QoreString* getAsString(bool& del, int foff, ExceptionSink* xsink) const;
 
-   // returns the type name as a c string
-   DLLLOCAL virtual const char* getTypeName() const {
-      return "function call";
-   }
+    // returns the type name as a c string
+    DLLLOCAL virtual const char* getTypeName() const {
+        return "function call";
+    }
 
-   DLLLOCAL QoreProgram* getProgram() const {
-      return const_cast<QoreProgram*>(pgm);
-   }
+    DLLLOCAL QoreProgram* getProgram() const {
+        return const_cast<QoreProgram*>(pgm);
+    }
 
-   DLLLOCAL AbstractQoreNode* parseInitCall(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo);
+    DLLLOCAL AbstractQoreNode* parseInitCall(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo);
 
-   DLLLOCAL void parseInitFinalizedCall(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo);
+    DLLLOCAL void parseInitFinalizedCall(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo);
 
-   DLLLOCAL virtual const char* getName() const {
-      return func ? func->getName() : c_str;
-   }
+    DLLLOCAL virtual const char* getName() const {
+        return fe ? fe->getName() : c_str;
+    }
 
-   DLLLOCAL const QoreFunction* getFunction() const {
-      return func;
-   }
+    DLLLOCAL const QoreFunction* getFunction() const {
+        return fe ? fe->getFunction() : nullptr;
+    }
 
-   // FIXME: delete when unresolved function call node implemented properly
-   DLLLOCAL char* takeName() {
-      char* str = c_str;
-      c_str = 0;
-      return str;
-   }
+    // FIXME: delete when unresolved function call node implemented properly
+    DLLLOCAL char* takeName() {
+        char* str = c_str;
+        c_str = 0;
+        return str;
+    }
 
-   // FIXME: delete when unresolved function call node implemented properly
-   DLLLOCAL QoreParseListNode* takeParseArgs() {
-      QoreParseListNode* rv = parse_args;
-      parse_args = nullptr;
-      return rv;
-   }
+    // FIXME: delete when unresolved function call node implemented properly
+    DLLLOCAL QoreParseListNode* takeParseArgs() {
+        QoreParseListNode* rv = parse_args;
+        parse_args = nullptr;
+        return rv;
+    }
 
-   DLLLOCAL QoreListNode* takeArgs() {
-      QoreListNode* rv = args;
-      args = nullptr;
-      return rv;
-   }
+    DLLLOCAL QoreListNode* takeArgs() {
+        QoreListNode* rv = args;
+        args = nullptr;
+        return rv;
+    }
 
-   DLLLOCAL AbstractQoreNode* makeReferenceNodeAndDeref() {
-      if (args) {
-         parse_error(loc, "argument given to call reference");
-         return this;
-      }
+    DLLLOCAL AbstractQoreNode* makeReferenceNodeAndDeref() {
+        if (args) {
+            parse_error(loc, "argument given to call reference");
+            return this;
+        }
 
-      assert(!func);
-      AbstractQoreNode* rv = makeReferenceNodeAndDerefImpl();
-      deref();
-      return rv;
-   }
+        assert(!fe);
+        AbstractQoreNode* rv = makeReferenceNodeAndDerefImpl();
+        deref();
+        return rv;
+    }
 
-   DLLLOCAL virtual AbstractQoreNode* makeReferenceNodeAndDerefImpl();
+    DLLLOCAL virtual AbstractQoreNode* makeReferenceNodeAndDerefImpl();
 
-   DLLLOCAL bool isFinalized() const {
-      return finalized;
-   }
+    DLLLOCAL bool isFinalized() const {
+        return finalized;
+    }
 
-   DLLLOCAL void setFinalized() {
-      finalized = true;
-   }
+    DLLLOCAL void setFinalized() {
+        finalized = true;
+    }
 };
 
 class ProgramFunctionCallNode : public FunctionCallNode {
 public:
-   DLLLOCAL ProgramFunctionCallNode(const QoreProgramLocation& loc, char* name, QoreParseListNode* a) : FunctionCallNode(loc, name, a, NT_PROGRAM_FUNC_CALL) {
-   }
+    DLLLOCAL ProgramFunctionCallNode(const QoreProgramLocation& loc, char* name, QoreParseListNode* a) : FunctionCallNode(loc, name, a, NT_PROGRAM_FUNC_CALL) {
+    }
 
-   DLLLOCAL virtual AbstractQoreNode* parseInitImpl(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo) {
-      return parseInitCall(oflag, pflag, lvids, typeInfo);
-   }
+    DLLLOCAL virtual AbstractQoreNode* parseInitImpl(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo) {
+        return parseInitCall(oflag, pflag, lvids, typeInfo);
+    }
 
-   DLLLOCAL virtual AbstractQoreNode* makeReferenceNodeAndDerefImpl();
+    DLLLOCAL virtual AbstractQoreNode* makeReferenceNodeAndDerefImpl();
 };
 
 class AbstractMethodCallNode : public AbstractFunctionCallNode {
@@ -293,7 +296,7 @@ protected:
    // note that the class and method are set in QoreDotEvalOperatorNode::parseInitImpl()
    DLLLOCAL virtual AbstractQoreNode* parseInitImpl(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo) {
       typeInfo = 0;
-      lvids += parseArgs(oflag, pflag, 0, typeInfo);
+      lvids += parseArgs(oflag, pflag, nullptr, nullptr, typeInfo);
       return this;
    }
 

--- a/include/qore/intern/FunctionList.h
+++ b/include/qore/intern/FunctionList.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -71,34 +71,34 @@ public:
       return func;
    }
 
-   DLLLOCAL QoreFunction* getFunction(bool runtime) const {
-      if (runtime && func->committedEmpty())
-	 return 0;
-      return func;
-   }
+    DLLLOCAL QoreFunction* getFunction(bool runtime) const {
+        if (runtime && func->committedEmpty())
+            return nullptr;
+        return func;
+    }
 
-   DLLLOCAL const char* getName() const {
-      return name.empty() ? func->getName() : name.c_str();
-   }
+    DLLLOCAL const char* getName() const {
+        return name.empty() ? func->getName() : name.c_str();
+    }
 
-   DLLLOCAL void parseInit() {
-      func->parseInit();
-   }
+    DLLLOCAL void parseInit() {
+        func->parseInit();
+    }
 
-   DLLLOCAL void parseCommit() {
-      func->parseCommit();
-   }
+    DLLLOCAL void parseCommit() {
+        func->parseCommit();
+    }
 
-   // returns -1 if the entry can be deleted
-   DLLLOCAL int parseRollback() {
-      // if there are no committed variants, then return -1 to erase the function entry entirely
-      if (func->committedEmpty())
-         return -1;
+    // returns -1 if the entry can be deleted
+    DLLLOCAL int parseRollback() {
+        // if there are no committed variants, then return -1 to erase the function entry entirely
+        if (func->committedEmpty())
+            return -1;
 
-      // otherwise just roll back the pending variants
-      func->parseRollback();
-      return 0;
-   }
+        // otherwise just roll back the pending variants
+        func->parseRollback();
+        return 0;
+    }
 
    DLLLOCAL ResolvedCallReferenceNode* makeCallReference(const QoreProgramLocation& loc) const;
 

--- a/include/qore/intern/FunctionList.h
+++ b/include/qore/intern/FunctionList.h
@@ -43,33 +43,48 @@
 class qore_ns_private;
 
 //  function calls are handled with FunctionCallNode
-class FunctionEntry {
+class FunctionEntry : public QoreReferenceCounter {
    friend class FunctionList;
 
 private:
-   // not implemented
-   DLLLOCAL FunctionEntry(const FunctionEntry& old);
+    // not implemented
+    FunctionEntry(const FunctionEntry& old) = delete;
 
 protected:
-   QoreFunction* func;
-   std::string name;
+    QoreFunction* func;
+    std::string name;
+    qore_ns_private* ns;
+
+    DLLLOCAL ~FunctionEntry() {
+        func->deref();
+    }
 
 public:
-   DLLLOCAL FunctionEntry(QoreFunction* u) : func(u) {
-   }
+    DLLLOCAL FunctionEntry(QoreFunction* u, qore_ns_private* ns) : func(u), ns(ns) {
+    }
 
-   DLLLOCAL FunctionEntry(const char* new_name, QoreFunction* u) : func(u), name(new_name) {
-   }
+    DLLLOCAL FunctionEntry(const char* new_name, QoreFunction* u, qore_ns_private* ns) : func(u), name(new_name), ns(ns) {
+    }
 
-   DLLLOCAL ~FunctionEntry() {
-      func->deref();
-   }
+    DLLLOCAL void ref() {
+        ROreference();
+    }
 
-   DLLLOCAL qore_ns_private* getNamespace() const;
+    DLLLOCAL bool deref() {
+        if (ROdereference()) {
+            delete this;
+            return true;
+        }
+        return false;
+    }
 
-   DLLLOCAL QoreFunction* getFunction() const {
-      return func;
-   }
+    DLLLOCAL qore_ns_private* getNamespace() const {
+        return ns;
+    }
+
+    DLLLOCAL QoreFunction* getFunction() const {
+        return func;
+    }
 
     DLLLOCAL QoreFunction* getFunction(bool runtime) const {
         if (runtime && func->committedEmpty())
@@ -82,7 +97,7 @@ public:
     }
 
     DLLLOCAL void parseInit() {
-        func->parseInit();
+        func->parseInit(ns);
     }
 
     DLLLOCAL void parseCommit() {
@@ -100,26 +115,28 @@ public:
         return 0;
     }
 
-   DLLLOCAL ResolvedCallReferenceNode* makeCallReference(const QoreProgramLocation& loc) const;
+    DLLLOCAL ResolvedCallReferenceNode* makeCallReference(const QoreProgramLocation& loc) const;
 
-   DLLLOCAL bool isPublic() const {
-      return func->hasPublic();
-   }
+    DLLLOCAL bool isPublic() const {
+        return func->hasPublic();
+    }
 
-   DLLLOCAL bool isUserPublic() const {
-      return func->hasUserPublic();
-   }
+    DLLLOCAL bool isUserPublic() const {
+        return func->hasUserPublic();
+    }
 
-   DLLLOCAL bool hasBuiltin() const {
-      return func->hasBuiltin();
-   }
+    DLLLOCAL bool hasBuiltin() const {
+        return func->hasBuiltin();
+    }
 
-   DLLLOCAL void updateNs(qore_ns_private* ns);
+    DLLLOCAL void updateNs(qore_ns_private* ns) {
+        this->ns = ns;
+    }
 };
 
 class ModuleImportedFunctionEntry : public FunctionEntry {
 public:
-   DLLLOCAL ModuleImportedFunctionEntry(const FunctionEntry& old, qore_ns_private* ns);
+    DLLLOCAL ModuleImportedFunctionEntry(const FunctionEntry& old, qore_ns_private* ns);
 };
 
 #ifdef HAVE_QORE_HASH_MAP
@@ -134,43 +151,43 @@ typedef std::map<const char*, FunctionEntry*, ltstr> fl_map_t;
 
 class FunctionList : public fl_map_t {
 public:
-   DLLLOCAL FunctionList() {
-   }
+    DLLLOCAL FunctionList() {
+    }
 
-   DLLLOCAL FunctionList(const FunctionList& old, qore_ns_private* ns, int64 po);
+    DLLLOCAL FunctionList(const FunctionList& old, qore_ns_private* ns, int64 po);
 
-   DLLLOCAL ~FunctionList() {
-      del();
-   }
+    DLLLOCAL ~FunctionList() {
+        del();
+    }
 
-   DLLLOCAL FunctionEntry* add(QoreFunction* func);
-   DLLLOCAL FunctionEntry* import(QoreFunction* func, qore_ns_private* ns);
-   DLLLOCAL FunctionEntry* import(const char* new_name, QoreFunction* func, qore_ns_private* ns, bool inject);
-   DLLLOCAL QoreFunction* find(const char* name, bool runtime) const;
-   DLLLOCAL FunctionEntry* findNode(const char* name) const;
+    DLLLOCAL FunctionEntry* add(QoreFunction* func, qore_ns_private* ns);
+    DLLLOCAL FunctionEntry* import(QoreFunction* func, qore_ns_private* ns);
+    DLLLOCAL FunctionEntry* import(const char* new_name, QoreFunction* func, qore_ns_private* ns, bool inject);
+    DLLLOCAL QoreFunction* find(const char* name, bool runtime) const;
+    DLLLOCAL FunctionEntry* findNode(const char* name, bool runtime = false) const;
 
-   DLLLOCAL void mergeUserPublic(const FunctionList& src, qore_ns_private* ns) {
-      for (fl_map_t::const_iterator i = src.begin(), e = src.end(); i != e; ++i) {
-         if (!i->second->isUserPublic())
-            continue;
+    DLLLOCAL void mergeUserPublic(const FunctionList& src, qore_ns_private* ns) {
+        for (fl_map_t::const_iterator i = src.begin(), e = src.end(); i != e; ++i) {
+            if (!i->second->isUserPublic())
+                continue;
 
-         assert(!findNode(i->first));
-         FunctionEntry* fe = new ModuleImportedFunctionEntry(*i->second, ns);
-         //printd(5, "FunctionList::mergePublic() this: %p merging in %s (%p)\n", this, i->first, fe);
-         assert(!fe->isUserPublic());
-         insert(fl_map_t::value_type(fe->getName(), fe));
-      }
-   }
+            assert(!findNode(i->first));
+            FunctionEntry* fe = new ModuleImportedFunctionEntry(*i->second, ns);
+            //printd(5, "FunctionList::mergePublic() this: %p merging in %s (%p)\n", this, i->first, fe);
+            assert(!fe->isUserPublic());
+            insert(fl_map_t::value_type(fe->getName(), fe));
+        }
+    }
 
-   // returns the number of functions imported
-   DLLLOCAL int importSystemFunctions(const FunctionList& src, qore_ns_private* ns, ExceptionSink* xsink);
+    // returns the number of functions imported
+    DLLLOCAL int importSystemFunctions(const FunctionList& src, qore_ns_private* ns, ExceptionSink* xsink);
 
-   DLLLOCAL void del();
-   DLLLOCAL void parseInit();
-   DLLLOCAL void parseRollback();
-   DLLLOCAL void parseCommit();
-   DLLLOCAL QoreListNode* getList();
-   DLLLOCAL void assimilate(FunctionList& fl, qore_ns_private* ns);
+    DLLLOCAL void del();
+    DLLLOCAL void parseInit();
+    DLLLOCAL void parseRollback();
+    DLLLOCAL void parseCommit();
+    DLLLOCAL QoreListNode* getList();
+    DLLLOCAL void assimilate(FunctionList& fl, qore_ns_private* ns);
 };
 
 #endif

--- a/include/qore/intern/ModuleInfo.h
+++ b/include/qore/intern/ModuleInfo.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -87,186 +87,163 @@ public:
 
 class QoreAbstractModule {
 private:
-   // not implemented
-   DLLLOCAL QoreAbstractModule(const QoreAbstractModule&);
-   DLLLOCAL QoreAbstractModule& operator=(const QoreAbstractModule&);
+    // not implemented
+    DLLLOCAL QoreAbstractModule(const QoreAbstractModule&);
+    DLLLOCAL QoreAbstractModule& operator=(const QoreAbstractModule&);
 
 protected:
-   QoreString filename,
-      name,
-      desc,
-      author,
-      url,
-      license,
-      orig_name;
+    QoreString filename,
+        name,
+        desc,
+        author,
+        url,
+        license,
+        orig_name;
 
-   // link to associated modules (originals with reinjection, etc)
-   QoreAbstractModule* prev, * next;
+    // link to associated modules (originals with reinjection, etc)
+    QoreAbstractModule* prev, * next;
 
-   bool priv : 1,
-      injected : 1,
-      reinjected : 1;
+    bool priv : 1,
+        injected : 1,
+        reinjected : 1;
 
-   DLLLOCAL QoreHashNode* getHashIntern(bool with_filename = true) const {
-      QoreHashNode* h = new QoreHashNode;
+    DLLLOCAL QoreHashNode* getHashIntern(bool with_filename = true) const;
 
-      if (with_filename)
-         h->setKeyValue("filename", new QoreStringNode(filename), 0);
-      h->setKeyValue("name", new QoreStringNode(name), 0);
-      h->setKeyValue("desc", new QoreStringNode(desc), 0);
-      h->setKeyValue("version", new QoreStringNode(*version_list), 0);
-      h->setKeyValue("author", new QoreStringNode(author), 0);
-      if (!url.empty())
-         h->setKeyValue("url", new QoreStringNode(url), 0);
-      if (!license.empty())
-         h->setKeyValue("license", new QoreStringNode(license), 0);
-      if (!rmod.empty()) {
-         QoreListNode* l = new QoreListNode;
-         for (name_vec_t::const_iterator i = rmod.begin(), e = rmod.end(); i != e; ++i)
-            l->push(new QoreStringNode(*i));
-         h->setKeyValue("reexported-modules", l, 0);
-      }
-      h->setKeyValue("injected", get_bool_node(injected), 0);
-      h->setKeyValue("reinjected", get_bool_node(injected), 0);
+    DLLLOCAL virtual void addToProgramImpl(QoreProgram* pgm, ExceptionSink& xsink) const = 0;
 
-      return h;
-   }
-
-   DLLLOCAL virtual void addToProgramImpl(QoreProgram* pgm, ExceptionSink& xsink) const = 0;
-
-   DLLLOCAL void set(const char* d, const char* v, const char* a, const char* u, const QoreString& l) {
-      desc = d;
-      author = a;
-      url = u;
-      license = l;
-      version_list = v;
-   }
+    DLLLOCAL void set(const char* d, const char* v, const char* a, const char* u, const QoreString& l) {
+        desc = d;
+        author = a;
+        url = u;
+        license = l;
+        version_list = v;
+    }
 
 public:
-   version_list_t version_list;
-   // list of dependent modules to reexport
-   name_vec_t rmod;
+    version_list_t version_list;
+    // list of dependent modules to reexport
+    name_vec_t rmod;
 
-   // for binary modules
-   DLLLOCAL QoreAbstractModule(const char* cwd, const char* fn, const char* n, const char* d, const char* v, const char* a, const char* u, const QoreString& l) : filename(fn), name(n), desc(d), author(a), url(u), license(l), prev(0), next(0), priv(false), injected(false), reinjected(false), version_list(v) {
-      q_normalize_path(filename, cwd);
-   }
+    // for binary modules
+    DLLLOCAL QoreAbstractModule(const char* cwd, const char* fn, const char* n, const char* d, const char* v, const char* a, const char* u, const QoreString& l) : filename(fn), name(n), desc(d), author(a), url(u), license(l), prev(0), next(0), priv(false), injected(false), reinjected(false), version_list(v) {
+        q_normalize_path(filename, cwd);
+    }
 
-   // for user modules
-   DLLLOCAL QoreAbstractModule(const char* cwd, const char* fn, const char* n, unsigned load_opt) : filename(fn), name(n), prev(0), next(0), priv(load_opt & QMLO_PRIVATE), injected(load_opt & QMLO_INJECT), reinjected(load_opt & QMLO_REINJECT) {
-      q_normalize_path(filename, cwd);
-   }
+    // for user modules
+    DLLLOCAL QoreAbstractModule(const char* cwd, const char* fn, const char* n, unsigned load_opt) : filename(fn), name(n), prev(0), next(0), priv(load_opt & QMLO_PRIVATE), injected(load_opt & QMLO_INJECT), reinjected(load_opt & QMLO_REINJECT) {
+        q_normalize_path(filename, cwd);
+    }
 
-   DLLLOCAL virtual ~QoreAbstractModule() {
-      //printd(5, "QoreAbstractModule::~QoreAbstractModule() this: %p name: %s\n", this, name.getBuffer());
-      if (next) {
-         assert(next->prev == this);
-         next->prev = prev;
-      }
-      if (prev) {
-         assert(prev->next == this);
-         prev->next = next;
-      }
-   }
+    DLLLOCAL virtual ~QoreAbstractModule() {
+        //printd(5, "QoreAbstractModule::~QoreAbstractModule() this: %p name: %s\n", this, name.getBuffer());
+        if (next) {
+            assert(next->prev == this);
+            next->prev = prev;
+        }
+        if (prev) {
+            assert(prev->next == this);
+            prev->next = next;
+        }
+    }
 
-   DLLLOCAL const char* getName() const {
-      return name.getBuffer();
-   }
+    DLLLOCAL const char* getName() const {
+        return name.getBuffer();
+    }
 
-   DLLLOCAL const char* getFileName() const {
-      return filename.getBuffer();
-   }
+    DLLLOCAL const char* getFileName() const {
+        return filename.getBuffer();
+    }
 
-   DLLLOCAL const QoreString& getFileNameStr() const {
-      return filename;
-   }
+    DLLLOCAL const QoreString& getFileNameStr() const {
+        return filename;
+    }
 
-   DLLLOCAL const char* getDesc() const {
-      return desc.getBuffer();
-   }
+    DLLLOCAL const char* getDesc() const {
+        return desc.getBuffer();
+    }
 
-   DLLLOCAL const char* getVersion() const {
-      return* version_list;
-   }
+    DLLLOCAL const char* getVersion() const {
+        return* version_list;
+    }
 
-   DLLLOCAL const char* getURL() const {
-      return url.getBuffer();
-   }
+    DLLLOCAL const char* getURL() const {
+        return url.getBuffer();
+    }
 
-   DLLLOCAL const char* getOrigName() const {
-      return orig_name.empty() ? 0 : orig_name.getBuffer();
-   }
+    DLLLOCAL const char* getOrigName() const {
+        return orig_name.empty() ? 0 : orig_name.getBuffer();
+    }
 
-   DLLLOCAL void resetName() {
-      assert(!orig_name.empty());
-      name = orig_name;
-      orig_name.clear();
-   }
+    DLLLOCAL void resetName() {
+        assert(!orig_name.empty());
+        name = orig_name;
+        orig_name.clear();
+    }
 
-   DLLLOCAL bool isInjected() const {
-      return injected;
-   }
+    DLLLOCAL bool isInjected() const {
+        return injected;
+    }
 
-   DLLLOCAL bool isReInjected() const {
-      return reinjected;
-   }
+    DLLLOCAL bool isReInjected() const {
+        return reinjected;
+    }
 
-   DLLLOCAL void addModuleReExport(const char* m) {
-      rmod.push_back(m);
-   }
+    DLLLOCAL void addModuleReExport(const char* m) {
+        rmod.push_back(m);
+    }
 
-   DLLLOCAL void reexport(ExceptionSink& xsink, QoreProgram* pgm) const;
+    DLLLOCAL void reexport(ExceptionSink& xsink, QoreProgram* pgm) const;
 
-   DLLLOCAL void addToProgram(QoreProgram* pgm, ExceptionSink& xsink) const {
-      addToProgramImpl(pgm, xsink);
-      if (!xsink)
-         reexport(xsink, pgm);
-   }
+    DLLLOCAL void addToProgram(QoreProgram* pgm, ExceptionSink& xsink) const {
+        addToProgramImpl(pgm, xsink);
+        if (!xsink)
+            reexport(xsink, pgm);
+    }
 
-   DLLLOCAL bool equalTo(const QoreAbstractModule* m) const {
-      assert(name == m->name);
-      return filename == m->filename;
-   }
+    DLLLOCAL bool equalTo(const QoreAbstractModule* m) const {
+        assert(name == m->name);
+        return filename == m->filename;
+    }
 
-   DLLLOCAL bool isPath(const char* p) const {
-      return filename == p;
-   }
+    DLLLOCAL bool isPath(const char* p) const {
+        return filename == p;
+    }
 
-   DLLLOCAL void rename(const QoreString& n) {
-      assert(orig_name.empty());
-      name = n;
-   }
+    DLLLOCAL void rename(const QoreString& n) {
+        assert(orig_name.empty());
+        name = n;
+    }
 
-   DLLLOCAL void setOrigName(const char* n) {
-      assert(orig_name.empty());
-      orig_name = n;
-   }
+    DLLLOCAL void setOrigName(const char* n) {
+        assert(orig_name.empty());
+        orig_name = n;
+    }
 
-   DLLLOCAL bool isPrivate() const {
-      return priv;
-   }
+    DLLLOCAL bool isPrivate() const {
+        return priv;
+    }
 
-   DLLLOCAL void setPrivate(bool p = true) {
-      assert(priv != p);
-      priv = p;
-   }
+    DLLLOCAL void setPrivate(bool p = true) {
+        assert(priv != p);
+        priv = p;
+    }
 
-   DLLLOCAL void setLink(QoreAbstractModule* n) {
-      //printd(5, "AbstractQoreModule::setLink() n: %p '%s'\n", n, n->getName());
-      assert(!next);
-      assert(!n->prev);
-      next = n;
-      n->prev = this;
-   }
+    DLLLOCAL void setLink(QoreAbstractModule* n) {
+        //printd(5, "AbstractQoreModule::setLink() n: %p '%s'\n", n, n->getName());
+        assert(!next);
+        assert(!n->prev);
+        next = n;
+        n->prev = this;
+    }
 
-   DLLLOCAL QoreAbstractModule* getNext() const {
-      return next;
-   }
+    DLLLOCAL QoreAbstractModule* getNext() const {
+        return next;
+    }
 
-   DLLLOCAL virtual bool isBuiltin() const = 0;
-   DLLLOCAL virtual bool isUser() const = 0;
-   DLLLOCAL virtual QoreHashNode* getHash(bool with_filename = true) const = 0;
-   DLLLOCAL virtual void issueParseCmd(const QoreProgramLocation& loc, QoreString &cmd) = 0;
+    DLLLOCAL virtual bool isBuiltin() const = 0;
+    DLLLOCAL virtual bool isUser() const = 0;
+    DLLLOCAL virtual QoreHashNode* getHash(bool with_filename = true) const = 0;
+    DLLLOCAL virtual void issueParseCmd(const QoreProgramLocation& loc, QoreString &cmd) = 0;
 };
 
 // list/dequeue of strings
@@ -529,10 +506,10 @@ public:
 #ifdef DEBUG
       /*
       else {
-	 QoreString str("[");
-	 for (strset_t::iterator si = i->second.begin(), se = i->second.end(); si != se; ++si)
-	    str.sprintf("'%s',", (*si).c_str());
-	 str.concat("]");
+         QoreString str("[");
+         for (strset_t::iterator si = i->second.begin(), se = i->second.end(); si != se; ++si)
+            str.sprintf("'%s',", (*si).c_str());
+         str.concat("]");
          //printd(5, "QoreModuleManager::trySetUserModule('%s') UMSET NOT SET: md_map: %s\n", name, str.getBuffer());
       }
       */
@@ -592,96 +569,88 @@ DLLLOCAL extern QoreModuleManager QMM;
 
 class QoreBuiltinModule : public QoreAbstractModule {
 protected:
-   unsigned api_major, api_minor;
-   qore_module_init_t module_init;
-   qore_module_ns_init_t module_ns_init;
-   qore_module_delete_t module_delete;
-   qore_module_parse_cmd_t module_parse_cmd;
-   const void* dlptr;
+    unsigned api_major, api_minor;
+    qore_module_init_t module_init;
+    qore_module_ns_init_t module_ns_init;
+    qore_module_delete_t module_delete;
+    qore_module_parse_cmd_t module_parse_cmd;
+    const void* dlptr;
 
-   DLLLOCAL virtual void addToProgramImpl(QoreProgram* pgm, ExceptionSink& xsink) const;
+    DLLLOCAL virtual void addToProgramImpl(QoreProgram* pgm, ExceptionSink& xsink) const;
 
 public:
-   DLLLOCAL QoreBuiltinModule(const char* cwd, const char* fn, const char* n, const char* d, const char* v, const char* a, const char* u, const QoreString& l, unsigned major, unsigned minor, qore_module_init_t init, qore_module_ns_init_t ns_init, qore_module_delete_t del, qore_module_parse_cmd_t pcmd, const void* p) : QoreAbstractModule(cwd, fn, n, d, v, a, u, l), api_major(major), api_minor(minor), module_init(init), module_ns_init(ns_init), module_delete(del), module_parse_cmd(pcmd), dlptr(p) {
-   }
+    DLLLOCAL QoreBuiltinModule(const char* cwd, const char* fn, const char* n, const char* d, const char* v, const char* a, const char* u, const QoreString& l, unsigned major, unsigned minor, qore_module_init_t init, qore_module_ns_init_t ns_init, qore_module_delete_t del, qore_module_parse_cmd_t pcmd, const void* p) : QoreAbstractModule(cwd, fn, n, d, v, a, u, l), api_major(major), api_minor(minor), module_init(init), module_ns_init(ns_init), module_delete(del), module_parse_cmd(pcmd), dlptr(p) {
+    }
 
-   DLLLOCAL virtual ~QoreBuiltinModule() {
-      printd(5, "QoreBuiltinModule::~QoreBuiltinModule() '%s': %s calling module_delete: %p\n", name.getBuffer(), filename.getBuffer(), module_delete);
-      module_delete();
-      // we do not close binary modules because we may have thread local data that needs to be
-      // destroyed when exit() is called
-   }
+    DLLLOCAL virtual ~QoreBuiltinModule() {
+        printd(5, "QoreBuiltinModule::~QoreBuiltinModule() '%s': %s calling module_delete: %p\n", name.getBuffer(), filename.getBuffer(), module_delete);
+        module_delete();
+        // we do not close binary modules because we may have thread local data that needs to be
+        // destroyed when exit() is called
+    }
 
-   DLLLOCAL unsigned getAPIMajor() const {
-      return api_major;
-   }
+    DLLLOCAL unsigned getAPIMajor() const {
+        return api_major;
+    }
 
-   DLLLOCAL unsigned getAPIMinor() const {
-      return api_minor;
-   }
+    DLLLOCAL unsigned getAPIMinor() const {
+        return api_minor;
+    }
 
-   DLLLOCAL virtual bool isBuiltin() const {
-      return true;
-   }
+    DLLLOCAL virtual bool isBuiltin() const {
+        return true;
+    }
 
-   DLLLOCAL virtual bool isUser() const {
-      return false;
-   }
+    DLLLOCAL virtual bool isUser() const {
+        return false;
+    }
 
-   DLLLOCAL QoreHashNode* getHash(bool with_filename = true) const {
-      QoreHashNode* h = getHashIntern(with_filename);
+    DLLLOCAL QoreHashNode* getHash(bool with_filename = true) const;
 
-      h->setKeyValue("user", &False, 0);
-      h->setKeyValue("api_major", new QoreBigIntNode(api_major), 0);
-      h->setKeyValue("api_minor", new QoreBigIntNode(api_minor), 0);
+    DLLLOCAL const void* getPtr() const {
+        return dlptr;
+    }
 
-      return h;
-   }
-
-   DLLLOCAL const void* getPtr() const {
-      return dlptr;
-   }
-
-   DLLLOCAL virtual void issueParseCmd(const QoreProgramLocation& loc, QoreString &cmd);
+    DLLLOCAL virtual void issueParseCmd(const QoreProgramLocation& loc, QoreString &cmd);
 };
 
 class QoreUserModule : public QoreAbstractModule {
 protected:
-   QoreProgram* pgm;
-   QoreClosureParseNode* del; // deletion closure
+    QoreProgram* pgm;
+    QoreClosureParseNode* del; // deletion closure
 
-   DLLLOCAL virtual void addToProgramImpl(QoreProgram* pgm, ExceptionSink& xsink) const;
+    DLLLOCAL virtual void addToProgramImpl(QoreProgram* pgm, ExceptionSink& xsink) const;
 
 public:
-   DLLLOCAL QoreUserModule(const char* cwd, const char* fn, const char* n, QoreProgram* p, unsigned load_opt) : QoreAbstractModule(cwd, fn, n, load_opt), pgm(p), del(0) {
-   }
+    DLLLOCAL QoreUserModule(const char* cwd, const char* fn, const char* n, QoreProgram* p, unsigned load_opt) : QoreAbstractModule(cwd, fn, n, load_opt), pgm(p), del(0) {
+    }
 
-   DLLLOCAL void set(const char* d, const char* v, const char* a, const char* u, const QoreString& l, QoreClosureParseNode* dl) {
-      QoreAbstractModule::set(d, v, a, u, l);
-      del = dl;
-   }
+    DLLLOCAL void set(const char* d, const char* v, const char* a, const char* u, const QoreString& l, QoreClosureParseNode* dl) {
+        QoreAbstractModule::set(d, v, a, u, l);
+        del = dl;
+    }
 
-   DLLLOCAL QoreProgram* getProgram() const {
-      return pgm;
-   }
+    DLLLOCAL QoreProgram* getProgram() const {
+        return pgm;
+    }
 
-   DLLLOCAL virtual ~QoreUserModule();
+    DLLLOCAL virtual ~QoreUserModule();
 
-   DLLLOCAL virtual bool isBuiltin() const {
-      return false;
-   }
+    DLLLOCAL virtual bool isBuiltin() const {
+        return false;
+    }
 
-   DLLLOCAL virtual bool isUser() const {
-      return true;
-   }
+    DLLLOCAL virtual bool isUser() const {
+        return true;
+    }
 
-   DLLLOCAL virtual QoreHashNode* getHash(bool with_filename = true) const {
-      return getHashIntern(with_filename);
-   }
+    DLLLOCAL virtual QoreHashNode* getHash(bool with_filename = true) const {
+        return getHashIntern(with_filename);
+    }
 
-   DLLLOCAL virtual void issueParseCmd(const QoreProgramLocation& loc, QoreString &cmd) {
-      parseException(loc, "PARSE-COMMAND-ERROR", "module '%s' loaded from '%s' is a user module; only builtin modules can support parse commands", name.getBuffer(), filename.getBuffer());
-   }
+    DLLLOCAL virtual void issueParseCmd(const QoreProgramLocation& loc, QoreString &cmd) {
+        parseException(loc, "PARSE-COMMAND-ERROR", "module '%s' loaded from '%s' is a user module; only builtin modules can support parse commands", name.getBuffer(), filename.getBuffer());
+    }
 };
 
 class QoreUserModuleDefContextHelper : public QoreModuleDefContextHelper {

--- a/include/qore/intern/NamedScope.h
+++ b/include/qore/intern/NamedScope.h
@@ -4,11 +4,11 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   NamedScopes are children of a program object.  there is a parse
   lock per program object to ensure that objects are added (or backed out)
-  atomically per program object.  All the objects referenced here should 
+  atomically per program object.  All the objects referenced here should
   be safe to read & copied at all times.  They will only be deleted when the
   program object is deleted (except the pending structures, which will be
   deleted any time there is a parse error, together with all other
@@ -47,85 +47,93 @@
 // for parsing namespace/class scope resolution
 class NamedScope {
 protected:
-   typedef std::vector<std::string> nslist_t;
+    typedef std::vector<std::string> nslist_t;
 
-   bool del;
+    bool del;
 
-   DLLLOCAL void init();
+    DLLLOCAL void init();
 
 public:
-   char *ostr;
-   nslist_t strlist;
+    char* ostr;
+    nslist_t strlist;
 
-   DLLLOCAL NamedScope(char *str) : del(true), ostr(str) {
-      assert(str);
-      init();
-   }
+    DLLLOCAL NamedScope(char *str) : del(true), ostr(str) {
+        assert(str);
+        init();
+    }
 
-   DLLLOCAL NamedScope(const char *str) : del(false), ostr((char *)str) {
-      assert(str);
-      init();
-   }
+    DLLLOCAL NamedScope(const char *str) : del(false), ostr((char *)str) {
+        assert(str);
+        init();
+    }
 
-   // takes all values from and deletes the argument
-   DLLLOCAL NamedScope(NamedScope *ns) : del(ns->del), ostr(ns->ostr), strlist(ns->strlist) {
-      ns->ostr = 0;
-      delete ns;
-   }
+    // takes all values from and deletes the argument
+    DLLLOCAL NamedScope(NamedScope *ns) : del(ns->del), ostr(ns->ostr), strlist(ns->strlist) {
+        ns->ostr = 0;
+        delete ns;
+    }
 
-   DLLLOCAL NamedScope(const NamedScope &old) : del(true), ostr(strdup(old.ostr)), strlist(old.strlist) {
-   }
+    DLLLOCAL NamedScope(const NamedScope &old) : del(old.del), ostr(old.del ? strdup(old.ostr) : old.ostr), strlist(old.strlist) {
+    }
 
-   DLLLOCAL ~NamedScope() {
-      clear();
-   }
+    DLLLOCAL ~NamedScope() {
+        clear();
+    }
 
-   DLLLOCAL void clear() {
-      if (ostr && del)
-         free(ostr);
-      strlist.clear();
-      ostr = 0;
-      del = false;
-   }
+    DLLLOCAL void clear() {
+        if (ostr && del)
+            free(ostr);
+        strlist.clear();
+        ostr = nullptr;
+        del = false;
+    }
 
-   DLLLOCAL const char *getIdentifier() const {
-      return strlist[strlist.size() - 1].c_str();
-   }
+    DLLLOCAL const char *getIdentifier() const {
+        return strlist[strlist.size() - 1].c_str();
+    }
 
-   DLLLOCAL const std::string &getIdentifierStr() const {
-      return strlist[strlist.size() - 1];
-   }
+    DLLLOCAL const std::string &getIdentifierStr() const {
+        return strlist[strlist.size() - 1];
+    }
 
-   DLLLOCAL const char* get(unsigned i) const {
-      assert(i < strlist.size());
-      return strlist[i].c_str();
-   }
+    DLLLOCAL const char* get(unsigned i) const {
+        assert(i < strlist.size());
+        return strlist[i].c_str();
+    }
 
-   DLLLOCAL const char* operator[](unsigned i) const {
-      assert(i < strlist.size());
-      return strlist[i].c_str();
-   }         
+    DLLLOCAL const char* operator[](unsigned i) const {
+        assert(i < strlist.size());
+        return strlist[i].c_str();
+    }
 
-   DLLLOCAL unsigned size() const {
-      return strlist.size(); 
-   }
+    DLLLOCAL unsigned size() const {
+        return strlist.size();
+    }
 
-   DLLLOCAL NamedScope *copy() const;
-   DLLLOCAL void fixBCCall();
+    DLLLOCAL NamedScope *copy() const;
+    DLLLOCAL void fixBCCall();
 
-   DLLLOCAL char *takeName() {
-      char *rv = del ? ostr : strdup(ostr);
-      ostr = 0;
-      clear();
-      return rv;
-   }
+    DLLLOCAL char* takeName() {
+        char *rv = del ? ostr : strdup(ostr);
+        ostr = 0;
+        clear();
+        return rv;
+    }
+
+    /*
+    DLLLOCAL void truncate() {
+        while (strlist.size() > 1) {
+            strlist.erase(strlist.begin());
+        }
+    }
+    */
 };
 
 class ltns {
 public:
-   DLLLOCAL bool operator()(const NamedScope& s1, const NamedScope& s2) const {
-      return strcmp(s1.ostr, s2.ostr) < 0;
-   }
+    DLLLOCAL bool operator()(const NamedScope& s1, const NamedScope& s2) const {
+        return strcmp(s1.ostr, s2.ostr) < 0;
+    }
 };
 
 #endif // QORE_NAMEDSCOPE_H

--- a/include/qore/intern/NamedScope.h
+++ b/include/qore/intern/NamedScope.h
@@ -73,7 +73,7 @@ public:
         delete ns;
     }
 
-    DLLLOCAL NamedScope(const NamedScope &old) : del(old.del), ostr(old.del ? strdup(old.ostr) : old.ostr), strlist(old.strlist) {
+    DLLLOCAL NamedScope(const NamedScope &old) : del(true), ostr(strdup(old.ostr)), strlist(old.strlist) {
     }
 
     DLLLOCAL ~NamedScope() {

--- a/include/qore/intern/QoreAssignmentOperatorNode.h
+++ b/include/qore/intern/QoreAssignmentOperatorNode.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/include/qore/intern/QoreClassIntern.h
+++ b/include/qore/intern/QoreClassIntern.h
@@ -1709,78 +1709,78 @@ struct SelfInstantiatorHelper {
 // class "signature" hash for comparing classes with the same name from different program objects at runtime
 class SignatureHash {
 protected:
-   unsigned char buf[SH_SIZE];
-   bool is_set;
+    unsigned char buf[SH_SIZE];
+    bool is_set;
 
-   DLLLOCAL void set(const QoreString& str);
+    DLLLOCAL void set(const QoreString& str);
 
-   DLLLOCAL void clearHash() {
-      memset(buf, 0, SH_SIZE);
-   }
+    DLLLOCAL void clearHash() {
+        memset(buf, 0, SH_SIZE);
+    }
 
-   DLLLOCAL void copyHash(const SignatureHash& other) {
-      memcpy(buf, other.buf, SH_SIZE);
-   }
+    DLLLOCAL void copyHash(const SignatureHash& other) {
+        memcpy(buf, other.buf, SH_SIZE);
+    }
 
 public:
-   DLLLOCAL SignatureHash() : is_set(false) {
-      clearHash();
-   }
+    DLLLOCAL SignatureHash() : is_set(false) {
+        clearHash();
+    }
 
-   DLLLOCAL SignatureHash(const SignatureHash& old) : is_set(old.is_set) {
-      if (is_set)
-         copyHash(old);
-   }
+    DLLLOCAL SignatureHash(const SignatureHash& old) : is_set(old.is_set) {
+        if (is_set)
+            copyHash(old);
+    }
 
-   DLLLOCAL void update(const QoreString& str);
+    DLLLOCAL void update(const QoreString& str);
 
-   DLLLOCAL void updateEmpty() {
-      assert(!is_set);
-      clearHash();
-      is_set = true;
-   }
+    DLLLOCAL void updateEmpty() {
+        assert(!is_set);
+        clearHash();
+        is_set = true;
+    }
 
-   DLLLOCAL bool operator==(const SignatureHash& other) const {
-      // if either one of the hashes is not set, then the comparison always fails
-      if (!is_set || !other.is_set)
-         return false;
-      return !memcmp(buf, other.buf, SH_SIZE);
-   }
+    DLLLOCAL bool operator==(const SignatureHash& other) const {
+        // if either one of the hashes is not set, then the comparison always fails
+        if (!is_set || !other.is_set)
+            return false;
+        return !memcmp(buf, other.buf, SH_SIZE);
+    }
 
-   DLLLOCAL SignatureHash& operator=(const SignatureHash& other) {
-      if (!other.is_set) {
-         assert(false);
-         clear();
-      }
-      else {
-         if (!is_set)
-            is_set = true;
-         copyHash(other);
-      }
-      return *this;
-   }
+    DLLLOCAL SignatureHash& operator=(const SignatureHash& other) {
+        if (!other.is_set) {
+            assert(false);
+            clear();
+        }
+        else {
+            if (!is_set)
+                is_set = true;
+            copyHash(other);
+        }
+        return *this;
+    }
 
-   DLLLOCAL operator bool() const {
-      return is_set;
-   }
+    DLLLOCAL operator bool() const {
+        return is_set;
+    }
 
-   // appends the hash to the string
-   DLLLOCAL void toString(QoreString& str) const {
-      for (unsigned i = 0; i < SH_SIZE; ++i)
-         str.sprintf("%02x", buf[i]);
-   }
+    // appends the hash to the string
+    DLLLOCAL void toString(QoreString& str) const {
+        for (unsigned i = 0; i < SH_SIZE; ++i)
+            str.sprintf("%02x", buf[i]);
+    }
 
-   DLLLOCAL char* getHash() const {
-      assert(is_set);
-      return (char*)buf;
-   }
+    DLLLOCAL char* getHash() const {
+        assert(is_set);
+        return (char*)buf;
+    }
 
-   DLLLOCAL void clear() {
-      if (is_set) {
-         is_set = false;
-         clearHash();
-      }
-   }
+    DLLLOCAL void clear() {
+        if (is_set) {
+            is_set = false;
+            clearHash();
+        }
+    }
 };
 
 #define QCCM_NORMAL (1 << 0)

--- a/include/qore/intern/QoreClassIntern.h
+++ b/include/qore/intern/QoreClassIntern.h
@@ -1145,11 +1145,11 @@ public:
       return new QoreVarInfo(*this);
    }
 
-   DLLLOCAL AbstractQoreNode* assignInit(AbstractQoreNode* v) {
-      // try to set an optimized value type for the value holder if possible
-      val.set(getTypeInfo());
-      return val.assignInitial(v);
-   }
+    DLLLOCAL AbstractQoreNode* assignInit(QoreValue v) {
+        // try to set an optimized value type for the value holder if possible
+        val.set(getTypeInfo());
+        return val.assignInitial(v);
+    }
 
    DLLLOCAL void getLValue(LValueHelper& lvh) {
       lvh.setAndLock(rwl);
@@ -1218,15 +1218,15 @@ public:
    typedef typename member_map_t::const_iterator SigOrderIterator;
 
 public:
-   DLLLOCAL ~QoreMemberMapBase() {
-      for (typename member_map_t::iterator i = map.begin(), e = map.end(); i != e; ++i) {
-         //printd(5, "QoreMemberMap::~QoreMemberMap() this: %p freeing pending private member %p '%s'\n", this, i->second, i->first);
-         delete i->second;
-         free(i->first);
-      }
-      map.clear();
-      list.clear();
-   }
+    DLLLOCAL ~QoreMemberMapBase() {
+        for (typename member_map_t::iterator i = map.begin(), e = map.end(); i != e; ++i) {
+            //printd(5, "QoreMemberMap::~QoreMemberMap() this: %p freeing member %p '%s'\n", this, i->second, i->first);
+            delete i->second;
+            free(i->first);
+        }
+        map.clear();
+        list.clear();
+    }
 
    DLLLOCAL bool inList(const char* name) const {
       return map.find(const_cast<char*>(name)) != map.end();

--- a/include/qore/intern/QoreClassIntern.h
+++ b/include/qore/intern/QoreClassIntern.h
@@ -3016,7 +3016,7 @@ public:
 
     DLLLOCAL static QoreClass* makeImportClass(const QoreClass& qc, QoreProgram* spgm, const char* nme, bool inject, const qore_class_private* injectedClass) {
         qore_class_private* priv = new qore_class_private(*qc.priv, nme, inject, injectedClass);
-        printd(5, "qore_program_private::makeImportClass() name: '%s' (%s) inject: %d rv: %p\n", qc.getName(), nme ? nme : "n/a", inject, priv->cls);
+        //printd(5, "qore_program_private::makeImportClass() name: '%s' as '%s' inject: %d rv: %p\n", qc.getName(), priv->name.c_str(), inject, priv->cls);
         return priv->cls;
     }
 

--- a/include/qore/intern/QoreClassIntern.h
+++ b/include/qore/intern/QoreClassIntern.h
@@ -3243,142 +3243,142 @@ public:
 
 class qore_method_private {
 public:
-   const QoreClass* parent_class;
-   MethodFunctionBase* func;
-   bool static_flag, all_user;
+    const QoreClass* parent_class;
+    MethodFunctionBase* func;
+    bool static_flag, all_user;
 
-   DLLLOCAL qore_method_private(const QoreClass* n_parent_class, MethodFunctionBase* n_func, bool n_static) : parent_class(n_parent_class), func(n_func), static_flag(n_static), all_user(true) {
-      assert(parent_class == n_func->getClass());
-   }
+    DLLLOCAL qore_method_private(const QoreClass* n_parent_class, MethodFunctionBase* n_func, bool n_static) : parent_class(n_parent_class), func(n_func), static_flag(n_static), all_user(true) {
+        assert(parent_class == n_func->getClass());
+    }
 
-   DLLLOCAL ~qore_method_private() {
-      func->deref();
-   }
+    DLLLOCAL ~qore_method_private() {
+        func->deref();
+    }
 
-   DLLLOCAL void setBuiltin() {
-      if (all_user)
-         all_user = false;
-   }
+    DLLLOCAL void setBuiltin() {
+        if (all_user)
+            all_user = false;
+    }
 
-   DLLLOCAL bool isUniquelyUser() const {
-      return all_user;
-   }
+    DLLLOCAL bool isUniquelyUser() const {
+        return all_user;
+    }
 
-   DLLLOCAL int addUserVariant(MethodVariantBase* variant) {
-      return func->parseAddUserMethodVariant(variant);
-   }
+    DLLLOCAL int addUserVariant(MethodVariantBase* variant) {
+        return func->parseAddUserMethodVariant(variant);
+    }
 
-   DLLLOCAL void addBuiltinVariant(MethodVariantBase* variant) {
-      setBuiltin();
-      func->addBuiltinMethodVariant(variant);
-   }
+    DLLLOCAL void addBuiltinVariant(MethodVariantBase* variant) {
+        setBuiltin();
+        func->addBuiltinMethodVariant(variant);
+    }
 
-   DLLLOCAL MethodFunctionBase* getFunction() const {
-      return const_cast<MethodFunctionBase* >(func);
-   }
+    DLLLOCAL MethodFunctionBase* getFunction() const {
+        return const_cast<MethodFunctionBase* >(func);
+    }
 
-   DLLLOCAL const char* getName() const {
-      return func->getName();
-   }
+    DLLLOCAL const char* getName() const {
+        return func->getName();
+    }
 
-   DLLLOCAL const std::string& getNameStr() const {
-      return func->getNameStr();
-   }
+    DLLLOCAL const std::string& getNameStr() const {
+        return func->getNameStr();
+    }
 
-   DLLLOCAL void parseInit();
+    DLLLOCAL void parseInit();
 
-   DLLLOCAL void parseInitStatic() {
-      assert(static_flag);
-      func->parseInit();
-      // make sure the method doesn't override a "final" method in a base class
-      func->checkFinal();
-   }
+    DLLLOCAL void parseInitStatic() {
+        assert(static_flag);
+        func->parseInit();
+        // make sure the method doesn't override a "final" method in a base class
+        func->checkFinal();
+    }
 
-   DLLLOCAL const QoreTypeInfo* getUniqueReturnTypeInfo() const {
-      return func->getUniqueReturnTypeInfo();
-   }
+    DLLLOCAL const QoreTypeInfo* getUniqueReturnTypeInfo() const {
+        return func->getUniqueReturnTypeInfo();
+    }
 
-   DLLLOCAL void evalConstructor(const AbstractQoreFunctionVariant* variant, QoreObject* self, const QoreValueList* args, BCEAList* bceal, ExceptionSink* xsink) {
-      CONMF(func)->evalConstructor(variant, *parent_class, self, args, parent_class->priv->scl, bceal, xsink);
-   }
+    DLLLOCAL void evalConstructor(const AbstractQoreFunctionVariant* variant, QoreObject* self, const QoreValueList* args, BCEAList* bceal, ExceptionSink* xsink) {
+        CONMF(func)->evalConstructor(variant, *parent_class, self, args, parent_class->priv->scl, bceal, xsink);
+    }
 
-   DLLLOCAL void evalConstructor(const AbstractQoreFunctionVariant* variant, QoreObject* self, const QoreListNode* args, BCEAList* bceal, ExceptionSink* xsink) {
-      CONMF(func)->evalConstructor(variant, *parent_class, self, args, parent_class->priv->scl, bceal, xsink);
-   }
+    DLLLOCAL void evalConstructor(const AbstractQoreFunctionVariant* variant, QoreObject* self, const QoreListNode* args, BCEAList* bceal, ExceptionSink* xsink) {
+        CONMF(func)->evalConstructor(variant, *parent_class, self, args, parent_class->priv->scl, bceal, xsink);
+    }
 
-   DLLLOCAL void evalCopy(QoreObject* self, QoreObject* old, ExceptionSink* xsink) const {
-      COPYMF(func)->evalCopy(*parent_class, self, old, parent_class->priv->scl, xsink);
-   }
+    DLLLOCAL void evalCopy(QoreObject* self, QoreObject* old, ExceptionSink* xsink) const {
+        COPYMF(func)->evalCopy(*parent_class, self, old, parent_class->priv->scl, xsink);
+    }
 
-   DLLLOCAL bool evalDeleteBlocker(QoreObject* self) const {
-      // can only be builtin
-      return self->evalDeleteBlocker(parent_class->priv->methodID, reinterpret_cast<BuiltinDeleteBlocker*>(func));
-   }
+    DLLLOCAL bool evalDeleteBlocker(QoreObject* self) const {
+        // can only be builtin
+        return self->evalDeleteBlocker(parent_class->priv->methodID, reinterpret_cast<BuiltinDeleteBlocker*>(func));
+    }
 
-   DLLLOCAL void evalDestructor(QoreObject* self, ExceptionSink* xsink) const {
-      DESMF(func)->evalDestructor(*parent_class, self, xsink);
-   }
+    DLLLOCAL void evalDestructor(QoreObject* self, ExceptionSink* xsink) const {
+        DESMF(func)->evalDestructor(*parent_class, self, xsink);
+    }
 
-   DLLLOCAL void evalSystemDestructor(QoreObject* self, ExceptionSink* xsink) const {
-      // execute function directly
-      DESMF(func)->evalDestructor(*parent_class, self, xsink);
-   }
+    DLLLOCAL void evalSystemDestructor(QoreObject* self, ExceptionSink* xsink) const {
+        // execute function directly
+        DESMF(func)->evalDestructor(*parent_class, self, xsink);
+    }
 
-   DLLLOCAL void evalSystemConstructor(QoreObject* self, int code, va_list args) const {
-      BSYSCONB(func)->eval(*parent_class, self, code, args);
-   }
+    DLLLOCAL void evalSystemConstructor(QoreObject* self, int code, va_list args) const {
+        BSYSCONB(func)->eval(*parent_class, self, code, args);
+    }
 
-   DLLLOCAL QoreValue eval(ExceptionSink* xsink, QoreObject* self, const QoreListNode* args, const qore_class_private* cctx = nullptr) const {
-      if (!static_flag) {
-         assert(self);
-         return NMETHF(func)->evalMethod(xsink, 0, self, args, cctx);
-      }
-      return SMETHF(func)->evalMethod(xsink, 0, args, cctx);
-   }
+    DLLLOCAL QoreValue eval(ExceptionSink* xsink, QoreObject* self, const QoreListNode* args, const qore_class_private* cctx = nullptr) const {
+        if (!static_flag) {
+            assert(self);
+            return NMETHF(func)->evalMethod(xsink, 0, self, args, cctx);
+        }
+        return SMETHF(func)->evalMethod(xsink, 0, args, cctx);
+    }
 
-   DLLLOCAL QoreValue evalTmpArgs(ExceptionSink* xsink, QoreObject* self, QoreListNode* args, const qore_class_private* cctx = nullptr) const {
-      if (!static_flag) {
-         assert(self);
-         return NMETHF(func)->evalMethodTmpArgs(xsink, nullptr, self, args, cctx);
-      }
-      return SMETHF(func)->evalMethodTmpArgs(xsink, nullptr, args, cctx);
-   }
+    DLLLOCAL QoreValue evalTmpArgs(ExceptionSink* xsink, QoreObject* self, QoreListNode* args, const qore_class_private* cctx = nullptr) const {
+        if (!static_flag) {
+            assert(self);
+            return NMETHF(func)->evalMethodTmpArgs(xsink, nullptr, self, args, cctx);
+        }
+        return SMETHF(func)->evalMethodTmpArgs(xsink, nullptr, args, cctx);
+    }
 
-   DLLLOCAL QoreValue evalPseudoMethod(const AbstractQoreFunctionVariant* variant, const QoreValue n, const QoreListNode* args, ExceptionSink* xsink) const {
-      QORE_TRACE("qore_method_private::evalPseudoMethod()");
+    DLLLOCAL QoreValue evalPseudoMethod(const AbstractQoreFunctionVariant* variant, const QoreValue n, const QoreListNode* args, ExceptionSink* xsink) const {
+        QORE_TRACE("qore_method_private::evalPseudoMethod()");
 
-      assert(!static_flag);
+        assert(!static_flag);
 
-      QoreValue rv = NMETHF(func)->evalPseudoMethod(xsink, variant, n, args);
-      printd(5, "qore_method_private::evalPseudoMethod() %s::%s() returning type: %s\n", parent_class->getName(), getName(), rv.getTypeName());
-      return rv;
-   }
+        QoreValue rv = NMETHF(func)->evalPseudoMethod(xsink, variant, n, args);
+        printd(5, "qore_method_private::evalPseudoMethod() %s::%s() returning type: %s\n", parent_class->getName(), getName(), rv.getTypeName());
+        return rv;
+    }
 
-   DLLLOCAL QoreValue evalNormalVariant(QoreObject* self, const QoreExternalMethodVariant* ev, const QoreListNode* args, ExceptionSink* xsink) const;
+    DLLLOCAL QoreValue evalNormalVariant(QoreObject* self, const QoreExternalMethodVariant* ev, const QoreListNode* args, ExceptionSink* xsink) const;
 
-   // returns the lowest access code for all variants
-   DLLLOCAL ClassAccess getAccess() const;
+    // returns the lowest access code for all variants
+    DLLLOCAL ClassAccess getAccess() const;
 
-   // returns the lowest access code for all variants including uncommitted variants
-   DLLLOCAL static ClassAccess getAccess(const QoreMethod& m) {
-      return m.priv->getAccess();
-   }
+    // returns the lowest access code for all variants including uncommitted variants
+    DLLLOCAL static ClassAccess getAccess(const QoreMethod& m) {
+        return m.priv->getAccess();
+    }
 
-   DLLLOCAL static QoreValue evalNormalVariant(const QoreMethod& m, ExceptionSink* xsink, QoreObject* self, const QoreExternalMethodVariant* ev, const QoreListNode* args) {
-      return m.priv->evalNormalVariant(self, ev, args, xsink);
-   }
+    DLLLOCAL static QoreValue evalNormalVariant(const QoreMethod& m, ExceptionSink* xsink, QoreObject* self, const QoreExternalMethodVariant* ev, const QoreListNode* args) {
+        return m.priv->evalNormalVariant(self, ev, args, xsink);
+    }
 
-   DLLLOCAL static QoreValue evalPseudoMethod(const QoreMethod& m, ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, const QoreValue n, const QoreListNode* args) {
-      return m.priv->evalPseudoMethod(variant, n, args, xsink);
-   }
+    DLLLOCAL static QoreValue evalPseudoMethod(const QoreMethod& m, ExceptionSink* xsink, const AbstractQoreFunctionVariant* variant, const QoreValue n, const QoreListNode* args) {
+        return m.priv->evalPseudoMethod(variant, n, args, xsink);
+    }
 
-   DLLLOCAL static QoreValue eval(const QoreMethod& m, ExceptionSink* xsink, QoreObject* self, const QoreListNode* args, const qore_class_private* cctx = nullptr) {
-      return m.priv->eval(xsink, self, args, cctx);
-   }
+    DLLLOCAL static QoreValue eval(const QoreMethod& m, ExceptionSink* xsink, QoreObject* self, const QoreListNode* args, const qore_class_private* cctx = nullptr) {
+        return m.priv->eval(xsink, self, args, cctx);
+    }
 
-   DLLLOCAL static QoreValue evalTmpArgs(const QoreMethod& m, ExceptionSink* xsink, QoreObject* self, QoreListNode* args, const qore_class_private* cctx = nullptr) {
-      return m.priv->evalTmpArgs(xsink, self, args, cctx);
-   }
+    DLLLOCAL static QoreValue evalTmpArgs(const QoreMethod& m, ExceptionSink* xsink, QoreObject* self, QoreListNode* args, const qore_class_private* cctx = nullptr) {
+        return m.priv->evalTmpArgs(xsink, self, args, cctx);
+    }
 };
 
 #endif

--- a/include/qore/intern/QoreClassList.h
+++ b/include/qore/intern/QoreClassList.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/include/qore/intern/QoreClassList.h
+++ b/include/qore/intern/QoreClassList.h
@@ -104,7 +104,7 @@ public:
    DLLLOCAL void assimilate(QoreClassList& n, qore_ns_private& ns);
    DLLLOCAL QoreHashNode* getInfo();
 
-   DLLLOCAL AbstractQoreNode* findConstant(const char* cname, const QoreTypeInfo*& typeInfo);
+   //DLLLOCAL QoreValue findConstant(const char* cname, const QoreTypeInfo*& typeInfo, bool& found);
 
    //DLLLOCAL AbstractQoreNode* parseResolveBareword(const QoreProgramLocation& loc, const char* name, const QoreTypeInfo*& typeInfo);
 

--- a/include/qore/intern/QoreClassList.h
+++ b/include/qore/intern/QoreClassList.h
@@ -47,9 +47,20 @@
 #include <qore/hash_map_include.h>
 #include "qore/intern/xxhash.h"
 
-typedef HASH_MAP<const char*, QoreClass*, qore_hash_str, eqstr> hm_qc_t;
+struct cl_rec_t {
+    QoreClass* cls = nullptr;
+    bool priv = false;
+
+    DLLLOCAL cl_rec_t() {
+    }
+
+    DLLLOCAL cl_rec_t(QoreClass* c, bool p) : cls(c), priv(p) {
+    }
+};
+
+typedef HASH_MAP<const char*, cl_rec_t, qore_hash_str, eqstr> hm_qc_t;
 #else
-typedef std::map<const char*, QoreClass*, ltstr> hm_qc_t;
+typedef std::map<const char*, cl_rec_t, ltstr> hm_qc_t;
 #endif
 
 class QoreNamespaceList;
@@ -69,7 +80,7 @@ private:
 
    DLLLOCAL void remove(hm_qc_t::iterator i);
 
-   DLLLOCAL void addInternal(QoreClass* ot);
+   DLLLOCAL void addInternal(QoreClass* ot, bool priv);
 
 public:
    DLLLOCAL QoreClassList() {}
@@ -128,7 +139,7 @@ public:
    }
 
    DLLLOCAL QoreClass* get() const {
-      return i->second;
+      return i->second.cls;
    }
 
    DLLLOCAL bool isPublic() const;
@@ -158,7 +169,7 @@ public:
    }
 
    DLLLOCAL const QoreClass* get() const {
-      return i->second;
+      return i->second.cls;
    }
 
    DLLLOCAL bool isPublic() const;

--- a/include/qore/intern/QoreExistsOperatorNode.h
+++ b/include/qore/intern/QoreExistsOperatorNode.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -33,7 +33,7 @@
 
 #define _QORE_QOREEXISTSOPERATORNODE_H
 
-class QoreExistsOperatorNode : public QoreSingleExpressionOperatorNode<QoreOperatorNode> {
+class QoreExistsOperatorNode : public QoreSingleValueExpressionOperatorNode<QoreOperatorNode> {
 protected:
    DLLLOCAL static QoreString Exists_str;
 
@@ -42,7 +42,7 @@ protected:
    DLLLOCAL virtual AbstractQoreNode* parseInitImpl(LocalVar* oflag, int pflag, int &lvids, const QoreTypeInfo*& typeInfo);
 
 public:
-   DLLLOCAL QoreExistsOperatorNode(const QoreProgramLocation& loc, AbstractQoreNode* n_exp) : QoreSingleExpressionOperatorNode<QoreOperatorNode>(loc, n_exp) {
+   DLLLOCAL QoreExistsOperatorNode(const QoreProgramLocation& loc, QoreValue exp) : QoreSingleValueExpressionOperatorNode<QoreOperatorNode>(loc, exp) {
    }
 
    DLLLOCAL virtual QoreString* getAsString(bool& del, int foff, ExceptionSink* xsink) const;

--- a/include/qore/intern/QoreHashListIterator.h
+++ b/include/qore/intern/QoreHashListIterator.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -38,193 +38,192 @@ extern QoreClass* QC_HASHLISTITERATOR;
 // the c++ object
 class QoreHashListIterator : public QoreIteratorBase {
 protected:
-   QoreHashNode* h;
-   qore_offset_t i, limit;
-   bool is_list;
+    QoreHashNode* h;
+    qore_offset_t i, limit;
+    bool is_list;
 
-   DLLLOCAL virtual ~QoreHashListIterator() {
-   }
+    DLLLOCAL virtual ~QoreHashListIterator() {
+    }
 
-   DLLLOCAL int checkPtr(ExceptionSink* xsink) const {
-      if (i < 0) {
-         xsink->raiseException("ITERATOR-ERROR", "the %s is not pointing at a valid element; make sure %s::next() returns True before calling this method", getName(), getName());
-         return -1;
-      }
-      return 0;
-   }
+    DLLLOCAL int checkPtr(ExceptionSink* xsink) const {
+        if (i < 0) {
+            xsink->raiseException("ITERATOR-ERROR", "the %s is not pointing at a valid element; make sure %s::next() returns True before calling this method", getName(), getName());
+            return -1;
+        }
+        return 0;
+    }
 
-   DLLLOCAL AbstractQoreNode* getReferencedValueIntern(const AbstractQoreNode* n, const char* key, ExceptionSink* xsink) const {
-      qore_type_t t = get_node_type(n);
-      if (t == NT_NOTHING)
-         return 0;
+    DLLLOCAL QoreValue getReferencedValueIntern(const QoreValue n, const char* key, ExceptionSink* xsink) const {
+        qore_type_t t = n.getType();
+        if (t == NT_NOTHING)
+            return QoreValue();
 
-      if (!is_list || t != NT_LIST)
-         return n->refSelf();
+        if (!is_list || t != NT_LIST)
+            return n.refSelf();
 
-      const QoreListNode* l = reinterpret_cast<const QoreListNode*>(n);
-      if (l->size() != (size_t)limit) {
-         xsink->raiseException("HASHLISTITERATOR-ERROR", "hash key '%s' is assigned to a list of size " QSD "; expecting a list of size " QSD, key, l->size(), limit);
-         return 0;
-      }
+        const QoreListNode* l = n.get<const QoreListNode>();
+        if (l->size() != (size_t)limit) {
+            xsink->raiseException("HASHLISTITERATOR-ERROR", "hash key '%s' is assigned to a list of size " QSD "; expecting a list of size " QSD, key, l->size(), limit);
+            return QoreValue();
+        }
 
-      return reinterpret_cast<const QoreListNode*>(n)->get_referenced_entry(i);
-   }
+        return l->get_referenced_entry(i);
+    }
 
-   DLLLOCAL AbstractQoreNode* getReferencedKeyValueIntern(const char* key, ExceptionSink* xsink) const {
-      return getReferencedValueIntern(h->getKeyValue(key), key, xsink);
-   }
+    DLLLOCAL QoreValue getReferencedKeyValueIntern(const char* key, ExceptionSink* xsink) const {
+        return getReferencedValueIntern(h->getValueKeyValue(key), key, xsink);
+    }
 
 public:
-   DLLLOCAL QoreHashListIterator(const QoreHashNode* n_h) : h(n_h->hashRefSelf()), i(-1), limit(0), is_list(false) {
-      if (h->empty())
-         return;
-      // see if the hash has any lists assigned to it
-      ConstHashIterator hi(h);
-      while (hi.next()) {
-         const AbstractQoreNode* n = hi.getValue();
-         if (get_node_type(n) == NT_LIST) {
-            is_list = true;
-            limit = (qore_offset_t)reinterpret_cast<const QoreListNode*>(n)->size();
-            break;
-         }
-      }
-      if (!is_list)
-         limit = 1;
-   }
+    DLLLOCAL QoreHashListIterator(const QoreHashNode* n_h) : h(n_h->hashRefSelf()), i(-1), limit(0), is_list(false) {
+        if (h->empty())
+            return;
+        // see if the hash has any lists assigned to it
+        ConstHashIterator hi(h);
+        while (hi.next()) {
+            if (hi.get().getType() == NT_LIST) {
+                is_list = true;
+                limit = (qore_offset_t)hi.get().get<const QoreListNode>()->size();
+                break;
+            }
+        }
+        if (!is_list)
+            limit = 1;
+    }
 
-   DLLLOCAL QoreHashListIterator() : h(0), i(-1), limit(0), is_list(false) {
-   }
+    DLLLOCAL QoreHashListIterator() : h(0), i(-1), limit(0), is_list(false) {
+    }
 
-   DLLLOCAL QoreHashListIterator(const QoreHashListIterator& old) : h(old.h ? old.h->hashRefSelf() : 0), i(old.i), limit(old.limit), is_list(old.is_list) {
-   }
+    DLLLOCAL QoreHashListIterator(const QoreHashListIterator& old) : h(old.h ? old.h->hashRefSelf() : 0), i(old.i), limit(old.limit), is_list(old.is_list) {
+    }
 
-   DLLLOCAL void reset() {
-      if (i != -1)
-         i = -1;
-   }
+    DLLLOCAL void reset() {
+        if (i != -1)
+            i = -1;
+    }
 
-   using AbstractPrivateData::deref;
-   DLLLOCAL virtual void deref(ExceptionSink* xsink) {
-      if (ROdereference()) {
-         if (h)
-            h->deref(xsink);
-         delete this;
-      }
-   }
+    using AbstractPrivateData::deref;
+    DLLLOCAL virtual void deref(ExceptionSink* xsink) {
+        if (ROdereference()) {
+            if (h)
+                h->deref(xsink);
+            delete this;
+        }
+    }
 
-   DLLLOCAL bool next() {
-      if (++i == limit) {
-         i = -1;
-         return false; // finished
-      }
-      return true;
-   }
+    DLLLOCAL bool next() {
+        if (++i == limit) {
+            i = -1;
+            return false; // finished
+        }
+        return true;
+    }
 
-   DLLLOCAL bool prev() {
-      if (!limit)
-         return false; // empty
-      if (i == -1) {
-         i = limit - 1;
-         return true;
-      }
-      --i;
-      return i >= 0;
-   }
+    DLLLOCAL bool prev() {
+        if (!limit)
+            return false; // empty
+        if (i == -1) {
+            i = limit - 1;
+            return true;
+        }
+        --i;
+        return i >= 0;
+    }
 
-   DLLLOCAL bool empty() const {
-      return !limit;
-   }
+    DLLLOCAL bool empty() const {
+        return !limit;
+    }
 
-   // returns true if the iterator is pointing to a valid element
-   DLLLOCAL bool valid() const {
-      return i != -1;
-   }
+    // returns true if the iterator is pointing to a valid element
+    DLLLOCAL bool valid() const {
+        return i != -1;
+    }
 
-   // returns the current iterator position in the list or -1 if not pointing at a valid element
-   DLLLOCAL qore_size_t index() const {
-      return i;
-   }
+    // returns the current iterator position in the list or -1 if not pointing at a valid element
+    DLLLOCAL qore_size_t index() const {
+        return i;
+    }
 
-   // returns the number of elements in the list
-   DLLLOCAL qore_size_t max() const {
-      return limit;
-   }
+    // returns the number of elements in the list
+    DLLLOCAL qore_size_t max() const {
+        return limit;
+    }
 
-   // returns true when the iterator is pointing to the first element in the list
-   DLLLOCAL bool first() const {
-      return i == 0;
-   }
+    // returns true when the iterator is pointing to the first element in the list
+    DLLLOCAL bool first() const {
+        return i == 0;
+    }
 
-    // returns true when the iterator is pointing to the last element in the list
-   DLLLOCAL bool last() const {
-      return i == (limit - 1);
-   }
+        // returns true when the iterator is pointing to the last element in the list
+    DLLLOCAL bool last() const {
+        return i == (limit - 1);
+    }
 
-   DLLLOCAL bool set(qore_offset_t pos) {
-      if (pos < 0 || pos >= limit) {
-         i = -1;
-         return false;
-      }
-      i = pos;
-      return true;
-   }
+    DLLLOCAL bool set(qore_offset_t pos) {
+        if (pos < 0 || pos >= limit) {
+            i = -1;
+            return false;
+        }
+        i = pos;
+        return true;
+    }
 
-   DLLLOCAL AbstractQoreNode* getReferencedKeyValue(const char* key, ExceptionSink* xsink) const {
-      if (checkPtr(xsink))
-         return 0;
+    DLLLOCAL QoreValue getReferencedKeyValue(const char* key, ExceptionSink* xsink) const {
+        if (checkPtr(xsink))
+            return QoreValue();
 
-      return getReferencedKeyValueIntern(key, xsink);
-   }
+        return getReferencedKeyValueIntern(key, xsink);
+    }
 
-   DLLLOCAL QoreHashNode* getRow(ExceptionSink* xsink) const {
-      if (checkPtr(xsink))
-         return 0;
+    DLLLOCAL QoreHashNode* getRow(ExceptionSink* xsink) const {
+        if (checkPtr(xsink))
+            return nullptr;
 
-      if (!is_list)
-         return h->hashRefSelf();
+        if (!is_list)
+            return h->hashRefSelf();
 
-      ReferenceHolder<QoreHashNode> rv(new QoreHashNode, xsink);
+        ReferenceHolder<QoreHashNode> rv(new QoreHashNode, xsink);
 
-      ConstHashIterator hi(h);
-      while (hi.next()) {
-         AbstractQoreNode* n = const_cast<AbstractQoreNode*>(hi.getValue());
-         n = getReferencedValueIntern(n, hi.getKey(), xsink);
-         if (*xsink)
-            return 0;
-         rv->setKeyValue(hi.getKey(), n, xsink);
-         // cannot have an exception here
-         assert(!*xsink);
-      }
+        ConstHashIterator hi(h);
+        while (hi.next()) {
+            QoreValue n = hi.get();
+            n = getReferencedValueIntern(n, hi.getKey(), xsink);
+            if (*xsink)
+                return nullptr;
+            rv->setValueKeyValue(hi.getKey(), n, xsink);
+            // cannot have an exception here
+            assert(!*xsink);
+        }
 
-      return rv.release();
-   }
+        return rv.release();
+    }
 
-   DLLLOCAL QoreHashNode* getSlice(const QoreListNode* args, ExceptionSink* xsink) const {
-      if (checkPtr(xsink))
-         return 0;
+    DLLLOCAL QoreHashNode* getSlice(const QoreListNode* args, ExceptionSink* xsink) const {
+        if (checkPtr(xsink))
+            return nullptr;
 
-      ReferenceHolder<QoreHashNode> rv(new QoreHashNode, xsink);
+        ReferenceHolder<QoreHashNode> rv(new QoreHashNode, xsink);
 
-      ConstListIterator li(args);
-      while (li.next()) {
-         QoreStringValueHelper str(li.getValue(), QCS_UTF8, xsink);
-         if (*xsink)
-            return 0;
-         const char* key = str->getBuffer();
-         AbstractQoreNode* n = getReferencedKeyValueIntern(key, xsink);
-         if (*xsink)
-            return 0;
-         rv->setKeyValue(key, n, xsink);
-         // cannot have an exception here
-         assert(!*xsink);
-      }
+        ConstListIterator li(args);
+        while (li.next()) {
+            QoreStringValueHelper str(li.getValue(), QCS_UTF8, xsink);
+            if (*xsink)
+                return nullptr;
+            const char* key = str->c_str();
+            QoreValue n = getReferencedKeyValueIntern(key, xsink);
+            if (*xsink)
+                return nullptr;
+            rv->setValueKeyValue(key, n, xsink);
+            // cannot have an exception here
+            assert(!*xsink);
+        }
 
-      return rv.release();
-   }
+        return rv.release();
+    }
 
-   DLLLOCAL virtual const char* getName() const {
-      return "HashListIterator";
-   }
+    DLLLOCAL virtual const char* getName() const {
+        return "HashListIterator";
+    }
 };
 
 #endif // _QORE_QOREHASHLISTITERATOR_H

--- a/include/qore/intern/QoreHashNodeIntern.h
+++ b/include/qore/intern/QoreHashNodeIntern.h
@@ -404,7 +404,7 @@ public:
     DLLLOCAL void setKeyValueIntern(const char* key, QoreValue v) {
         hash_assignment_priv ha(*this, key);
 #ifdef DEBUG
-        assert(!ha.swap(v.takeNode()).isNothing());
+        assert(ha.swap(v.takeNode()).isNothing());
 #else
         ha.swap(v.takeNode());
 #endif

--- a/include/qore/intern/QoreHashNodeIntern.h
+++ b/include/qore/intern/QoreHashNodeIntern.h
@@ -377,7 +377,7 @@ public:
 #ifdef DEBUG
             assert(ha.swap(i->val.refSelf()).isNothing());
 #else
-            ha.swap(i->val);
+            ha.swap(i->val.refSelf());
 #endif
         }
     }

--- a/include/qore/intern/QoreHashNodeIntern.h
+++ b/include/qore/intern/QoreHashNodeIntern.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -33,22 +33,23 @@
 
 #define _QORE_QOREHASHNODEINTERN_H
 
-#include <qore/qlist>
+#include <list>
 
 // to maintain the order of inserts
 class HashMember {
 public:
-   AbstractQoreNode* node;
-   std::string key;
+    QoreValue val;
+    //AbstractQoreNode* node = nullptr;
+    std::string key;
 
-   DLLLOCAL HashMember(const char* n_key) : node(0), key(n_key) {
-   }
+    DLLLOCAL HashMember(const char* n_key) : key(n_key) {
+    }
 
-   DLLLOCAL ~HashMember() {
-   }
+    DLLLOCAL ~HashMember() {
+    }
 };
 
-typedef qlist<HashMember*> qhlist_t;
+typedef std::list<HashMember*> qhlist_t;
 
 #ifdef HAVE_QORE_HASH_MAP
 //#warning compiling with hash_map
@@ -63,469 +64,481 @@ typedef std::map<const char*, qhlist_t::iterator, ltstr> hm_hm_t;
 // QoreHashIterator private class
 class qhi_priv {
 public:
-   qhlist_t::iterator i;
-   bool val;
+    qhlist_t::iterator i;
+    bool val;
 
-   DLLLOCAL qhi_priv() : val(false) {
-   }
+    DLLLOCAL qhi_priv() : val(false) {
+    }
 
-   DLLLOCAL qhi_priv(const qhi_priv& old) : i(old.i), val(old.val) {
-   }
+    DLLLOCAL qhi_priv(const qhi_priv& old) : i(old.i), val(old.val) {
+    }
 
-   DLLLOCAL bool valid() const {
-      return val;
-   }
+    DLLLOCAL bool valid() const {
+        return val;
+    }
 
-   DLLLOCAL bool next(qhlist_t& ml) {
-      //printd(0, "qhi_priv::next() this: %p val: %d\n", this, val);
-      if (!val) {
-         if (ml.begin() != ml.end()) {
-            i = ml.begin();
-            val = true;
-         }
-      }
-      else {
-         ++i;
-         if (i == ml.end())
-            val = false;
-      }
-      return val;
-   }
+    DLLLOCAL bool next(qhlist_t& ml) {
+        //printd(0, "qhi_priv::next() this: %p val: %d\n", this, val);
+        if (!val) {
+            if (ml.begin() != ml.end()) {
+                i = ml.begin();
+                val = true;
+            }
+        }
+        else {
+            ++i;
+            if (i == ml.end())
+                val = false;
+        }
+        return val;
+    }
 
-   DLLLOCAL bool prev(qhlist_t& ml) {
-      if (!val) {
-         if (ml.begin() != ml.end()) {
-            i = ml.end();
-            --i;
-            val = true;
-         }
-      }
-      else {
-         if (i == ml.begin())
-            val = false;
-         else
-            --i;
-      }
-      return val;
-   }
+    DLLLOCAL bool prev(qhlist_t& ml) {
+        if (!val) {
+            if (ml.begin() != ml.end()) {
+                i = ml.end();
+                --i;
+                val = true;
+            }
+        }
+        else {
+            if (i == ml.begin())
+                val = false;
+            else
+                --i;
+        }
+        return val;
+    }
 
-   DLLLOCAL void reset() {
-      val = false;
-   }
+    DLLLOCAL void reset() {
+        val = false;
+    }
 
-   DLLLOCAL static qhi_priv* get(HashIterator& i) {
-       return i.priv;
-   }
+    DLLLOCAL static qhi_priv* get(HashIterator& i) {
+        return i.priv;
+    }
 };
 
 class qore_hash_private {
 public:
-   qhlist_t member_list;
-   hm_hm_t hm;
-   // either hashdecl or complexTypeInfo can be set, but not both
-   const TypedHashDecl* hashdecl = nullptr;
-   const QoreTypeInfo* complexTypeInfo = nullptr;
-   unsigned obj_count = 0;
+    qhlist_t member_list;
+    hm_hm_t hm;
+    // either hashdecl or complexTypeInfo can be set, but not both
+    const TypedHashDecl* hashdecl = nullptr;
+    const QoreTypeInfo* complexTypeInfo = nullptr;
+    unsigned obj_count = 0;
 #ifdef DEBUG
-   bool is_obj = false;
+    bool is_obj = false;
 #endif
 
-   DLLLOCAL qore_hash_private() {
-   }
+    DLLLOCAL qore_hash_private() {
+    }
 
-   // hashes should always be empty by the time they are deleted
-   // because object destructors need to be run...
-   DLLLOCAL ~qore_hash_private() {
-      assert(member_list.empty());
-   }
+    // hashes should always be empty by the time they are deleted
+    // because object destructors need to be run...
+    DLLLOCAL ~qore_hash_private() {
+        assert(member_list.empty());
+    }
 
-   DLLLOCAL QoreValue getValueKeyValueIntern(const char* key) const;
+    DLLLOCAL QoreValue getValueKeyValueIntern(const char* key) const;
 
-   DLLLOCAL QoreValue getValueKeyValueExistence(const char* key, bool& exists, ExceptionSink* xsink) const;
+    DLLLOCAL QoreValue getValueKeyValueExistence(const char* key, bool& exists, ExceptionSink* xsink) const;
 
-   DLLLOCAL QoreValue getValueKeyValueExistenceIntern(const char* key, bool& exists) const;
+    DLLLOCAL QoreValue getValueKeyValueExistenceIntern(const char* key, bool& exists) const;
 
-   DLLLOCAL int checkKey(const char* key, ExceptionSink* xsink) const;
+    DLLLOCAL int checkKey(const char* key, ExceptionSink* xsink) const;
 
-   DLLLOCAL AbstractQoreNode* getReferencedKeyValueIntern(const char* key) const {
-      bool exists;
-      return getReferencedKeyValueIntern(key, exists);
-   }
+    DLLLOCAL QoreValue getReferencedKeyValueIntern(const char* key) const {
+        bool exists;
+        return getReferencedKeyValueIntern(key, exists);
+    }
 
-   DLLLOCAL AbstractQoreNode* getReferencedKeyValueIntern(const char* key, bool& exists) const {
-      assert(key);
+    DLLLOCAL QoreValue getReferencedKeyValueIntern(const char* key, bool& exists) const {
+        assert(key);
 
-      hm_hm_t::const_iterator i = hm.find(key);
+        hm_hm_t::const_iterator i = hm.find(key);
+        if (i != hm.end()) {
+            exists = true;
+            return (*(i->second))->val.refSelf();
+        }
 
-      if (i != hm.end()) {
-         exists = true;
-         if ((*i->second)->node)
-            return (*i->second)->node->refSelf();
+        exists = false;
+        return QoreValue();
+    }
 
-         return nullptr;
-      }
-      exists = false;
-      return nullptr;
-   }
+    DLLLOCAL int64 getKeyAsBigInt(const char* key, bool &found) const {
+        assert(key);
+        hm_hm_t::const_iterator i = hm.find(key);
 
-   DLLLOCAL int64 getKeyAsBigInt(const char* key, bool &found) const {
-      assert(key);
-      hm_hm_t::const_iterator i = hm.find(key);
+        if (i != hm.end()) {
+            found = true;
+            return (*(i->second))->val.getAsBigInt();
+        }
 
-      if (i != hm.end()) {
-         found = true;
-         return (*(i->second))->node ? (*(i->second))->node->getAsBigInt() : 0;
-      }
+        found = false;
+        return 0;
+    }
 
-      found = false;
-      return 0;
-   }
+    DLLLOCAL bool getKeyAsBool(const char* key, bool& found) const {
+        assert(key);
+        hm_hm_t::const_iterator i = hm.find(key);
 
-   DLLLOCAL bool getKeyAsBool(const char* key, bool& found) const {
-      assert(key);
-      hm_hm_t::const_iterator i = hm.find(key);
+        if (i != hm.end()) {
+            found = true;
+            return (*(i->second))->val.getAsBool();
+        }
 
-      if (i != hm.end()) {
-         found = true;
-         return (*(i->second))->node ? (*(i->second))->node->getAsBool() : false;
-      }
+        found = false;
+        return false;
+    }
 
-      found = false;
-      return false;
-   }
+    DLLLOCAL bool existsKey(const char* key) const {
+        assert(key);
+        return hm.find(key) != hm.end();
+    }
 
-   DLLLOCAL bool existsKey(const char* key) const {
-      assert(key);
-      return hm.find(key) != hm.end();
-   }
+    DLLLOCAL bool existsKeyValue(const char* key) const {
+        assert(key);
+        hm_hm_t::const_iterator i = hm.find(key);
+        if (i == hm.end())
+            return false;
+        return !(*(i->second))->val.isNothing();
+    }
 
-   DLLLOCAL bool existsKeyValue(const char* key) const {
-      assert(key);
-      hm_hm_t::const_iterator i = hm.find(key);
-      if (i == hm.end())
-         return false;
-      return !is_nothing((*(i->second))->node);
-   }
-
-   DLLLOCAL HashMember* findMember(const char* key) {
-      assert(key);
-      hm_hm_t::iterator i = hm.find(key);
-      return i != hm.end() ? (*(i->second)) : nullptr;
-   }
+    DLLLOCAL HashMember* findMember(const char* key) {
+        assert(key);
+        hm_hm_t::iterator i = hm.find(key);
+        return i != hm.end() ? (*(i->second)) : nullptr;
+    }
 
    DLLLOCAL HashMember* findCreateMember(const char* key) {
-      // otherwise create the new hash entry
-      HashMember* om = findMember(key);
-      if (om)
-         return om;
+        // otherwise create the new hash entry
+        HashMember* om = findMember(key);
+        if (om)
+            return om;
 
-      om = new HashMember(key);
-      member_list.push_back(om);
+        om = new HashMember(key);
+        assert(om->val.isNothing());
+        member_list.push_back(om);
 
-      // add to the map
-      qhlist_t::iterator i = member_list.end();
-      --i;
-      hm[om->key.c_str()] = i;
+        // add to the map
+        qhlist_t::iterator i = member_list.end();
+        --i;
+        hm[om->key.c_str()] = i;
 
-      // return the new member
-      return om;
-   }
+        // return the new member
+        return om;
+    }
 
-   DLLLOCAL AbstractQoreNode** getKeyValuePtr(const char* key) {
-      return &findCreateMember(key)->node;
-   }
+    DLLLOCAL static void convertToNode(QoreValue& val) {
+        switch (val.type) {
+            case QV_Bool:
+                val.v.n = get_bool_node(val.v.b);
+                val.type = QV_Node;
+                break;
+            case QV_Int:
+                val.v.n = new QoreBigIntNode(val.v.i);
+                val.type = QV_Node;
+                break;
+            case QV_Float:
+                val.v.n = new QoreFloatNode(val.v.f);
+                val.type = QV_Node;
+                break;
+            case QV_Ref:
+                assert(false);
+            default:
+                break;
+        }
+    }
 
-   // NOTE: does not delete the value, this must be done by the caller before this call
-   // also does not delete map entry; must be done outside this call
-   DLLLOCAL void internDeleteKey(qhlist_t::iterator i) {
-      HashMember* om = *i;
+    DLLLOCAL AbstractQoreNode** getKeyValuePtr(const char* key) {
+        QoreValue& val = findCreateMember(key)->val;
+        convertToNode(val);
+        return &val.v.n;
+    }
 
-      member_list.erase(i);
+    DLLLOCAL QoreValue& getValueRef(const char* key) {
+        return findCreateMember(key)->val;
+    }
 
-      // free om memory
-      delete om;
-   }
+    // NOTE: does not delete the value, this must be done by the caller before this call
+    // also does not delete map entry; must be done outside this call
+    DLLLOCAL void internDeleteKey(qhlist_t::iterator i) {
+        HashMember* om = *i;
 
-   DLLLOCAL void deleteKey(const char* key, ExceptionSink *xsink) {
-      assert(key);
+        member_list.erase(i);
 
-      hm_hm_t::iterator i = hm.find(key);
+        // free om memory
+        delete om;
+    }
 
-      if (i == hm.end())
-         return;
+    DLLLOCAL void deleteKey(const char* key, ExceptionSink *xsink) {
+        assert(key);
 
-      qhlist_t::iterator li = i->second;
-      hm.erase(i);
+        hm_hm_t::iterator i = hm.find(key);
 
-      // dereference node if present
-      if ((*li)->node) {
-         if (needs_scan((*li)->node))
+        if (i == hm.end())
+            return;
+
+        qhlist_t::iterator li = i->second;
+        hm.erase(i);
+
+        // dereference node if present
+        AbstractQoreNode* n = (*li)->val.assignNothing();
+        if (n) {
+            if (needs_scan(n))
+                incScanCount(-1);
+
+            if (n->getType() == NT_OBJECT)
+                reinterpret_cast<QoreObject*>(n)->doDelete(xsink);
+            n->deref(xsink);
+        }
+
+        internDeleteKey(li);
+    }
+
+    // removes the value and dereferences it, without performing a delete on it
+    DLLLOCAL void removeKey(const char* key, ExceptionSink *xsink) {
+        takeKeyValueIntern(key).discard(xsink);
+    }
+
+    DLLLOCAL QoreValue takeKeyValueIntern(const char* key) {
+        assert(key);
+
+        hm_hm_t::iterator i = hm.find(key);
+
+        if (i == hm.end())
+            return QoreValue();
+
+        qhlist_t::iterator li = i->second;
+        hm.erase(i);
+
+        QoreValue rv = (*li)->val;
+        internDeleteKey(li);
+
+        if (needs_scan(rv))
             incScanCount(-1);
 
-         if ((*li)->node->getType() == NT_OBJECT)
-            reinterpret_cast<QoreObject*>((*li)->node)->doDelete(xsink);
-         (*li)->node->deref(xsink);
-      }
+        return rv;
+    }
 
-      internDeleteKey(li);
-   }
+    DLLLOCAL const char* getFirstKey() const  {
+        return member_list.empty() ? nullptr : member_list.front()->key.c_str();
+    }
 
-   // removes the value and dereferences it, without performing a delete on it
-   DLLLOCAL void removeKey(const char* key, ExceptionSink *xsink) {
-      assert(key);
+    DLLLOCAL const char* getLastKey() const {
+        return member_list.empty() ? nullptr : member_list.back()->key.c_str();
+    }
 
-      hm_hm_t::iterator i = hm.find(key);
+    DLLLOCAL QoreListNode* getKeys() const;
 
-      if (i == hm.end())
-         return;
+    DLLLOCAL QoreListNode* getValues(bool with_type_info = true) const;
 
-      qhlist_t::iterator li = i->second;
-      hm.erase(i);
+    DLLLOCAL void merge(const qore_hash_private& h, ExceptionSink* xsink);
 
-      // dereference node if present
-      if ((*li)->node) {
-         if (needs_scan((*li)->node))
-            incScanCount(-1);
-         (*li)->node->deref(xsink);
-      }
+    DLLLOCAL int getLValue(const char* key, LValueHelper& lvh, bool for_remove, ExceptionSink* xsink);
 
-      internDeleteKey(li);
-   }
+    DLLLOCAL void getTypeName(QoreString& str) const {
+        if (hashdecl)
+            str.sprintf("hash<%s>", hashdecl->getName());
+        else if (complexTypeInfo)
+            str.concat(QoreTypeInfo::getName(complexTypeInfo));
+        else
+            str.concat("hash");
+    }
 
-   DLLLOCAL AbstractQoreNode* takeKeyValue(const char* key) {
-      assert(key);
+    DLLLOCAL QoreHashNode* getCopy() const {
+        QoreHashNode* h = new QoreHashNode;
+        if (hashdecl)
+            h->priv->hashdecl = hashdecl;
+        if (complexTypeInfo)
+            h->priv->complexTypeInfo = complexTypeInfo;
+        return h;
+    }
 
-      hm_hm_t::iterator i = hm.find(key);
+    DLLLOCAL QoreHashNode* copy(const QoreTypeInfo* newComplexTypeInfo) const {
+        QoreHashNode* h = new QoreHashNode;
+        h->priv->complexTypeInfo = newComplexTypeInfo;
+        copyIntern(*h->priv);
+        return h;
+    }
 
-      if (i == hm.end())
-         return 0;
+    // strip = copy without type information
+    DLLLOCAL QoreHashNode* copy(bool strip = false) const {
+        QoreHashNode* h = strip ? new QoreHashNode : getCopy();
+        copyIntern(*h->priv);
+        return h;
+    }
 
-      qhlist_t::iterator li = i->second;
-      hm.erase(i);
-
-      AbstractQoreNode *rv = (*li)->node;
-      internDeleteKey(li);
-
-      if (needs_scan(rv))
-         incScanCount(-1);
-
-      return rv;
-   }
-
-   DLLLOCAL const char* getFirstKey() const  {
-      return member_list.empty() ? nullptr : member_list.front()->key.c_str();
-   }
-
-   DLLLOCAL const char* getLastKey() const {
-      return member_list.empty() ? nullptr : member_list.back()->key.c_str();
-   }
-
-   DLLLOCAL QoreListNode* getKeys() const;
-
-   DLLLOCAL QoreListNode* getValues(bool with_type_info = true) const;
-
-   DLLLOCAL void merge(const qore_hash_private& h, ExceptionSink* xsink);
-
-   DLLLOCAL int getLValue(const char* key, LValueHelper& lvh, bool for_remove, ExceptionSink* xsink);
-
-   DLLLOCAL void getTypeName(QoreString& str) const {
-       if (hashdecl)
-          str.sprintf("hash<%s>", hashdecl->getName());
-       else if (complexTypeInfo)
-          str.concat(QoreTypeInfo::getName(complexTypeInfo));
-       else
-          str.concat("hash");
-   }
-
-   DLLLOCAL QoreHashNode* getCopy() const {
-      QoreHashNode* h = new QoreHashNode;
-      if (hashdecl)
-         h->priv->hashdecl = hashdecl;
-      if (complexTypeInfo)
-         h->priv->complexTypeInfo = complexTypeInfo;
-      return h;
-   }
-
-   DLLLOCAL QoreHashNode* copy(const QoreTypeInfo* newComplexTypeInfo) const {
-      QoreHashNode* h = new QoreHashNode;
-      h->priv->complexTypeInfo = newComplexTypeInfo;
-      copyIntern(*h->priv);
-      return h;
-   }
-
-   // strip = copy without type information
-   DLLLOCAL QoreHashNode* copy(bool strip = false) const {
-      QoreHashNode* h = strip ? new QoreHashNode : getCopy();
-      copyIntern(*h->priv);
-      return h;
-   }
-
-   DLLLOCAL void copyIntern(qore_hash_private& h) const {
-      // copy all members to new object
-      for (auto& i : member_list) {
-         hash_assignment_priv ha(h, i->key.c_str());
+    DLLLOCAL void copyIntern(qore_hash_private& h) const {
+        // copy all members to new object
+        for (auto& i : member_list) {
+            hash_assignment_priv ha(h, i->key.c_str());
 #ifdef DEBUG
-         assert(!ha.swap(i->node ? i->node->refSelf() : nullptr));
+            assert(ha.swap(i->val.refSelf()).isNothing());
 #else
-         ha.swap(i->node ? i->node->refSelf() : nullptr);
+            ha.swap(i->val);
 #endif
-      }
-   }
+        }
+    }
 
-   DLLLOCAL QoreHashNode* plusEquals(const QoreHashNode* h, ExceptionSink* xsink) const {
-      bool strip = hashdecl || h->priv->hashdecl || !QoreTypeInfo::equal(complexTypeInfo, h->priv->complexTypeInfo);
-      ReferenceHolder<QoreHashNode> rv(copy(strip), xsink);
-      rv->merge(h, xsink);
-      return *xsink ? nullptr : rv.release();
-   }
+    DLLLOCAL QoreHashNode* plusEquals(const QoreHashNode* h, ExceptionSink* xsink) const {
+        bool strip = hashdecl || h->priv->hashdecl || !QoreTypeInfo::equal(complexTypeInfo, h->priv->complexTypeInfo);
+        ReferenceHolder<QoreHashNode> rv(copy(strip), xsink);
+        rv->merge(h, xsink);
+        return *xsink ? nullptr : rv.release();
+    }
 
-   DLLLOCAL AbstractQoreNode* evalImpl(ExceptionSink* xsink) const {
-      QoreHashNodeHolder h(getCopy(), xsink);
+    DLLLOCAL AbstractQoreNode* evalImpl(ExceptionSink* xsink) const {
+        QoreHashNodeHolder h(getCopy(), xsink);
 
-      for (qhlist_t::const_iterator i = member_list.begin(), e = member_list.end(); i != e; ++i) {
-         h->setKeyValue((*i)->key, (*i)->node ? (*i)->node->eval(xsink) : nullptr, xsink);
-         if (*xsink)
-            return nullptr;
-      }
+        for (qhlist_t::const_iterator i = member_list.begin(), e = member_list.end(); i != e; ++i) {
+            h->priv->setKeyValue((*i)->key, (*i)->val.refSelf(), xsink);
+            if (*xsink)
+                return nullptr;
+        }
 
-      return h.release();
-   }
+        return h.release();
+    }
 
-   DLLLOCAL void setKeyValueIntern(const char* key, QoreValue v) {
-      hash_assignment_priv ha(*this, key);
+    DLLLOCAL void setKeyValueIntern(const char* key, QoreValue v) {
+        hash_assignment_priv ha(*this, key);
 #ifdef DEBUG
-      assert(!ha.swap(v.takeNode()));
+        assert(!ha.swap(v.takeNode()).isNothing());
 #else
-      ha.swap(v.takeNode());
+        ha.swap(v.takeNode());
 #endif
-   }
+    }
 
-   DLLLOCAL void setKeyValue(const std::string& key, AbstractQoreNode* val, ExceptionSink* xsink) {
-      hash_assignment_priv ha(*this, key.c_str());
-      ha.assign(val, xsink);
-   }
+    DLLLOCAL void setKeyValue(const char* key, QoreValue val, ExceptionSink* xsink) {
+        hash_assignment_priv ha(*this, key);
+        ha.assign(val, xsink);
+    }
 
-   DLLLOCAL void setKeyValue(const char* key, AbstractQoreNode* val, qore_object_private* o, ExceptionSink* xsink) {
-      hash_assignment_priv ha(*this, key, false, o);
-      ha.assign(val, xsink);
-   }
+    DLLLOCAL void setKeyValue(const std::string& key, QoreValue val, ExceptionSink* xsink) {
+        hash_assignment_priv ha(*this, key.c_str());
+        ha.assign(val, xsink);
+    }
 
-   DLLLOCAL bool derefImpl(ExceptionSink* xsink, bool reverse = false) {
-      if (reverse) {
-         for (qhlist_t::reverse_iterator i = member_list.rbegin(), e = member_list.rend(); i != e; ++i) {
-            if ((*i)->node)
-               (*i)->node->deref(xsink);
-            delete *i;
-         }
-      } else {
-         for (qhlist_t::iterator i = member_list.begin(), e = member_list.end(); i != e; ++i) {
-            if ((*i)->node)
-               (*i)->node->deref(xsink);
-            delete *i;
-         }
-      }
+    DLLLOCAL void setKeyValue(const char* key, QoreValue val, qore_object_private* o, ExceptionSink* xsink) {
+        hash_assignment_priv ha(*this, key, false, o);
+        ha.assign(val, xsink);
+    }
 
-      member_list.clear();
-      hm.clear();
-      obj_count = 0;
-      return true;
-   }
+    DLLLOCAL bool derefImpl(ExceptionSink* xsink, bool reverse = false) {
+        if (reverse) {
+            for (qhlist_t::reverse_iterator i = member_list.rbegin(), e = member_list.rend(); i != e; ++i) {
+                (*i)->val.discard(xsink);
+                delete *i;
+            }
+        } else {
+            for (qhlist_t::iterator i = member_list.begin(), e = member_list.end(); i != e; ++i) {
+                (*i)->val.discard(xsink);
+                delete *i;
+            }
+        }
 
-   DLLLOCAL AbstractQoreNode* swapKeyValue(const char* key, AbstractQoreNode* val, qore_object_private* o) {
-      //printd(0, "qore_hash_private::swapKeyValue() this: %p key: %s val: %p (%s) deprecated API called\n", this, key, val, get_node_type(val));
-      //assert(false);
-      hash_assignment_priv ha(*this, key, false, o);
-      return ha.swap(val);
-   }
+        member_list.clear();
+        hm.clear();
+        obj_count = 0;
+        return true;
+    }
 
-   DLLLOCAL void clear(ExceptionSink* xsink, bool reverse) {
-      derefImpl(xsink, reverse);
-   }
+    DLLLOCAL QoreValue swapKeyValue(const char* key, QoreValue val, qore_object_private* o) {
+        //printd(0, "qore_hash_private::swapKeyValue() this: %p key: %s val: %p (%s) deprecated API called\n", this, key, val, get_node_type(val));
+        //assert(false);
+        hash_assignment_priv ha(*this, key, false, o);
+        return ha.swap(val);
+    }
 
-   DLLLOCAL size_t size() const {
-      return member_list.size();
-   }
+    DLLLOCAL void clear(ExceptionSink* xsink, bool reverse) {
+        derefImpl(xsink, reverse);
+    }
 
-   DLLLOCAL bool empty() const {
-      return member_list.empty();
-   }
+    DLLLOCAL size_t size() const {
+        return member_list.size();
+    }
 
-   DLLLOCAL void incScanCount(int dt) {
-      assert(!is_obj);
-      assert(dt);
-      assert(obj_count || dt > 0);
-      //printd(5, "qore_hash_private::incScanCount() this: %p dt: %d: %d -> %d\n", this, dt, obj_count, obj_count + dt);
-      obj_count += dt;
-   }
+    DLLLOCAL bool empty() const {
+        return member_list.empty();
+    }
 
-   DLLLOCAL const QoreTypeInfo* getValueTypeInfo() const {
-      return complexTypeInfo ? QoreTypeInfo::getUniqueReturnComplexHash(complexTypeInfo) : nullptr;
-   }
+    DLLLOCAL void incScanCount(int dt) {
+        assert(!is_obj);
+        assert(dt);
+        assert(obj_count || dt > 0);
+        //printd(5, "qore_hash_private::incScanCount() this: %p dt: %d: %d -> %d\n", this, dt, obj_count, obj_count + dt);
+        obj_count += dt;
+    }
 
-   DLLLOCAL const QoreTypeInfo* getTypeInfo() const {
-      if (hashdecl)
-          return hashdecl->getTypeInfo();
-      if (complexTypeInfo)
-          return complexTypeInfo;
-      return hashTypeInfo;
-   }
+    DLLLOCAL const QoreTypeInfo* getValueTypeInfo() const {
+        return complexTypeInfo ? QoreTypeInfo::getUniqueReturnComplexHash(complexTypeInfo) : nullptr;
+    }
 
-   DLLLOCAL const TypedHashDecl* getHashDecl() const {
-      return hashdecl;
-   }
+    DLLLOCAL const QoreTypeInfo* getTypeInfo() const {
+        if (hashdecl)
+            return hashdecl->getTypeInfo();
+        if (complexTypeInfo)
+            return complexTypeInfo;
+        return hashTypeInfo;
+    }
 
-   DLLLOCAL static QoreHashNode* getPlainHash(QoreHashNode* h) {
-       if (!h->priv->hashdecl && !h->priv->complexTypeInfo)
-          return h;
-       // no exception is possible
-       ReferenceHolder<QoreHashNode> holder(h, nullptr);
-       return h->priv->copy(true);
-   }
+    DLLLOCAL const TypedHashDecl* getHashDecl() const {
+        return hashdecl;
+    }
 
-   DLLLOCAL static QoreHashNode* newHashDecl(const TypedHashDecl* hd) {
-      QoreHashNode* rv = new QoreHashNode;
-      rv->priv->hashdecl = hd;
-      return rv;
-   }
+    DLLLOCAL static QoreHashNode* getPlainHash(QoreHashNode* h) {
+        if (!h->priv->hashdecl && !h->priv->complexTypeInfo)
+            return h;
+        // no exception is possible
+        ReferenceHolder<QoreHashNode> holder(h, nullptr);
+        return h->priv->copy(true);
+    }
 
-   DLLLOCAL static qore_hash_private* get(QoreHashNode& h) {
-      return h.priv;
-   }
+    DLLLOCAL static QoreHashNode* newHashDecl(const TypedHashDecl* hd) {
+        QoreHashNode* rv = new QoreHashNode;
+        rv->priv->hashdecl = hd;
+        return rv;
+    }
 
-   DLLLOCAL static const qore_hash_private* get(const QoreHashNode& h) {
-      return h.priv;
-   }
+    DLLLOCAL static qore_hash_private* get(QoreHashNode& h) {
+        return h.priv;
+    }
 
-   // returns -1 if no checks are needed or if an error is raised, 0 if OK to check
-   DLLLOCAL static int parseInitHashInitialization(const QoreProgramLocation& loc, LocalVar *oflag, int pflag, int& lvids, QoreParseListNode* args, const QoreTypeInfo*& argTypeInfo, const AbstractQoreNode*& arg);
+    DLLLOCAL static const qore_hash_private* get(const QoreHashNode& h) {
+        return h.priv;
+    }
 
-   DLLLOCAL static int parseInitComplexHashInitialization(const QoreProgramLocation& loc, LocalVar *oflag, int pflag, QoreParseListNode* args, const QoreTypeInfo* vti);
+    // returns -1 if no checks are needed or if an error is raised, 0 if OK to check
+    DLLLOCAL static int parseInitHashInitialization(const QoreProgramLocation& loc, LocalVar *oflag, int pflag, int& lvids, QoreParseListNode* args, const QoreTypeInfo*& argTypeInfo, const AbstractQoreNode*& arg);
 
-   DLLLOCAL static void parseCheckComplexHashInitialization(const QoreProgramLocation& loc, const QoreTypeInfo* typeInfo, const QoreTypeInfo* expTypeInfo, const AbstractQoreNode* exp, const char* context_action, bool strict_check = true);
+    DLLLOCAL static int parseInitComplexHashInitialization(const QoreProgramLocation& loc, LocalVar *oflag, int pflag, QoreParseListNode* args, const QoreTypeInfo* vti);
 
-   DLLLOCAL static void parseCheckTypedAssignment(const QoreProgramLocation& loc, const AbstractQoreNode* arg, const QoreTypeInfo* vti, const char* context_action, bool strict_check = true);
+    DLLLOCAL static void parseCheckComplexHashInitialization(const QoreProgramLocation& loc, const QoreTypeInfo* typeInfo, const QoreTypeInfo* expTypeInfo, const AbstractQoreNode* exp, const char* context_action, bool strict_check = true);
 
-   DLLLOCAL static QoreHashNode* newComplexHash(const QoreTypeInfo* typeInfo, const QoreParseListNode* args, ExceptionSink* xsink);
+    DLLLOCAL static void parseCheckTypedAssignment(const QoreProgramLocation& loc, const AbstractQoreNode* arg, const QoreTypeInfo* vti, const char* context_action, bool strict_check = true);
 
-   DLLLOCAL static QoreHashNode* newComplexHashFromHash(const QoreTypeInfo* typeInfo, QoreHashNode* init, ExceptionSink* xsink);
+    DLLLOCAL static QoreHashNode* newComplexHash(const QoreTypeInfo* typeInfo, const QoreParseListNode* args, ExceptionSink* xsink);
 
-   DLLLOCAL static unsigned getScanCount(const QoreHashNode& h) {
-      assert(!h.priv->is_obj);
-      return h.priv->obj_count;
-   }
+    DLLLOCAL static QoreHashNode* newComplexHashFromHash(const QoreTypeInfo* typeInfo, QoreHashNode* init, ExceptionSink* xsink);
 
-   DLLLOCAL static void incScanCount(const QoreHashNode& h, int dt) {
-      assert(!h.priv->is_obj);
-      h.priv->incScanCount(dt);
-   }
+    DLLLOCAL static unsigned getScanCount(const QoreHashNode& h) {
+        assert(!h.priv->is_obj);
+        return h.priv->obj_count;
+    }
 
-   DLLLOCAL static AbstractQoreNode* getFirstKeyValue(const QoreHashNode* h) {
-      return h->priv->member_list.empty() ? nullptr : h->priv->member_list.front()->node;
-   }
+    DLLLOCAL static void incScanCount(const QoreHashNode& h, int dt) {
+        assert(!h.priv->is_obj);
+        h.priv->incScanCount(dt);
+    }
 
-   DLLLOCAL static AbstractQoreNode* getLastKeyValue(const QoreHashNode* h) {
-      return h->priv->member_list.empty() ? nullptr : h->priv->member_list.back()->node;
-   }
+    DLLLOCAL static QoreValue getFirstKeyValue(const QoreHashNode* h) {
+        return h->priv->member_list.empty() ? QoreValue() : h->priv->member_list.front()->val;
+    }
+
+    DLLLOCAL static QoreValue getLastKeyValue(const QoreHashNode* h) {
+        return h->priv->member_list.empty() ? QoreValue() : h->priv->member_list.back()->val;
+    }
 };
 
 #endif

--- a/include/qore/intern/QoreLValue.h
+++ b/include/qore/intern/QoreLValue.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -542,54 +542,6 @@ public:
       reset();
    }
 
-   // NOTE: destructive for "val":
-   DLLLOCAL AbstractQoreNode* assignAssume(QoreValue& val) {
-      if (fixed_type) {
-         if (!assigned)
-            assigned = true;
-         switch (type) {
-            case QV_Bool: v.b = val.getAsBool(); break;
-            case QV_Int: v.i = val.getAsBigInt(); break;
-            case QV_Float: v.f = val.getAsFloat(); break;
-            default: assert(false);
-               // no break
-         }
-         return val.takeIfNode();
-      }
-
-      AbstractQoreNode* rv;
-      if (assigned) {
-         if (type == QV_Node) {
-            if (!is_closure)
-               check_lvalue_object_in_out(0, v.n);
-            rv = v.n;
-         }
-         else
-            rv = 0;
-      }
-      else {
-         assigned = true;
-         rv = 0;
-      }
-
-      switch (val.type) {
-         case QV_Bool: v.b = val.v.b; if (type != QV_Bool) type = QV_Bool; break;
-         case QV_Int: v.i = val.v.i; if (type != QV_Int) type = QV_Int; break;
-         case QV_Float: v.f = val.v.f; if (type != QV_Float) type = QV_Float; break;
-         case QV_Node:
-            v.n = val.takeNode();
-            if (type != QV_Node)
-               type = QV_Node;
-            if (!is_closure)
-               check_lvalue_object_in_out(v.n, 0);
-            break;
-         default: assert(false);
-            // no break
-      }
-
-      return rv;
-   }
-
    DLLLOCAL AbstractQoreNode* assign(bool b) {
       if (fixed_type) {
          if (!assigned)
@@ -825,6 +777,59 @@ public:
          check_lvalue_object_in_out(v.n, 0);
       return 0;
    }
+
+    DLLLOCAL AbstractQoreNode* assignInitial(QoreValue n) {
+        assert(!assigned);
+        return assignAssume(n);
+    }
+
+    // NOTE: destructive for "val":
+    DLLLOCAL AbstractQoreNode* assignAssume(QoreValue& val) {
+        if (fixed_type) {
+            if (!assigned)
+                assigned = true;
+            switch (type) {
+                case QV_Bool: v.b = val.getAsBool(); break;
+                case QV_Int: v.i = val.getAsBigInt(); break;
+                case QV_Float: v.f = val.getAsFloat(); break;
+                default: assert(false);
+                // no break
+            }
+            return val.takeIfNode();
+        }
+
+        AbstractQoreNode* rv;
+        if (assigned) {
+            if (type == QV_Node) {
+                if (!is_closure)
+                check_lvalue_object_in_out(0, v.n);
+                rv = v.n;
+            }
+            else
+                rv = nullptr;
+        }
+        else {
+            assigned = true;
+            rv = nullptr;
+        }
+
+        switch (val.type) {
+            case QV_Bool: v.b = val.v.b; if (type != QV_Bool) type = QV_Bool; break;
+            case QV_Int: v.i = val.v.i; if (type != QV_Int) type = QV_Int; break;
+            case QV_Float: v.f = val.v.f; if (type != QV_Float) type = QV_Float; break;
+            case QV_Node:
+                v.n = val.takeNode();
+                if (type != QV_Node)
+                    type = QV_Node;
+                if (!is_closure)
+                    check_lvalue_object_in_out(v.n, 0);
+                break;
+            default: assert(false);
+                // no break
+        }
+
+        return rv;
+    }
 
    // the node is already referenced for the assignment
    DLLLOCAL AbstractQoreNode* assign(AbstractQoreNode* n) {

--- a/include/qore/intern/QoreLibIntern.h
+++ b/include/qore/intern/QoreLibIntern.h
@@ -138,6 +138,7 @@ typedef std::set<QoreObject*> obj_set_t;
 
 // returns true if the node needs to be scanned for recursive references or not
 DLLLOCAL bool needs_scan(const AbstractQoreNode* n);
+DLLLOCAL bool needs_scan(const QoreValue& v);
 // increments or decrements the object count depending on the sign of the argument (cannot be 0)
 DLLLOCAL void inc_container_obj(const AbstractQoreNode* n, int dt);
 
@@ -676,17 +677,17 @@ public:
 
    DLLLOCAL void reassign(const char* key, bool must_already_exist = false);
 
-   DLLLOCAL AbstractQoreNode* swapImpl(AbstractQoreNode* v);
+   DLLLOCAL QoreValue swapImpl(QoreValue v);
 
-   DLLLOCAL AbstractQoreNode* getValueImpl() const;
+   DLLLOCAL QoreValue getImpl() const;
 
-   DLLLOCAL AbstractQoreNode* operator*() const {
-      return getValueImpl();
+   DLLLOCAL QoreValue operator*() const {
+      return getImpl();
    }
 
-   DLLLOCAL void assign(AbstractQoreNode* v, ExceptionSink* xsink);
+   DLLLOCAL void assign(QoreValue v, ExceptionSink* xsink);
 
-   DLLLOCAL AbstractQoreNode* swap(AbstractQoreNode* v) {
+   DLLLOCAL QoreValue swap(QoreValue v) {
       return swapImpl(v);
    }
 
@@ -698,7 +699,7 @@ public:
 DLLLOCAL void qore_machine_backtrace();
 
 #ifndef QORE_THREAD_STACK_BLOCK
-#define QORE_THREAD_STACK_BLOCK 1024
+#define QORE_THREAD_STACK_BLOCK 64
 #endif
 
 template <typename T, int S1 = QORE_THREAD_STACK_BLOCK>

--- a/include/qore/intern/QoreLibIntern.h
+++ b/include/qore/intern/QoreLibIntern.h
@@ -136,6 +136,8 @@ extern char* strcasestr(const char* s1, const char* s2);
 
 typedef std::set<QoreObject*> obj_set_t;
 
+DLLLOCAL void parse_init_value(QoreValue& val, LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo);
+
 // returns true if the node needs to be scanned for recursive references or not
 DLLLOCAL bool needs_scan(const AbstractQoreNode* n);
 DLLLOCAL bool needs_scan(const QoreValue& v);

--- a/include/qore/intern/QoreNamespaceIntern.h
+++ b/include/qore/intern/QoreNamespaceIntern.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -325,28 +325,28 @@ public:
       return 0;
    }
 
-   DLLLOCAL QoreClass* runtimeImportClass(ExceptionSink* xsink, const QoreClass* c, QoreProgram* spgm, const char* new_name = nullptr, bool inject = false, const qore_class_private* injectedClass = nullptr) {
-      if (checkImportClass(new_name ? new_name : c->getName(), xsink))
-         return nullptr;
+    DLLLOCAL QoreClass* runtimeImportClass(ExceptionSink* xsink, const QoreClass* c, QoreProgram* spgm, const char* new_name = nullptr, bool inject = false, const qore_class_private* injectedClass = nullptr) {
+        if (checkImportClass(new_name ? new_name : c->getName(), xsink))
+            return nullptr;
 
-      QoreClass* nc = qore_class_private::makeImportClass(*c, spgm, new_name, inject, injectedClass);
-      qore_class_private::setNamespace(nc, this);
-      classList.add(nc);
+        QoreClass* nc = qore_class_private::makeImportClass(*c, spgm, new_name, inject, injectedClass);
+        qore_class_private::setNamespace(nc, this);
+        classList.add(nc);
 
-      return nc;
-   }
+        return nc;
+    }
 
-   DLLLOCAL TypedHashDecl* runtimeImportHashDecl(ExceptionSink* xsink, const TypedHashDecl* hd, QoreProgram* spgm, const char* new_name = nullptr) {
-      if (checkImportHashDecl(new_name ? new_name : hd->getName(), xsink))
-         return nullptr;
+    DLLLOCAL TypedHashDecl* runtimeImportHashDecl(ExceptionSink* xsink, const TypedHashDecl* hd, QoreProgram* spgm, const char* new_name = nullptr) {
+        if (checkImportHashDecl(new_name ? new_name : hd->getName(), xsink))
+            return nullptr;
 
-      TypedHashDecl* nhd = new TypedHashDecl(*hd);
-      if (new_name)
-         typed_hash_decl_private::get(*nhd)->setName(new_name);
-      hashDeclList.add(nhd);
+        TypedHashDecl* nhd = new TypedHashDecl(*hd);
+        if (new_name)
+            typed_hash_decl_private::get(*nhd)->setName(new_name);
+        hashDeclList.add(nhd);
 
-      return nhd;
-   }
+        return nhd;
+    }
 
    DLLLOCAL const QoreFunction* runtimeFindFunction(const char* name) {
       return func_list.find(name, true);

--- a/include/qore/intern/QoreNamespaceIntern.h
+++ b/include/qore/intern/QoreNamespaceIntern.h
@@ -1246,7 +1246,6 @@ protected:
         }
 
         QoreValue rv = parseFindOnlyConstantValueIntern(loc, cname, typeInfo, found);
-
         if (found) {
             return rv;
         }

--- a/include/qore/intern/QoreNamespaceIntern.h
+++ b/include/qore/intern/QoreNamespaceIntern.h
@@ -713,67 +713,67 @@ struct FunctionEntryInfo {
 typedef std::map<const char*, FunctionEntryInfo, ltstr> femap_t;
 class FunctionEntryRootMap : public femap_t {
 private:
-   // not implemented
-   DLLLOCAL FunctionEntryRootMap(const FunctionEntryRootMap& old);
-   // not implemented
-   DLLLOCAL FunctionEntryRootMap& operator=(const FunctionEntryRootMap& m);
+    // not implemented
+    DLLLOCAL FunctionEntryRootMap(const FunctionEntryRootMap& old);
+    // not implemented
+    DLLLOCAL FunctionEntryRootMap& operator=(const FunctionEntryRootMap& m);
 
 public:
-   DLLLOCAL FunctionEntryRootMap() {
-   }
+    DLLLOCAL FunctionEntryRootMap() {
+    }
 
-   DLLLOCAL void update(const char* name, FunctionEntry* obj) {
-      // get current lookup map entry for this object
-      femap_t::iterator i = find(name);
-      if (i == end())
-         insert(femap_t::value_type(name, FunctionEntryInfo(obj)));
-      else // if the old depth is > the new depth, then replace
-         if (i->second.depth() > obj->getNamespace()->depth)
-            i->second.assign(obj);
-   }
+    DLLLOCAL void update(const char* name, FunctionEntry* obj) {
+        // get current lookup map entry for this object
+        femap_t::iterator i = find(name);
+        if (i == end())
+            insert(femap_t::value_type(name, FunctionEntryInfo(obj)));
+        else // if the old depth is > the new depth, then replace
+            if (i->second.depth() > obj->getNamespace()->depth)
+                i->second.assign(obj);
+    }
 
-   DLLLOCAL void update(femap_t::const_iterator ni) {
-      // get current lookup map entry for this object
-      femap_t::iterator i = find(ni->first);
-      if (i == end()) {
-         //printd(5, "FunctionEntryRootMap::update(iterator) inserting '%s' new depth: %d\n", ni->first, ni->second.depth());
-         insert(femap_t::value_type(ni->first, ni->second));
-      }
-      else {
-         // if the old depth is > the new depth, then replace
-         if (i->second.depth() > ni->second.depth()) {
-            //printd(5, "FunctionEntryRootMap::update(iterator) replacing '%s' current depth: %d new depth: %d\n", ni->first, i->second.depth(), ni->second.depth());
-            i->second = ni->second;
-         }
-         //else
-         //printd(5, "FunctionEntryRootMap::update(iterator) ignoring '%s' current depth: %d new depth: %d\n", ni->first, i->second.depth(), ni->second.depth());
-      }
-   }
+    DLLLOCAL void update(femap_t::const_iterator ni) {
+        // get current lookup map entry for this object
+        femap_t::iterator i = find(ni->first);
+        if (i == end()) {
+            //printd(5, "FunctionEntryRootMap::update(iterator) inserting '%s' new depth: %d\n", ni->first, ni->second.depth());
+            insert(femap_t::value_type(ni->first, ni->second));
+        }
+        else {
+            // if the old depth is > the new depth, then replace
+            if (i->second.depth() > ni->second.depth()) {
+                //printd(5, "FunctionEntryRootMap::update(iterator) replacing '%s' current depth: %d new depth: %d\n", ni->first, i->second.depth(), ni->second.depth());
+                i->second = ni->second;
+            }
+            //else
+            //printd(5, "FunctionEntryRootMap::update(iterator) ignoring '%s' current depth: %d new depth: %d\n", ni->first, i->second.depth(), ni->second.depth());
+        }
+    }
 
-   FunctionEntry* findObj(const char* name) {
-      femap_t::iterator i = find(name);
-      return i == end() ? 0 : i->second.obj;
-   }
+    FunctionEntry* findObj(const char* name) {
+        femap_t::iterator i = find(name);
+        return i == end() ? 0 : i->second.obj;
+    }
 };
 
 class NamespaceDepthList {
-   friend class NamespaceDepthListIterator;
+    friend class NamespaceDepthListIterator;
 protected:
-   // map from depth to namespace
-   typedef std::multimap<unsigned, qore_ns_private*> nsdmap_t;
-   nsdmap_t nsdmap;
+    // map from depth to namespace
+    typedef std::multimap<unsigned, qore_ns_private*> nsdmap_t;
+    nsdmap_t nsdmap;
 
 public:
-   DLLLOCAL NamespaceDepthList() {
-   }
+    DLLLOCAL NamespaceDepthList() {
+    }
 
-   DLLLOCAL void add(qore_ns_private* ns) {
-      nsdmap.insert(nsdmap_t::value_type(ns->depth, ns));
-   }
+    DLLLOCAL void add(qore_ns_private* ns) {
+        nsdmap.insert(nsdmap_t::value_type(ns->depth, ns));
+    }
 
-   DLLLOCAL void clear() {
-      nsdmap.clear();
-   }
+    DLLLOCAL void clear() {
+        nsdmap.clear();
+    }
 };
 
 class NamespaceDepthListIterator {

--- a/include/qore/intern/QoreObjectIntern.h
+++ b/include/qore/intern/QoreObjectIntern.h
@@ -660,11 +660,7 @@ public:
    DLLLOCAL QoreValue evalBuiltinMethodWithPrivateData(const QoreMethod& method, const BuiltinNormalMethodVariantBase* meth, const QoreValueList* args, q_rt_flags_t rtflags, ExceptionSink* xsink);
 
     // no locking necessary; if class_ctx is non-null, an internal member is being initialized
-    QoreValue& getMemberValueRefForInitialization(const char* member, const qore_class_private* class_ctx) {
-        QoreHashNode* odata = class_ctx ? getCreateInternalData(class_ctx) : data;
-        //printd(5, "qore_object_private::getMemberValueRefForInitialization() this: %p mem: '%s' class_ctx: %p %s odata: %p\n", this, member, class_ctx, class_ctx ? class_ctx->name.c_str() : "n/a", odata);
-        return odata->getValueRef(member);
-    }
+    DLLLOCAL QoreValue& getMemberValueRefForInitialization(const char* member, const qore_class_private* class_ctx);
 
    //! retuns member data of the object (or 0 if there's an exception), private members are excluded if called outside the class, caller owns the QoreHashNode reference returned
    /**

--- a/include/qore/intern/QoreObjectIntern.h
+++ b/include/qore/intern/QoreObjectIntern.h
@@ -37,6 +37,7 @@
 
 #include <stdlib.h>
 #include <assert.h>
+#include <string.h>
 
 #include <map>
 #include <set>
@@ -65,8 +66,15 @@
 
 class LValueHelper;
 
+class lthash {
+public:
+    DLLLOCAL bool operator()(char* s1, char* s2) const {
+        return memcmp(s1, s2, SH_SIZE) < 0;
+    }
+};
+
 // per-class internal data
-typedef std::map<char*, QoreHashNode*, ltstr> cdmap_t;
+typedef std::map<char*, QoreHashNode*, lthash> cdmap_t;
 
 /*
   Qore internal class data is stored against the object with this data structure
@@ -366,148 +374,148 @@ public:
       return ((access > Public) && !class_ctx) ? QOA_PRIV_ERROR : QOA_OK;
    }
 
-   // must be called in the object read lock
-   DLLLOCAL const QoreHashNode* getInternalData(const qore_class_private* class_ctx) const {
-      if (!cdmap)
-         return 0;
-      cdmap_t::const_iterator i = cdmap->find(class_ctx->getHash());
-      return i != cdmap->end() ? i->second : 0;
-   }
+    // must be called in the object read lock
+    DLLLOCAL const QoreHashNode* getInternalData(const qore_class_private* class_ctx) const {
+        if (!cdmap)
+            return nullptr;
+        cdmap_t::const_iterator i = cdmap->find(class_ctx->getHash());
+        return i != cdmap->end() ? i->second : nullptr;
+    }
 
-   // must be called in the object read lock
-   DLLLOCAL QoreHashNode* getInternalData(const qore_class_private* class_ctx) {
-      if (!cdmap)
-         return 0;
-      cdmap_t::iterator i = cdmap->find(class_ctx->getHash());
-      return i != cdmap->end() ? i->second : 0;
-   }
+    // must be called in the object read lock
+    DLLLOCAL QoreHashNode* getInternalData(const qore_class_private* class_ctx) {
+        if (!cdmap)
+            return nullptr;
+        cdmap_t::iterator i = cdmap->find(class_ctx->getHash());
+        return i != cdmap->end() ? i->second : nullptr;
+    }
 
-   // must be called in the object write lock
-   DLLLOCAL QoreHashNode* getCreateInternalData(const qore_class_private* class_ctx) {
-      if (cdmap) {
-         cdmap_t::iterator i = cdmap->find(class_ctx->getHash());
-         if (i != cdmap->end())
-            return i->second;
-      }
-      else
-         cdmap = new cdmap_t;
+    // must be called in the object write lock
+    DLLLOCAL QoreHashNode* getCreateInternalData(const qore_class_private* class_ctx) {
+        if (cdmap) {
+            cdmap_t::iterator i = cdmap->find(class_ctx->getHash());
+            if (i != cdmap->end())
+                return i->second;
+        }
+        else
+            cdmap = new cdmap_t;
 
-      QoreHashNode* id = new QoreHashNode;
-      cdmap->insert(cdmap_t::value_type(class_ctx->getHash(), id));
-      return id;
-   }
+        QoreHashNode* id = new QoreHashNode;
+        cdmap->insert(cdmap_t::value_type(class_ctx->getHash(), id));
+        return id;
+    }
 
-   DLLLOCAL void setValue(const char* key, AbstractQoreNode* val, ExceptionSink* xsink);
+    DLLLOCAL void setValue(const char* key, AbstractQoreNode* val, ExceptionSink* xsink);
 
-   DLLLOCAL void setValueIntern(const qore_class_private* class_ctx, const char* key, QoreValue val, ExceptionSink* xsink);
+    DLLLOCAL void setValueIntern(const qore_class_private* class_ctx, const char* key, QoreValue val, ExceptionSink* xsink);
 
-   DLLLOCAL int checkMemberAccess(const char* mem, const qore_class_private* class_ctx, bool& internal_member) const {
-      ClassAccess access;
-      const qore_class_private* qc = qore_class_private::runtimeGetMemberClass(*theclass, mem, access, class_ctx, internal_member);
-      if (!qc)
-         return theclass->runtimeHasPublicMembersInHierarchy() ? QOA_PUB_ERROR : QOA_OK;
-      // if internal_member is true, then private access has already been verified
-      if (internal_member)
-         return QOA_OK;
+    DLLLOCAL int checkMemberAccess(const char* mem, const qore_class_private* class_ctx, bool& internal_member) const {
+        ClassAccess access;
+        const qore_class_private* qc = qore_class_private::runtimeGetMemberClass(*theclass, mem, access, class_ctx, internal_member);
+        if (!qc)
+            return theclass->runtimeHasPublicMembersInHierarchy() ? QOA_PUB_ERROR : QOA_OK;
+        // if internal_member is true, then private access has already been verified
+        if (internal_member)
+            return QOA_OK;
 
-      return ((access > Public) && !class_ctx) ? QOA_PRIV_ERROR : QOA_OK;
-   }
+        return ((access > Public) && !class_ctx) ? QOA_PRIV_ERROR : QOA_OK;
+    }
 
-   DLLLOCAL int checkMemberAccess(const char* mem, const qore_class_private* class_ctx, bool& internal_member, ExceptionSink* xsink) const {
-      int rc = checkMemberAccess(mem, class_ctx, internal_member);
-      if (!rc)
-         return 0;
+    DLLLOCAL int checkMemberAccess(const char* mem, const qore_class_private* class_ctx, bool& internal_member, ExceptionSink* xsink) const {
+        int rc = checkMemberAccess(mem, class_ctx, internal_member);
+        if (!rc)
+            return 0;
 
-      if (rc == QOA_PRIV_ERROR)
-         doPrivateException(mem, xsink);
-      else
-         doPublicException(mem, xsink);
-      return -1;
-   }
-
-   DLLLOCAL int checkMemberAccessGetTypeInfo(ExceptionSink* xsink, const char* mem, const qore_class_private* class_ctx, bool& internal_member, const QoreTypeInfo*& typeInfo) const {
-      ClassAccess access;
-      const QoreMemberInfo* mi = qore_class_private::runtimeGetMemberInfo(*theclass, mem, access, class_ctx, internal_member);
-      if (mi) {
-         if (access > Public && !class_ctx) {
+        if (rc == QOA_PRIV_ERROR)
             doPrivateException(mem, xsink);
+        else
+            doPublicException(mem, xsink);
+        return -1;
+    }
+
+    DLLLOCAL int checkMemberAccessGetTypeInfo(ExceptionSink* xsink, const char* mem, const qore_class_private* class_ctx, bool& internal_member, const QoreTypeInfo*& typeInfo) const {
+        ClassAccess access;
+        const QoreMemberInfo* mi = qore_class_private::runtimeGetMemberInfo(*theclass, mem, access, class_ctx, internal_member);
+        if (mi) {
+            if (access > Public && !class_ctx) {
+                doPrivateException(mem, xsink);
+                return -1;
+            }
+
+            typeInfo = mi->getTypeInfo();
+            return 0;
+        }
+
+        // member is not declared
+        if (theclass->runtimeHasPublicMembersInHierarchy()) {
+            doPublicException(mem, xsink);
             return -1;
-         }
+        }
+        return 0;
+    }
 
-         typeInfo = mi->getTypeInfo();
-         return 0;
-      }
+    DLLLOCAL QoreValue takeMember(ExceptionSink* xsink, const char* mem, bool check_access = true);
 
-      // member is not declared
-      if (theclass->runtimeHasPublicMembersInHierarchy()) {
-         doPublicException(mem, xsink);
-         return -1;
-      }
-      return 0;
-   }
+    DLLLOCAL QoreValue takeMember(LValueHelper& lvh, const char* mem);
 
-   DLLLOCAL QoreValue takeMember(ExceptionSink* xsink, const char* mem, bool check_access = true);
+    DLLLOCAL void takeMembers(QoreLValueGeneric& rv, LValueHelper& lvh, const QoreListNode* l);
 
-   DLLLOCAL QoreValue takeMember(LValueHelper& lvh, const char* mem);
+    DLLLOCAL QoreValue getReferencedMemberNoMethod(const char* mem, ExceptionSink* xsink) const;
 
-   DLLLOCAL void takeMembers(QoreLValueGeneric& rv, LValueHelper& lvh, const QoreListNode* l);
+    // lock not held on entry
+    DLLLOCAL void doDeleteIntern(ExceptionSink* xsink) {
+        printd(5, "qore_object_private::doDeleteIntern() execing destructor() obj: %p\n", obj);
 
-   DLLLOCAL QoreValue getReferencedMemberNoMethod(const char* mem, ExceptionSink* xsink) const;
+        // increment reference count temporarily for destructor
+        {
+            AutoLocker slr(rlck);
+            ++obj->references;
+        }
 
-   // lock not held on entry
-   DLLLOCAL void doDeleteIntern(ExceptionSink* xsink) {
-      printd(5, "qore_object_private::doDeleteIntern() execing destructor() obj: %p\n", obj);
+        theclass->execDestructor(obj, xsink);
 
-      // increment reference count temporarily for destructor
-      {
-         AutoLocker slr(rlck);
-         ++obj->references;
-      }
+        cdmap_t* cdm;
+        QoreHashNode* td;
+        {
+            QoreAutoVarRWWriteLocker al(rml);
+            assert(status != OS_DELETED);
+            assert(data);
+            status = OS_DELETED;
 
-      theclass->execDestructor(obj, xsink);
+            cdm = cdmap;
+            cdmap = 0;
 
-      cdmap_t* cdm;
-      QoreHashNode* td;
-      {
-         QoreAutoVarRWWriteLocker al(rml);
-         assert(status != OS_DELETED);
-         assert(data);
-         status = OS_DELETED;
+            td = data;
+            data = 0;
 
-         cdm = cdmap;
-         cdmap = 0;
+            removeInvalidateRSetIntern();
+        }
 
-         td = data;
-         data = 0;
+        cleanup(xsink, td, cdm);
 
-         removeInvalidateRSetIntern();
-      }
+        obj->deref(xsink);
+    }
 
-      cleanup(xsink, td, cdm);
-
-      obj->deref(xsink);
-   }
-
-   DLLLOCAL void cleanup(ExceptionSink* xsink, QoreHashNode* td, cdmap_t* cdm) {
-      if (privateData) {
-         printd(5, "qore_object_private::cleanup() this: %p privateData: %p\n", this, privateData);
-         delete privateData;
+    DLLLOCAL void cleanup(ExceptionSink* xsink, QoreHashNode* td, cdmap_t* cdm) {
+        if (privateData) {
+            printd(5, "qore_object_private::cleanup() this: %p privateData: %p\n", this, privateData);
+            delete privateData;
 #ifdef DEBUG
-         privateData = 0;
+            privateData = 0;
 #endif
-      }
+        }
 
-      td->clear(xsink, true);
-      td->deref(xsink);
+        td->clear(xsink, true);
+        td->deref(xsink);
 
-      if (cdm) {
-         for (auto& i : *cdm) {
-            i.second->clear(xsink, true);
-            i.second->deref(xsink);
-         }
-         delete cdm;
-      }
-   }
+        if (cdm) {
+            for (auto& i : *cdm) {
+                i.second->clear(xsink, true);
+                i.second->deref(xsink);
+            }
+            delete cdm;
+        }
+    }
 
    // this method is called when there is an exception in a constructor and the object should be deleted
    DLLLOCAL void obliterate(ExceptionSink* xsink) {

--- a/include/qore/intern/QoreObjectIntern.h
+++ b/include/qore/intern/QoreObjectIntern.h
@@ -205,8 +205,6 @@ public:
 
    DLLLOCAL int getLValue(const char* key, LValueHelper& lvh, const qore_class_private* class_ctx, bool for_remove, ExceptionSink* xsink);
 
-   DLLLOCAL AbstractQoreNode** getMemberValuePtr(const char* key, AutoVLock* vl, const QoreTypeInfo*& typeInfo, ExceptionSink* xsink) const;
-
    DLLLOCAL QoreStringNode* firstKey(ExceptionSink* xsink) {
       // get the current class context
       const qore_class_private* class_ctx = runtime_get_class();
@@ -401,7 +399,7 @@ public:
 
    DLLLOCAL void setValue(const char* key, AbstractQoreNode* val, ExceptionSink* xsink);
 
-   DLLLOCAL void setValueIntern(const qore_class_private* class_ctx, const char* key, AbstractQoreNode* val, ExceptionSink* xsink);
+   DLLLOCAL void setValueIntern(const qore_class_private* class_ctx, const char* key, QoreValue val, ExceptionSink* xsink);
 
    DLLLOCAL int checkMemberAccess(const char* mem, const qore_class_private* class_ctx, bool& internal_member) const {
       ClassAccess access;
@@ -652,7 +650,7 @@ public:
 
    DLLLOCAL AbstractPrivateData* getAndRemovePrivateData(qore_classid_t key, ExceptionSink* xsink) {
       QoreSafeVarRWWriteLocker sl(rml);
-      return privateData ? privateData->getAndRemovePtr(key) : 0;
+      return privateData ? privateData->getAndRemovePtr(key) : nullptr;
    }
 
    DLLLOCAL AbstractPrivateData* getReferencedPrivateData(qore_classid_t key, ExceptionSink* xsink) const;
@@ -661,12 +659,12 @@ public:
 
    DLLLOCAL QoreValue evalBuiltinMethodWithPrivateData(const QoreMethod& method, const BuiltinNormalMethodVariantBase* meth, const QoreValueList* args, q_rt_flags_t rtflags, ExceptionSink* xsink);
 
-   // no locking necessary; if class_ctx is non-null, an internal member is being initialized
-   AbstractQoreNode** getMemberValuePtrForInitialization(const char* member, const qore_class_private* class_ctx) {
-      QoreHashNode* odata = class_ctx ? getCreateInternalData(class_ctx) : data;
-      //printd(5, "qore_object_private::getMemberValuePtrForInitialization() this: %p mem: '%s' class_ctx: %p %s odata: %p\n", this, member, class_ctx, class_ctx ? class_ctx->name.c_str() : "n/a", odata);
-      return odata->getKeyValuePtr(member);
-   }
+    // no locking necessary; if class_ctx is non-null, an internal member is being initialized
+    QoreValue& getMemberValueRefForInitialization(const char* member, const qore_class_private* class_ctx) {
+        QoreHashNode* odata = class_ctx ? getCreateInternalData(class_ctx) : data;
+        //printd(5, "qore_object_private::getMemberValueRefForInitialization() this: %p mem: '%s' class_ctx: %p %s odata: %p\n", this, member, class_ctx, class_ctx ? class_ctx->name.c_str() : "n/a", odata);
+        return odata->getValueRef(member);
+    }
 
    //! retuns member data of the object (or 0 if there's an exception), private members are excluded if called outside the class, caller owns the QoreHashNode reference returned
    /**
@@ -753,10 +751,6 @@ public:
 
    DLLLOCAL static int getLValue(const QoreObject& obj, const char* key, LValueHelper& lvh, const qore_class_private* class_ctx, bool for_remove, ExceptionSink* xsink) {
       return obj.priv->getLValue(key, lvh, class_ctx, for_remove, xsink);
-   }
-
-   DLLLOCAL static AbstractQoreNode** getMemberValuePtr(const QoreObject* obj, const char* key, AutoVLock *vl, const QoreTypeInfo*& typeInfo, ExceptionSink* xsink) {
-      return obj->priv->getMemberValuePtr(key, vl, typeInfo, xsink);
    }
 
    DLLLOCAL static void plusEquals(QoreObject* obj, const AbstractQoreNode* v, AutoVLock& vl, ExceptionSink* xsink) {

--- a/include/qore/intern/QoreObjectIntern.h
+++ b/include/qore/intern/QoreObjectIntern.h
@@ -446,13 +446,13 @@ public:
       return 0;
    }
 
-   DLLLOCAL AbstractQoreNode* takeMember(ExceptionSink* xsink, const char* mem, bool check_access = true);
+   DLLLOCAL QoreValue takeMember(ExceptionSink* xsink, const char* mem, bool check_access = true);
 
-   DLLLOCAL AbstractQoreNode* takeMember(LValueHelper& lvh, const char* mem);
+   DLLLOCAL QoreValue takeMember(LValueHelper& lvh, const char* mem);
 
    DLLLOCAL void takeMembers(QoreLValueGeneric& rv, LValueHelper& lvh, const QoreListNode* l);
 
-   DLLLOCAL AbstractQoreNode* getReferencedMemberNoMethod(const char* mem, ExceptionSink* xsink) const;
+   DLLLOCAL QoreValue getReferencedMemberNoMethod(const char* mem, ExceptionSink* xsink) const;
 
    // lock not held on entry
    DLLLOCAL void doDeleteIntern(ExceptionSink* xsink) {
@@ -733,11 +733,11 @@ public:
       return obj.priv;
    }
 
-   DLLLOCAL static AbstractQoreNode* takeMember(QoreObject& obj, ExceptionSink* xsink, const char* mem, bool check_access = true) {
+   DLLLOCAL static QoreValue takeMember(QoreObject& obj, ExceptionSink* xsink, const char* mem, bool check_access = true) {
       return obj.priv->takeMember(xsink, mem, check_access);
    }
 
-   DLLLOCAL static AbstractQoreNode* takeMember(QoreObject& obj, LValueHelper& lvh, const char* mem) {
+   DLLLOCAL static QoreValue takeMember(QoreObject& obj, LValueHelper& lvh, const char* mem) {
       return obj.priv->takeMember(lvh, mem);
    }
 

--- a/include/qore/intern/QoreOperatorNode.h
+++ b/include/qore/intern/QoreOperatorNode.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -35,6 +35,7 @@
 #include <stdarg.h>
 
 DLLLOCAL AbstractQoreNode* copy_and_resolve_lvar_refs(const AbstractQoreNode* n, ExceptionSink* xsink);
+DLLLOCAL QoreValue copy_value_and_resolve_lvar_refs(const QoreValue& n, ExceptionSink* xsink);
 
 // type of logical operator function
 typedef bool (*op_log_func_t)(QoreValue l, QoreValue r, ExceptionSink* xsink);
@@ -77,53 +78,104 @@ public:
 template <class T = QoreOperatorNode>
 class QoreSingleExpressionOperatorNode : public T {
 protected:
-   AbstractQoreNode* exp;
+    AbstractQoreNode* exp;
 
-   DLLLOCAL ~QoreSingleExpressionOperatorNode() {
-      if (exp)
-         exp->deref(nullptr);
-   }
+    DLLLOCAL ~QoreSingleExpressionOperatorNode() {
+        if (exp)
+            exp->deref(nullptr);
+    }
 
 public:
-   DLLLOCAL QoreSingleExpressionOperatorNode(const QoreProgramLocation& loc, AbstractQoreNode* n_exp) : T(loc), exp(n_exp) {
-   }
+    DLLLOCAL QoreSingleExpressionOperatorNode(const QoreProgramLocation& loc, AbstractQoreNode* n_exp) : T(loc), exp(n_exp) {
+    }
 
-   DLLLOCAL AbstractQoreNode* getExp() {
-      return exp;
-   }
+    DLLLOCAL AbstractQoreNode* getExp() {
+        return exp;
+    }
 
-   DLLLOCAL const AbstractQoreNode* getExp() const {
-      return exp;
-   }
+    DLLLOCAL const AbstractQoreNode* getExp() const {
+        return exp;
+    }
 
-   DLLLOCAL AbstractQoreNode* takeExp() {
-      AbstractQoreNode* rv = exp;
-      exp = nullptr;
-      return rv;
-   }
+    DLLLOCAL AbstractQoreNode* takeExp() {
+        AbstractQoreNode* rv = exp;
+        exp = nullptr;
+        return rv;
+    }
 
-   template <class O>
-   DLLLOCAL QoreSingleExpressionOperatorNode* makeSpecialization() {
-      AbstractQoreNode* e = exp;
-      exp = nullptr;
-      SimpleRefHolder<QoreSingleExpressionOperatorNode> del(this);
-      O* rv = new O(this->loc, e);
-      if (!this->ref_rv)
-         rv->ignoreReturnValue();
-      return rv;
-   }
+    template <class O>
+    DLLLOCAL QoreSingleExpressionOperatorNode* makeSpecialization() {
+        AbstractQoreNode* e = exp;
+        exp = nullptr;
+        SimpleRefHolder<QoreSingleExpressionOperatorNode> del(this);
+        O* rv = new O(this->loc, e);
+        if (!this->ref_rv)
+            rv->ignoreReturnValue();
+        return rv;
+    }
 
-   DLLLOCAL virtual bool hasEffect() const {
-      return ::node_has_effect(exp);
-   }
+    DLLLOCAL virtual bool hasEffect() const {
+        return ::node_has_effect(exp);
+    }
 
-   template <class O>
-   DLLLOCAL O* copyBackgroundExplicit(ExceptionSink* xsink) const {
-      ReferenceHolder<> n_exp(copy_and_resolve_lvar_refs(exp, xsink), xsink);
-      if (*xsink)
-         return 0;
-      return new O(this->loc, n_exp.release());
-   }
+    template <class O>
+    DLLLOCAL O* copyBackgroundExplicit(ExceptionSink* xsink) const {
+        ReferenceHolder<> n_exp(copy_and_resolve_lvar_refs(exp, xsink), xsink);
+        if (*xsink)
+            return 0;
+        return new O(this->loc, n_exp.release());
+    }
+};
+
+template <class T = QoreOperatorNode>
+class QoreSingleValueExpressionOperatorNode : public T {
+protected:
+    QoreValue exp;
+
+    DLLLOCAL ~QoreSingleValueExpressionOperatorNode() {
+        exp.discard(nullptr);
+    }
+
+public:
+    DLLLOCAL QoreSingleValueExpressionOperatorNode(const QoreProgramLocation& loc, QoreValue exp) : T(loc), exp(exp) {
+    }
+
+    DLLLOCAL QoreValue getExp() {
+        return exp;
+    }
+
+    DLLLOCAL const QoreValue getExp() const {
+        return exp;
+    }
+
+    DLLLOCAL QoreValue takeExp() {
+        QoreValue rv = exp;
+        exp.clear();
+        return rv;
+    }
+
+    template <class O>
+    DLLLOCAL QoreSingleValueExpressionOperatorNode* makeSpecialization() {
+        QoreValue e = exp;
+        exp.clear();
+        SimpleRefHolder<QoreSingleValueExpressionOperatorNode> del(this);
+        O* rv = new O(this->loc, e);
+        if (!this->ref_rv)
+            rv->ignoreReturnValue();
+        return rv;
+    }
+
+    DLLLOCAL virtual bool hasEffect() const {
+        return exp.hasNode() && ::node_has_effect(exp.getInternalNode());
+    }
+
+    template <class O>
+    DLLLOCAL O* copyBackgroundExplicit(ExceptionSink* xsink) const {
+        ValueHolder n_exp(copy_value_and_resolve_lvar_refs(exp, xsink), xsink);
+        if (*xsink)
+            return nullptr;
+        return new O(this->loc, n_exp.release());
+    }
 };
 
 template <class T = QoreOperatorNode>

--- a/include/qore/intern/VarRefNode.h
+++ b/include/qore/intern/VarRefNode.h
@@ -187,7 +187,7 @@ public:
       assert(type != VT_GLOBAL);
       type = VT_LOCAL;
       new_decl = true;
-      ref.id = 0;
+      ref.id = nullptr;
    }
    // called when a list of variables is declared
    DLLLOCAL virtual void makeGlobal();

--- a/include/qore/intern/Variable.h
+++ b/include/qore/intern/Variable.h
@@ -471,7 +471,7 @@ public:
     }
 
    DLLLOCAL void setValue(QoreValue& nqv, const QoreTypeInfo* ti = nullptr) {
-        printd(0, "LValueHelper::setValue() this: %p new qv: %p\n", this, &nqv);
+        //printd(5, "LValueHelper::setValue() this: %p new qv: %p\n", this, &nqv);
         assert(!v);
         assert(!val);
         assert(!qv);

--- a/include/qore/intern/qore_ds_private.h
+++ b/include/qore/intern/qore_ds_private.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   The Datasource class provides the low-level interface to Qore DBI drivers.
 
@@ -147,28 +147,7 @@ struct qore_ds_private {
       return private_data ? qore_dbi_private::get(*dsl)->getOptionHash(ds) : opt->hashRefSelf();
    }
 
-   DLLLOCAL QoreHashNode* getCurrentOptionHash(bool ensure_hash = false) const {
-      QoreHashNode* options = 0;
-
-      ReferenceHolder<QoreHashNode> opts(getOptionHash(), 0);
-      ConstHashIterator hi(*opts);
-      while (hi.next()) {
-         const QoreHashNode* ov = reinterpret_cast<const QoreHashNode*>(hi.getValue());
-         const AbstractQoreNode* v = ov->getKeyValue("value");
-         if (!v || v == &False)
-            continue;
-
-         if (!options)
-            options = new QoreHashNode;
-
-         options->setKeyValue(hi.getKey(), v->refSelf(), 0);
-      }
-
-      if (ensure_hash && !options)
-         options = new QoreHashNode;
-
-      return options;
-   }
+    DLLLOCAL QoreHashNode* getCurrentOptionHash(bool ensure_hash = false) const;
 
    DLLLOCAL void setEventQueue(Queue* q, AbstractQoreNode* arg, ExceptionSink* xsink) {
       if (event_queue)

--- a/include/qore/intern/qore_program_private.h
+++ b/include/qore/intern/qore_program_private.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -457,6 +457,9 @@ typedef std::list<QoreBreakpoint*> QoreBreakpointList_t;
 
 class qore_program_private : public qore_program_private_base {
 private:
+    bool ns_cleared = false;
+    bool constants_cleared = false;
+
    mutable QoreCounter debug_program_counter;  // number of thread calls to debug program instance.
    DLLLOCAL void init(QoreProgram* n_pgm, int64 n_parse_options, const AbstractQoreZoneInfo *n_TZ = QTZM.getLocalZoneInfo()) {
    }
@@ -2087,6 +2090,18 @@ public:
    DLLLOCAL unsigned getProgramId() const {
       return programId;
    }
+
+    // called locked
+    DLLLOCAL void clearNamespaceData(ExceptionSink* xsink) {
+        if (ns_cleared) {
+            return;
+        }
+        assert(RootNS);
+        ns_cleared = true;
+        // delete all global variables, etc
+        // this call can only be made once
+        qore_root_ns_private::clearData(*RootNS, xsink);
+    }
 
    DLLLOCAL static QoreProgram* resolveProgramId(unsigned programId) {
       printd(5, "qore_program_private::resolveProgramId(%x)\n", programId);

--- a/include/qore/intern/qore_program_private.h
+++ b/include/qore/intern/qore_program_private.h
@@ -135,7 +135,7 @@ private:
       }
    }
    // to call onAttach when debug is attached or detached, -1 .. detach, 1 .. attach
-   DLLLOCAL int attachFlag;
+   int attachFlag;
    DLLLOCAL void checkAttach(ExceptionSink* xsink);
 
 public:

--- a/include/qore/intern/qore_socket_private.h
+++ b/include/qore/intern/qore_socket_private.h
@@ -372,63 +372,63 @@ struct qore_socket_private {
       return port;
    }
 
-   DLLLOCAL static void do_header(const char* key, QoreString& hdr, const AbstractQoreNode* v) {
-      switch (get_node_type(v)) {
-         case NT_STRING:
-            hdr.sprintf("%s: %s\r\n", key, reinterpret_cast<const QoreStringNode*>(v)->getBuffer());
-            break;
-         case NT_INT:
-            hdr.sprintf("%s: " QLLD "\r\n", key, reinterpret_cast<const QoreBigIntNode*>(v)->val);
-            break;
-         case NT_FLOAT: {
-            hdr.sprintf("%s: ", key);
-            size_t offset = hdr.size();
-            hdr.sprintf("%f\r\n", reinterpret_cast<const QoreFloatNode*>(v)->f);
-            // issue 1556: external modules that call setlocale() can change
-            // the decimal point character used here from '.' to ','
-            // only search the double added, QoreString::sprintf() concatenates
-            q_fix_decimal(&hdr, offset);
-            break;
-         }
-         case NT_NUMBER:
-            hdr.sprintf("%s: ", key);
-            reinterpret_cast<const QoreNumberNode*>(v)->toString(hdr);
-            hdr.concat("\r\n");
-            break;
-         case NT_BOOLEAN:
-            hdr.sprintf("%s: %d\r\n", key, reinterpret_cast<const QoreBoolNode*>(v)->getValue());
-            break;
-      }
-   }
-
-   DLLLOCAL static void do_headers(QoreString& hdr, const QoreHashNode* headers, qore_size_t size, bool addsize = false) {
-      // RFC-2616 4.4 (http://tools.ietf.org/html/rfc2616#section-4.4)
-      // add Content-Length: 0 to headers for responses without a body where there is no transfer-encoding
-      if (headers) {
-         ConstHashIterator hi(headers);
-
-         while (hi.next()) {
-            const AbstractQoreNode* v = hi.getValue();
-            const char* key = hi.getKey();
-            if (addsize && !strcasecmp(key, "transfer-encoding"))
-               addsize = false;
-            if (addsize && !strcasecmp(key, "content-length"))
-               addsize = false;
-            if (v && v->getType() == NT_LIST) {
-               ConstListIterator li(reinterpret_cast<const QoreListNode* >(v));
-               while (li.next())
-                  do_header(key, hdr, li.getValue());
+    DLLLOCAL static void do_header(const char* key, QoreString& hdr, const QoreValue& v) {
+        switch (v.getType()) {
+            case NT_STRING:
+                hdr.sprintf("%s: %s\r\n", key, v.get<const QoreStringNode>()->c_str());
+                break;
+            case NT_INT:
+                hdr.sprintf("%s: " QLLD "\r\n", key, v.getAsBigInt());
+                break;
+            case NT_FLOAT: {
+                hdr.sprintf("%s: ", key);
+                size_t offset = hdr.size();
+                hdr.sprintf("%f\r\n", v.getAsFloat());
+                // issue 1556: external modules that call setlocale() can change
+                // the decimal point character used here from '.' to ','
+                // only search the double added, QoreString::sprintf() concatenates
+                q_fix_decimal(&hdr, offset);
+                break;
             }
-            else
-               do_header(key, hdr, hi.getValue());
-         }
-      }
-      // add data and content-length header if necessary
-      if (size || addsize)
-         hdr.sprintf("Content-Length: " QSD "\r\n", size);
+            case NT_NUMBER:
+                hdr.sprintf("%s: ", key);
+                v.get<const QoreNumberNode>()->toString(hdr);
+                hdr.concat("\r\n");
+                break;
+            case NT_BOOLEAN:
+                hdr.sprintf("%s: %d\r\n", key, (int)v.getAsBool());
+                break;
+        }
+    }
 
-      hdr.concat("\r\n");
-   }
+    DLLLOCAL static void do_headers(QoreString& hdr, const QoreHashNode* headers, qore_size_t size, bool addsize = false) {
+        // RFC-2616 4.4 (http://tools.ietf.org/html/rfc2616#section-4.4)
+        // add Content-Length: 0 to headers for responses without a body where there is no transfer-encoding
+        if (headers) {
+            ConstHashIterator hi(headers);
+
+            while (hi.next()) {
+                const QoreValue v = hi.get();
+                const char* key = hi.getKey();
+                if (addsize && !strcasecmp(key, "transfer-encoding"))
+                    addsize = false;
+                if (addsize && !strcasecmp(key, "content-length"))
+                    addsize = false;
+                if (v.getType() == NT_LIST) {
+                    ConstListIterator li(v.get<const QoreListNode>());
+                    while (li.next())
+                        do_header(key, hdr, li.getValue());
+                }
+                else
+                    do_header(key, hdr, v);
+            }
+        }
+        // add data and content-length header if necessary
+        if (size || addsize)
+            hdr.sprintf("Content-Length: " QSD "\r\n", size);
+
+        hdr.concat("\r\n");
+    }
 
    DLLLOCAL int listen(int backlog = 20) {
       if (sock == QORE_INVALID_SOCKET)
@@ -2134,149 +2134,149 @@ struct qore_socket_private {
       return 0;
    }
 
-   DLLLOCAL int sendHttpChunkedWithCallback(ExceptionSink* xsink, const char* cname, const char* mname, const ResolvedCallReferenceNode& send_callback, QoreThreadLock& l, int source, int timeout_ms = -1, bool* aborted = 0) {
-      assert(xsink);
-      assert(!aborted || !(*aborted));
+    DLLLOCAL int sendHttpChunkedWithCallback(ExceptionSink* xsink, const char* cname, const char* mname, const ResolvedCallReferenceNode& send_callback, QoreThreadLock& l, int source, int timeout_ms = -1, bool* aborted = 0) {
+        assert(xsink);
+        assert(!aborted || !(*aborted));
 
-      if (sock == QORE_INVALID_SOCKET) {
-         se_not_open(cname, mname, xsink);
-         return QSE_NOT_OPEN;
-      }
-      if (in_op >= 0) {
-         if (in_op == gettid()) {
-            se_in_op(cname, mname, xsink);
+        if (sock == QORE_INVALID_SOCKET) {
+            se_not_open(cname, mname, xsink);
+            return QSE_NOT_OPEN;
+        }
+        if (in_op >= 0) {
+            if (in_op == gettid()) {
+                se_in_op(cname, mname, xsink);
+                return 0;
+            }
+            se_in_op_thread(cname, mname, xsink);
             return 0;
-         }
-         se_in_op_thread(cname, mname, xsink);
-         return 0;
-      }
+        }
 
-      PrivateQoreSocketThroughputHelper th(this, true);
+        PrivateQoreSocketThroughputHelper th(this, true);
 
-      // set the non-blocking flag (for use with non-ssl connections)
-      bool nb = (timeout_ms >= 0);
-      // set non-blocking I/O (and restore on exit) if we have a timeout and a non-ssl connection
-      OptionalNonBlockingHelper onbh(*this, !ssl && nb, xsink);
-      if (*xsink)
-         return -1;
+        // set the non-blocking flag (for use with non-ssl connections)
+        bool nb = (timeout_ms >= 0);
+        // set non-blocking I/O (and restore on exit) if we have a timeout and a non-ssl connection
+        OptionalNonBlockingHelper onbh(*this, !ssl && nb, xsink);
+        if (*xsink)
+            return -1;
 
-      qore_socket_op_helper oh(this);
+        qore_socket_op_helper oh(this);
 
-      qore_offset_t rc;
-      int64 total = 0;
-      bool done = false;
+        qore_offset_t rc;
+        int64 total = 0;
+        bool done = false;
 
-      while (!done) {
-         // if we have response data already, then we assume an error and abort
-         if (aborted) {
-            bool data_available = tryReadSocketData(mname, xsink);
-            //printd(5, "qore_socket_private::sendHttpChunkedWithCallback() this: %p aborted: %p iDA: %d\n", this, aborted, data_available);
-            if (data_available || *xsink) {
-               *aborted = true;
-               return *xsink ? -1 : 0;
-            }
-         }
-
-         // FIXME: subtract callback execution time from socket performance measurement
-         ValueHolder res(xsink);
-         rc = runCallback(xsink, cname, mname, res, send_callback, &l);
-         if (rc)
-            return rc;
-
-         //printd(5, "qore_socket_private::sendHttpChunkedWithCallback() this: %p res: %s\n", this, get_type_name(*res));
-
-         // check callback return val
-         QoreString buf;
-
-         switch (res->getType()) {
-            case NT_STRING: {
-               const QoreStringNode* str = res->get<const QoreStringNode>();
-               if (str->empty()) {
-                  done = true;
-                  break;
-               }
-               buf.sprintf("%x\r\n", (int)str->size());
-               buf.concat(str->getBuffer(), str->size());
-               break;
+        while (!done) {
+            // if we have response data already, then we assume an error and abort
+            if (aborted) {
+                bool data_available = tryReadSocketData(mname, xsink);
+                //printd(5, "qore_socket_private::sendHttpChunkedWithCallback() this: %p aborted: %p iDA: %d\n", this, aborted, data_available);
+                if (data_available || *xsink) {
+                    *aborted = true;
+                    return *xsink ? -1 : 0;
+                }
             }
 
-            case NT_BINARY: {
-               const BinaryNode* b = res->get<const BinaryNode>();
-               if (b->empty()) {
-                  done = true;
-                  break;
-               }
-               buf.sprintf("%x\r\n", (int)b->size());
-               buf.concat((const char*)b->getPtr(), b->size());
-               break;
+            // FIXME: subtract callback execution time from socket performance measurement
+            ValueHolder res(xsink);
+            rc = runCallback(xsink, cname, mname, res, send_callback, &l);
+            if (rc)
+                return rc;
+
+            //printd(5, "qore_socket_private::sendHttpChunkedWithCallback() this: %p res: %s\n", this, get_type_name(*res));
+
+            // check callback return val
+            QoreString buf;
+
+            switch (res->getType()) {
+                case NT_STRING: {
+                    const QoreStringNode* str = res->get<const QoreStringNode>();
+                    if (str->empty()) {
+                        done = true;
+                        break;
+                    }
+                    buf.sprintf("%x\r\n", (int)str->size());
+                    buf.concat(str->getBuffer(), str->size());
+                    break;
+                }
+
+                case NT_BINARY: {
+                    const BinaryNode* b = res->get<const BinaryNode>();
+                    if (b->empty()) {
+                        done = true;
+                        break;
+                    }
+                    buf.sprintf("%x\r\n", (int)b->size());
+                    buf.concat((const char*)b->getPtr(), b->size());
+                    break;
+                }
+
+                case NT_HASH: {
+                    buf.concat("0\r\n");
+
+                    ConstHashIterator hi(res->get<const QoreHashNode>());
+
+                    while (hi.next()) {
+                        const QoreValue v = hi.get();
+                        const char* key = hi.getKey();
+
+                        //printd(5, "qore_socket_private::sendHttpChunkedWithCallback() this: %p trailer %s\n", this, key);
+
+                        if (v.getType() == NT_LIST) {
+                            ConstListIterator li(v.get<const QoreListNode>());
+                            while (li.next())
+                                do_header(key, buf, li.getValue());
+                        }
+                        else
+                            do_header(key, buf, v);
+                    }
+
+                    // fall through to next case
+                }
+
+                case NT_NOTHING:
+                case NT_NULL:
+                    done = true;
+                    break;
+
+                default:
+                    xsink->raiseException("SOCKET-CALLBACK-ERROR", "HTTP chunked data callback returned type '%s'; expecting one of: 'string', 'binary', 'hash', 'nothing' (or 'NULL')", res->getTypeName());
+                    return -1;
             }
 
-            case NT_HASH: {
-               buf.concat("0\r\n");
+            if (buf.empty())
+                buf.concat("0\r\n");
 
-               ConstHashIterator hi(res->get<const QoreHashNode>());
+            // add trailing \r\n
+            buf.concat("\r\n");
 
-               while (hi.next()) {
-                  const AbstractQoreNode* v = hi.getValue();
-                  const char* key = hi.getKey();
+            // send chunk buffer data
+            rc = sendIntern(xsink, cname, mname, buf.getBuffer(), buf.size(), timeout_ms, total, true);
 
-                  //printd(5, "qore_socket_private::sendHttpChunkedWithCallback() this: %p trailer %s\n", this, key);
+            if (rc < 0) {
+                // if we have a socket I/O error, but also data to be read on the socket, then clear the exception and return 0
+                if (aborted && *xsink) {
+                    bool data_available = tryReadSocketData(mname, xsink);
+                    //printd(5, "qore_socket_private::sendHttpChunkedWithCallback() this: %p aborted: %p iDA: %d\n", this, aborted, data_available);
+                    if (data_available) {
+                        *aborted = true;
+                        return *xsink ? -1 : 0;
+                    }
+                }
 
-                  if (v && v->getType() == NT_LIST) {
-                     ConstListIterator li(reinterpret_cast<const QoreListNode* >(v));
-                     while (li.next())
-                        do_header(key, buf, li.getValue());
-                  }
-                  else
-                     do_header(key, buf, hi.getValue());
-               }
-
-               // fall through to next case
+                //printd(5, "qore_socket_private::sendHttpChunkedWithCallback() this: %p rc: %d sock: %d xsink: %d\n", this, rc, sock, xsink->isException());
             }
 
-            case NT_NOTHING:
-            case NT_NULL:
-               done = true;
-               break;
+            //printd(5, "qore_socket_private::sendHttpChunkedWithCallback() this: %p sent: %s\n", this, buf.getBuffer());
 
-            default:
-               xsink->raiseException("SOCKET-CALLBACK-ERROR", "HTTP chunked data callback returned type '%s'; expecting one of: 'string', 'binary', 'hash', 'nothing' (or 'NULL')", res->getTypeName());
-               return -1;
-         }
+            if (rc < 0 || sock == QORE_INVALID_SOCKET)
+                break;
+        }
 
-         if (buf.empty())
-            buf.concat("0\r\n");
+        th.finalize(total);
 
-         // add trailing \r\n
-         buf.concat("\r\n");
-
-         // send chunk buffer data
-         rc = sendIntern(xsink, cname, mname, buf.getBuffer(), buf.size(), timeout_ms, total, true);
-
-         if (rc < 0) {
-            // if we have a socket I/O error, but also data to be read on the socket, then clear the exception and return 0
-            if (aborted && *xsink) {
-               bool data_available = tryReadSocketData(mname, xsink);
-               //printd(5, "qore_socket_private::sendHttpChunkedWithCallback() this: %p aborted: %p iDA: %d\n", this, aborted, data_available);
-               if (data_available) {
-                  *aborted = true;
-                  return *xsink ? -1 : 0;
-               }
-            }
-
-            //printd(5, "qore_socket_private::sendHttpChunkedWithCallback() this: %p rc: %d sock: %d xsink: %d\n", this, rc, sock, xsink->isException());
-         }
-
-         //printd(5, "qore_socket_private::sendHttpChunkedWithCallback() this: %p sent: %s\n", this, buf.getBuffer());
-
-         if (rc < 0 || sock == QORE_INVALID_SOCKET)
-            break;
-      }
-
-      th.finalize(total);
-
-      return rc < 0 || sock == QORE_INVALID_SOCKET ? -1 : 0;
-   }
+        return rc < 0 || sock == QORE_INVALID_SOCKET ? -1 : 0;
+    }
 
    DLLLOCAL int sendIntern(ExceptionSink* xsink, const char* cname, const char* mname, const char* buf, qore_size_t size, int timeout_ms, int64& total, bool stream = false) {
       assert(xsink);
@@ -2533,41 +2533,41 @@ struct qore_socket_private {
       th.finalize(total);
    }
 
-   DLLLOCAL void sendHttpChunkedBodyTrailer(const QoreHashNode* headers, int timeout, ExceptionSink* xsink) {
-      if (sock == QORE_INVALID_SOCKET) {
-         se_not_open("Socket", "sendHttpChunkedBodyTrailer", xsink);
-         return;
-      }
-      if (in_op >= 0) {
-         if (in_op == gettid()) {
-            se_in_op("Socket", "sendHttpChunkedBodyTrailer", xsink);
+    DLLLOCAL void sendHttpChunkedBodyTrailer(const QoreHashNode* headers, int timeout, ExceptionSink* xsink) {
+        if (sock == QORE_INVALID_SOCKET) {
+            se_not_open("Socket", "sendHttpChunkedBodyTrailer", xsink);
             return;
-         }
-         se_in_op_thread("Socket", "sendHttpChunkedBodyTrailer", xsink);
-         return;
-      }
-
-      QoreString buf;
-      if (!headers) {
-         ConstHashIterator hi(headers);
-
-         while (hi.next()) {
-            const AbstractQoreNode* v = hi.getValue();
-            const char* key = hi.getKey();
-
-            if (v && v->getType() == NT_LIST) {
-               ConstListIterator li(reinterpret_cast<const QoreListNode* >(v));
-               while (li.next())
-                  do_header(key, buf, li.getValue());
+        }
+        if (in_op >= 0) {
+            if (in_op == gettid()) {
+                se_in_op("Socket", "sendHttpChunkedBodyTrailer", xsink);
+                return;
             }
-            else
-               do_header(key, buf, hi.getValue());
-         }
-      }
-      buf.concat("\r\n");
-      int64 total;
-      sendIntern(xsink, "Socket", "sendHttpChunkedBodyTrailer", buf.getBuffer(), buf.size(), timeout, total, true);
-   }
+            se_in_op_thread("Socket", "sendHttpChunkedBodyTrailer", xsink);
+            return;
+        }
+
+        QoreString buf;
+        if (!headers) {
+            ConstHashIterator hi(headers);
+
+            while (hi.next()) {
+                const QoreValue v = hi.get();
+                const char* key = hi.getKey();
+
+                if (v.getType() == NT_LIST) {
+                    ConstListIterator li(v.get<const QoreListNode>());
+                    while (li.next())
+                        do_header(key, buf, li.getValue());
+                }
+                else
+                do_header(key, buf, v);
+            }
+        }
+        buf.concat("\r\n");
+        int64 total;
+        sendIntern(xsink, "Socket", "sendHttpChunkedBodyTrailer", buf.getBuffer(), buf.size(), timeout, total, true);
+    }
 
    DLLLOCAL int sendHttpMessage(ExceptionSink* xsink, QoreHashNode* info, const char* cname, const char* mname, const char* method, const char* path, const char* http_version, const QoreHashNode* headers, const void *data, qore_size_t size, const ResolvedCallReferenceNode* send_callback, InputStream* is, size_t max_chunk_size, const ResolvedCallReferenceNode* trailer_callback, int source, int timeout_ms = -1, QoreThreadLock* l = 0, bool* aborted = 0) {
       assert(xsink);

--- a/include/qore/intern/qore_socket_private.h
+++ b/include/qore/intern/qore_socket_private.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -3165,13 +3165,13 @@ struct qore_socket_private {
 
          // see if header exists, and if so make it a list and add value to the list
          hash_assignment_priv ha(*h, buf);
-         if (*ha) {
+         if (!(*ha).isNothing()) {
             QoreListNode* l;
-            if ((*ha)->getType() == NT_LIST)
-               l = reinterpret_cast<QoreListNode* >(*ha);
+            if ((*ha).getType() == NT_LIST)
+               l = (*ha).get<QoreListNode>();
             else {
                l = new QoreListNode;
-               l->push(ha.swap(l));
+               l->push(ha.swap(l).takeNode());
             }
             l->push(val);
          }

--- a/include/qore/intern/typed_hash_decl_private.h
+++ b/include/qore/intern/typed_hash_decl_private.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -163,15 +163,13 @@ public:
 
     DLLLOCAL int initHash(QoreHashNode* h, const QoreHashNode* init, ExceptionSink* xsink) const;
 
-    DLLLOCAL int runtimeAssignKey(const char* key, ReferenceHolder<>& val, ExceptionSink* xsink) const {
+    DLLLOCAL int runtimeAssignKey(const char* key, ValueHolder& val, ExceptionSink* xsink) const {
         const HashDeclMemberInfo* mem = members.find(key);
         if (!mem) {
             xsink->raiseException("HASHDECL-KEY-ERROR", "cannot assign unknown key '%s' to hashdecl '%s'", key, name.c_str());
             return -1;
         }
-        QoreValue v(val.release());
-        QoreTypeInfo::acceptInputKey(mem->getTypeInfo(), key, v, xsink);
-        val = v.takeNode();
+        QoreTypeInfo::acceptInputKey(mem->getTypeInfo(), key, *val, xsink);
         return *xsink ? -1 : 0;
     }
 

--- a/include/qore/qlist
+++ b/include/qore/qlist
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -35,96 +35,10 @@
 
 #include <list>
 
-// this is a templated class wrapper for std::list that also maintains the list size (ie size() is O(1)
+// this class is no longer necessary since from c++11+ the list class supports list::size() as O(1)
 
 template<typename T>
-class qlist {
-protected:
-   typedef std::list<T> list_t;
-   list_t l;
-   size_t len;
-
-public:
-   typedef typename list_t::iterator iterator;
-   typedef typename list_t::const_iterator const_iterator;
-   typedef typename list_t::reverse_iterator reverse_iterator;
-
-   DLLLOCAL qlist() : len(0) {
-   }
-
-   DLLLOCAL iterator begin() {
-      return l.begin();
-   }
-
-   DLLLOCAL iterator end() {
-      return l.end();
-   }
-
-   DLLLOCAL const_iterator begin() const {
-      return l.begin();
-   }
-
-   DLLLOCAL const_iterator end() const {
-      return l.end();
-   }
-
-   DLLLOCAL reverse_iterator rbegin() {
-      return l.rbegin();
-   }
-
-   DLLLOCAL reverse_iterator rend() {
-      return l.rend();
-   }
-
-   DLLLOCAL T& front() {
-      return l.front();
-   }
-
-   DLLLOCAL T& back() {
-      return l.back();
-   }
-
-   DLLLOCAL const T& front() const {
-      return l.front();
-   }
-
-   DLLLOCAL const T& back() const {
-      return l.back();
-
-   }
-
-   DLLLOCAL void pop_front() {
-      l.pop_front();
-      --len;
-   }
-
-   DLLLOCAL void push_back(const T& t) {
-      l.push_back(t);
-      ++len;
-   }
-
-   DLLLOCAL iterator insert(iterator i, const T& val) {
-      ++len;
-      return l.insert(i, val);
-   }
-
-   DLLLOCAL size_t size() const {
-      return len;
-   }
-
-   DLLLOCAL bool empty() const {
-      return l.empty();
-   }
-
-   DLLLOCAL void erase(iterator i) {
-      l.erase(i);
-      --len;
-   }
-
-   DLLLOCAL void clear() {
-      l.clear();
-      len = 0;
-   }
+class qlist : public std::list<T> {
 };
 
 #endif

--- a/lib/AbstractQoreNode.cpp
+++ b/lib/AbstractQoreNode.cpp
@@ -451,15 +451,15 @@ static QoreValueList* crlr_list_copy(const QoreValueList* n, ExceptionSink* xsin
 */
 
 static AbstractQoreNode* crlr_hash_copy(const QoreHashNode* n, ExceptionSink* xsink) {
-   assert(xsink);
-   ReferenceHolder<QoreHashNode> h(new QoreHashNode(true), xsink);
-   ConstHashIterator hi(n);
-   while (hi.next()) {
-      h->setKeyValue(hi.getKey(), copy_and_resolve_lvar_refs(hi.getValue(), xsink), xsink);
-      if (*xsink)
-         return 0;
-   }
-   return h.release();
+    assert(xsink);
+    ReferenceHolder<QoreHashNode> h(new QoreHashNode(true), xsink);
+    ConstHashIterator hi(n);
+    while (hi.next()) {
+        h->setValueKeyValue(hi.getKey(), copy_value_and_resolve_lvar_refs(hi.get(), xsink), xsink);
+        if (*xsink)
+            return nullptr;
+    }
+    return h.release();
 }
 
 static AbstractQoreNode* crlr_hash_copy(const QoreParseHashNode* n, ExceptionSink* xsink) {

--- a/lib/AbstractQoreNode.cpp
+++ b/lib/AbstractQoreNode.cpp
@@ -65,20 +65,20 @@ AbstractQoreNode::~AbstractQoreNode() {
 
 /*
 bool test(const AbstractQoreNode* n) {
-   return n->getType() == NT_HASH;
+   return n->getType() == NT_RTCONSTREF;
 }
 static void break_ref() {}
+static void break_deref() {}
 */
 
 void AbstractQoreNode::ref() const {
 #ifdef DEBUG
-   /*
+/*
    if (test(this)) {
-      printd(0, "AbstractQoreNode::ref() %p type: %d %s (%d->%d)\n", this, type, getTypeName(), references, references + 1);
+      printd(0, "AbstractQoreNode::ref() %p type: %d %s (%d->%d)\n", this, type, getTypeName(), reference_count(), reference_count() + 1);
       break_ref();
    }
-   */
-
+*/
 #if TRACK_REFS
    if (type == NT_OBJECT) {
       const QoreObject *o = reinterpret_cast<const QoreObject*>(this);
@@ -113,16 +113,15 @@ void AbstractQoreNode::customDeref(ExceptionSink* xsink) {
    assert(false);
 }
 
-//static void break_deref() {}
 void AbstractQoreNode::deref(ExceptionSink* xsink) {
    //QORE_TRACE("AbstractQoreNode::deref()");
 #ifdef DEBUG
-   /*
+/*
    if (test(this)) {
-      printd(0, "AbstractQoreNode::deref() %p type: %d %s (%d->%d)\n", this, type, getTypeName(), references, references - 1);
+      printd(0, "AbstractQoreNode::deref() %p type: %d %s (%d->%d)\n", this, type, getTypeName(), reference_count(), reference_count() - 1);
       break_deref();
    }
-   */
+*/
 #if TRACK_REFS
    if (type == NT_OBJECT)
       printd(REF_LVL, "QoreObject::deref() %p class: %s (%d->%d) %d\n", this, ((QoreObject*)this)->getClassName(), references.load(), references.load() - 1, custom_reference_handlers);

--- a/lib/AbstractQoreNode.cpp
+++ b/lib/AbstractQoreNode.cpp
@@ -659,19 +659,23 @@ int64 get_ms_zero(const QoreValue& n) {
 }
 
 bool needs_scan(const AbstractQoreNode* n) {
-   if (!n)
-      return false;
+    if (!n)
+        return false;
 
-   switch (n->getType()) {
-      case NT_LIST: return qore_list_private::getScanCount(*static_cast<const QoreListNode*>(n)) ? true : false;
-      case NT_HASH: return qore_hash_private::getScanCount(*static_cast<const QoreHashNode*>(n)) ? true : false;
-      case NT_OBJECT: return true;
-      case NT_VALUE_LIST: /*assert(false);*/ return qore_value_list_private::getScanCount(*static_cast<const QoreValueList*>(n)) ? true : false;
-      case NT_RUNTIME_CLOSURE: return static_cast<const QoreClosureBase*>(n)->needsScan();
-      case NT_REFERENCE: return lvalue_ref::get(static_cast<const ReferenceNode*>(n))->needsScan();
-   }
+    switch (n->getType()) {
+        case NT_LIST: return qore_list_private::getScanCount(*static_cast<const QoreListNode*>(n)) ? true : false;
+        case NT_HASH: return qore_hash_private::getScanCount(*static_cast<const QoreHashNode*>(n)) ? true : false;
+        case NT_OBJECT: return true;
+        case NT_VALUE_LIST: /*assert(false);*/ return qore_value_list_private::getScanCount(*static_cast<const QoreValueList*>(n)) ? true : false;
+        case NT_RUNTIME_CLOSURE: return static_cast<const QoreClosureBase*>(n)->needsScan();
+        case NT_REFERENCE: return lvalue_ref::get(static_cast<const ReferenceNode*>(n))->needsScan();
+    }
 
-   return false;
+    return false;
+}
+
+bool needs_scan(const QoreValue& v) {
+    return needs_scan(v.getInternalNode());
 }
 
 void inc_container_obj(const AbstractQoreNode* n, int dt) {

--- a/lib/BarewordNode.cpp
+++ b/lib/BarewordNode.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -45,50 +45,55 @@ BarewordNode::~BarewordNode() {
 // use the QoreNodeAsStringHelper class (defined in QoreStringNode.h) instead of using these functions directly
 // returns -1 for exception raised, 0 = OK
 int BarewordNode::getAsString(QoreString &qstr, int foff, ExceptionSink *xsink) const {
-   qstr.sprintf("%s '%s' (%p)", getTypeName(), str ? str : "<null>", this);
-   return 0;
+    qstr.sprintf("%s '%s' (%p)", getTypeName(), str ? str : "<null>", this);
+    return 0;
 }
 
 // if del is true, then the returned QoreString * should be deleted, if false, then it must not be
 QoreString *BarewordNode::getAsString(bool &del, int foff, ExceptionSink *xsink) const {
-   del = true;
-   QoreString *rv = new QoreString();
-   getAsString(*rv, foff, xsink);
-   return rv;
+    del = true;
+    QoreString *rv = new QoreString();
+    getAsString(*rv, foff, xsink);
+    return rv;
 }
 
 // returns the data type
 qore_type_t BarewordNode::getType() const {
-   return NT_BAREWORD;
+    return NT_BAREWORD;
 }
 
 // returns the type name as a c string
 const char *BarewordNode::getTypeName() const {
-   return "bareword";
+    return "bareword";
 }
 
 QoreStringNode *BarewordNode::makeQoreStringNode() {
-   assert(str);
-   int len = strlen(str);
-   QoreStringNode *qstr = new QoreStringNode(str, len, len + 1, QCS_DEFAULT);
-   str = 0;
-   return qstr;
+    assert(str);
+    int len = strlen(str);
+    QoreStringNode *qstr = new QoreStringNode(str, len, len + 1, QCS_DEFAULT);
+    str = 0;
+    return qstr;
 }
 
 char *BarewordNode::takeString() {
-   assert(str);
-   char *p = str;
-   str = 0;
-   return p;
+    assert(str);
+    char *p = str;
+    str = 0;
+    return p;
 }
 
-AbstractQoreNode *BarewordNode::parseInitImpl(LocalVar *oflag, int pflag, int &lvids, const QoreTypeInfo *&typeInfo) {
-   //printd(5, "BarewordNode::parseInitImpl() this: %p str: %s\n", this, str);
-   AbstractQoreNode *n = qore_root_ns_private::parseResolveBareword(loc, str, typeInfo);
-   if (!n)
-      return this;
+AbstractQoreNode* BarewordNode::parseInitImpl(LocalVar *oflag, int pflag, int &lvids, const QoreTypeInfo *&typeInfo) {
+    //printd(5, "BarewordNode::parseInitImpl() this: %p str: %s\n", this, str);
+    bool found;
+    QoreValue n = qore_root_ns_private::parseResolveBareword(loc, str, typeInfo, found);
+    if (!found)
+        return this;
 
-   deref(0);
-   typeInfo = 0;
-   return n->parseInit(oflag, pflag, lvids, typeInfo);
+    deref(nullptr);
+    if (n.isNothing()) {
+        typeInfo = nothingTypeInfo;
+        return &Nothing;
+    }
+    typeInfo = nullptr;
+    return n.getReferencedValue()->parseInit(oflag, pflag, lvids, typeInfo);
 }

--- a/lib/BarewordNode.cpp
+++ b/lib/BarewordNode.cpp
@@ -95,5 +95,5 @@ AbstractQoreNode* BarewordNode::parseInitImpl(LocalVar *oflag, int pflag, int &l
         return &Nothing;
     }
     typeInfo = nullptr;
-    return n.getReferencedValue()->parseInit(oflag, pflag, lvids, typeInfo);
+    return n.takeNode()->parseInit(oflag, pflag, lvids, typeInfo);
 }

--- a/lib/ConstantList.cpp
+++ b/lib/ConstantList.cpp
@@ -50,8 +50,7 @@ ConstantEntry::ConstantEntry(const QoreProgramLocation& loc, const char* n, Qore
     if (pgm)
         pwo = qore_program_private::getParseWarnOptions(pgm);
 
-    if (name == "closure")
-    printd(0, "ConstantEntry::ConstantEntry() this: %p '%s' ti: '%s' nti: '%s'\n", this, n, QoreTypeInfo::getName(typeInfo), QoreTypeInfo::getName(val.getTypeInfo()));
+    //printd(5, "ConstantEntry::ConstantEntry() this: %p '%s' ti: '%s' nti: '%s'\n", this, n, QoreTypeInfo::getName(typeInfo), QoreTypeInfo::getName(val.getTypeInfo()));
 }
 
 ConstantEntry::ConstantEntry(const ConstantEntry& old) :
@@ -63,8 +62,7 @@ ConstantEntry::ConstantEntry(const ConstantEntry& old) :
     assert(!old.in_init);
     assert(old.init);
 
-    if (name == "closure")
-    printd(0, "ConstantEntry::ConstantEntry() this: %p copy '%s' ti: '%s' nti: '%s'\n", this, name.c_str(), QoreTypeInfo::getName(typeInfo), QoreTypeInfo::getName(val.getTypeInfo()));
+    //printd(5, "ConstantEntry::ConstantEntry() this: %p copy '%s' ti: '%s' nti: '%s'\n", this, name.c_str(), QoreTypeInfo::getName(typeInfo), QoreTypeInfo::getName(val.getTypeInfo()));
 }
 
 int ConstantEntry::scanValue(const QoreValue& n) const {
@@ -121,6 +119,7 @@ void ConstantEntry::del(ExceptionSink* xsink) {
         val.discard(xsink);
         saved_node->deref(xsink);
 #ifdef DEBUG
+        val.clear();
         saved_node = nullptr;
 #endif
     }
@@ -128,6 +127,9 @@ void ConstantEntry::del(ExceptionSink* xsink) {
         // abort if an object is present and we are calling deref without an ExceptionSink object
         assert(val.getType() != NT_OBJECT || xsink);
         val.discard(xsink);
+#ifdef DEBUG
+        val.clear();
+#endif
     }
 }
 

--- a/lib/ConstantList.cpp
+++ b/lib/ConstantList.cpp
@@ -74,8 +74,8 @@ static void check_constant_cycle(QoreProgram* pgm, AbstractQoreNode* n) {
 #endif
 
 ConstantEntry::ConstantEntry(const QoreProgramLocation& loc, const char* n, AbstractQoreNode* v, const QoreTypeInfo* ti, bool n_pub, bool n_init, bool n_builtin, ClassAccess n_access)
-   : saved_node(nullptr), access(n_access), loc(loc), name(n), typeInfo(ti), node(v), in_init(false), pub(n_pub),
-     init(n_init), builtin(n_builtin) {
+   : loc(loc), name(n), typeInfo(ti), node(v), in_init(false), pub(n_pub),
+     init(n_init), builtin(n_builtin), saved_node(nullptr), access(n_access) {
    QoreProgram* pgm = getProgram();
    if (pgm)
       pwo = qore_program_private::getParseWarnOptions(pgm);
@@ -84,13 +84,13 @@ ConstantEntry::ConstantEntry(const QoreProgramLocation& loc, const char* n, Abst
 }
 
 ConstantEntry::ConstantEntry(const ConstantEntry& old) :
-   saved_node(old.saved_node ? old.saved_node->refSelf() : nullptr),
-   access(old.access),
-   loc(old.loc), pwo(old.pwo), name(old.name),
-   typeInfo(old.typeInfo), node(old.node ? old.node->refSelf() : nullptr),
-   in_init(false), pub(old.builtin), init(true), builtin(old.builtin) {
-   assert(!old.in_init);
-   assert(old.init);
+    loc(old.loc), pwo(old.pwo), name(old.name),
+    typeInfo(old.typeInfo), node(old.node ? old.node->refSelf() : nullptr),
+    in_init(false), pub(old.builtin), init(true), builtin(old.builtin),
+    saved_node(old.saved_node ? old.saved_node->refSelf() : nullptr),
+    access(old.access) {
+    assert(!old.in_init);
+    assert(old.init);
 }
 
 int ConstantEntry::scanValue(const QoreValue& n) const {

--- a/lib/ConstantList.cpp
+++ b/lib/ConstantList.cpp
@@ -46,7 +46,7 @@ const char* ClassNs::getName() const {
 
 ConstantEntry::ConstantEntry(const QoreProgramLocation& loc, const char* n, QoreValue val, const QoreTypeInfo* ti, bool n_pub, bool n_init, bool n_builtin, ClassAccess n_access)
    : loc(loc), name(n), typeInfo(ti), val(val), in_init(false), pub(n_pub),
-     init(n_init), builtin(n_builtin), saved_node(nullptr), access(n_access) {
+     init(n_init), builtin(n_builtin), access(n_access) {
     QoreProgram* pgm = getProgram();
     if (pgm)
         pwo = qore_program_private::getParseWarnOptions(pgm);

--- a/lib/ConstantList.cpp
+++ b/lib/ConstantList.cpp
@@ -362,7 +362,7 @@ ConstantEntry *ConstantList::findEntry(const char* name) {
    return i == cnemap.end() ? 0 : i->second;
 }
 
-AbstractQoreNode* ConstantList::parseFind(const char* name, const QoreTypeInfo*& constantTypeInfo, ClassAccess& access) {
+AbstractQoreNode* ConstantList::find(const char* name, const QoreTypeInfo*& constantTypeInfo, ClassAccess& access) {
    cnemap_t::iterator i = cnemap.find(name);
    if (i != cnemap.end()) {
       if (!i->second->parseInit(ptr)) {
@@ -372,18 +372,6 @@ AbstractQoreNode* ConstantList::parseFind(const char* name, const QoreTypeInfo*&
       }
       constantTypeInfo = nothingTypeInfo;
       return &Nothing;
-   }
-
-   constantTypeInfo = nullptr;
-   return 0;
-}
-
-AbstractQoreNode* ConstantList::find(const char* name, const QoreTypeInfo*& constantTypeInfo, ClassAccess& access) {
-   cnemap_t::iterator i = cnemap.find(name);
-   if (i != cnemap.end()) {
-      constantTypeInfo = i->second->typeInfo;
-      access = i->second->getAccess();
-      return i->second->node;
    }
 
    constantTypeInfo = nullptr;

--- a/lib/ConstantList.cpp
+++ b/lib/ConstantList.cpp
@@ -33,6 +33,7 @@
 #include "qore/intern/QoreClassIntern.h"
 #include "qore/intern/qore_program_private.h"
 #include "qore/intern/QoreNamespaceIntern.h"
+#include "qore/intern/QoreHashNodeIntern.h"
 
 #include <string.h>
 #include <stdlib.h>

--- a/lib/DatasourcePool.cpp
+++ b/lib/DatasourcePool.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -76,7 +76,7 @@ Datasource* DatasourceConfig::get(DatasourceStatementHelper* dsh, ExceptionSink*
       if (!strcmp(hi.getKey(), "min") || !strcmp(hi.getKey(), "max"))
          continue;
 
-      if (ds->setOption(hi.getKey(), hi.getValue(), xsink))
+      if (ds->setOption(hi.getKey(), hi.get(), xsink))
          break;
    }
 

--- a/lib/Function.cpp
+++ b/lib/Function.cpp
@@ -100,9 +100,9 @@ int64 AbstractQoreFunctionVariant::getParseOptions(int64 po) const {
 }
 
 void AbstractQoreFunctionVariant::parseResolveUserSignature() {
-   UserVariantBase* uvb = getUserVariantBase();
-   if (uvb)
-      uvb->getUserSignature()->resolve();
+    UserVariantBase* uvb = getUserVariantBase();
+    if (uvb)
+        uvb->getUserSignature()->resolve();
 }
 
 bool AbstractQoreFunctionVariant::hasBody() const {
@@ -756,7 +756,7 @@ const AbstractQoreFunctionVariant* QoreFunction::runtimeFindVariant(ExceptionSin
    int match = -1;
    const AbstractQoreFunctionVariant* variant = nullptr;
 
-   printd(5, "QoreFunction::runtimeFindVariant() this: %p %s%s%s() vlist: %d (pend: %d) ilist: %d args: %p (%d)\n", this, className() ? className() : "", className() ? "::" : "", getName(), vlist.size(), pending_vlist.size(), ilist.size(), args, args ? args->size() : 0);
+   printd(5, "QoreFunction::runtimeFindVariant() this: %p %s%s%s() vlist: %d ilist: %d args: %p (%d)\n", this, className() ? className() : "", className() ? "::" : "", getName(), vlist.size(), ilist.size(), args, args ? args->size() : 0);
 
    unsigned nargs = args ? args->size() : 0;
 
@@ -952,7 +952,7 @@ const AbstractQoreFunctionVariant* QoreFunction::runtimeFindVariant(ExceptionSin
 const AbstractQoreFunctionVariant* QoreFunction::runtimeFindExactVariant(ExceptionSink* xsink, const type_vec_t& args, const qore_class_private* class_ctx) const {
    const AbstractQoreFunctionVariant* variant = nullptr;
 
-   //printd(5, "QoreFunction::runtimeFindExactVariant() this: %p %s%s%s() vlist: %d (pend: %d) ilist: %d args: %p (%d)\n", this, className() ? className() : "", className() ? "::" : "", getName(), vlist.size(), pending_vlist.size(), ilist.size(), args.size());
+   //printd(5, "QoreFunction::runtimeFindExactVariant() this: %p %s%s%s() vlist: %d ilist: %d args: %p (%d)\n", this, className() ? className() : "", className() ? "::" : "", getName(), vlist.size(), ilist.size(), args.size());
 
    const QoreFunction* aqf = nullptr;
    AbstractFunctionSignature* sig = nullptr;
@@ -1092,7 +1092,7 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
    const AbstractQoreFunctionVariant* pvariant = nullptr;
    unsigned num_args = argTypeInfo.size();
 
-   //printd(5, "QoreFunction::parseFindVariant() this: %p %s() vlist: %d pend: %d ilist: %d num_args: %d\n", this, getName(), vlist.size(), pending_vlist.size(), ilist.size(), num_args);
+   //printd(5, "QoreFunction::parseFindVariant() this: %p %s() vlist: %d ilist: %d num_args: %d\n", this, getName(), vlist.size(), ilist.size(), num_args);
 
    QoreFunction* aqf = nullptr;
 
@@ -1114,7 +1114,7 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
       if (!aqf)
          break;
       //printd(5, "QoreFunction::parseFindVariant() %p %s testing function %p\n", this, getName(), aqf);
-      assert(!aqf->vlist.empty() || !aqf->pending_vlist.empty());
+      assert(!aqf->vlist.empty());
 
       // check committed list
       for (vlist_t::const_iterator i = aqf->vlist.begin(), e = aqf->vlist.end(); i != e; ++i) {
@@ -1196,7 +1196,7 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
                if (rc == QTI_NOT_EQUAL) {
                   ok = false;
                   // raise a detailed parse exception immediately if there is only one variant
-                  if (ilist.size() == 1 && aqf->pending_vlist.singular() && aqf->vlist.empty() && getProgram()->getParseExceptionSink())
+                  if (ilist.size() == 1 && aqf->vlist.singular() && getProgram()->getParseExceptionSink())
                      return doSingleVariantTypeException(loc, pi + 1, aqf->className(), getName(), sig->getSignatureText(), t, a);
                   break;
                }
@@ -1263,140 +1263,6 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
          break;
       }
 
-      // check pending list
-      for (vlist_t::iterator i = aqf->pending_vlist.begin(), e = aqf->pending_vlist.end(); i != e; ++i) {
-         // skip if the variant is not accessible
-         if (last_class && skip_method_variant(*i, class_ctx, internal_access))
-            continue;
-
-         // get variant parse flags
-         int64 vflags = (*i)->getFlags();
-         // does the variant accept extra arguments?
-         bool uses_extra_args = vflags & QC_USES_EXTRA_ARGS;
-
-         // if we should ignore "noop" variants
-         bool strict_args = (*i)->getParseOptions(po) & (PO_REQUIRE_TYPES|PO_STRICT_ARGS);
-
-         // it must not be possible to have a "noop" pending variant
-         assert(!(vflags & (QC_NOOP | QC_RUNTIME_NOOP)));
-
-         ++cnt;
-
-         UserVariantBase *uvb = (*i)->getUserVariantBase();
-         UserSignature* sig = uvb->getUserSignature();
-         // resolve types in signature if necessary
-         sig->resolve();
-
-         // issue 1507: ensure that calls with no arguments and no params are considered a perfect match
-         if (!num_args && !sig->numParams()) {
-            variant = *i;
-            break;
-         }
-
-         // skip variants with signatures with fewer possible elements than the best match already
-         if ((int)(sig->numParams() * QTI_IDENT) > match) {
-            int variant_pmatch = 0;
-            int count = 0;
-            int variant_nperfect = 0;
-            bool variant_runtime_match = false;
-            bool ok = true;
-
-            for (unsigned pi = 0; pi < sig->numParams(); ++pi) {
-               const QoreTypeInfo* t = sig->getParamTypeInfo(pi);
-               bool pos_has_arg = num_args && num_args > pi;
-               const QoreTypeInfo* a = pos_has_arg ? argTypeInfo[pi] : nullptr;
-               if (pos_has_arg)
-                  pos_has_arg = (bool)a;
-
-               //printd(5, "QoreFunction::parseFindVariant() %s(%s) uncommitted pi: %d num_args: %d t: %s (has type: %d) a: %s (%p) t->parseAccepts(a): %d\n", getName(), sig->getSignatureText(), pi, num_args, QoreTypeInfo::getName(t), QoreTypeInfo::hasType(t), QoreTypeInfo::getName(a), a, QoreTypeInfo::parseAccepts(t, a));
-
-               int rc = QTI_UNASSIGNED;
-               if (QoreTypeInfo::hasType(t)) {
-                  if (!QoreTypeInfo::hasType(a)) {
-                     if (pi < num_args) {
-                        //printd(5, "QoreFunction::parseFindVariant() missing arg type - setting variant_runtime_match\n");
-                        // we are missing parse-time type information, we need to match at runtime
-                        variant_runtime_match = true;
-                        continue;
-                     }
-                     else if (sig->hasDefaultArg(pi))
-                        rc = QTI_IGNORE;
-                     else
-                        a = nothingTypeInfo;
-                  }
-                  else if (QoreTypeInfo::isType(a, NT_NOTHING) && sig->hasDefaultArg(pi))
-                     rc = QTI_IDENT;
-               }
-
-               if (rc == QTI_UNASSIGNED) {
-                  bool may_not_match = false;
-                  rc = QoreTypeInfo::parseAccepts(t, a, may_not_match);
-                  // if we might not match, we need to match at runtime
-                  if (may_not_match) {
-                     //printd(5, "QoreFunction::parseFindVariant() may not match - setting variant_runtime_match\n");
-                     variant_runtime_match = true;
-                     continue;
-                  }
-                  if (rc == QTI_IDENT)
-                     ++variant_nperfect;
-               }
-
-               if (rc == QTI_NOT_EQUAL) {
-                  ok = false;
-                  // raise a detailed parse exception immediately if there is only one variant
-                  if (ilist.size() == 1 && aqf->pending_vlist.singular() && aqf->vlist.empty() && getProgram()->getParseExceptionSink())
-                     return doSingleVariantTypeException(loc, pi + 1, aqf->className(), getName(), sig->getSignatureText(), t, a);
-                  break;
-               }
-               ++variant_pmatch;
-               //printd(5, "QoreFunction::parseFindVariant() this: %p %s() variant: %p i: %d match (param %s == %s)\n", this, getName(), variant, pi, QoreTypeInfo::getName(t), QoreTypeInfo::getName(a));
-               if (rc != QTI_IGNORE && pos_has_arg)
-                  count += rc;
-            }
-            //printd(5, "QoreFunction::parseFindVariant() this: %p tested %s(%s) ok: %d count: %d match: %d variant_pmatch: %d variant_nperfect: %d nperfect: %d params: %d args: %d uea: %d sa: %d cea: %d\n", this, getName(), sig->getSignatureText(), ok, count, match, variant_pmatch, variant_nperfect, nperfect, sig->numParams(), num_args, uses_extra_args, strict_args, check_extra_args(sig, argTypeInfo));
-            if (!ok)
-               continue;
-
-            if (variant_runtime_match) {
-               runtime_match = true;
-               break;
-            }
-
-            // now check if additional args are present
-            if ((sig->numParams() < num_args) && !uses_extra_args && strict_args && check_extra_args(sig, argTypeInfo))
-               continue;
-
-            pvariant = !npv ? variant : nullptr;
-
-            ++npv;
-
-            //printd(5, "QoreFunction::parseFindVariant() variant: %p count: %d match: %d pmatch: %d variant_pmatch: %d nperfect: %d variant_nperfect: %d match_len: %d\n", variant, count, match, pmatch, variant_pmatch, nperfect, variant_nperfect, match_len);
-
-            if (count > match || (count == match && (variant_nperfect > nperfect || (variant_nperfect == nperfect && (match_len == -1 || sig->numParams() < (unsigned)match_len))))) {
-               // if we could possibly match less than another variant
-               // then we have to match at runtime
-               if (variant_pmatch < pmatch)
-                  variant = nullptr;
-               else {
-                  // only set variant if it's the longest absolute match and the
-                  // longest potential match
-                  pmatch = variant_pmatch;
-                  match = count;
-                  match_len = sig->numParams();
-                  nperfect = variant_nperfect;
-                  //printd(5, "QoreFunction::parseFindVariant() assigning pending variant %p %s(%s)\n", *i, getName(), sig->getSignatureText());
-                  variant = *i;
-               }
-            }
-            else if (variant_pmatch && variant_pmatch >= pmatch) {
-               // if we could possibly match less than another variant
-               // then we have to match at runtime
-               variant = nullptr;
-               pmatch = variant_pmatch;
-            }
-         }
-      }
-
       if (runtime_match) {
          if (variant)
             variant = nullptr;
@@ -1444,16 +1310,6 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
 
                // ignore "noop" variants if necessary
                if (strict_args && ((*i)->getFlags() & (QC_NOOP | QC_RUNTIME_NOOP)))
-                  continue;
-
-               desc->concat("\n   ");
-               if (class_name)
-                  desc->sprintf("%s::", class_name);
-               desc->sprintf("%s(%s)", getName(), (*i)->getSignature()->getSignatureText());
-            }
-            for (vlist_t::const_iterator i = aqf->pending_vlist.begin(), e = aqf->pending_vlist.end(); i != e; ++i) {
-               // skip if the variant is not accessible
-               if (last_class && skip_method_variant(*i, class_ctx, internal_access))
                   continue;
 
                desc->concat("\n   ");
@@ -1789,8 +1645,8 @@ int QoreFunction::parseCheckDuplicateSignature(AbstractQoreFunctionVariant* vari
    unsigned vtp = sig->getParamTypes();
    unsigned vmp = sig->getMinParamTypes();
 
-   // first check pending variants
-   for (vlist_t::iterator i = pending_vlist.begin(), e = pending_vlist.end(); i != e; ++i) {
+   // check all variants
+   for (vlist_t::iterator i = vlist.begin(), e = vlist.end(); i != e; ++i) {
       UserSignature* vs = reinterpret_cast<UserSignature*>((*i)->getSignature());
       assert(!vs->resolved);
       // get the minimum number of parameters with type information that need to match
@@ -1818,11 +1674,11 @@ int QoreFunction::parseCheckDuplicateSignature(AbstractQoreFunctionVariant* vari
       unsigned max = QORE_MAX(np, vnp);
       for (unsigned pi = 0; pi < max; ++pi) {
          const QoreTypeInfo* variantTypeInfo = vs->getParamTypeInfo(pi);
-         const QoreParseTypeInfo* variantParseTypeInfo = variantTypeInfo ? 0 : vs->getParseParamTypeInfo(pi);
+         const QoreParseTypeInfo* variantParseTypeInfo = variantTypeInfo ? nullptr : vs->getParseParamTypeInfo(pi);
          bool variantHasDefaultArg = vs->hasDefaultArg(pi);
 
          const QoreTypeInfo* typeInfo = sig->getParamTypeInfo(pi);
-         const QoreParseTypeInfo* parseTypeInfo = typeInfo ? 0 : sig->getParseParamTypeInfo(pi);
+         const QoreParseTypeInfo* parseTypeInfo = typeInfo ? nullptr : sig->getParseParamTypeInfo(pi);
          bool thisHasDefaultArg = sig->hasDefaultArg(pi);
 
          // FIXME: this is a horribly-complicated if/then/else structure
@@ -1887,172 +1743,136 @@ int QoreFunction::parseCheckDuplicateSignature(AbstractQoreFunctionVariant* vari
       if (recheck)
          variant->setRecheck();
    }
-   // now check already-committed variants
-   for (vlist_t::iterator i = vlist.begin(), e = vlist.end(); i != e; ++i) {
-      AbstractFunctionSignature* uvsig = (*i)->getSignature();
-
-      // get the minimum number of parameters with type information that need to match
-      unsigned mp = uvsig->getMinParamTypes();
-      // get total number of parameters with type information
-      unsigned tp = uvsig->getParamTypes();
-
-      // shortcut: if the two variants have different numbers of parameters with type information, then they do not match
-      if (vmp > tp || vtp < mp)
-         continue;
-
-      // the 2 signatures have the same number of parameters with type information
-      if (!tp) {
-         duplicateSignatureException(className(), getName(), sig);
-         return -1;
-      }
-
-      unsigned np = uvsig->numParams();
-
-      bool dup = true;
-      bool ambiguous = false;
-      unsigned max = QORE_MAX(np, vnp);
-      bool recheck = false;
-      for (unsigned pi = 0; pi < max; ++pi) {
-         const QoreTypeInfo* variantTypeInfo = uvsig->getParamTypeInfo(pi);
-         bool variantHasDefaultArg = uvsig->hasDefaultArg(pi);
-
-         const QoreTypeInfo* typeInfo = sig->getParamTypeInfo(pi);
-         const QoreParseTypeInfo* parseTypeInfo = typeInfo ? 0 : sig->getParseParamTypeInfo(pi);
-         bool thisHasDefaultArg = sig->hasDefaultArg(pi);
-
-         // compare the to-be-committed types with resolved types in committed variants
-         if (parseTypeInfo) {
-            if (!variantTypeInfo && thisHasDefaultArg) {
-               ambiguous = true;
-            }
-            else if (!QoreParseTypeInfo::parseStageOneIdenticalWithParsed(parseTypeInfo, variantTypeInfo, recheck)) {
-               recheck = false;
-               dup = false;
-               break;
-            }
-         }
-         else {
-            if (!typeInfo && variantTypeInfo && variantHasDefaultArg) {
-               ambiguous = true;
-            }
-            else if (typeInfo && !variantTypeInfo && thisHasDefaultArg) {
-               ambiguous = true;
-            }
-            else if (!QoreTypeInfo::isInputIdentical(typeInfo, variantTypeInfo)) {
-               dup = false;
-               break;
-            }
-         }
-      }
-      if (dup) {
-         if (ambiguous)
-            ambiguousDuplicateSignatureException(className(), getName(), uvsig, sig);
-         else
-            duplicateSignatureException(className(), getName(), sig);
-         return -1;
-      }
-      if (recheck)
-         variant->setRecheck();
-   }
 
    return 0;
 }
 
 AbstractFunctionSignature* QoreFunction::parseGetUniqueSignature() const {
-   if (vlist.singular() && pending_vlist.empty())
-      return first()->getSignature();
+    if (vlist.singular()) {
+        const UserVariantBase* uvb = first()->getUserVariantBase();
+        if (uvb) {
+            UserSignature* sig = uvb->getUserSignature();
+            sig->resolve();
+            return sig;
+        }
+        return first()->getSignature();
+    }
 
-   if (pending_vlist.singular() && vlist.empty()) {
-      assert(pending_first()->getUserVariantBase());
-      UserSignature* sig = pending_first()->getUserVariantBase()->getUserSignature();
-      sig->resolve();
-      return sig;
-   }
-
-   return 0;
+    return nullptr;
 }
 
 void QoreFunction::resolvePendingSignatures() {
-   const QoreTypeInfo* ti = 0;
+    if (!check_parse) {
+        return;
+    }
 
-   for (vlist_t::iterator i = pending_vlist.begin(), e = pending_vlist.end(); i != e; ++i) {
-      assert((*i)->getUserVariantBase());
-      UserSignature* sig = (*i)->getUserVariantBase()->getUserSignature();
-      sig->resolve();
+    const QoreTypeInfo* ti = nullptr;
 
-      if (same_return_type && parse_same_return_type) {
-         const QoreTypeInfo* st = sig->getReturnTypeInfo();
-         if (i != pending_vlist.begin() && !QoreTypeInfo::isInputIdentical(st, ti))
-            parse_same_return_type = false;
-         ti = st;
-      }
-   }
+    for (vlist_t::iterator i = vlist.begin(), e = vlist.end(); i != e; ++i) {
+        UserVariantBase* uvb = (*i)->getUserVariantBase();
+        if (!uvb) {
+            continue;
+        }
+
+        UserSignature* sig = uvb->getUserSignature();
+        sig->resolve();
+
+        if (same_return_type && parse_same_return_type) {
+            const QoreTypeInfo* st = sig->getReturnTypeInfo();
+            if (i != vlist.begin() && !QoreTypeInfo::isInputIdentical(st, ti))
+                parse_same_return_type = false;
+            ti = st;
+        }
+    }
 }
 
 int QoreFunction::addPendingVariant(AbstractQoreFunctionVariant* variant) {
-   parse_rt_done = false;
-   parse_init_done = false;
+    if (!vlist.empty() && parse_init_done) {
+        UserSignature* sig = reinterpret_cast<UserSignature*>(variant->getSignature());
+        const QoreClass* cls = getClass();
+        const char* cname = cls ? cls->getName() : nullptr;
+        const char* name = getName();
+        parse_error(sig->getParseLocation(), "variant %s%s%s(%s) cannot be added to an existing function", cname ? cname : "", cname ? "::" : ""
+, name, sig->getSignatureText());
+        variant->deref();
+        return -1;
+    }
 
-   // check for duplicate signature with existing variants
-   if (parseCheckDuplicateSignature(variant)) {
-      variant->deref();
-      return -1;
-   }
+    parse_rt_done = false;
+    parse_init_done = false;
+    if (!check_parse) {
+        check_parse = true;
+    }
 
-   pending_vlist.push_back(variant);
+    // check for duplicate signature with existing variants
+    if (parseCheckDuplicateSignature(variant)) {
+        variant->deref();
+        return -1;
+    }
 
-   return 0;
+    vlist.push_back(variant);
+
+    return 0;
 }
 
 void QoreFunction::parseCommit() {
-   parseCheckReturnType();
+    if (!check_parse) {
+        return;
+    }
+    check_parse = false;
 
-   for (vlist_t::iterator i = pending_vlist.begin(), e = pending_vlist.end(); i != e; ++i) {
-      vlist.push_back(*i);
+    parseCheckReturnType();
 
-      if ((*i)->isUser()) {
-         if (!has_mod_pub && (*i)->isModulePublic())
-            has_mod_pub = true;
-         if (!has_user)
-            has_user = true;
-      }
-      else if (!has_builtin)
-         has_builtin = true;
+    for (vlist_t::iterator i = vlist.begin(), e = vlist.end(); i != e; ++i) {
+        if ((*i)->isUser()) {
+            if (!has_mod_pub && (*i)->isModulePublic())
+                has_mod_pub = true;
+            if (!has_user)
+                has_user = true;
+        }
+        else if (!has_builtin)
+            has_builtin = true;
 
-      (*i)->parseCommit();
-   }
-   pending_vlist.clear();
+        (*i)->parseCommit();
+    }
 
-   if (!parse_same_return_type && same_return_type)
-      same_return_type = false;
+    if (!parse_same_return_type && same_return_type)
+        same_return_type = false;
 
-   parse_rt_done = true;
-   parse_init_done = true;
+    parse_rt_done = true;
+    parse_init_done = true;
 }
 
 void QoreFunction::parseRollback() {
-   pending_vlist.del();
+    // noop: object will be destroyed
+    /*
+    if (!parse_same_return_type && same_return_type)
+        parse_same_return_type = true;
 
-   if (!parse_same_return_type && same_return_type)
-      parse_same_return_type = true;
+    parse_rt_done = true;
+    parse_init_done = true;
 
-   parse_rt_done = true;
-   parse_init_done = true;
+    if (check_parse) {
+        check_parse = false;
+    }
+    */
 }
 
 void QoreFunction::parseInit() {
-   if (parse_init_done)
-      return;
-   parse_init_done = true;
+    if (parse_init_done)
+        return;
+    parse_init_done = true;
 
-   if (parse_same_return_type)
-      parse_same_return_type = same_return_type;
+    if (parse_same_return_type)
+        parse_same_return_type = same_return_type;
 
-   OptionalNamespaceParseContextHelper pch(ns);
+    OptionalNamespaceParseContextHelper pch(ns);
 
-   for (vlist_t::iterator i = pending_vlist.begin(), e = pending_vlist.end(); i != e; ++i) {
-      (*i)->parseInit(this);
-   }
+    if (check_parse) {
+        for (vlist_t::iterator i = vlist.begin(), e = vlist.end(); i != e; ++i) {
+            (*i)->parseInit(this);
+        }
+    }
 }
 
 QoreValue UserClosureFunction::evalClosure(const QoreClosureBase& closure_base, QoreProgram* pgm, const QoreListNode* args, QoreObject *self, const qore_class_private* class_ctx, ExceptionSink* xsink) const {

--- a/lib/FunctionCallNode.cpp
+++ b/lib/FunctionCallNode.cpp
@@ -410,10 +410,10 @@ AbstractQoreNode* FunctionCallNode::parseInitCall(LocalVar* oflag, int pflag, in
             n = new GlobalVarRefNode(loc, takeName(), v);
     }
 
-    bool found = false;
+    bool found = !n.isNothing();
 
     // see if a constant can be resolved
-    if (n.isNothing()) {
+    if (!found) {
         n = qore_root_ns_private::parseFindConstantValue(loc, c_str, returnTypeInfo, found, false);
         if (found) {
             n.ref();
@@ -421,7 +421,7 @@ AbstractQoreNode* FunctionCallNode::parseInitCall(LocalVar* oflag, int pflag, in
     }
 
     if (found) {
-        CallReferenceCallNode* crcn = new CallReferenceCallNode(loc, n.getReferencedValue(), takeParseArgs());
+        CallReferenceCallNode* crcn = new CallReferenceCallNode(loc, n.takeNode(), takeParseArgs());
         deref();
         return crcn->parseInit(oflag, pflag, lvids, returnTypeInfo);
     }

--- a/lib/FunctionCallNode.cpp
+++ b/lib/FunctionCallNode.cpp
@@ -155,7 +155,7 @@ int FunctionCallBase::parseArgsVariant(const QoreProgramLocation& loc, LocalVar*
 
       returnTypeInfo = variant ? variant->parseGetReturnTypeInfo() : func->parseGetUniqueReturnTypeInfo();
 
-      //printd(5, "FunctionCallBase::parseArgsVariant() this: %p func: %s variant: %p pflag: %d pe: %d\n", this, func ? func->getName() : "n/a", variant, pflag, func ? func->pendingEmpty() : -1);
+      //printd(5, "FunctionCallBase::parseArgsVariant() this: %p func: %s variant: %p pflag: %d pe: %d\n", this, func ? func->getName() : "n/a", variant, pflag, func ? func->empty() : -1);
 
       // if the function call is being made as a part of a constant expression and
       // there are uncommitted user variants in the function, then raise an error
@@ -484,7 +484,7 @@ AbstractQoreNode* ScopedObjectCallNode::parseInitImpl(LocalVar* oflag, int pflag
 
    //printd(5, "ScopedObjectCallNode::parseInitImpl() this: %p constructor: %p variant: %p\n", this, constructor, variant);
 
-   if (((constructor && (qore_method_private::parseGetAccess(*constructor) > Public)) || (variant && CONMV_const(variant)->isPrivate())) && !qore_class_private::parseCheckPrivateClassAccess(*oc)) {
+   if (((constructor && (qore_method_private::getAccess(*constructor) > Public)) || (variant && CONMV_const(variant)->isPrivate())) && !qore_class_private::parseCheckPrivateClassAccess(*oc)) {
       if (variant)
          parse_error(loc, "illegal external access to private constructor %s::constructor(%s)", oc->getName(), variant->getSignature()->getSignatureText());
       else

--- a/lib/FunctionCallNode.cpp
+++ b/lib/FunctionCallNode.cpp
@@ -358,7 +358,7 @@ AbstractQoreNode* FunctionCallNode::parseInitImpl(LocalVar* oflag, int pflag, in
         }
 
         if (!n.isNothing()) {
-            CallReferenceCallNode* crcn = new CallReferenceCallNode(loc, n.getReferencedValue(), takeParseArgs());
+            CallReferenceCallNode* crcn = new CallReferenceCallNode(loc, n.takeNode(), takeParseArgs());
             deref();
             return crcn->parseInit(oflag, pflag, lvids, returnTypeInfo);
         }

--- a/lib/FunctionList.cpp
+++ b/lib/FunctionList.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -34,158 +34,173 @@
 
 #include <string.h>
 
-qore_ns_private* FunctionEntry::getNamespace() const {
-   return func->getNamespace();
-}
-
 ResolvedCallReferenceNode* FunctionEntry::makeCallReference(const QoreProgramLocation& loc) const {
    return new LocalFunctionCallReferenceNode(loc, func);
 }
 
-void FunctionEntry::updateNs(qore_ns_private* ns) {
-   func->updateNs(ns);
-}
-
-ModuleImportedFunctionEntry::ModuleImportedFunctionEntry(const FunctionEntry& old, qore_ns_private* ns) : FunctionEntry(old.getName(), new QoreFunction(*(old.getFunction()), PO_NO_SYSTEM_FUNC_VARIANTS, ns)) {
+ModuleImportedFunctionEntry::ModuleImportedFunctionEntry(const FunctionEntry& old, qore_ns_private* ns) : FunctionEntry(old.getName(), new QoreFunction(*(old.getFunction()), PO_NO_SYSTEM_FUNC_VARIANTS), ns) {
 }
 
 FunctionList::FunctionList(const FunctionList& old, qore_ns_private* ns, int64 po) {
-   bool no_user = po & PO_NO_INHERIT_USER_FUNC_VARIANTS;
-   bool no_builtin = po & PO_NO_SYSTEM_FUNC_VARIANTS;
-   for (fl_map_t::const_iterator i = old.begin(), e = old.end(); i != e; ++i) {
-      QoreFunction* f = i->second->getFunction();
-      if (!f->hasBuiltin()) {
-         if (no_user || !f->hasUserPublic())
+    bool no_user = po & PO_NO_INHERIT_USER_FUNC_VARIANTS;
+    bool no_builtin = po & PO_NO_SYSTEM_FUNC_VARIANTS;
+    for (fl_map_t::const_iterator i = old.begin(), e = old.end(); i != e; ++i) {
+        QoreFunction* f = i->second->getFunction();
+        if (f->allPrivate()) {
             continue;
-      }
-      else if (no_builtin && !f->hasUserPublic())
-         continue;
+        }
+        if (!f->hasBuiltin()) {
+            if (no_user || !f->hasUserPublic())
+                continue;
+        }
+        else if (no_builtin && !f->hasUserPublic())
+            continue;
 
-      FunctionEntry* fe = new FunctionEntry(i->first, new QoreFunction(*f, po, ns));
-      insert(std::make_pair(fe->getName(), fe));
-      //if (!strcmp(i->first, "make_select_list2"))
-      //if (f->hasUser())  printd(0, "FunctionList::FunctionList() this: %p copying fe: %p %s user: %d builtin: %d public: %d\n", this, i->second, i->first, f->hasUser(), f->hasBuiltin(), f->hasUserPublic());
-   }
+        // copy by reference if possible
+        FunctionEntry* fe;
+        if (!f->hasPrivate() && (!no_user || !f->hasUser()) && (!no_builtin || !f->hasBuiltin())) {
+            QoreFunction* func = i->second->getFunction();
+            func->ref();
+            fe = new FunctionEntry(i->first, func, ns);;
+        }
+        else {
+            // otherwise we have to make a new function object with only the desired visible variants
+            fe = new FunctionEntry(i->first, new QoreFunction(*f, po), ns);
+        }
+        insert(std::make_pair(fe->getName(), fe));
+        //if (!strcmp(i->first, "make_select_list2"))
+        //if (f->hasUser())  printd(0, "FunctionList::FunctionList() this: %p copying fe: %p %s user: %d builtin: %d public: %d\n", this, i->second, i->first, f->hasUser(), f->hasBuiltin(), f->hasUserPublic());
+    }
 }
 
 void FunctionList::del() {
-   for (fl_map_t::iterator i = begin(), e = end(); i != e; ++i)
-      delete i->second;
-   clear();
-   assert(empty());
+    for (auto& i : *this) {
+        i.second->deref();
+    }
+    /*
+    for (fl_map_t::iterator i = begin(), e = end(); i != e; ++i)
+        delete i->second;
+    */
+    clear();
+    assert(empty());
 }
 
-FunctionEntry* FunctionList::add(QoreFunction* func) {
-   QORE_TRACE("FunctionList::add()");
-   assert(!findNode(func->getName()));
-   assert(func->getNamespace());
+FunctionEntry* FunctionList::add(QoreFunction* func, qore_ns_private* ns) {
+    QORE_TRACE("FunctionList::add()");
+    assert(!findNode(func->getName()));
 
-   FunctionEntry* n = new FunctionEntry(func);
-   insert(std::make_pair(func->getName(), n));
-   return n;
+    FunctionEntry* n = new FunctionEntry(func, ns);
+    insert(std::make_pair(func->getName(), n));
+    return n;
 }
 
 FunctionEntry* FunctionList::import(QoreFunction* func, qore_ns_private* ns) {
-   QORE_TRACE("FunctionList::import()");
-   assert(!findNode(func->getName()));
-   assert(func->getNamespace());
+    QORE_TRACE("FunctionList::import()");
+    assert(!findNode(func->getName()));
 
-   // copy function entry for import and insert into map
-   FunctionEntry* fe = new FunctionEntry(new QoreFunction(*func, 0, ns));
-   insert(fl_map_t::value_type(fe->getName(), fe));
-   return fe;
+    // copy function entry for import and insert into map
+    FunctionEntry* fe = new FunctionEntry(new QoreFunction(*func, 0), ns);
+    insert(fl_map_t::value_type(fe->getName(), fe));
+    return fe;
 }
 
 FunctionEntry* FunctionList::import(const char* new_name, QoreFunction* func, qore_ns_private* ns, bool inject) {
-   QORE_TRACE("FunctionList::import()");
+    QORE_TRACE("FunctionList::import()");
 
-   assert(!findNode(new_name));
+    assert(!findNode(new_name));
 
-   // copy function entry for import and insert into map
-   FunctionEntry* fe = new FunctionEntry(new_name, new QoreFunction(*func, 0, ns, true, inject));
-   insert(std::make_pair(fe->getName(), fe));
-   return fe;
+    // copy function entry for import and insert into map
+    FunctionEntry* fe = new FunctionEntry(new_name, new QoreFunction(*func, 0, true, inject), ns);
+    insert(std::make_pair(fe->getName(), fe));
+    return fe;
 }
 
-FunctionEntry* FunctionList::findNode(const char* name) const {
-   printd(5, "FunctionList::findNode(%s)\n", name);
+FunctionEntry* FunctionList::findNode(const char* name, bool runtime) const {
+    printd(5, "FunctionList::findNode(%s)\n", name);
 
-   fl_map_t::const_iterator i = fl_map_t::find(name);
-   return i != end() ? i->second : 0;
+    fl_map_t::const_iterator i = fl_map_t::find(name);
+    if (i != end()) {
+        if (runtime && i->second->getFunction()->committedEmpty()) {
+            return nullptr;
+        }
+
+        return i->second;
+    }
+    return nullptr;
 }
 
 QoreFunction* FunctionList::find(const char* name, bool runtime) const {
-   printd(5, "FunctionList::findFunction(%s) (QoreFunction)\n", name);
+    printd(5, "FunctionList::findFunction(%s) (QoreFunction)\n", name);
 
-   fl_map_t::const_iterator i = fl_map_t::find(name);
-   if (i != end())
-      return i->second->getFunction(runtime);
+    fl_map_t::const_iterator i = fl_map_t::find(name);
+    if (i != end())
+        return i->second->getFunction(runtime);
 
-   return 0;
+    return nullptr;
 }
 
 QoreListNode* FunctionList::getList() {
-   QoreListNode* l = new QoreListNode;
+    QoreListNode* l = new QoreListNode;
 
-   for (fl_map_t::iterator i = begin(), e = end(); i != e; ++i)
-      l->push(new QoreStringNode(i->first));
+    for (fl_map_t::iterator i = begin(), e = end(); i != e; ++i)
+        l->push(new QoreStringNode(i->first));
 
-   return l;
+    return l;
 }
 
 void FunctionList::parseInit() {
-   for (fl_map_t::iterator i = begin(), e = end(); i != e; ++i)
-      i->second->parseInit();
+    for (fl_map_t::iterator i = begin(), e = end(); i != e; ++i)
+        i->second->parseInit();
 }
 
 void FunctionList::parseCommit() {
-   // commit pending variants in all functions
-   for (fl_map_t::iterator i = begin(), e = end(); i != e; ++i)
-      i->second->parseCommit();
+    // commit pending variants in all functions
+    for (fl_map_t::iterator i = begin(), e = end(); i != e; ++i)
+        i->second->parseCommit();
 }
 
 void FunctionList::parseRollback() {
-   for (fl_map_t::iterator i = begin(), e = end(); i != e;) {
-      if (i->second->parseRollback()) {
-	 delete i->second;
-	 erase(i++);
-	 continue;
-      }
+    for (fl_map_t::iterator i = begin(), e = end(); i != e;) {
+        if (i->second->parseRollback()) {
+            i->second->deref();
+            erase(i++);
+            continue;
+        }
 
-      ++i;
-   }
+        ++i;
+    }
 }
 
 void FunctionList::assimilate(FunctionList& fl, qore_ns_private* ns) {
-   for (fl_map_t::iterator i = fl.begin(), e = fl.end(); i != e;) {
-      fl_map_t::const_iterator li = fl_map_t::find(i->first);
-      if (li == end()) {
-	 insert(fl_map_t::value_type(i->first, i->second));
-	 i->second->updateNs(ns);
-      }
-      else {
-	 li->second->getFunction()->parseAssimilate(*(i->second->getFunction()));
-	 delete i->second;
-      }
+    for (fl_map_t::iterator i = fl.begin(), e = fl.end(); i != e;) {
+        fl_map_t::const_iterator li = fl_map_t::find(i->first);
+        if (li == end()) {
+            insert(fl_map_t::value_type(i->first, i->second));
+            i->second->updateNs(ns);
+        }
+        else {
+            li->second->getFunction()->parseAssimilate(*(i->second->getFunction()));
+            i->second->deref();
+        }
 
-      fl.erase(i++);
-   }
+        fl.erase(i++);
+    }
 }
 
 int FunctionList::importSystemFunctions(const FunctionList& src, qore_ns_private* ns, ExceptionSink* xsink) {
-   int cnt = 0;
-   for (fl_map_t::const_iterator i = src.begin(), e = src.end(); i != e; ++i) {
-      if (i->second->hasBuiltin()) {
-	 fl_map_t::const_iterator ci = fl_map_t::find(i->second->getName());
-	 if (ci != fl_map_t::end() && !ci->second->getFunction()->injected()) {
-	    xsink->raiseException("IMPORT-SYSTEM-API-ERROR", "cannot import system function %s::%s() due to an existing function without the injection flag set", ns->name.c_str(), ci->second->getName());
-	    break;
-	 }
+    int cnt = 0;
+    for (fl_map_t::const_iterator i = src.begin(), e = src.end(); i != e; ++i) {
+        if (i->second->hasBuiltin()) {
+            fl_map_t::const_iterator ci = fl_map_t::find(i->second->getName());
+            if (ci != fl_map_t::end() && !ci->second->getFunction()->injected()) {
+                xsink->raiseException("IMPORT-SYSTEM-API-ERROR", "cannot import system function %s::%s() due to an existing function without the injection flag set", ns->name.c_str(), ci->second->getName());
+                break;
+            }
 
-	 import(i->second->getFunction(), ns);
-	 ++cnt;
-      }
-   }
-   return cnt;
+            import(i->second->getFunction(), ns);
+            ++cnt;
+        }
+    }
+    return cnt;
 }
 

--- a/lib/ModuleManager.cpp
+++ b/lib/ModuleManager.cpp
@@ -5,7 +5,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -103,6 +103,33 @@ ModuleReExportHelper::ModuleReExportHelper(QoreAbstractModule* mi, bool reexp) :
 
 ModuleReExportHelper::~ModuleReExportHelper() {
    set_reexport(m, reexport);
+}
+
+QoreHashNode* QoreAbstractModule::getHashIntern(bool with_filename) const {
+    QoreHashNode* h = new QoreHashNode;
+
+    qore_hash_private* ph = qore_hash_private::get(*h);
+
+    if (with_filename)
+        ph->setKeyValueIntern("filename", new QoreStringNode(filename));
+    ph->setKeyValueIntern("name", new QoreStringNode(name));
+    ph->setKeyValueIntern("desc", new QoreStringNode(desc));
+    ph->setKeyValueIntern("version", new QoreStringNode(*version_list));
+    ph->setKeyValueIntern("author", new QoreStringNode(author));
+    if (!url.empty())
+        ph->setKeyValueIntern("url", new QoreStringNode(url));
+    if (!license.empty())
+        ph->setKeyValueIntern("license", new QoreStringNode(license));
+    if (!rmod.empty()) {
+        QoreListNode* l = new QoreListNode;
+        for (name_vec_t::const_iterator i = rmod.begin(), e = rmod.end(); i != e; ++i)
+            l->push(new QoreStringNode(*i));
+        ph->setKeyValueIntern("reexported-modules", l);
+    }
+    ph->setKeyValueIntern("injected", injected);
+    ph->setKeyValueIntern("reinjected", reinjected);
+
+    return h;
 }
 
 void QoreAbstractModule::reexport(ExceptionSink& xsink, QoreProgram* pgm) const {
@@ -305,6 +332,18 @@ void QoreBuiltinModule::addToProgramImpl(QoreProgram* pgm, ExceptionSink& xsink)
    // commit all module changes
    qmc.commit();
    pgm->addFeature(name.getBuffer());
+}
+
+QoreHashNode* QoreBuiltinModule::getHash(bool with_filename) const {
+    QoreHashNode* h = getHashIntern(with_filename);
+
+    qore_hash_private* ph = qore_hash_private::get(*h);
+
+    ph->setKeyValueIntern("user", false);
+    ph->setKeyValueIntern("api_major", api_major);
+    ph->setKeyValueIntern("api_minor", api_minor);
+
+    return h;
 }
 
 QoreUserModule::~QoreUserModule() {
@@ -568,229 +607,229 @@ void QoreModuleManager::reinjectModule(QoreAbstractModule* mi) {
 }
 
 void QoreModuleManager::loadModuleIntern(ExceptionSink& xsink, const char* name, QoreProgram* pgm, bool reexport, mod_op_e op, version_list_t* version, const char* src, QoreProgram* mpgm, unsigned load_opt) {
-   assert(!version || (version && op != MOD_OP_NONE));
+    assert(!version || (version && op != MOD_OP_NONE));
 
-   //printd(5, "QoreModuleManager::loadModuleIntern() '%s' reexport: %d pgm: %p\n", name, reexport, pgm);
+    //printd(5, "QoreModuleManager::loadModuleIntern() '%s' reexport: %d pgm: %p\n", name, reexport, pgm);
 
-   ReferenceHolder<QoreProgram> pholder(mpgm, &xsink);
+    ReferenceHolder<QoreProgram> pholder(mpgm, &xsink);
 
-   // check for special "qore" feature
-   if (!strcmp(name, "qore")) {
-      if (version)
-         check_qore_version(name, op, *version, xsink);
-      return;
-   }
-
-   module_map_t::iterator mmi = map.find(name);
-   assert(mmi == map.end() || !strcmp(mmi->second->getName(), name));
-
-   QoreAbstractModule* mi = (mmi == map.end() ? 0 : mmi->second);
-
-   // handle module reloads
-   if (load_opt & QMLO_RELOAD) {
-      assert(!version);
-      assert(!src);
-      // only loaded & injected modules can be reloaded
-      if (!mi || !mi->isInjected())
-         return;
-
-      // rename module and make private
-      map.erase(mmi);
-
-      QoreString orig_name(mi->getName());
-      // rename to unique name
-      QoreString nname;
-      getUniqueName(nname, mi->getName(), "private");
-      mi->rename(nname);
-      mi->setOrigName(orig_name.getBuffer());
-      mi->setPrivate();
-      assert(mi->isUser());
-      addModule(mi);
-
-      QoreAbstractModule* nmi = loadUserModuleFromPath(xsink, mi->getFileName(), mi->getOrigName(), pgm, reexport, pholder.release(), load_opt & QMLO_REINJECT ? mpgm : 0, load_opt);
-      if (xsink) {
-         mmi = map.find(mi->getName());
-         assert(mmi != map.end());
-         map.erase(mmi);
-         mi->resetName();
-         mi->setPrivate(false);
-         addModule(mi);
-      }
-      else {
-         assert(umset.find(mi->getName()) == umset.end());
-         nmi->setLink(mi);
-         trySetUserModuleDependency(mi);
-      }
-      return;
-   }
-
-   // if the feature already exists in this program, then return
-   if (pgm && pgm->checkFeature(name)) {
-      //printd(5, "QoreModuleManager::loadModuleIntern() '%s' pgm has feature\n" , name);
-
-      if (load_opt & QMLO_INJECT)
-         xsink.raiseException("LOAD-MODULE-ERROR", "cannot load module '%s' for injection because the module has already been loaded", name);
-
-      // check version if necessary
-      if (version) {
-         // if no module is found, then this is a builtin feature
-         if (!mi)
+    // check for special "qore" feature
+    if (!strcmp(name, "qore")) {
+        if (version)
             check_qore_version(name, op, *version, xsink);
-         else
-            check_module_version(mi, op, *version, xsink);
-      }
+        return;
+    }
 
-      if (mi)
-         trySetUserModuleDependency(mi);
-      return;
-   }
+    module_map_t::iterator mmi = map.find(name);
+    assert(mmi == map.end() || !strcmp(mmi->second->getName(), name));
 
-   // check if parse options allow loading any modules at all
-   if (pgm && (pgm->getParseOptions64() & PO_NO_MODULES)) {
-      xsink.raiseExceptionArg("LOAD-MODULE-ERROR", new QoreStringNode(name), "cannot load modules ('%s' requested) into the current Program object because PO_NO_MODULES is set", name);
-      return;
-   }
+    QoreAbstractModule* mi = (mmi == map.end() ? 0 : mmi->second);
 
-   // if the feature already exists, then load the namespace changes into this program and register the feature
-
-   if (mi) {
-      if (!(load_opt & QMLO_REINJECT)) {
-         if (load_opt & QMLO_INJECT)
-            xsink.raiseException("LOAD-MODULE-ERROR", "cannot load module '%s' for injection because the module has already been loaded; to reinject a module, call Program::loadApplyToUserModule() with the reinject flag set to True", name);
-         else {
-            //printd(5, "QoreModuleManager::loadModuleIntern() name: %s inject: %d, reinject: %d found: %p (%s, %s) injected: %d reinjected: %d\n", name, load_opt & QMLO_INJECT, load_opt & QMLO_REINJECT, mi, mi->getName(), mi->getFileName(), mi->isInjected(), mi->isReInjected());
-
-            qore_check_load_module_intern(mi, op, version, pgm, xsink);
-            // make sure to add reexport info if the module should be reexported
-            if (reexport && !xsink)
-               ModuleReExportHelper mrh(mi, true);
-         }
-         return;
-      }
-   }
-
-   //printd(5, "QoreModuleManager::loadModuleIntern() this: %p name: %s not found\n", this, name);
-
-   // see if we are loading a user module from explicit source
-   if (src) {
-      mi = loadUserModuleFromSource(xsink, name, name, pgm, src, reexport, pholder.release());
-      if (xsink) {
-         assert(!mi);
-         return;
-      }
-      assert(mi);
-      qore_check_load_module_intern(mi, op, version, pgm, xsink);
-      return;
-   }
-
-   // see if this is actually a path
-   if (q_find_first_path_sep(name)) {
-      // see if it's a user or binary module
-      size_t len = strlen(name);
-      if (len > 5 && !strcasecmp(".qmod", name + len - 5)) {
-         if (mpgm) {
-            xsink.raiseException("LOAD-MODULE-ERROR", "cannot load a binary module with a Program container");
+    // handle module reloads
+    if (load_opt & QMLO_RELOAD) {
+        assert(!version);
+        assert(!src);
+        // only loaded & injected modules can be reloaded
+        if (!mi || !mi->isInjected())
             return;
-         }
-         if (load_opt & QMLO_REINJECT) {
-            xsink.raiseException("LOAD-MODULE-ERROR", "cannot reinject module '%s' because reinjection is not currently supported for binary modules", name);
+
+        // rename module and make private
+        map.erase(mmi);
+
+        QoreString orig_name(mi->getName());
+        // rename to unique name
+        QoreString nname;
+        getUniqueName(nname, mi->getName(), "private");
+        mi->rename(nname);
+        mi->setOrigName(orig_name.getBuffer());
+        mi->setPrivate();
+        assert(mi->isUser());
+        addModule(mi);
+
+        QoreAbstractModule* nmi = loadUserModuleFromPath(xsink, mi->getFileName(), mi->getOrigName(), pgm, reexport, pholder.release(), load_opt & QMLO_REINJECT ? mpgm : 0, load_opt);
+        if (xsink) {
+            mmi = map.find(mi->getName());
+            assert(mmi != map.end());
+            map.erase(mmi);
+            mi->resetName();
+            mi->setPrivate(false);
+            addModule(mi);
+        }
+        else {
+            assert(umset.find(mi->getName()) == umset.end());
+            nmi->setLink(mi);
+            trySetUserModuleDependency(mi);
+        }
+        return;
+    }
+
+    // if the feature already exists in this program, then return
+    if (pgm && pgm->checkFeature(name)) {
+        //printd(5, "QoreModuleManager::loadModuleIntern() '%s' pgm has feature\n" , name);
+
+        if (load_opt & QMLO_INJECT)
+            xsink.raiseException("LOAD-MODULE-ERROR", "cannot load module '%s' for injection because the module has already been loaded", name);
+
+        // check version if necessary
+        if (version) {
+            // if no module is found, then this is a builtin feature
+            if (!mi)
+                check_qore_version(name, op, *version, xsink);
+            else
+                check_module_version(mi, op, *version, xsink);
+        }
+
+        if (mi)
+            trySetUserModuleDependency(mi);
+        return;
+    }
+
+    // check if parse options allow loading any modules at all
+    if (pgm && (pgm->getParseOptions64() & PO_NO_MODULES)) {
+        xsink.raiseExceptionArg("LOAD-MODULE-ERROR", new QoreStringNode(name), "cannot load modules ('%s' requested) into the current Program object because PO_NO_MODULES is set", name);
+        return;
+    }
+
+    // if the feature already exists, then load the namespace changes into this program and register the feature
+
+    if (mi) {
+        if (!(load_opt & QMLO_REINJECT)) {
+            if (load_opt & QMLO_INJECT)
+                xsink.raiseException("LOAD-MODULE-ERROR", "cannot load module '%s' for injection because the module has already been loaded; to reinject a module, call Program::loadApplyToUserModule() with the reinject flag set to True", name);
+            else {
+                //printd(5, "QoreModuleManager::loadModuleIntern() name: %s inject: %d, reinject: %d found: %p (%s, %s) injected: %d reinjected: %d\n", name, load_opt & QMLO_INJECT, load_opt & QMLO_REINJECT, mi, mi->getName(), mi->getFileName(), mi->isInjected(), mi->isReInjected());
+
+                qore_check_load_module_intern(mi, op, version, pgm, xsink);
+                // make sure to add reexport info if the module should be reexported
+                if (reexport && !xsink)
+                ModuleReExportHelper mrh(mi, true);
+            }
             return;
-         }
+        }
+    }
 
-         mi = loadBinaryModuleFromPath(xsink, name, 0, pgm, reexport);
-      }
-      else {
-         QoreString n(name);
-         qore_offset_t i = n.rfind('.');
-         if (i > 0)
-            n.terminate(i);
-#ifdef _Q_WINDOWS
-         i = n.rfindAny("\\/");
-#else
-         i = n.rfind(QORE_DIR_SEP);
-#endif
-         if (i >= 0)
-            n.replace(0, i + 1, (const char*)0);
+    //printd(5, "QoreModuleManager::loadModuleIntern() this: %p name: %s not found\n", this, name);
 
-         mi = loadUserModuleFromPath(xsink, name, n.getBuffer(), pgm, reexport, pholder.release(), load_opt & QMLO_REINJECT ? mpgm : 0, load_opt);
-      }
+    // see if we are loading a user module from explicit source
+    if (src) {
+        mi = loadUserModuleFromSource(xsink, name, name, pgm, src, reexport, pholder.release());
+        if (xsink) {
+            assert(!mi);
+            return;
+        }
+        assert(mi);
+        qore_check_load_module_intern(mi, op, version, pgm, xsink);
+        return;
+    }
 
-      if (xsink) {
-         assert(!mi);
-         return;
-      }
-
-      assert(mi);
-      qore_check_load_module_intern(mi, op, version, pgm, xsink);
-      return;
-   }
-
-   // otherwise, try to find module in the module path
-   QoreString str;
-   struct stat sb;
-
-   strdeque_t::const_iterator w = moduleDirList.begin();
-   while (w != moduleDirList.end()) {
-      // try to find module with supported api tags
-      for (unsigned ai = 0; ai <= qore_mod_api_list_len; ++ai) {
-         // build path to binary module
-         str.clear();
-         str.sprintf("%s" QORE_DIR_SEP_STR "%s", (*w).c_str(), name);
-
-         // make new extension string
-         if (ai < qore_mod_api_list_len)
-            str.sprintf("-api-%d.%d.qmod", qore_mod_api_list[ai].major, qore_mod_api_list[ai].minor);
-         else
-            str.concat(".qmod");
-
-         //printd(5, "ModuleManager::loadModule(%s) trying binary module: %s\n", name, str.getBuffer());
-         if (!stat(str.getBuffer(), &sb)) {
-            printd(5, "ModuleManager::loadModule(%s) found binary module: %s\n", name, str.getBuffer());
+    // see if this is actually a path
+    if (q_find_first_path_sep(name)) {
+        // see if it's a user or binary module
+        size_t len = strlen(name);
+        if (len > 5 && !strcasecmp(".qmod", name + len - 5)) {
             if (mpgm) {
-               xsink.raiseException("LOAD-MODULE-ERROR", "cannot load a binary module with a Program container");
-               return;
+                xsink.raiseException("LOAD-MODULE-ERROR", "cannot load a binary module with a Program container");
+                return;
+            }
+            if (load_opt & QMLO_REINJECT) {
+                xsink.raiseException("LOAD-MODULE-ERROR", "cannot reinject module '%s' because reinjection is not currently supported for binary modules", name);
+                return;
             }
 
-            mi = loadBinaryModuleFromPath(xsink, str.getBuffer(), name, pgm, reexport);
-            if (xsink) {
-               assert(!mi);
-               return;
-            }
+            mi = loadBinaryModuleFromPath(xsink, name, 0, pgm, reexport);
+        }
+        else {
+            QoreString n(name);
+            qore_offset_t i = n.rfind('.');
+            if (i > 0)
+                n.terminate(i);
+#ifdef _Q_WINDOWS
+            i = n.rfindAny("\\/");
+#else
+            i = n.rfind(QORE_DIR_SEP);
+#endif
+            if (i >= 0)
+                n.replace(0, i + 1, (const char*)0);
 
-            assert(mi);
-            qore_check_load_module_intern(mi, op, version, pgm, xsink);
+            mi = loadUserModuleFromPath(xsink, name, n.getBuffer(), pgm, reexport, pholder.release(), load_opt & QMLO_REINJECT ? mpgm : 0, load_opt);
+        }
+
+        if (xsink) {
+            assert(!mi);
             return;
-         }
+        }
 
-         // build path to user module
-         str.clear();
-         str.sprintf("%s" QORE_DIR_SEP_STR "%s.qm", (*w).c_str(), name);
+        assert(mi);
+        qore_check_load_module_intern(mi, op, version, pgm, xsink);
+        return;
+    }
 
-         //printd(5, "ModuleManager::loadModule(%s) trying user module: %s\n", name, str.getBuffer());
-         if (!stat(str.getBuffer(), &sb)) {
-            // see if this is a relative path; if so normalize it; we cannot send a relative path to loadUserModuleFromPath()
-            // since it will try to normalize the path using the current program's directory as the cwd
-            if (!q_absolute_path(str.getBuffer()))
-               q_normalize_path(str);
-            printd(5, "ModuleManager::loadModule(%s) found user module: %s\n", name, str.getBuffer());
-            mi = loadUserModuleFromPath(xsink, str.getBuffer(), name, pgm, reexport, pholder.release(), load_opt & QMLO_REINJECT ? mpgm : 0, load_opt);
-            if (xsink) {
-               assert(!mi);
-               return;
+    // otherwise, try to find module in the module path
+    QoreString str;
+    struct stat sb;
+
+    strdeque_t::const_iterator w = moduleDirList.begin();
+    while (w != moduleDirList.end()) {
+        // try to find module with supported api tags
+        for (unsigned ai = 0; ai <= qore_mod_api_list_len; ++ai) {
+            // build path to binary module
+            str.clear();
+            str.sprintf("%s" QORE_DIR_SEP_STR "%s", (*w).c_str(), name);
+
+            // make new extension string
+            if (ai < qore_mod_api_list_len)
+                str.sprintf("-api-%d.%d.qmod", qore_mod_api_list[ai].major, qore_mod_api_list[ai].minor);
+            else
+                str.concat(".qmod");
+
+            //printd(5, "ModuleManager::loadModule(%s) trying binary module: %s\n", name, str.getBuffer());
+            if (!stat(str.getBuffer(), &sb)) {
+                printd(5, "ModuleManager::loadModule(%s) found binary module: %s\n", name, str.getBuffer());
+                if (mpgm) {
+                xsink.raiseException("LOAD-MODULE-ERROR", "cannot load a binary module with a Program container");
+                return;
+                }
+
+                mi = loadBinaryModuleFromPath(xsink, str.getBuffer(), name, pgm, reexport);
+                if (xsink) {
+                assert(!mi);
+                return;
+                }
+
+                assert(mi);
+                qore_check_load_module_intern(mi, op, version, pgm, xsink);
+                return;
             }
 
-            assert(mi);
-            qore_check_load_module_intern(mi, op, version, pgm, xsink);
-            return;
-         }
-      }
+            // build path to user module
+            str.clear();
+            str.sprintf("%s" QORE_DIR_SEP_STR "%s.qm", (*w).c_str(), name);
 
-      ++w;
-   }
+            //printd(5, "ModuleManager::loadModule(%s) trying user module: %s\n", name, str.getBuffer());
+            if (!stat(str.getBuffer(), &sb)) {
+                // see if this is a relative path; if so normalize it; we cannot send a relative path to loadUserModuleFromPath()
+                // since it will try to normalize the path using the current program's directory as the cwd
+                if (!q_absolute_path(str.getBuffer()))
+                q_normalize_path(str);
+                printd(5, "ModuleManager::loadModule(%s) found user module: %s\n", name, str.getBuffer());
+                mi = loadUserModuleFromPath(xsink, str.getBuffer(), name, pgm, reexport, pholder.release(), load_opt & QMLO_REINJECT ? mpgm : 0, load_opt);
+                if (xsink) {
+                assert(!mi);
+                return;
+                }
 
-   QoreStringNode* desc = new QoreStringNodeMaker("feature '%s' is not builtin and no module with this name could be found in the module path: ", name);
-   moduleDirList.appendPath(*desc);
-   xsink.raiseExceptionArg("LOAD-MODULE-ERROR", new QoreStringNode(name), desc);
+                assert(mi);
+                qore_check_load_module_intern(mi, op, version, pgm, xsink);
+                return;
+            }
+        }
+
+        ++w;
+    }
+
+    QoreStringNode* desc = new QoreStringNodeMaker("feature '%s' is not builtin and no module with this name could be found in the module path: ", name);
+    moduleDirList.appendPath(*desc);
+    xsink.raiseExceptionArg("LOAD-MODULE-ERROR", new QoreStringNode(name), desc);
 }
 
 void ModuleManager::registerUserModuleFromSource(const char* name, const char* src, QoreProgram* pgm, ExceptionSink* xsink) {
@@ -1371,15 +1410,15 @@ QoreHashNode* ModuleManager::getModuleHash() {
 }
 
 QoreHashNode* QoreModuleManager::getModuleHash() {
-   bool with_filename = !(runtime_get_parse_options() & PO_NO_EXTERNAL_INFO);
-   QoreHashNode* h = new QoreHashNode(hashTypeInfo);
-   qore_hash_private* ph = qore_hash_private::get(*h);
-   AutoLocker al(mutex);
-   for (module_map_t::const_iterator i = map.begin(); i != map.end(); ++i) {
-      if (!i->second->isPrivate())
-         ph->setKeyValueIntern(i->second->getName(), i->second->getHash(with_filename));
-   }
-   return h;
+    bool with_filename = !(runtime_get_parse_options() & PO_NO_EXTERNAL_INFO);
+    QoreHashNode* h = new QoreHashNode(hashTypeInfo);
+    qore_hash_private* ph = qore_hash_private::get(*h);
+    AutoLocker al(mutex);
+    for (module_map_t::const_iterator i = map.begin(); i != map.end(); ++i) {
+        if (!i->second->isPrivate())
+            ph->setKeyValueIntern(i->second->getName(), i->second->getHash(with_filename));
+    }
+    return h;
 }
 
 QoreListNode* ModuleManager::getModuleList() {

--- a/lib/NamedScope.cpp
+++ b/lib/NamedScope.cpp
@@ -1,18 +1,18 @@
 /*
   NamedScope.cpp
- 
+
   Qore Programming Language
- 
-  Copyright (C) 2003 - 2015 David Nichols
- 
+
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
+
   NamedScopes are children of a program object.  there is a parse
   lock per program object to ensure that objects are added (or backed out)
-  atomically per program object.  All the objects referenced here should 
+  atomically per program object.  All the objects referenced here should
   be safe to read & copied at all times.  They will only be deleted when the
   program object is deleted (except the pending structures, which will be
   deleted any time there is a parse error, together with all other
   pending structures)
- 
+
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
   to deal in the Software without restriction, including without limitation
@@ -49,11 +49,11 @@ NamedScope *NamedScope::copy() const {
 }
 
 void NamedScope::init() {
-   const char *str = ostr;
+    const char *str = ostr;
 
-   while (char *p = (char *)strstr(str, "::")) {
-      strlist.push_back(std::string(str, (p - str)));
-      str = p + 2;
-   }
-   strlist.push_back(std::string(str));
+    while (char *p = (char*)strstr(str, "::")) {
+        strlist.push_back(std::string(str, (p - str)));
+        str = p + 2;
+    }
+    strlist.push_back(std::string(str));
 }

--- a/lib/Pseudo_QC_Hash.qpp
+++ b/lib/Pseudo_QC_Hash.qpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -151,8 +151,7 @@ auto v = h.firstValue();
     @see <hash>::lastValue()
  */
 auto <hash>::firstValue() [flags=CONSTANT] {
-   AbstractQoreNode* rv = qore_hash_private::getFirstKeyValue(h);
-   return rv ? rv->refSelf() : 0;
+    return qore_hash_private::getFirstKeyValue(h).refSelf();
 }
 
 //! Returns the last key name in the hash or @ref nothing if the hash has no keys
@@ -187,8 +186,7 @@ auto v = h.lastValue();
     @see <hash>::firstValue()
  */
 auto <hash>::lastValue() [flags=CONSTANT] {
-   AbstractQoreNode* rv = qore_hash_private::getLastKeyValue(h);
-   return rv ? rv->refSelf() : 0;
+    return qore_hash_private::getLastKeyValue(h).refSelf();
 }
 
 //! Returns @ref True if the key exists in the hash (may or may not be assigned a value), @ref False if not

--- a/lib/QC_Datasource.qpp
+++ b/lib/QC_Datasource.qpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -45,7 +45,7 @@ static int ds_set_options(ManagedDatasource* ds, const QoreHashNode* opts, Excep
       if (!strcmp(hi.getKey(), "min") || !strcmp(hi.getKey(), "max"))
          continue;
 
-      if (ds->setOptionInit(hi.getKey(), hi.getValue(), xsink))
+      if (ds->setOptionInit(hi.getKey(), hi.get(), xsink))
          return -1;
    }
    return 0;

--- a/lib/QC_GetOpt.qpp
+++ b/lib/QC_GetOpt.qpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -40,39 +40,39 @@ static inline int process_type(const char* key, int& attributes, char* opt, qore
    // get type
    switch (*opt) {
       case 's':
-	 at = NT_STRING;
-	 type_name = QoreStringNode::getStaticTypeName();
-	 break;
+         at = NT_STRING;
+         type_name = QoreStringNode::getStaticTypeName();
+         break;
       case 'i':
-	 at = NT_INT;
-	 type_name = QoreBigIntNode::getStaticTypeName();
-	 break;
+         at = NT_INT;
+         type_name = QoreBigIntNode::getStaticTypeName();
+         break;
       case 'f':
-	 at = NT_FLOAT;
-	 type_name = QoreFloatNode::getStaticTypeName();
-	 break;
+         at = NT_FLOAT;
+         type_name = QoreFloatNode::getStaticTypeName();
+         break;
       case 'b':
-	 at = NT_BOOLEAN;
-	 type_name = QoreBoolNode::getStaticTypeName();
-	 break;
+         at = NT_BOOLEAN;
+         type_name = QoreBoolNode::getStaticTypeName();
+         break;
       case 'd':
-	 at = NT_DATE;
-	 type_name = DateTimeNode::getStaticTypeName();
-	 break;
+         at = NT_DATE;
+         type_name = DateTimeNode::getStaticTypeName();
+         break;
       case 'h':
-	 at = NT_HASH;
-	 type_name = QoreHashNode::getStaticTypeName();
-	 break;
+         at = NT_HASH;
+         type_name = QoreHashNode::getStaticTypeName();
+         break;
       case '@':
-	 at = NT_STRING;
-	 attributes |= QGO_OPT_LIST;
-	 type_name = QoreStringNode::getStaticTypeName();
-	 break;
+         at = NT_STRING;
+         attributes |= QGO_OPT_LIST;
+         type_name = QoreStringNode::getStaticTypeName();
+         break;
       case '+':
-	 at = NT_INT;
-	 attributes |= QGO_OPT_ADDITIVE;
-	 type_name = QoreBigIntNode::getStaticTypeName();
-	 break;
+         at = NT_INT;
+         attributes |= QGO_OPT_ADDITIVE;
+         type_name = QoreBigIntNode::getStaticTypeName();
+         break;
    }
    if (at == -1) {
       xsink->raiseException("GETOPT-OPTION-ERROR", "type '%c' for key '%s' is unknown", *opt, key);
@@ -89,28 +89,28 @@ static inline int process_type(const char* key, int& attributes, char* opt, qore
    // process modifiers
    if (opt[1] == '@') {
       if (attributes & QGO_OPT_LIST) {
-	 xsink->raiseException("GETOPT-OPTION-ERROR", "list attribute doubled in option key '%s'", key);
-	 return -1;
+         xsink->raiseException("GETOPT-OPTION-ERROR", "list attribute doubled in option key '%s'", key);
+         return -1;
       }
       if (attributes & QGO_OPT_ADDITIVE) {
-	 xsink->raiseException("GETOPT-OPTION-ERROR", "option '%s' cannot have both additive and list attributes turned on", key);
-	 return -1;
+         xsink->raiseException("GETOPT-OPTION-ERROR", "option '%s' cannot have both additive and list attributes turned on", key);
+         return -1;
       }
       attributes |= QGO_OPT_LIST;
       return 0;
    }
    if (opt[1] == '+') {
       if (attributes & QGO_OPT_ADDITIVE) {
-	 xsink->raiseException("GETOPT-OPTION-ERROR", "additive attribute doubled in option key '%s'", key);
-	 return -1;
+         xsink->raiseException("GETOPT-OPTION-ERROR", "additive attribute doubled in option key '%s'", key);
+         return -1;
       }
       if (attributes & QGO_OPT_LIST) {
-	 xsink->raiseException("GETOPT-OPTION-ERROR", "option '%s' cannot have both additive and list attributes turned on", key);
-	 return -1;
+         xsink->raiseException("GETOPT-OPTION-ERROR", "option '%s' cannot have both additive and list attributes turned on", key);
+         return -1;
       }
       if (at != NT_INT && at != NT_FLOAT) {
-	 xsink->raiseException("GETOPT-OPTION-ERROR", "additive attributes for type '%s' are not supported (option '%s')", type_name, key);
-	 return -1;
+         xsink->raiseException("GETOPT-OPTION-ERROR", "additive attributes for type '%s' are not supported (option '%s')", type_name, key);
+         return -1;
       }
       attributes |= QGO_OPT_ADDITIVE;
       return 0;
@@ -185,93 +185,93 @@ GetOpt getopt(ProgramOptions);
     @throw GETOPT-OPTION-ERROR list option specified as optional; empty option key value string; multiple long options given for key; duplicate options given; invalid attributes for option; unknown modifier given for option
  */
 GetOpt::constructor(hash options) {
-   SimpleRefHolder<GetOpt> g(new GetOpt);
+    SimpleRefHolder<GetOpt> g(new GetOpt);
 
-   ConstHashIterator hi(options);
-   QoreString vstr;
-   while (hi.next()) {
-      const char *k = hi.getKey();
-      if (!strcmp(k, "_ERRORS_")) {
-	 xsink->raiseException("GETOPT-PARAMETER-ERROR", "option key '%s' is reserved for errors in the output hash", k);
-	 break;
-      }
+    ConstHashIterator hi(options);
+    QoreString vstr;
+    while (hi.next()) {
+        const char *k = hi.getKey();
+        if (!strcmp(k, "_ERRORS_")) {
+            xsink->raiseException("GETOPT-PARAMETER-ERROR", "option key '%s' is reserved for errors in the output hash", k);
+            break;
+        }
 
-      const AbstractQoreNode* v = hi.getValue();
-      if (get_node_type(v) != NT_STRING) {
-	 xsink->raiseException("GETOPT-PARAMETER-ERROR", "value of option key '%s' is not a string (%s)", k, get_type_name(v));
-	 break;
-      }
+        const QoreValue v = hi.get();
+        if (v.getType() != NT_STRING) {
+            xsink->raiseException("GETOPT-PARAMETER-ERROR", "value of option key '%s' is not a string (%s)", k, v.getTypeName());
+            break;
+        }
 
-      const QoreStringNode* str = reinterpret_cast<const QoreStringNode*>(v);
+        const QoreStringNode* str = v.get<const QoreStringNode>();
 
-      qore_type_t at = -1;
-      const char *long_opt = 0;
-      char short_opt = '\0';
-      int attributes = QGO_OPT_NONE;
+        qore_type_t at = -1;
+        const char *long_opt = 0;
+        char short_opt = '\0';
+        int attributes = QGO_OPT_NONE;
 
-      // reset buffer
-      vstr.clear();
-      vstr.concat(str->getBuffer());
-      const char* val = vstr.getBuffer();
+        // reset buffer
+        vstr.clear();
+        vstr.concat(str->getBuffer());
+        const char* val = vstr.getBuffer();
 
-      // get data type, if any
-      char *tok = strchrs(val, "=:");
-      if (tok) {
-	 if (tok[1] && process_type(k, attributes, tok + 1, at, xsink))
-	    break;
-	 if ((*tok) == '=')
-	    attributes |= QGO_OPT_MANDATORY;
-	 else if (attributes & QGO_OPT_LIST) {
-	    xsink->raiseException("GETOPT-OPTION-ERROR", "option '%s' takes a list and therefore must have mandatory arguments", k);
-	    break;
-	 }
+        // get data type, if any
+        char *tok = strchrs(val, "=:");
+        if (tok) {
+            if (tok[1] && process_type(k, attributes, tok + 1, at, xsink))
+                break;
+            if ((*tok) == '=')
+                attributes |= QGO_OPT_MANDATORY;
+            else if (attributes & QGO_OPT_LIST) {
+                xsink->raiseException("GETOPT-OPTION-ERROR", "option '%s' takes a list and therefore must have mandatory arguments", k);
+                break;
+            }
 
-	 (*tok) = '\0';
-      }
-      // get option names
-      if (!val[0]) {
-	 //printd(5, "making exception key='%s' tok=%p val=%p val='%s'\n", k, tok, val, val);
-	 xsink->raiseException("GETOPT-PARAMETER-ERROR", "value of option key '%s' has no option specifiers", k);
-	 break;
-      }
-      tok = (char*)strchr(val, ',');
-      if (tok) {
-	 if (tok == (val + 1)) {
-	    short_opt = val[0];
-	    long_opt = val + 2;
-	 }
-	 else if (tok - val == (signed)(strlen(val) - 2)) {
-	    (*tok) = 0;
-	    short_opt = tok[1];
-	    long_opt = val;
-	 }
-	 else { // if the comma is not in the second or second-to-last position, then it's an error
-	    xsink->raiseException("GETOPT-OPTION-ERROR", "user options can only be specified with one short option and one long option, however two long options were given for key '%s' (%s)", k, val);
-	    break;
-	 }
-      }
-      else if (val[1])
-	 long_opt = val;
-      else
-	 short_opt = val[0];
-      int rc = g->add(k, short_opt, long_opt, at, attributes);
-      if (rc == QGO_ERR_DUP_SHORT_OPT) {
-	 xsink->raiseException("GETOPT-OPTION-ERROR", "short option '%c' was duplicated in key '%s'", short_opt, k);
-	 break;
-      }
-      if (rc == QGO_ERR_DUP_LONG_OPT) {
-	 xsink->raiseException("GETOPT-OPTION-ERROR", "long option '%s' was duplicated in key '%s'", long_opt, k);
-	 break;
-      }
-      if (rc == QGO_ERR_DUP_NAME) {
-	 xsink->raiseException("GETOPT-OPTION-ERROR", "option '%s' was duplicated", k);
-	 break;
-      }
-   }
-   if (*xsink)
-      return;
+            (*tok) = '\0';
+        }
+        // get option names
+        if (!val[0]) {
+            //printd(5, "making exception key='%s' tok=%p val=%p val='%s'\n", k, tok, val, val);
+            xsink->raiseException("GETOPT-PARAMETER-ERROR", "value of option key '%s' has no option specifiers", k);
+            break;
+        }
+        tok = (char*)strchr(val, ',');
+        if (tok) {
+            if (tok == (val + 1)) {
+                short_opt = val[0];
+                long_opt = val + 2;
+            }
+            else if (tok - val == (signed)(strlen(val) - 2)) {
+                (*tok) = 0;
+                short_opt = tok[1];
+                long_opt = val;
+            }
+            else { // if the comma is not in the second or second-to-last position, then it's an error
+                xsink->raiseException("GETOPT-OPTION-ERROR", "user options can only be specified with one short option and one long option, however two long options were given for key '%s' (%s)", k, val);
+                break;
+            }
+        }
+        else if (val[1])
+            long_opt = val;
+        else
+            short_opt = val[0];
+        int rc = g->add(k, short_opt, long_opt, at, attributes);
+        if (rc == QGO_ERR_DUP_SHORT_OPT) {
+            xsink->raiseException("GETOPT-OPTION-ERROR", "short option '%c' was duplicated in key '%s'", short_opt, k);
+            break;
+        }
+        if (rc == QGO_ERR_DUP_LONG_OPT) {
+            xsink->raiseException("GETOPT-OPTION-ERROR", "long option '%s' was duplicated in key '%s'", long_opt, k);
+            break;
+        }
+        if (rc == QGO_ERR_DUP_NAME) {
+            xsink->raiseException("GETOPT-OPTION-ERROR", "option '%s' was duplicated", k);
+            break;
+        }
+    }
+    if (*xsink)
+        return;
 
-   self->setPrivate(CID_GETOPT, g.release());
+    self->setPrivate(CID_GETOPT, g.release());
 }
 
 //! Throws an exception; objects of this class cannot be copied

--- a/lib/QC_HashKeyReverseIterator.qpp
+++ b/lib/QC_HashKeyReverseIterator.qpp
@@ -3,7 +3,7 @@
 /*
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/lib/QoreChompOperatorNode.cpp
+++ b/lib/QoreChompOperatorNode.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -30,6 +30,7 @@
 
 #include <qore/Qore.h>
 #include "qore/intern/qore_program_private.h"
+#include "qore/intern/QoreHashNodeIntern.h"
 
 QoreString QoreChompOperatorNode::chomp_str("chomp operator expression");
 

--- a/lib/QoreChompOperatorNode.cpp
+++ b/lib/QoreChompOperatorNode.cpp
@@ -45,53 +45,56 @@ int QoreChompOperatorNode::getAsString(QoreString& str, int foff, ExceptionSink*
 }
 
 QoreValue QoreChompOperatorNode::evalValueImpl(bool& needs_deref, ExceptionSink* xsink) const {
-   LValueHelper val(exp, xsink);
-   if (!val)
-      return QoreValue();
+    LValueHelper val(exp, xsink);
+    if (!val)
+        return QoreValue();
 
-   qore_type_t vtype = val.getType();
-   if (vtype != NT_LIST && vtype != NT_STRING && vtype != NT_HASH)
-      return QoreValue();
+    qore_type_t vtype = val.getType();
+    if (vtype != NT_LIST && vtype != NT_STRING && vtype != NT_HASH)
+        return QoreValue();
 
-   // note that no exception can happen here
-   val.ensureUnique();
-   assert(!*xsink);
+    // note that no exception can happen here
+    val.ensureUnique();
+    assert(!*xsink);
 
-   if (vtype == NT_STRING)
-      return reinterpret_cast<QoreStringNode*>(val.getValue())->chomp();
+    if (vtype == NT_STRING)
+        return reinterpret_cast<QoreStringNode*>(val.getValue())->chomp();
 
-   int64 count = 0;
+    int64 count = 0;
 
-   if (vtype == NT_LIST) {
-      QoreListNode* l = reinterpret_cast<QoreListNode*>(val.getValue());
-      ListIterator li(l);
-      while (li.next()) {
-	 AbstractQoreNode** v = li.getValuePtr();
-	 if (*v && (*v)->getType() == NT_STRING) {
-	    // note that no exception can happen here
-	    ensure_unique(v, xsink);
-	    assert(!*xsink);
-	    QoreStringNode* vs = reinterpret_cast<QoreStringNode*>(*v);
-	    count += vs->chomp();
-	 }
-      }
-      return count;
-   }
+    if (vtype == NT_LIST) {
+        QoreListNode* l = reinterpret_cast<QoreListNode*>(val.getValue());
+        ListIterator li(l);
+        while (li.next()) {
+            AbstractQoreNode** v = li.getValuePtr();
+            if (*v && (*v)->getType() == NT_STRING) {
+                // note that no exception can happen here
+                ensure_unique(v, xsink);
+                assert(!*xsink);
+                QoreStringNode* vs = reinterpret_cast<QoreStringNode*>(*v);
+                count += vs->chomp();
+            }
+        }
+        return count;
+    }
 
-   // must be a hash
-   QoreHashNode* vh = reinterpret_cast<QoreHashNode*>(val.getValue());
-   HashIterator hi(vh);
-   while (hi.next()) {
-      AbstractQoreNode** v = hi.getValuePtr();
-      if (*v && (*v)->getType() == NT_STRING) {
-	 // note that no exception can happen here
-	 ensure_unique(v, xsink);
-	 assert(!*xsink);
-	 QoreStringNode* vs = reinterpret_cast<QoreStringNode*>(*v);
-	 count += vs->chomp();
-      }
-   }
-   return count;
+    // must be a hash
+    QoreHashNode* vh = reinterpret_cast<QoreHashNode*>(val.getValue());
+    HashIterator hi(vh);
+    while (hi.next()) {
+        if (hi.get().getType() == NT_STRING) {
+            QoreValue& v = (*qhi_priv::get(hi)->i)->val;
+            QoreStringNode* vs = v.get<QoreStringNode>();
+            if (!vs->is_unique()) {
+                QoreStringNode* old = vs;
+                vs = vs->copy();
+                old->deref();
+                v = vs;
+            }
+            count += vs->chomp();
+        }
+    }
+    return count;
 }
 
 AbstractQoreNode* QoreChompOperatorNode::parseInitImpl(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo) {

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -1731,15 +1731,15 @@ bool BCNode::runtimeIsPrivateMember(const char* str, bool toplevel) const {
    return sclass->priv->runtimeIsPrivateMemberIntern(str, false);
 }
 
-AbstractQoreNode* BCNode::parseFindConstantValue(const char* cname, const QoreTypeInfo*& typeInfo, const qore_class_private* class_ctx, bool allow_internal) const {
+const QoreValue BCNode::parseFindConstantValue(const char* cname, const QoreTypeInfo*& typeInfo, bool& found, const qore_class_private* class_ctx, bool allow_internal) const {
    // sclass can be 0 if the class could not be found during parse initialization
-   if (!sclass)
-      return nullptr;
+    if (!sclass)
+        return QoreValue();
 
-   if (access == Internal && !allow_internal)
-      return nullptr;
+    if (access == Internal && !allow_internal)
+        return QoreValue();
 
-   return sclass->priv->parseFindConstantValueIntern(cname, typeInfo, class_ctx);
+    return sclass->priv->parseFindConstantValueIntern(cname, typeInfo, found, class_ctx);
 }
 
 bool BCNode::parseCheckHierarchy(const QoreClass* cls, ClassAccess& n_access, bool toplevel) const {
@@ -2135,16 +2135,16 @@ void BCList::resolveCopy() {
    sml.resolveCopy();
 }
 
-AbstractQoreNode* BCList::parseFindConstantValue(const char* cname, const QoreTypeInfo*& typeInfo, const qore_class_private* class_ctx, bool allow_internal) const {
-   if (!valid)
-      return nullptr;
+const QoreValue BCList::parseFindConstantValue(const char* cname, const QoreTypeInfo*& typeInfo, bool& found, const qore_class_private* class_ctx, bool allow_internal) const {
+    if (!valid)
+        return QoreValue();
 
-   for (auto& i : *this) {
-      AbstractQoreNode* rv = (*i).parseFindConstantValue(cname, typeInfo, class_ctx, allow_internal);
-      if (rv)
-         return rv;
-   }
-   return nullptr;
+    for (auto& i : *this) {
+       const QoreValue rv = (*i).parseFindConstantValue(cname, typeInfo, found, class_ctx, allow_internal);
+       if (found)
+           return rv;
+    }
+    return QoreValue();
 }
 
 QoreVarInfo* BCList::parseFindStaticVar(const char* vname, const QoreClass*& qc, ClassAccess& access, bool check, bool toplevel) const {

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -484,7 +484,7 @@ qore_class_private::qore_class_private(const qore_class_private& old, const char
      has_new_user_changes(false),
      has_sig_changes(false),
      owns_ornothingtypeinfo(false),
-     pub(false), // the public flag must be explicitly set if necessary after this constructor
+     pub(old.pub),
      final(old.final),
      inject(inject),
      gate_access(old.gate_access),

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -466,7 +466,7 @@ qore_class_private::qore_class_private(QoreClass* n_cls, std::string&& nme, int6
 }
 
 // only called while the parse lock for the QoreProgram owning "old" is held
-qore_class_private::qore_class_private(const qore_class_private& old, const char* new_name, bool inject, const qore_class_private* injectedClass)
+qore_class_private::qore_class_private(const qore_class_private& old, QoreProgram* spgm, const char* new_name, bool inject, const qore_class_private* injectedClass)
    : name(new_name ? new_name : old.name),
      ahm(old.ahm),
      constlist(old.constlist, 0, this),    // committed constants
@@ -501,10 +501,10 @@ qore_class_private::qore_class_private(const qore_class_private& old, const char
      hash(old.hash),
      ptr(old.ptr),
      mud(old.mud ? old.mud->copy() : nullptr),
-     spgm(old.spgm ? old.spgm->programRefSelf() : nullptr) {
+     spgm(spgm ? spgm->programRefSelf() : nullptr) {
     QORE_TRACE("qore_class_private::qore_class_private(const qore_class_private& old)");
     if (!old.initialized)
-        const_cast<qore_class_private &>(old).initialize();
+        const_cast<qore_class_private&>(old).initialize();
 
     // must set after old class has been initialized
     has_delete_blocker = old.has_delete_blocker;
@@ -767,9 +767,7 @@ int qore_class_private::initializeIntern() {
     if (has_sig_changes) {
         // process constants for class signature, private first, then public
         do_sig(csig, constlist);
-    }
 
-    if (has_sig_changes) {
         if (!csig.empty()) {
             printd(5, "qore_class_private::initializeIntern() this: %p '%s' sig:\n%s", this, name.c_str(), csig.getBuffer());
             hash.update(csig);

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -1732,7 +1732,7 @@ bool BCNode::runtimeIsPrivateMember(const char* str, bool toplevel) const {
 }
 
 QoreValue BCNode::parseFindConstantValue(const char* cname, const QoreTypeInfo*& typeInfo, bool& found, const qore_class_private* class_ctx, bool allow_internal) const {
-   // sclass can be 0 if the class could not be found during parse initialization
+    // sclass can be 0 if the class could not be found during parse initialization
     if (!sclass)
         return QoreValue();
 

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -2682,7 +2682,7 @@ QoreMethod::QoreMethod(const QoreClass* n_parent_class, MethodFunctionBase* n_fu
 }
 
 QoreMethod::~QoreMethod() {
-   delete priv;
+    delete priv;
 }
 
 MethodFunctionBase* QoreMethod::getFunction() const {
@@ -2761,7 +2761,7 @@ const QoreTypeInfo* QoreMethod::getUniqueReturnTypeInfo() const {
 
 static const QoreClass* getStackClass() {
    const qore_class_private* qc = runtime_get_class();
-   return qc ? qc->cls : 0;
+   return qc ? qc->cls : nullptr;
 }
 
 void QoreClass::addPublicMember(const char* mname, const QoreTypeInfo* n_typeInfo, AbstractQoreNode* initial_value) {

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -927,7 +927,7 @@ int qore_class_private::runtimeInitMembers(QoreObject& o, bool& need_scan, bool 
                     if (*xsink)
                         return -1;
                 }
-                //val.sanitize();
+                val.sanitize();
                 v = val.takeReferencedValue();
                 if (needs_scan(v)) {
                     qore_object_private::incScanCount(o, 1);

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -1457,7 +1457,7 @@ void BCANode::parseInit(BCList* bcl, const char* classname) {
          int lvids = 0;
          if (m) {
             const QoreTypeInfo* argTypeInfo = nullptr;
-            lvids = parseArgsVariant(loc, qore_class_private::getSelfId(*sclass), 0, m->getFunction(), argTypeInfo);
+            lvids = parseArgsVariant(loc, qore_class_private::getSelfId(*sclass), 0, m->getFunction(), nullptr, argTypeInfo);
          }
          else {
             if (parse_args) {
@@ -4365,7 +4365,7 @@ void QoreClass::setGateAccessFlag() {
 }
 
 void MethodFunctionBase::parseInit() {
-   QoreFunction::parseInit();
+    QoreFunction::parseInit(qore_class_private::get(*qc)->ns);
 }
 
 void MethodFunctionBase::parseCommit() {

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -643,25 +643,25 @@ static void do_sig(QoreString& csig, BCNode& n) {
 
 // process signature entries for class members
 static void do_sig(QoreString& csig, QoreMemberMap::SigOrderIterator i) {
-   if (i->second)
-      csig.sprintf("%s mem %s %s %s\n", privpub(i->second->access), QoreTypeInfo::getName(i->second->getTypeInfo()), i->first, get_type_name(i->second->exp));
-   else
-      csig.sprintf("%s mem %s\n", privpub(i->second->access), i->first);
+    if (i->second)
+        csig.sprintf("%s mem %s %s %s\n", privpub(i->second->access), QoreTypeInfo::getName(i->second->getTypeInfo()), i->first, get_type_name(i->second->exp));
+    else
+        csig.sprintf("%s mem %s\n", privpub(i->second->access), i->first);
 }
 
 // process signature entries for class static vars
 static void do_sig(QoreString& csig, QoreVarMap::SigOrderIterator i) {
-   if (i->second)
-      csig.sprintf("%s var %s %s %s\n", privpub(i->second->access), QoreTypeInfo::getName(i->second->getTypeInfo()), i->first, get_type_name(i->second->exp));
-   else
-      csig.sprintf("%s var %s\n", privpub(i->second->access), i->first);
+    if (i->second)
+        csig.sprintf("%s var %s %s %s\n", privpub(i->second->access), QoreTypeInfo::getName(i->second->getTypeInfo()), i->first, get_type_name(i->second->exp));
+    else
+        csig.sprintf("%s var %s\n", privpub(i->second->access), i->first);
 }
 
 // process signature entries for class constants
 static void do_sig(QoreString& csig, ConstantList& clist) {
-   ConstantListIterator cli(clist);
-   while (cli.next())
-      csig.sprintf("%s const %s %s\n", privpub(cli.getAccess()), cli.getName().c_str(), get_type_name(cli.getValue()));
+    ConstantListIterator cli(clist);
+    while (cli.next())
+        csig.sprintf("%s const %s %s\n", privpub(cli.getAccess()), cli.getName().c_str(), cli.getValue().getTypeName());
 }
 
 int qore_class_private::initializeIntern() {
@@ -1731,7 +1731,7 @@ bool BCNode::runtimeIsPrivateMember(const char* str, bool toplevel) const {
    return sclass->priv->runtimeIsPrivateMemberIntern(str, false);
 }
 
-const QoreValue BCNode::parseFindConstantValue(const char* cname, const QoreTypeInfo*& typeInfo, bool& found, const qore_class_private* class_ctx, bool allow_internal) const {
+QoreValue BCNode::parseFindConstantValue(const char* cname, const QoreTypeInfo*& typeInfo, bool& found, const qore_class_private* class_ctx, bool allow_internal) const {
    // sclass can be 0 if the class could not be found during parse initialization
     if (!sclass)
         return QoreValue();
@@ -2135,12 +2135,12 @@ void BCList::resolveCopy() {
    sml.resolveCopy();
 }
 
-const QoreValue BCList::parseFindConstantValue(const char* cname, const QoreTypeInfo*& typeInfo, bool& found, const qore_class_private* class_ctx, bool allow_internal) const {
+QoreValue BCList::parseFindConstantValue(const char* cname, const QoreTypeInfo*& typeInfo, bool& found, const qore_class_private* class_ctx, bool allow_internal) const {
     if (!valid)
         return QoreValue();
 
     for (auto& i : *this) {
-       const QoreValue rv = (*i).parseFindConstantValue(cname, typeInfo, found, class_ctx, allow_internal);
+       QoreValue rv = (*i).parseFindConstantValue(cname, typeInfo, found, class_ctx, allow_internal);
        if (found)
            return rv;
     }

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -933,7 +933,6 @@ int qore_class_private::runtimeInitMembers(QoreObject& o, bool& need_scan, bool 
                     if (!need_scan)
                         need_scan = true;
                 }
-                }
                 //printd(5, "qore_class_private::initMembers() '%s' obj: %d v: '%s' (%p) refs: %d exp: %p refs: %d\n", i->first, needs_scan(v), v.getTypeName(), v.getInternalNode(), v.hasNode() ? v.getInternalNode()->reference_count() : 0, i->second->exp, i->second->exp->reference_count());
             }
 #ifdef QORE_ENFORCE_DEFAULT_LVALUE

--- a/lib/QoreClassList.cpp
+++ b/lib/QoreClassList.cpp
@@ -235,15 +235,18 @@ QoreHashNode *QoreClassList::getInfo() {
     return h;
 }
 
-AbstractQoreNode* QoreClassList::findConstant(const char *cname, const QoreTypeInfo *&typeInfo) {
+/*
+QoreValue QoreClassList::findConstant(const char *cname, const QoreTypeInfo *&typeInfo, bool& found) {
     for (hm_qc_t::iterator i = hm.begin(), e = hm.end(); i != e; ++i) {
-        AbstractQoreNode *rv = qore_class_private::parseFindLocalConstantValue(i->second.cls, cname, typeInfo);
-        if (rv)
+        QoreValue rv = qore_class_private::parseFindLocalConstantValue(i->second.cls, cname, typeInfo, found);
+        if (found) {
             return rv;
+        }
     }
 
-    return nullptr;
+    return QoreValue();
 }
+*/
 
 void QoreClassList::clearConstants(QoreListNode& l) {
     for (hm_qc_t::iterator i = hm.begin(), e = hm.end(); i != e; ++i) {

--- a/lib/QoreClassList.cpp
+++ b/lib/QoreClassList.cpp
@@ -229,52 +229,52 @@ void QoreClassList::assimilate(QoreClassList& n, qore_ns_private& ns) {
 }
 
 QoreHashNode *QoreClassList::getInfo() {
-   QoreHashNode *h = new QoreHashNode;
-   for (hm_qc_t::iterator i = hm.begin(), e = hm.end(); i != e; ++i)
-      h->setKeyValue(i->first, i->second->getMethodList(), 0);
-   return h;
+    QoreHashNode *h = new QoreHashNode;
+    for (hm_qc_t::iterator i = hm.begin(), e = hm.end(); i != e; ++i)
+        h->setKeyValue(i->first, i->second->getMethodList(), nullptr);
+    return h;
 }
 
-AbstractQoreNode *QoreClassList::findConstant(const char *cname, const QoreTypeInfo *&typeInfo) {
-   for (hm_qc_t::iterator i = hm.begin(), e = hm.end(); i != e; ++i) {
-      AbstractQoreNode *rv = qore_class_private::parseFindLocalConstantValue(i->second, cname, typeInfo);
-      if (rv)
-         return rv;
-   }
+AbstractQoreNode* QoreClassList::findConstant(const char *cname, const QoreTypeInfo *&typeInfo) {
+    for (hm_qc_t::iterator i = hm.begin(), e = hm.end(); i != e; ++i) {
+        AbstractQoreNode *rv = qore_class_private::parseFindLocalConstantValue(i->second, cname, typeInfo);
+        if (rv)
+            return rv;
+    }
 
-   return 0;
+    return nullptr;
 }
 
 void QoreClassList::clearConstants(QoreListNode& l) {
-   for (hm_qc_t::iterator i = hm.begin(), e = hm.end(); i != e; ++i) {
-      qore_class_private::clearConstants(i->second, l);
-   }
+    for (hm_qc_t::iterator i = hm.begin(), e = hm.end(); i != e; ++i) {
+        qore_class_private::clearConstants(i->second, l);
+    }
 }
 
 void QoreClassList::clear(ExceptionSink *xsink) {
-   for (hm_qc_t::iterator i = hm.begin(), e = hm.end(); i != e; ++i) {
-      qore_class_private::clear(i->second, xsink);
-   }
+    for (hm_qc_t::iterator i = hm.begin(), e = hm.end(); i != e; ++i) {
+        qore_class_private::clear(i->second, xsink);
+    }
 }
 
 void QoreClassList::deleteClassData(ExceptionSink *xsink) {
-   for (hm_qc_t::iterator i = hm.begin(), e = hm.end(); i != e; ++i) {
-      qore_class_private::deleteClassData(i->second, xsink);
-   }
+    for (hm_qc_t::iterator i = hm.begin(), e = hm.end(); i != e; ++i) {
+        qore_class_private::deleteClassData(i->second, xsink);
+    }
 }
 
 bool ClassListIterator::isPublic() const {
-   return qore_class_private::isPublic(*i->second);
+    return qore_class_private::isPublic(*i->second);
 }
 
 bool ConstClassListIterator::isPublic() const {
-   return qore_class_private::isPublic(*i->second);
+    return qore_class_private::isPublic(*i->second);
 }
 
 bool ClassListIterator::isUserPublic() const {
-   return qore_class_private::isUserPublic(*i->second);
+    return qore_class_private::isUserPublic(*i->second);
 }
 
 bool ConstClassListIterator::isUserPublic() const {
-   return qore_class_private::isUserPublic(*i->second);
+    return qore_class_private::isUserPublic(*i->second);
 }

--- a/lib/QoreClassList.cpp
+++ b/lib/QoreClassList.cpp
@@ -110,7 +110,7 @@ void QoreClassList::mergeUserPublic(const QoreClassList& old, qore_ns_private* n
 
       QoreClass* qc = find(i->first);
       if (qc) {
-         assert(qore_class_private::injected(*qc));
+         assert(qore_class_private::injected(*qc) || qore_class_private::get(*qc) == qore_class_private::get(*i->second));
          continue;
       }
 

--- a/lib/QoreClassList.cpp
+++ b/lib/QoreClassList.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -104,20 +104,21 @@ QoreClassList::QoreClassList(const QoreClassList& old, int64 po, qore_ns_private
 }
 
 void QoreClassList::mergeUserPublic(const QoreClassList& old, qore_ns_private* ns) {
-   for (hm_qc_t::const_iterator i = old.hm.begin(), e = old.hm.end(); i != e; ++i) {
-      if (!qore_class_private::isUserPublic(*i->second))
-         continue;
+    for (hm_qc_t::const_iterator i = old.hm.begin(), e = old.hm.end(); i != e; ++i) {
+        if (!qore_class_private::isUserPublic(*i->second))
+            continue;
 
-      QoreClass* qc = find(i->first);
-      if (qc) {
-         assert(qore_class_private::injected(*qc) || qore_class_private::get(*qc) == qore_class_private::get(*i->second));
-         continue;
-      }
+        QoreClass* qc = find(i->first);
+        if (qc) {
+            // the class must be injected or already imported
+            assert(qore_class_private::injected(*qc) || qore_class_private::get(*qc) == qore_class_private::get(*i->second));
+            continue;
+        }
 
-      qc = new QoreClass(*i->second);
-      qore_class_private::setNamespace(qc, ns);
-      addInternal(qc);
-   }
+        qc = new QoreClass(*i->second);
+        qore_class_private::setNamespace(qc, ns);
+        addInternal(qc);
+    }
 }
 
 int QoreClassList::importSystemClasses(const QoreClassList& source, qore_ns_private* ns, ExceptionSink* xsink) {

--- a/lib/QoreClosureParseNode.cpp
+++ b/lib/QoreClosureParseNode.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -66,7 +66,7 @@ AbstractQoreNode* QoreClosureParseNode::parseInitImpl(LocalVar* oflag, int pflag
       in_method = true;
       uf->setClassType(oflag->getTypeInfo());
    }
-   uf->parseInit();
+   uf->parseInit(nullptr);
    uf->parseCommit();
    typeInfo = runTimeClosureTypeInfo;
    return this;

--- a/lib/QoreDotEvalOperatorNode.cpp
+++ b/lib/QoreDotEvalOperatorNode.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -186,7 +186,7 @@ AbstractQoreNode* QoreDotEvalOperatorNode::parseInitImpl(LocalVar* oflag, int pf
    lvids += m->parseArgs(oflag, pflag, meth->getFunction(), returnTypeInfo);
    expTypeInfo = returnTypeInfo;
 
-   printd(5, "QoreDotEvalOperatorNode::parseInitImpl() %s::%s() method=%p (%s::%s()) (private=%s, static=%s) rv=%s\n", qc->getName(), mname, meth, meth ? meth->getClassName() : "n/a", mname, meth && (qore_method_private::parseGetAccess(*meth) > Public) ? "true" : "false", meth->isStatic() ? "true" : "false", QoreTypeInfo::getName(returnTypeInfo));
+   printd(5, "QoreDotEvalOperatorNode::parseInitImpl() %s::%s() method=%p (%s::%s()) (private=%s, static=%s) rv=%s\n", qc->getName(), mname, meth, meth ? meth->getClassName() : "n/a", mname, meth && (qore_method_private::getAccess(*meth) > Public) ? "true" : "false", meth->isStatic() ? "true" : "false", QoreTypeInfo::getName(returnTypeInfo));
 
    return this;
 }

--- a/lib/QoreDotEvalOperatorNode.cpp
+++ b/lib/QoreDotEvalOperatorNode.cpp
@@ -103,7 +103,7 @@ AbstractQoreNode* QoreDotEvalOperatorNode::parseInitImpl(LocalVar* oflag, int pf
             m->parseSetClassAndMethod(qc, meth);
 
             // check parameters, if any
-            lvids += m->parseArgs(oflag, pflag, meth->getFunction(), returnTypeInfo);
+            lvids += m->parseArgs(oflag, pflag, meth->getFunction(), nullptr, returnTypeInfo);
             expTypeInfo = returnTypeInfo;
 
             return this;
@@ -183,7 +183,7 @@ AbstractQoreNode* QoreDotEvalOperatorNode::parseInitImpl(LocalVar* oflag, int pf
    m->parseSetClassAndMethod(qc, meth);
 
    // check parameters, if any
-   lvids += m->parseArgs(oflag, pflag, meth->getFunction(), returnTypeInfo);
+   lvids += m->parseArgs(oflag, pflag, meth->getFunction(), nullptr ,returnTypeInfo);
    expTypeInfo = returnTypeInfo;
 
    printd(5, "QoreDotEvalOperatorNode::parseInitImpl() %s::%s() method=%p (%s::%s()) (private=%s, static=%s) rv=%s\n", qc->getName(), mname, meth, meth ? meth->getClassName() : "n/a", mname, meth && (qore_method_private::getAccess(*meth) > Public) ? "true" : "false", meth->isStatic() ? "true" : "false", QoreTypeInfo::getName(returnTypeInfo));

--- a/lib/QoreException.cpp
+++ b/lib/QoreException.cpp
@@ -3,7 +3,7 @@
 
   Qore programming language exception handling support
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -42,25 +42,25 @@ void QoreException::del(ExceptionSink *xsink) {
    if (callStack) {
       callStack->deref(xsink);
 #ifdef DEBUG
-      callStack = 0;
+      callStack = nullptr;
 #endif
    }
    if (err) {
       err->deref(xsink);
 #ifdef DEBUG
-      err = 0;
+      err = nullptr;
 #endif
    }
    if (desc) {
       desc->deref(xsink);
 #ifdef DEBUG
-      desc = 0;
+      desc = nullptr;
 #endif
    }
    if (arg) {
       arg->deref(xsink);
 #ifdef DEBUG
-      arg = 0;
+      arg = nullptr;
 #endif
    }
    if (next)

--- a/lib/QoreGetOpt.cpp
+++ b/lib/QoreGetOpt.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -86,15 +86,15 @@ int QoreGetOpt::add(const char* name, char short_opt, const char* long_opt, qore
 }
 
 static void addError(QoreHashNode* h, QoreStringNode* err) {
-   //printd(5, "addError() adding: %s\n", err->getBuffer())
-   hash_assignment_priv ha(*h, "_ERRORS_");
-   QoreListNode* l = reinterpret_cast<QoreListNode* >(*ha);
-   if (!l) {
-      l = new QoreListNode;
-      ha.assign(l, 0);
-   }
+    //printd(5, "addError() adding: %s\n", err->getBuffer())
+    hash_assignment_priv ha(*h, "_ERRORS_");
+    QoreListNode* l = (*ha).get<QoreListNode>();
+    if (!l) {
+        l = new QoreListNode;
+        ha.assign(l, 0);
+    }
 
-   l->push(err);
+    l->push(err);
 }
 
 // private, static method
@@ -103,102 +103,101 @@ DateTimeNode* QoreGetOpt::parseDate(const char* val) {
 }
 
 void QoreGetOpt::doOption(class QoreGetOptNode* n, class QoreHashNode* h, const char* val) {
-   hash_assignment_priv ha(*h, n->name);
+    hash_assignment_priv ha(*h, n->name);
 
-   // get a value ready
-   if (n->argtype == -1) {
-      if (*ha)
-	 return;
-      ha.assign(&True, 0);
-      return;
-   }
+    // get a value ready
+    if (n->argtype == -1) {
+        if (!(*ha).isNothing())
+            return;
+        ha.assign(true, 0);
+        return;
+    }
 
-   // handle option values
-   if (!val) {
-      if (n->option & QGO_OPT_ADDITIVE) {
-	 if (n->argtype == NT_INT) {
-	    if (!*ha)
-	       ha.assign(new QoreBigIntNode(1), 0);
-	    else {
-	       QoreBigIntNode* b = reinterpret_cast<QoreBigIntNode* >(*ha);
-	       b->val++;
-	    }
-	 }
-	 else {
-	    if (!*ha)
-	       ha.assign(ZeroFloat->refSelf(), 0);
-	    else {
-	       QoreFloatNode* f = reinterpret_cast<QoreFloatNode* >(*ha);
-	       f->f++;
-	    }
-	 }
-      }
-      else if (!*ha)
-	 ha.assign(&True, 0);
-      return;
-   }
+    // handle option values
+    if (!val) {
+        if (n->option & QGO_OPT_ADDITIVE) {
+            if (n->argtype == NT_INT) {
+                if ((*ha).isNothing()) {
+                    ha.assign(1, 0);
+                }
+                else {
+                    ha.assign((*ha).getAsBigInt() + 1, nullptr);
+                }
+            }
+            else {
+                if ((*ha).isNothing()) {
+                    ha.assign(0.0, 0);
+                }
+                else {
+                    ha.assign((*ha).getAsFloat() + 1, nullptr);
+                }
+            }
+        }
+        else if ((*ha).isNothing()) {
+            ha.assign(true, nullptr);
+        }
+        return;
+    }
 
-   AbstractQoreNode* v;
-   if (n->argtype == NT_STRING)
-      v = new QoreStringNode(val);
-   else if (n->argtype == NT_INT)
-      v = new QoreBigIntNode(strtoll(val, 0, 10));
-   else if (n->argtype == NT_FLOAT)
-      v = new QoreFloatNode(strtod(val, 0));
-   else if (n->argtype == NT_DATE)
-      v = parseDate(val);
-   else if (n->argtype == NT_BOOLEAN)
-      v = get_bool_node((bool)strtol(val, 0, 10));
-   else // default string
-      v = new QoreStringNode(val);
+    QoreValue v;
+    if (n->argtype == NT_STRING)
+        v = new QoreStringNode(val);
+    else if (n->argtype == NT_INT)
+        v = strtoll(val, 0, 10);
+    else if (n->argtype == NT_FLOAT)
+        v = strtod(val, 0);
+    else if (n->argtype == NT_DATE)
+        v = parseDate(val);
+    else if (n->argtype == NT_BOOLEAN)
+        v = (bool)strtol(val, 0, 10);
+    else // default string
+        v = new QoreStringNode(val);
 
-   if (!(n->option & QGO_OPT_LIST_OR_ADD)) {
-      ha.assign(v, 0);
-      return;
-   }
+    if (!(n->option & QGO_OPT_LIST_OR_ADD)) {
+        ha.assign(v, nullptr);
+        return;
+    }
 
-   if (n->option & QGO_OPT_LIST) {
-      QoreListNode* l = reinterpret_cast<QoreListNode* >(*ha);
-      if (!l) {
-	 l = new QoreListNode;
-	 ha.assign(l, 0);
-      }
-      //else printf("cv->getType()=%s\n", cv->getTypeName());
-      l->push(v);
-      return;
-   }
+    if (n->option & QGO_OPT_LIST) {
+        QoreListNode* l = (*ha).get<QoreListNode>();
+        if (!l) {
+            l = new QoreListNode;
+            ha.assign(l, nullptr);
+        }
+        //else printf("cv->getType()=%s\n", cv->getTypeName());
+        l->push(v.takeNode());
+        return;
+    }
 
-   // additive
-   if (*ha) {
-      if (n->argtype == NT_INT) {
-	 QoreBigIntNode* b = reinterpret_cast<QoreBigIntNode* >(*ha);
-	 b->val += reinterpret_cast<QoreBigIntNode* >(v)->val;
-      }
-      else { // float
-	 QoreFloatNode* f = reinterpret_cast<QoreFloatNode* >(*ha);
-	 f->f += reinterpret_cast<const QoreFloatNode* >(v)->f;
-      }
-      v->deref(0);
-      return;
-   }
+    // additive
+    if (!(*ha).isNothing()) {
+        if (n->argtype == NT_INT) {
+            ha.om->val.v.i += v.v.i;
+        }
+        else { // float
+            ha.om->val.v.f += v.v.f;
+        }
+        v.discard(nullptr);
+        return;
+    }
 
-   ha.assign(v, 0);
+    ha.assign(v, nullptr);
 }
 
-char* QoreGetOpt::getNextArgument(QoreListNode* l, QoreHashNode* h, unsigned &i, const char* lopt, char sopt) {
-   if (i < (l->size() - 1)) {
-      i++;
-      QoreStringNode* n = dynamic_cast<QoreStringNode* >(l->retrieve_entry(i));
-      if (n)
-	 return (char* )n->getBuffer();
-   }
-   QoreStringNode* err = new QoreStringNode;
-   if (lopt)
-      err->sprintf("long option '--%s' requires an argument", lopt);
-   else
-      err->sprintf("short option '-%c' requires an argument", sopt);
-   addError(h, err);
-   return 0;
+char* QoreGetOpt::getNextArgument(QoreListNode* l, QoreHashNode* h, unsigned& i, const char* lopt, char sopt) {
+    if (i < (l->size() - 1)) {
+        i++;
+        QoreStringNode* n = dynamic_cast<QoreStringNode* >(l->retrieve_entry(i));
+        if (n)
+            return (char*)n->c_str();
+    }
+    QoreStringNode* err = new QoreStringNode;
+    if (lopt)
+        err->sprintf("long option '--%s' requires an argument", lopt);
+    else
+        err->sprintf("short option '-%c' requires an argument", sopt);
+    addError(h, err);
+    return nullptr;
 }
 
 void QoreGetOpt::processLongArg(const char* arg, QoreListNode* l, class QoreHashNode* h, unsigned &i, bool modify) {
@@ -233,9 +232,9 @@ void QoreGetOpt::processLongArg(const char* arg, QoreListNode* l, class QoreHash
    if (w->argtype && !val && (w->option & QGO_OPT_MANDATORY)) {
       val = (char* )getNextArgument(l, h, i, opt, '\0');
       if (val && modify)
-	 do_modify = true;
+         do_modify = true;
       if (!val)
-	 return;
+         return;
    }
    doOption(w, h, val);
    if (do_modify)
@@ -255,17 +254,17 @@ int QoreGetOpt::processShortArg(const char* arg, QoreListNode* l, class QoreHash
    const char* val = 0;
    if (w->argtype != -1) {
       if ((j < (signed)(strlen(arg) - 1))
-	  && ((w->option & QGO_OPT_MANDATORY) || ((arg + j + 1)[0] == '='))) {
-	 val = arg + j + 1;
-	 if (*val == '=')
-	    val++;
-	 j = 0;
+          && ((w->option & QGO_OPT_MANDATORY) || ((arg + j + 1)[0] == '='))) {
+         val = arg + j + 1;
+         if (*val == '=')
+            val++;
+         j = 0;
       }
       else if (w->option & QGO_OPT_MANDATORY) {
-	 if (!(val = getNextArgument(l, h, i, 0, opt)))
-	    return 0;
-	 if (modify)
-	    do_modify = true;
+         if (!(val = getNextArgument(l, h, i, 0, opt)))
+            return 0;
+         if (modify)
+            do_modify = true;
       }
    }
    doOption(w, h, val);
@@ -282,29 +281,29 @@ QoreHashNode* QoreGetOpt::parse(QoreListNode* l, bool modify, ExceptionSink *xsi
       //printf("QoreGetOpt::parse() %d/%d\n", i, l->size());
       AbstractQoreNode* n = l->retrieve_entry(i);
       if (get_node_type(n) != NT_STRING)
-	 continue;
+         continue;
 
       QoreStringNode* str = reinterpret_cast<QoreStringNode*>(n);
       const char* arg = str->getBuffer();
 
       if (arg[0] == '-') {
-	 if (!arg[1])
-	    continue;
-	 if (arg[1] == '-') {
-	    if (!arg[2])
-	       break;
-	    processLongArg(arg + 2, l, h, i, modify);
-	    if (modify) {
-	       //printd(5, "parse() opt=%s size=%d\n", arg, l->size());
-	       l->pop_entry(i--, 0);
-	       //printd(5, "parse() popped entry, size=%d\n", l->size());
-	    }
-	    continue;
-	 }
-	 int len = strlen(arg);
-	 for (int j = 1; j < len; j++)
-	    if (processShortArg(arg, l, h, i, j, modify))
-	       break;
+         if (!arg[1])
+            continue;
+         if (arg[1] == '-') {
+            if (!arg[2])
+               break;
+            processLongArg(arg + 2, l, h, i, modify);
+            if (modify) {
+               //printd(5, "parse() opt=%s size=%d\n", arg, l->size());
+               l->pop_entry(i--, 0);
+               //printd(5, "parse() popped entry, size=%d\n", l->size());
+            }
+            continue;
+         }
+         int len = strlen(arg);
+         for (int j = 1; j < len; j++)
+            if (processShortArg(arg, l, h, i, j, modify))
+               break;
          if (modify)
             l->pop_entry(i--, 0);
       }

--- a/lib/QoreGetOpt.cpp
+++ b/lib/QoreGetOpt.cpp
@@ -30,6 +30,7 @@
 
 #include <qore/Qore.h>
 #include "qore/intern/QoreGetOpt.h"
+#include "qore/intern/QoreHashNodeIntern.h"
 
 #include <string.h>
 #include <stdlib.h>

--- a/lib/QoreHashNode.cpp
+++ b/lib/QoreHashNode.cpp
@@ -551,12 +551,12 @@ void QoreHashNode::merge(const class QoreHashNode* h, ExceptionSink* xsink) {
 
 // returns the same order
 QoreHashNode* QoreHashNode::copy() const {
-   return priv->copy();
+    return priv->copy();
 }
 
 QoreHashNode* QoreHashNode::hashRefSelf() const {
-   ref();
-   return const_cast<QoreHashNode*>(this);
+    ref();
+    return const_cast<QoreHashNode*>(this);
 }
 
 // returns a hash with the same order
@@ -1146,6 +1146,7 @@ void hash_assignment_priv::reassign(const char* key, bool must_already_exist) {
 QoreValue hash_assignment_priv::swapImpl(QoreValue v) {
     assert(om);
     QoreValue old = om->val;
+    v.sanitize();
     om->val = v;
 
     bool before = needs_scan(old);

--- a/lib/QoreHashNode.cpp
+++ b/lib/QoreHashNode.cpp
@@ -467,14 +467,14 @@ void QoreHashNode::setKeyValue(const QoreString* key, AbstractQoreNode* val, Exc
 
 // deprecated
 void QoreHashNode::setKeyValue(const QoreString& key, AbstractQoreNode* val, ExceptionSink* xsink) {
-   setKeyValue(&key, val, xsink);
+    setKeyValue(&key, val, xsink);
 }
 
 // deprecated
 void QoreHashNode::setKeyValue(const char* key, AbstractQoreNode* val, ExceptionSink* xsink) {
-   assert(reference_count() == 1);
-   hash_assignment_priv ha(*priv, key);
-   ha.assign(val, xsink);
+    assert(reference_count() == 1);
+    hash_assignment_priv ha(*priv, key);
+    ha.assign(val, xsink);
 }
 
 AbstractQoreNode* QoreHashNode::swapKeyValue(const QoreString* key, AbstractQoreNode* val, ExceptionSink* xsink) {

--- a/lib/QoreHashNode.cpp
+++ b/lib/QoreHashNode.cpp
@@ -68,47 +68,48 @@ QoreListNode* qore_hash_private::getValues(bool with_type_info) const {
     qore_list_private::get(*list)->reserve(member_list.size());
 
     for (auto& i : member_list) {
-        list->push(i->node ? i->node->refSelf() : nullptr);
+        list->push(i->val.getReferencedValue());
     }
     return list;
 }
 
 void qore_hash_private::merge(const qore_hash_private& h, ExceptionSink* xsink) {
-   for (auto& i : h.member_list) {
-      setKeyValue(i->key, i->node ? i->node->refSelf() : nullptr, xsink);
-   }
+    for (auto& i : h.member_list) {
+        setKeyValue(i->key, i->val.refSelf(), xsink);
+    }
 }
 
 int qore_hash_private::getLValue(const char* key, LValueHelper& lvh, bool for_remove, ExceptionSink* xsink) {
-   const QoreTypeInfo* memTypeInfo = nullptr;
+    const QoreTypeInfo* memTypeInfo = nullptr;
 
-   if (hashdecl) {
-      const HashDeclMemberInfo* m = typed_hash_decl_private::get(*hashdecl)->findMember(key);
-      if (!m) {
-         xsink->raiseException("INVALID-MEMBER", "'%s' is not a registered member of hashdecl '%s'", key, hashdecl->getName());
-         lvh.clearPtr();
-         return -1;
-      }
+    if (hashdecl) {
+        const HashDeclMemberInfo* m = typed_hash_decl_private::get(*hashdecl)->findMember(key);
+        if (!m) {
+            xsink->raiseException("INVALID-MEMBER", "'%s' is not a registered member of hashdecl '%s'", key, hashdecl->getName());
+            lvh.clearPtr();
+            return -1;
+        }
 
-      memTypeInfo = m->getTypeInfo();
-   }
-   else if (complexTypeInfo)
-      memTypeInfo = QoreTypeInfo::getUniqueReturnComplexHash(complexTypeInfo);
+        memTypeInfo = m->getTypeInfo();
+    }
+    else if (complexTypeInfo)
+        memTypeInfo = QoreTypeInfo::getUniqueReturnComplexHash(complexTypeInfo);
 
-   hm_hm_t::const_iterator i = hm.find(key);
-   HashMember* m;
-   if (i == hm.end()) {
-      if (for_remove)
-         return -1;
-      m = findCreateMember(key);
-   }
-   else
-      m = (*(i->second));
+    hm_hm_t::const_iterator i = hm.find(key);
+    HashMember* m;
+    if (i == hm.end()) {
+        if (for_remove)
+            return -1;
+        m = findCreateMember(key);
+    }
+    else
+        m = (*(i->second));
 
-   //printd(5, "qore_hash_private::getLValue() this: %p hd: %p ct: %p key: '%s' type: '%s'\n", this, hashdecl, complexTypeInfo, key, QoreTypeInfo::getName(memTypeInfo));
+    //printd(5, "qore_hash_private::getLValue() this: %p hd: %p ct: %p key: '%s' type: '%s'\n", this, hashdecl, complexTypeInfo, key, QoreTypeInfo::getName(memTypeInfo));
 
-   lvh.resetPtr(&m->node, memTypeInfo);
-   return 0;
+    lvh.resetValue(m->val, memTypeInfo);
+    //lvh.resetPtr(&m->node, memTypeInfo);
+    return 0;
 }
 
 int qore_hash_private::parseInitHashInitialization(const QoreProgramLocation& loc, LocalVar* oflag, int pflag, int& lvids, QoreParseListNode* args, const QoreTypeInfo*& argTypeInfo, const AbstractQoreNode*& arg) {
@@ -237,7 +238,7 @@ QoreHashNode* qore_hash_private::newComplexHashFromHash(const QoreTypeInfo* type
         while (i.next()) {
             // check types
             HashAssignmentHelper hah(i);
-            QoreValue qv(hash_assignment_priv::get(hah)->swap(nullptr));
+            QoreValue qv(hash_assignment_priv::get(hah)->swap(QoreValue()));
             QoreTypeInfo::acceptInputMember(vti, i.getKey(), qv, xsink);
             hash_assignment_priv::get(hah)->swap(qv.takeNode());
             if (*xsink)
@@ -275,7 +276,7 @@ QoreValue qore_hash_private::getValueKeyValueExistenceIntern(const char* key, bo
 
     if (i != hm.end()) {
         exists = true;
-        return (*i->second)->node;
+        return (*i->second)->val;
     }
 
     exists = false;
@@ -284,7 +285,7 @@ QoreValue qore_hash_private::getValueKeyValueExistenceIntern(const char* key, bo
 
 QoreValue qore_hash_private::getValueKeyValueIntern(const char* key) const {
     hm_hm_t::const_iterator i = hm.find(key);
-    return i != hm.end() ? (*i->second)->node : QoreValue();
+    return i != hm.end() ? (*i->second)->val : QoreValue();
 }
 
 QoreHashNode::QoreHashNode(bool ne) : AbstractQoreNode(NT_HASH, !ne, ne), priv(new qore_hash_private) {
@@ -382,6 +383,10 @@ AbstractQoreNode** QoreHashNode::getKeyValuePtr(const char* key) {
    return priv->getKeyValuePtr(key);
 }
 
+QoreValue& QoreHashNode::getValueRef(const char* key) {
+    return priv->getValueRef(key);
+}
+
 // deprecated
 int64 QoreHashNode::getKeyAsBigInt(const char* key, bool &found) const {
    return priv->getKeyAsBigInt(key, found);
@@ -417,7 +422,7 @@ AbstractQoreNode* QoreHashNode::takeKeyValue(const QoreString* key, ExceptionSin
    if (*xsink)
       return 0;
 
-   return priv->takeKeyValue(tmp->getBuffer());
+   return priv->takeKeyValueIntern(tmp->c_str()).takeNode();
 }
 
 // deprecated
@@ -477,29 +482,29 @@ void QoreHashNode::setKeyValue(const char* key, AbstractQoreNode* val, Exception
 }
 
 AbstractQoreNode* QoreHashNode::swapKeyValue(const QoreString* key, AbstractQoreNode* val, ExceptionSink* xsink) {
-   assert(reference_count() == 1);
-   TempEncodingHelper tmp(key, QCS_DEFAULT, xsink);
-   if (*xsink) {
-      if (val)
-         val->deref(xsink);
-      return 0;
-   }
+    assert(reference_count() == 1);
+    TempEncodingHelper tmp(key, QCS_DEFAULT, xsink);
+    if (*xsink) {
+        if (val)
+            val->deref(xsink);
+        return 0;
+    }
 
-   hash_assignment_priv ha(*priv, tmp->getBuffer());
-   return ha.swap(val);
+    hash_assignment_priv ha(*priv, tmp->getBuffer());
+    return ha.swap(val).takeNode();
 }
 
 AbstractQoreNode* QoreHashNode::swapKeyValue(const char* key, AbstractQoreNode* val) {
    //printd(0, "QoreHashNode::swapKeyValue() this=%p key=%s val=%p (%s) deprecated API called\n", this, key, val, get_node_type(val));
    //assert(false);
    hash_assignment_priv ha(*priv, key);
-   return ha.swap(val);
+   return ha.swap(val).takeNode();
 }
 
 AbstractQoreNode* QoreHashNode::swapKeyValue(const char* key, AbstractQoreNode* val, ExceptionSink* xsink) {
    assert(reference_count() == 1);
    hash_assignment_priv ha(*priv, key);
-   return ha.swap(val);
+   return ha.swap(val).takeNode();
 }
 
 // deprecated
@@ -597,21 +602,23 @@ AbstractQoreNode* QoreHashNode::evalKeyValue(const QoreString* key, ExceptionSin
 
    hm_hm_t::const_iterator i = priv->hm.find(k->c_str());
 
-   if (i != priv->hm.end() && (*i->second)->node)
-      return (*i->second)->node->refSelf();
+   if (i != priv->hm.end())
+      return (*i->second)->val.getReferencedValue();
 
    return nullptr;
 }
 
 AbstractQoreNode* QoreHashNode::getKeyValue(const char* key) {
-   assert(key);
+    assert(key);
 
-   hm_hm_t::const_iterator i = priv->hm.find(key);
+    hm_hm_t::const_iterator i = priv->hm.find(key);
 
-   if (i != priv->hm.end())
-      return (*i->second)->node;
+    if (i != priv->hm.end()) {
+        priv->convertToNode((*i->second)->val);
+        return (*i->second)->val.getInternalNode();
+    }
 
-   return 0;
+    return nullptr;
 }
 
 const AbstractQoreNode* QoreHashNode::getKeyValue(const char* key) const {
@@ -619,17 +626,18 @@ const AbstractQoreNode* QoreHashNode::getKeyValue(const char* key) const {
 }
 
 AbstractQoreNode* QoreHashNode::getKeyValueExistence(const char* key, bool &exists) {
-   assert(key);
+    assert(key);
 
-   hm_hm_t::const_iterator i = priv->hm.find(key);
+    hm_hm_t::const_iterator i = priv->hm.find(key);
 
-   if (i != priv->hm.end()) {
-      exists = true;
-      return (*i->second)->node;
-   }
+    if (i != priv->hm.end()) {
+        exists = true;
+        priv->convertToNode((*i->second)->val);
+        return (*i->second)->val.getInternalNode();
+    }
 
-   exists = false;
-   return 0;
+    exists = false;
+    return nullptr;
 }
 
 const AbstractQoreNode* QoreHashNode::getKeyValueExistence(const char* key, bool &exists) const {
@@ -639,47 +647,51 @@ const AbstractQoreNode* QoreHashNode::getKeyValueExistence(const char* key, bool
 // does a "soft" compare (values of different types are converted if necessary and then compared)
 // 0 = equal, 1 = not equal
 bool QoreHashNode::compareSoft(const QoreHashNode* h, ExceptionSink* xsink) const {
-   if (h->priv->size() != priv->size())
-      return 1;
+    if (h->priv->size() != priv->size())
+        return 1;
 
-   ConstHashIterator hi(this);
-   while (hi.next()) {
-      hm_hm_t::const_iterator j = h->priv->hm.find(hi.getKey());
-      if (j == h->priv->hm.end())
-         return 1;
+    ConstHashIterator hi(this);
+    while (hi.next()) {
+        hm_hm_t::const_iterator j = h->priv->hm.find(hi.getKey());
+        if (j == h->priv->hm.end())
+            return 1;
 
-      if (q_compare_soft(hi.getValue(), (*j->second)->node, xsink))
-         return 1;
-   }
-   return 0;
+        if (!hi.get().isEqualSoft((*j->second)->val, xsink)) {
+            return 1;
+        }
+    }
+    return 0;
 }
 
 // does a "hard" compare (types must be exactly the same)
 // 0 = equal, 1 = not equal
 bool QoreHashNode::compareHard(const QoreHashNode* h, ExceptionSink* xsink) const {
-   if (h->priv->size() != priv->size())
-      return 1;
+    if (h->priv->size() != priv->size())
+        return 1;
 
-   ConstHashIterator hi(this);
-   while (hi.next()) {
-      hm_hm_t::const_iterator j = h->priv->hm.find(hi.getKey());
-      if (j == h->priv->hm.end())
-         return 1;
+    ConstHashIterator hi(this);
+    while (hi.next()) {
+        hm_hm_t::const_iterator j = h->priv->hm.find(hi.getKey());
+        if (j == h->priv->hm.end())
+            return 1;
 
-      if (::compareHard(hi.getValue(), (*j->second)->node, xsink))
-         return 1;
-   }
-   return 0;
+        if (!hi.get().isEqualHard((*j->second)->val)) {
+            return 1;
+        }
+    }
+    return 0;
 }
 
 // deprecated
 AbstractQoreNode** QoreHashNode::getExistingValuePtr(const char* key) {
-   hm_hm_t::const_iterator i = priv->hm.find(key);
+    hm_hm_t::const_iterator i = priv->hm.find(key);
 
-   if (i != priv->hm.end())
-      return &(*i->second)->node;
+    if (i != priv->hm.end()) {
+        qore_hash_private::convertToNode((*i->second)->val);
+        return &(*i->second)->val.v.n;
+    }
 
-   return nullptr;
+    return nullptr;
 }
 
 bool QoreHashNode::derefImpl(ExceptionSink* xsink) {
@@ -703,7 +715,7 @@ void QoreHashNode::removeKey(const char* key, ExceptionSink* xsink) {
 
 AbstractQoreNode* QoreHashNode::takeKeyValue(const char* key) {
    assert(reference_count() == 1);
-   return priv->takeKeyValue(key);
+   return priv->takeKeyValueIntern(key).takeNode();
 }
 
 qore_size_t QoreHashNode::size() const {
@@ -867,11 +879,15 @@ QoreHashNode* HashIterator::getHash() const {
 }
 
 AbstractQoreNode* HashIterator::getReferencedValue() const {
-   return !priv->valid() || !(*(priv->i))->node ? 0 : (*(priv->i))->node->refSelf();
+    return !priv->valid() ? nullptr : (*(priv->i))->val.getReferencedValue();
+}
+
+QoreValue HashIterator::getReferenced() const {
+    return !priv->valid() ? QoreValue() : (*(priv->i))->val.refSelf();
 }
 
 QoreString* HashIterator::getKeyString() const {
-   return !priv->valid() ? 0 : new QoreString((*(priv->i))->key);
+   return !priv->valid() ? nullptr : new QoreString((*(priv->i))->key);
 }
 
 bool HashIterator::next() {
@@ -890,37 +906,43 @@ const char* HashIterator::getKey() const {
 }
 
 AbstractQoreNode* HashIterator::getValue() const {
-   if (!priv->valid())
-      return nullptr;
+    if (!priv->valid())
+        return nullptr;
 
-   return (*(priv->i))->node;
+    qore_hash_private::convertToNode((*(priv->i))->val);
+    return (*(priv->i))->val.getInternalNode();
+}
+
+QoreValue HashIterator::get() const {
+    if (!priv->valid())
+        return QoreValue();
+
+    return (*(priv->i))->val;
 }
 
 AbstractQoreNode* HashIterator::takeValueAndDelete() {
-   if (!priv->valid())
-      return nullptr;
+    if (!priv->valid())
+        return nullptr;
 
-   AbstractQoreNode* rv = (*(priv->i))->node;
-   (*(priv->i))->node = 0;
+    AbstractQoreNode* rv = (*(priv->i))->val.assignNothing();
 
-   qhlist_t::iterator ni = priv->i;
-   priv->prev(h->priv->member_list);
+    qhlist_t::iterator ni = priv->i;
+    priv->prev(h->priv->member_list);
 
-   // remove key from map before deleting hash member with key pointer
-   hm_hm_t::iterator i = h->priv->hm.find((*ni)->key.c_str());
-   assert(i != h->priv->hm.end());
-   h->priv->hm.erase(i);
-   h->priv->internDeleteKey(ni);
+    // remove key from map before deleting hash member with key pointer
+    hm_hm_t::iterator i = h->priv->hm.find((*ni)->key.c_str());
+    assert(i != h->priv->hm.end());
+    h->priv->hm.erase(i);
+    h->priv->internDeleteKey(ni);
 
-   return rv;
+    return rv;
 }
 
 void HashIterator::deleteKey(ExceptionSink* xsink) {
    if (!priv->valid())
       return;
 
-   discard((*(priv->i))->node, xsink);
-   (*(priv->i))->node = nullptr;
+   (*(priv->i))->val.discard(xsink);
 
    qhlist_t::iterator ni = priv->i;
    priv->prev(h->priv->member_list);
@@ -933,34 +955,35 @@ void HashIterator::deleteKey(ExceptionSink* xsink) {
 
 // deprecated
 AbstractQoreNode** HashIterator::getValuePtr() const {
-   if (!priv->valid())
-      return nullptr;
+    if (!priv->valid())
+        return nullptr;
 
-   return &((*(priv->i))->node);
+    qore_hash_private::convertToNode((*(priv->i))->val);
+    return &(*(priv->i))->val.v.n;
 }
 
 bool HashIterator::last() const {
-   if (!priv->valid())
-      return false;
+    if (!priv->valid())
+        return false;
 
-   qhlist_t::const_iterator ni = priv->i;
-   ++ni;
-   return ni == h->priv->member_list.end() ? true : false;
+    qhlist_t::const_iterator ni = priv->i;
+    ++ni;
+    return ni == h->priv->member_list.end() ? true : false;
 }
 
 bool HashIterator::first() const {
-   if (!priv->valid())
-      return false;
+    if (!priv->valid())
+        return false;
 
-   return priv->i == h->priv->member_list.begin();
+    return priv->i == h->priv->member_list.begin();
 }
 
 bool HashIterator::empty() const {
-   return h->empty();
+    return h->empty();
 }
 
 bool HashIterator::valid() const {
-   return priv->valid();
+    return priv->valid();
 }
 
 ReverseHashIterator::ReverseHashIterator(QoreHashNode* h) : HashIterator(h) {
@@ -1006,11 +1029,15 @@ const QoreHashNode* ConstHashIterator::getHash() const {
 }
 
 AbstractQoreNode* ConstHashIterator::getReferencedValue() const {
-   return !priv->valid() || !(*(priv->i))->node ? 0 : (*(priv->i))->node->refSelf();
+    return !priv->valid() ? nullptr : (*(priv->i))->val.getReferencedValue();
+}
+
+QoreValue ConstHashIterator::getReferenced() const {
+    return !priv->valid() ? QoreValue() : (*(priv->i))->val.refSelf();
 }
 
 QoreString* ConstHashIterator::getKeyString() const {
-   return !priv->valid() ? 0 : new QoreString((*(priv->i))->key);
+   return !priv->valid() ? nullptr : new QoreString((*(priv->i))->key);
 }
 
 bool ConstHashIterator::next() {
@@ -1028,10 +1055,18 @@ const char* ConstHashIterator::getKey() const {
 }
 
 const AbstractQoreNode* ConstHashIterator::getValue() const {
-   if (!priv->valid())
-      return 0;
+    if (!priv->valid())
+        return nullptr;
 
-   return (*(priv->i))->node;
+    qore_hash_private::convertToNode((*(priv->i))->val);
+    return (*(priv->i))->val.getInternalNode();
+}
+
+const QoreValue ConstHashIterator::get() const {
+    if (!priv->valid())
+        return QoreValue();
+
+    return (*(priv->i))->val;
 }
 
 bool ConstHashIterator::last() const {
@@ -1116,57 +1151,50 @@ void hash_assignment_priv::reassign(const char* key, bool must_already_exist) {
    om = must_already_exist ? h.findMember(key) : h.findCreateMember(key);
 }
 
-AbstractQoreNode* hash_assignment_priv::swapImpl(AbstractQoreNode* v) {
-   assert(om);
-   // before we can entirely get rid of QoreNothingNode, try to convert pointers to NOTHING to 0
-   if (v == &Nothing)
-      v = 0;
-   AbstractQoreNode* old = om->node;
-   om->node = v;
+QoreValue hash_assignment_priv::swapImpl(QoreValue v) {
+    assert(om);
+    QoreValue old = om->val;
+    om->val = v;
 
-   bool before = needs_scan(old);
-   bool after = needs_scan(v);
-   if (before) {
-      if (!after) {
-         if (o)
-            o->incScanCount(-1);
-         else
-            h.incScanCount(-1);
-      }
-   }
-   else if (after) {
-      if (o)
-         o->incScanCount(1);
-      else
-         h.incScanCount(1);
-   }
+    bool before = needs_scan(old);
+    bool after = needs_scan(v);
+    if (before) {
+        if (!after) {
+            if (o)
+                o->incScanCount(-1);
+            else
+                h.incScanCount(-1);
+        }
+    }
+    else if (after) {
+        if (o)
+            o->incScanCount(1);
+        else
+            h.incScanCount(1);
+    }
 
-   return old;
+    return old;
 }
 
-void hash_assignment_priv::assign(AbstractQoreNode* v, ExceptionSink* xsink) {
-   ReferenceHolder<> val(v, xsink);
-   if (h.hashdecl) {
-      if (typed_hash_decl_private::get(*h.hashdecl)->runtimeAssignKey(om->key.c_str(), val, xsink))
-         return;
-   }
-   else if (h.complexTypeInfo) {
-      QoreValue v(val.release());
-      QoreTypeInfo::acceptInputKey(QoreTypeInfo::getUniqueReturnComplexHash(h.complexTypeInfo), om->key.c_str(), v, xsink);
-      val = v.takeNode();
-      if (*xsink)
-         return;
-   }
+void hash_assignment_priv::assign(QoreValue v, ExceptionSink* xsink) {
+    ValueHolder val(v, xsink);
+    if (h.hashdecl) {
+        if (typed_hash_decl_private::get(*h.hashdecl)->runtimeAssignKey(om->key.c_str(), val, xsink))
+            return;
+    }
+    else if (h.complexTypeInfo) {
+        val.release();
+        QoreTypeInfo::acceptInputKey(QoreTypeInfo::getUniqueReturnComplexHash(h.complexTypeInfo), om->key.c_str(), v, xsink);
+        val = v;
+        if (*xsink)
+            return;
+    }
 
-   AbstractQoreNode* old = swapImpl(val.release());
-   if (old) {
-      // "remove" logic here
-      old->deref(xsink);
-   }
+    swapImpl(val.release()).discard(xsink);
 }
 
-AbstractQoreNode* hash_assignment_priv::getValueImpl() const {
-   return om->node;
+QoreValue hash_assignment_priv::getImpl() const {
+   return om->val;
 }
 
 HashAssignmentHelper::HashAssignmentHelper(QoreHashNode& h, const char* key, bool must_already_exist) : priv(new hash_assignment_priv(*h.priv, key, must_already_exist)) {
@@ -1217,12 +1245,13 @@ void HashAssignmentHelper::assign(AbstractQoreNode* v, ExceptionSink* xsink) {
 
 AbstractQoreNode* HashAssignmentHelper::swap(AbstractQoreNode* v, ExceptionSink* xsink) {
    assert(priv);
-   return priv->swap(v);
+   return priv->swap(v).takeNode();
 }
 
 AbstractQoreNode* HashAssignmentHelper::operator*() const {
-   assert(priv);
-   return **priv;
+    assert(priv);
+    qore_hash_private::convertToNode(priv->om->val);
+    return (**priv).getInternalNode();
 }
 
 void QoreParseHashNode::doDuplicateWarning(const QoreProgramLocation& newloc, const char* key) {

--- a/lib/QoreHashNode.cpp
+++ b/lib/QoreHashNode.cpp
@@ -383,10 +383,6 @@ AbstractQoreNode** QoreHashNode::getKeyValuePtr(const char* key) {
    return priv->getKeyValuePtr(key);
 }
 
-QoreValue& QoreHashNode::getValueRef(const char* key) {
-    return priv->getValueRef(key);
-}
-
 // deprecated
 int64 QoreHashNode::getKeyAsBigInt(const char* key, bool &found) const {
    return priv->getKeyAsBigInt(key, found);

--- a/lib/QoreLib.cpp
+++ b/lib/QoreLib.cpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -138,7 +138,8 @@ char table64[64] = {
    'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
    'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
    'w', 'x', 'y', 'z', '0', '1', '2', '3',
-   '4', '5', '6', '7', '8', '9', '+', '/' };
+   '4', '5', '6', '7', '8', '9', '+', '/',
+};
 
 const qore_option_s qore_option_list_l[] = {
    { QORE_OPT_ATOMIC_OPERATIONS,
@@ -427,29 +428,29 @@ const qore_option_s* qore_option_list = qore_option_list_l;
 size_t qore_option_list_size = QORE_OPTION_LIST_SIZE;
 
 bool q_get_option_value(const char* opt) {
-   for (unsigned i = 0; i < QORE_OPTION_LIST_SIZE; ++i) {
-      if (!strcasecmp(opt, qore_option_list_l[i].option))
-         return qore_option_list_l[i].value;
-   }
-   return false;
+    for (unsigned i = 0; i < QORE_OPTION_LIST_SIZE; ++i) {
+        if (!strcasecmp(opt, qore_option_list_l[i].option))
+            return qore_option_list_l[i].value;
+    }
+    return false;
 }
 
 bool q_get_option_constant_value(const char* opt) {
-   for (unsigned i = 0; i < QORE_OPTION_LIST_SIZE; ++i) {
-      if (!strcasecmp(opt, qore_option_list_l[i].constant))
-         return qore_option_list_l[i].value;
-   }
-   return false;
+    for (unsigned i = 0; i < QORE_OPTION_LIST_SIZE; ++i) {
+        if (!strcasecmp(opt, qore_option_list_l[i].constant))
+            return qore_option_list_l[i].value;
+    }
+    return false;
 }
 
-static inline int get_number(char** param) {
-   int num = 0;
-   while (isdigit(**param)) {
-      num = num*10 + (**param - '0');
-      ++(*param);
-   }
-   //printd(0, "get_number(%x: %s) num: %d\n", *param, *param, num);
-   return num;
+static int get_number(char** param) {
+    int num = 0;
+    while (isdigit(**param)) {
+        num = num*10 + (**param - '0');
+        ++(*param);
+    }
+    //printd(0, "get_number(%x: %s) num: %d\n", *param, *param, num);
+    return num;
 }
 
 // print options
@@ -464,6 +465,19 @@ bool qore_has_debug() {
 #else
    return false;
 #endif
+}
+
+void parse_init_value(QoreValue& val, LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo) {
+    if (val.hasNode()) {
+        AbstractQoreNode* n = val.getInternalNode();
+        AbstractQoreNode* nn = n->parseInit(oflag, pflag, lvids, typeInfo);
+        if (nn != n) {
+            val = nn;
+        }
+        return;
+    }
+
+    typeInfo = val.getTypeInfo();
 }
 
 QoreAbstractIteratorBase::QoreAbstractIteratorBase() : tid(gettid()) {

--- a/lib/QoreLib.cpp
+++ b/lib/QoreLib.cpp
@@ -470,7 +470,9 @@ bool qore_has_debug() {
 void parse_init_value(QoreValue& val, LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo) {
     if (val.hasNode()) {
         AbstractQoreNode* n = val.getInternalNode();
+        printd(0, "parse_init_value() n: %p '%s'\n", n, get_type_name(n));
         AbstractQoreNode* nn = n->parseInit(oflag, pflag, lvids, typeInfo);
+        printd(0, "parse_init_value() n: %p nn: %p '%s'\n", n, nn, get_type_name(nn));
         if (nn != n) {
             val = nn;
         }

--- a/lib/QoreLib.cpp
+++ b/lib/QoreLib.cpp
@@ -470,9 +470,9 @@ bool qore_has_debug() {
 void parse_init_value(QoreValue& val, LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo) {
     if (val.hasNode()) {
         AbstractQoreNode* n = val.getInternalNode();
-        printd(0, "parse_init_value() n: %p '%s'\n", n, get_type_name(n));
+        //printd(5, "parse_init_value() n: %p '%s'\n", n, get_type_name(n));
         AbstractQoreNode* nn = n->parseInit(oflag, pflag, lvids, typeInfo);
-        printd(0, "parse_init_value() n: %p nn: %p '%s'\n", n, nn, get_type_name(nn));
+        //printd(5, "parse_init_value() n: %p nn: %p '%s'\n", n, nn, get_type_name(nn));
         if (nn != n) {
             val = nn;
         }

--- a/lib/QoreNamespace.cpp
+++ b/lib/QoreNamespace.cpp
@@ -2288,7 +2288,8 @@ void qore_ns_private::scanMergeCommittedNamespace(const qore_ns_private& mns, Qo
 
          const QoreClass* c = classList.find(cli.getName());
          if (c) {
-            if (!qore_class_private::injected(*c))
+             if (qore_class_private::get(*c) != qore_class_private::get(*cli.get()) &&
+                !qore_class_private::injected(*c))
                qmc.error("duplicate class %s::%s", name.c_str(), cli.getName());
          }
          else if (pendClassList.find(cli.getName()))

--- a/lib/QoreNamespace.cpp
+++ b/lib/QoreNamespace.cpp
@@ -2511,7 +2511,7 @@ AbstractQoreNode* qore_ns_private::getConstantValue(const char* cname, const Qor
    if (rv)
       return rv;
 
-   return pendConstant.parseFind(cname, typeInfo);
+   return pendConstant.find(cname, typeInfo);
 }
 
 QoreNamespace* qore_ns_private::resolveNameScope(const QoreProgramLocation& loc, const NamedScope& nscope) const {
@@ -2853,7 +2853,7 @@ AbstractQoreNode* qore_ns_private::parseCheckScopedReference(const QoreProgramLo
 
 AbstractQoreNode* qore_ns_private::parseFindLocalConstantValue(const char* cname, const QoreTypeInfo*& typeInfo) {
    AbstractQoreNode* rv = constant.find(cname, typeInfo);
-   return rv ? rv : pendConstant.parseFind(cname, typeInfo);
+   return rv ? rv : pendConstant.find(cname, typeInfo);
 }
 
 QoreNamespace* qore_ns_private::parseFindLocalNamespace(const char* nname) {

--- a/lib/QoreNamespace.cpp
+++ b/lib/QoreNamespace.cpp
@@ -2300,7 +2300,12 @@ void qore_ns_private::scanMergeCommittedNamespace(const qore_ns_private& mns, Qo
                 // ignore if the class is injected or already imported
                 if (qore_class_private::get(*c) != qore_class_private::get(*cli.get()) &&
                     !qore_class_private::injected(*c))
-                qmc.error("duplicate class %s::%s", name.c_str(), cli.getName());
+                qmc.error("duplicate class %s::%s" , name.c_str(), cli.getName());
+                /*
+                qmc.error("duplicate class %s::%s (c: %p cli: %p c inj: %d cli inj: %d)", name.c_str(), cli.getName(),
+                    qore_class_private::get(*c), qore_class_private::get(*cli.get()),
+                    qore_class_private::injected(*c), qore_class_private::injected(*cli.get()));
+                */
             }
             else if (pendClassList.find(cli.getName()))
                 qmc.error("duplicate pending class %s::%s", name.c_str(), cli.getName());

--- a/lib/QoreNamespace.cpp
+++ b/lib/QoreNamespace.cpp
@@ -299,29 +299,29 @@ void qore_ns_private::setClassHandler(q_ns_class_handler_t n_class_handler) {
 }
 
 void qore_ns_private::runtimeImportSystemClasses(const qore_ns_private& source, qore_root_ns_private& rns, ExceptionSink* xsink) {
-   assert(xsink);
-   if (classList.importSystemClasses(source.classList, this, xsink))
-      rns.runtimeRebuildClassIndexes(this);
+    assert(xsink);
+    if (classList.importSystemClasses(source.classList, this, xsink))
+        rns.runtimeRebuildClassIndexes(this);
 
-   if (*xsink)
-      return;
+    if (*xsink)
+        return;
 
-   // add sub namespaces
-   for (nsmap_t::const_iterator i = source.nsl.nsmap.begin(), e = source.nsl.nsmap.end(); i != e; ++i) {
-      QoreNamespace* nns = nsl.find(i->first);
-      if (!nns) {
-         qore_ns_private* npns = new qore_ns_private(i->first.c_str());
-         nns = npns->ns;
-         nns->priv->pub = i->second->priv->pub;
-         nns->priv->imported = true;
-         nsl.runtimeAdd(nns, this);
-      }
+    // add sub namespaces
+    for (nsmap_t::const_iterator i = source.nsl.nsmap.begin(), e = source.nsl.nsmap.end(); i != e; ++i) {
+        QoreNamespace* nns = nsl.find(i->first);
+        if (!nns) {
+            qore_ns_private* npns = new qore_ns_private(i->first.c_str());
+            nns = npns->ns;
+            nns->priv->pub = i->second->priv->pub;
+            nns->priv->imported = true;
+            nsl.runtimeAdd(nns, this);
+        }
 
-      nns->priv->runtimeImportSystemClasses(*i->second->priv, rns, xsink);
-      //printd(5, "qore_ns_private::runtimeImportSystemClasses() this: %p '%s::' imported %p '%s::'\n", this, name.c_str(), ns, ns->getName());
-      if (*xsink)
-         break;
-   }
+        nns->priv->runtimeImportSystemClasses(*i->second->priv, rns, xsink);
+        //printd(5, "qore_ns_private::runtimeImportSystemClasses() this: %p '%s::' imported %p '%s::'\n", this, name.c_str(), ns, ns->getName());
+        if (*xsink)
+            break;
+    }
 }
 
 void qore_ns_private::runtimeImportSystemHashDecls(const qore_ns_private& source, qore_root_ns_private& rns, ExceptionSink* xsink) {

--- a/lib/QoreNamespace.cpp
+++ b/lib/QoreNamespace.cpp
@@ -1153,7 +1153,6 @@ QoreValue qore_root_ns_private::parseResolveBarewordIntern(const QoreProgramLoca
     }
 
     rv = parseFindOnlyConstantValueIntern(loc, bword, typeInfo, found);
-
     if (found) {
         return rv.refSelf();
     }
@@ -2558,8 +2557,9 @@ QoreClass* qore_ns_private::parseFindLocalClass(const char* cname) {
 QoreValue qore_ns_private::getConstantValue(const char* cname, const QoreTypeInfo*& typeInfo, bool& found) {
     assert(!found);
     QoreValue rv = constant.find(cname, typeInfo, found);
-    if (found)
+    if (found) {
         return rv;
+    }
 
     return pendConstant.find(cname, typeInfo, found);
 }

--- a/lib/QoreObject.cpp
+++ b/lib/QoreObject.cpp
@@ -478,7 +478,7 @@ int qore_object_private::getLValue(const char* key, LValueHelper& lvh, const qor
 
     QoreHashNode* odata = internal_member ? getCreateInternalData(class_ctx) : data;
 
-    printd(0, "qore_object_private::getLValue() this: %p %s::%s type %s for_remove: %d int: %d odata: %p\n", this, theclass->getName(), key, QoreTypeInfo::getName(mti), for_remove, internal_member, odata);
+    //printd(5, "qore_object_private::getLValue() this: %p %s::%s type %s for_remove: %d int: %d odata: %p\n", this, theclass->getName(), key, QoreTypeInfo::getName(mti), for_remove, internal_member, odata);
 
     HashMember* m;
     if (for_remove) {

--- a/lib/QoreObject.cpp
+++ b/lib/QoreObject.cpp
@@ -460,6 +460,12 @@ void qore_object_private::mergeDataToHash(QoreHashNode* hash, ExceptionSink* xsi
    }
 }
 
+QoreValue& qore_object_private::getMemberValueRefForInitialization(const char* member, const qore_class_private* class_ctx) {
+    QoreHashNode* odata = class_ctx ? getCreateInternalData(class_ctx) : data;
+    //printd(5, "qore_object_private::getMemberValueRefForInitialization() this: %p mem: '%s' class_ctx: %p %s odata: %p\n", this, member, class_ctx, class_ctx ? class_ctx->name.c_str() : "n/a", odata);
+    return qore_hash_private::get(*odata)->getValueRef(member);
+}
+
 int qore_object_private::getLValue(const char* key, LValueHelper& lvh, const qore_class_private* class_ctx, bool for_remove, ExceptionSink* xsink) {
     const QoreTypeInfo* mti = nullptr;
     bool internal_member;

--- a/lib/QoreObject.cpp
+++ b/lib/QoreObject.cpp
@@ -288,12 +288,12 @@ QoreHashNode* qore_object_private::getRuntimeMemberHash(ExceptionSink* xsink) co
     // get the current class context for possible internal data
     const qore_class_private* class_ctx = runtime_get_class();
     if (class_ctx && !qore_class_private::runtimeCheckPrivateClassAccess(*theclass, class_ctx))
-        class_ctx = 0;
+        class_ctx = nullptr;
 
     QoreSafeVarRWReadLocker sl(rml);
 
     if (status == OS_DELETED)
-        return 0;
+        return nullptr;
 
     // return all member data if called inside the class
     if (class_ctx) {

--- a/lib/QoreParseHashNode.cpp
+++ b/lib/QoreParseHashNode.cpp
@@ -131,15 +131,16 @@ QoreValue QoreParseHashNode::evalValueImpl(bool& needs_deref, ExceptionSink* xsi
 
         QoreStringValueHelper key(*k);
         AbstractQoreNode* val = v.getReferencedValue();
+        const QoreTypeInfo* vti = getTypeInfoForValue(val);
         h->setKeyValue(key->c_str(), val, xsink);
         if (xsink && *xsink)
             return QoreValue();
 
         if (!i) {
-            vtype = getTypeInfoForValue(val);
+            vtype = vti;
             vcommon = true;
         }
-        else if (vcommon && !QoreTypeInfo::matchCommonType(vtype, getTypeInfoForValue(val)))
+        else if (vcommon && !QoreTypeInfo::matchCommonType(vtype, vti))
             vcommon = false;
     }
 

--- a/lib/QoreParseHashNode.cpp
+++ b/lib/QoreParseHashNode.cpp
@@ -103,7 +103,7 @@ AbstractQoreNode* QoreParseHashNode::parseInitImpl(LocalVar* oflag, int pflag, i
     qore_hash_private* ph = qore_hash_private::get(**h);
     for (size_t i = 0; i < keys.size(); ++i) {
         QoreStringValueHelper key(keys[i]);
-        discard(ph->swapKeyValue(key->c_str(), values[i], nullptr), nullptr);
+        ph->swapKeyValue(key->c_str(), values[i], nullptr).discard(nullptr);
         values[i] = nullptr;
     }
 

--- a/lib/QorePreIncrementOperatorNode.cpp
+++ b/lib/QorePreIncrementOperatorNode.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -33,29 +33,29 @@
 QoreString QorePreIncrementOperatorNode::op_str("++ (pre-increment) operator expression");
 
 AbstractQoreNode *QorePreIncrementOperatorNode::parseInitImpl(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& outTypeInfo) {
-   parseInitIntern(op_str.getBuffer(), oflag, pflag, lvids, outTypeInfo);
+    parseInitIntern(op_str.getBuffer(), oflag, pflag, lvids, outTypeInfo);
 
-   // version for local var
-   return (typeInfo == bigIntTypeInfo || typeInfo == softBigIntTypeInfo) ? makeSpecialization<QoreIntPreIncrementOperatorNode>() : this;
+    // version for local var
+    return (typeInfo == bigIntTypeInfo || typeInfo == softBigIntTypeInfo) ? makeSpecialization<QoreIntPreIncrementOperatorNode>() : this;
 }
 
 QoreValue QorePreIncrementOperatorNode::evalValueImpl(bool& needs_deref, ExceptionSink* xsink) const {
-   // get ptr to current value (lvalue is locked for the scope of the LValueHelper object)
-   LValueHelper n(exp, xsink);
-   if (!n)
-      return QoreValue();
+    // get ptr to current value (lvalue is locked for the scope of the LValueHelper object)
+    LValueHelper n(exp, xsink);
+    if (!n)
+        return QoreValue();
 
-   if (n.getType() == NT_NUMBER) {
-      n.preIncrementNumber("<++ (pre) operator>");
-      assert(!*xsink);
-      return !ref_rv ? QoreValue() : n.getReferencedValue();
-   }
+    if (n.getType() == NT_NUMBER) {
+        n.preIncrementNumber("<++ (pre) operator>");
+        assert(!*xsink);
+        return !ref_rv ? QoreValue() : n.getReferencedValue();
+    }
 
-   if (n.getType() == NT_FLOAT) {
-      double f = n.preIncrementFloat("<++ (pre) operator>");
-      assert(!*xsink);
-      return f;
-   }
+    if (n.getType() == NT_FLOAT) {
+        double f = n.preIncrementFloat("<++ (pre) operator>");
+        assert(!*xsink);
+        return f;
+    }
 
-   return n.preIncrementBigInt("<++ (pre) operator>");
+    return n.preIncrementBigInt("<++ (pre) operator>");
 }

--- a/lib/QoreProgram.cpp
+++ b/lib/QoreProgram.cpp
@@ -1482,34 +1482,35 @@ AbstractQoreNode* QoreProgram::runTopLevel(ExceptionSink* xsink) {
 }
 
 AbstractQoreNode* QoreProgram::callFunction(const char* name, const QoreListNode* args, ExceptionSink* xsink) {
-   SimpleRefHolder<FunctionCallNode> fc;
+    SimpleRefHolder<FunctionCallNode> fc;
 
-   printd(5, "QoreProgram::callFunction() creating function call to %s()\n", name);
+    printd(5, "QoreProgram::callFunction() creating function call to %s()\n", name);
 
-   const qore_ns_private* ns = 0;
-   const QoreFunction* qf;
+    //const qore_ns_private* ns = nullptr;
+    //const QoreFunction* qf;
+    const FunctionEntry* fe;
 
-   // need to grab parse lock for safe access to the user function map and imported function map
-   {
-      ProgramRuntimeParseAccessHelper pah(xsink, this);
-      if (*xsink)
-         return 0;
-      qf = qore_root_ns_private::runtimeFindFunction(*priv->RootNS, name, ns);
-   }
+    // need to grab parse lock for safe access to the user function map and imported function map
+    {
+        ProgramRuntimeParseAccessHelper pah(xsink, this);
+        if (*xsink)
+            return nullptr;
+        fe = qore_root_ns_private::runtimeFindFunctionEntry(*priv->RootNS, name);
+    }
 
-   if (!qf) {
-      xsink->raiseException("NO-FUNCTION", "function name '%s' does not exist", name);
-      return 0;
-   }
+    if (!fe) {
+        xsink->raiseException("NO-FUNCTION", "function name '%s' does not exist", name);
+        return nullptr;
+    }
 
-   // we assign the args to 0 below so that they will not be deleted
-   fc = new FunctionCallNode(get_runtime_location(), qf, const_cast<QoreListNode*>(args), this);
-   AbstractQoreNode* rv = !*xsink ? fc->eval(xsink) : 0;
+    // we assign the args to 0 below so that they will not be deleted
+    fc = new FunctionCallNode(get_runtime_location(), fe, const_cast<QoreListNode*>(args), this);
+    AbstractQoreNode* rv = !*xsink ? fc->eval(xsink) : nullptr;
 
-   // let caller delete function arguments if necessary
-   fc->takeArgs();
+    // let caller delete function arguments if necessary
+    fc->takeArgs();
 
-   return rv;
+    return rv;
 }
 
 void QoreProgram::parseCommit(ExceptionSink* xsink, ExceptionSink* wS, int wm) {

--- a/lib/QoreProgram.cpp
+++ b/lib/QoreProgram.cpp
@@ -255,66 +255,66 @@ bool qore_program_private::setThreadInit(const ResolvedCallReferenceNode* n_thr_
 }
 
 void qore_program_private_base::newProgram() {
-   base_object = true;
-   po_locked = false;
-   exec_class = false;
+    base_object = true;
+    po_locked = false;
+    exec_class = false;
 
-   // init thread local storage key
-   thread_local_storage = new qpgm_thread_local_storage_t;
+    // init thread local storage key
+    thread_local_storage = new qpgm_thread_local_storage_t;
 
-   // save thread local storage hash
-   assert(!thread_local_storage->get());
-   thread_local_storage->set(new QoreHashNode);
+    // save thread local storage hash
+    assert(!thread_local_storage->get());
+    thread_local_storage->set(new QoreHashNode);
 
-   //printd(5, "qore_program_private_base::newProgram() this: %p\n", this);
+    //printd(5, "qore_program_private_base::newProgram() this: %p\n", this);
 
-   // copy global feature list to local list
-   for (FeatureList::iterator i = qoreFeatureList.begin(), e = qoreFeatureList.end(); i != e; ++i)
-      featureList.push_back((*i).c_str());
+    // copy global feature list to local list
+    for (FeatureList::iterator i = qoreFeatureList.begin(), e = qoreFeatureList.end(); i != e; ++i)
+        featureList.push_back((*i).c_str());
 
-   QoreProgramContextHelper pch(pgm);
+    QoreProgramContextHelper pch(pgm);
 
-   // setup namespaces
-   RootNS = qore_root_ns_private::copy(*staticSystemNamespace, pwo.parse_options);
-   QoreNS = RootNS->rootGetQoreNamespace();
-   assert(QoreNS);
+    // setup namespaces
+    RootNS = qore_root_ns_private::copy(*staticSystemNamespace, pwo.parse_options);
+    QoreNS = RootNS->rootGetQoreNamespace();
+    assert(QoreNS);
 
-   // setup initial defines
-   // add platform defines
-   dmap["QoreVersionString"] = new QoreStringNode(qore_version_string);
-   dmap["QoreVersionMajor"] = new QoreBigIntNode(qore_version_major);
-   dmap["QoreVersionMinor"] = new QoreBigIntNode(qore_version_minor);
-   dmap["QoreVersionSub"] = new QoreBigIntNode(qore_version_sub);
-   dmap["QoreVersionBuild"] = new QoreBigIntNode(qore_build_number);
-   dmap["QoreVersionBits"] = new QoreBigIntNode(qore_target_bits);
-   dmap["QorePlatformCPU"] = new QoreStringNode(TARGET_ARCH);
-   dmap["QorePlatformOS"] = new QoreStringNode(TARGET_OS);
+    // setup initial defines
+    // add platform defines
+    dmap["QoreVersionString"] = new QoreStringNode(qore_version_string);
+    dmap["QoreVersionMajor"] = new QoreBigIntNode(qore_version_major);
+    dmap["QoreVersionMinor"] = new QoreBigIntNode(qore_version_minor);
+    dmap["QoreVersionSub"] = new QoreBigIntNode(qore_version_sub);
+    dmap["QoreVersionBuild"] = new QoreBigIntNode(qore_build_number);
+    dmap["QoreVersionBits"] = new QoreBigIntNode(qore_target_bits);
+    dmap["QorePlatformCPU"] = new QoreStringNode(TARGET_ARCH);
+    dmap["QorePlatformOS"] = new QoreStringNode(TARGET_OS);
 
 #ifdef _Q_WINDOWS
-   dmap["Windows"] = &True;
+    dmap["Windows"] = &True;
 #else
-   dmap["Unix"] = &True;
+    dmap["Unix"] = &True;
 #endif
 
-   if (pwo.parse_options & PO_IN_MODULE)
-      dmap["QoreHasUserModuleLicense"] = &True;
+    if (pwo.parse_options & PO_IN_MODULE)
+        dmap["QoreHasUserModuleLicense"] = &True;
 
-   QoreNamespace* ns = QoreNS->findLocalNamespace("Option");
-   assert(ns);
-   ConstantListIterator cli(qore_ns_private::getConstantList(ns));
-   while (cli.next()) {
-      AbstractQoreNode* v = cli.getValue();
-      assert(v);
-      // skip boolean options defined as False
-      if (v->getType() == NT_BOOLEAN && !reinterpret_cast<QoreBoolNode*>(v)->getValue())
-         continue;
+    QoreNamespace* ns = QoreNS->findLocalNamespace("Option");
+    assert(ns);
+    ConstantListIterator cli(qore_ns_private::getConstantList(ns));
+    while (cli.next()) {
+        QoreValue v = cli.getValue();
+        // skip boolean options defined as False
+        if (v.getType() == NT_BOOLEAN && !v.getAsBool()) {
+            continue;
+        }
 
-      dmap[cli.getName()] = v->refSelf();
-   }
+        dmap[cli.getName()] = v.getReferencedValue();
+    }
 
 #ifdef DEBUG
-   // if Qore library debugging is enabled, then set an option
-   dmap["QoreDebug"] = &True;
+    // if Qore library debugging is enabled, then set an option
+    dmap["QoreDebug"] = &True;
 #endif
 }
 

--- a/lib/QoreProgram.cpp
+++ b/lib/QoreProgram.cpp
@@ -660,8 +660,16 @@ void qore_program_private::importClass(ExceptionSink* xsink, qore_program_privat
             if (oc) {
                 // get injected target class pointer for new injected class
                 injectedClass = qore_class_private::get(*oc);
-                // mark source class as compatible with the injected target class as well
-                const_cast<qore_class_private*>(qore_class_private::get(*c))->injectedClass = injectedClass;
+                // can only inject for a single class
+                qore_class_private* wc = const_cast<qore_class_private*>(qore_class_private::get(*c));
+                if (wc->injectedClass != injectedClass) {
+                    if (wc->injectedClass) {
+                        xsink->raiseException("CLASS-IMPORT-ERROR", "class \"%s\" has already been injected to impersonate class '%s' and therefore cannot be injected to impersonate class '%s'; only a single class can be impersonated by any one source class", c->getName(), wc->injectedClass->name.c_str(), injectedClass->name.c_str());
+                        return;
+                    }
+                    // mark source class as compatible with the injected target class as well
+                    wc->injectedClass = injectedClass;
+                }
             }
             //printd(5, "qore_program_private::importClass() this: %p path: '%s' new_name: '%s' oc: %p\n", this, path, new_name ? new_name : "n/a", oc);
         }

--- a/lib/QorePseudoMethods.cpp
+++ b/lib/QorePseudoMethods.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/lib/QoreRegex.cpp
+++ b/lib/QoreRegex.cpp
@@ -2,7 +2,7 @@
 /*
   QoreRegex.cpp
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -123,7 +123,7 @@ bool QoreRegex::exec(const char* str, size_t len) const {
       rc = pcre_exec(p, 0, str, len, 0, 0, ovector, vsize);
       if (!rc) {
          // rc == 0 means not enough space was available in ovector
-         printd(0, "QoreRegex::exec() ovector too small: vsize: %d -> %d (max: %d)\n", vsize, vsize << 1, OVECMAX);
+         printd(5, "QoreRegex::exec() ovector too small: vsize: %d -> %d (max: %d)\n", vsize, vsize << 1, OVECMAX);
          vsize <<= 1;
          if (vsize >= OVECMAX) {
             rc = -1;

--- a/lib/QoreTrimOperatorNode.cpp
+++ b/lib/QoreTrimOperatorNode.cpp
@@ -30,6 +30,7 @@
 
 #include <qore/Qore.h>
 #include "qore/intern/qore_program_private.h"
+#include "qore/intern/QoreHashNodeIntern.h"
 
 QoreString QoreTrimOperatorNode::trim_str("trim operator expression");
 

--- a/lib/QoreTrimOperatorNode.cpp
+++ b/lib/QoreTrimOperatorNode.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -45,78 +45,82 @@ int QoreTrimOperatorNode::getAsString(QoreString& str, int foff, ExceptionSink* 
 }
 
 QoreValue QoreTrimOperatorNode::evalValueImpl(bool& needs_deref, ExceptionSink* xsink) const {
-   // get ptr to current value (lvalue is locked for the scope of the LValueHelper object)
-   LValueHelper val(exp, xsink);
-   if (!val)
-      return QoreValue();
+    // get ptr to current value (lvalue is locked for the scope of the LValueHelper object)
+    LValueHelper val(exp, xsink);
+    if (!val)
+        return QoreValue();
 
-   qore_type_t vtype = val.getType();
-   if (vtype != NT_LIST && vtype != NT_STRING && vtype != NT_HASH)
-      return QoreValue();
+    qore_type_t vtype = val.getType();
+    if (vtype != NT_LIST && vtype != NT_STRING && vtype != NT_HASH)
+        return QoreValue();
 
-   // note that no exception can happen here
-   val.ensureUnique();
-   assert(!*xsink);
+    // note that no exception can happen here
+    val.ensureUnique();
+    assert(!*xsink);
 
-   if (vtype == NT_STRING) {
-      QoreStringNode* vs = reinterpret_cast<QoreStringNode*>(val.getValue());
-      if (vs->trim(xsink))
-         return QoreValue();
-   }
-   else if (vtype == NT_LIST) {
-      QoreListNode* l = reinterpret_cast<QoreListNode*>(val.getValue());
-      ListIterator li(l);
-      while (li.next()) {
-         AbstractQoreNode** v = li.getValuePtr();
-         if (*v && (*v)->getType() == NT_STRING) {
-            // note that no exception can happen here
-            ensure_unique(v, xsink);
-            assert(!*xsink);
-            QoreStringNode* vs = reinterpret_cast<QoreStringNode*>(*v);
-            if (vs->trim(xsink))
-               return QoreValue();
-         }
-      }
-   }
-   else { // is a hash
-      QoreHashNode* vh = reinterpret_cast<QoreHashNode*>(val.getValue());
-      HashIterator hi(vh);
-      while (hi.next()) {
-         AbstractQoreNode** v = hi.getValuePtr();
-         if (*v && (*v)->getType() == NT_STRING) {
-            // note that no exception can happen here
-            assert(!*xsink);
-            ensure_unique(v, xsink);
-            QoreStringNode* vs = reinterpret_cast<QoreStringNode*>(*v);
-            if (vs->trim(xsink))
-               return QoreValue();
-         }
-      }
-   }
+    if (vtype == NT_STRING) {
+        QoreStringNode* vs = reinterpret_cast<QoreStringNode*>(val.getValue());
+        if (vs->trim(xsink))
+            return QoreValue();
+    }
+    else if (vtype == NT_LIST) {
+        QoreListNode* l = reinterpret_cast<QoreListNode*>(val.getValue());
+        ListIterator li(l);
+        while (li.next()) {
+            AbstractQoreNode** v = li.getValuePtr();
+            if (*v && (*v)->getType() == NT_STRING) {
+                // note that no exception can happen here
+                ensure_unique(v, xsink);
+                assert(!*xsink);
+                QoreStringNode* vs = reinterpret_cast<QoreStringNode*>(*v);
+                if (vs->trim(xsink))
+                return QoreValue();
+            }
+        }
+    }
+    else { // is a hash
+        QoreHashNode* vh = reinterpret_cast<QoreHashNode*>(val.getValue());
+        HashIterator hi(vh);
+        while (hi.next()) {
+            if (hi.get().getType() == NT_STRING) {
+                QoreValue& v = (*qhi_priv::get(hi)->i)->val;
+                QoreStringNode* vs = v.get<QoreStringNode>();
+                if (!vs->is_unique()) {
+                    QoreStringNode* old = vs;
+                    vs = vs->copy();
+                    old->deref();
+                    v = vs;
+                }
+                if (vs->trim(xsink)) {
+                    return QoreValue();
+                }
+            }
+        }
+    }
 
-   // reference for return value
-   if (!ref_rv)
-      return QoreValue();
-   return val.getReferencedValue();
+    // reference for return value
+    if (!ref_rv)
+        return QoreValue();
+    return val.getReferencedValue();
 }
 
 AbstractQoreNode* QoreTrimOperatorNode::parseInitImpl(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& typeInfo) {
-   assert(!typeInfo);
-   if (!exp)
-      return this;
-   exp = exp->parseInit(oflag, pflag, lvids, typeInfo);
-   if (exp)
-      checkLValue(exp, pflag);
+    assert(!typeInfo);
+    if (!exp)
+        return this;
+    exp = exp->parseInit(oflag, pflag, lvids, typeInfo);
+    if (exp)
+        checkLValue(exp, pflag);
 
-   if (QoreTypeInfo::hasType(typeInfo)
-       && !QoreTypeInfo::parseAcceptsReturns(typeInfo, NT_STRING)
-       && !QoreTypeInfo::parseAcceptsReturns(typeInfo, NT_LIST)
-       && !QoreTypeInfo::parseAcceptsReturns(typeInfo, NT_HASH)) {
-      QoreStringNode* desc = new QoreStringNode("the lvalue expression with the trim operator is ");
-      QoreTypeInfo::getThisType(typeInfo, *desc);
-      desc->sprintf(", therefore this operation will have no effect on the lvalue and will always return NOTHING; this operator only works on strings, lists, and hashes");
-      qore_program_private::makeParseWarning(getProgram(), loc, QP_WARN_INVALID_OPERATION, "INVALID-OPERATION", desc);
-   }
-   returnTypeInfo = typeInfo;
-   return this;
+    if (QoreTypeInfo::hasType(typeInfo)
+        && !QoreTypeInfo::parseAcceptsReturns(typeInfo, NT_STRING)
+        && !QoreTypeInfo::parseAcceptsReturns(typeInfo, NT_LIST)
+        && !QoreTypeInfo::parseAcceptsReturns(typeInfo, NT_HASH)) {
+        QoreStringNode* desc = new QoreStringNode("the lvalue expression with the trim operator is ");
+        QoreTypeInfo::getThisType(typeInfo, *desc);
+        desc->sprintf(", therefore this operation will have no effect on the lvalue and will always return NOTHING; this operator only works on strings, lists, and hashes");
+        qore_program_private::makeParseWarning(getProgram(), loc, QP_WARN_INVALID_OPERATION, "INVALID-OPERATION", desc);
+    }
+    returnTypeInfo = typeInfo;
+    return this;
 }

--- a/lib/QoreTypeInfo.cpp
+++ b/lib/QoreTypeInfo.cpp
@@ -752,9 +752,9 @@ bool QoreTypeSpec::acceptInput(ExceptionSink* xsink, const QoreTypeInfo& typeInf
             HashIterator i(h);
             while (i.next()) {
                hash_assignment_priv ha(*qore_hash_private::get(*h), *qhi_priv::get(i)->i);
-               QoreValue hn(ha.swap(nullptr));
+               QoreValue hn(ha.swap(QoreValue()));
                u.ti->acceptInputIntern(xsink, obj, param_num, param_name, hn);
-               ha.swap(hn.takeNode());
+               ha.swap(hn);
                if (*xsink)
                   return true;
             }

--- a/lib/QoreValue.cpp
+++ b/lib/QoreValue.cpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/lib/QoreValue.cpp
+++ b/lib/QoreValue.cpp
@@ -373,7 +373,7 @@ qore_type_t QoreValue::getType() const {
       case QV_Bool: return NT_BOOLEAN;
       case QV_Int: return NT_INT;
       case QV_Float: return NT_FLOAT;
-      case QV_Node: return v.n ? v.n->getType() : 0;
+      case QV_Node: return v.n ? v.n->getType() : NT_NOTHING;
       default: assert(false);
          // no break
    }
@@ -408,7 +408,7 @@ const char* QoreValue::getFullTypeName() const {
 AbstractQoreNode* QoreValue::takeNodeIntern() {
    assert(type == QV_Node);
    AbstractQoreNode* rv = v.n;
-   v.n = 0;
+   v.n = nullptr;
    return rv;
 }
 

--- a/lib/QoreValue.cpp
+++ b/lib/QoreValue.cpp
@@ -32,312 +32,350 @@
 #include <qore/Qore.h>
 #include "qore/intern/ParseNode.h"
 
+AbstractQoreNode* QoreSimpleValue::takeNode() {
+    switch (type) {
+        case QV_Int: return new QoreBigIntNode(v.i);
+        case QV_Float: return new QoreFloatNode(v.f);
+        case QV_Bool: return get_bool_node(v.b);
+        case QV_Node:
+            break;
+        default:
+            assert(false);
+    }
+    return v.n;
+}
+
 QoreValue::QoreValue() : type(QV_Node) {
-   v.n = 0;
+    v.n = nullptr;
 }
 
 QoreValue::QoreValue(bool b) : type(QV_Bool) {
-   v.b = b;
+    v.b = b;
 }
 
 QoreValue::QoreValue(int64 i) : type(QV_Int) {
-   v.i = i;
+    v.i = i;
 }
 
 QoreValue::QoreValue(unsigned long long i) : type(QV_Int) {
-   v.i = (long long)i;
+    v.i = (long long)i;
 }
 
 QoreValue::QoreValue(int i) : type(QV_Int) {
-   v.i = i;
+    v.i = i;
 }
 
 QoreValue::QoreValue(unsigned int i) : type(QV_Int) {
-   v.i = i;
+    v.i = i;
 }
 
 QoreValue::QoreValue(long i) : type(QV_Int) {
-   v.i = i;
+    v.i = i;
 }
 
 QoreValue::QoreValue(unsigned long i) : type(QV_Int) {
-   v.i = i;
+    v.i = i;
 }
 
 QoreValue::QoreValue(double f) : type(QV_Float) {
-   v.f = f;
+    v.f = f;
 }
 
 QoreValue::QoreValue(AbstractQoreNode* n) : type(QV_Node) {
-   v.n = n && n->getType() == NT_NOTHING ? 0 : n;
+    v.n = n && n->getType() == NT_NOTHING ? nullptr : n;
 }
 
 QoreValue::QoreValue(const AbstractQoreNode* n) {
-   switch (get_node_type(n)) {
-      case NT_NOTHING:
-         type = QV_Node;
-         v.n = 0;
-         return;
-      case NT_INT:
-         type = QV_Int;
-         v.i = reinterpret_cast<const QoreBigIntNode*>(n)->val;
-         return;
-      case NT_FLOAT:
-         type = QV_Float;
-         v.f = reinterpret_cast<const QoreFloatNode*>(n)->f;
-         return;
-      case NT_BOOLEAN:
-         type = QV_Bool;
-         v.b = reinterpret_cast<const QoreBoolNode*>(n)->getValue();
-         return;
-   }
-   type = QV_Node;
-   v.n = const_cast<AbstractQoreNode*>(n);
+    switch (get_node_type(n)) {
+        case NT_NOTHING:
+            type = QV_Node;
+            v.n = 0;
+            return;
+        case NT_INT:
+            type = QV_Int;
+            v.i = reinterpret_cast<const QoreBigIntNode*>(n)->val;
+            return;
+        case NT_FLOAT:
+            type = QV_Float;
+            v.f = reinterpret_cast<const QoreFloatNode*>(n)->f;
+            return;
+        case NT_BOOLEAN:
+            type = QV_Bool;
+            v.b = reinterpret_cast<const QoreBoolNode*>(n)->getValue();
+            return;
+    }
+    type = QV_Node;
+    v.n = const_cast<AbstractQoreNode*>(n);
+}
+
+QoreValue::QoreValue(const QoreSimpleValue n): type(n.type) {
+    switch (type) {
+        case QV_Bool: v.b = n.v.b; break;
+        case QV_Int: v.i = n.v.i; break;
+        case QV_Float: v.f = n.v.f; break;
+        case QV_Node: v.n = n.v.n; break;
+        default:
+            assert(false);
+            // no break
+    }
 }
 
 QoreValue::QoreValue(const QoreValue& old): type(old.type) {
-   switch (type) {
-      case QV_Bool: v.b = old.v.b; break;
-      case QV_Int: v.i = old.v.i; break;
-      case QV_Float: v.f = old.v.f; break;
-      case QV_Node: v.n = old.v.n; break;
-      default:
-         assert(false);
-         // no break
-   }
+    switch (type) {
+        case QV_Bool: v.b = old.v.b; break;
+        case QV_Int: v.i = old.v.i; break;
+        case QV_Float: v.f = old.v.f; break;
+        case QV_Node: v.n = old.v.n; break;
+        default:
+            assert(false);
+            // no break
+    }
 }
 
 void QoreValue::swap(QoreValue& val) {
-   QoreValue v1(*this);
-   *this = val;
-   val = v1;
+    QoreValue v1(*this);
+    *this = val;
+    val = v1;
 }
 
 QoreValue& QoreValue::operator=(const QoreValue& n) {
-   type = n.type;
-   switch (type) {
-      case QV_Bool: v.b = n.v.b; break;
-      case QV_Int: v.i = n.v.i; break;
-      case QV_Float: v.f = n.v.f; break;
-      case QV_Node: v.n = n.v.n; break;
-      default: assert(false);
-         // no break
-   }
-   return *this;
+    type = n.type;
+    switch (type) {
+        case QV_Bool: v.b = n.v.b; break;
+        case QV_Int: v.i = n.v.i; break;
+        case QV_Float: v.f = n.v.f; break;
+        case QV_Node: v.n = n.v.n; break;
+        default: assert(false);
+            // no break
+    }
+    return *this;
+}
+
+QoreValue& QoreValue::operator=(const QoreSimpleValue& n) {
+    type = n.type;
+    switch (type) {
+        case QV_Bool: v.b = n.v.b; break;
+        case QV_Int: v.i = n.v.i; break;
+        case QV_Float: v.f = n.v.f; break;
+        case QV_Node: v.n = n.v.n; break;
+        default: assert(false);
+            // no break
+    }
+    return *this;
 }
 
 bool QoreValue::getAsBool() const {
-   switch (type) {
-      case QV_Bool: return v.b;
-      case QV_Int: return (bool)v.i;
-      case QV_Float: return (bool)v.f;
-      case QV_Node: return v.n ? v.n->getAsBool() : false;
-      default: assert(false);
-         // no break
-   }
-   return false;
+    switch (type) {
+        case QV_Bool: return v.b;
+        case QV_Int: return (bool)v.i;
+        case QV_Float: return (bool)v.f;
+        case QV_Node: return v.n ? v.n->getAsBool() : false;
+        default: assert(false);
+            // no break
+    }
+    return false;
 }
 
 int64 QoreValue::getAsBigInt() const {
-   switch (type) {
-      case QV_Bool: return (int64)v.b;
-      case QV_Int: return v.i;
-      case QV_Float: return (int64)v.f;
-      case QV_Node: return v.n ? v.n->getAsBigInt() : 0;
-      default: assert(false);
-         // no break
-   }
-   return 0;
+    switch (type) {
+        case QV_Bool: return (int64)v.b;
+        case QV_Int: return v.i;
+        case QV_Float: return (int64)v.f;
+        case QV_Node: return v.n ? v.n->getAsBigInt() : 0;
+        default: assert(false);
+            // no break
+    }
+    return 0;
 }
 
 double QoreValue::getAsFloat() const {
-   switch (type) {
-      case QV_Bool: return (double)v.b;
-      case QV_Int: return (double)v.i;
-      case QV_Float: return v.f;
-      case QV_Node: return v.n ? v.n->getAsFloat() : 0.0;
-      default: assert(false);
-         // no break
-   }
-   return 0.0;
+    switch (type) {
+        case QV_Bool: return (double)v.b;
+        case QV_Int: return (double)v.i;
+        case QV_Float: return v.f;
+        case QV_Node: return v.n ? v.n->getAsFloat() : 0.0;
+        default: assert(false);
+            // no break
+    }
+    return 0.0;
 }
 
 AbstractQoreNode* QoreValue::getInternalNode() {
-   return type == QV_Node ? v.n : 0;
+    return type == QV_Node ? v.n : nullptr;
 }
 
 void QoreValue::ref() const {
-   if (type == QV_Node && v.n)
-      v.n->ref();
+    if (type == QV_Node && v.n)
+        v.n->ref();
 }
 
 QoreValue QoreValue::refSelf() const {
-   ref();
-   return const_cast<QoreValue&>(*this);
+    ref();
+    return const_cast<QoreValue&>(*this);
 }
 
 const AbstractQoreNode* QoreValue::getInternalNode() const {
-   return type == QV_Node ? v.n : 0;
+    return type == QV_Node ? v.n : nullptr;
 }
 
 AbstractQoreNode* QoreValue::assign(AbstractQoreNode* n) {
-   AbstractQoreNode* rv = takeIfNode();
-   type = QV_Node;
-   v.n = n && n->getType() == NT_NOTHING ? 0 : n;
-   return rv;
+    AbstractQoreNode* rv = takeIfNode();
+    type = QV_Node;
+    v.n = n && n->getType() == NT_NOTHING ? nullptr : n;
+    return rv;
 }
 
 AbstractQoreNode* QoreValue::assignAndSanitize(const QoreValue n) {
-   AbstractQoreNode* rv = takeIfNode();
-   switch (n.getType()) {
-      case NT_NOTHING:
-         type = QV_Node;
-         v.n = 0;
-         break;
-      case NT_INT:
-         type = QV_Int;
-         v.i = n.getAsBigInt();
-         break;
-      case NT_FLOAT:
-         type = QV_Float;
-         v.f = n.getAsFloat();
-         break;
-      case NT_BOOLEAN:
-         type = QV_Bool;
-         v.b = n.getAsBool();
-         break;
-      default:
-         type = QV_Node;
-         v.n = n.v.n;
-         break;
-   }
-   return rv;
+    AbstractQoreNode* rv = takeIfNode();
+    switch (n.getType()) {
+        case NT_NOTHING:
+            type = QV_Node;
+            v.n = nullptr;
+            break;
+        case NT_INT:
+            type = QV_Int;
+            v.i = n.getAsBigInt();
+            break;
+        case NT_FLOAT:
+            type = QV_Float;
+            v.f = n.getAsFloat();
+            break;
+        case NT_BOOLEAN:
+            type = QV_Bool;
+            v.b = n.getAsBool();
+            break;
+        default:
+            type = QV_Node;
+            v.n = n.v.n;
+            break;
+    }
+    return rv;
 }
 
 AbstractQoreNode* QoreValue::assign(int64 n) {
-   AbstractQoreNode* rv = takeIfNode();
-   type = QV_Int;
-   v.i = n;
-   return rv;
+    AbstractQoreNode* rv = takeIfNode();
+    type = QV_Int;
+    v.i = n;
+    return rv;
 }
 
 AbstractQoreNode* QoreValue::assign(double n) {
-   AbstractQoreNode* rv = takeIfNode();
-   type = QV_Float;
-   v.f = n;
-   return rv;
+    AbstractQoreNode* rv = takeIfNode();
+    type = QV_Float;
+    v.f = n;
+    return rv;
 }
 
 AbstractQoreNode* QoreValue::assign(bool n) {
-   AbstractQoreNode* rv = takeIfNode();
-   type = QV_Bool;
-   v.b = n;
-   return rv;
+    AbstractQoreNode* rv = takeIfNode();
+    type = QV_Bool;
+    v.b = n;
+    return rv;
 }
 
 AbstractQoreNode* QoreValue::assignNothing() {
-   AbstractQoreNode* rv = takeIfNode();
-   type = QV_Node;
-   v.n = 0;
-   return rv;
+    AbstractQoreNode* rv = takeIfNode();
+    type = QV_Node;
+    v.n = nullptr;
+    return rv;
 }
 
 bool QoreValue::isEqualSoft(const QoreValue v, ExceptionSink* xsink) const {
-   return QoreLogicalEqualsOperatorNode::softEqual(*this, v, xsink);
+    return QoreLogicalEqualsOperatorNode::softEqual(*this, v, xsink);
 }
 
 bool QoreValue::isEqualHard(const QoreValue n) const {
-   qore_type_t t = getType();
-   if (t != n.getType())
-      return false;
-   switch (t) {
-      case NT_INT: return getAsBigInt() == n.getAsBigInt();
-      case NT_BOOLEAN: return getAsBool() == n.getAsBool();
-      case NT_FLOAT: return getAsFloat() == n.getAsFloat();
-      case NT_NOTHING:
-      case NT_NULL:
-         return true;
-   }
-   ExceptionSink xsink;
-   bool rv = !compareHard(v.n, n.v.n, &xsink);
-   xsink.clear();
-   return rv;
+    qore_type_t t = getType();
+    if (t != n.getType())
+        return false;
+    switch (t) {
+        case NT_INT: return getAsBigInt() == n.getAsBigInt();
+        case NT_BOOLEAN: return getAsBool() == n.getAsBool();
+        case NT_FLOAT: return getAsFloat() == n.getAsFloat();
+        case NT_NOTHING:
+        case NT_NULL:
+            return true;
+    }
+    ExceptionSink xsink;
+    bool rv = !compareHard(v.n, n.v.n, &xsink);
+    xsink.clear();
+    return rv;
 }
 
 void QoreValue::sanitize() {
-   if (type != QV_Node || !v.n)
-      return;
-   switch (v.n->getType()) {
-      case NT_NOTHING: v.n = 0; break;
-      case NT_INT: {
-         int64 i = reinterpret_cast<QoreBigIntNode*>(v.n)->val;
-         type = QV_Int;
-         v.n->deref(0);
-         v.i = i;
-         break;
-      }
-      case NT_FLOAT: {
-         double f = reinterpret_cast<QoreFloatNode*>(v.n)->f;
-         type = QV_Float;
-         v.n->deref(0);
-         v.f = f;
-         break;
-      }
-      case NT_BOOLEAN: {
-         bool b = reinterpret_cast<QoreBoolNode*>(v.n)->getValue();
-         type = QV_Bool;
-         v.b = b;
-         break;
-      }
-   }
+    if (type != QV_Node || !v.n)
+        return;
+    switch (v.n->getType()) {
+        case NT_NOTHING: v.n = nullptr; break;
+        case NT_INT: {
+            int64 i = reinterpret_cast<QoreBigIntNode*>(v.n)->val;
+            type = QV_Int;
+            v.n->deref(0);
+            v.i = i;
+            break;
+        }
+        case NT_FLOAT: {
+            double f = reinterpret_cast<QoreFloatNode*>(v.n)->f;
+            type = QV_Float;
+            v.n->deref(0);
+            v.f = f;
+            break;
+        }
+        case NT_BOOLEAN: {
+            bool b = reinterpret_cast<QoreBoolNode*>(v.n)->getValue();
+            type = QV_Bool;
+            v.b = b;
+            break;
+        }
+    }
 }
 
 void QoreValue::discard(ExceptionSink* xsink) {
-   if (type == QV_Node && v.n) {
-      v.n->deref(xsink);
-      v.n = 0;
-   }
+    if (type == QV_Node && v.n) {
+        v.n->deref(xsink);
+        v.n = nullptr;
+    }
 }
 
 void QoreValue::clear() {
-   if (type != QV_Node)
-      type = QV_Node;
-   if (v.n)
-      v.n = 0;
+    if (type != QV_Node)
+        type = QV_Node;
+    if (v.n)
+        v.n = nullptr;
 }
 
 int QoreValue::getAsString(QoreString& str, int format_offset, ExceptionSink *xsink) const {
-   if (isNothing()) {
-      str.concat(format_offset == FMT_YAML_SHORT ? &YamlNullString : &NothingTypeString);
-      return 0;
-   }
-   switch (type) {
-      case QV_Int: str.sprintf(QLLD, v.i); break;
-      case QV_Bool: str.concat(v.b ? &TrueString : &FalseString); break;
-      case QV_Float: str.sprintf("%.9g", v.f); q_fix_decimal(&str); break;
-      case QV_Node: return v.n->getAsString(str, format_offset, xsink);
-      default:
-         assert(false);
-         // no break;
-   }
-   return 0;
+    if (isNothing()) {
+        str.concat(format_offset == FMT_YAML_SHORT ? &YamlNullString : &NothingTypeString);
+        return 0;
+    }
+    switch (type) {
+        case QV_Int: str.sprintf(QLLD, v.i); break;
+        case QV_Bool: str.concat(v.b ? &TrueString : &FalseString); break;
+        case QV_Float: str.sprintf("%.9g", v.f); q_fix_decimal(&str); break;
+        case QV_Node: return v.n->getAsString(str, format_offset, xsink);
+        default:
+            assert(false);
+            // no break;
+    }
+    return 0;
 }
 
 QoreString* QoreValue::getAsString(bool& del, int format_offset, ExceptionSink* xsink) const {
-   if (isNothing()) {
-      del = false;
-      return format_offset == FMT_YAML_SHORT ? &YamlNullString : &NothingTypeString;
-   }
-   switch (type) {
-      case QV_Int: del = true; return new QoreStringMaker(QLLD, v.i);
-      case QV_Bool: del = false; return v.b ? &TrueString : &FalseString;
-      case QV_Float: del = true; return q_fix_decimal(new QoreStringMaker("%.9g", v.f));
-      case QV_Node: return v.n->getAsString(del, format_offset, xsink);
-      default:
-         assert(false);
-         // no break;
-   }
-   return 0;
+    if (isNothing()) {
+        del = false;
+        return format_offset == FMT_YAML_SHORT ? &YamlNullString : &NothingTypeString;
+    }
+    switch (type) {
+        case QV_Int: del = true; return new QoreStringMaker(QLLD, v.i);
+        case QV_Bool: del = false; return v.b ? &TrueString : &FalseString;
+        case QV_Float: del = true; return q_fix_decimal(new QoreStringMaker("%.9g", v.f));
+        case QV_Node: return v.n->getAsString(del, format_offset, xsink);
+        default:
+            assert(false);
+            // no break;
+    }
+    return nullptr;
 }
 
 AbstractQoreNode* QoreValue::getReferencedValue() const {
@@ -349,211 +387,237 @@ AbstractQoreNode* QoreValue::getReferencedValue() const {
       default: assert(false);
          // no break
    }
-   return 0;
+   return nullptr;
 }
 
 AbstractQoreNode* QoreValue::takeNode() {
-   switch (type) {
-      case QV_Bool: return get_bool_node(v.b);
-      case QV_Int: return new QoreBigIntNode(v.i);
-      case QV_Float: return new QoreFloatNode(v.f);
-      case QV_Node: return takeNodeIntern();
-      default: assert(false);
-         // no break
-   }
-   return 0;
+    switch (type) {
+        case QV_Bool: return get_bool_node(v.b);
+        case QV_Int: return new QoreBigIntNode(v.i);
+        case QV_Float: return new QoreFloatNode(v.f);
+        case QV_Node: return takeNodeIntern();
+        default: assert(false);
+            // no break
+    }
+    return nullptr;
 }
 
 AbstractQoreNode* QoreValue::takeIfNode() {
-   return type == QV_Node ? takeNodeIntern() : 0;
+    return type == QV_Node ? takeNodeIntern() : nullptr;
 }
 
 qore_type_t QoreValue::getType() const {
-   switch (type) {
-      case QV_Bool: return NT_BOOLEAN;
-      case QV_Int: return NT_INT;
-      case QV_Float: return NT_FLOAT;
-      case QV_Node: return v.n ? v.n->getType() : NT_NOTHING;
-      default: assert(false);
-         // no break
-   }
-   // to avoid a warning
-   return NT_NOTHING;
+    switch (type) {
+        case QV_Bool: return NT_BOOLEAN;
+        case QV_Int: return NT_INT;
+        case QV_Float: return NT_FLOAT;
+        case QV_Node: return v.n ? v.n->getType() : NT_NOTHING;
+        default: assert(false);
+            // no break
+    }
+    // to avoid a warning
+    return NT_NOTHING;
 }
 
 const char* QoreValue::getTypeName() const {
-   switch (type) {
-      case QV_Bool: return QoreBoolNode::getStaticTypeName();
-      case QV_Int: return QoreBigIntNode::getStaticTypeName();
-      case QV_Float: return QoreFloatNode::getStaticTypeName();
-      case QV_Node: return get_type_name(v.n);
-      default: assert(false);
-         // no break
-   }
-   return nullptr;
+    switch (type) {
+        case QV_Bool: return QoreBoolNode::getStaticTypeName();
+        case QV_Int: return QoreBigIntNode::getStaticTypeName();
+        case QV_Float: return QoreFloatNode::getStaticTypeName();
+        case QV_Node: return get_type_name(v.n);
+        default: assert(false);
+            // no break
+    }
+    return nullptr;
 }
 
 const char* QoreValue::getFullTypeName() const {
-   switch (type) {
-      case QV_Bool: return QoreBoolNode::getStaticTypeName();
-      case QV_Int: return QoreBigIntNode::getStaticTypeName();
-      case QV_Float: return QoreFloatNode::getStaticTypeName();
-      case QV_Node: return get_full_type_name(v.n);
-      default: assert(false);
-         // no break
-   }
-   return nullptr;
+    switch (type) {
+        case QV_Bool: return QoreBoolNode::getStaticTypeName();
+        case QV_Int: return QoreBigIntNode::getStaticTypeName();
+        case QV_Float: return QoreFloatNode::getStaticTypeName();
+        case QV_Node: return get_full_type_name(v.n);
+        default: assert(false);
+            // no break
+    }
+    return nullptr;
 }
 
 AbstractQoreNode* QoreValue::takeNodeIntern() {
-   assert(type == QV_Node);
-   AbstractQoreNode* rv = v.n;
-   v.n = nullptr;
-   return rv;
+    assert(type == QV_Node);
+    AbstractQoreNode* rv = v.n;
+    v.n = nullptr;
+    return rv;
 }
 
 bool QoreValue::hasNode() const {
-   return type == QV_Node && v.n;
+    return type == QV_Node && v.n;
 }
 
 bool QoreValue::isNothing() const {
-   return type == QV_Node && is_nothing(v.n);
+    return type == QV_Node && is_nothing(v.n);
 }
 
 bool QoreValue::isNull() const {
-   return type == QV_Node && is_null(v.n);
+    return type == QV_Node && is_null(v.n);
 }
 
 bool QoreValue::isNullOrNothing() const {
-   return type == QV_Node && (is_nothing(v.n) || is_null(v.n));
+    return type == QV_Node && (is_nothing(v.n) || is_null(v.n));
 }
 
 const QoreTypeInfo* QoreValue::getTypeInfo() const {
-   switch (type) {
-      case QV_Bool: return boolTypeInfo;
-      case QV_Int: return bigIntTypeInfo;
-      case QV_Float: return floatTypeInfo;
-      case QV_Node: return getTypeInfoForValue(v.n);
-      default: assert(false);
-   }
-   return nullptr;
+    switch (type) {
+        case QV_Bool: return boolTypeInfo;
+        case QV_Int: return bigIntTypeInfo;
+        case QV_Float: return floatTypeInfo;
+        case QV_Node: return getTypeInfoForValue(v.n);
+        default: assert(false);
+    }
+    return nullptr;
 }
 
 ValueHolder::~ValueHolder() {
-   discard(v.getInternalNode(), xsink);
+    discard(v.getInternalNode(), xsink);
 }
 
 AbstractQoreNode* ValueHolder::getReferencedValue() {
-   return v.takeNode();
+    return v.takeNode();
 }
 
 QoreValue ValueHolder::release() {
-   //printd(5, "ValueHolder::takeReferencedValue() %s\n", v.getTypeName());
-   if (v.type == QV_Node)
-      return v.takeNodeIntern();
-   return v;
+    //printd(5, "ValueHolder::takeReferencedValue() %s\n", v.getTypeName());
+    if (v.type == QV_Node)
+        return v.takeNodeIntern();
+    return v;
 }
 
 ValueOptionalRefHolder::~ValueOptionalRefHolder() {
-   if (needs_deref)
-      discard(v.getInternalNode(), xsink);
+    if (needs_deref)
+        discard(v.getInternalNode(), xsink);
 }
 
 void ValueOptionalRefHolder::ensureReferencedValue() {
-   if (!needs_deref && v.type == QV_Node && v.v.n) {
-      v.v.n->ref();
-      needs_deref = true;
-   }
+    if (!needs_deref && v.type == QV_Node && v.v.n) {
+        v.v.n->ref();
+        needs_deref = true;
+    }
 }
 
 AbstractQoreNode* ValueOptionalRefHolder::getReferencedValue() {
-   if (v.type == QV_Node) {
-      if (!needs_deref && v.v.n)
-         v.v.n->ref();
-      return v.takeNodeIntern();
-   }
-   return v.takeNode();
+    if (v.type == QV_Node) {
+        if (!needs_deref && v.v.n)
+            v.v.n->ref();
+        return v.takeNodeIntern();
+    }
+    return v.takeNode();
 }
 
 QoreValue ValueOptionalRefHolder::takeReferencedValue() {
-   if (v.type == QV_Node) {
-      if (needs_deref) {
-         needs_deref = false;
-         return v.takeNodeIntern();
-      }
-      if (v.v.n)
-         v.v.n->ref();
-      return v.takeNodeIntern();
-   }
-   return v;
+    if (v.type == QV_Node) {
+        if (needs_deref) {
+            needs_deref = false;
+            return v.takeNodeIntern();
+        }
+        if (v.v.n)
+            v.v.n->ref();
+        return v.takeNodeIntern();
+    }
+    return v;
 }
 
 void ValueOptionalRefHolder::sanitize() {
-   if (v.type != QV_Node || !v.v.n) {
-      if (needs_deref)
-         needs_deref = false;
-      return;
-   }
-   switch (v.v.n->getType()) {
-      case NT_NOTHING: {
-         v.v.n = 0;
-         if (needs_deref)
+    if (v.type != QV_Node || !v.v.n) {
+        if (needs_deref)
             needs_deref = false;
-         break;
-      }
-      case NT_INT: {
-         int64 i = reinterpret_cast<QoreBigIntNode*>(v.v.n)->val;
-         v.type = QV_Int;
-         if (needs_deref) {
-            v.v.n->deref(0);
-            needs_deref = false;
-         }
-         v.v.i = i;
-         break;
-      }
-      case NT_FLOAT: {
-         double f = reinterpret_cast<QoreFloatNode*>(v.v.n)->f;
-         v.type = QV_Float;
-         if (needs_deref) {
-            v.v.n->deref(0);
-            needs_deref = false;
-         }
-         v.v.f = f;
-         break;
-      }
-      case NT_BOOLEAN: {
-         bool b = reinterpret_cast<QoreBoolNode*>(v.v.n)->getValue();
-         v.type = QV_Bool;
-         v.v.b = b;
-         if (needs_deref)
-            needs_deref = false;
-         break;
-      }
-   }
+        return;
+    }
+    switch (v.v.n->getType()) {
+        case NT_NOTHING: {
+            v.v.n = nullptr;
+            if (needs_deref)
+                needs_deref = false;
+            break;
+        }
+        case NT_INT: {
+            int64 i = reinterpret_cast<QoreBigIntNode*>(v.v.n)->val;
+            v.type = QV_Int;
+            if (needs_deref) {
+                v.v.n->deref(0);
+                needs_deref = false;
+            }
+            v.v.i = i;
+            break;
+        }
+        case NT_FLOAT: {
+            double f = reinterpret_cast<QoreFloatNode*>(v.v.n)->f;
+            v.type = QV_Float;
+            if (needs_deref) {
+                v.v.n->deref(0);
+                needs_deref = false;
+            }
+            v.v.f = f;
+            break;
+        }
+        case NT_BOOLEAN: {
+            bool b = reinterpret_cast<QoreBoolNode*>(v.v.n)->getValue();
+            v.type = QV_Bool;
+            v.v.b = b;
+            if (needs_deref)
+                needs_deref = false;
+            break;
+        }
+    }
 }
 
 ValueEvalRefHolder::ValueEvalRefHolder(const AbstractQoreNode* exp, ExceptionSink* xs) : ValueOptionalRefHolder(xs) {
-   evalIntern(exp);
+    evalIntern(exp);
+}
+
+ValueEvalRefHolder::ValueEvalRefHolder(const QoreValue exp, ExceptionSink* xs) : ValueOptionalRefHolder(xs) {
+    evalIntern(exp);
 }
 
 ValueEvalRefHolder::ValueEvalRefHolder(ExceptionSink* xs) : ValueOptionalRefHolder(xs) {
 }
 
-void ValueEvalRefHolder::evalIntern(const AbstractQoreNode* exp) {
-   if (!exp)
-      return;
+int ValueEvalRefHolder::evalIntern(const AbstractQoreNode* exp) {
+    if (!exp)
+        return 0;
 
-   if (exp->hasValueApi()) {
-      const ParseNode* pn = reinterpret_cast<const ParseNode*>(exp);
-      v = pn->evalValue(needs_deref, xsink);
-      return;
-   }
+    if (exp->hasValueApi()) {
+        const ParseNode* pn = reinterpret_cast<const ParseNode*>(exp);
+        v = pn->evalValue(needs_deref, xsink);
+    }
+    else {
+        v = exp->eval(needs_deref, xsink);
+    }
 
-   v = exp->eval(needs_deref, xsink);
+    return xsink && *xsink ? -1 : 0;
+}
+
+int ValueEvalRefHolder::evalIntern(const QoreValue exp) {
+    if (exp.isNothing())
+        return 0;
+
+    if (!exp.hasNode()) {
+        needs_deref = false;
+        v = exp;
+        return 0;
+    }
+
+    if (exp.getInternalNode()->hasValueApi()) {
+        const ParseNode* pn = exp.get<const ParseNode>();
+        v = pn->evalValue(needs_deref, xsink);
+    }
+    else {
+        v = exp.getInternalNode()->eval(needs_deref, xsink);
+    }
+
+    return xsink && *xsink ? -1 : 0;
 }
 
 int ValueEvalRefHolder::eval(const AbstractQoreNode* exp) {
-   v.discard(xsink);
-   evalIntern(exp);
-   return *xsink ? -1 : 0;
+    v.discard(xsink);
+    return evalIntern(exp);
 }

--- a/lib/RSet.cpp
+++ b/lib/RSet.cpp
@@ -305,7 +305,7 @@ bool RSetHelper::checkIntern(AbstractQoreNode* n) {
             QoreHashNode* h = reinterpret_cast<QoreHashNode*>(n);
             HashIterator hi(h);
             while (hi.next()) {
-                assert(hi.getValue() != h);
+                assert(hi.get().getInternalNode() != h);
                 if (hi.get().hasNode() && checkIntern(hi.get().getInternalNode()))
                     return true;
             }

--- a/lib/RSet.cpp
+++ b/lib/RSet.cpp
@@ -252,7 +252,7 @@ public:
       // try to lock
       if (ro->rml.tryRSectionLockNotifyWaitRead(&n_orsh->notifier)) {
          ro = 0;
-	 return;
+         return;
       }
 
       orsh = n_orsh;
@@ -262,13 +262,13 @@ public:
 
    DLLLOCAL ~RSectionScanHelper() {
       if (!orsh)
-	 return;
+         return;
 
       // if no objects were added to the set, then unlock the lock
       if (orsh->size() == size) {
-	 ro->rml.rSectionUnlock();
+         ro->rml.rSectionUnlock();
          orsh->deccnt();
-	 return;
+         return;
       }
 
       // otherwise try to add the lock to the list to be released at the end of the scan
@@ -281,93 +281,93 @@ public:
 };
 
 bool RSetHelper::checkIntern(AbstractQoreNode* n) {
-   if (!needs_scan(n))
-      return false;
+    if (!needs_scan(n))
+        return false;
 
-   //printd(5, "RSetHelper::checkIntern() checking %p %s\n", n, get_type_name(n));
+    //printd(5, "RSetHelper::checkIntern() checking %p %s\n", n, get_type_name(n));
 
-   switch (get_node_type(n)) {
-      case NT_OBJECT:
-         return checkIntern(*qore_object_private::get(*reinterpret_cast<QoreObject*>(n)));
+    switch (get_node_type(n)) {
+        case NT_OBJECT:
+            return checkIntern(*qore_object_private::get(*reinterpret_cast<QoreObject*>(n)));
 
-      case NT_LIST: {
-         QoreListNode* l = reinterpret_cast<QoreListNode*>(n);
-         ListIterator li(l);
-         while (li.next()) {
-            if (checkIntern(li.getValue()))
-               return true;
-         }
-
-         return false;
-      }
-
-      case NT_HASH: {
-         QoreHashNode* h = reinterpret_cast<QoreHashNode*>(n);
-         HashIterator hi(h);
-         while (hi.next()) {
-            assert(hi.getValue() != h);
-            if (checkIntern(hi.getValue()))
-               return true;
-         }
-
-         return false;
-      }
-
-      case NT_RUNTIME_CLOSURE: {
-         QoreClosureBase* c = reinterpret_cast<QoreClosureBase*>(n);
-         // do not lock or scan if the closure cannot contain any closure-bound local vars with objects or closures (also not through a container)
-         if (!c->needsScan()) {
-            printd(QRO_LVL, "RSetHelper::checkIntern() closure %p: no scan\n", c);
-            return false;
-         }
-	 closure_set_t::iterator ci = closure_set.lower_bound(c);
-	 // return false if already scanned
-	 if (ci != closure_set.end() && *ci == c) {
-            printd(QRO_LVL, "RSetHelper::checkIntern() found dup closure %p\n", c);
-	    return false;
-         }
-	 // insert into scanned closure set
-	 closure_set.insert(ci, c);
-
-	 // do not scan any closure object since weak references are used
-         // iterate captured lvars
-         const cvar_map_t& cmap = c->getMap();
-
-         for (cvar_map_t::const_iterator i = cmap.begin(), e = cmap.end(); i != e; ++i) {
-            // do not grab the lock if the lvalue cannot contain an object or closure (also not through a container)
-            if (!i->second->needsScan(true)) {
-               printd(QRO_LVL, "RSetHelper::checkIntern() closure %p: var %s: no scan\n", c, i->first->getName());
-               continue;
+        case NT_LIST: {
+            QoreListNode* l = reinterpret_cast<QoreListNode*>(n);
+            ListIterator li(l);
+            while (li.next()) {
+                if (checkIntern(li.getValue()))
+                return true;
             }
-	    RSectionScanHelper rssh(this, i->second);
-            if (rssh.lockError())
-               return true;
+
+            return false;
+        }
+
+        case NT_HASH: {
+            QoreHashNode* h = reinterpret_cast<QoreHashNode*>(n);
+            HashIterator hi(h);
+            while (hi.next()) {
+                assert(hi.getValue() != h);
+                if (hi.get().hasNode() && checkIntern(hi.get().getInternalNode()))
+                    return true;
+            }
+
+            return false;
+        }
+
+        case NT_RUNTIME_CLOSURE: {
+            QoreClosureBase* c = reinterpret_cast<QoreClosureBase*>(n);
+            // do not lock or scan if the closure cannot contain any closure-bound local vars with objects or closures (also not through a container)
+            if (!c->needsScan()) {
+                printd(QRO_LVL, "RSetHelper::checkIntern() closure %p: no scan\n", c);
+                return false;
+            }
+            closure_set_t::iterator ci = closure_set.lower_bound(c);
+            // return false if already scanned
+            if (ci != closure_set.end() && *ci == c) {
+                printd(QRO_LVL, "RSetHelper::checkIntern() found dup closure %p\n", c);
+                return false;
+            }
+            // insert into scanned closure set
+            closure_set.insert(ci, c);
+
+            // do not scan any closure object since weak references are used
+            // iterate captured lvars
+            const cvar_map_t& cmap = c->getMap();
+
+            for (cvar_map_t::const_iterator i = cmap.begin(), e = cmap.end(); i != e; ++i) {
+                // do not grab the lock if the lvalue cannot contain an object or closure (also not through a container)
+                if (!i->second->needsScan(true)) {
+                    printd(QRO_LVL, "RSetHelper::checkIntern() closure %p: var %s: no scan\n", c, i->first->getName());
+                    continue;
+                }
+                RSectionScanHelper rssh(this, i->second);
+                if (rssh.lockError())
+                    return true;
 #ifdef DEBUG
-	    unsigned csize = size();
+                unsigned csize = size();
 #endif
 
-            if (checkIntern(*i->second))
-               return true;
+                if (checkIntern(*i->second))
+                    return true;
 
 #ifdef DEBUG
-	    if (csize != size())
-               printd(QRO_LVL, "RSetHelper::checkIntern() closure var '%s' found rref (type: %s)\n", i->first->getName(), i->second->val.getTypeName());
-            else
-               printd(QRO_LVL, "RSetHelper::checkIntern() closure var '%s' no rref; size: %d (type: %s)\n", i->first->getName(), csize, i->second->val.getTypeName());
+                if (csize != size())
+                    printd(QRO_LVL, "RSetHelper::checkIntern() closure var '%s' found rref (type: %s)\n", i->first->getName(), i->second->val.getTypeName());
+                else
+                    printd(QRO_LVL, "RSetHelper::checkIntern() closure var '%s' no rref; size: %d (type: %s)\n", i->first->getName(), csize, i->second->val.getTypeName());
 #endif
-         }
+            }
 
-         return false;
-      }
+            return false;
+        }
 
-      case NT_REFERENCE:
-         return lvalue_ref::get(static_cast<ReferenceNode*>(n))->scanReference(*this);
+        case NT_REFERENCE:
+            return lvalue_ref::get(static_cast<ReferenceNode*>(n))->scanReference(*this);
 
-      case NT_VALUE_LIST:
-         assert(false);
-   }
+        case NT_VALUE_LIST:
+            assert(false);
+    }
 
-   return false;
+    return false;
 }
 
 bool RSetHelper::removeInvalidate(RSet* ors, int tid) {
@@ -519,161 +519,161 @@ bool RSetHelper::makeChain(int i, omap_t::iterator fi, int tid) {
 // XXX RSectionScanHelper
 bool RSetHelper::checkIntern(RObject& obj) {
 #ifdef DEBUG
-   bool hl = obj.rml.hasRSectionLock();
+    bool hl = obj.rml.hasRSectionLock();
 #endif
-   if (obj.rml.tryRSectionLockNotifyWaitRead(&notifier)) {
-      printd(QRO_LVL, "RSetHelper::checkIntern() + obj %p '%s' cannot enter rsection: rsection tid: %d\n", &obj, obj.getName(), obj.rml.rSectionTid());
-      return true;
-   }
+    if (obj.rml.tryRSectionLockNotifyWaitRead(&notifier)) {
+        printd(QRO_LVL, "RSetHelper::checkIntern() + obj %p '%s' cannot enter rsection: rsection tid: %d\n", &obj, obj.getName(), obj.rml.rSectionTid());
+        return true;
+    }
 #ifdef DEBUG
-   if (!hl)
-      inccnt();
+    if (!hl)
+        inccnt();
 #endif
 
-   // check object status; do not scan invalid objects or objects being deleted
-   if (!obj.isValid()) {
-      obj.rml.rSectionUnlock();
-      deccnt();
-      return false;
-   }
+    // check object status; do not scan invalid objects or objects being deleted
+    if (!obj.isValid()) {
+        obj.rml.rSectionUnlock();
+        deccnt();
+        return false;
+    }
 
-   int tid = gettid();
+    int tid = gettid();
 
-   // see if the object has been scanned
-   omap_t::iterator fi = fomap.lower_bound(&obj);
-   if (fi != fomap.end() && fi->first == &obj) {
-      printd(QRO_LVL, "RSetHelper::checkIntern() + found obj %p '%s' rcount: %d in_cycle: %d ok: %d\n", &obj, obj.getName(), fi->second.rcount, fi->second.in_cycle, fi->second.ok);
-      //printd(QRO_LVL, "RSetHelper::checkIntern() found obj %p '%s' incrementing rcount: %d -> %d\n", &obj, obj.getName(), fi->second.rcount, fi->second.rcount + 1);
+    // see if the object has been scanned
+    omap_t::iterator fi = fomap.lower_bound(&obj);
+    if (fi != fomap.end() && fi->first == &obj) {
+        printd(QRO_LVL, "RSetHelper::checkIntern() + found obj %p '%s' rcount: %d in_cycle: %d ok: %d\n", &obj, obj.getName(), fi->second.rcount, fi->second.in_cycle, fi->second.ok);
+        //printd(QRO_LVL, "RSetHelper::checkIntern() found obj %p '%s' incrementing rcount: %d -> %d\n", &obj, obj.getName(), fi->second.rcount, fi->second.rcount + 1);
 
-      if (fi->second.ok) {
-         assert(!fi->second.in_cycle);
-         printd(QRO_LVL, " + %p '%s' already scanned and ok\n", &obj, obj.getName());
-         return false;
-      }
-
-      if (fi->second.in_cycle) {
-         assert(fi->second.rset);
-         // check if this object is part of the current cycle already - if
-         // 1) it's already in the current scan vector, or
-         // 2) the parent object of the current object is already a part of the recursive set
-         if (inCurrentSet(fi)) {
-            printd(QRO_LVL, " + recursive obj %p '%s' already finalized and in current cycle (rcount: %d -> %d)\n", &obj, obj.getName(), fi->second.rcount, fi->second.rcount + 1);
-            ++fi->second.rcount;
-            // rcount can never be more than real references for the target object
-            assert(fi->first->references >= fi->second.rcount);
-         }
-         else if (!ovec.empty()) {
-            // FIXME: use this optimization in the loop below
-            if (ovec.back()->second.rset == fi->second.rset) {
-               printd(QRO_LVL, " + %p '%s': parent object %p '%s' in same cycle (rcount: %d -> %d)\n", &obj, obj.getName(), ovec.back()->first, ovec.back()->first->getName(), fi->second.rcount, fi->second.rcount + 1);
-               ++fi->second.rcount;
-               // rcount can never be more than real references for the target object
-               assert(fi->first->references >= fi->second.rcount);
-               return false;
-            }
-
-            // see if any parent of the current object is already in the same recursive cycle, if so, we have a new chain (quick comparison first)
-            for (int i = ovec.size() - 1; i >= 0; --i) {
-               if (fi->second.rset == ovec[i]->second.rset) {
-                  printd(QRO_LVL, " + recursive obj %p '%s' already finalized, cyclic ancestor %p '%s' in current cycle\n", &obj, obj.getName(), ovec[i]->first, ovec[i]->first->getName());
-
-                  return makeChain(i, fi, tid);
-               }
-            }
-
-            // see if any parent of the current object is already in a recursive cycle to be joined, if so, we have a new chain (slower comparison second)
-            for (int i = ovec.size() - 1; i >= 0; --i) {
-               if (fi->second.rset->find((ovec[i])->first) != fi->second.rset->end()) {
-                  printd(QRO_LVL, " + recursive obj %p '%s' already finalized, cyclic ancestor %p '%s' in current cycle\n", &obj, obj.getName(), ovec[i]->first, ovec[i]->first->getName());
-
-                  return makeChain(i, fi, tid);
-               }
-            }
-
-            printd(QRO_LVL, " + recursive obj %p '%s' already finalized but not in current cycle\n", &obj, obj.getName());
+        if (fi->second.ok) {
+            assert(!fi->second.in_cycle);
+            printd(QRO_LVL, " + %p '%s' already scanned and ok\n", &obj, obj.getName());
             return false;
-         }
-      }
-      else {
-         if (!inCurrentSet(fi)) {
-            printd(QRO_LVL, " + recursive obj %p '%s' not in current cycle\n", &obj, obj.getName());
-            return false;
-         }
-      }
+        }
 
-      // finalize current objects immediately
-      RSet* rset = fi->second.rset;
+        if (fi->second.in_cycle) {
+            assert(fi->second.rset);
+            // check if this object is part of the current cycle already - if
+            // 1) it's already in the current scan vector, or
+            // 2) the parent object of the current object is already a part of the recursive set
+            if (inCurrentSet(fi)) {
+                printd(QRO_LVL, " + recursive obj %p '%s' already finalized and in current cycle (rcount: %d -> %d)\n", &obj, obj.getName(), fi->second.rcount, fi->second.rcount + 1);
+                ++fi->second.rcount;
+                // rcount can never be more than real references for the target object
+                assert(fi->first->references >= fi->second.rcount);
+            }
+            else if (!ovec.empty()) {
+                // FIXME: use this optimization in the loop below
+                if (ovec.back()->second.rset == fi->second.rset) {
+                    printd(QRO_LVL, " + %p '%s': parent object %p '%s' in same cycle (rcount: %d -> %d)\n", &obj, obj.getName(), ovec.back()->first, ovec.back()->first->getName(), fi->second.rcount, fi->second.rcount + 1);
+                    ++fi->second.rcount;
+                    // rcount can never be more than real references for the target object
+                    assert(fi->first->references >= fi->second.rcount);
+                    return false;
+                }
+
+                // see if any parent of the current object is already in the same recursive cycle, if so, we have a new chain (quick comparison first)
+                for (int i = ovec.size() - 1; i >= 0; --i) {
+                    if (fi->second.rset == ovec[i]->second.rset) {
+                        printd(QRO_LVL, " + recursive obj %p '%s' already finalized, cyclic ancestor %p '%s' in current cycle\n", &obj, obj.getName(), ovec[i]->first, ovec[i]->first->getName());
+
+                        return makeChain(i, fi, tid);
+                    }
+                }
+
+                // see if any parent of the current object is already in a recursive cycle to be joined, if so, we have a new chain (slower comparison second)
+                for (int i = ovec.size() - 1; i >= 0; --i) {
+                    if (fi->second.rset->find((ovec[i])->first) != fi->second.rset->end()) {
+                        printd(QRO_LVL, " + recursive obj %p '%s' already finalized, cyclic ancestor %p '%s' in current cycle\n", &obj, obj.getName(), ovec[i]->first, ovec[i]->first->getName());
+
+                        return makeChain(i, fi, tid);
+                    }
+                }
+
+                printd(QRO_LVL, " + recursive obj %p '%s' already finalized but not in current cycle\n", &obj, obj.getName());
+                return false;
+            }
+        }
+        else {
+            if (!inCurrentSet(fi)) {
+                printd(QRO_LVL, " + recursive obj %p '%s' not in current cycle\n", &obj, obj.getName());
+                return false;
+            }
+        }
+
+        // finalize current objects immediately
+        RSet* rset = fi->second.rset;
 #ifdef DEBUG
-      if (rset)
-         printd(QRO_LVL, " + %p '%s': reusing RSet: %p\n", &obj, obj.getName(), rset);
+        if (rset)
+            printd(QRO_LVL, " + %p '%s': reusing RSet: %p\n", &obj, obj.getName(), rset);
 #endif
 
-      int i = (int)ovec.size() - 1;
-      while (i >= 0) {
-         assert(i >= 0);
+        int i = (int)ovec.size() - 1;
+        while (i >= 0) {
+            assert(i >= 0);
 
-         // get iterator to object record
-         omap_t::iterator oi = ovec[i];
+            // get iterator to object record
+            omap_t::iterator oi = ovec[i];
 
-         // merge rsets
-         if (!oi->second.rset) {
-            if (!rset) {
-               rset = new RSet;
-               printd(QRO_LVL, " + %p '%s': rcycle: %d second.rset: %p new RSet: %p\n", oi->first, oi->first->getName(), obj.rcycle, oi->second.rset, rset);
+            // merge rsets
+            if (!oi->second.rset) {
+                if (!rset) {
+                    rset = new RSet;
+                    printd(QRO_LVL, " + %p '%s': rcycle: %d second.rset: %p new RSet: %p\n", oi->first, oi->first->getName(), obj.rcycle, oi->second.rset, rset);
+                }
+
+                if (addToRSet(oi, rset, tid))
+                    return true;
+            }
+            else {
+                if (i > 0 && oi->first != &obj && !ovec[i-1]->second.in_cycle) {
+                    printd(QRO_LVL, " + %p '%s': parent not yet in cycle (rcount: %d -> %d)\n", &obj, obj.getName(), oi->second.rcount, oi->second.rcount + 1);
+                    ++oi->second.rcount;
+                }
+
+                mergeRSet(i, rset);
             }
 
-            if (addToRSet(oi, rset, tid))
-               return true;
-         }
-         else {
-            if (i > 0 && oi->first != &obj && !ovec[i-1]->second.in_cycle) {
-               printd(QRO_LVL, " + %p '%s': parent not yet in cycle (rcount: %d -> %d)\n", &obj, obj.getName(), oi->second.rcount, oi->second.rcount + 1);
-               ++oi->second.rcount;
-            }
+            if (oi->first == &obj)
+                break;
 
-            mergeRSet(i, rset);
-         }
+            --i;
+        }
 
-         if (oi->first == &obj)
-            break;
+        return false;
+    }
+    else {
+        printd(QRO_LVL, "RSetHelper::checkIntern() + adding new obj %p '%s' setting rcount = 0 (current: %d rset: %p)\n", &obj, obj.getName(), obj.rcount, obj.rset);
 
-         --i;
-      }
+        // insert into total scanned object set
+        fi = fomap.insert(fi, omap_t::value_type(&obj, RSetStat()));
 
-      return false;
-   }
-   else {
-      printd(QRO_LVL, "RSetHelper::checkIntern() + adding new obj %p '%s' setting rcount = 0 (current: %d rset: %p)\n", &obj, obj.getName(), obj.rcount, obj.rset);
+        // check if the object should be iterated
+        if (!obj.needsScan(true)) {
+            // remove from invalidation set if present
+            tr_out.erase(&obj);
 
-      // insert into total scanned object set
-      fi = fomap.insert(fi, omap_t::value_type(&obj, RSetStat()));
+            printd(QRO_LVL, "RSetHelper::checkIntern() obj %p '%s' will not be iterated since object count is 0\n", &obj, obj.getName());
+            fi->second.ok = true;
+            assert(!fi->second.rset);
+            return false;
+        }
+    }
 
-      // check if the object should be iterated
-      if (!obj.needsScan(true)) {
-         // remove from invalidation set if present
-         tr_out.erase(&obj);
+    // push on current vector chain
+    ovec.push_back(fi);
 
-         printd(QRO_LVL, "RSetHelper::checkIntern() obj %p '%s' will not be iterated since object count is 0\n", &obj, obj.getName());
-         fi->second.ok = true;
-         assert(!fi->second.rset);
-         return false;
-      }
-   }
+    // remove from invalidation set if present
+    tr_out.erase(&obj);
 
-   // push on current vector chain
-   ovec.push_back(fi);
+    // recursively check data members
+    if (obj.scanMembers(*this))
+        return true;
 
-   // remove from invalidation set if present
-   tr_out.erase(&obj);
+    // remove from current vector chain
+    ovec.pop_back();
 
-   // recursively check data members
-   if (obj.scanMembers(*this))
-      return true;
-
-   // remove from current vector chain
-   ovec.pop_back();
-
-   return false;
+    return false;
 }
 
 class RScanHelper {

--- a/lib/ScopedRefNode.cpp
+++ b/lib/ScopedRefNode.cpp
@@ -3,7 +3,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -75,14 +75,15 @@ NamedScope *ScopedRefNode::takeName() {
 }
 
 AbstractQoreNode* ScopedRefNode::parseInitImpl(LocalVar *oflag, int pflag, int &lvids, const QoreTypeInfo *&typeInfo) {
-   assert(!typeInfo);
-   printd(5, "ScopedRefNode::parseInit() resolving scoped constant \"%s\"\n", scoped_ref->ostr);
+    assert(!typeInfo);
+    printd(5, "ScopedRefNode::parseInit() resolving scoped constant \"%s\"\n", scoped_ref->ostr);
 
-   AbstractQoreNode* rv = qore_root_ns_private::parseResolveReferencedScopedReference(loc, *scoped_ref, typeInfo);
-   if (!rv)
-      return this;
+    bool found;
+    QoreValue rv = qore_root_ns_private::parseResolveReferencedScopedReference(loc, *scoped_ref, typeInfo, found);
+    if (!found)
+        return this;
 
-   deref(0);
-   typeInfo = 0;
-   return rv->parseInit(oflag, pflag, lvids, typeInfo);
+    deref(nullptr);
+    typeInfo = nullptr;
+    return rv.getReferencedValue()->parseInit(oflag, pflag, lvids, typeInfo);
 }

--- a/lib/ScopedRefNode.cpp
+++ b/lib/ScopedRefNode.cpp
@@ -80,10 +80,15 @@ AbstractQoreNode* ScopedRefNode::parseInitImpl(LocalVar *oflag, int pflag, int &
 
     bool found;
     QoreValue rv = qore_root_ns_private::parseResolveReferencedScopedReference(loc, *scoped_ref, typeInfo, found);
-    if (!found)
+    if (!found) {
         return this;
+    }
 
     deref(nullptr);
+    if (rv.isNothing()) {
+        typeInfo = nothingTypeInfo;
+        return &Nothing;
+    }
     typeInfo = nullptr;
-    return rv.getReferencedValue()->parseInit(oflag, pflag, lvids, typeInfo);
+    return rv.takeNode()->parseInit(oflag, pflag, lvids, typeInfo);
 }

--- a/lib/SelfVarrefNode.cpp
+++ b/lib/SelfVarrefNode.cpp
@@ -53,15 +53,15 @@ const char *SelfVarrefNode::getTypeName() const {
 }
 
 QoreValue SelfVarrefNode::evalValueImpl(bool &needs_deref, ExceptionSink *xsink) const {
-   assert(runtime_get_stack_object());
-   return runtime_get_stack_object()->getReferencedMemberNoMethod(str, xsink);
+    assert(runtime_get_stack_object());
+    return runtime_get_stack_object()->getReferencedMemberValueNoMethod(str, xsink);
 }
 
-char *SelfVarrefNode::takeString() {
-   assert(str);
-   char *p = str;
-   str = 0;
-   return p;
+char* SelfVarrefNode::takeString() {
+    assert(str);
+    char *p = str;
+    str = nullptr;
+    return p;
 }
 
 AbstractQoreNode *SelfVarrefNode::parseInitImpl(LocalVar *oflag, int pflag, int &lvids, const QoreTypeInfo *&typeInfo) {

--- a/lib/TypedHashDecl.cpp
+++ b/lib/TypedHashDecl.cpp
@@ -270,7 +270,7 @@ int typed_hash_decl_private::initHash(QoreHashNode* h, const QoreHashNode* init,
             continue;
 
         if (i->second->exp) {
-            QoreValue& v = h->getValueRef(i->first);
+            QoreValue& v = qore_hash_private::get(*h)->getValueRef(i->first);
             assert(v.isNothing());
 
             ValueEvalRefHolder val(i->second->exp, xsink);
@@ -285,7 +285,7 @@ int typed_hash_decl_private::initHash(QoreHashNode* h, const QoreHashNode* init,
         }
 #ifdef QORE_ENFORCE_DEFAULT_LVALUE
         else {
-            QoreValue& v = h->getValueRef(i->first);
+            QoreValue& v = qore_hash_private::get(*h)->getValueRef(i->first);
             assert(v.isNothing());
             v = QoreTypeInfo::getDefaultQoreValue(i->second->getTypeInfo());
         }

--- a/lib/TypedHashDecl.cpp
+++ b/lib/TypedHashDecl.cpp
@@ -259,9 +259,9 @@ int typed_hash_decl_private::initHash(QoreHashNode* h, const QoreHashNode* init,
                 QoreTypeInfo::acceptInputMember(i->second->getTypeInfo(), i->first, *val, xsink);
                 if (*xsink)
                     return -1;
-                AbstractQoreNode** v = h->getKeyValuePtr(i->first);
-                assert(!*v);
-                *v = val.release().takeNode();
+                QoreValue& v = qore_hash_private::get(*h)->getValueRef(i->first);
+                assert(v.isNothing());
+                v = val.release();
                 continue;
             }
         }

--- a/lib/VarRefNode.cpp
+++ b/lib/VarRefNode.cpp
@@ -123,45 +123,45 @@ QoreValue VarRefNode::evalValueImpl(bool& needs_deref, ExceptionSink* xsink) con
 }
 
 AbstractQoreNode* VarRefNode::parseInitIntern(LocalVar *oflag, int pflag, int &lvids, const QoreTypeInfo *typeInfo, bool is_new) {
-   if (pflag & PF_CONST_EXPRESSION) {
-      parseException(loc, "ILLEGAL-VARIABLE-REFERENCE", "variable reference '%s' used illegally in an expression executed at parse time to initialize a constant value", name.ostr);
-      return 0;
-   }
+    if (pflag & PF_CONST_EXPRESSION) {
+        parseException(loc, "ILLEGAL-VARIABLE-REFERENCE", "variable reference '%s' used illegally in an expression executed at parse time to initialize a constant value", name.ostr);
+        return 0;
+    }
 
-   //printd(5, "VarRefNode::parseInitIntern() this: %p '%s' type: %d %p '%s'\n", this, name.ostr, type, typeInfo, QoreTypeInfo::getName(typeInfo));
-   // if it is a new variable being declared
-   if (type == VT_LOCAL || type == VT_CLOSURE || type == VT_LOCAL_TS) {
-      if (!ref.id) {
-         ref.id = push_local_var(name.ostr, loc, typeInfo, false, is_new ? 1 : 0, pflag);
-         ++lvids;
-      }
-      //printd(5, "VarRefNode::parseInitIntern() this: %p local var '%s' declared (id: %p)\n", this, name.ostr, ref.id);
-   }
-   else if (type != VT_GLOBAL) {
-      assert(type == VT_UNRESOLVED);
-      // otherwise reference must be resolved
-      resolve(typeInfo);
-   }
+    //printd(5, "VarRefNode::parseInitIntern() this: %p '%s' type: %d %p '%s'\n", this, name.ostr, type, typeInfo, QoreTypeInfo::getName(typeInfo));
+    // if it is a new variable being declared
+    if (type == VT_LOCAL || type == VT_CLOSURE || type == VT_LOCAL_TS) {
+        if (!ref.id) {
+            ref.id = push_local_var(name.ostr, loc, typeInfo, false, is_new ? 1 : 0, pflag);
+            ++lvids;
+        }
+        //printd(5, "VarRefNode::parseInitIntern() this: %p local var '%s' declared (id: %p)\n", this, name.ostr, ref.id);
+    }
+    else if (type != VT_GLOBAL) {
+        assert(type == VT_UNRESOLVED);
+        // otherwise reference must be resolved
+        resolve(typeInfo);
+    }
 
-   return this;
+    return this;
 }
 
 AbstractQoreNode* VarRefNode::parseInitImpl(LocalVar* oflag, int pflag, int& lvids, const QoreTypeInfo*& outTypeInfo) {
-   parseInitIntern(oflag, pflag, lvids, 0);
+    parseInitIntern(oflag, pflag, lvids, 0);
 
-   bool is_assignment = pflag & PF_FOR_ASSIGNMENT;
+    bool is_assignment = pflag & PF_FOR_ASSIGNMENT;
 
-   // this expression returns nothing if it's a new local variable
-   // so if we're not assigning we return nothingTypeInfo as the
-   // return type
-   if (!is_assignment && new_decl) {
-      assert(!outTypeInfo);
-      outTypeInfo = nothingTypeInfo;
-   }
-   else
-      outTypeInfo = is_assignment && new_decl ? parseGetTypeInfoForInitialAssignment() : parseGetTypeInfo();
+    // this expression returns nothing if it's a new local variable
+    // so if we're not assigning we return nothingTypeInfo as the
+    // return type
+    if (!is_assignment && new_decl) {
+        assert(!outTypeInfo);
+        outTypeInfo = nothingTypeInfo;
+    }
+    else
+        outTypeInfo = is_assignment && new_decl ? parseGetTypeInfoForInitialAssignment() : parseGetTypeInfo();
 
-   return this;
+    return this;
 }
 
 VarRefNewObjectNode* VarRefNode::globalMakeNewCall(AbstractQoreNode* args) {
@@ -173,7 +173,7 @@ VarRefNewObjectNode* VarRefNode::globalMakeNewCall(AbstractQoreNode* args) {
       return rv;
    }
 
-   return 0;
+   return nullptr;
 }
 
 AbstractQoreNode* VarRefNode::makeNewCall(AbstractQoreNode* args) {

--- a/lib/VarRefNode.cpp
+++ b/lib/VarRefNode.cpp
@@ -3,7 +3,7 @@
 
   Qore programming language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -300,7 +300,7 @@ void VarRefNewObjectNode::parseInitConstructorCall(const QoreProgramLocation& lo
 
     //printd(5, "VarRefFunctionCallBase::parseInitConstructorCall() this: %p constructor: %p variant: %p\n", this, constructor, variant);
 
-    if (((constructor && (qore_method_private::parseGetAccess(*constructor) > Public)) || (variant && CONMV_const(variant)->isPrivate())) && !qore_class_private::parseCheckPrivateClassAccess(*qc)) {
+    if (((constructor && (qore_method_private::getAccess(*constructor) > Public)) || (variant && CONMV_const(variant)->isPrivate())) && !qore_class_private::parseCheckPrivateClassAccess(*qc)) {
         if (variant)
             parse_error(loc, "illegal external access to private constructor %s::constructor(%s)", qc->getName(), variant->getSignature()->getSignatureText());
         else

--- a/lib/VarRefNode.cpp
+++ b/lib/VarRefNode.cpp
@@ -296,7 +296,7 @@ void VarRefNewObjectNode::parseInitConstructorCall(const QoreProgramLocation& lo
     // FIXME: make common code with ScopedObjectCallNode
     const QoreMethod* constructor = qc ? qc->parseGetConstructor() : nullptr;
     const QoreTypeInfo* typeInfo;
-    lvids += parseArgsVariant(loc, oflag, pflag, constructor ? constructor->getFunction() : nullptr, typeInfo);
+    lvids += parseArgsVariant(loc, oflag, pflag, constructor ? constructor->getFunction() : nullptr, nullptr, typeInfo);
 
     //printd(5, "VarRefFunctionCallBase::parseInitConstructorCall() this: %p constructor: %p variant: %p\n", this, constructor, variant);
 

--- a/lib/Variable.cpp
+++ b/lib/Variable.cpp
@@ -596,10 +596,12 @@ int LValueHelper::assign(QoreValue n, const char* desc, bool check_types, bool w
 
     // perform assignment
     if (val) {
+        n.sanitize();
         saveTemp(val->assignAssume(n));
         return 0;
     }
     if (qv) {
+        n.sanitize();
         saveTemp(qv->takeIfNode());
         *qv = n;
         return 0;

--- a/lib/Variable.cpp
+++ b/lib/Variable.cpp
@@ -614,7 +614,7 @@ int LValueHelper::makeInt(const char* desc) {
     assert(val || qv);
 
     if (val) {
-        if (val->getType() == NT_INT) {
+        if (val->isInt()) {
             return 0;
         }
 
@@ -644,7 +644,7 @@ int LValueHelper::makeInt(const char* desc) {
 int LValueHelper::makeFloat(const char* desc) {
     assert(val || qv);
     if (val) {
-        if (val->getType() == NT_FLOAT) {
+        if (val->isFloat()) {
             return 0;
         }
 

--- a/lib/Variable.cpp
+++ b/lib/Variable.cpp
@@ -612,19 +612,29 @@ int LValueHelper::assign(QoreValue n, const char* desc, bool check_types, bool w
 
 int LValueHelper::makeInt(const char* desc) {
     assert(val || qv);
-    if ((val && val->getType() == NT_INT) || (qv && qv->getType() == NT_INT)) {
-        return 0;
-    }
-
-    if (typeInfo && !QoreTypeInfo::parseAccepts(typeInfo, bigIntTypeInfo)) {
-        typeInfo->doTypeException(0, desc, QoreTypeInfo::getName(bigIntTypeInfo), vl.xsink);
-        return -1;
-    }
 
     if (val) {
+        if (val->getType() == NT_INT) {
+            return 0;
+        }
+
+        if (typeInfo && !QoreTypeInfo::parseAccepts(typeInfo, bigIntTypeInfo)) {
+            typeInfo->doTypeException(0, desc, QoreTypeInfo::getName(bigIntTypeInfo), vl.xsink);
+            return -1;
+        }
+
         saveTemp(val->makeInt());
     }
     else {
+        if (!qv->hasNode() && qv->getType() == NT_INT) {
+           return 0;
+        }
+
+        if (typeInfo && qv->getType() != NT_INT && !QoreTypeInfo::parseAccepts(typeInfo, bigIntTypeInfo)) {
+            typeInfo->doTypeException(0, desc, QoreTypeInfo::getName(bigIntTypeInfo), vl.xsink);
+            return -1;
+        }
+
         saveTemp(qv->assign(qv->getAsBigInt()));
     }
 
@@ -633,19 +643,28 @@ int LValueHelper::makeInt(const char* desc) {
 
 int LValueHelper::makeFloat(const char* desc) {
     assert(val || qv);
-    if ((val && val->getType() == NT_FLOAT) || (qv && qv->getType() == NT_FLOAT)) {
-        return 0;
-    }
-
-    if (typeInfo && !QoreTypeInfo::parseAccepts(typeInfo, floatTypeInfo)) {
-        typeInfo->doTypeException(0, desc, QoreTypeInfo::getName(floatTypeInfo), vl.xsink);
-        return -1;
-    }
-
     if (val) {
+        if (val->getType() == NT_FLOAT) {
+            return 0;
+        }
+
+        if (typeInfo && !QoreTypeInfo::parseAccepts(typeInfo, floatTypeInfo)) {
+            typeInfo->doTypeException(0, desc, QoreTypeInfo::getName(floatTypeInfo), vl.xsink);
+            return -1;
+        }
+
         saveTemp(val->makeFloat());
     }
     else {
+        if (!qv->hasNode() && qv->getType() == NT_FLOAT) {
+           return 0;
+        }
+
+        if (typeInfo && qv->getType() != NT_FLOAT && !QoreTypeInfo::parseAccepts(typeInfo, bigIntTypeInfo)) {
+            typeInfo->doTypeException(0, desc, QoreTypeInfo::getName(bigIntTypeInfo), vl.xsink);
+            return -1;
+        }
+
         saveTemp(qv->assign(qv->getAsFloat()));
     }
 

--- a/lib/parser.ypp
+++ b/lib/parser.ypp
@@ -973,168 +973,168 @@ public:
 
 struct ParserTypeStruct {
 protected:
-   DLLLOCAL ParserTypeStruct() {
-   }
+    DLLLOCAL ParserTypeStruct() {
+    }
 
 public:
-   const QoreTypeInfo* typeInfo = nullptr;
-   QoreParseTypeInfo* parseTypeInfo = nullptr;
+    const QoreTypeInfo* typeInfo = nullptr;
+    QoreParseTypeInfo* parseTypeInfo = nullptr;
 
-   DLLLOCAL ParserTypeStruct(QoreParseTypeInfo* n_parseTypeInfo) : parseTypeInfo(n_parseTypeInfo) {
-   }
+    DLLLOCAL ParserTypeStruct(QoreParseTypeInfo* n_parseTypeInfo) : parseTypeInfo(n_parseTypeInfo) {
+    }
 
-   DLLLOCAL ParserTypeStruct(char* id, bool or_nothing) : typeInfo(or_nothing ? getBuiltinUserOrNothingTypeInfo(id) : getBuiltinUserTypeInfo(id)) {
-      //printd(0, "ParserTypeStruct::ParserTypeStruct('%s', %d) t: %p %s\n", id, or_nothing, typeInfo, QoreTypeInfo::getName(typeInfo));
-      if (typeInfo) {
-         free(id);
-         return;
-      }
+    DLLLOCAL ParserTypeStruct(char* id, bool or_nothing) : typeInfo(or_nothing ? getBuiltinUserOrNothingTypeInfo(id) : getBuiltinUserTypeInfo(id)) {
+        //printd(0, "ParserTypeStruct::ParserTypeStruct('%s', %d) t: %p %s\n", id, or_nothing, typeInfo, QoreTypeInfo::getName(typeInfo));
+        if (typeInfo) {
+            free(id);
+            return;
+        }
 
-      parseTypeInfo = new QoreParseTypeInfo(id, or_nothing);
-   }
+        parseTypeInfo = new QoreParseTypeInfo(id, or_nothing);
+    }
 
-   DLLLOCAL ~ParserTypeStruct() {
-      delete parseTypeInfo;
-   }
+    DLLLOCAL ~ParserTypeStruct() {
+        delete parseTypeInfo;
+    }
 
-   DLLLOCAL const QoreTypeInfo* getTypeInfo() const {
-      return typeInfo;
-   }
+    DLLLOCAL const QoreTypeInfo* getTypeInfo() const {
+        return typeInfo;
+    }
 
-   // static version of method, checking for null pointer
-   DLLLOCAL static const QoreTypeInfo* getTypeInfo(ParserTypeStruct* pts) {
-      return pts ? pts->getTypeInfo() : nullptr;
-   }
+    // static version of method, checking for null pointer
+    DLLLOCAL static const QoreTypeInfo* getTypeInfo(ParserTypeStruct* pts) {
+        return pts ? pts->getTypeInfo() : nullptr;
+    }
 
-   DLLLOCAL QoreParseTypeInfo* getParseTypeInfo() {
-      QoreParseTypeInfo* rv = parseTypeInfo;
-      parseTypeInfo = nullptr;
-      return rv;
-   }
+    DLLLOCAL QoreParseTypeInfo* getParseTypeInfo() {
+        QoreParseTypeInfo* rv = parseTypeInfo;
+        parseTypeInfo = nullptr;
+        return rv;
+    }
 
-   // static version of method, checking for null pointer
-   DLLLOCAL static QoreParseTypeInfo* getParseTypeInfo(ParserTypeStruct* pts) {
-      return pts ? pts->getParseTypeInfo() : nullptr;
-   }
+    // static version of method, checking for null pointer
+    DLLLOCAL static QoreParseTypeInfo* getParseTypeInfo(ParserTypeStruct* pts) {
+        return pts ? pts->getParseTypeInfo() : nullptr;
+    }
 
-   DLLLOCAL const char* getClassName() {
-      assert(parseTypeInfo);
-      return parseTypeInfo->cscope->ostr;
-   }
+    DLLLOCAL const char* getClassName() {
+        assert(parseTypeInfo);
+        return parseTypeInfo->cscope->ostr;
+    }
 
-   DLLLOCAL static ParserTypeStruct* getType(QoreProgramLocation&& loc, char* id, bool or_nothing) {
-      return new ParserTypeStruct(getParseType(loc, id, or_nothing));
-   }
+    DLLLOCAL static ParserTypeStruct* getType(QoreProgramLocation&& loc, char* id, bool or_nothing) {
+        return new ParserTypeStruct(getParseType(loc, id, or_nothing));
+    }
 
-   DLLLOCAL static void getSubTypes(const QoreProgramLocation& loc, const char* str, parse_type_vec_t& subtypes, bool raise_error = true) {
-      QoreString buf;
-      bool or_nothing = false;
-      bool comma = false;
+    DLLLOCAL static void getSubTypes(const QoreProgramLocation& loc, const char* str, parse_type_vec_t& subtypes, bool raise_error = true) {
+        QoreString buf;
+        bool or_nothing = false;
+        bool comma = false;
 
-      const char* p = str;
-      while (true) {
-         if (*p == '\0') {
-            if (buf.empty()) {
-               if (comma && raise_error)
-                  parse_error(loc, "empty subtype specification in type");
+        const char* p = str;
+        while (true) {
+            if (*p == '\0') {
+                if (buf.empty()) {
+                    if (comma && raise_error)
+                        parse_error(loc, "empty subtype specification in type");
+                }
+                else
+                    subtypes.push_back(getParseType(loc, buf.giveBuffer(), or_nothing));
+                break;
             }
-            else
-               subtypes.push_back(getParseType(loc, buf.giveBuffer(), or_nothing));
-            break;
-         }
-         switch (*p) {
-            case '<': {
-               if (buf.empty()) {
-                  if (raise_error)
-                     parse_error(loc, "invalid subtype specification in '%s'", str);
-                  return;
-               }
-               const char* e = strrchr(str, '>');
-               if (!e || e < p) {
-                  if (raise_error)
-                     parse_error(loc, "unbalanced angle brackets in subtype specification in '%s'", str);
-                  return;
-               }
-               buf.concat(p, e - p + 1);
-               //printd(5, "ST: '%s' (str: '%s') p: %p '%s'\n", buf.c_str(), str, p, p);
-               subtypes.push_back(getParseType(loc, buf.giveBuffer(), or_nothing));
-               buf.reset();
-               or_nothing = false;
-               //printd(5, "ST: p: %p -> %p\n", p, e);
-               p = e;
-               break;
+            switch (*p) {
+                case '<': {
+                    if (buf.empty()) {
+                        if (raise_error)
+                            parse_error(loc, "invalid subtype specification in '%s'", str);
+                        return;
+                    }
+                    const char* e = strrchr(str, '>');
+                    if (!e || e < p) {
+                        if (raise_error)
+                            parse_error(loc, "unbalanced angle brackets in subtype specification in '%s'", str);
+                        return;
+                    }
+                    buf.concat(p, e - p + 1);
+                    //printd(5, "ST: '%s' (str: '%s') p: %p '%s'\n", buf.c_str(), str, p, p);
+                    subtypes.push_back(getParseType(loc, buf.giveBuffer(), or_nothing));
+                    buf.reset();
+                    or_nothing = false;
+                    //printd(5, "ST: p: %p -> %p\n", p, e);
+                    p = e;
+                    break;
+                }
+                case ',':
+                    buf.trim();
+                    if (buf.empty()) {
+                        if (raise_error)
+                            parse_error(loc, "invalid subtype specification in '%s'", str);
+                        return;
+                    }
+                    subtypes.push_back(getParseType(loc, buf.giveBuffer(), or_nothing, raise_error));
+                    buf.reset();
+                    or_nothing = false;
+                    comma = true;
+                break;
+                case '*': {
+                    if (buf.empty())
+                        or_nothing = true;
+                    else
+                        buf.concat('*');
+                    if (comma)
+                        comma = false;
+                    break;
+                }
+                case ' ':
+                case '\t':
+                    if (!buf.empty())
+                        buf.concat(*p);
+                    break;
+                default:
+                    buf.concat(*p);
+                    if (comma)
+                        comma = false;
+                break;
             }
-            case ',':
-               buf.trim();
-               if (buf.empty()) {
-                  if (raise_error)
-                     parse_error(loc, "invalid subtype specification in '%s'", str);
-                  return;
-               }
-               subtypes.push_back(getParseType(loc, buf.giveBuffer(), or_nothing, raise_error));
-               buf.reset();
-               or_nothing = false;
-               comma = true;
-               break;
-            case '*': {
-               if (buf.empty())
-                  or_nothing = true;
-               else
-                  buf.concat('*');
-               if (comma)
-                  comma = false;
-               break;
+            ++p;
+        }
+    }
+
+    DLLLOCAL static QoreParseTypeInfo* getParseType(const QoreProgramLocation& loc, char* id, bool or_nothing, bool raise_error = true) {
+        //printd(0, "gPT() '%s'\n", id);
+        char* p0 = strchr(id, '<');
+        if (p0) {
+            char* p1 = strrchr(id, '>');
+            if (p1 > (p0 + 1)) {
+                // terminate main type string
+                *p0 = '\0';
+                // terminate type args
+                *p1 = '\0';
+
+                parse_type_vec_t subtypes;
+                getSubTypes(loc, p0 + 1, subtypes, raise_error);
+                return new QoreParseTypeInfo(id, or_nothing, std::move(subtypes));
             }
-            case ' ':
-            case '\t':
-               if (!buf.empty())
-                  buf.concat(*p);
-               break;
-            default:
-               buf.concat(*p);
-               if (comma)
-                  comma = false;
-               break;
-         }
-         ++p;
-      }
-   }
+        }
+        return new QoreParseTypeInfo(id, or_nothing);
+    }
 
-   DLLLOCAL static QoreParseTypeInfo* getParseType(const QoreProgramLocation& loc, char* id, bool or_nothing, bool raise_error = true) {
-      //printd(0, "gPT() '%s'\n", id);
-      char* p0 = strchr(id, '<');
-      if (p0) {
-         char* p1 = strrchr(id, '>');
-         if (p1 > (p0 + 1)) {
-            // terminate main type string
-            *p0 = '\0';
-            // terminate type args
-            *p1 = '\0';
-
-            parse_type_vec_t subtypes;
-            getSubTypes(loc, p0 + 1, subtypes, raise_error);
-            return new QoreParseTypeInfo(id, or_nothing, std::move(subtypes));
-         }
-      }
-      return new QoreParseTypeInfo(id, or_nothing);
-   }
-
-   DLLLOCAL static const QoreTypeInfo* getRuntimeType(const char* str) {
-      assert(str);
-      assert(str[0]);
-      char* p;
-      bool or_nothing;
-      if (str[0] == '*') {
-         or_nothing = true;
-         p = strdup(str + 1);
-      }
-      else {
-         or_nothing = false;
-         p = strdup(str);
-      }
-      std::unique_ptr<QoreParseTypeInfo> pt(ParserTypeStruct::getParseType(QoreProgramLocation(), p, or_nothing, false));
-      return QoreParseTypeInfo::resolveRuntime(pt.get());
-   }
+    DLLLOCAL static const QoreTypeInfo* getRuntimeType(const char* str) {
+        assert(str);
+        assert(str[0]);
+        char* p;
+        bool or_nothing;
+        if (str[0] == '*') {
+            or_nothing = true;
+            p = strdup(str + 1);
+        }
+        else {
+            or_nothing = false;
+            p = strdup(str);
+        }
+        std::unique_ptr<QoreParseTypeInfo> pt(ParserTypeStruct::getParseType(QoreProgramLocation(), p, or_nothing, false));
+        return QoreParseTypeInfo::resolveRuntime(pt.get());
+    }
 };
 
 const QoreTypeInfo* qore_get_type_from_string(const char* str) {

--- a/lib/parser.ypp
+++ b/lib/parser.ypp
@@ -1489,54 +1489,55 @@ static void check_operator_bin_xor(const AbstractQoreNode *n, const char *parent
 %error-verbose
 
 %union {
-   bool b;
-   int i4;
-   int64 integer;
-   double decimal;
-   QoreStringNode* String;
-   char* string;
-   BinaryNode* binary;
-   AbstractQoreNode* node;
-   QoreParseHashNode* hash;
-   QoreParseListNode* parse_list;
-   AbstractStatement* statement;
-   struct MemberInfo* memberinfo;
-   struct ClassVarInfo* classvarinfo;
-   StatementBlock *sblock;
-   ContextModList* cmods;
-   ContextMod *cmod;
-   class HashElement* hashelement;
-   QoreFunction* userfunc;
-   struct MethodNode* methodnode;
-   class MemberList* memberlist;
-   QoreClass* qoreclass;
-   typed_hash_decl_private* hashdeclpriv;
-   class ConstNode* constnode;
-   QoreNamespace *ns;
-   struct NSNodeList* nsnlist;
-   struct NSNode* nsn;
-   class ObjClassDef* classdef;
-   class HashDeclDef* hashdecldef;
-   DateTimeNode* datetime;
-   QoreRegexSubst* RegexSubst;
-   QoreTransliteration* Trans;
-   SwitchStatement* switchstmt;
-   CaseNode* casenode;
-   BCList* sclist;
-   class BCNode* sclnode;
-   BCAList* bcalist;
-   BCANode* bcanode;
-   NamedScope *nscope;
-   QoreRegex* Regex;
-   QoreImplicitArgumentNode* implicit_arg;
-   RetTypeInfo* returnTypeInfo;
-   struct ParserTypeStruct* parsertype;
-   class ParseUserFunction* parsefunc;
-   class ParseScopedUserFunction* sparsefunc;
-   struct GVarDecl* gv;
-   QoreNumberNode* num;
-   TryModuleError* trymod;
-   struct MethodDef* methoddef;
+    QoreSimpleValue qv;
+    bool b;
+    int i4;
+    int64 integer;
+    double decimal;
+    QoreStringNode* String;
+    char* string;
+    BinaryNode* binary;
+    AbstractQoreNode* node;
+    QoreParseHashNode* hash;
+    QoreParseListNode* parse_list;
+    AbstractStatement* statement;
+    struct MemberInfo* memberinfo;
+    struct ClassVarInfo* classvarinfo;
+    StatementBlock *sblock;
+    ContextModList* cmods;
+    ContextMod *cmod;
+    class HashElement* hashelement;
+    QoreFunction* userfunc;
+    struct MethodNode* methodnode;
+    class MemberList* memberlist;
+    QoreClass* qoreclass;
+    typed_hash_decl_private* hashdeclpriv;
+    class ConstNode* constnode;
+    QoreNamespace *ns;
+    struct NSNodeList* nsnlist;
+    struct NSNode* nsn;
+    class ObjClassDef* classdef;
+    class HashDeclDef* hashdecldef;
+    DateTimeNode* datetime;
+    QoreRegexSubst* RegexSubst;
+    QoreTransliteration* Trans;
+    SwitchStatement* switchstmt;
+    CaseNode* casenode;
+    BCList* sclist;
+    class BCNode* sclnode;
+    BCAList* bcalist;
+    BCANode* bcanode;
+    NamedScope *nscope;
+    QoreRegex* Regex;
+    QoreImplicitArgumentNode* implicit_arg;
+    RetTypeInfo* returnTypeInfo;
+    struct ParserTypeStruct* parsertype;
+    class ParseUserFunction* parsefunc;
+    class ParseScopedUserFunction* sparsefunc;
+    struct GVarDecl* gv;
+    QoreNumberNode* num;
+    TryModuleError* trymod;
+    struct MethodDef* methoddef;
 }
 
 %{
@@ -1732,7 +1733,7 @@ DLLLOCAL void yyerror(YYLTYPE* loc, yyscan_t scanner, const char* str) {
 %type <node>           exp_n
 %type <node>           exp_c
 %type <node>           myexp
-%type <node>           scalar
+%type <qv>             scalar
 %type <hash>           hash
 %type <hash>           alt_hash
 %type <node>           immediate_typed_hash
@@ -1789,8 +1790,8 @@ DLLLOCAL void yyerror(YYLTYPE* loc, yyscan_t scanner, const char* str) {
 %destructor { qore_class_private::get(*$$)->deref(); } class_attributes
 %destructor { free($$); } IDENTIFIER ANGLE_IDENTIFIER VAR_REF SELF_REF CONTEXT_REF COMPLEX_CONTEXT_REF BACKQUOTE SCOPED_REF SCOPED_VREF KW_IDENTIFIER_OPENPAREN QORE_CAST CLASS_STRING optname ident_openparen HASHDECL_IDENTIFIER_OPENCURLY
 %destructor { if ($$) $$->deref(); } namespace_decl namespace_decls string QUOTED_WORD DATETIME BINARY IMPLICIT_ARG_REF DOT_KW_IDENTIFIER hashdecl_attrs list list_n
-%destructor { if ($$) $$->deref(nullptr); } exp exp_n exp_c myexp scalar immediate_typed_hash
-
+%destructor { if ($$) $$->deref(nullptr); } exp exp_n exp_c myexp immediate_typed_hash
+%destructor { if ($$.type == QV_Node && $$.v.n) $$.v.n->deref(nullptr); } scalar
 %%
 top_level_commands:
         top_level_command
@@ -3210,7 +3211,7 @@ immediate_typed_hash:
 
 exp_c:
         scalar
-        { $$ = $1; }
+        { $$ = $1.takeNode(); }
         | BINARY
         { $$ = $1; }
         | '(' hash ')'
@@ -3860,11 +3861,11 @@ string:
         ;
 
 scalar:
-        QFLOAT        { $$ = new QoreFloatNode($1); }
-        | INTEGER     { $$ = new QoreBigIntNode($1); }
-        | string      { $$ = $1; }
-        | DATETIME    { $$ = $1; }
-        | NUMBER      { $$ = $1; }
+        QFLOAT        { $$.set($1); /*new QoreFloatNode($1);*/ }
+        | INTEGER     { $$.set($1); /*new QoreBigIntNode($1);*/ }
+        | string      { $$.set($1); /*$1;*/ }
+        | DATETIME    { $$.set($1); /*$1;*/ }
+        | NUMBER      { $$.set($1); /*$1;*/ }
         ;
 
 %%

--- a/lib/ql_pwd.qpp
+++ b/lib/ql_pwd.qpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -315,38 +315,38 @@ string name = getusername();
 */
 string getusername() [flags=RET_VALUE_ONLY;dom=EXTERNAL_INFO] {
 #ifdef HAVE_PWD_H
-   errno = 0;
-   ReferenceHolder<QoreHashNode> h(q_getpwuid(geteuid()), xsink);
-   if (!h) {
-      if (!errno)
-         return xsink->raiseException("GET-USERNAME-ERROR", "failed to retrieve information for UID %d", geteuid());
-      return xsink->raiseErrnoException("GET-USERNAME-ERROR", errno, "failed to retrieve information for UID %d", geteuid());
-   }
-   return qore_hash_private::get(**h)->takeKeyValue("pw_name");
+    errno = 0;
+    ReferenceHolder<QoreHashNode> h(q_getpwuid(geteuid()), xsink);
+    if (!h) {
+        if (!errno)
+            return xsink->raiseException("GET-USERNAME-ERROR", "failed to retrieve information for UID %d", geteuid());
+        return xsink->raiseErrnoException("GET-USERNAME-ERROR", errno, "failed to retrieve information for UID %d", geteuid());
+    }
+    return qore_hash_private::get(**h)->takeKeyValueIntern("pw_name");
 #else
 #ifdef _Q_WINDOWS
 #define USERNAME_MAX 255
-   SimpleRefHolder<QoreStringNode> name(new QoreStringNode);
-   name->reserve(USERNAME_MAX);
-   DWORD size = USERNAME_MAX + 1;
-   if (!GetUserName((LPSTR)name->getBuffer(), &size)) {
-      DWORD ec = GetLastError();
-      char* ebuf;
-      QoreStringNode* desc = new QoreStringNode("failed to retrieve username for current Windows user: ");
-      // get windows error message
-      if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER, 0, ec, LANG_USER_DEFAULT, (LPTSTR)&ebuf, 0, 0)) {
-         assert(!ebuf);
-         desc->sprintf("Windows FormatMessage() failed on error code %d", ec);
-      }
-      else {
-         assert(ebuf);
-         desc->concat(ebuf);
-      }
+    SimpleRefHolder<QoreStringNode> name(new QoreStringNode);
+    name->reserve(USERNAME_MAX);
+    DWORD size = USERNAME_MAX + 1;
+    if (!GetUserName((LPSTR)name->getBuffer(), &size)) {
+        DWORD ec = GetLastError();
+        char* ebuf;
+        QoreStringNode* desc = new QoreStringNode("failed to retrieve username for current Windows user: ");
+        // get windows error message
+        if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER, 0, ec, LANG_USER_DEFAULT, (LPTSTR)&ebuf, 0, 0)) {
+            assert(!ebuf);
+            desc->sprintf("Windows FormatMessage() failed on error code %d", ec);
+        }
+        else {
+            assert(ebuf);
+            desc->concat(ebuf);
+        }
 
-      return xsink->raiseException("GET-USERNAME-ERROR", desc);
-   }
-   name->terminate(size ? size - 1 : 0);
-   return name.release();
+        return xsink->raiseException("GET-USERNAME-ERROR", desc);
+    }
+    name->terminate(size ? size - 1 : 0);
+    return name.release();
 #else
 #error need getusername() support for this platform
 #endif


### PR DESCRIPTION
this does not close #2706 but improves develop's memory usage significantly and also fixes some memory issues and leaks only in develop.

summary of changes:
* classes and functions are now immutable - all transactional logic has been removed; once a class or function has been committed, it cannot be changed.  Classes can now be only built in or user, never a mix.
* `QoreValue` is now used much heavier than before - the full migration to `QoreValue` will take more time and will involve removing the `QoreBigIntNode`, `QoreFloatNode`, and `QoreBoolNode` classes (at least -probably also `QoreNothingNode` and `QoreNullNode`) and will also entail an API and ABI change, which will result in even more memory saved

The main change that's missing now to close #2706 is to optimize the storage of program locations - currently this is the area where the biggest reduction in static memory usage can be made.

With the changes in this branch, Qore's static memory usage on Linux when loading a series of common user modules went from ~ 57 MiB - ~29 MiB

```
dnichols@manatee:~/src/qore/git/qore/build$ git rev-parse --abbrev-ref HEAD
develop
dnichols@manatee:~/src/qore/git/qore/build$ qore -l process -nX 'get_byte_size(Process::getMemorySummaryInfo().priv)' -l Util -l Mapper -l TableMapper -l SqlUtil -l YamlRpcClient -l DataStreamUtil -l DataStreamClient -l TelnetClient -l WebSocketClient -l Ssh2Connections -l XmlRpcConnection -l JsonRpcConnection -l SoapClient -l SmtpClient -l Pop3Client -l RestClient -l SewioRestClient -l SewioWebSocketClient -l SalesforceRestClient -l BulkSqlUtil
"57.15 MiB"
```

```
dnichols@manatee:~/src/qore/git/qore/build$ git rev-parse --abbrev-ref HEAD
bugfix/2706_Program_memory
dnichols@manatee:~/src/qore/git/qore/build$ qore -l process -nX 'get_byte_size(Process::getMemorySummaryInfo().priv)' -l Util -l Mapper -l TableMapper -l SqlUtil -l YamlRpcClient -l DataStreamUtil -l DataStreamClient -l TelnetClient -l WebSocketClient -l Ssh2Connections -l XmlRpcConnection -l JsonRpcConnection -l SoapClient -l SmtpClient -l Pop3Client -l RestClient -l SewioRestClient -l SewioWebSocketClient -l SalesforceRestClient -l BulkSqlUtil
"28.80 MiB"
```

This is a massive set of changes but on the positive side has been extensively tested on Linux and macOS (also with valgrind).
