### PR TITLE
refs #1796 added a non-const QoreProgram::findNamespace() variant

### DIFF
--- a/include/qore/QoreProgram.h
+++ b/include/qore/QoreProgram.h
@@ -741,6 +741,14 @@ public:
     DLLEXPORT const TypedHashDecl* findHashDecl(const char* path, const QoreNamespace*& pns) const;
 
     //! search for the given namespace in the program; can be a simple namespace name or a namespace-prefixed path (ex: "NamespaceName::Namespace")
+    /** @note this function is safe to call during module initialization for the current Program (as returned by
+        getProgram())
+
+        @since %Qore 0.9
+    */
+    DLLEXPORT QoreNamespace* findNamespace(const QoreString& path);
+
+    //! search for the given namespace in the program; can be a simple namespace name or a namespace-prefixed path (ex: "NamespaceName::Namespace")
     /** @since %Qore 0.9
     */
     DLLEXPORT const QoreNamespace* findNamespace(const QoreString& path) const;

--- a/lib/QoreProgram.cpp
+++ b/lib/QoreProgram.cpp
@@ -2164,6 +2164,14 @@ const TypedHashDecl* QoreProgram::findHashDecl(const char* path, const QoreNames
     return th;
 }
 
+// issue #1796: include a non-const variant for binary modules
+QoreNamespace* QoreProgram::findNamespace(const QoreString& path) {
+    if (path == "::") {
+        return priv->RootNS;
+    }
+    return qore_root_ns_private::get(*priv->RootNS)->runtimeFindNamespace(path);
+}
+
 const QoreNamespace* QoreProgram::findNamespace(const QoreString& path) const {
     if (path == "::") {
         return priv->RootNS;


### PR DESCRIPTION
it turns out that no locking is needed for this call when in module initialization code, which is where it's used in the jni module for example