### PR TITLE
fixes #2963 pgsqlutil: schema align fails when there are functions to…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -12,6 +12,9 @@
       - <a href="../../modules/ConnectionProvider/html/index.html">ConnectionProvider</a>:
         - removed unnecessary serialization from AbstractConnection::get()
           (<a href="https://github.com/qorelanguage/qore/issues/2880">issue 2880</a>)
+      - <a href="../../modules/PgsqlSqlUtil/html/index.html">PgsqlSqlUtil</a>
+        - fixed schema alignment when there are functions to be droped
+          (a href="https://github.com/qorelanguage/qore/issues/2963">issue 2963</a>)
     - fixed a race condition in @ref Qore::Thread::ThreadPool "ThreadPool" destruction that could
       cause a crash
       (<a href="https://github.com/qorelanguage/qore/issues/2906">issue 2906</a>)

--- a/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
@@ -89,6 +89,30 @@ class PgsqlTestSchema inherits SqlUtilTestSchema {
     }
 }
 
+
+# A minimal schema just to create simple table to test bug #2963
+#  = to drop triggers and functions during the schema alignment
+class Bug2963Schema inherits SqlUtilTestSchema {
+    constructor(AbstractDatasource ds, *string dts, *string its) : SqlUtilTestSchema(ds, dts, its) {
+    }
+    private string getNameImpl() {
+        return "Bug2963Schema";
+    }
+    private string getVersionImpl() {
+        return "1.0";
+    }
+    private *hash getTablesImpl() {
+        return {
+            "pgsql_test_2963": {
+                "columns": {
+                    "id": c_number(14, True, "an example comment with 'quotes'"),
+                },
+            },
+        };
+    }
+} # class Bug2963Schema
+
+
 class PgsqlTest inherits SqlTestBase {
     public {
         const CustomColumns = (
@@ -206,6 +230,7 @@ class PgsqlTest inherits SqlTestBase {
             addTestCase("sequence operators", \testSequenceOperators());
             addTestCase("analytic/window functions", \testAnalyticFunctions());
             addTestCase("default value", \testDefaultValue());
+            addTestCase("pgsqlutil: schema align with trigger drop #2963", \test2963());
         }
 
         set_return_value(main());
@@ -240,6 +265,31 @@ class PgsqlTest inherits SqlTestBase {
         assertNRegex("::character varying", new_col.def_val);
         list l = c.getModifySql(table, new_col);
         assertEq((), l);
+    }
+
+    private test2963() {
+        AbstractDatasource ds = getDatasource();
+        on_exit ds.rollback();
+
+        Bug2963Schema schema(ds);
+        # to create test schema without triggers
+        auto res = schema.align(False, m_options.verbose);
+
+        # create trigger outseide the schema
+        ds.execRaw("create function pgsql_test_2963_func() returns trigger\n"
+                   "language plpgsql as $function$\n"
+                   "begin\n"
+                   "   null;\n"
+                   "end;\n"
+                   "$function$");
+        ds.execRaw("create trigger pgsql_test_2963_func "
+                   "before insert on pgsql_test_2963 execute procedure pgsql_test_2963_func()");
+
+        # align the schema again to drop trigger (and function)
+        res = schema.align(False, m_options.verbose);
+        # 1 = drop trigger
+        # 2 = drop function
+        assertEq(2, res, "2 actions must be performed");
     }
 
     private string getResultSetSql() {

--- a/qlib/PgsqlSqlUtil.qm
+++ b/qlib/PgsqlSqlUtil.qm
@@ -1868,7 +1868,7 @@ auto v = c.name;
                         l += AbstractDatabase::doCallback(opt, triggers{f.trigger}.getDropSql(name), AbstractDatabase::AC_Drop, "trigger", f.trigger, name);
                         triggers.take(f.trigger);
                     }
-                    l += AbstractDatabase::doCallback(opt, f.getDropSql(opt.force), AbstractDatabase::AC_Drop, "trigger function", f.name, name);
+                    l += AbstractDatabase::doCallback(opt, f.getDropSql(opt), AbstractDatabase::AC_Drop, "trigger function", f.name, name);
                 }
             }
 


### PR DESCRIPTION
… be droped