### PR TITLE
refs #3077 made exception sink func public so they can be used from m…

### DIFF
--- a/include/qore/ExceptionSink.h
+++ b/include/qore/ExceptionSink.h
@@ -92,7 +92,7 @@ public:
     /** The AbstractQoreNode pointer returned is always 0; used to simplify error handling code.
         @param err the exception code string
         @param fmt the format string for the description for the exception
-        @return always returns 0
+        @return always returns nullptr
     */
     DLLEXPORT AbstractQoreNode* raiseException(const char *err, const char *fmt, ...);
 
@@ -101,7 +101,7 @@ public:
         @param err the exception code string
         @param en the error number (normally "errno")
         @param fmt the format string for the description for the exception
-        @return always returns 0
+        @return always returns nullptr
     */
     DLLEXPORT AbstractQoreNode* raiseErrnoException(const char *err, int en, const char *fmt, ...);
 
@@ -110,7 +110,7 @@ public:
         @param err the exception code string
         @param en the error number (normally "errno")
         @param desc the error description (the ExceptionSink object takes over ownership of the reference count)
-        @return always returns 0
+        @return always returns nullptr
     */
     DLLEXPORT AbstractQoreNode* raiseErrnoException(const char *err, int en, QoreStringNode* desc);
 
@@ -119,7 +119,7 @@ public:
         @param err the exception code string
         @param arg the 'arg' member of the Qore-language exception object; will be dereferenced when the QoreException object is destroyed
         @param fmt the format string for the description for the exception
-        @return always returns 0
+        @return always returns nullptr
     */
     DLLEXPORT AbstractQoreNode* raiseExceptionArg(const char* err, QoreValue arg, const char* fmt, ...);
 
@@ -128,7 +128,7 @@ public:
         @param err the exception code string
         @param arg the 'arg' member of the Qore-language exception object; will be dereferenced when the QoreException object is destroyed
         @param desc the description string for the exception; the ExceptionSink object takes ownership of the reference count
-        @return always returns 0
+        @return always returns nullptr
     */
     DLLEXPORT AbstractQoreNode* raiseExceptionArg(const char* err, QoreValue arg, QoreStringNode* desc);
 
@@ -139,17 +139,31 @@ public:
         @param desc the description string for the exception; the ExceptionSink object takes ownership of the reference count
         @param stack a call stack to prepend to the Qore call stack
 
-        @return always returns 0
+        @return always returns nullptr
 
         @since %Qore 0.8.13
     */
     DLLEXPORT AbstractQoreNode* raiseExceptionArg(const char* err, QoreValue arg, QoreStringNode* desc, const QoreCallStack& stack);
 
+    //! appends a Qore-language exception to the list, and sets the 'arg' member (this object takes over the reference counts of 'arg' and 'desc')
+    /** The AbstractQoreNode pointer returned is always 0; used to simplify error handling code.
+        @param loc the source location for the exception
+        @param err the exception code string
+        @param arg the 'arg' member of the Qore-language exception object; will be dereferenced when the QoreException object is destroyed
+        @param desc the description string for the exception; the ExceptionSink object takes ownership of the reference count
+        @param stack a call stack to prepend to the Qore call stack
+
+        @return always returns nullptr
+
+        @since %Qore 0.9
+    */
+    DLLEXPORT AbstractQoreNode* raiseExceptionArg(const QoreProgramLocation& loc, const char* err, QoreValue arg, QoreStringNode* desc, const QoreCallStack& stack);
+
     //! appends a Qore-language exception to the list; takes owenership of the "desc" argument reference
     /** The AbstractQoreNode pointer returned is always 0; used to simplify error handling code.
         @param err the exception code string
         @param desc the description string for the exception; the ExceptionSink object takes ownership of the reference count
-        @return always returns 0
+        @return always returns nullptr
     */
     DLLEXPORT AbstractQoreNode* raiseException(const char *err, QoreStringNode* desc);
 
@@ -157,7 +171,7 @@ public:
     /** The AbstractQoreNode pointer returned is always 0; used to simplify error handling code.
         @param err the exception code string for the exception; the ExceptionSink object takes ownership of the reference count
         @param desc the description string for the exception; the ExceptionSink object takes ownership of the reference count
-        @return always returns 0
+        @return always returns nullptr
     */
     DLLEXPORT AbstractQoreNode* raiseException(QoreStringNode *err, QoreStringNode* desc);
 

--- a/include/qore/ExceptionSink.h
+++ b/include/qore/ExceptionSink.h
@@ -161,6 +161,28 @@ public:
     */
     DLLEXPORT AbstractQoreNode* raiseException(QoreStringNode *err, QoreStringNode* desc);
 
+    //! appends a Qore-language exception to the list; takes owenership of the "desc" argument reference
+    /**
+        @param loc the source location for the exception
+        @param err the exception code string for the exception
+        @param arg the 'arg' member of the Qore-language exception object; will be dereferenced when the QoreException object is destroyed
+        @param desc the description string for the exception; the ExceptionSink object takes ownership of the reference count
+
+        @since %Qore 0.9.0
+    */
+    DLLEXPORT void raiseException(const QoreProgramLocation& loc, const char* err, QoreValue arg, QoreValue desc);
+
+    //! appends a Qore-language exception to the list; takes owenership of the "desc" argument reference
+    /**
+        @param loc the source location for the exception
+        @param err the exception code string for the exception
+        @param arg the 'arg' member of the Qore-language exception object; will be dereferenced when the QoreException object is destroyed
+        @param fmt the format string for the description for the exception
+
+        @since %Qore 0.9.0
+    */
+    DLLEXPORT void raiseException(const QoreProgramLocation& loc, const char* err, QoreValue arg, const char* fmt, ...);
+
     //! sets the "thread_exit" flag; will cause the current thread to terminate
     DLLEXPORT void raiseThreadExit();
 
@@ -194,8 +216,6 @@ public:
 
     DLLLOCAL void raiseException(QoreException* e);
     DLLLOCAL void raiseException(const QoreListNode* n);
-    DLLLOCAL void raiseException(const QoreProgramLocation& loc, const char* err, QoreValue arg, QoreValue desc);
-    DLLLOCAL void raiseException(const QoreProgramLocation& loc, const char* err, QoreValue arg, const char* fmt, ...);
     DLLLOCAL QoreException* catchException();
     DLLLOCAL QoreException* getException();
     DLLLOCAL void overrideLocation(const QoreProgramLocation& loc);

--- a/include/qore/ExceptionSink.h
+++ b/include/qore/ExceptionSink.h
@@ -311,7 +311,29 @@ static inline void makeAccessDeletedObjectException(ExceptionSink *xsink, const 
 }
 
 // returns a custom Qore program location for external modules to generate runtime exceptions with the source location
-DLLLOCAL QoreProgramLocation qore_get_program_location(const char* file, int start_line, int end_line,
-    const char* source = nullptr, int offset = 0);
+class QoreExternalProgramLocationWrapper {
+public:
+    DLLEXPORT QoreExternalProgramLocationWrapper();
+
+    DLLEXPORT QoreExternalProgramLocationWrapper(const char* file, int start_line, int end_line,
+        const char* source = nullptr, int offset = 0);
+
+    DLLEXPORT ~QoreExternalProgramLocationWrapper();
+
+    DLLEXPORT void set(const char* file, int start_line, int end_line,
+        const char* source = nullptr, int offset = 0);
+
+    DLLEXPORT const QoreProgramLocation& get() const {
+        return *loc;
+    }
+
+private:
+    // save strings for exceptions in case they are epheremal when this object is created
+    std::string file_str;
+    std::string source_str;
+
+    // actual exception location
+    DLLLOCAL QoreProgramLocation* loc;
+};
 
 #endif

--- a/include/qore/ExceptionSink.h
+++ b/include/qore/ExceptionSink.h
@@ -310,4 +310,8 @@ static inline void makeAccessDeletedObjectException(ExceptionSink *xsink, const 
     xsink->raiseException("OBJECT-ALREADY-DELETED", "attempt to access an already-deleted object of class '%s'", cname);
 }
 
+// returns a custom Qore program location for external modules to generate runtime exceptions with the source location
+DLLLOCAL QoreProgramLocation qore_get_program_location(const char* file, int start_line, int end_line,
+    const char* source = nullptr, int offset = 0);
+
 #endif

--- a/include/qore/intern/QoreLibIntern.h
+++ b/include/qore/intern/QoreLibIntern.h
@@ -255,7 +255,14 @@ public:
     int16_t offset = 0;
 
 protected:
-    DLLLOCAL explicit QoreProgramLocation(const char* f, int sline = 0, int eline = 0) : QoreProgramLineLocation(sline, eline), file(f) {
+    DLLLOCAL explicit QoreProgramLocation(const char* f, int sline = 0, int eline = 0) :
+        QoreProgramLineLocation(sline, eline), file(f) {
+    }
+
+public:
+    DLLLOCAL explicit QoreProgramLocation(const char* f, int sline, int eline, const char* source, int offset) :
+        QoreProgramLineLocation(sline, eline), file(f), source(source), offset(offset) {
+        assert(offset <= 0xffff);
     }
 };
 

--- a/lib/ExceptionSink.cpp
+++ b/lib/ExceptionSink.cpp
@@ -220,6 +220,13 @@ AbstractQoreNode* ExceptionSink::raiseExceptionArg(const char* err, QoreValue ar
     return nullptr;
 }
 
+AbstractQoreNode* ExceptionSink::raiseExceptionArg(const QoreProgramLocation& loc, const char* err, QoreValue arg, QoreStringNode *desc, const QoreCallStack& stack) {
+    printd(5, "ExceptionSink::raiseExceptionArg(loc, %s, %s, %p)\n", err, desc->getBuffer(), &stack);
+    priv->insert(new QoreException(loc, err, desc, arg));
+    priv->addStackInfo(stack);
+    return nullptr;
+}
+
 AbstractQoreNode* ExceptionSink::raiseExceptionArg(const char* err, QoreValue arg, const char* fmt, ...) {
     QoreStringNode *desc = new QoreStringNode;
 

--- a/lib/ExceptionSink.cpp
+++ b/lib/ExceptionSink.cpp
@@ -315,3 +315,8 @@ void ExceptionSink::outOfMemory() {
     _Exit(1);
 #endif
 }
+
+QoreProgramLocation qore_get_program_location(const char* file, int start_line, int end_line,
+    const char* source, int offset) {
+    return QoreProgramLocation(file, start_line, end_line, source, offset);
+}

--- a/lib/ExceptionSink.cpp
+++ b/lib/ExceptionSink.cpp
@@ -332,7 +332,7 @@ QoreExternalProgramLocationWrapper::~QoreExternalProgramLocationWrapper() {
 
 void QoreExternalProgramLocationWrapper::set(const char* file, int start_line, int end_line,
     const char* source, int offset) {
-    // we need to save strings in case the are epheremal on the caller's side
+    // we need to save strings in case they are epheremal when this object is created
     if (!file) {
         file_str.clear();
     } else {


### PR DESCRIPTION
…odules; no tests necessary as these have already already heavily tested as they have been a necessary part of the Qore API for a long time