### PR TITLE
refs #3162 - AbstractConnection: new setup which will not use parse_u…

### DIFF
--- a/qlib/ConnectionProvider.qm
+++ b/qlib/ConnectionProvider.qm
@@ -654,6 +654,17 @@ schema://user:pass@hostname:port/path
             }
         }
 
+        #! Parse the URL to a hash
+        /** @param url a string with url
+            @return hash with url - string as url
+
+            The reason for this is to avoid a unwanted Qore::parse_url() call in connections
+            with custom parseUrl() implementation.
+         */
+        private hash parseUrl(string url) {
+            return {"url": url};
+        }
+
         #! throws an exception because the object is invalid
         private object getImpl(bool connect = True, *hash rtopts) {
             throw "INVALID-CONNECTION", sprintf("connection %y (type %y url %y) is invalid and therefore could not be loaded: %s", name, urlh.protocol, url, error);


### PR DESCRIPTION
…rl() for all constructors. InvalidConnection cannot call parse_url() for custom parsed URL connections