### PR TITLE
fixed #2757 OracleSqlUtil: synonym resolving can fail with duplicated…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -16,7 +16,7 @@
           with very early versions of CsvUtil
           (<a href="https://github.com/qorelanguage/qore/issues/2476">issue 2476</a>)
       - <a href="../../modules/OracleSqlUtil/html/index.html">OracleSqlUtil</a> module changes
-        - synonym resolving can fail with duplicated object name(<a href="https://github.com/qorelanguage/qore/issues/2758">issue 758</a>)  
+        - synonym resolving can fail with duplicated object name (<a href="https://github.com/qorelanguage/qore/issues/2758">issue 758</a>)  
 
     @section qore_08133 Qore 0.8.13.3
 

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -15,6 +15,8 @@
           value to return an empty string when parsing rather than @ref nothing for backwards compatibility
           with very early versions of CsvUtil
           (<a href="https://github.com/qorelanguage/qore/issues/2476">issue 2476</a>)
+      - <a href="../../modules/OracleSqlUtil/html/index.html">OracleSqlUtil</a> module changes
+        - synonym resolving can fail with duplicated object name(<a href="https://github.com/qorelanguage/qore/issues/2758">issue 758</a>)  
 
     @section qore_08133 Qore 0.8.13.3
 

--- a/examples/test/qlib/SqlUtil/OracleSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/OracleSqlUtil.qtest
@@ -419,6 +419,9 @@ class OracleTest inherits SqlTestBase {
         AbstractDatasource ds = table.getDatasource();
         ds.exec("create table test_oracle_syn (dummy varchar2(1))");
         ds.exec("insert into test_oracle_syn values ('X')");
+        # issue #2757 OracleSqlUtil: synonym resolving can fail with duplicated object name
+        # some people are crazy to create objects with the same name for table and eg. index
+        ds.exec("create index test_oracle_syn on test_oracle_syn (dummy)");
         ds.exec("create or replace synonym oracle_test_syn1 for test_oracle_syn");
         ds.exec("create or replace synonym oracle_test_syn2 for oracle_test_syn1");
         ds.exec("create or replace synonym oracle_test_syn3 for oracle_test_syn2");

--- a/qlib/OracleSqlUtil.qm
+++ b/qlib/OracleSqlUtil.qm
@@ -2285,7 +2285,8 @@ auto v = c.name;
                                             and s.table_name = o.object_name
                                         )
                                     where s.owner = %v
-                                        and s.synonym_name = %v",
+                                        and s.synonym_name = %v
+                                        and o.object_type in ('TABLE', 'VIEW', 'SYNONYM')",
                                 s_owner.upr(), s_name.upr());
 
                 # ret can be NOTHING in case:


### PR DESCRIPTION
… object name