### PR TITLE
Fix reflection module nonscu autotools build

### DIFF
--- a/modules/reflection/src/Makefile.am
+++ b/modules/reflection/src/Makefile.am
@@ -54,7 +54,7 @@ if COND_SINGLE_COMPILATION_UNIT
 REFLECTION_SOURCES = reflection_scu.cpp
 reflection_scu.cpp: $(GENERATED_SOURCES)
 else
-REFLECTION_SOURCES = reflection-module.cpp
+REFLECTION_SOURCES = AbstractReflectionObject.cpp reflection-module.cpp
 nodist_reflection_la_SOURCES = $(GENERATED_SOURCES)
 endif
 


### PR DESCRIPTION
AbstractReflectionObject.cpp was missing from the reflection modules sources and by that crashing the link stage of the nonscu build.
So lets add it.