### PR TITLE
refs #3024 fixed a bug where call references did not set the executio…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -46,8 +46,8 @@
       - @ref Qore::FtpClient::getDataPeerInfo() "FtpClient::getDataPeerInfo()"
       - @ref Qore::FtpClient::getDataSocketInfo() "FtpClient::getDataSocketInfo()"
       - @ref Qore::Program::getParseOptionStringList() "Program::getParseOptionStringList()"
-      - @ref Qore::Program::parse() "Program::parse()" 
-      - @ref Qore::Program::parsePending() "Program::parsePending()" 
+      - @ref Qore::Program::parse() "Program::parse()"
+      - @ref Qore::Program::parsePending() "Program::parsePending()"
       - @ref Qore::StreamReader::getInputStream() "StreamReader::getInputStream()"
       - @ref Qore::StreamWriter::getOutputStream() "StreamWriter::getOutputStream()"
     - new functions:
@@ -79,9 +79,9 @@
       - \c "IF": the value in <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a> format for both @ref relative_dates "relative" (ex: \c "P2Y1M3DT5H7M9.002S") and @ref absolute_dates "absolute" dates (ex: \c "2018-03-23T10:43:12.067628+01:00")
       - \c "Iw" and \c "IW": <a href="http://en.wikipedia.org/wiki/ISO_week_date">ISO-8601 week</a> number
       - \c "Iy" and \c "IY": <a href="http://en.wikipedia.org/wiki/ISO_week_date">ISO-8601 week</a> year
-    - @ref Qore::Program::parse() "Program::parse()" and @ref Qore::Program::parsePending() "Program::parsePending()" updates: 
+    - @ref Qore::Program::parse() "Program::parse()" and @ref Qore::Program::parsePending() "Program::parsePending()" updates:
       the \a format_label parameter is obsolete/ignored
-      (<a href="https://github.com/qorelanguage/qore/issues/2903">issue 2903</a>)      
+      (<a href="https://github.com/qorelanguage/qore/issues/2903">issue 2903</a>)
     - module updates
       - a new binary module: <a href="../../modules/reflection/html/index.html">reflection</a>
         providing a reflection API to %Qore
@@ -134,6 +134,10 @@
         - command line utils display source line code when interrupted
 
     @subsection qore_09_bug_fixes Bug Fixes in Qore
+    - fixed a bug where call references did not set the execution context with builtin functions
+      and therefore calls to builtin functions in modules (such as @ref jniintro "jni") with
+      per-program private data would fail
+      (<a href="https://github.com/qorelanguage/qore/issues/3024">issue 3024</a>)
     - fixed a bug where rvalue references with complex subtypes could get modified during an assignment
       (<a href="https://github.com/qorelanguage/qore/issues/2891">issue 2891</a>)
     - fixed a bug where class members could be initialized multiple times in a class with multiple

--- a/include/qore/QoreLib.h
+++ b/include/qore/QoreLib.h
@@ -673,4 +673,10 @@ DLLEXPORT const QoreClass* qore_pseudo_get_class(qore_type_t t);
 /** @since %Qore 0.9
 */
 DLLEXPORT const QoreClass* qore_pseudo_get_class(const QoreTypeInfo* t);
+
+//! returns the caller's Program context, if any
+/** @since %Qore 0.9
+*/
+DLLEXPORT QoreProgram* qore_get_call_program_context();
+
 #endif // _QORE_QORELIB_H

--- a/include/qore/intern/qore_program_private.h
+++ b/include/qore/intern/qore_program_private.h
@@ -439,9 +439,8 @@ public:
             thr_init(nullptr), pgm(n_pgm) {
         printd(QPP_DBG_LVL, "qore_program_private_base::qore_program_private_base() this: %p pgm: %p po: " QLLD "\n", this, pgm, n_parse_options);
 
-#ifdef DEBUG
+        // must set priv before calling setParent()
         pgm->priv = (qore_program_private*)this;
-#endif
 
         if (p_pgm)
             setParent(p_pgm, n_parse_options);

--- a/include/qore/intern/qore_thread_intern.h
+++ b/include/qore/intern/qore_thread_intern.h
@@ -349,6 +349,10 @@ DLLLOCAL const QoreTypeInfo* getReturnTypeInfo();
 
 DLLLOCAL const QoreTypeInfo* parse_get_return_type_info();
 
+DLLLOCAL QoreProgram* get_set_program_call_context(QoreProgram* new_pgm);
+DLLLOCAL void set_program_call_context(QoreProgram* new_pgm);
+DLLLOCAL QoreProgram* get_program_call_context();
+
 #ifdef QORE_RUNTIME_THREAD_STACK_TRACE
 DLLLOCAL void pushCall(CallNode* cn);
 DLLLOCAL void popCall(ExceptionSink* xsink);
@@ -362,6 +366,22 @@ DLLLOCAL QoreListNode* getCallStackList();
 #endif
 #define popCall(x)
 #endif
+
+class ProgramCallContextHelper {
+public:
+    DLLLOCAL ProgramCallContextHelper(QoreProgram* new_pgm)
+        : pgm(new_pgm ? get_set_program_call_context(new_pgm) : reinterpret_cast<QoreProgram*>(-1)) {
+    }
+
+    DLLLOCAL ~ProgramCallContextHelper() {
+        if (pgm != reinterpret_cast<QoreProgram*>(-1)) {
+            set_program_call_context(pgm);
+        }
+    }
+
+private:
+    QoreProgram* pgm;
+};
 
 class ModuleReExportHelper {
 protected:

--- a/include/qore/intern/qore_thread_intern.h
+++ b/include/qore/intern/qore_thread_intern.h
@@ -351,7 +351,6 @@ DLLLOCAL const QoreTypeInfo* parse_get_return_type_info();
 
 DLLLOCAL QoreProgram* get_set_program_call_context(QoreProgram* new_pgm);
 DLLLOCAL void set_program_call_context(QoreProgram* new_pgm);
-DLLLOCAL QoreProgram* get_program_call_context();
 
 #ifdef QORE_RUNTIME_THREAD_STACK_TRACE
 DLLLOCAL void pushCall(CallNode* cn);

--- a/lib/CallReferenceNode.cpp
+++ b/lib/CallReferenceNode.cpp
@@ -572,18 +572,18 @@ bool LocalFunctionCallReferenceNode::is_equal_hard(const AbstractQoreNode* v, Ex
 }
 
 bool FunctionCallReferenceNode::derefImpl(ExceptionSink* xsink) {
-   //printd(5, "FunctionCallReferenceNode::deref() this: %p pgm: %p refs: %d -> %d\n", this, pgm, reference_count(), reference_count() - 1);
-   pgm->depDeref();
-   return true;
+    //printd(5, "FunctionCallReferenceNode::deref() this: %p pgm: %p refs: %d -> %d\n", this, pgm, reference_count(), reference_count() - 1);
+    pgm->depDeref();
+    return true;
 }
 
 QoreValue FunctionCallReferenceNode::execValue(const QoreListNode* args, ExceptionSink* xsink) const {
-   return uf->evalFunction(0, args, pgm, xsink);
+    return uf->evalFunction(0, args, pgm, xsink);
 }
 
 ResolvedCallReferenceNode::ResolvedCallReferenceNode(bool n_needs_eval, qore_type_t n_type) : AbstractCallReferenceNode(n_needs_eval, n_type) {
 }
 
 QoreProgram* ResolvedCallReferenceNode::getProgram() const {
-   return 0;
+    return 0;
 }

--- a/lib/Function.cpp
+++ b/lib/Function.cpp
@@ -1380,8 +1380,8 @@ QoreValue QoreFunction::evalFunction(const AbstractQoreFunctionVariant* variant,
     const char* fname = getName();
     CodeEvaluationHelper ceh(xsink, this, variant, fname, args);
     if (*xsink) return QoreValue();
-    // issue #3024
-    QoreProgramContextHelper pch(pgm);
+    // issue #3024: make the caller's call context available
+    ProgramCallContextHelper pcch(pgm);
 
     return variant->evalFunction(fname, ceh, xsink);
 }
@@ -1391,8 +1391,8 @@ QoreValue QoreFunction::evalFunctionTmpArgs(const AbstractQoreFunctionVariant* v
     const char* fname = getName();
     CodeEvaluationHelper ceh(xsink, this, variant, fname, args);
     if (*xsink) return QoreValue();
-    // issue #3024
-    QoreProgramContextHelper pch(pgm);
+    // issue #3024: make the caller's call context available
+    ProgramCallContextHelper pcch(pgm);
 
     return variant->evalFunction(fname, ceh, xsink);
 }

--- a/lib/Function.cpp
+++ b/lib/Function.cpp
@@ -1377,31 +1377,35 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
 
 // if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL, then it is identified at run time
 QoreValue QoreFunction::evalFunction(const AbstractQoreFunctionVariant* variant, const QoreListNode* args, QoreProgram *pgm, ExceptionSink* xsink) const {
-   const char* fname = getName();
-   CodeEvaluationHelper ceh(xsink, this, variant, fname, args);
-   if (*xsink) return QoreValue();
+    const char* fname = getName();
+    CodeEvaluationHelper ceh(xsink, this, variant, fname, args);
+    if (*xsink) return QoreValue();
+    // issue #3024
+    QoreProgramContextHelper pch(pgm);
 
-   return variant->evalFunction(fname, ceh, xsink);
+    return variant->evalFunction(fname, ceh, xsink);
 }
 
 // if the variant was identified at parse time, then variant will not be NULL, otherwise if NULL, then it is identified at run time
 QoreValue QoreFunction::evalFunctionTmpArgs(const AbstractQoreFunctionVariant* variant, QoreListNode* args, QoreProgram *pgm, ExceptionSink* xsink) const {
-   const char* fname = getName();
-   CodeEvaluationHelper ceh(xsink, this, variant, fname, args);
-   if (*xsink) return QoreValue();
+    const char* fname = getName();
+    CodeEvaluationHelper ceh(xsink, this, variant, fname, args);
+    if (*xsink) return QoreValue();
+    // issue #3024
+    QoreProgramContextHelper pch(pgm);
 
-   return variant->evalFunction(fname, ceh, xsink);
+    return variant->evalFunction(fname, ceh, xsink);
 }
 
 // finds a variant and checks variant capabilities against current
 // program parse options
 QoreValue QoreFunction::evalDynamic(const QoreListNode* args, ExceptionSink* xsink) const {
-   const char* fname = getName();
-   const AbstractQoreFunctionVariant* variant = 0;
-   CodeEvaluationHelper ceh(xsink, this, variant, fname, args);
-   if (*xsink) return QoreValue();
+    const char* fname = getName();
+    const AbstractQoreFunctionVariant* variant = 0;
+    CodeEvaluationHelper ceh(xsink, this, variant, fname, args);
+    if (*xsink) return QoreValue();
 
-   return variant->evalFunction(fname, ceh, xsink);
+    return variant->evalFunction(fname, ceh, xsink);
 }
 
 void QoreFunction::addBuiltinVariant(AbstractQoreFunctionVariant* variant) {

--- a/lib/QC_Program.qpp
+++ b/lib/QC_Program.qpp
@@ -2017,10 +2017,11 @@ ProgramControl Program::getProgram() [flags=RET_VALUE_ONLY; dom=DEBUGGER] {
 //! issues a module command for the given module; the module is loaded into the current %Program object if it is not already present
 /** @par Example:
     @code{.py}
+pgm.issueModuleCmd("jni", "define-class " + java_class_path_name + " " + byte_code.toBase64());
     @endcode
 
     @param module the module name
-    @param cmd the command string to execute
+    @param cmd the command string to execute to be parsed by the module
 
     @throw PARSE-COMMAND-ERROR the module does not support commands
 

--- a/lib/QoreLib.cpp
+++ b/lib/QoreLib.cpp
@@ -2664,3 +2664,7 @@ QoreHashNode* get_source_location(const QoreProgramLocation* loc) {
 const char* type_get_name(const QoreTypeInfo* t) {
     return QoreTypeInfo::getName(t);
 }
+
+QoreProgram* qore_get_call_program_context() {
+    return get_program_call_context();
+}

--- a/lib/QoreLib.cpp
+++ b/lib/QoreLib.cpp
@@ -2664,7 +2664,3 @@ QoreHashNode* get_source_location(const QoreProgramLocation* loc) {
 const char* type_get_name(const QoreTypeInfo* t) {
     return QoreTypeInfo::getName(t);
 }
-
-QoreProgram* qore_get_call_program_context() {
-    return get_program_call_context();
-}

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -1408,14 +1408,22 @@ void ModuleContextFunctionList::clear() {
 }
 
 QoreProgramContextHelper::QoreProgramContextHelper(QoreProgram* pgm) {
-   ThreadData* td  = thread_data.get();
-   old_pgm = td->current_pgm;
-   td->current_pgm = pgm;
+    // allow the program context to be skipped with a nullptr arg
+    if (!pgm) {
+        old_pgm = reinterpret_cast<QoreProgram*>(-1);
+        return;
+    }
+    ThreadData* td  = thread_data.get();
+    old_pgm = td->current_pgm;
+    td->current_pgm = pgm;
 }
 
 QoreProgramContextHelper::~QoreProgramContextHelper() {
-   ThreadData* td  = thread_data.get();
-   td->current_pgm = old_pgm;
+    if (old_pgm == reinterpret_cast<QoreProgram*>(-1)) {
+        return;
+    }
+    ThreadData* td  = thread_data.get();
+    td->current_pgm = old_pgm;
 }
 
 ObjectSubstitutionHelper::ObjectSubstitutionHelper(QoreObject* obj, const qore_class_private* c) {

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -249,201 +249,204 @@ typedef std::set<const lvalue_ref*> ref_set_t;
 // this structure holds all thread-specific data
 class ThreadData {
 public:
-   int64 runtime_po = 0;
-   int tid;
+    int64 runtime_po = 0;
+    int tid;
 
-   VLock vlock;     // for deadlock detection
+    VLock vlock;     // for deadlock detection
 
-   Context* context_stack = nullptr;
-   ProgramParseContext* plStack = nullptr;
-   const QoreProgramLocation* runtime_loc = &loc_builtin;
-   const AbstractStatement* runtime_statement;
-   const char* parse_code = nullptr; // the current function, method, or closure being parsed
-   const char* parse_file = nullptr; // the current file or label being parsed
-   const char* parse_source = nullptr; // the current source being parsed
-   int parse_offset = 0; // the current offset in the source being parsed
-   void* parseState = nullptr;
-   VNode* vstack = nullptr;  // used during parsing (local variable stack)
-   CVNode* cvarstack = nullptr;
-   QoreClass* parseClass = nullptr; // current class being parsed
-   QoreException* catchException = nullptr;
+    Context* context_stack = nullptr;
+    ProgramParseContext* plStack = nullptr;
+    const QoreProgramLocation* runtime_loc = &loc_builtin;
+    const AbstractStatement* runtime_statement;
+    const char* parse_code = nullptr; // the current function, method, or closure being parsed
+    const char* parse_file = nullptr; // the current file or label being parsed
+    const char* parse_source = nullptr; // the current source being parsed
+    int parse_offset = 0; // the current offset in the source being parsed
+    void* parseState = nullptr;
+    VNode* vstack = nullptr;  // used during parsing (local variable stack)
+    CVNode* cvarstack = nullptr;
+    QoreClass* parseClass = nullptr; // current class being parsed
+    QoreException* catchException = nullptr;
 
-   std::list<block_list_t::iterator> on_block_exit_list;
+    std::list<block_list_t::iterator> on_block_exit_list;
 
-   ThreadResourceList* trlist = new ThreadResourceList;
+    ThreadResourceList* trlist = new ThreadResourceList;
 
-   // for detecting circular references at runtime
-   ref_set_t ref_set;
+    // for detecting circular references at runtime
+    ref_set_t ref_set;
 
-   // current function/method name
-   const char* current_code = nullptr;
+    // current function/method name
+    const char* current_code = nullptr;
 
-   // current object context
-   QoreObject* current_obj = nullptr;
+    // current object context
+    QoreObject* current_obj = nullptr;
 
-   // current class context
-   const qore_class_private* current_class = nullptr;
+    // current class context
+    const qore_class_private* current_class = nullptr;
 
-   // current program context
-   QoreProgram* current_pgm = nullptr;
+    // current program context
+    QoreProgram* current_pgm = nullptr;
 
-   // current program context helper
-   ProgramThreadCountContextHelper* current_pgm_ctx = nullptr;
+    // issue #3024: program context for calls prior to a call
+    QoreProgram* call_program_context = nullptr;
 
-   // current namespace context for parsing
-   qore_ns_private* current_ns = nullptr;
+    // current program context helper
+    ProgramThreadCountContextHelper* current_pgm_ctx = nullptr;
 
-   // current implicit argument
-   QoreListNode* current_implicit_arg = nullptr;
+    // current namespace context for parsing
+    qore_ns_private* current_ns = nullptr;
 
-   // this data structure is stored in the current Program object on a per-thread basis
-   ThreadLocalProgramData* tlpd = nullptr;
+    // current implicit argument
+    QoreListNode* current_implicit_arg = nullptr;
 
-   // this data structure contains the set of Program objects that this thread has data in
-   ThreadProgramData* tpd;
+    // this data structure is stored in the current Program object on a per-thread basis
+    ThreadLocalProgramData* tlpd = nullptr;
 
-   // current parsing closure environment
-   ClosureParseEnvironment* closure_parse_env = nullptr;
+    // this data structure contains the set of Program objects that this thread has data in
+    ThreadProgramData* tpd;
 
-   // current runtime closure environment
-   const QoreClosureBase* closure_rt_env = nullptr;
+    // current parsing closure environment
+    ClosureParseEnvironment* closure_parse_env = nullptr;
 
-   ArgvRefStack argv_refs;
+    // current runtime closure environment
+    const QoreClosureBase* closure_rt_env = nullptr;
+
+    ArgvRefStack argv_refs;
 
 #ifdef QORE_MANAGE_STACK
-   size_t stack_limit;
-   // this thread's stack size for error reporting
-   size_t stack_size;
+    size_t stack_limit;
+    // this thread's stack size for error reporting
+    size_t stack_size;
 #ifdef IA64_64
-   size_t rse_limit;
+    size_t rse_limit;
 #endif
 #endif
 
-   // used to detect output of recursive data structures at runtime
-   const_node_set_t node_set;
+    // used to detect output of recursive data structures at runtime
+    const_node_set_t node_set;
 
-   // currently-executing/parsing block's return type
-   const QoreTypeInfo* returnTypeInfo = nullptr;
+    // currently-executing/parsing block's return type
+    const QoreTypeInfo* returnTypeInfo = nullptr;
 
-   // parse-time block return type
-   const QoreTypeInfo* parse_return_type_info = nullptr;
+    // parse-time block return type
+    const QoreTypeInfo* parse_return_type_info = nullptr;
 
-   // parse-time implicit argument type
-   const QoreTypeInfo* implicit_arg_type_info = nullptr;
+    // parse-time implicit argument type
+    const QoreTypeInfo* implicit_arg_type_info = nullptr;
 
-   // current implicit element offset
-   int element = 0;
+    // current implicit element offset
+    int element = 0;
 
-   // start of global thread-local variables for the current thread and program being parsed
-   VNode* global_vnode = nullptr;
+    // start of global thread-local variables for the current thread and program being parsed
+    VNode* global_vnode = nullptr;
 
-   // Maintains the conditional parse block count for each file parsed
-   ParseConditionalStack* pcs = nullptr;
+    // Maintains the conditional parse block count for each file parsed
+    ParseConditionalStack* pcs = nullptr;
 
-   // Maintains the %try-module block count for each file
-   ParseCountHelper tm;
+    // Maintains the %try-module block count for each file
+    ParseCountHelper tm;
 
-   // for capturing namespace and class names while parsing
-   typedef std::vector<std::string> npvec_t;
-   npvec_t npvec;
+    // for capturing namespace and class names while parsing
+    typedef std::vector<std::string> npvec_t;
+    npvec_t npvec;
 
-   // used for error handling when merging module code into a Program object
-   QoreModuleContext* qmc = nullptr;
+    // used for error handling when merging module code into a Program object
+    QoreModuleContext* qmc = nullptr;
 
-   // used to capture the module definition in user modules
-   QoreModuleDefContext* qmd = nullptr;
+    // used to capture the module definition in user modules
+    QoreModuleDefContext* qmd = nullptr;
 
-   // user to track the current user module context
-   const char* user_module_context_name = nullptr;
+    // user to track the current user module context
+    const char* user_module_context_name = nullptr;
 
-   // AbstractQoreModule* with boolean ptr in bit 0
-   uintptr_t qmi = 0;
+    // AbstractQoreModule* with boolean ptr in bit 0
+    uintptr_t qmi = 0;
 
-   bool
-      foreign : 1, // true if the thread is a foreign thread
-      try_reexport : 1;
+    bool
+        foreign : 1, // true if the thread is a foreign thread
+        try_reexport : 1;
 
-   DLLLOCAL ThreadData(int ptid, QoreProgram* p, bool n_foreign = false) :
-      tid(ptid),
-      vlock(ptid),
-      current_pgm(p),
-      tpd(new ThreadProgramData(this)),
-      foreign(n_foreign),
-      try_reexport(false) {
+    DLLLOCAL ThreadData(int ptid, QoreProgram* p, bool n_foreign = false) :
+        tid(ptid),
+        vlock(ptid),
+        current_pgm(p),
+        tpd(new ThreadProgramData(this)),
+        foreign(n_foreign),
+        try_reexport(false) {
 
 #ifdef QORE_MANAGE_STACK
-      // save this thread's stack size as the default stack size can change
-      stack_size = qore_thread_stack_size;
+        // save this thread's stack size as the default stack size can change
+        stack_size = qore_thread_stack_size;
 #ifdef STACK_DIRECTION_DOWN
-      stack_limit = get_stack_pos() - qore_thread_stack_limit;
+        stack_limit = get_stack_pos() - qore_thread_stack_limit;
 #else
-      stack_limit = get_stack_pos() + qore_thread_stack_limit;
+        stack_limit = get_stack_pos() + qore_thread_stack_limit;
 #endif // #ifdef STACK_DIRECTION_DOWN
 
 #ifdef IA64_64
-      // RSE stack grows up
-      rse_limit = get_rse_bsp() + qore_thread_stack_limit;
+        // RSE stack grows up
+        rse_limit = get_rse_bsp() + qore_thread_stack_limit;
 #endif // #ifdef IA64_64
 
 #endif // #ifdef QORE_MANAGE_STACK
-   }
+    }
 
-   DLLLOCAL ~ThreadData() {
-      assert(on_block_exit_list.empty());
-      assert(!tpd);
-      assert(!trlist->prev);
-      delete pcs;
-      delete trlist;
-   }
+    DLLLOCAL ~ThreadData() {
+        assert(on_block_exit_list.empty());
+        assert(!tpd);
+        assert(!trlist->prev);
+        delete pcs;
+        delete trlist;
+    }
 
-   DLLLOCAL void endFileParsing() {
-      if (pcs) {
-         pcs->purge();
-         delete pcs;
-         pcs = 0;
-      }
-      tm.purge();
-   }
+    DLLLOCAL void endFileParsing() {
+        if (pcs) {
+            pcs->purge();
+            delete pcs;
+            pcs = 0;
+        }
+        tm.purge();
+    }
 
-   DLLLOCAL int getElement() {
-      return element;
-   }
+    DLLLOCAL int getElement() {
+        return element;
+    }
 
-   DLLLOCAL int saveElement(int n_element) {
-      int rc = element;
-      element = n_element;
-      return rc;
-   }
+    DLLLOCAL int saveElement(int n_element) {
+        int rc = element;
+        element = n_element;
+        return rc;
+    }
 
-   DLLLOCAL void del(ExceptionSink* xsink) {
-      tpd->del(xsink);
-      tpd->deref();
-      tpd = 0;
-   }
+    DLLLOCAL void del(ExceptionSink* xsink) {
+        tpd->del(xsink);
+        tpd->deref();
+        tpd = 0;
+    }
 
-   DLLLOCAL void pushName(const char* name) {
-      npvec.push_back(name);
-   }
+    DLLLOCAL void pushName(const char* name) {
+        npvec.push_back(name);
+    }
 
-   DLLLOCAL std::string popName() {
-      assert(!npvec.empty());
-      std::string rv = npvec.back();
-      npvec.pop_back();
-      return rv;
-   }
+    DLLLOCAL std::string popName() {
+        assert(!npvec.empty());
+        std::string rv = npvec.back();
+        npvec.pop_back();
+        return rv;
+    }
 
-   DLLLOCAL void parseRollback() {
-      npvec.clear();
-   }
+    DLLLOCAL void parseRollback() {
+        npvec.clear();
+    }
 
-   DLLLOCAL qore_ns_private* set_ns(qore_ns_private* ns) {
-      if (ns == current_ns)
-         return ns;
+    DLLLOCAL qore_ns_private* set_ns(qore_ns_private* ns) {
+        if (ns == current_ns)
+            return ns;
 
-      qore_ns_private* rv = current_ns;
-      current_ns = ns;
-      return rv;
-   }
+        qore_ns_private* rv = current_ns;
+        current_ns = ns;
+        return rv;
+    }
 };
 
 static QoreThreadLocalStorage<ThreadData> thread_data;
@@ -798,28 +801,47 @@ int check_stack(ExceptionSink* xsink) {
 }
 #endif
 
+QoreProgram* get_set_program_call_context(QoreProgram* new_pgm) {
+    ThreadData* td = thread_data.get();
+    QoreProgram* pgm = td->call_program_context;
+    td->call_program_context = new_pgm;
+    return pgm;
+}
+
+void set_program_call_context(QoreProgram* new_pgm) {
+    thread_data.get()->call_program_context = new_pgm;
+}
+
+// returns the current call context if set, otherwise the current program context
+QoreProgram* get_program_call_context() {
+    ThreadData* td = thread_data.get();
+    assert(td);
+    QoreProgram* rv = td->call_program_context;
+    return rv ? rv : td->current_pgm;
+}
+
 QoreAbstractModule* set_reexport(QoreAbstractModule* m, bool current_reexport, bool& old_reexport) {
-   ThreadData* td = thread_data.get();
-   uintptr_t rv = td->qmi;
-   if (rv & 1) {
-      old_reexport = true;
-      rv ^= 1;
-   }
-   else
-      old_reexport = false;
+    ThreadData* td = thread_data.get();
+    uintptr_t rv = td->qmi;
+    if (rv & 1) {
+        old_reexport = true;
+        rv ^= 1;
+    }
+    else
+        old_reexport = false;
 
-   td->qmi = (uintptr_t)m;
-   if (current_reexport)
-      td->qmi |= 1;
+    td->qmi = (uintptr_t)m;
+    if (current_reexport)
+        td->qmi |= 1;
 
-   return (QoreAbstractModule*)rv;
+    return (QoreAbstractModule*)rv;
 }
 
 void set_reexport(QoreAbstractModule* m, bool reexport) {
-   ThreadData* td = thread_data.get();
-   td->qmi = (uintptr_t)m;
-   if (reexport)
-      td->qmi |= 1;
+    ThreadData* td = thread_data.get();
+    td->qmi = (uintptr_t)m;
+    if (reexport)
+        td->qmi |= 1;
 }
 
 // returns 1 if data structure is already on stack, 0 if not (=OK)

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -813,7 +813,9 @@ void set_program_call_context(QoreProgram* new_pgm) {
 }
 
 // returns the current call context if set, otherwise the current program context
-QoreProgram* get_program_call_context() {
+/* this function is exported in the public Qore API
+*/
+QoreProgram* qore_get_call_program_context() {
     ThreadData* td = thread_data.get();
     assert(td);
     QoreProgram* rv = td->call_program_context;


### PR DESCRIPTION
…n context with builtin functions and therefore calls to builtin functions in modules with per-program private data would fail

test is in the jni module; requires a binary module with private data to test