### PR TITLE
refs #3337 fixed a bug where an invalid parse exception would be rais…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -15,6 +15,9 @@
       deserializing lists with complex type information
 
     @subsection qore_091_bug_fixes Bug Fixes in Qore
+    - fixed a bug where an invalid parse exception would be raised with an assignment of a global variable to another
+      global variable with the same name in a different namespace
+      (<a href="https://github.com/qorelanguage/qore/issues/3318">issue 3318</a>)
     - implemented support for serializing and deserializing complex type information in lists and hashes
       (<a href="https://github.com/qorelanguage/qore/issues/3318">issue 3318</a>)
     - fixed a memory leak in copy onstructor execution in complex class hierarchies

--- a/examples/test/qore/operators/assignment.qtest
+++ b/examples/test/qore/operators/assignment.qtest
@@ -1,0 +1,51 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+%no-child-restrictions
+
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class AssignmentTest
+
+our int i;
+
+class AssignmentTest inherits QUnit::Test {
+    constructor() : QUnit::Test("assignment test", "1.0", \ARGV) {
+        addTestCase("basic case", \basicCase());
+        set_return_value(main());
+    }
+
+    basicCase() {
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("namespace T { our int i; } T::i = 1; our int i = T::i; int sub t() { return ::i; }", "test");
+            p.run();
+            assertEq(1, p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            assertThrows("PARSE-EXCEPTION", "to itself", \p.parse(), ("int i = i;", "test"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            assertThrows("PARSE-EXCEPTION", "to itself", \p.parse(), ("our int i = i;", "test"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.importGlobalVariable("i");
+            assertThrows("PARSE-EXCEPTION", "to itself", \p.parse(), ("i = ::i;", "test"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            assertThrows("PARSE-EXCEPTION", "to itself", \p.parse(), ("int i; reference r = \\i; i = i;", "test"));
+        }
+    }
+}

--- a/include/qore/intern/VarRefNode.h
+++ b/include/qore/intern/VarRefNode.h
@@ -131,6 +131,11 @@ public:
         }
     }
 
+    //! returns true if the two variable references refer to the same variable
+    /** can be called only at parse time with the parse lock held
+    */
+    DLLLOCAL bool parseEqualTo(const VarRefNode& other) const;
+
     DLLLOCAL virtual int getAsString(QoreString& str, int foff, ExceptionSink* xsink) const;
     DLLLOCAL virtual QoreString* getAsString(bool& del, int foff, ExceptionSink* xsink) const;
 

--- a/include/qore/intern/Variable.h
+++ b/include/qore/intern/Variable.h
@@ -182,7 +182,7 @@ public:
     }
 
     DLLLOCAL const Var* parseGetVar() const {
-        return (type == QV_Ref) ? val.v.getPtr()->parseGetVar() : this;
+        return (val.type == QV_Ref) ? val.v.getPtr()->parseGetVar() : this;
     }
 
     DLLLOCAL bool isImported() const;

--- a/include/qore/intern/Variable.h
+++ b/include/qore/intern/Variable.h
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -179,6 +179,10 @@ public:
         // try to set an optimized value type for the value holder if possible
         val.set(typeInfo);
         discard(val.assignInitial(v), nullptr);
+    }
+
+    DLLLOCAL const Var* parseGetVar() const {
+        return (type == QV_Ref) ? val.v.getPtr()->parseGetVar() : this;
     }
 
     DLLLOCAL bool isImported() const;

--- a/lib/QoreAssignmentOperatorNode.cpp
+++ b/lib/QoreAssignmentOperatorNode.cpp
@@ -60,9 +60,13 @@ void QoreAssignmentOperatorNode::parseInitIntern(LocalVar* oflag, int pflag, int
 
     //printd(5, "QoreAssignmentOperatorNode::parseInitImpl() this: %p left: %s ti: %p '%s', right: %s ti: %s\n", this, get_type_name(left), ti, QoreTypeInfo::getName(ti), get_type_name(right), QoreTypeInfo::getName(r));
 
+    // issue #3337: make sure that the two varrefs are pointing to the same variable
     if (left.getType() == NT_VARREF && right.getType() == NT_VARREF
-        && !strcmp(left.get<VarRefNode>()->getName(), right.get<VarRefNode>()->getName()))
-        qore_program_private::makeParseException(getProgram(), *loc, "PARSE-EXCEPTION", new QoreStringNodeMaker("illegal assignment of variable \"%s\" to itself", left.get<VarRefNode>()->getName()));
+        && left.get<VarRefNode>()->parseEqualTo(*right.get<VarRefNode>())) {
+        qore_program_private::makeParseException(getProgram(), *loc, "PARSE-EXCEPTION",
+            new QoreStringNodeMaker("illegal assignment of variable \"%s\" to itself",
+                left.get<VarRefNode>()->getName()));
+    }
 
     qore_type_result_e res;
     if (ti == autoTypeInfo) {

--- a/lib/VarRefNode.cpp
+++ b/lib/VarRefNode.cpp
@@ -37,6 +37,27 @@
 #include "qore/intern/QoreHashNodeIntern.h"
 #include "qore/intern/qore_list_private.h"
 
+bool VarRefNode::parseEqualTo(const VarRefNode& other) const {
+    if (type != other.type) {
+        return false;
+    }
+    switch (type) {
+        case VT_LOCAL:
+        case VT_CLOSURE:
+        case VT_LOCAL_TS:
+            return ref.id == other.ref.id;
+        case VT_GLOBAL:
+            return ref.var->parseGetVar() == other.ref.var->parseGetVar();
+        case VT_IMMEDIATE:
+            return ref.cvv == other.ref.cvv;
+        default:
+            assert(false);
+            break;
+    }
+
+    return false;
+}
+
 // get string representation (for %n and %N), foff is for multi-line formatting offset, -1 = no line breaks
 // the ExceptionSink is only needed for QoreObject where a method may be executed
 // use the QoreNodeAsStringHelper class (defined in QoreStringNode.h) instead of using these functions directly


### PR DESCRIPTION
…ed with an assignment of a global variable to another global variable with the same name in a different namespace