### PR TITLE
refs 3162 AbstractConnection related features cleanup. It has followi…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -128,7 +128,7 @@
         - The \c AbstractConnection::getConstructorInfo() method (and supporting declarations) was added to allow
           connections to be created dynamically, potentially in another process from a network call (<a href="https://github.com/qorelanguage/qore/issues/2628">issue 2628</a>)
         - The \c AbstractConnection has new public flag \c enabled. Also constructors are updated. (<a href="https://github.com/qorelanguage/qore/issues/3001">issue 3001</a>)
-        - The \c AbstractConnection has new constructors, old onews are obsolete. Custom URL/URI parsing is possible (<a href="https://github.com/qorelanguage/qore/issues/3162">issue 3162</a>)
+        - The \c AbstractConnection has new constructors, old ones are obsolete. Custom URL/URI parsing is possible (<a href="https://github.com/qorelanguage/qore/issues/3162">issue 3162</a>)
       - <a href="../../modules/FreetdsSqlUtil/html/index.html">FreetdsSqlUtil</a> module changes:
         - Added support for serializing and deserializing \c AbstractTable objects (<a href="https://github.com/qorelanguage/qore/issues/2663">issue 2663</a>)
       - <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module changes:

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -128,6 +128,7 @@
         - The \c AbstractConnection::getConstructorInfo() method (and supporting declarations) was added to allow
           connections to be created dynamically, potentially in another process from a network call (<a href="https://github.com/qorelanguage/qore/issues/2628">issue 2628</a>)
         - The \c AbstractConnection has new public flag \c enabled. Also constructors are updated. (<a href="https://github.com/qorelanguage/qore/issues/3001">issue 3001</a>)
+        - The \c AbstractConnection has new constructors, old onews are obsolete. Custom URL/URI parsing is possible (<a href="https://github.com/qorelanguage/qore/issues/3162">issue 3162</a>)
       - <a href="../../modules/FreetdsSqlUtil/html/index.html">FreetdsSqlUtil</a> module changes:
         - Added support for serializing and deserializing \c AbstractTable objects (<a href="https://github.com/qorelanguage/qore/issues/2663">issue 2663</a>)
       - <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module changes:

--- a/examples/test/qlib/ConnectionProvider/ConnectionProvider.qtest
+++ b/examples/test/qlib/ConnectionProvider/ConnectionProvider.qtest
@@ -20,13 +20,31 @@ const KeyPassword = "password";
 public class ConnectionProviderTest inherits QUnit::Test {
     constructor() : Test("ConnectionProvider Test", "1.0") {
         addTestCase("ftp", \ftpConnectionTest());
+        addTestCase("ftp deprecated", \ftpConnectionTestDeprecated());
         addTestCase("http", \httpConnectionTest());
+        addTestCase("http deprecated", \httpConnectionTestDeprecated());
+        addTestCase("fs", \fsConnectionTest());
+        addTestCase("fs deprecated", \fsConnectionTestDeprecated());
+        addTestCase("invalid", \invalidConnectionTest());
+        addTestCase("custom parseUrl", \customParseUrlTest());
 
         # Return for compatibility with a test harness that checks the return value
         set_return_value(main());
     }
 
     ftpConnectionTest() {
+        string url = "ftp://user:pass@localhost:1234/some_path";
+        FtpConnection fc("name", "desc", url);
+        assertEq(True, fc.enabled, "connection is enabled by default");
+        assertEq(True, fc.monitor, "connection is monitored by default");
+
+        hash<ConnectionConstructorInfo> info = fc.getConstructorInfo();
+        assertEq("FtpClient", info.class_name);
+        assertEq(url, info.args[0]);
+        checkPreAndPostProcessing(info);
+    }
+
+    ftpConnectionTestDeprecated() {
         string url = "ftp://user:pass@localhost:1234/some_path";
         hash urlh = parse_url(url);
         FtpConnection fc("name", "desc", url, True, NOTHING, urlh);
@@ -63,13 +81,15 @@ public class ConnectionProviderTest inherits QUnit::Test {
         # use IPv4 localhost to work around potential issues with localhost -> ::1 and IPv6 -> IPv4 mappings
         # (ex: Windows)
         string url = "https://127.0.0.1:" + server.getPort();
-        hash urlh = parse_url(url);
         hash opts = (
             "ssl_cert_path": CertPath,
             "ssl_key_path": KeyPath,
             "ssl_key_password": KeyPassword,
         );
-        HttpConnection hc("name", "desc", url, True, opts, urlh);
+        hash attributes = {
+            "monitor": True,
+        };
+        HttpConnection hc("name", "desc", url, attributes, opts);
         assertEq(True, hc.enabled, "connection is enabled by default");
 
         HTTPClient client = hc.get();
@@ -94,10 +114,107 @@ public class ConnectionProviderTest inherits QUnit::Test {
         server.acceptAllCertificates(True);
         # verify server certificate in the client
         opts.ssl_verify_cert = True;
-        hc = new HttpConnection("name", "desc", url, True, opts, urlh);
+        hc = new HttpConnection("name", "desc", url, attributes, opts);
         # verify that exceptions are raised in the server & client when connecting
         assertThrows("SOCKET-SSL-ERROR", \hc.get());
         assertEq("SOCKET-SSL-ERROR", server.waitException().err);
+    }
+
+    httpConnectionTestDeprecated() {
+        string url = "http://127.0.0.1";
+        HttpConnection hc("name", "desc", url, True, NOTHING, Qore::parse_url(url));
+        assertEq(True, hc.enabled, "connection is enabled by default");
+    }
+
+    fsConnectionTest() {
+        string url = Util::tmp_location();
+        hash opts = (
+            "readonly": False,
+        );
+        hash attributes = {
+            "monitor": True,
+        };
+
+        FilesystemConnection fs("name", "desc", url, attributes, opts);
+        assertEq(True, fs.enabled, "connection is enabled by default");
+        assertEq(False, fs.opts.readonly, "readonly enabled by opts");
+
+        Dir d = fs.get();
+        assertEq(Util::tmp_location(), d.path(), "Path equality");
+    }
+
+    fsConnectionTestDeprecated() {
+        string url = Util::tmp_location();
+        FilesystemConnection fs("name", "desc", url, True, NOTHING, Qore::parse_url(url));
+        assertEq(True, fs.enabled, "connection is enabled by default");
+
+        Dir d = fs.get();
+        assertEq(Util::tmp_location(), d.path(), "Path equality");
+    }
+
+    invalidConnectionTest() {
+        InvalidConnection ic1("name", "desc", "url");
+        assertEq("unknown error", ic1.error);
+
+        hash attributes = {
+            "error": "lorem ipsum",
+        };
+        InvalidConnection ic2("name", "desc", "url", attributes);
+        assertEq(attributes.error, ic2.error);
+    }
+
+    customParseUrlTest() {
+        # Qore::parse_url() must fail on this URL
+        assertThrows("PARSE-URL-ERROR", \Qore::parse_url(), MyConnection::URL);
+
+        # and now the custom parsing
+        MyConnection db();
+        assertEq("pgsql", db.urlh.type);
+        assertEq("user", db.urlh.user);
+        assertEq("pass", db.urlh.pass);
+        assertEq("db", db.urlh.db);
+        assertEq("host", db.urlh.host);
+        assertEq(1234, db.urlh.port);
+
+        # safe url
+        assertEq("pgsql:user@db%host:1234", db.safe_url);
+    }
+}
+
+class MyConnection inherits AbstractConnection {
+    public {
+        # let's simulate a DB connection (without DatasourcePool options for a simplicity)
+        const URL = "sql://pgsql:user/pass@db%host:1234";
+    }
+
+    constructor() : AbstractConnection("name", "desc", URL) {
+    }
+
+    private hash parseUrl(string url) {
+        url = replace(url, "sql://", "");
+        return parse_datasource(url);
+    }
+
+    private string getSafeUrl(hash urlh) {
+        string url = sprintf("%s:%s@%s", urlh.type, urlh.user, urlh.db);
+        if (urlh.host.val()) {
+            url += "%" + urlh.host;
+        }
+        if (urlh.port.val()) {
+            url += ":" + urlh.port;
+        }
+        return url;
+    }
+
+    # just to implement abstract methods
+    string getType() {
+        return "sql";
+    }
+    hash<ConnectionConstructorInfo> getConstructorInfoImpl() {
+        return hash<ConnectionConstructorInfo>{};
+    }
+    object getImpl(bool _ = True, *hash __) {
+        return new Dir(); # just a silence the missing abtsract method. No use for Dir at all
     }
 }
 

--- a/examples/test/qlib/ConnectionProvider/ConnectionProviderModule.qtest
+++ b/examples/test/qlib/ConnectionProvider/ConnectionProviderModule.qtest
@@ -71,7 +71,7 @@ public class ConnectionProviderModuleTest inherits QUnit::Test {
         p.parse("FilesystemConnection sub get_conn() {
     string dir = tmp_location() + '/' + get_random_string() + '/' + get_random_string();
     string url = 'file://' + dir;
-    return new FilesystemConnection('test', 'desc', url, False, NOTHING, parse_url(url));
+    return new FilesystemConnection('test', 'desc', url);
 }", "");
 
         object o = p.callFunction("get_conn");

--- a/examples/test/qlib/ConnectionProvider/TestConnectionProvider.qm
+++ b/examples/test/qlib/ConnectionProvider/TestConnectionProvider.qm
@@ -47,7 +47,7 @@ class TestConnection inherits AbstractConnection {
         const Url = "test://user:pass@x";
     }
 
-    constructor() : AbstractConnection("test", "test", Url, False, NOTHING, parse_url(Url)) {
+    constructor() : AbstractConnection("test", "test", Url) {
     }
 
     string getType() {

--- a/examples/test/qlib/Pop3Client/Pop3Client.qtest
+++ b/examples/test/qlib/Pop3Client/Pop3Client.qtest
@@ -6,6 +6,7 @@
 %require-types
 %strict-args
 
+%requires ../../../../qlib/ConnectionProvider.qm
 %requires ../../../../qlib/Pop3Client.qm
 %requires ../../../../qlib/QUnit.qm
 
@@ -37,6 +38,10 @@ public class Pop3ClientTest inherits QUnit::Test {
         string url = "pop3s://user:pass@localhost:8099";
         Pop3Connection conn("test", "test", url, False, NOTHING, parse_url(url));
         Pop3Client client = conn.get(False);
+        assertEq("localhost:8099", client.getTarget());
+
+        conn = new Pop3Connection("test", "test", url, {"monitor": False});
+        client = conn.get(False);
         assertEq("localhost:8099", client.getTarget());
 
         hash<ConnectionConstructorInfo> info = conn.getConstructorInfo();

--- a/examples/test/qlib/RestClient/RestClient.qtest
+++ b/examples/test/qlib/RestClient/RestClient.qtest
@@ -197,6 +197,12 @@ public class Main inherits QUnit::Test {
         RestClient client = conn.get(False);
         assertEq(url, client.getURL());
 
+        conn = new RestConnection("test", "test", url, {"monitor": False}, {});
+        client = conn.get(False);
+        assertEq(url, client.getURL());
+        assertEq(False, conn.monitor);
+        assertEq(True, conn.enabled);
+
         hash<ConnectionConstructorInfo> info = conn.getConstructorInfo();
         assertEq("RestClient", info.module);
         assertEq("RestClient", info.class_name);

--- a/examples/test/qlib/SalesforceRestClient/SalesforceRestClient.qtest
+++ b/examples/test/qlib/SalesforceRestClient/SalesforceRestClient.qtest
@@ -4,6 +4,7 @@
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/Mime.qm
+%requires ../../../../qlib/ConnectionProvider.qm
 %requires ../../../../qlib/RestClient.qm
 %requires ../../../../qlib/SalesforceRestClient.qm
 
@@ -116,7 +117,9 @@ class SalesforceTest inherits QUnit::Test {
         SalesforceRestConnection swsc("test", "test", url, True, sfopts, parse_url(url));
         assertEq(True, swsc instanceof SalesforceRestConnection);
 
-        assertThrows("CONNECTION-ERROR", sub () { SalesforceRestConnection swsc1("test", "test", url, True, ("x": 1), parse_url(url)); });
+        assertThrows("CONNECTION-ERROR", sub () {
+            SalesforceRestConnection swsc1("test", "test", url, {"monitor": True}, {"x": 1});
+            });
 
         hash<ConnectionConstructorInfo> info = swsc.getConstructorInfo();
         assertEq("SalesforceRestClient", info.module);

--- a/examples/test/qlib/SewioRestClient/SewioRestClient.qtest
+++ b/examples/test/qlib/SewioRestClient/SewioRestClient.qtest
@@ -10,6 +10,7 @@
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/Mime.qm
 %requires ../../../../qlib/HttpServerUtil.qm
+%requires ../../../../qlib/ConnectionProvider.qm
 %requires ../../../../qlib/RestClient.qm
 %requires ../../../../qlib/SewioRestClient.qm
 %requires ../../../../qlib/HttpServer.qm
@@ -113,10 +114,10 @@ public class Main inherits QUnit::Test {
     connectionTest() {
         checkModule();
         string url = "http://localhost:8080";
-        SewioRestConnection swsc("test", "test", url, True, ("apikey": "x"), parse_url(url));
+        SewioRestConnection swsc("test", "test", url, {}, ("apikey": "x"));
         assertEq(True, swsc instanceof SewioRestConnection);
 
-        assertThrows("SEWIORESTCONNECTION-ERROR", sub () { SewioRestConnection swsc1("test", "test", url, True, NOTHING, parse_url(url)); });
+        assertThrows("SEWIORESTCONNECTION-ERROR", sub () { SewioRestConnection swsc1("test", "test", url);});
 
         hash<ConnectionConstructorInfo> info = swsc.getConstructorInfo();
         assertEq("SewioRestClient", info.module);

--- a/examples/test/qlib/SewioWebSocketClient/SewioWebSocketClient.qtest
+++ b/examples/test/qlib/SewioWebSocketClient/SewioWebSocketClient.qtest
@@ -11,6 +11,7 @@
 %requires ../../../../qlib/HttpServerUtil.qm
 %requires ../../../../qlib/HttpServer.qm
 %requires ../../../../qlib/WebSocketUtil.qm
+%requires ../../../../qlib/ConnectionProvider.qm
 %requires ../../../../qlib/WebSocketHandler.qm
 %requires ../../../../qlib/WebSocketClient.qm
 %requires ../../../../qlib/SewioWebSocketClient.qm
@@ -94,10 +95,10 @@ class SewioWebSocketClientTest inherits QUnit::Test {
 
     sewioWebSocketConnectionTests() {
         string url = "sewiows://localhost:8080";
-        SewioWebSocketConnection swsc("test", "test", url, True, ("apikey": "x"), parse_url(url));
+        SewioWebSocketConnection swsc("test", "test", url, {"monitor": True}, ("apikey": "x"));
         assertEq(True, swsc instanceof SewioWebSocketConnection);
 
-        assertThrows("SEWIOWEBSOCKETCONNECTION-ERROR", sub () { SewioWebSocketConnection swsc1("test", "test", url, True, NOTHING, parse_url(url)); });
+        assertThrows("SEWIOWEBSOCKETCONNECTION-ERROR", sub () { SewioWebSocketConnection swsc1("test", "test", url); });
     }
 
     private log(string str) {

--- a/examples/test/qlib/TelnetClient/TelnetClient.qtest
+++ b/examples/test/qlib/TelnetClient/TelnetClient.qtest
@@ -6,6 +6,7 @@
 %require-types
 %strict-args
 
+%requires ../../../../qlib/ConnectionProvider.qm
 %requires ../../../../qlib/TelnetClient.qm
 %requires ../../../../qlib/QUnit.qm
 
@@ -37,6 +38,10 @@ public class TelnetClientTest inherits QUnit::Test {
         string url = "telnet://localhost:8099";
         TelnetConnection conn("test", "test", url, False, NOTHING, parse_url(url));
         TelnetClient client = conn.get(False);
+        assertEq("localhost:8099", client.getTarget());
+
+        conn = new TelnetConnection("test", "test", url, {"monitor": False});
+        client = conn.get(False);
         assertEq("localhost:8099", client.getTarget());
 
         hash<ConnectionConstructorInfo> info = conn.getConstructorInfo();

--- a/examples/test/qlib/WebSocketClient/WebSocketClient.qtest
+++ b/examples/test/qlib/WebSocketClient/WebSocketClient.qtest
@@ -8,6 +8,7 @@
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm
+%requires ../../../../qlib/ConnectionProvider.qm
 %requires ../../../../qlib/HttpServerUtil.qm
 %requires ../../../../qlib/HttpServer.qm
 %requires ../../../../qlib/WebSocketUtil.qm
@@ -94,6 +95,10 @@ class WebSocketClientTest inherits QUnit::Test {
         string url = "ws://localhost:8099";
         WebSocketConnectionObject conn("test", "test", url, False, NOTHING, parse_url(url));
         WebSocketClient client = conn.get(False);
+        assertEq(url, client.getUrl());
+
+        conn = new WebSocketConnectionObject("test", "test", url, {"monitor": False});
+        client = conn.get(False);
         assertEq(url, client.getUrl());
 
         hash<ConnectionConstructorInfo> info = conn.getConstructorInfo();

--- a/qlib/ConnectionProvider.qm
+++ b/qlib/ConnectionProvider.qm
@@ -179,7 +179,7 @@ public namespace ConnectionProvider {
         bool up = False;  #!< a boolean vaue indicating the connection is known to be up (will be @ref Qore::False "False" if not checked)
         *date updated;    #!< the date/time value of the update (or @ref nothing if not updated)
         string url;       #!< the URL for the connection including the password (if any present and the \a with_password argument is @ref Qore::True "True")
-        hash url_hash;    #!< a hash of URL information as returned by @ref Qore::parse_url() "parse_url()"
+        hash url_hash;    #!< a hash of URL information as returned by AbstractConnection::parseUrl()
         bool enabled;     #!< a boolean value indicating if the connection should be enabled or not. This flag does not affect anything by default, it is for user re-implementations
     }
 
@@ -338,7 +338,7 @@ string connstr = get_connection(str);
             #! connection options
             *hash opts;
 
-            #! broken down URL hash (as returned by @ref Qore::parse_url())
+            #! broken down URL hash (as returned by AbstractConnection::parseUrl())
             hash urlh;
 
             #! date/time of last check/ping
@@ -382,7 +382,7 @@ string connstr = get_connection(str);
         constructor(string n_name, string n_desc, string n_url, bool n_monitor, *hash n_opts, hash n_urlh, *string n_safe_url,
                     *bool n_enabled) {
             hash attributes = {
-                "monitor": n_monitor ?? True,
+                "monitor": n_monitor,
                 "enabled": n_enabled ?? True,
             };
             constructorInit(n_name, n_desc, n_url, attributes, n_opts ?? {});
@@ -402,22 +402,6 @@ string connstr = get_connection(str);
             For now there are:
                 - \c enabled, default \c True
                 - \c monitor, default \c True
-
-            @par Safe URL
-
-            Public attribute \c safe_url is created from the \c url calling
-            AbstractConnection::getSafeUrl(). Reimplement this method if your
-            connection does not follow standard URL in form:
-            @code
-            schema://user:pass@hostname:port/path
-            @endcode
-
-            @par URL parsing
-
-            The \c url argument is parsed by AbstractConnection::parseUrl().
-            @ref Qore::parse_url() is called in the base implementation.
-            Reimplement \c parseUrl() if your connection uses different URL schema.
-            Like eg. Qore::Datasource connection string.
          */
         constructor(string name, string description, string url, hash attributes = {}, hash options = {}) {
             constructorInit(name, description, url, attributes, options);
@@ -450,15 +434,32 @@ string connstr = get_connection(str);
             self.opts = options;
         }
 
+        #! Parse the URL to a hash
+        /** @param url a string with url
+            @return hash untyped, depends on the parsing method
+
+            The base implementation calls @ref Qore::parse_url().
+
+            Reimplement \c parseUrl() if your connection uses different URL schema.
+            Like eg. Qore::Datasource connection string.
+         */
         private hash parseUrl(string url) {
             return Qore::parse_url(url);
         }
 
         #! creates a "safe" URL string with password information removed
-        /** This base/default implementation expects the \c urlh
+        /** @param urlh a parsed hash (as returned from parseUrl()
+            @return string with safe URL
+
+            This base/default implementation expects the \c urlh
             as returned by @ref Qore::parse_url())
 
-            @return a "safe" URL string with password information removed
+            Public attribute \c safe_url is created from the \c url calling
+            AbstractConnection::getSafeUrl(). Reimplement this method if your
+            connection does not follow standard URL in form:
+            @code
+schema://user:pass@hostname:port/path
+            @endcode
          */
         private string getSafeUrl(hash urlh) {
             string url = urlh.protocol + "://";
@@ -927,6 +928,7 @@ string connstr = get_connection(str);
         #! DEPRECATED: static constructor
         /** @deprecated since Qore 0.9 in favor of new constructor and Qore::Reflection
          */
+        deprecated
         static HttpConnection make(string name, string desc, string url, bool monitor, *hash opts, hash urlh) {
             hash attributes = {
                 "monitor": monitor,

--- a/qlib/ConnectionProvider.qm
+++ b/qlib/ConnectionProvider.qm
@@ -33,7 +33,7 @@
 %requires Util
 
 module ConnectionProvider {
-    version = "1.1";
+    version = "1.2";
     desc    = "API for pluggable connection providers to Qore";
     author  = "David Nichols <david.nichols@qoretechnologies.com>";
     url     = "http://qore.org";
@@ -99,6 +99,15 @@ $env:QORE_CONNECTION_PROVIDERS="MyConnectionProvider;OtherConnectionProvider"
     @endverbatim
 
     @section connectionproviderrelnotes Release Notes
+
+    @subsection connectionprovider_1_2 ConnectionProvider 1.2
+    - the @ref ConnectionProvider::AbstractConnection::consructor() "AbstractConnection::consructor()" refactoring
+    - all connection clases have unified constructor
+    - old contructors and static make() constructors are deprecated
+    - ConnectionProvider::AbstractConnection::parseUrl() is introduced
+    - ConnectionProvider::AbstractConnection::getSafeurl() is not static anymore
+    - it allows their reimplementation in the inherited class. It can be used
+      to parse strange and unexpected URLs like eg. pure json strings, or Datasource connection strings.
 
     @subsection connectionprovider_1_1 ConnectionProvider 1.1
     - the @ref ConnectionProvider::AbstractConnection::getConstructorInfo() "AbstractConnection::getConstructorInfo()"
@@ -357,7 +366,7 @@ string connstr = get_connection(str);
             bool enabled = True;
         }
 
-        #! creates the AbstractConnection object
+        #! DEPRECATED: creates the AbstractConnection object
         /** @param n_name the name of the connection
             @param n_desc connection description
             @param n_url connection URL (potentially with password info)
@@ -366,34 +375,92 @@ string connstr = get_connection(str);
             @param n_urlh broken down URL hash (as returned by @ref Qore::parse_url())
             @param n_safe_url "safe" URL (password information removed); if not set this will be set automatically by calling @ref getSafeUrl()
             @param n_enabled enabled/disabled flag
+
+            @deprecated since Qore 0.9
          */
+        deprecated
         constructor(string n_name, string n_desc, string n_url, bool n_monitor, *hash n_opts, hash n_urlh, *string n_safe_url,
                     *bool n_enabled) {
-            name = n_name;
-            desc = n_desc;
-            url = n_url;
-            monitor = n_monitor;
-            safe_url = n_safe_url ? n_safe_url : AbstractConnection::getSafeUrl(n_urlh);
-            urlh = n_urlh;
-            orig_opts = n_opts;
-            n_opts = getDefaultOptions() + n_opts;
-            if (n_opts) {
+            hash attributes = {
+                "monitor": n_monitor ?? True,
+                "enabled": n_enabled ?? True,
+            };
+            constructorInit(n_name, n_desc, n_url, attributes, n_opts ?? {});
+        }
+
+        #! creates the AbstractConnection object
+        /** @param name the name of the connection
+            @param description connection description
+            @param url connection URL (potentially with password info)
+            @param attributes various attributes. See below
+            @param options connection options
+
+            @par Attributes
+
+            Attributes are special flags for given connection - stored as public
+            attributes of the object instance.
+            For now there are:
+                - \c enabled, default \c True
+                - \c monitor, default \c True
+
+            @par Safe URL
+
+            Public attribute \c safe_url is created from the \c url calling
+            AbstractConnection::getSafeUrl(). Reimplement this method if your
+            connection does not follow standard URL in form:
+            @code
+            schema://user:pass@hostname:port/path
+            @endcode
+
+            @par URL parsing
+
+            The \c url argument is parsed by AbstractConnection::parseUrl().
+            @ref Qore::parse_url() is called in the base implementation.
+            Reimplement \c parseUrl() if your connection uses different URL schema.
+            Like eg. Qore::Datasource connection string.
+         */
+        constructor(string name, string description, string url, hash attributes = {}, hash options = {}) {
+            constructorInit(name, description, url, attributes, options);
+        }
+
+        private:internal constructorInit(string name, string description, string url, hash attributes, hash options) {
+            # metadata
+            self.name = name;
+            self.desc = description;
+
+            # url handling
+            self.url = url;
+            self.urlh = parseUrl(self.url);
+            self.safe_url = getSafeUrl(self.urlh);
+
+            # attributes to flags
+            self.monitor = attributes.monitor ?? True;
+            self.enabled = attributes.enabled ?? True;
+
+            self.orig_opts = options;
+
+            options = getDefaultOptions() + options;
+            if (options) {
                 *hash oh = getOptions();
-                foreach string opt in (n_opts.keyIterator()) {
+                foreach string opt in (options.keyIterator()) {
                     if (!oh{opt})
                         throw "CONNECTION-ERROR", sprintf("connection %y (type %y url %y) has unknown option %y (known options: %y)", name, urlh.protocol, url, opt, oh.keys());
                 }
             }
-            opts = n_opts;
-            enabled = n_enabled ?? True;
+            self.opts = options;
+        }
+
+        private hash parseUrl(string url) {
+            return Qore::parse_url(url);
         }
 
         #! creates a "safe" URL string with password information removed
-        /** @param urlh broken down URL hash (as returned by @ref Qore::parse_url())
+        /** This base/default implementation expects the \c urlh
+            as returned by @ref Qore::parse_url())
 
             @return a "safe" URL string with password information removed
          */
-        private static string getSafeUrl(hash urlh) {
+        private string getSafeUrl(hash urlh) {
             string url = urlh.protocol + "://";
             if (urlh.username)
                 url += urlh.username + "@";
@@ -545,13 +612,38 @@ string connstr = get_connection(str);
 
     #! this class is used to mark invalid connections so they can be loaded and reported as invalid
     public class InvalidConnection inherits AbstractConnection {
-        private {
-            string error;
+        public {
+            #! Error message provided by constructor's \c attributes.error
+            string error = "unknown error";
+        }
+
+        #! DEPRECATED: creates the invalid connection object
+        /** @deprecated since Qore 0.9
+         */
+        deprecated
+        constructor(string n_name, string n_desc, string n_url, *hash n_opts, string n_error, hash urlh)
+            : AbstractConnection(n_name, n_desc, n_url, {"monitor": False}, n_opts ?? {}) {
+            error = n_error;
         }
 
         #! creates the invalid connection object
-        constructor(string n_name, string n_desc, string n_url, *hash n_opts, string n_error, hash urlh) : AbstractConnection(n_name, n_desc, n_url, False, n_opts, urlh) {
-            error = n_error;
+        /** @param name the name of the connection
+            @param description connection description
+            @param url connection URL (potentially with password info)
+            @param attributes various attributes. See below
+            @param options connection options
+
+            See @ref AbstractConnection::constructor() for \c attributes and \c options reference.
+
+            @par Additional Attributes
+
+                - \c error a custom error string
+         */
+        constructor(string name, string description, string url, hash attributes = {}, hash options = {})
+            : AbstractConnection(name, description, url, attributes, options) {
+            if (attributes.error.val()) {
+                self.error = attributes.error;
+            }
         }
 
         #! throws an exception because the object is invalid
@@ -571,13 +663,36 @@ string connstr = get_connection(str);
     }
 
     #! base class for HTTP-based connections that need their URLs rewritten to create the real connection object
+    /** Example of the usage is in the RestConnection. Schema \c rest:// is internally used as \c http://
+     */
     public class HttpBasedConnection inherits AbstractConnection {
         public {
+            #! A string containing real url. With http(s) internal schema.
             string real_url;
         }
 
-        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh) : AbstractConnection(name, desc, url, monitor, opts, urlh) {
-            # sets an HTTP-based URL for the URL argument
+        deprecated
+        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh)
+            : AbstractConnection(name, desc, url, {"monitor": monitor}, opts ?? {}) {
+            constructorInit();
+        }
+
+        #! creates the invalid connection object
+        /** @param name the name of the connection
+            @param description connection description
+            @param url connection URL (potentially with password info)
+            @param attributes various attributes. See below
+            @param options connection options
+
+            See @ref AbstractConnection::constructor() for \c attributes and \c options reference.
+         */
+        constructor(string name, string desc, string url, hash attributes, hash options)
+            : AbstractConnection(name, desc, url, attributes, options) {
+            constructorInit();
+        }
+
+        # sets an HTTP-based URL for the URL argument
+        private:internal constructorInit() {
             string scheme = (url =~ x/^([^:]+)/)[0];
             bool ssl = (scheme =~ /s$/);
             string targ = "http" + (ssl ? "s" : "");
@@ -591,15 +706,32 @@ string connstr = get_connection(str);
         - \c "path_add": appends the given string to the path component of the URL at runtime
     */
     public class FtpConnection inherits AbstractConnection {
-        #! creates the FtpConnection object
+        #! DEPRECATED: creates the FtpConnection object
         /** @param name the name of the connection
             @param desc connection description
             @param url connection URL (potentially with password info)
             @param monitor monitoring flag
             @param opts connection options
             @param urlh broken down URL hash (as returned by @ref Qore::parse_url())
+
+            @deprecated since Qore 0.9
         */
-        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh) : AbstractConnection(name, desc, url, monitor, opts, urlh) {
+        deprecated
+        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh)
+            : AbstractConnection(name, desc, url, {"monitor": monitor}, opts ?? {}) {
+        }
+
+        #! creates the FtpConnection object
+        /** @param name the name of the connection
+            @param description connection description
+            @param url connection URL (potentially with password info)
+            @param attributes various attributes. See below
+            @param options connection options
+
+            See @ref AbstractConnection::constructor() for \c attributes and \c options reference.
+         */
+        constructor(string name, string description, string url, hash attributes = {}, hash options = {})
+            : AbstractConnection(name, description, url, attributes, options) {
         }
 
         #! returns \c "ftp"
@@ -656,9 +788,16 @@ string connstr = get_connection(str);
             });
         }
 
-        #! static constructor
+        #! DEPRECATED: static constructor
+        /** @deprecated since Qore 0.9 in favor of new constructor and Qore::Reflection
+         */
+        deprecated
         static FtpConnection make(string name, string desc, string url, bool monitor, *hash opts, hash urlh) {
-            return new FtpConnection(name, desc, url, monitor, opts, urlh);
+            hash attributes = {
+                "monitor": monitor,
+            };
+
+            return new FtpConnection(name, desc, url, attributes, opts ?? {});
         }
     }
 
@@ -700,15 +839,32 @@ string connstr = get_connection(str);
             const OptionList = Options.keys();
         }
 
-        #! creates the HttpConnection object
+        #! DEPRECATED: creates the HttpConnection object
         /** @param name the name of the connection
             @param desc connection description
             @param url connection URL (potentially with password info)
             @param monitor monitoring flag
             @param opts connection options (@see getOptions() for valid options)
             @param urlh broken down URL hash (as returned by @ref Qore::parse_url())
+
+            @deprecated since Qorus 0.9
         */
-        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh) : AbstractConnection(name, desc, url, monitor, opts, urlh) {
+        deprecated
+        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh)
+            : AbstractConnection(name, desc, url, {"monitor": monitor}, opts ?? {}) {
+        }
+
+        #! creates the HttpConnection object
+        /** @param name the name of the connection
+            @param description connection description
+            @param url connection URL (potentially with password info)
+            @param attributes various attributes. See below
+            @param options connection options
+
+            See @ref AbstractConnection::constructor() for \c attributes and \c options reference.
+         */
+        constructor(string name, string description, string url, hash attributes = {}, hash options = {})
+            : AbstractConnection(name, description, url, attributes, options) {
         }
 
         #! returns an @ref Qore::HTTPClient object
@@ -768,9 +924,15 @@ string connstr = get_connection(str);
             return "http";
         }
 
-        #! static constructor
+        #! DEPRECATED: static constructor
+        /** @deprecated since Qore 0.9 in favor of new constructor and Qore::Reflection
+         */
         static HttpConnection make(string name, string desc, string url, bool monitor, *hash opts, hash urlh) {
-            return new HttpConnection(name, desc, url, monitor, opts, urlh);
+            hash attributes = {
+                "monitor": monitor,
+            };
+
+            return new HttpConnection(name, desc, url, attributes, opts ?? {});
         }
     }
 
@@ -789,15 +951,37 @@ string connstr = get_connection(str);
             const OptionList = Options.keys();
         }
 
-        #! creates the FilesystemConnection object
+        #! DEPRECATED: creates the FilesystemConnection object
         /** @param name the name of the connection
             @param desc connection description
             @param url connection URL
             @param monitor monitoring flag
             @param opts connection options
             @param n_urlh broken down URL hash (as returned by @ref Qore::parse_url())
+
+            @deprecated since Qore 0.9
          */
-        constructor(string name, string desc, string url, bool monitor, *hash opts, hash n_urlh) : AbstractConnection(name, desc, url, monitor, opts, n_urlh) {
+        deprecated
+        constructor(string name, string desc, string url, bool monitor, *hash opts, hash n_urlh)
+            : AbstractConnection(name, desc, url, {"monitor": monitor}, opts ?? {}) {
+            constructorInit();
+        }
+
+        #! creates the FilesystemConnection object
+        /** @param name the name of the connection
+            @param description connection description
+            @param url connection URL (potentially with password info)
+            @param attributes various attributes. See below
+            @param options connection options
+
+            See @ref AbstractConnection::constructor() for \c attributes and \c options reference.
+         */
+        constructor(string name, string description, string url, hash attributes = {}, hash options = {})
+            : AbstractConnection(name, description, url, attributes, options) {
+            constructorInit();
+        }
+
+        private:internal constructorInit() {
             # the URL hash is parsed with parse_url() which will put a string in the
             # "host" key if it does not look like an absolute path, in which case "host"
             # needs to be prepended back to the path
@@ -867,9 +1051,16 @@ string connstr = get_connection(str);
             return Options;
         }
 
-        #! static constructor
+        #! DEPRECATED: static constructor
+        /** @deprecated since Qore 0.9 in favor of new constructor and Qore::Reflection
+         */
+        deprecated
         static FilesystemConnection make(string name, string desc, string url, bool monitor, *hash opts, hash urlh) {
-            return new FilesystemConnection(name, desc, url, monitor, opts, urlh);
+            hash attributes = {
+                "monitor": monitor,
+            };
+
+            return new FilesystemConnection(name, desc, url, attributes, opts ?? {});
         }
     }
 }

--- a/qlib/Pop3Client.qm
+++ b/qlib/Pop3Client.qm
@@ -987,6 +987,7 @@ pop3.clearStats();
 
             @deprecated since Qore 0.9
         */
+        deprecated
         constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh)
             : AbstractConnection(name, desc, url, {"monitor": monitor}, opts) {
         }

--- a/qlib/Pop3Client.qm
+++ b/qlib/Pop3Client.qm
@@ -32,7 +32,7 @@
 %requires MailMessage >= 1.0
 
 # requires the ConnectionProvider module
-%requires(reexport) ConnectionProvider >= 1.1
+%requires(reexport) ConnectionProvider >= 1.2
 
 # assume local var scope, do not use "$" for vars, members, and method calls
 %new-style
@@ -41,7 +41,7 @@
 %enable-all-warnings
 
 module Pop3Client {
-    version = "1.6";
+    version = "1.7";
     desc = "POP3 client support module";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -93,6 +93,9 @@ if (!h)
     @note based on http://tools.ietf.org/html/rfc1939 (POP3)
 
     @section pop3client_relnotes Pop3Client Module Release Notes
+
+    @subsection pop3client_v1_7 Pop3Client 1.7
+    - all connection clases have unified constructor
 
     @subsection pop3client_v1_6 Pop3Client 1.6
     - added the @ref Pop3Client::Pop3Connection::getConstructorInfo() "Pop3Connection::getConstructorInfo()"
@@ -974,15 +977,31 @@ pop3.clearStats();
         @since %Pop3Client 1.5
     */
     public class Pop3Connection inherits ConnectionProvider::AbstractConnection {
-        #! creates the Pop3Connection object
+        #! DEPRECATED: creates the Pop3Connection object
         /** @param name the name of the connection
             @param desc connection description
             @param url connection URL
             @param monitor monitoring flag
             @param opts connection options
             @param urlh broken down URL hash (as returned by @ref Qore::parse_url())
+
+            @deprecated since Qore 0.9
         */
-        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh) : AbstractConnection(name, desc, url, monitor, opts, urlh) {
+        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh)
+            : AbstractConnection(name, desc, url, {"monitor": monitor}, opts) {
+        }
+
+        #! creates the RestConnection connection object
+        /** @param name the name of the connection
+            @param description connection description
+            @param url connection URL (potentially with password info)
+            @param attributes various attributes. See below
+            @param options connection options
+
+            See @ref AbstractConnection::constructor() for \c attributes and \c options reference.
+         */
+        constructor(string name, string description, string url, hash attributes = {}, hash options = {})
+            : AbstractConnection(name, description, url, attributes, options) {
         }
 
         #! returns \c "pop3"
@@ -1030,9 +1049,12 @@ pop3.clearStats();
             });
         }
 
-        #! static constructor
+        #! DEPRECATED: static constructor
+        /** @deprecated since Qore 0.9 in favor of new constructor and Qore::Reflection
+         */
+        deprecated
         static Pop3Connection make(string name, string desc, string url, bool monitor, *hash opts, hash urlh) {
-            return new Pop3Connection(name, desc, url, monitor, opts, urlh);
+            return new Pop3Connection(name, desc, url, {"monitor": monitor}, opts ?? {});
         }
     }
 }

--- a/qlib/RestClient.qm
+++ b/qlib/RestClient.qm
@@ -959,6 +959,7 @@ hash ans = rest.doRequest("DELETE", "/orders/1");
 
             @deprecated since Qore 0.9
         */
+        deprecated
         constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh)
             : HttpBasedConnection(name, desc, url, {"monitor": monitor}, opts ?? {}) {
             real_opts = {"url": real_url} + opts;

--- a/qlib/RestClient.qm
+++ b/qlib/RestClient.qm
@@ -37,7 +37,7 @@
 %enable-all-warnings
 
 %requires Mime >= 1.3
-%requires(reexport) ConnectionProvider >= 1.1
+%requires(reexport) ConnectionProvider >= 1.2
 %requires(reexport) RestSchemaValidator >= 1.0
 %requires Swagger >= 0.1
 
@@ -54,7 +54,7 @@
 %endtry
 
 module RestClient {
-    version = "1.5";
+    version = "1.6";
     desc = "user module for calling REST services";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -123,6 +123,9 @@ printf("%N\n", ans.body);
     could lead to compatibility problems; see @ref httpclient_get_with_body for more information
 
     @section restclientrelnotes Release Notes
+
+    @subsection restclientv1_6 RestClient v1.6
+    - all connection clases have unified constructor
 
     @subsection restclientv1_5 RestClient v1.5
     - added the @ref RestClient::RestConnection::getConstructorInfo() "RestConnection::getConstructorInfo()"
@@ -946,16 +949,37 @@ hash ans = rest.doRequest("DELETE", "/orders/1");
             const OptionList = Options.keys();
         }
 
-        #! creates the RestConnection object
+        #! DEPRECATED: creates the RestConnection object
         /** @param name the name of the connection
             @param desc connection description
             @param url connection URL (potentially with password info)
             @param monitor monitoring flag
             @param opts connection options
             @param urlh broken down URL hash (as returned by @ref Qore::parse_url())
+
+            @deprecated since Qore 0.9
         */
-        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh) : HttpBasedConnection(name, desc, url, monitor, opts, urlh) {
+        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh)
+            : HttpBasedConnection(name, desc, url, {"monitor": monitor}, opts ?? {}) {
             real_opts = {"url": real_url} + opts;
+        }
+
+        #! creates the RestConnection connection object
+        /** @param name the name of the connection
+            @param description connection description
+            @param url connection URL (potentially with password info)
+            @param attributes various attributes. See below
+            @param options connection options
+
+            See @ref AbstractConnection::constructor() for \c attributes and \c options reference.
+
+            @par Additional Attributes
+
+                - \c error a custom error string
+         */
+        constructor(string name, string description, string url, hash attributes = {}, hash options = {})
+            : HttpBasedConnection(name, description, url, attributes, options) {
+            real_opts = {"url": real_url} + options;
         }
 
         #! returns a @ref RestClient::RestClient "RestClient" object
@@ -1009,9 +1033,15 @@ hash ans = rest.doRequest("DELETE", "/orders/1");
             return "rest";
         }
 
-        #! static constructor
+        #! DEPRECATED: static constructor
+        /** @deprecated since Qore 0.9 in favor of new constructor and Qore::Reflection
+         */
+        deprecated
         static RestConnection make(string name, string desc, string url, bool monitor, *hash opts, hash urlh) {
-            return new RestConnection(name, desc, url, monitor, opts, urlh);
+            hash attributes = {
+                "monitor": monitor,
+            };
+            return new RestConnection(name, desc, url, attributes, opts ?? {});
         }
     }
 }

--- a/qlib/SalesforceRestClient.qm
+++ b/qlib/SalesforceRestClient.qm
@@ -1030,7 +1030,7 @@ sfrest.logout();
         */
         deprecated
         constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh)
-            : RestConnection(name, desc, url, monitor, opts, urlh) {
+            : RestConnection(name, desc, url, {"monitor": monitor}, opts) {
             real_opts = ("url": real_url) + urlh.("username", "password") + opts;
         }
 

--- a/qlib/SalesforceRestClient.qm
+++ b/qlib/SalesforceRestClient.qm
@@ -39,10 +39,10 @@
 
 %requires(reexport) Mime >= 1.3
 %requires(reexport) RestClient >= 1.3.1
-%requires(reexport) ConnectionProvider >= 1.1
+%requires(reexport) ConnectionProvider >= 1.2
 
 module SalesforceRestClient {
-    version = "1.2";
+    version = "1.3";
     desc = "user module for calling Salesforce.com REST services";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -149,6 +149,9 @@ rc.bulkJobClose(h.id);
     functionality and a more detailed example of code using this module.
 
     @section salesforcerestclientrelnotes Release Notes
+
+    @subsection salesforcerestclientv1_3 SalesforceRestClient v1.3
+    - all connection clases have unified constructor
 
     @subsection salesforcerestclientv1_2 SalesforceRestClient v1.2
     - added the @ref SalesforceRestClient::SalesforceRestConnection::getConstructorInfo() "SalesforceRestConnection::getConstructorInfo()"
@@ -1015,15 +1018,33 @@ sfrest.logout();
             const OptionList = Options.keys();
         }
 
-        #! creates the SalesforceRestConnection object
+        #! DEPRECATED: creates the SalesforceRestConnection object
         /** @param name the name of the connection
             @param desc connection description
             @param url connection URL (potentially with password info)
             @param monitor monitoring flag
             @param opts connection options
             @param urlh broken down URL hash (as returned by @ref Qore::parse_url())
+
+            @deprecated since Qore 0.9
         */
-        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh) : RestConnection(name, desc, url, monitor, opts, urlh) {
+        deprecated
+        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh)
+            : RestConnection(name, desc, url, monitor, opts, urlh) {
+            real_opts = ("url": real_url) + urlh.("username", "password") + opts;
+        }
+
+        #! creates the SalesforceRestConnection connection object
+        /** @param name the name of the connection
+            @param description connection description
+            @param url connection URL (potentially with password info)
+            @param attributes various attributes. See below
+            @param options connection options
+
+            See @ref AbstractConnection::constructor() for \c attributes and \c options reference.
+         */
+        constructor(string name, string description, string url, hash attributes = {}, hash options = {})
+            : RestConnection(name, description, url, attributes, options) {
             real_opts = ("url": real_url) + urlh.("username", "password") + opts;
         }
 
@@ -1079,9 +1100,15 @@ sfrest.logout();
             return "rest";
         }
 
-        #! static constructor
+        #! DEPRECATED: static constructor
+        /** @deprecated since Qore 0.9 in favor of new constructor and QQore::Reflection
+         */
+        deprecated
         static SalesforceRestConnection make(string name, string desc, string url, bool monitor, *hash opts, hash urlh) {
-            return new SalesforceRestConnection(name, desc, url, monitor, opts, urlh);
+            hash attributes = {
+                "monitor": monitor,
+            };
+            return new SalesforceRestConnection(name, desc, url, attributes, opts ?? {});
         }
     }
 }

--- a/qlib/SewioRestClient.qm
+++ b/qlib/SewioRestClient.qm
@@ -39,10 +39,10 @@
 
 %requires(reexport) Mime >= 1.3
 %requires(reexport) RestClient >= 1.3.1
-%requires(reexport) ConnectionProvider >= 1.1
+%requires(reexport) ConnectionProvider >= 1.2
 
 module SewioRestClient {
-    version = "1.1";
+    version = "1.2";
     desc = "user module for calling Sewio.net RTLS Studio REST services";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -86,6 +86,9 @@ printf("%N\n", ans.body);
     @endcode
 
     @section Sewiorestclientrelnotes Release Notes
+
+    @subsection Sewiorestclientv1_2 SewioRestClient v1.2
+    - all connection clases have unified constructor
 
     @subsection Sewiorestclientv1_1 SewioRestClient v1.1
     - added the @ref SewioRestClient::SewioRestConnection::getConstructorInfoImpl() "SewioConnection::getConstructorInfoImpl()"
@@ -193,7 +196,7 @@ SewioRestClient rest(("url": "http://rtlsstudio.com/sensmapserver", "apikey": ap
             const OptionList = Options.keys();
         }
 
-        #! creates the SewioRestConnection object
+        #! DEPRECATED: creates the SewioRestConnection object
         /** @param name the name of the connection
             @param desc connection description
             @param url connection URL (potentially with password info)
@@ -202,8 +205,32 @@ SewioRestClient rest(("url": "http://rtlsstudio.com/sensmapserver", "apikey": ap
             @param urlh broken down URL hash (as returned by @ref Qore::parse_url())
 
             @throws SEWIORESTCONNECTION-ERROR missing apikey option
+
+            @deprecated since Qore 0.9
         */
-        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh) : RestConnection(name, desc, url, monitor, opts, urlh) {
+        deprecated
+        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh)
+            : RestConnection(name, desc, url, {"monitor": monitor}, opts ?? {}) {
+            constructorInit();
+        }
+
+        #! creates the SewioRestConnection object
+        /** @param name the name of the connection
+            @param description connection description
+            @param url connection URL (potentially with password info)
+            @param attributes various attributes. See below
+            @param options connection options
+
+            See @ref AbstractConnection::constructor() for \c attributes and \c options reference.
+
+            @throws SEWIORESTCONNECTION-ERROR missing apikey option
+         */
+        constructor(string name, string description, string url, hash attributes = {}, hash options = {})
+            : RestConnection(name, description, url, attributes, options) {
+            constructorInit();
+        }
+
+        private:internal constructorInit() {
             if (!opts.apikey.val())
                 throw "SEWIORESTCONNECTION-ERROR", sprintf("missing 'apikey' option for connection %y with url %y (%s)", name, url, desc);
             real_opts = ("url": real_url) + urlh.("username", "password") + opts;
@@ -259,9 +286,16 @@ SewioRestClient rest(("url": "http://rtlsstudio.com/sensmapserver", "apikey": ap
             return "sewiorest";
         }
 
-        #! static constructor
+        #! DEPRECATED: static constructor
+        /** @deprecated since Qore 0.9 in favor of new constructor and Qore::Reflection
+         */
+        deprecated
         static SewioRestConnection make(string name, string desc, string url, bool monitor, *hash opts, hash urlh) {
-            return new SewioRestConnection(name, desc, url, monitor, opts, urlh);
+            hash attributes = {
+                "monitor": monitor,
+            };
+
+            return new SewioRestConnection(name, desc, url, attributes, opts ?? {});
         }
     }
 }

--- a/qlib/SewioWebSocketClient.qm
+++ b/qlib/SewioWebSocketClient.qm
@@ -33,7 +33,7 @@
 
 %requires(reexport) WebSocketClient >= 1.0
 %requires Util >= 1.0
-%requires(reexport) ConnectionProvider >= 1.0
+%requires(reexport) ConnectionProvider >= 1.2
 
 %new-style
 
@@ -42,7 +42,7 @@
 %endtry
 
 module SewioWebSocketClient {
-    version = "1.0";
+    version = "1.1";
     desc = "user module for providing client support for the WebSocket protocol for Sewio.net RTLS Studio servers";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -91,6 +91,9 @@ c.waitForZero();
     @endcode
 
     @section sewiowebsocketclient_relnotes SewioWebSocketClient Module Release History
+
+    @subsection swsc_v1_0 v1.1
+    - all connection clases have unified constructor
 
     @subsection swsc_v1_0 v1.0
     - the initial version of the SewioWebSocketClient module
@@ -227,7 +230,7 @@ SewioWebSocketClient ws(\event(), ("url": "ws://example.com:8080/path"));
         - \c "log": a closure accepting a single string for logging
     */
     public class SewioWebSocketConnection inherits WebSocketClient::WebSocketConnectionObject {
-        #! creates the SewioWebSocketConnection object
+        #! DEPRECATED: creates the SewioWebSocketConnection object
         /** @param name the name of the connection
             @param desc connection description
             @param url connection URL
@@ -236,8 +239,29 @@ SewioWebSocketClient ws(\event(), ("url": "ws://example.com:8080/path"));
             @param urlh broken down URL hash (as returned by @ref Qore::parse_url())
 
             @throws SEWIOWEBSOCKETCONNECTION-ERROR missing apikey option
+
+            @deprecated since Qore 0.9
         */
-        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh) : WebSocketConnectionObject(name, desc, url, monitor, opts, urlh) {
+        deprecated
+        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh)
+            : WebSocketConnectionObject(name, desc, url, {"monitor": monitor}, opts) {
+            if (!opts.apikey.val())
+                throw "SEWIOWEBSOCKETCONNECTION-ERROR", sprintf("missing 'apikey' option for connection %y with url %y (%s)", name, url, desc);
+        }
+
+        #! creates the SewioWebSocketConnection connection object
+        /** @param name the name of the connection
+            @param description connection description
+            @param url connection URL (potentially with password info)
+            @param attributes various attributes. See below
+            @param options connection options
+
+            See @ref AbstractConnection::constructor() for \c attributes and \c options reference.
+
+            @throws SEWIOWEBSOCKETCONNECTION-ERROR missing apikey option
+          */
+        constructor(string name, string description, string url, hash attributes = {}, hash options = {})
+            : WebSocketConnectionObject(name, description, url, attributes, options) {
             if (!opts.apikey.val())
                 throw "SEWIOWEBSOCKETCONNECTION-ERROR", sprintf("missing 'apikey' option for connection %y with url %y (%s)", name, url, desc);
         }
@@ -280,9 +304,12 @@ SewioWebSocketClient ws(\event(), ("url": "ws://example.com:8080/path"));
             return WebSocketConnectionObject::getDefaultOptions();
         }
 
-        #! static constructor
+        #! DEPRECATED: static constructor
+        /** @deprecated since Qore 0.9 in favor of new constructor and Qore::Reflection
+          */
+        deprecated
         static SewioWebSocketConnection make(string name, string desc, string url, bool monitor, *hash opts, hash urlh) {
-            return new SewioWebSocketConnection(name, desc, url, monitor, opts, urlh);
+            return new SewioWebSocketConnection(name, desc, url, {"monitor": monitor}, opts ?? {});
         }
     }
 }

--- a/qlib/SmtpClient.qm
+++ b/qlib/SmtpClient.qm
@@ -827,17 +827,34 @@ smtp.clearStats();
         @since %SmtpClient 1.6
     */
     public class SmtpConnection inherits ConnectionProvider::AbstractConnection {
-        #! creates the SmtpConnection object
+        #! DEPRECATED: creates the SmtpConnection object
         /** @param name the name of the connection
             @param desc connection description
             @param url connection URL
             @param monitor monitoring flag
             @param opts connection options
             @param urlh broken down URL hash (as returned by @ref Qore::parse_url())
+
+            @deprecated since Qore 0.9
         */
-        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh) : AbstractConnection(name, desc, url, monitor, opts, urlh) {
+        deprecated
+        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh)
+            : AbstractConnection(name, desc, url, {"monitor": monitor}, opts) {
             #code log = sub (string fmt) { vprintf(fmt + "\n", argv); };
             #opts.dbglog = opts.log = log;
+        }
+
+        #! creates the SmtpConnection connection object
+        /** @param name the name of the connection
+            @param description connection description
+            @param url connection URL (potentially with password info)
+            @param attributes various attributes. See below
+            @param options connection options
+
+            See @ref AbstractConnection::constructor() for \c attributes and \c options reference.
+         */
+        constructor(string name, string description, string url, hash attributes = {}, hash options = {})
+            : AbstractConnection(name, description, url, attributes, options) {
         }
 
         #! returns \c "smtp"
@@ -885,9 +902,15 @@ smtp.clearStats();
             });
         }
 
-        #! static constructor
+        #! DEPRECATED: static constructor
+        /** @deprecated since Qore 0.9 in favor of new constructor and Qore::Reflection
+         */
+        deprecated
         static SmtpConnection make(string name, string desc, string url, bool monitor, *hash opts, hash urlh) {
-            return new SmtpConnection(name, desc, url, monitor, opts, urlh);
+            hash attributes = {
+                "monitor": monitor,
+            };
+            return new SmtpConnection(name, desc, url, attributes, opts ?? {});
         }
     }
 }

--- a/qlib/TelnetClient.qm
+++ b/qlib/TelnetClient.qm
@@ -33,10 +33,10 @@
 %require-types
 %enable-all-warnings
 
-%requires(reexport) ConnectionProvider >= 1.1
+%requires(reexport) ConnectionProvider >= 1.2
 
 module TelnetClient {
-    version = "1.4";
+    version = "1.5";
     desc = "allows connections to a Telnet server, to remotely execute commands and read their output";
     author = "Pavol Potancok <ppotancok@gmail.com>";
     url = "http://qore.org";
@@ -65,6 +65,9 @@ module TelnetClient {
     - @ref TelnetOptionCodes "TelnetOptionCodes": telnet protocol option codes and a lookup map
 
     @section telnetclient_relnotes TelnetClient Module Release Notes
+
+    @subsection telnetclient_v1_5 TelnetClient v1.5
+    - all connection clases have unified constructor
 
     @subsection telnetclient_v1_4 TelnetClient v1.4
     - added the @ref TelnetClient::TelnetConnection::getConstructorInfo() "TelnetConnection::getConstructorInfo()"
@@ -925,15 +928,32 @@ telnet.clearStats();
         @since %TelnetClient 1.3
     */
     public class TelnetConnection inherits ConnectionProvider::AbstractConnection {
-        #! creates the TelnetConnection object
+        #! DEPRECATED: creates the TelnetConnection object
         /** @param name the name of the connection
             @param desc connection description
             @param url connection URL
             @param monitor monitoring flag
             @param opts connection options
             @param urlh broken down URL hash (as returned by @ref Qore::parse_url())
+
+            @deprecated since Qore 0.9
         */
-        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh) : AbstractConnection(name, desc, url, monitor, opts, urlh) {
+        deprecated
+        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh)
+            : AbstractConnection(name, desc, url, {"monitor": monitor}, opts ?? {}) {
+        }
+
+        #! creates the RestConnection connection object
+        /** @param name the name of the connection
+            @param description connection description
+            @param url connection URL (potentially with password info)
+            @param attributes various attributes. See below
+            @param options connection options
+
+            See @ref AbstractConnection::constructor() for \c attributes and \c options reference.
+         */
+        constructor(string name, string description, string url, hash attributes = {}, hash options = {})
+            : AbstractConnection(name, description, url, attributes, options) {
         }
 
         #! returns \c "telnet"
@@ -981,9 +1001,15 @@ telnet.clearStats();
             });
         }
 
-        #! static constructor
+        #! DEPRECATED: static constructor
+        /** @deprecated since Qore 0.9 in favor of new constructor and Qore::Reflection
+         */
+        deprecated
         static TelnetConnection make(string name, string desc, string url, bool monitor, *hash opts, hash urlh) {
-            return new TelnetConnection(name, desc, url, monitor, opts, urlh);
+            hash attributes = {
+                "monitor": monitor,
+            };
+            return new TelnetConnection(name, desc, url, attributes, opts ?? {});
         }
     }
 }

--- a/qlib/WebSocketClient.qm
+++ b/qlib/WebSocketClient.qm
@@ -624,11 +624,12 @@ ws.clearStats();
 
             @deprecated since Qore 0.9
         */
+        deprecated
         constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh)
             : AbstractConnection(name, desc, url, {"monitor": monitor}, opts ?? {}) {
         }
 
-        #! creates the RestConnection connection object
+        #! creates the WebSocketConnectionObject connection object
         /** @param name the name of the connection
             @param description connection description
             @param url connection URL (potentially with password info)

--- a/qlib/WebSocketClient.qm
+++ b/qlib/WebSocketClient.qm
@@ -33,12 +33,12 @@
 
 %requires WebSocketUtil >= 1.0
 %requires Util >= 1.0
-%requires(reexport) ConnectionProvider >= 1.1
+%requires(reexport) ConnectionProvider >= 1.2
 
 %new-style
 
 module WebSocketClient {
-    version = "1.7";
+    version = "1.8";
     desc = "user module for providing client support for the WebSocket protocol";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -86,6 +86,9 @@ c.waitForZero();
     @endcode
 
     @section websocketclient_relnotes WebSocketClient Module Release History
+
+    @subsection wsc_v1_8 v1.8
+    - all connection clases have unified constructor
 
     @subsection wsc_v1_7 v1.7
     - added the @ref WebSocketClient::WebSocketConnectionObject::getConstructorInfo() "WebSocketConnectionObject::getConstructorInfo()"
@@ -611,15 +614,31 @@ ws.clearStats();
         - \c "yield": a closure to yield current thread execution
     */
     public class WebSocketConnectionObject inherits ConnectionProvider::AbstractConnection {
-        #! creates the WebSocketConnectionObject object
+        #! DEPRECATED: creates the WebSocketConnectionObject object
         /** @param name the name of the connection
             @param desc connection description
             @param url connection URL
             @param monitor monitoring flag
             @param opts connection options
             @param urlh broken down URL hash (as returned by @ref Qore::parse_url())
+
+            @deprecated since Qore 0.9
         */
-        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh) : AbstractConnection(name, desc, url, monitor, opts, urlh) {
+        constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh)
+            : AbstractConnection(name, desc, url, {"monitor": monitor}, opts ?? {}) {
+        }
+
+        #! creates the RestConnection connection object
+        /** @param name the name of the connection
+            @param description connection description
+            @param url connection URL (potentially with password info)
+            @param attributes various attributes. See below
+            @param options connection options
+
+            See @ref AbstractConnection::constructor() for \c attributes and \c options reference.
+         */
+        constructor(string name, string description, string url, hash attributes = {}, hash options = {})
+            : AbstractConnection(name, description, url, attributes, options) {
         }
 
         #! returns \c "websocket"
@@ -702,9 +721,15 @@ ws.clearStats();
                 );
         }
 
-        #! static constructor
+        #! DEPRECATED: static constructor
+        /** @deprecated since Qore 0.9 in favor of new constructor and Qore::Reflection
+         */
+        deprecated
         static WebSocketConnectionObject make(string name, string desc, string url, bool monitor, *hash opts, hash urlh) {
-            return new WebSocketConnectionObject(name, desc, url, monitor, opts, urlh);
+            hash attributes = {
+                "monitor": monitor,
+            };
+            return new WebSocketConnectionObject(name, desc, url, attributes, opts ?? {});
         }
     }
 }


### PR DESCRIPTION
…ng new features:

 * all connection clases have unified constructor
 * old contructors and static make() constructors are deprecated
 * AbstractConnection::parseUrl() and AbstractConnection::getSafeurl() are not static anymore
   to allow their reimplementation in the inherited class. It can be used
   to parse strange and unexpected URLs like eg. pure json strings, or Datasource connection
   strings.