### PR TITLE
refs #3026 updated to WebUtil and HTTP infrastructure to allow for cl…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -149,11 +149,19 @@
           connections to be created dynamically, potentially in another process from a network call (<a href="https://github.com/qorelanguage/qore/issues/2628">issue 2628</a>)
         - The \c AbstractConnection has new public flag \c enabled. Also constructors are updated. (<a href="https://github.com/qorelanguage/qore/issues/3001">issue 3001</a>)
         - The \c AbstractConnection has new constructors, old ones are obsolete. Custom URL/URI parsing is possible (<a href="https://github.com/qorelanguage/qore/issues/3162">issue 3162</a>)
+      - <a href="../../modules/CsvUtil/html/index.html">CsvUtil</a> module updates:
+        - Added public methods \c AbstractCsvIterator::getRawLine() and \c AbstractCsvIterator::getRawLineValues() (<a href="https://github.com/qorelanguage/qore/issues/2739">issue 2739</a>)
       - <a href="../../modules/FreetdsSqlUtil/html/index.html">FreetdsSqlUtil</a> module changes:
         - Added support for serializing and deserializing \c AbstractTable objects (<a href="https://github.com/qorelanguage/qore/issues/2663">issue 2663</a>)
       - <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module changes:
+        - added the \c "header-info" hash to the context argument when calling handlers
+          (<a href="https://github.com/qorelanguage/qore/issues/3260">issue 3260</a>)
         - Added support for adding new HTTP methods to the server with the \c HttpServer::addHttpMethod() method
           (<a href="https://github.com/qorelanguage/qore/issues/2805">issue 2805</a>)
+      - <a href="../../modules/Mime/html/index.html">Mime</a> module changes:
+        - allow the default type for unknown extensions to be overridden in
+          @ref Mime::get_mime_type_from_ext() "get_mime_type_from_ext()"
+          (<a href="https://github.com/qorelanguage/qore/issues/3260">issue 3260</a>)
       - <a href="../../modules/MysqlSqlUtil/html/index.html">MysqlSqlUtil</a> module changes:
         - Added support for serializing and deserializing \c AbstractTable objects (<a href="https://github.com/qorelanguage/qore/issues/2663">issue 2663</a>)
       - <a href="../../modules/OracleSqlUtil/html/index.html">OracleSqlUtil</a> module changes:
@@ -188,6 +196,9 @@
           @ref Qore::SQL::SQLStatement "SQLStatement"
           (<a href="https://github.com/qorelanguage/qore/issues/2326">issue 2326</a>)
         - Added support for serializing and deserializing \c AbstractTable objects (<a href="https://github.com/qorelanguage/qore/issues/2663">issue 2663</a>)
+      - <a href="../../modules/Swagger/html/index.html">Swagger</a>:
+        - Swagger module does not accept multipart/form-data content-type and also does not work with list and hash parameters
+          (<a href="https://github.com/qorelanguage/qore/issues/2932">issue 2932</a>)
       - <a href="../../modules/Util/html/index.html">Util</a> module updates:
         - Added public function \c parse_ranges() (<a href="https://github.com/qorelanguage/qore/issues/2438">issue 2438</a>)
         - Added public function \c check_ip_address() (<a href="https://github.com/qorelanguage/qore/issues/2483">issue 2483</a>)
@@ -196,14 +207,12 @@
           (<a href="https://github.com/qorelanguage/qore/issues/3138">issue 3138</a>)
         - updated @ref Util::get_exception_string() "get_exception_string()" to show the \c lang value
           (<a href="https://github.com/qorelanguage/qore/issues/3182">issue 3182</a>)
-      - <a href="../../modules/CsvUtil/html/index.html">CsvUtil</a> module updates:
-        - Added public methods \c AbstractCsvIterator::getRawLine() and \c AbstractCsvIterator::getRawLineValues() (<a href="https://github.com/qorelanguage/qore/issues/2739">issue 2739</a>)
-      - <a href="../../modules/Swagger/html/index.html">Swagger</a>:
-        - Swagger module does not accept multipart/form-data content-type and also does not work with list and hash parameters
-          (<a href="https://github.com/qorelanguage/qore/issues/2932">issue 2932</a>)
       - <a href="../../modules/WebSocketHandler/html/index.html">WebSocketHandler</a>:
         - added stopping connection from server side via @ref WebSocketHandler::WebSocketConnection::stop(), @ref WebSocketHandler::WebSocketHandler::stopOne()
           and WebSocketClient handling of WSCC_GoingAway event
+      - <a href="../../modules/WebUtil/html/index.html">WebUtil</a> module changes:
+        - updated to allow more control over file serving
+          (<a href="https://github.com/qorelanguage/qore/issues/3260">issue 3260</a>)
     - @ref relative_dates "Relative date" changes
       - Fractional seconds are accepted in the @ref single_reldates
       - Fractional date components are accepted in the @ref short_reldates based on <a href="https://en.wikipedia.org/wiki/ISO_8601#Durations">ISO-8601 durations</a>
@@ -1656,7 +1665,7 @@
       - \c schema member incorrectly set by @ref Qore::SQL::AbstractDatasource::getUserName() "AbstractDatasource::getUserName()" instead of @ref Qore::SQL::AbstractDatasource::getDBName() "AbstractDatasource::getDBName()" (<a href="https://github.com/qorelanguage/qore/pull/519">issue 519</a>)
     -  <a href="../../modules/WebUtil/html/index.html">WebUtil</a> module fixes:
       - fixed a bug where template programs with @ref Qore::PO_ALLOW_BARE_REFS set did not work
-      - fixed a bug serviing index files in \c FileHandler::tryServeRequest() where index files could be incorrectly served with a \c "204 No Content" response (<a href="https://github.com/qorelanguage/qore/issues/616">issue 616</a>)
+      - fixed a bug serving index files in \c FileHandler::tryServeRequest() where index files could be incorrectly served with a \c "204 No Content" response (<a href="https://github.com/qorelanguage/qore/issues/616">issue 616</a>)
     - <a href="../../modules/WebSocketHandler/html/index.html">WebSocketHandler</a> module fixes:
       - fixed a bug where the connection object was deleted when the connection closes which could cause excess exceptions in multithreaded server code
       - added the WebSocketConnection::connectionClosed() method to be called when the connection is closed

--- a/examples/test/qlib/Mime/mime.qtest
+++ b/examples/test/qlib/Mime/mime.qtest
@@ -54,6 +54,7 @@ aωb\r
     }
 
     constructor() : Test("MimeTest", "1.0") {
+        addTestCase("mime type from ext", \mimeTypeTest());
         addTestCase("Printable test", \printableTest());
         addTestCase("Base64 test", \base64Test());
         addTestCase("Header word q test", \wordQTest());
@@ -64,6 +65,11 @@ aωb\r
 
         # Return for compatibility with test harness that checks return value.
         set_return_value(main());
+    }
+
+    mimeTypeTest() {
+        assertEq(MimeTypeUnknown, get_mime_type_from_ext("/"));
+        assertEq(MimeTypeHtml, get_mime_type_from_ext("/", MimeTypeHtml));
     }
 
     printableTest() {

--- a/examples/test/qlib/WebUtil/WebUtil.qtest
+++ b/examples/test/qlib/WebUtil/WebUtil.qtest
@@ -25,10 +25,9 @@ class TestFileHandler inherits FileHandler {
     }
 
     constructor(string fileRoot, string urlRoot = "/", *hash opt) : FileHandler(fileRoot, urlRoot, opt) {
-        #
     }
 
-    private *hash getResponseHeadersForFile(string path, hash cx, hash hdr) {
+    private *hash<auto> getResponseHeadersForFile(string path, hash<auto> cx, hash<auto> hdr) {
         if (addHeaders)
             return {"Cache-Control": "private, max-age=86400"};
     }
@@ -73,6 +72,9 @@ public class WebUtilTest inherits QUnit::Test {
         result = client.get("/test_file.txt", NOTHING, \info);
         respHdr = info."response-headers";
         assertEq("abc", trim(result));
+        # remove the "charset" from the content-type
+        respHdr."content-type" =~ s/;.*//;
+        assertEq(MimeTypeHtml, respHdr."content-type");
         assertTrue(respHdr.hasKey("Cache-Control") || respHdr.hasKey("cache-control"));
     }
 }

--- a/lib/QC_FileInputStream.qpp
+++ b/lib/QC_FileInputStream.qpp
@@ -3,7 +3,7 @@
 /*
   Qore Programming Language
 
-  Copyright (C) 2016 - 2018 Qore Technologies, s.r.o.
+  Copyright (C) 2016 - 2019 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -67,6 +67,8 @@ qclass FileInputStream [system_constructor=FILEINPUTSTREAM_system_constructor; a
     @param timeout_ms a timeout period with a resolution of milliseconds (a @ref relative_dates
            "relative date/time value"; integer arguments will be assumed to be milliseconds);
            if not given or negative the operations will never time out
+
+    @throws FILE-OPEN2-ERROR if the file cannot be opened (does not exist, permission error, etc)
  */
 FileInputStream::constructor(string fileName, timeout timeout_ms = -1) {
    SimpleRefHolder<FileInputStream> fis(new FileInputStream(fileName, timeout_ms, xsink));

--- a/qlib/HttpServer.qm
+++ b/qlib/HttpServer.qm
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! @file HttpServer.qm HTTP multi-threaded server module definition
 
-/*  HttpServer.qm Copyright (C) 2012 - 2018 Qore Technologies, s.r.o.
+/*  HttpServer.qm Copyright (C) 2012 - 2019 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -74,14 +74,14 @@ module HttpServer {
 %new-style
 
 class MyHandler inherits AbstractHttpRequestHandler {
-    hash handleRequest(hash cx, hash hdr, *data body) {
+    hash handleRequest(hash<auto> cx, hash<auto> hdr, *data body) {
         # NOTE: change "%y" to "%N" to get a more readable multi-line output format for container values
         log("request received on %s from %s: context: %y hdr: %y body size: %d byte%s", cx."peer-info".desc, cx."socket-info".desc, cx, hdr, body.size(), body.size() == 1 ? "" : "s");
-        return (
+        return {
             "code": 200,
             "body": sprintf("<title>Test Page</title><body><h1>Qore HTTP server v%s</h1><p>%y on %s PID %s TID %d connection %d</p><p>Qore %s</p></body>", HttpServer::Version, now_us(), gethostname(), getpid(), gettid(), cx.id, Qore::VersionString),
             "close": True,
-            );
+        };
     }
 }
 
@@ -113,6 +113,8 @@ log("started listener on %s", lh.desc);
     @section http_relnotes HttpServer Module Release Notes
 
     @subsection http0313 HttpServer 0.3.13
+    - added the \c "header-info" hash to the context argument when calling handlers
+      (<a href="https://github.com/qorelanguage/qore/issues/XXXX">issue XXXX</a>)
     - added support for adding new HTTP methods to the server with the
       @ref HttpServer::HttpServer::addHttpMethod() "HttpServer::addHttpMethod()" method
       (<a href="https://github.com/qorelanguage/qore/issues/2805">issue 2805</a>)
@@ -310,7 +312,7 @@ class HttpServer::HandlerInfo {
     }
 
     #! called when matching a request; returns a code giving the match level; 0 = no match, 1 = only the Content-Type matches, 2 = special header matches, 3 = URL matches
-    int matchRequest(hash hdr, int score) {
+    int matchRequest(hash<auto> hdr, int score) {
         if (path && hdr.path && isregex && regex(hdr.path, path)) {
             return 3;
         }
@@ -366,7 +368,7 @@ class HttpServer::HttpHandlerList {
     }
 
     # matches a handler to the request
-    *HandlerInfo findHandler(hash hdr, reference<int> score, bool finalv = False, *reference<string> root_path) {
+    *HandlerInfo findHandler(hash<auto> hdr, reference<int> score, bool finalv = False, *reference<string> root_path) {
         if (!handlers)
             return;
 
@@ -492,7 +494,7 @@ class HttpServer::DynamicHttpHandlerList inherits HttpServer::HttpHandlerList {
         c.waitForZero();
     }
 
-    *DynamicHandlerInfo findHandler(hash hdr, reference<int> score, reference<DynamicHandlerHelper> dhh, *reference<string> root_path) {
+    *DynamicHandlerInfo findHandler(hash<auto> hdr, reference<int> score, reference<DynamicHandlerHelper> dhh, *reference<string> root_path) {
         dhl.readLock();
         on_exit dhl.readUnlock();
 
@@ -624,7 +626,7 @@ public class HttpServer::HttpServer inherits HttpServer::AbstractLogger {
         ThreadPool threadPool(-1, DefaultIdleThreads);
 
         # other misc response headers
-        hash hdr;
+        hash<auto> hdr;
 
         # override message body encoding if none is received from the sender; http://tools.ietf.org/html/rfc2616#section-3.7.1 states that it must be iso-8850-1
         *string override_encoding;
@@ -1194,7 +1196,7 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
     }
 
     #! sends an HTTP error message on the socket
-    sendHttpError(HttpListener listener, hash cx, Socket s, int code, string msg, *hash extra_hdrs, *string encoding, bool head) {
+    sendHttpError(HttpListener listener, hash<auto> cx, Socket s, int code, string msg, *hash extra_hdrs, *string encoding, bool head) {
         if (!s.isOpen()) {
             listener.log("cid %d: connection closed by peer", cx.id);
             return;
@@ -1338,7 +1340,7 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
     }
 
     #! helper method to set HTTP response headers
-    static nothing setReplyHeaders(Socket s, hash cx, reference<hash> rv) {
+    static nothing setReplyHeaders(Socket s, hash<auto> cx, reference<hash> rv) {
         return HttpServer::http_set_reply_headers(s, cx, \rv);
     }
 
@@ -1437,7 +1439,7 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
     }
 
     # don't reimplement this method; fix/enhance it in the module
-    final private hash<HttpResponseInfo> noHandlerError(hash cx, hash hdr, auto body) {
+    final private hash<HttpResponseInfo> noHandlerError(hash<auto> cx, hash<auto> hdr, auto body) {
         string str = "";
         if (hdr.path)
             str = sprintf("url=%y", hdr.path);
@@ -1458,7 +1460,7 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
 
     # handles an incoming request - do not call externally; this method is called by the listeners when a request is received
     # don't reimplement this method; fix/enhance it in the module
-    final handleRequest(HttpListener listener, Socket s, reference<hash> cx, hash hdr, hash hh, *data body, bool head = False, HttpPersistentHandlerInfo phi, hash<auto> info) {
+    final handleRequest(HttpListener listener, Socket s, reference<hash> cx, hash<auto> hdr, *data body, bool head = False, HttpPersistentHandlerInfo phi, hash<auto> info) {
         if (!http_methods{hdr.method}) {
             string err = sprintf("unknown / unsupported HTTP method %n", hdr.method);
             string str = sprintf("%s: received from %s via %s", err, info.address_desc, listener.getListenerSocketInfo().address_desc);
@@ -1468,13 +1470,17 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
             return;
         }
 
-        foreach string enc in (hh."accept-encoding") {
+        # get first supported encoding for response
+        foreach string enc in (cx."header-info"."accept-encoding") {
             *string e = ContentEncodings{enc};
             if (!e)
                 continue;
             cx.encoding = e;
             break;
         }
+
+        # convert "accept-encoding" to a hash
+        cx."header-info"."accept-encoding" = map {$1: True}, cx."header-info"."accept-encoding";
 
         # erase the encoding string on exit
         on_exit remove cx.encoding;
@@ -1483,17 +1489,17 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
         if (body && body.typeCode() == NT_STRING && override_encoding && hdr."_qore_orig_content_type" !~ /charset=/)
             body = force_encoding(body, override_encoding);
 
-        hash url = (
+        hash url = {
             "path": hdr.path,
-            );
+        };
 
         # add logging functions and url
-        cx += (
+        cx += {
             "logfunc"     : logfunc,
             "errlogfunc"  : errlogfunc,
             "url"         : url,
             "debug"       : debug,
-            );
+        };
 
         HttpServer::AbstractHttpRequestHandler handler;
         # the dynamic handler helper maintains the request count for dynamic handlers so any call to remove the handler will only return after all in-progress requests are completed; the object is only allocated if needed
@@ -1501,8 +1507,7 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
 
         if (phi.handler) {
             handler = phi.handler;
-        }
-        else {
+        } else {
             # find a handler for the request
             *HandlerInfo hi;
             int score = 0;
@@ -1517,8 +1522,7 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
                         return;
                     }
                 }
-            }
-            else {
+            } else {
                 hi = handlers.findHandler(hdr, \score, False, \root_path);
                 if (score < 3) {
                     *HandlerInfo dhi = dhandlers.findHandler(hdr, \score, \dhh, \root_path);
@@ -1552,8 +1556,7 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
             if (!handler) {
                 cx.handler_name = "error";
                 rv = noHandlerError(cx, hdr, body);
-            }
-            else {
+            } else {
                 # check for authentication info
                 #printf("HTTP DEBUG: handler: %y (auth: %y) hdr: %y\n", cx.handler_name, exists handler.auth && handler.auth.requiresAuthentication(), hdr);
 
@@ -1594,12 +1597,12 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
                 if (!phi.handler) {
                     if (handler.isPersistent())
                         phi.assign(dhh, handler);
-                }
-                else if (!handler.isPersistent())
+                } else if (!handler.isPersistent())
                     phi.clear();
 
-                if (rv.reply_sent)
+                if (rv.reply_sent) {
                     return;
+                }
             }
 
             sendReply(listener, s, handler, rv, \cx, hdr, head);
@@ -1628,7 +1631,7 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
 
     # sends a reply to a request
     # don't reimplement this method; fix/enhance it in the module
-    final sendReply(HttpListener listener, Socket s, HttpServer::AbstractHttpRequestHandler handler, hash rv, reference<hash> cx, hash hdr, bool head) {
+    final sendReply(HttpListener listener, Socket s, HttpServer::AbstractHttpRequestHandler handler, hash rv, reference<hash> cx, hash<auto> hdr, bool head) {
         if (exists rv.close)
             cx.close = boolean(rv.close);
 
@@ -1679,7 +1682,7 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
             #printf("\n**** RESPONSE: %d ct: %s encoding: %y: %N\n", rv.code, rv.hdr."Content-Type", cx.encoding, rv.body);
 
             # compress body if eligible for compression
-            if (rv.body && rv.body.size() > CompressionThreshold) {
+            if (rv.body && !rv.hdr."Content-Encoding" && rv.body.size() > CompressionThreshold) {
                 if (cx.encoding == "deflate") {
                     rv.hdr."Content-Encoding" = "deflate";
                     rv.body = compress(rv.body);
@@ -2017,7 +2020,7 @@ class HttpServer::HttpListener inherits Qore::Socket, HttpServer::HttpListenerIn
         }
     }
 
-    logResponse(hash cx, int code, *data body, *hash hdr) {
+    logResponse(hash<auto> cx, int code, *data body, *hash<auto> hdr) {
         # do log msg
         string lstr = sprintf("cid %d: HTTP/1.1 %d %s", cx.id, code, HttpServer::HttpCodes{code});
         if (cx.handler_name)
@@ -2036,7 +2039,7 @@ class HttpServer::HttpListener inherits Qore::Socket, HttpServer::HttpListenerIn
             log("cid %d: SEND BODY: %y", cx.id, body);
     }
 
-    logResponse(hash cx, hash rv) {
+    logResponse(hash<auto> cx, hash<auto> rv) {
         logResponse(cx, rv.code, rv.body, rv.hdr);
     }
 
@@ -2145,16 +2148,16 @@ class HttpServer::HttpListener inherits Qore::Socket, HttpServer::HttpListenerIn
         if (info.port)
             info.desc += ":" + info.port;
 
-        hash cx = (
+        hash<auto> cx = {
             "socket": socket,
             "socket-info": socket_info,
             "peer-info": info,
             "id": ss.next(),
             "ssl": ssl,
             "listener-id": id,
-            );
+        };
 
-        my (hash hdr, auto body);
+        my (hash<auto> hdr, auto body);
 
         # set TCP_NODELAY on incoming socket
         #s.setNoDelay(True);
@@ -2178,9 +2181,9 @@ class HttpServer::HttpListener inherits Qore::Socket, HttpServer::HttpListenerIn
                     continue;
                 }
 
-                hash hi;
+                hash<auto> header_info;
                 try {
-                    hdr = s.readHTTPHeader(HttpServer::ReadTimeout, \hi);
+                    hdr = s.readHTTPHeader(HttpServer::ReadTimeout, \header_info);
                 } catch (hash<ExceptionInfo> ex) {
                     # according to RFC 2616 sec 8.1.2.1 (http://tools.ietf.org/html/rfc2616#section-8.1.2), clients claiming http 1.1
                     # protocol compatibility SHOULD only close the connection after
@@ -2212,7 +2215,7 @@ class HttpServer::HttpListener inherits Qore::Socket, HttpServer::HttpListenerIn
                     log("RECV HEADER: %y", hdr);
 
                 # DEBUG:
-                #printf("HTTP DEBUG: id: %d, hdr: %y, hi: %y\n", cx.id, hdr, hi);
+                #printf("HTTP DEBUG: id: %d, hdr: %y, header_info: %y\n", cx.id, hdr, header_info);
 
                 # process ascii encodings in url if present
                 cx.raw_path = hdr.path;
@@ -2229,17 +2232,17 @@ class HttpServer::HttpListener inherits Qore::Socket, HttpServer::HttpListenerIn
                 # save original content-type
                 if (hdr."content-type")
                     hdr."_qore_orig_content_type" = hdr."content-type";
-                hdr."content-type" = hi."body-content-type";
+                hdr."content-type" = header_info."body-content-type";
 
                 # the Socket's encoding is set in Socket::readHTTPHeader() according to any charset declaration in the Content-Type
                 cx.char_encoding = s.getEncoding();
-                cx."response-encoding" = hi."accept-charset";
+                cx."response-encoding" = header_info."accept-charset";
 
                 # check if we need to close the connection
                 # RFC 2068 19.7.1: Persistent connections in HTTP/1.0 must be explicitly negotiated as they are not the default behavior
                 # RFC 1945 1.3: Except for experimental applications, current practice requires that the connection be established by the client prior to each request and closed by the server after sending the response.
                 # so we MUST close the connection when a request is received by an HTTP 1.0 client without an explicit request to keep the connection open: the above rules are followed by Socket::readHTTPHeader()
-                cx.close = hi.close;
+                cx.close = header_info.close;
 
                 # if we need to get a body
                 if (hdr."content-length") {
@@ -2249,8 +2252,7 @@ class HttpServer::HttpListener inherits Qore::Socket, HttpServer::HttpListenerIn
                         else
                             body = s.recv(hdr."content-length", HttpServer::ReadTimeout);
                         #printf("HTTP DEBUG: %s\n", body);
-                    }
-                    catch (hash<ExceptionInfo> ex) {
+                    } catch (hash<ExceptionInfo> ex) {
                         string etxt = sprintf("error reading body in %s (Content-Length: %d): %s: %s", hdr.method, hdr."content-length", ex.err, ex.desc);
                         string str = sprintf("%s: received from %s via %s (header=%n)", etxt, info.address_desc, socket_info.address_desc, hdr);
                         logError(str);
@@ -2291,7 +2293,8 @@ class HttpServer::HttpListener inherits Qore::Socket, HttpServer::HttpListenerIn
                 }
 
                 cx.uctx = get_thread_data("uctx");
-                serv.handleRequest(self, s, \cx, hdr, hi, body, hdr.method == "HEAD", phi, info);
+                cx."header-info" = header_info;
+                serv.handleRequest(self, s, \cx, hdr, body, hdr.method == "HEAD", phi, info);
 
                 #log("DBG cid %d: cx.close: %y", cx.id, cx.close);
 

--- a/qlib/HttpServer.qm
+++ b/qlib/HttpServer.qm
@@ -114,7 +114,7 @@ log("started listener on %s", lh.desc);
 
     @subsection http0313 HttpServer 0.3.13
     - added the \c "header-info" hash to the context argument when calling handlers
-      (<a href="https://github.com/qorelanguage/qore/issues/XXXX">issue XXXX</a>)
+      (<a href="https://github.com/qorelanguage/qore/issues/3026">issue 3026</a>)
     - added support for adding new HTTP methods to the server with the
       @ref HttpServer::HttpServer::addHttpMethod() "HttpServer::addHttpMethod()" method
       (<a href="https://github.com/qorelanguage/qore/issues/2805">issue 2805</a>)

--- a/qlib/HttpServerUtil.qm
+++ b/qlib/HttpServerUtil.qm
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! @file HttpServerUtil.qm HTTP server base code
 
-/*  HttpServerUtil.qm Copyright (C) 2014 - 2018 Qore Technologies, s.r.o.
+/*  HttpServerUtil.qm Copyright (C) 2014 - 2019 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -237,7 +237,7 @@ public namespace HttpServer {
         softbool close = False;
 
         #! set this key to a hash of extra header information to be returned with the response
-        *hash hdr;
+        *hash<auto> hdr;
 
         #! this key can be set to @ref Qore::True "True" if the reply has already been sent (by a chunked callback for example)
         bool reply_sent = False;
@@ -261,7 +261,7 @@ public namespace HttpServer {
         softbool close = False;
 
         #! set this key to a hash of extra header information to be returned with the response
-        *hash hdr;
+        *hash<auto> hdr;
 
         #! this key can be set to @ref Qore::True "True" if the reply has already been sent (by a chunked callback for example)
         bool reply_sent = False;
@@ -325,7 +325,7 @@ public namespace HttpServer {
     }
 
     #! helper function for setting HTTP response headers
-    public nothing sub http_set_reply_headers(Socket s, hash cx, reference rv, *string server_string) {
+    public nothing sub http_set_reply_headers(Socket s, hash<auto> cx, reference rv, *string server_string) {
         if (!rv.hdr.Connection) {
             if (rv.close) # RFC 2616 section 14.10 is "close" in all lower-case
                 rv.hdr.Connection = "close";
@@ -419,6 +419,14 @@ public class HttpServer::HttpListenerInterface inherits HttpServer::AbstractLogg
     /** @param k the key to remove from the \c "uctx" context hash; if no argument is provided, then the \c "uctx" context hash is removed entirely
     */
     abstract auto removeUserThreadContext(*string k);
+
+    #! method to log a response message
+    /** @param cx the call context
+        @param the response hash
+    */
+    logResponse(hash<auto> cx, hash<auto> rv) {
+        # no implementation in the base class
+    }
 }
 
 #! abstract base class for external authentication
@@ -476,8 +484,21 @@ public class HttpServer::AbstractAuthenticator {
     /** @param listener an HttpListenerInterface object for the listener serving the request for logging purposes
         @param hdr a hash of request headers
         @param cx a reference to the call context hash; set the \c "user" key to the user name if a user was identified and authorized; this hash will have the following keys:
+        - \c header-info: a hash of information about the request header with the following keys:
+          - \c request-uri: gives the request URI in an HTTP request
+          - \c body-content-type: this is the \c "Content-Type" header without any charset declaration
+          - \c charset: if there is a charset declaration in the \c "Content-Type" header, the value is returned in
+            this key
+          - \c close: set to @ref Qore::True "True" if the connection should be closed after responding,
+            @ref Qore::False "False" if not (as derived from the request header)
+          - \c accept-charset: this key will be set to an appropriate value from any \c "Accept-Charset" header; if
+            any of \c "*", \c "utf8", or \c "utf-8" are present, then this will be set to \c "utf8", otherwise it will
+            be set to the first requested character encoding in the list
+          - \c accept-encoding: a hash where keys are values from any \c "Accept-Encoding" header and the values are
+            @ref True
         - \c socket: the bind address used to bind the listener (\c "socket-info" provides more detailed information)
-        - \c socket-info: a hash of socket information for the listening socket (as returned by @ref Qore::Socket::getSocketInfo())
+        - \c socket-info: a hash of socket information for the listening socket (as returned by
+          @ref Qore::Socket::getSocketInfo())
         - \c peer-info: a hash of socket information for the remote socket (as returned by @ref Qore::Socket::getPeerInfo())
         - \c url: a hash of broken-down URL information (as returned from @ref Qore::parse_url())
         - \c id: the unique HTTP connection ID
@@ -491,7 +512,7 @@ public class HttpServer::AbstractAuthenticator {
         - \c "body": the error message body
         - \c "hdr": an optional hash of headers for the error response
     */
-    *hash<HttpResponseInfo> authenticateRequest(HttpListenerInterface listener, hash hdr, reference<hash> cx) {
+    *hash<HttpResponseInfo> authenticateRequest(HttpListenerInterface listener, hash<auto> hdr, reference<hash> cx) {
         #printf("HTTP DEBUG %s::authenticateRequest() called\n", self.className());
         if (!requiresAuthentication())
             return;
@@ -547,8 +568,21 @@ public class HttpServer::PermissiveAuthenticator inherits HttpServer::AbstractAu
     /** @param listener an HttpListenerInterface object for the listener serving the request for logging purposes
         @param hdr a hash of request headers
         @param cx a reference to the call context hash; set the \c "user" key to the user name if a user was identified and authorized; this hash will have the following keys:
+        - \c header-info: a hash of information about the request header with the following keys:
+          - \c request-uri: gives the request URI in an HTTP request
+          - \c body-content-type: this is the \c "Content-Type" header without any charset declaration
+          - \c charset: if there is a charset declaration in the \c "Content-Type" header, the value is returned in
+            this key
+          - \c close: set to @ref Qore::True "True" if the connection should be closed after responding,
+            @ref Qore::False "False" if not (as derived from the request header)
+          - \c accept-charset: this key will be set to an appropriate value from any \c "Accept-Charset" header; if
+            any of \c "*", \c "utf8", or \c "utf-8" are present, then this will be set to \c "utf8", otherwise it will
+            be set to the first requested character encoding in the list
+          - \c accept-encoding: a hash where keys are values from any \c "Accept-Encoding" header and the values are
+            @ref True
         - \c socket: the bind address used to bind the listener (\c "socket-info" provides more detailed information)
-        - \c socket-info: a hash of socket information for the listening socket (as returned by @ref Qore::Socket::getSocketInfo())
+        - \c socket-info: a hash of socket information for the listening socket (as returned by
+          @ref Qore::Socket::getSocketInfo())
         - \c peer-info: a hash of socket information for the remote socket (as returned by @ref Qore::Socket::getPeerInfo())
         - \c url: a hash of broken-down URL information (as returned from @ref Qore::parse_url())
         - \c id: the unique HTTP connection ID
@@ -559,7 +593,7 @@ public class HttpServer::PermissiveAuthenticator inherits HttpServer::AbstractAu
 
         @return returns @ref nothing indicating that the request is authenticated
     */
-    *hash<HttpResponseInfo> authenticateRequest(HttpListenerInterface listener, hash hdr, reference<hash> cx) {
+    *hash<HttpResponseInfo> authenticateRequest(HttpListenerInterface listener, hash<auto> hdr, reference<hash> cx) {
         return;
     }
 }
@@ -584,9 +618,9 @@ public class HttpServer::AbstractStreamRequest {
         #! the Socket object for the response
         Socket s;
         #! the call context variable
-        hash cx;
+        hash<auto> cx;
         #! a hash of request headers
-        hash hdr;
+        hash<auto> hdr;
         #! any message body given in a non-chunked request; could already be deserialized
         auto body;
         #! send and receive timeout
@@ -623,8 +657,7 @@ public class HttpServer::AbstractStreamRequest {
             recv(dh);
             # signal end of data
             recvImpl(("hdr": NOTHING));
-        }
-        else {
+        } else {
             if (hdr."transfer-encoding" == "chunked") {
                 if (hdr."content-encoding")
                     s.readHTTPChunkedBodyBinaryWithCallback(\recv(), timeout_ms);
@@ -640,7 +673,7 @@ public class HttpServer::AbstractStreamRequest {
 
     #! called to either create the response hash or send a chunked response directly
     /** This method calls getResponseHeaderMessageImpl() to get the response code, headers and optionally a response message body.
-        If a \c "Content-Encoding: chunked" header is included, then the response is sent chunked using the send() callback;
+        If a \c "Transfer-Encoding: chunked" header is included, then the response is sent chunked using the send() callback;
         in this case the \c "reply_sent" key in the response is set to @ref Qore::True "True".
         Otherwise, any message body is immediately encoded (if accepted by the requestor).
     */
@@ -653,8 +686,8 @@ public class HttpServer::AbstractStreamRequest {
 
         # send chunked response
         s.sendHTTPResponseWithCallback(\send(), rv.code, HttpServer::HttpCodes.(rv.code), "1.1", rv.hdr, timeout_ms);
-
         rv.reply_sent = True;
+        listener.logResponse(cx, rv);
         return rv;
     }
 
@@ -724,11 +757,11 @@ private logChunk(bool send, int size) {
         @note this method is called after the message body has been received
     */
     private hash<HttpResponseInfo> getResponseHeaderMessageImpl() {
-        return new hash<HttpResponseInfo>((
+        return new hash<HttpResponseInfo>({
             "code": 501,
             "body": sprintf("default handler (%s) has no implementation", self.className()),
             "close": True,
-            ));
+        });
     }
 
     #! callback method for receiving chunked data; the default implementation in this base class does nothing
@@ -853,7 +886,7 @@ public class HttpServer::AbstractHttpRequestHandler {
     }
 
     #! this method will throw an exception if a persistent connection cannot be granted
-    private nothing checkPersistent(hash cx, hash hdr) {
+    private nothing checkPersistent(hash<auto> cx, hash<auto> hdr) {
         # Socket::readHTTPHeader() sets the value in cx.close according to the HTTP version and the Connection header
         if (cx.close)
             throw "PERSISTENT-ERROR", sprintf("a persistent connection cannot be granted because the requesting HTTP level is %y and the Connection header is %y", hdr.http_version, hdr.connection);
@@ -862,8 +895,21 @@ public class HttpServer::AbstractHttpRequestHandler {
     #! will be called when a request is received that should be directed to the handler
     /**
         @param cx call context hash; this hash will have the following keys:
+        - \c header-info: a hash of information about the request header with the following keys:
+          - \c request-uri: gives the request URI in an HTTP request
+          - \c body-content-type: this is the \c "Content-Type" header without any charset declaration
+          - \c charset: if there is a charset declaration in the \c "Content-Type" header, the value is returned in
+            this key
+          - \c close: set to @ref Qore::True "True" if the connection should be closed after responding,
+            @ref Qore::False "False" if not (as derived from the request header)
+          - \c accept-charset: this key will be set to an appropriate value from any \c "Accept-Charset" header; if
+            any of \c "*", \c "utf8", or \c "utf-8" are present, then this will be set to \c "utf8", otherwise it will
+            be set to the first requested character encoding in the list
+          - \c accept-encoding: a hash where keys are values from any \c "Accept-Encoding" header and the values are
+            @ref True
         - \c socket: the bind address used to bind the listener (\c "socket-info" provides more detailed information)
-        - \c socket-info: a hash of socket information for the listening socket (as returned by @ref Qore::Socket::getSocketInfo())
+        - \c socket-info: a hash of socket information for the listening socket (as returned by
+          @ref Qore::Socket::getSocketInfo())
         - \c peer-info: a hash of socket information for the remote socket (as returned by @ref Qore::Socket::getPeerInfo())
         - \c url: a hash of broken-down URL information (as returned from @ref Qore::parse_url())
         - \c id: the unique HTTP connection ID
@@ -885,7 +931,7 @@ public class HttpServer::AbstractHttpRequestHandler {
 
         @note the default implementation simply returns a 501 error code for all requests; reimplement this method in a subclass to provide the required functionality
     */
-    hash<HttpResponseInfo> handleRequest(hash cx, hash hdr, *data body) {
+    hash<HttpResponseInfo> handleRequest(hash<auto> cx, hash<auto> hdr, *data body) {
         return new hash<HttpResponseInfo>((
             "code": 501,
             "body": sprintf("default handler (%s) has no implementation", self.className()),
@@ -894,7 +940,7 @@ public class HttpServer::AbstractHttpRequestHandler {
     }
 
     #! top-level request handling method
-    hash<HttpResponseInfo> handleRequest(HttpListenerInterface listener, Socket s, hash cx, hash hdr, *data body) {
+    hash<HttpResponseInfo> handleRequest(HttpListenerInterface listener, Socket s, hash<auto> cx, hash<auto> hdr, *data body) {
         # classic, non-streaming interface
         if (!stream) {
             auto rv = handleRequest(cx, hdr, body ?? getMessageBody(s, hdr, body));
@@ -912,7 +958,7 @@ public class HttpServer::AbstractHttpRequestHandler {
     }
 
     #! returns the AbstractStreamRequest object for handling chunked requests
-    private AbstractStreamRequest getStreamRequestImpl(HttpListenerInterface listener, Socket s, hash cx, hash hdr, *data body) {
+    private AbstractStreamRequest getStreamRequestImpl(HttpListenerInterface listener, Socket s, hash<auto> cx, hash<auto> hdr, *data body) {
         return new AbstractStreamRequest(listener, self, s, cx, hdr, body);
     }
 
@@ -950,7 +996,7 @@ public class HttpServer::AbstractHttpRequestHandler {
     }
 
     #! optionally retrieves and post-processes any message body
-    *data getMessageBody(Socket s, hash hdr, *data body, bool decode = True) {
+    *data getMessageBody(Socket s, hash<auto> hdr, *data body, bool decode = True) {
         if (!body && hdr."transfer-encoding" == "chunked") {
             hdr += (hdr."content-encoding" ? s.readHTTPChunkedBodyBinary(timeout_ms) : s.readHTTPChunkedBody(timeout_ms));
             body = remove hdr.body;
@@ -964,8 +1010,21 @@ public class HttpServer::AbstractHttpRequestHandler {
 
     #! helper method for handling log messages
     /** @param cx the call context hash; this hash will have the following keys:
+        - \c header-info: a hash of information about the request header with the following keys:
+          - \c request-uri: gives the request URI in an HTTP request
+          - \c body-content-type: this is the \c "Content-Type" header without any charset declaration
+          - \c charset: if there is a charset declaration in the \c "Content-Type" header, the value is returned in
+            this key
+          - \c close: set to @ref Qore::True "True" if the connection should be closed after responding,
+            @ref Qore::False "False" if not (as derived from the request header)
+          - \c accept-charset: this key will be set to an appropriate value from any \c "Accept-Charset" header; if
+            any of \c "*", \c "utf8", or \c "utf-8" are present, then this will be set to \c "utf8", otherwise it will
+            be set to the first requested character encoding in the list
+          - \c accept-encoding: a hash where keys are values from any \c "Accept-Encoding" header and the values are
+            @ref True
         - \c socket: the bind address used to bind the listener (\c "socket-info" provides more detailed information)
-        - \c socket-info: a hash of socket information for the listening socket (as returned by @ref Qore::Socket::getSocketInfo())
+        - \c socket-info: a hash of socket information for the listening socket (as returned by
+          @ref Qore::Socket::getSocketInfo())
         - \c peer-info: a hash of socket information for the remote socket (as returned by @ref Qore::Socket::getPeerInfo())
         - \c url: a hash of broken-down URL information (as returned from @ref Qore::parse_url())
         - \c id: the unique HTTP connection ID
@@ -979,7 +1038,7 @@ public class HttpServer::AbstractHttpRequestHandler {
 
         @return a string if the message should be logged, otherwise @ref nothing
     */
-    static *string getLogMessage(hash cx, hash api, reference params, *reference<string> args) {
+    static *string getLogMessage(hash<auto> cx, hash api, reference params, *reference<string> args) {
         on_exit {
             if (params.typeCode() == NT_LIST)
                 unshift params, cx;
@@ -1042,7 +1101,7 @@ public class HttpServer::AbstractHttpRequestHandler {
     }
 
     #! creates a hash for an HTTP response with the response code and the response message body as a formatted string
-    static hash<HttpResponseInfo> makeResponse(hash hdr, int code, string fmt) {
+    static hash<HttpResponseInfo> makeResponse(hash<auto> hdr, int code, string fmt) {
         return new hash<HttpResponseInfo>((
             "code": code,
             "body": vsprintf(fmt, argv),
@@ -1051,7 +1110,7 @@ public class HttpServer::AbstractHttpRequestHandler {
     }
 
     #! creates a hash for an HTTP response with the response code and a literal response message body
-    static hash<HttpResponseInfo> makeResponse(int code, *data body, *hash hdr) {
+    static hash<HttpResponseInfo> makeResponse(int code, *data body, *hash<auto> hdr) {
         return new hash<HttpResponseInfo>((
             "code": code,
             "body": body,
@@ -1065,7 +1124,7 @@ public class HttpServer::AbstractHttpRequestHandler {
     }
 
     #! creates a hash for an HTTP 400 error response with the response message body as a string
-    static hash<HttpResponseInfo> make400(hash hdr, string fmt) {
+    static hash<HttpResponseInfo> make400(hash<auto> hdr, string fmt) {
         return AbstractHttpRequestHandler::makeResponse(400, vsprintf(fmt, argv), hdr);
     }
 
@@ -1075,12 +1134,12 @@ public class HttpServer::AbstractHttpRequestHandler {
     }
 
     #! creates a hash for an HTTP 501 error response with the response message body as a string
-    static hash<HttpResponseInfo> make501(hash hdr, string fmt) {
+    static hash<HttpResponseInfo> make501(hash<auto> hdr, string fmt) {
         return AbstractHttpRequestHandler::makeResponse(501, vsprintf(fmt, argv), hdr);
     }
 
     #! generates a redirect hash for the given path
-    static hash<HttpResponseInfo> redirect(hash cx, hash hdr, string path) {
+    static hash<HttpResponseInfo> redirect(hash<auto> cx, hash<auto> hdr, string path) {
         # make sure no forward slashes are doubled in the path
         path =~ s/\/+/\//g;
         string uri = sprintf("http%s://%s/%s", cx.ssl ? "s" : "", hdr.host, path);
@@ -1148,8 +1207,21 @@ public class HttpServer::AbstractHttpSocketHandler inherits HttpServer::Abstract
 
         @param lid the listener ID
         @param cx call context hash; this hash will have the following keys:
+        - \c header-info: a hash of information about the request header with the following keys:
+          - \c request-uri: gives the request URI in an HTTP request
+          - \c body-content-type: this is the \c "Content-Type" header without any charset declaration
+          - \c charset: if there is a charset declaration in the \c "Content-Type" header, the value is returned in
+            this key
+          - \c close: set to @ref Qore::True "True" if the connection should be closed after responding,
+            @ref Qore::False "False" if not (as derived from the request header)
+          - \c accept-charset: this key will be set to an appropriate value from any \c "Accept-Charset" header; if
+            any of \c "*", \c "utf8", or \c "utf-8" are present, then this will be set to \c "utf8", otherwise it will
+            be set to the first requested character encoding in the list
+          - \c accept-encoding: a hash where keys are values from any \c "Accept-Encoding" header and the values are
+            @ref True
         - \c socket: the bind address used to bind the listener (\c "socket-info" provides more detailed information)
-        - \c socket-info: a hash of socket information for the listening socket (as returned by @ref Qore::Socket::getSocketInfo())
+        - \c socket-info: a hash of socket information for the listening socket (as returned by
+          @ref Qore::Socket::getSocketInfo())
         - \c peer-info: a hash of socket information for the remote socket (as returned by @ref Qore::Socket::getPeerInfo())
         - \c url: a hash of broken-down URL information (as returned from @ref Qore::parse_url())
         - \c id: the unique HTTP connection ID
@@ -1160,7 +1232,7 @@ public class HttpServer::AbstractHttpSocketHandler inherits HttpServer::Abstract
         @param hdr a hash of headers in the request
         @param s the @ref Qore::Socket "Socket" object for the dedicated connection
      */
-    start(softstring lid, hash cx, hash hdr, Socket s) {
+    start(softstring lid, hash<auto> cx, hash<auto> hdr, Socket s) {
         {
             m.lock();
             on_exit m.unlock();
@@ -1207,8 +1279,21 @@ public class HttpServer::AbstractHttpSocketHandler inherits HttpServer::Abstract
     /** To accept a new dedicated socket connection, make sure the return value returns code 101 (ie \c "Switching Protocols"); after which this class's start() (and then startImpl()) methods are called
 
         @param cx call context hash; this hash will have the following keys:
+        - \c header-info: a hash of information about the request header with the following keys:
+          - \c request-uri: gives the request URI in an HTTP request
+          - \c body-content-type: this is the \c "Content-Type" header without any charset declaration
+          - \c charset: if there is a charset declaration in the \c "Content-Type" header, the value is returned in
+            this key
+          - \c close: set to @ref Qore::True "True" if the connection should be closed after responding,
+            @ref Qore::False "False" if not (as derived from the request header)
+          - \c accept-charset: this key will be set to an appropriate value from any \c "Accept-Charset" header; if
+            any of \c "*", \c "utf8", or \c "utf-8" are present, then this will be set to \c "utf8", otherwise it will
+            be set to the first requested character encoding in the list
+          - \c accept-encoding: a hash where keys are values from any \c "Accept-Encoding" header and the values are
+            @ref True
         - \c socket: the bind address used to bind the listener (\c "socket-info" provides more detailed information)
-        - \c socket-info: a hash of socket information for the listening socket (as returned by @ref Qore::Socket::getSocketInfo())
+        - \c socket-info: a hash of socket information for the listening socket (as returned by
+          @ref Qore::Socket::getSocketInfo())
         - \c peer-info: a hash of socket information for the remote socket (as returned by @ref Qore::Socket::getPeerInfo())
         - \c url: a hash of broken-down URL information (as returned from @ref Qore::parse_url())
         - \c id: the unique HTTP connection ID
@@ -1232,7 +1317,7 @@ public class HttpServer::AbstractHttpSocketHandler inherits HttpServer::Abstract
         - \c "close": (optional) set this key to @ref Qore::True "True" if the connection should be unconditionally closed when the handler returns
         - \c "hdr": (optional) set this key to a hash of extra header information to be returned with the response
      */
-    abstract hash handleRequest(hash cx, hash hdr, *data b);
+    abstract hash handleRequest(hash<auto> cx, hash<auto> hdr, *data b);
 
     #! called from the HTTP server after the handleRequest() method indicates that a dedicated connection should be established
     /** This method should not return until the connection is closed or the stop() (and therefore stopImpl()) method is called
@@ -1251,7 +1336,7 @@ public class HttpServer::AbstractHttpSocketHandler inherits HttpServer::Abstract
         @param hdr a hash of headers in the request
         @param s the @ref Qore::Socket "Socket" object for the dedicated connection
      */
-    private abstract startImpl(softstring lid, hash cx, hash hdr, Socket s);
+    private abstract startImpl(softstring lid, hash<auto> cx, hash<auto> hdr, Socket s);
 
     #! called from the HTTP server when the socket should be closed because the listener is stopping; the start() method for all connections handled by the given listener should return as soon as possible after this method is called
     /** @param lid the listener ID

--- a/qlib/Mime.qm
+++ b/qlib/Mime.qm
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! @file Mime.qm Mime module definition
 
-/*  Mime.qm Copyright (C) 2012 - 2018 Qore Technologies, s.r.o.
+/*  Mime.qm Copyright (C) 2012 - 2019 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -90,6 +90,9 @@ printf("%y: header word b: %y\n", mime_decode_header(mime_encode_header_word_b(s
     @section mimereleasenotes Release Notes
 
     @subsection mime_1_4_1 v1.4.1
+    - allow the default type for unknown extensions to be overridden in
+      @ref Mime::get_mime_type_from_ext() "get_mime_type_from_ext()"
+      (<a href="https://github.com/qorelanguage/qore/issues/3260">issue 3260</a>)
     - fixed a bug in @ref Mime::mime_parse_form_urlencoded_string() "mime_parse_form_urlencoded_string()" where
       repeated elements would be overwriteen by subsequent keys with the same name
       (<a href="https://github.com/qorelanguage/qore/issues/2761">issue 2761</a>)
@@ -746,10 +749,10 @@ public namespace Mime {
     /** @defgroup MimeMiscFunctions Misc MIME Functions
      */
     #@{
-    #! returns the mime type for the given filename from the extension or @ref Mime::MimeTypeUnknown if the extension is not present or unknown
-    public string sub get_mime_type_from_ext(string path) {
+    #! returns the mime type for the given filename from the extension or the default type if the extension is not present or unknown
+    public string sub get_mime_type_from_ext(string path, string def_type = MimeTypeUnknown) {
         *string ext = (path =~ x/\.([a-z0-9]+)$/i)[0];
-        return (ext && (ext = MimeTypes{ext.lwr()})) ? ext : MimeTypeUnknown;
+        return (ext && (ext = MimeTypes{ext.lwr()})) ? ext : def_type;
     }
 
     #! returns a single string in MIME URL encoded format

--- a/qlib/WebUtil.qm
+++ b/qlib/WebUtil.qm
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! @file WebUtil.qm Qore user module supprting web server operations
 
-/*  WebUtil.qm Copyright (C) 2013 - 2018 Qore Technologies, s.r.o.
+/*  WebUtil.qm Copyright (C) 2013 - 2019 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -68,6 +68,8 @@ module WebUtil {
     @section webutil_relnotes Release Notes
 
     @subsection webutil_v1_5 WebUtil v1.5
+    - added support for custom file serving
+      (<a href="https://github.com/qorelanguage/qore/issues/3260">issue 3260</a>)
     - updated for Qore 0.9
 
     @subsection webutil_v1_4_1 WebUtil v1.4.1
@@ -102,19 +104,16 @@ public namespace WebUtil {
             ReadOnlyFile f;
             #! text flag
             bool txt;
-            #! Content-Type
-            string ct;
             #! chunk size
             int cs;
             #! response headers
-            *hash respHdr;
+            *hash<auto> respHdr;
         }
 
         #! creates the object
-        constructor(HttpServer::HttpListenerInterface listener, HttpServer::AbstractHttpRequestHandler handler, Qore::Socket s, hash cx, hash hdr, *data body, Qore::ReadOnlyFile file, bool textflag, string content_type, int chunk_size, *hash respHdr) : HttpServer::AbstractStreamRequest(listener, handler, s, cx, hdr, body) {
+        constructor(HttpServer::HttpListenerInterface listener, HttpServer::AbstractHttpRequestHandler handler, Qore::Socket s, hash<auto> cx, hash<auto> hdr, *data body, Qore::ReadOnlyFile file, bool textflag, int chunk_size, *hash<auto> respHdr) : HttpServer::AbstractStreamRequest(listener, handler, s, cx, hdr, body) {
             f = file;
             txt = textflag;
-            ct = content_type;
             cs = chunk_size;
             self.respHdr = respHdr;
         }
@@ -124,7 +123,6 @@ public namespace WebUtil {
             return {
                 "code": 200,
                 "hdr": {
-                    "Content-Type": ct,
                     "Transfer-Encoding": "chunked",
                  } + respHdr,
             };
@@ -133,6 +131,45 @@ public namespace WebUtil {
         #! returns data to send
         private auto sendImpl() {
             return txt ? f.read(cs, 1m) : f.readBinary(cs, 1m);
+        }
+    }
+
+    #! this class handles chunked file sends
+    public class InputStreamRequest inherits HttpServer::AbstractStreamRequest {
+        public {}
+
+        private {
+            #! input stream object
+            InputStream stream;
+            #! chunk size
+            int cs;
+            #! response headers
+            *hash<auto> respHdr;
+        }
+
+        #! creates the object
+        constructor(HttpServer::HttpListenerInterface listener, HttpServer::AbstractHttpRequestHandler handler,
+            Qore::Socket s, hash<auto> cx, hash<auto> hdr, *data body, InputStream stream,
+            int chunk_size, *hash<auto> respHdr)
+            : HttpServer::AbstractStreamRequest(listener, handler, s, cx, hdr, body) {
+            self.stream = stream;
+            cs = chunk_size;
+            self.respHdr = respHdr;
+        }
+
+        #! returns the reponse headers
+        private hash getResponseHeaderMessageImpl() {
+            return {
+                "code": 200,
+                "hdr": {
+                    "Transfer-Encoding": "chunked",
+                 } + respHdr,
+            };
+        }
+
+        #! returns data to send
+        private auto sendImpl() {
+            return stream.read(cs);
         }
     }
 
@@ -150,7 +187,7 @@ string qhtml = "<form id=\"upload_form\" enctype=\"multipart/form-data\" method=
     <fieldset class=\"workflow_list\">
         <legend>Step 1: Select Workflow</legend>
           <select class=\"worfklows\" name=\"workflow\" id=\"workflow\">
-            {% foreach my hash $h ($ctx.workflows.pairIterator()) { %}
+            {% foreach my hash<auto> $h ($ctx.workflows.pairIterator()) { %}
             <option value="{{ $h.key }}">{{ $h.value.label }}</option>
             {% } %}
           </select>
@@ -210,7 +247,7 @@ StaticTextTemplateBase::add(p, "/html/index.qhtml", qhtml, "t0");
             # check if PO_ALLOW_BARE_REFS is set in the template program
             softbool bare_refs = (p.getParseOptions() & PO_ALLOW_BARE_REFS);
 
-            foreach hash h in (\l) {
+            foreach hash<auto> h in (\l) {
                 switch (h.type) {
                     case "text": h.text =~ s/"/\"/g; src += h.text; break;
                     case "exp": src += StaticTextTemplateBase::getCode(bare_refs, "\";my auto $tmp_TEMPLATE_%d=(%s);$rv_TEMPLATE_str+=(($tmp_TEMPLATE_%d.strp()||!exists $tmp_TEMPLATE_%d||$tmp_TEMPLATE_%d===NULL)?$tmp_TEMPLATE_%d.toString():sprintf(\"%%y\",$tmp_TEMPLATE_%d));$rv_TEMPLATE_str+=\"", vc, h.text, vc, vc, vc, vc, vc); ++vc; break;
@@ -345,7 +382,7 @@ StaticTextTemplateBase::add(p, "/html/index.qhtml", qhtml, "t0");
         #! explicitly renders the given template with the given argument
         /** @par Example:
             @code{.py}
-hash h = qft.render(ctx);
+hash<auto> h = qft.render(ctx);
             @endcode
 
             @param new_mtime the modified date/time of the file, used to determine if the template should be recomiled or not
@@ -358,7 +395,7 @@ hash h = qft.render(ctx);
             - \c body: the rendered template
             - \c hdr: a hash of headers corresponding to the \a hdr argument plus the \c "Content-Type" key set from the template's \c "Content-Type" value)
         */
-        hash render(date new_mtime, hash ctx, int code = 200, *hash hdr) {
+        hash<auto> render(date new_mtime, hash ctx, int code = 200, *hash<auto> hdr) {
             rwl.readLock();
             on_exit rwl.readUnlock();
 
@@ -449,7 +486,7 @@ hash h = tm.render(resource_path, path, mtime, ctx);
             - \c body: the rendered template
             - \c hdr: a hash of headers corresponding to the \a hdr argument plus the \c "Content-Type" key set from the template's "Content-Type" value)
         */
-        hash render(string tname, string path, date mtime, hash ctx, int code = 200, *hash hdr) {
+        hash render(string tname, string path, date mtime, hash ctx, int code = 200, *hash<auto> hdr) {
             {
                 rwl.readLock();
                 on_exit rwl.readUnlock();
@@ -585,7 +622,7 @@ hash h = tm.render("html/index.qhtml", ctx);
 
             @throw TEMPLATE-ERROR the given template does not exist
         */
-        hash render(string tname, hash ctx, int code = 200, *hash hdr) {
+        hash render(string tname, hash ctx, int code = 200, *hash<auto> hdr) {
             *hash vth = th{tname};
             if (!vth)
                 throw "TEMPLATE-ERROR", sprintf("no template %y exists; known templates: %y", tname, th.keys());
@@ -613,7 +650,7 @@ hash h = tm.render("html/index.qhtml", ctx);
             - \c body: the rendered template
             - \c hdr: a hash of headers corresponding to the \a hdr argument plus the \c "Content-Type" key set from the template's "Content-Type" value)
         */
-        *hash tryRender(string tname, hash ctx, int code = 200, *hash hdr) {
+        *hash tryRender(string tname, hash ctx, int code = 200, *hash<auto> hdr) {
             *hash vth = th{tname};
             if (!vth) {
                 return;
@@ -672,6 +709,9 @@ hash h = tm.render("html/index.qhtml", ctx);
 
             #! flag for UNIX operating systems
             const Unix = (PlatformOS != "Windows");
+
+            #! default read timeout for serving files
+            const DefaultFileReadTimeout = 20s;
 
             #! directory separator character
             /** actually defined in Qore, exported here for backwards-compatibility
@@ -809,7 +849,7 @@ hash h = tm.render("html/index.qhtml", ctx);
 
             If handleRequestImpl() returns @ref nothing and the requested path cannot be matched and served, then unhandledRequest() is called to handle the error
         */
-        hash handleRequest(HttpServer::HttpListenerInterface listener, Qore::Socket s, hash cx, hash hdr, *data body) {
+        hash handleRequest(HttpServer::HttpListenerInterface listener, Qore::Socket s, hash<auto> cx, hash<auto> hdr, *data body) {
             # get local request path and "localize" it and strip off any query args
             string path = getRelativePath(hdr.path);
 
@@ -829,9 +869,7 @@ hash h = tm.render("html/index.qhtml", ctx);
                 }
                 if (h)
                     return h;
-
-            }
-            catch (hash<ExceptionInfo> ex) {
+            } catch (hash<ExceptionInfo> ex) {
                 return serverError(cx, ex);
             }
 
@@ -856,7 +894,7 @@ hash h = tm.render("html/index.qhtml", ctx);
         #! this method returns a 404 \c "Not Found" error code to \c GET requests and a 501 \c "Not Implemented" error code to all other requests
         /** this method is called when a request cannot be handled; reimplement this method in subclasses to customize unhandled request error handling
         */
-        private hash unhandledRequest(hash cx, hash hdr, *data body) {
+        private hash unhandledRequest(hash<auto> cx, hash<auto> hdr, *data body) {
             return hdr.method == "GET"
                 ? makeResponse(404, "The requested page cannot be found")
                 : make501("The requested operation is not supported");
@@ -865,14 +903,14 @@ hash h = tm.render("html/index.qhtml", ctx);
         #! this method returns a 400 \c "Bad Request" error code when a file should be served that's not a regular file
         /** this method is called when a file cannot be served because it's not a regular file; reimplement this method in subclasses to customize error handling
         */
-        private hash fileError(hash cx, hash sh) {
+        private hash fileError(hash<auto> cx, hash sh) {
             return makeResponse(400, "The requested resource cannot be served");
         }
 
         #! this method returns a 500 \c "Internal Server Error" error code when an exception occurs
         /** this method is called when an exception occurs; reimplement this method in subclasses to customize error handling
         */
-        private hash serverError(hash cx, hash ex) {
+        private hash serverError(hash<auto> cx, hash ex) {
             string errstr = get_exception_string(ex);
             logError(errstr);
             string desc;
@@ -886,21 +924,15 @@ hash h = tm.render("html/index.qhtml", ctx);
         }
 
         #! tries to serve the request from the filesystem
-        private *hash tryServeRequest(HttpServer::HttpListenerInterface listener, Qore::Socket s, hash cx, hash hdr, *data body) {
-            *string path = cx.resource_path;
-
-            # use Windows directory separator chars on Windows
-            if (!Unix)
-                path =~ s/\//\\/g;
-
-            path = file_root + path;
-
-            *hash sh = hstat(path);
-            if (!sh)
+        private *hash tryServeRequest(HttpServer::HttpListenerInterface listener, Qore::Socket s, hash<auto> cx, hash<auto> hdr, *data body) {
+            string path;
+            *hash<StatInfo> stat_hash = statPath(cx, hdr, \path);
+            if (!stat_hash) {
                 return;
+            }
 
             # add index if the request corresponds to a directory
-            if (sh.type == "DIRECTORY") {
+            if (stat_hash.type == "DIRECTORY") {
                 bool found = False;
                 foreach string idx in (indexes) {
                     string p = path + DirSep + idx;
@@ -912,66 +944,95 @@ hash h = tm.render("html/index.qhtml", ctx);
                         break;
                     }
                 }
-                if (!found)
+                if (!found) {
                     return renderDirectory(cx, path);
+                }
+            } else if (stat_hash.type != "REGULAR") {
+                return fileError(cx, stat_hash);
             }
-            else if (sh.type != "REGULAR")
-                return fileError(cx, sh);
 
             # see if we should handle as a template
             *string ext = (cx.resource_path =~ x/\.([a-z0-9]+)$/i)[0];
-            if (ext && template_extensions{ext})
-                return render(cx.resource_path, path, sh.mtime, cx);
-
-            ReadOnlyFile f;
-            try {
-                f = new ReadOnlyFile(path);
-                sh = f.hstat();
+            if (ext && template_extensions{ext}) {
+                return render(cx.resource_path, path, stat_hash.mtime, cx);
             }
-            catch (hash<ExceptionInfo> ex) {
-                if (ex.err == "READONLYFILE-OPEN-ERROR")
+
+            return sendFilePath(listener, s, cx, hdr, body, path, stat_hash);
+        }
+
+        private *hash<auto> sendFilePath(HttpServer::HttpListenerInterface listener, Qore::Socket s, hash<auto> cx,
+            hash<auto> hdr, *data body, string path, hash<StatInfo> stat_hash) {
+            # send an empty response for an empty file
+            if (!stat_hash.size) {
+                return makeResponse(204, "");
+            }
+
+            FileInputStream stream;
+            try {
+                stream = new FileInputStream(path, DefaultFileReadTimeout);
+            } catch (hash<ExceptionInfo> ex) {
+                if (ex.err == "FILE-OPEN2-ERROR") {
                     return;
+                }
                 rethrow;
             }
 
-            if (!sh.size)
-                return makeResponse(204, "");
-
-            string ct = get_mime_type_from_ext(path);
-            bool txt = (ext =~ /^text\//) || (ext =~ /^application\/.*(json|xml|yaml|javascript|tex|tcl|troff|postscript)/);
-
-            *hash respHdr = getResponseHeadersForFile(path, cx, hdr);
-            return sh.size > chunked_threshold ? sendFileChunked(listener, s, cx, hdr, body, f, txt, ct, respHdr) : sendFile(f, txt, ct, respHdr);
+            *hash<auto> respHdr = getResponseHeadersForFile(path, cx, hdr);
+            # add the content type if it's missing for backwards compatibilitye
+            if (!hdr."Content-Type") {
+                hdr."Content-Type" = get_mime_type_from_ext(path);
+            }
+            return stat_hash.size > chunked_threshold
+                ? sendFileChunked(listener, s, cx, hdr, body, stream, respHdr)
+                : sendFile(stream, respHdr);
         }
 
-        #! must return a FileStreamRequest object to stream the requested file with chunked transfer encoding
-        private FileStreamRequest getFileStreamRequestImpl(HttpServer::HttpListenerInterface listener, Qore::Socket s, hash cx, hash hdr, *data body, Qore::ReadOnlyFile f, bool txt, string ct, *hash respHdr) {
-            return new FileStreamRequest(listener, self, s, cx, hdr, body, f, txt, ct, chunk_size, respHdr);
+        private *hash<StatInfo> statPath(hash<auto> cx, hash<auto> hdr, reference<string> path) {
+            path = file_root + cx.resource_path;
+            # no need to convert UNIX-style dir separators to Windows-style on Windows
+            # because Windows supports UNIX-style dir separators as well
+            return hstat(path);
         }
 
-        #! this method returns @ref nothing by default but can be subclassed to add headers to the response
-        /** this method is called before a file is sent to get additional headers to include in response; reimplement this method in subclasses to add response headers
+        #! must return a AbstractStreamRequest object to stream the requested file with chunked transfer encoding
+        private AbstractStreamRequest getStreamRequestImpl(HttpServer::HttpListenerInterface listener, Qore::Socket s, hash<auto> cx, hash<auto> hdr, *data body, InputStream stream, *hash<auto> respHdr) {
+            return new InputStreamRequest(listener, self, s, cx, hdr, body, stream, chunk_size, respHdr);
+        }
+
+        #! this method returns a hash giving response headers with a default content type for the file to be served based on its extenion and can be subclassed to add headers to the response
+        /** This method is called before a file is sent to get additional headers to include in response; reimplement
+            this method in subclasses to add response headers.  This method must return the content type for the file
+            being served.
 
             @param path filepath
             @param cx original request cx hash
-            @param hdr original request headers
+            @param request_hdr original request headers
+
+            @return a hash giving response headers with a default content type for the file to be served based on its
+            extenion and can be subclassed to add headers to the response
         */
-        private *hash getResponseHeadersForFile(string path, hash cx, hash hdr) {
-            return NOTHING;
+        private hash<auto> getResponseHeadersForFile(string path, hash<auto> cx, hash<auto> request_hdr) {
+            return {
+                "Content-Type": get_mime_type_from_ext(path),
+            };
         }
 
-        #! returns a handler hash response with the file's data to be sent in a monolithic message
-        private hash sendFile(ReadOnlyFile f, bool txt, string ct, *hash respHdr) {
-            return (
+        #! returns a handler hash response with the data to be sent in a monolithic message
+        private hash<auto> sendFile(InputStream stream, *hash<auto> respHdr) {
+            binary rv;
+            while (*binary bin = stream.read(1024 * 16)) {
+                rv += bin;
+            }
+            return {
                 "code": 200,
-                "body": txt ? f.read(-1) : f.readBinary(-1),
-                "hdr": ("Content-Type": ct) + respHdr,
-                );
+                "body": rv,
+                "hdr": respHdr,
+            };
         }
 
         #! returns a handler hash response with the file's data to be sent in a HTTP message with chunked transfer encoding
-        private hash sendFileChunked(HttpServer::HttpListenerInterface listener, Qore::Socket s, hash cx, hash hdr, *data body, Qore::ReadOnlyFile f, bool txt, string ct, *hash respHdr) {
-            FileStreamRequest fsr = getFileStreamRequestImpl(listener, s, cx, hdr, body, f, txt, ct, respHdr);
+        private hash<auto> sendFileChunked(HttpServer::HttpListenerInterface listener, Qore::Socket s, hash<auto> cx, hash<auto> hdr, *data body, InputStream stream, *hash<auto> respHdr) {
+            AbstractStreamRequest fsr = getStreamRequestImpl(listener, s, cx, hdr, body, stream, respHdr);
             return fsr.handleRequest();
         }
 
@@ -979,7 +1040,7 @@ hash h = tm.render("html/index.qhtml", ctx);
         /** if this method returns @ref nothing then any \a default_target will be used, so to turn off directory rendering,
             subclass this class and have the reimplemented method return @ref nothing
         */
-        *hash renderDirectory(hash cx, string path) {
+        *hash<auto> renderDirectory(hash<auto> cx, string path) {
             cx += (
                 "path": path,
                 "parent_url": "/" + dirname(cx.hdr.path),
@@ -1019,7 +1080,7 @@ hash h = tm.render("html/index.qhtml", ctx);
             - this method has the following additional keys in the \a cx hash: \c resource_path, \c url_root, and \c isregex
             - the default implementation simply returns @ref nothing all requests; reimplement this method in a subclass to provide the required functionality
         */
-        private *hash handleRequestImpl(reference<hash> cx, hash hdr, *data body) {
+        private *hash handleRequestImpl(reference<hash> cx, hash<auto> hdr, *data body) {
         }
     }
 }


### PR DESCRIPTION
…asses derived from WebUtil to serve arbitrary content such as *.gz files for the file name without the gz suffix and to set the Content-Type accordingly; the internal streaming methods were updated to use streams as well