### PR TITLE
refs #3404 do not break compatibility with existing code by default, …

### DIFF
--- a/doxygen/lang/245_parse_directives.dox.tmpl
+++ b/doxygen/lang/245_parse_directives.dox.tmpl
@@ -22,7 +22,6 @@
     |@ref append-module-path "%append-module-path"|Appends the given directories to qore's module path; also performs environment variable substitution <br><br>Since %Qore 0.8.6
     |@ref assume-global "%assume-global"|Resets the default %Qore behavior of assuming global variable scope when variables are first referenced if no @ref my "my" or @ref our "our" is present; use after @ref assume-local "%assume-local" to reset the default parsing behavior.<br><br>This parse option is also set with @ref old-style "%old-style" <br><br>Since %Qore 0.8.4
     |@ref assume-local "%assume-local"|Assume local variable scope when variables are first referenced if no @ref my "my" or @ref our "our" is present. When used with @ref allow-bare-refs "%allow-bare-refs", local variables without @ref my "my" must be declared with a data type restriction (can be @ref any_type "any").<br><br>This parse option is set by default with @ref new-style "%new-style"; see also @ref assume-global "%assume-global" <br><br>Since %Qore 0.8.1
-    |@ref broken-abstract "%broken-abstract"|Use pre-0.9.3 \c \b abstract method matching where complex types in arguments in abstract methods and in overriding concrete methods did not need to match exactly
     |@ref broken-int-assignments "%broken-int-assignments"|Use old pre-0.8.12 broken @ref int_type "int" and @ref softint_type "softint" runtime handling where type errors were ignored at runtime
     |@ref broken-list-parsing "%broken-list-parsing"|Use old pre-0.8.12 broken list parsing where certain lists without parentheses would be rewritten to make top-level statements like <tt>list l = 1, 2, 3;</tt> valid
     |@ref broken-logic-precedence "%broken-logic-precedence"|Use old pre-0.8.12 precedence of logical and bitwise operators
@@ -30,7 +29,6 @@
     |@ref broken-operators "%broken-operators"|Accept spaces in multi-character operators as with pre-0.8.12
     |@ref broken-references "%broken-references"|Do not enforce @ref reference_type "reference" and @ref reference_or_nothing_type "*reference" type restrictions as with pre-0.8.13
     |@ref broken-sprintf "%broken-sprintf"|Use pre-0.9 sprintf format handling where no argument is handled differently than @ref nothing
-    |@ref correct-abstract "%correct-abstract"|revert the effect of the @ref broken-abstract "%broken-abstract" parse option
     |@ref correct-int-assignments "%correct-int-assignments"|revert the effect of the @ref broken-int-assignments "%broken-int-assignments" parse option
     |@ref correct-list-parsing "%correct-list-parsing"|revert the effect of the @ref broken-list-parsing "%broken-list-parsing" parse option
     |@ref correct-logic-precedence "%correct-logic-precedence"|revert the effect of the @ref broken-logic-precedence "%broken-logic-precedence" parse option
@@ -268,26 +266,6 @@
     @see @ref assume-global "%assume-global"
 
     <hr>
-    @section broken-abstract %broken-abstract
-
-    @par Parse Directive:
-    <tt>%%broken-abstract</tt>
-
-    @par Command Line:
-    <tt>-pbroken-abstract</tt>
-
-    @par Parse Option Constant:
-    @ref Qore::PO_BROKEN_ABSTRACT
-
-    @par Description:
-    Use old pre-0.9.3 \c \b abstract method matching where complex types in arguments in abstract methods and in
-    overriding concrete methods did not need to match exactly
-
-    @see @ref correct-abstract "%correct-abstract"
-
-    @since %Qore 0.9.3
-
-    <hr>
     @section broken-int-assignments %broken-int-assignments
 
     @par Parse Directive:
@@ -458,25 +436,6 @@ i+ =4;
     @see @ref correct-sprintf "%correct-sprintf"
 
     @since %Qore 0.9
-
-    <hr>
-    @section correct-abstract %correct-abstract
-
-    @par Parse Directive:
-    n/a
-
-    @par Command Line:
-    n/a
-
-    @par Parse Option Constant:
-    n/a
-
-    @par Description:
-    Reverts the effect of the @ref broken-abstract "%broken-abstract" parse option.
-
-    @see @ref broken-abstract "%broken-abstract"
-
-    @since %Qore 0.9.3
 
     <hr>
     @section correct-int-assignments %correct-int-assignments

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -10,10 +10,9 @@
 
     @subsection qore_093_compatibility Fixes That Can Affect Backwards-Compatibility
     Complex type fixes in this release have the effect that complex type declarations are not exactly equal to
-    the base types without a complex type restrictions, which can cause concrete implementations of abstract methods
-    to no longer match if their parameters are not exactly the same; ex: <tt>hash != hash<auto></tt>.  Use the
-    @ref broken-abstract "%broken-abstract" parse directive (introduced in this release) to maintain compatibility
-    with the old behavior regarding abstract method hierarchies.
+    the base types without a complex type restrictions, and also abstract argument type matching with concrete
+    implementations has been loosened to accept nearly identical matches, so that for example an abstract method may
+    declare a parameter with a \c hash<auto> type which may be implemented by a concrete method with type \c hash.
 
     @subsection qore_093_new_features New Features in Qore
     - the <a href="../../modules/ConnectionProvider/html/index.html">ConnectionProvider</a> module was updated to
@@ -72,19 +71,24 @@
       enable remote certificates to be retrieved in listeners and handlers by default; added new API entry points for
       listeners and handlers with more flexible and saner parameters, deprecated old complex methods
       (<a href="https://github.com/qorelanguage/qore/issues/3512">issue 3512</a>)
-    - the <a href="../../modules/RestClient/html/index.html">RestClient</a> module was updated so that
-      \c RestConnection objects now support the \c "headers" option
-      (<a href="https://github.com/qorelanguage/qore/issues/3455">issue 3455</a>)
+    - the <a href="../../modules/Mapper/html/index.html">Mapper</a> module now supports the \c "runtime_keys" option
+      for adding support for new field keys to existing classes
+      (<a href="https://github.com/qorelanguage/qore/issues/3535">issue 3535</a>)
     - the <a href="../../modules/Mapper/html/index.html">Mapper</a> module now supports \c "hash" and \c "any" types
       for output fields
       (<a href="https://github.com/qorelanguage/qore/issues/3453">issue 3453</a>)
     - the <a href="../../modules/Mapper/html/index.html">Mapper</a> module now supports dot notation in output fields
       for the "hash" output type
       (<a href="https://github.com/qorelanguage/qore/issues/3413">issue 3413</a>)
+    - the <a href="../../modules/RestClient/html/index.html">RestClient</a> module was updated so that
+      \c RestConnection objects now support the \c "headers" option
+      (<a href="https://github.com/qorelanguage/qore/issues/3455">issue 3455</a>)
     - \c qdbg-vsc-adapter supports the VSCode Debug Protocol
       (<a href="https://github.com/qorelanguage/qore/issues/3392">issue 3392</a>)
 
     @subsection qore_093_bug_fixes Bug Fixes in Qore
+    - fixed bugs in handling object members assigned to references
+      (<a href="https://github.com/qorelanguage/qore/issues/3523">issue 3523</a>)
     - fixed bugs in thread-local variable handling and Program destruction
       (<a href="https://github.com/qorelanguage/qore/issues/3521">issue 3521</a>)
     - fixed a bug where a crash would result when serializing imported typed hashes
@@ -131,9 +135,9 @@
       (<a href="https://github.com/qorelanguage/qore/issues/3406">issue 3406</a>)
     - fixed a bug where an lvalue with a complex type accepted incompatible assignments from values without complex
       types if the base type was the same; this fix also ensures that complex type declarations with \c auto are not
-      treated as identical to the base type without any complex type restrictions; also the
-      @ref broken-abstract "%broken-abstract" and @ref correct-abstract "%correct-abstract" parse directives were
-      implemented to avoid breaking code that depends on this bug
+      treated as identical to the base type without any complex type restrictions, in addition abstract type matching
+      was loosened to accept near matches with parameter types so that ab stract method with a parameter type of
+      \c hash<auto> can be implemented with a concrete method with a \c hash parameter type, for example.
       (<a href="https://github.com/qorelanguage/qore/issues/3404">issue 3404</a>)
     - fixed a bug where a crash could result when deserializing invalid integer data
       (<a href="https://github.com/qorelanguage/qore/issues/3395">issue 3395</a>)

--- a/examples/test/qlib/Mapper/mapper.qtest
+++ b/examples/test/qlib/Mapper/mapper.qtest
@@ -301,9 +301,105 @@ public class MapperTest inherits QUnit::Test {
                 },
             },
         };
+
+        const TypeMap3 = {
+            "out0": {
+                "name": "inp0",
+            },
+            "out1": {
+                "context0": "contextstr0",
+            },
+            "out2": {
+                "context1": "contextstr1",
+                "name": "inp1",
+            },
+        };
+
+        const TypeOpts3 = {
+            "input": {
+                "inp0": {
+                    "type": "string",
+                    "desc": "input",
+                },
+                "inp1": {
+                    "type": "string",
+                    "desc": "input",
+                }
+            },
+            "output": {
+                "out0": {
+                    "type": "string",
+                },
+                "out1": {
+                    "type": "string",
+                },
+                "out2": {
+                    "type": "string",
+                },
+            },
+            "runtime_keys": {
+                "context0": <MapperRuntimeKeyInfo>{
+                    "handler": auto sub (auto arg) {
+                        return arg + "-ctx";
+                    },
+                },
+                "context1": <MapperRuntimeKeyInfo>{
+                    "requires_input": True,
+                    "handler": auto sub (auto arg, auto val) {
+                        return val + "-" + arg + "-ctx";
+                    },
+                },
+            },
+        };
+
+        const TypeMap3_1 = TypeMap3 + {
+            "out1": {
+                "context0": "contextstr0",
+                "context1": 1,
+            },
+            "out2": {
+                "context1": 2,
+                "name": "inp1",
+            },
+        };
+
+        const TypeMap3_2 = TypeMap3 + {
+            "out1": {
+                "context0": "contextstr0",
+            },
+            "out2": {
+                "context1": 2,
+                "name": "inp1",
+            },
+        };
+
+        const TypeOpts3_1 = TypeOpts3 + {
+            "runtime_keys": {
+                # test auto cast from hash
+                "context0": {
+                    "conflicting_keys": {
+                        "context1": True,
+                    },
+                    "handler": auto sub (auto arg) {
+                        return arg + "-ctx";
+                    },
+                },
+                "context1": <MapperRuntimeKeyInfo>{
+                    "conflicting_keys": {
+                        "context0": True,
+                    },
+                    "requires_input": True,
+                    "value_type": Type::Int,
+                    "handler": auto sub (int arg, auto val) {
+                        return val + "-" + arg + "-ctx";
+                    },
+                },
+            },
+        };
     }
 
     constructor() : Test("MapperTest", "1.0") {
+        addTestCase("runtime keys", \runtimeKeys());
         addTestCase("hash output", \hashOutputTest());
         addTestCase("test types", \testTypes());
         addTestCase("Test mapAll()", \testMapperMapAll());
@@ -325,6 +421,29 @@ public class MapperTest inherits QUnit::Test {
     }
 
     setUp() {
+    }
+
+    runtimeKeys() {
+        {
+            Mapper m(TypeMap3, TypeOpts3);
+            hash<auto> h = m.mapData({"inp0": "input-0", "inp1": "input-1"});
+            assertEq({
+                "out0": "input-0",
+                "out1": "contextstr0-ctx",
+                "out2": "input-1-contextstr1-ctx",
+            }, h);
+        }
+        assertThrows("MAP-ERROR", "context1.*expected type", sub () { Mapper m(TypeMap3, TypeOpts3_1); });
+        assertThrows("MAP-ERROR", "context.*conflict.*key", sub () { Mapper m(TypeMap3_1, TypeOpts3_1); });
+        {
+            Mapper m(TypeMap3_2, TypeOpts3_1);
+            hash<auto> h = m.mapData({"inp0": "input-0", "inp1": "input-1"});
+            assertEq({
+                "out0": "input-0",
+                "out1": "contextstr0-ctx",
+                "out2": "input-1-2-ctx",
+            }, h);
+        }
     }
 
     hashOutputTest() {

--- a/examples/test/qlib/RestHandler/RestHandler.qtest
+++ b/examples/test/qlib/RestHandler/RestHandler.qtest
@@ -29,6 +29,9 @@
 %define NoYaml
 %endtry
 
+# this test explicitly tests deprecated funtionality
+%disable-warning deprecated
+
 %exec-class RestHandlerTest
 
 class MyStaticRestClass inherits AbstractRestClass {

--- a/examples/test/qlib/TableMapper/SqlStatementMapperIterator.qtest
+++ b/examples/test/qlib/TableMapper/SqlStatementMapperIterator.qtest
@@ -24,7 +24,7 @@ const SELECT_HASH = (
 const MAPV = (
         "mapped_a": "a",
         "mapped_b": "b",
-        "created_c" : ( "code": *string sub (*any v, hash rec) { return sprintf("%n - %n", rec.a, rec.b); } ),
+        "created_c" : ( "code": *string sub (*auto v, hash<auto> rec) { return sprintf("%n - %n", rec.a, rec.b); } ),
         "constant_d" : ( "constant" : 1 ),
     );
 
@@ -50,39 +50,39 @@ class FakeSQLStatement inherits Qore::SQL::AbstractSQLStatement {
 
     bool valid() { return True; }
 
-    any getValue() {
-        hash ret = INPUT[m_ix];
+    auto getValue() {
+        hash<auto> ret = INPUT[m_ix];
         m_ix++;
         return ret;
     }
 
     prepare(string s) {}
-    execArgs(list l) {}
-    hash getOutput() {}
+    execArgs(list<auto> l) {}
+    hash<auto> getOutput() {}
     getSQL() {}
 
-    hash fetchColumns(softint rows = -1) { throw "X"; }
+    hash<auto> fetchColumns(softint rows = -1) { throw "X"; }
     nothing rollback() { throw "X"; }
-    list fetchRows(softint rows = -1) { throw "X"; }
-    hash describe() { throw "X"; }
+    list<auto> fetchRows(softint rows = -1) { throw "X"; }
+    hash<auto> describe() { throw "X"; }
     nothing commit() { throw "X"; }
-    nothing bindArgs(softlist vargs) { throw "X"; }
-    nothing execArgs(softlist vargs) { throw "X"; }
-    hash getOutputRows() { throw "X"; }
+    nothing bindArgs(softlist<auto> vargs) { throw "X"; }
+    nothing execArgs(softlist<auto> vargs) { throw "X"; }
+    hash<auto> getOutputRows() { throw "X"; }
     nothing prepareRaw(string sql) { throw "X"; }
     bool active() { throw "X"; }
     nothing bindPlaceholders() { throw "X"; }
-    *hash fetchRow() { throw "X"; }
+    *hash<auto> fetchRow() { throw "X"; }
     nothing define() { throw "X"; }
     bool currentThreadInTransaction() { throw "X"; }
     nothing bindValues() { throw "X"; }
     int affectedRows() { throw "X"; }
     nothing bind() { throw "X"; }
-    nothing bindValuesArgs(softlist vargs) { throw "X"; }
+    nothing bindValuesArgs(softlist<auto> vargs) { throw "X"; }
     nothing close() { throw "X"; }
     nothing exec() { throw "X"; }
     nothing beginTransaction() { throw "X"; }
-    nothing bindPlaceholdersArgs(softlist vargs) { throw "X"; }
+    nothing bindPlaceholdersArgs(softlist<auto> vargs) { throw "X"; }
 }
 
 # dummy datasource-like class for FakeAbstractTable
@@ -90,27 +90,27 @@ class FakeDatasource inherits Qore::SQL::AbstractDatasource {
     *string getPassword() {}
     *string getOSEncoding() {}
     *string getDBName() {}
-    any selectRows(string sql) {}
+    auto selectRows(string sql) {}
     bool inTransaction() { return False;}
-    any getClientVersion() {}
-    any exec(string sql) {}
+    auto getClientVersion() {}
+    auto exec(string sql) {}
     *int getPort() {}
-    any execRaw(string sql) {}
-    any getServerVersion() {}
+    auto execRaw(string sql) {}
+    auto getServerVersion() {}
     *string getHostName() {}
     string getDriverName() { return ""; }
-    any select(string sql) {}
+    auto select(string sql) {}
     string getDBEncoding() { return ""; }
-    any vselect(string sql, *softlist vargs) {}
+    auto vselect(string sql, *softlist<auto> vargs) {}
     string getConfigString() { return ""; }
-    any vselectRows(string sql, *softlist vargs) {}
+    auto vselectRows(string sql, *softlist<auto> vargs) {}
     nothing beginTransaction() {}
     nothing rollback() {}
-    any selectRow(string sql) {}
-    hash getConfigHash() {}
+    auto selectRow(string sql) {}
+    hash<auto> getConfigHash() {}
     nothing commit() {}
-    any vselectRow(string sql, *softlist vargs) {}
-    any vexec(string sql, *softlist vargs) {}
+    auto vselectRow(string sql, *softlist<auto> vargs) {}
+    auto vexec(string sql, *softlist<auto> vargs) {}
     *string getUserName() {}
     AbstractSQLStatement getSQLStatement() { return new FakeSQLStatement(); }
 }
@@ -118,44 +118,44 @@ class FakeDatasource inherits Qore::SQL::AbstractDatasource {
 # Actually we don't need real table. Just a FakeSQLStatement returned from getRowIterator()
 class FakeAbstractTable inherits SqlUtil::AbstractTable {
     constructor() : SqlUtil::AbstractTable(new FakeDatasource(), "foo_table") {}
-    AbstractIterator getRowIterator(hash h, *reference<string> sql) { return new FakeSQLStatement(); }
-    AbstractIterator getRowIteratorNoExec(hash h) { return new FakeSQLStatement(); }
-    AbstractIterator getStatement(hash h, *reference<string> sql) { return new FakeSQLStatement(); }
-    AbstractIterator getStatementNoExec(hash h, *reference<string> sql) { return new FakeSQLStatement(); }
+    AbstractIterator getRowIterator(hash<auto> h, *reference<string> sql) { return new FakeSQLStatement(); }
+    AbstractIterator getRowIteratorNoExec(hash<auto> h) { return new FakeSQLStatement(); }
+    AbstractIterator getStatement(hash<auto> h, *reference<string> sql) { return new FakeSQLStatement(); }
+    AbstractIterator getStatementNoExec(hash<auto> h, *reference<string> sql) { return new FakeSQLStatement(); }
 
     string getRenameSqlImpl(string new_name) {}
-    AbstractPrimaryKey getPrimaryKeyImpl(any a) {}
-    Constraints getConstraintsImpl(any a)  { return new Constraints(); }
-    AbstractCheckConstraint addCheckConstraintImpl(string cname, string src, *hash opt) {}
-    nothing setupTableImpl(hash desc, *hash opt) {}
-    bool uniqueIndexCreatesConstraintImpl(any a) {}
-    ForeignConstraints getForeignConstraintsImpl(*hash opt) {}
-    bool checkExistenceImpl(any a) {}
-    AbstractPrimaryKey addPrimaryKeyImpl(string cname, hash ch, *hash opt) {}
-    AbstractColumn addColumnImpl(string cname, hash opt, bool nullable = True) {}
-    Indexes getIndexesImpl(any a) {}
-    AbstractForeignConstraint addForeignConstraintImpl(string cname, hash ch, string table, hash tch, *hash opt) {}
+    AbstractPrimaryKey getPrimaryKeyImpl(auto a) {}
+    Constraints getConstraintsImpl(auto a)  { return new Constraints(); }
+    AbstractCheckConstraint addCheckConstraintImpl(string cname, string src, *hash<auto> opt) {}
+    nothing setupTableImpl(hash<auto> desc, *hash<auto> opt) {}
+    bool uniqueIndexCreatesConstraintImpl(auto a) {}
+    ForeignConstraints getForeignConstraintsImpl(*hash<auto> opt) {}
+    bool checkExistenceImpl(auto a) {}
+    AbstractPrimaryKey addPrimaryKeyImpl(string cname, hash<auto> ch, *hash<auto> opt) {}
+    AbstractColumn addColumnImpl(string cname, hash<auto> opt, bool nullable = True) {}
+    Indexes getIndexesImpl(auto a) {}
+    AbstractForeignConstraint addForeignConstraintImpl(string cname, hash<auto> ch, string table, hash<auto> tch, *hash<auto> opt) {}
     Columns describeImpl() { return new Columns(("a": NOTHING, "b": NOTHING)); }
-    AbstractTrigger addTriggerImpl(string tname, string src, *hash opt) {}
-    AbstractIndex addIndexImpl(string iname, bool enabled, hash ch, *hash opt) {}
-    *list getAlignSqlImpl(AbstractTable t, *hash opt) {}
-    Triggers getTriggersImpl(any a) {}
-    string getCreateTableSqlImpl(*hash opt) {}
-    bool tryInsertImpl(string sql, hash row) {}
-    bool supportsTablespacesImpl(any a) {}
-    *string getSqlValueImpl(any v) {}
-    AbstractUniqueConstraint addUniqueConstraintImpl(string cname, hash ch, *hash opt) {}
-    hash getQoreTypeMapImpl(any a) {}
-    *hash doReturningImpl(hash opt, reference<string> sql, list args) {}
-    hash getTypeMapImpl(any a) {}
-    bool constraintsLinkedToIndexesImpl(any a) {}
-    bool emptyImpl(any a) {}
-    *list getCreateMiscSqlImpl(*hash opt, bool cache) {}
-    string getCreateSqlImpl(list l) {}
-    bool hasArrayBind(any a) {}
-    nothing doSelectLimitOnlyUnlockedImpl(reference<string> sql, reference<list> args, *hash qh) {}
+    AbstractTrigger addTriggerImpl(string tname, string src, *hash<auto> opt) {}
+    AbstractIndex addIndexImpl(string iname, bool enabled, hash<auto> ch, *hash<auto> opt) {}
+    *list<auto> getAlignSqlImpl(AbstractTable t, *hash<auto> opt) {}
+    Triggers getTriggersImpl(auto a) {}
+    string getCreateTableSqlImpl(*hash<auto> opt) {}
+    bool tryInsertImpl(string sql, hash<auto> row) {}
+    bool supportsTablespacesImpl(auto a) {}
+    *string getSqlValueImpl(auto v) {}
+    AbstractUniqueConstraint addUniqueConstraintImpl(string cname, hash<auto> ch, *hash<auto> opt) {}
+    hash<auto> getQoreTypeMapImpl(auto a) {}
+    *hash<auto> doReturningImpl(hash<auto> opt, reference<string> sql, list<auto> args) {}
+    hash<auto> getTypeMapImpl(auto a) {}
+    bool constraintsLinkedToIndexesImpl(auto a) {}
+    bool emptyImpl(auto a) {}
+    *list<auto> getCreateMiscSqlImpl(*hash<auto> opt, bool cache) {}
+    string getCreateSqlImpl(list<auto> l) {}
+    bool hasArrayBind(auto a) {}
+    nothing doSelectLimitOnlyUnlockedImpl(reference<string> sql, reference<list> args, *hash<auto> qh) {}
     nothing copyImpl(AbstractTable old) {}
-    nothing doSelectOrderByWithOffsetSqlUnlockedImpl(reference<string> sql, reference<list> args, *hash qh, *hash jch, *hash ch, *hash psch, list coll) {}
+    nothing doSelectOrderByWithOffsetSqlUnlockedImpl(reference<string> sql, reference<list> args, *hash<auto> qh, *hash<auto> jch, *hash<auto> ch, *hash<auto> psch, list<auto> coll) {}
 }
 
 class Main inherits QUnit::Test {
@@ -172,7 +172,7 @@ class Main inherits QUnit::Test {
 
         int i = 0;
         while (m.next()) {
-            hash row = m.getValue();
+            hash<auto> row = m.getValue();
             testAssertion(sprintf("Row verification: %d", i), \equals(), (row, OUTPUT[i]));
             i++;
         }

--- a/examples/test/qlib/TableMapper/SqlStatementOutboundMapper.qtest
+++ b/examples/test/qlib/TableMapper/SqlStatementOutboundMapper.qtest
@@ -23,7 +23,7 @@ const SELECT_HASH = (
 const MAPV = (
     "mapped_a": "a",
     "mapped_b": "b",
-    "created_c": ("code": *string sub (*any v, hash rec) { return sprintf("%n - %n", rec.a, rec.b); }),
+    "created_c": ("code": *string sub (*any v, hash<auto> rec) { return sprintf("%n - %n", rec.a, rec.b); }),
     "constant_d": ("constant" : 1),
     "runtime": ("runtime": "rt"),
     );
@@ -51,13 +51,13 @@ class FakeSQLStatement inherits Qore::SQL::AbstractSQLStatement {
     bool valid() { return True; }
 
     any getValue() {
-        hash ret = INPUT[m_ix];
+        hash<auto> ret = INPUT[m_ix];
         m_ix++;
         return ret;
     }
 
-    private list getAdvancePtr(int rows) {
-        list l = INPUT;
+    private list<auto> getAdvancePtr(int rows) {
+        list<auto> l = INPUT;
 
         if (m_ix)
             splice l, 0, m_ix;
@@ -70,45 +70,45 @@ class FakeSQLStatement inherits Qore::SQL::AbstractSQLStatement {
         return l;
     }
 
-    list fetchRows(softint rows = -1) {
+    list<auto> fetchRows(softint rows = -1) {
         return getAdvancePtr(rows);
     }
 
-    hash fetchColumns(softint rows = -1) {
-        hash h = map {$1: ()}, INPUT[0].keyIterator();
+    hash<auto> fetchColumns(softint rows = -1) {
+        hash<auto> h = map {$1: ()}, INPUT[0].keyIterator();
         map (map h{$1.key} += $1.value, $1.pairIterator()), getAdvancePtr(rows);
         return h;
     }
 
-    bindArgs(softlist vargs) {}
+    bindArgs(softlist<auto> vargs) {}
 
     commit() {}
     rollback() {}
 
     prepare(string s) {}
-    execArgs(list l) {}
-    hash getOutput() {}
+    execArgs(list<auto> l) {}
+    hash<auto> getOutput() {}
     getSQL() {}
 
-    *hash describe() {
+    *hash<auto> describe() {
     }
 
-    nothing execArgs(softlist vargs) { throw "X"; }
-    hash getOutputRows() { throw "X"; }
+    nothing execArgs(softlist<auto> vargs) { throw "X"; }
+    hash<auto> getOutputRows() { throw "X"; }
     nothing prepareRaw(string sql) { throw "X"; }
     bool active() { throw "X"; }
     nothing bindPlaceholders() { throw "X"; }
-    *hash fetchRow() { throw "X"; }
+    *hash<auto> fetchRow() { throw "X"; }
     nothing define() { throw "X"; }
     bool currentThreadInTransaction() { throw "X"; }
     nothing bindValues() { throw "X"; }
     int affectedRows() { throw "X"; }
     nothing bind() { throw "X"; }
-    nothing bindValuesArgs(softlist vargs) { throw "X"; }
+    nothing bindValuesArgs(softlist<auto> vargs) { throw "X"; }
     nothing close() { throw "X"; }
     nothing exec() { throw "X"; }
     nothing beginTransaction() { throw "X"; }
-    nothing bindPlaceholdersArgs(softlist vargs) { throw "X"; }
+    nothing bindPlaceholdersArgs(softlist<auto> vargs) { throw "X"; }
 }
 
 # dummy datasource-like class for FakeAbstractTable
@@ -127,16 +127,16 @@ class FakeDatasource inherits Qore::SQL::AbstractDatasource {
     string getDriverName() { return ""; }
     any select(string sql) {}
     string getDBEncoding() { return ""; }
-    any vselect(string sql, *softlist vargs) {}
+    any vselect(string sql, *softlist<auto> vargs) {}
     string getConfigString() { return ""; }
-    any vselectRows(string sql, *softlist vargs) {}
+    any vselectRows(string sql, *softlist<auto> vargs) {}
     nothing beginTransaction() {}
     nothing rollback() {}
     any selectRow(string sql) {}
-    hash getConfigHash() {}
+    hash<auto> getConfigHash() {}
     nothing commit() {}
-    any vselectRow(string sql, *softlist vargs) {}
-    any vexec(string sql, *softlist vargs) {}
+    any vselectRow(string sql, *softlist<auto> vargs) {}
+    any vexec(string sql, *softlist<auto> vargs) {}
     *string getUserName() {}
     bool currentThreadInTransaction() { return False; }
     AbstractSQLStatement getSQLStatement() { return new FakeSQLStatement(); }
@@ -148,43 +148,43 @@ class FakeAbstractTable inherits SqlUtil::AbstractTable {
         FakeDatasource fds();
     }
     constructor() : SqlUtil::AbstractTable(fds, "foo_table") {}
-    AbstractIterator getRowIterator(hash h, *reference<string> sql) { return new FakeSQLStatement(); }
-    AbstractIterator getStatement(hash h, *reference<string> sql) { return new FakeSQLStatement(); }
-    AbstractIterator getStatementNoExec(hash h, *reference<string> sql) { return new FakeSQLStatement(); }
+    AbstractIterator getRowIterator(hash<auto> h, *reference<string> sql) { return new FakeSQLStatement(); }
+    AbstractIterator getStatement(hash<auto> h, *reference<string> sql) { return new FakeSQLStatement(); }
+    AbstractIterator getStatementNoExec(hash<auto> h, *reference<string> sql) { return new FakeSQLStatement(); }
 
     string getRenameSqlImpl(string new_name) {}
     AbstractPrimaryKey getPrimaryKeyImpl(any a) {}
     Constraints getConstraintsImpl(any a)  { return new Constraints(); }
-    AbstractCheckConstraint addCheckConstraintImpl(string cname, string src, *hash opt) {}
-    nothing setupTableImpl(hash desc, *hash opt) {}
+    AbstractCheckConstraint addCheckConstraintImpl(string cname, string src, *hash<auto> opt) {}
+    nothing setupTableImpl(hash<auto> desc, *hash<auto> opt) {}
     bool uniqueIndexCreatesConstraintImpl(any a) {}
-    ForeignConstraints getForeignConstraintsImpl(*hash opt) {}
+    ForeignConstraints getForeignConstraintsImpl(*hash<auto> opt) {}
     bool checkExistenceImpl(any a) {}
-    AbstractPrimaryKey addPrimaryKeyImpl(string cname, hash ch, *hash opt) {}
-    AbstractColumn addColumnImpl(string cname, hash opt, bool nullable = True) {}
+    AbstractPrimaryKey addPrimaryKeyImpl(string cname, hash<auto> ch, *hash<auto> opt) {}
+    AbstractColumn addColumnImpl(string cname, hash<auto> opt, bool nullable = True) {}
     Indexes getIndexesImpl(any a) {}
-    AbstractForeignConstraint addForeignConstraintImpl(string cname, hash ch, string table, hash tch, *hash opt) {}
+    AbstractForeignConstraint addForeignConstraintImpl(string cname, hash<auto> ch, string table, hash<auto> tch, *hash<auto> opt) {}
     Columns describeImpl() {}
-    AbstractTrigger addTriggerImpl(string tname, string src, *hash opt) {}
-    AbstractIndex addIndexImpl(string iname, bool enabled, hash ch, *hash opt) {}
-    *list getAlignSqlImpl(AbstractTable t, *hash opt) {}
+    AbstractTrigger addTriggerImpl(string tname, string src, *hash<auto> opt) {}
+    AbstractIndex addIndexImpl(string iname, bool enabled, hash<auto> ch, *hash<auto> opt) {}
+    *list<auto> getAlignSqlImpl(AbstractTable t, *hash<auto> opt) {}
     Triggers getTriggersImpl(any a) {}
-    string getCreateTableSqlImpl(*hash opt) {}
-    bool tryInsertImpl(string sql, hash row) {}
+    string getCreateTableSqlImpl(*hash<auto> opt) {}
+    bool tryInsertImpl(string sql, hash<auto> row) {}
     bool supportsTablespacesImpl(any a) {}
     *string getSqlValueImpl(any v) {}
-    AbstractUniqueConstraint addUniqueConstraintImpl(string cname, hash ch, *hash opt) {}
-    hash getQoreTypeMapImpl(any a) {}
-    *hash doReturningImpl(hash opt, reference<string> sql, list args) {}
-    hash getTypeMapImpl(any a) {}
+    AbstractUniqueConstraint addUniqueConstraintImpl(string cname, hash<auto> ch, *hash<auto> opt) {}
+    hash<auto> getQoreTypeMapImpl(any a) {}
+    *hash<auto> doReturningImpl(hash<auto> opt, reference<string> sql, list<auto> args) {}
+    hash<auto> getTypeMapImpl(any a) {}
     bool constraintsLinkedToIndexesImpl(any a) {}
     bool emptyImpl(any a) {}
-    *list getCreateMiscSqlImpl(*hash opt, bool cache) {}
-    string getCreateSqlImpl(list l) {}
+    *list<auto> getCreateMiscSqlImpl(*hash<auto> opt, bool cache) {}
+    string getCreateSqlImpl(list<auto> l) {}
     bool hasArrayBind(any a) {}
-    nothing doSelectLimitOnlyUnlockedImpl(reference<string> sql, reference<list> args, *hash qh) {}
+    nothing doSelectLimitOnlyUnlockedImpl(reference<string> sql, reference<list> args, *hash<auto> qh) {}
     nothing copyImpl(AbstractTable old) {}
-    nothing doSelectOrderByWithOffsetSqlUnlockedImpl(reference<string> sql, reference<list> args, *hash qh, *hash jch, *hash ch, *hash psch, list coll) {}
+    nothing doSelectOrderByWithOffsetSqlUnlockedImpl(reference<string> sql, reference<list> args, *hash<auto> qh, *hash<auto> jch, *hash<auto> ch, *hash<auto> psch, list<auto> coll) {}
 }
 
 
@@ -216,7 +216,7 @@ class Main inherits QUnit::DependencyInjectedTest {
 
         int i = 0;
         while (it.next()) {
-            hash row = it.getValue();
+            hash<auto> row = it.getValue();
             testAssertion(sprintf("Row verification: %d", i), \equals(), (row, OUTPUT[i]));
             i++;
         }
@@ -225,8 +225,8 @@ class Main inherits QUnit::DependencyInjectedTest {
     private testHashRows() {
         FakeAbstractTable t();
         SqlStatementOutboundMapper m(t, SELECT_HASH, MAPV, ("runtime": ("rt": "rtv")));
-        list l = ();
-        while (*list tl = m.getDataRows()) {
+        list<auto> l = ();
+        while (*list<auto> tl = m.getDataRows()) {
             l += tl;
         }
         assertEq(OUTPUT, l, "getDataRows()");
@@ -235,8 +235,8 @@ class Main inherits QUnit::DependencyInjectedTest {
     private testContext() {
         FakeAbstractTable t();
         SqlStatementOutboundMapper m(t, SELECT_HASH, MAPV, ("runtime": ("rt": "rtv")));
-        list l = ();
-        while (*hash th = m.getData()) {
+        list<auto> l = ();
+        while (*hash<auto> th = m.getData()) {
             map l += $1, th.contextIterator();
         }
         assertEq(OUTPUT, l, "getData()");

--- a/examples/test/qore/misc/broken-abstract.qtest
+++ b/examples/test/qore/misc/broken-abstract.qtest
@@ -17,6 +17,16 @@ class BrokenAbstractTest inherits QUnit::Test {
             "return {}; } } hash<auto> sub test() { C c(); return c.get(); }";
         const CompatArgTypes = "class B { abstract get(hash a); } class C inherits B { get(hash<auto> a) {} } "
             "sub test() { C c(); c.get({}); }";
+        const CompatArgTypes2 = "class B { abstract get(hash<auto> a); } class C inherits B { get(hash a) {} } "
+            "sub test() { C c(); c.get({}); }";
+        const CompatArgTypes3 = "class B { abstract get(*hash<auto> a); } class C inherits B { get(*hash a) {} } "
+            "sub test() { C c(); c.get({}); }";
+        const CompatArgTypes4 = "class B { abstract get(*hash a); } class C inherits B { get(*hash<auto> a) {} } "
+            "sub test() { C c(); c.get({}); }";
+        const CompatArgTypes5 = "class B { abstract get(*reference<hash<auto>> a); } class C inherits B { get(*reference<hash> a) {} } "
+            "sub test() { C c(); c.get(); }";
+        const CompatArgTypes6 = "class B { abstract get(*reference<hash> a); } class C inherits B { get(*reference<hash<auto>> a) {} } "
+            "sub test() { C c(); c.get(); }";
     }
 
     constructor() : QUnit::Test("Broken abstract test", "1.0") {
@@ -33,21 +43,46 @@ class BrokenAbstractTest inherits QUnit::Test {
         }
 
         {
-            Program p(PO_NEW_STYLE | PO_BROKEN_ABSTRACT | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+            Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
             p.parse(CompatReturnTypes, "test");
             assertEq({}, p.callFunction("test"));
         }
 
-        # argument types must be idenitical in abstract method hierarchies
+        # argument types must be a near match in abstract method hierarchies
         {
-            Program p(PO_NEW_STYLE | PO_BROKEN_ABSTRACT | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+            Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
             p.parse(CompatArgTypes, "test");
             assertNothing(p.callFunction("test"));
         }
 
         {
             Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
-            assertThrows("ABSTRACT-CLASS-ERROR", \p.parse(), (CompatArgTypes, "test"));
+            p.parse(CompatArgTypes2, "test");
+            assertNothing(p.callFunction("test"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+            p.parse(CompatArgTypes3, "test");
+            assertNothing(p.callFunction("test"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+            p.parse(CompatArgTypes4, "test");
+            assertNothing(p.callFunction("test"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+            p.parse(CompatArgTypes5, "test");
+            assertNothing(p.callFunction("test"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+            p.parse(CompatArgTypes6, "test");
+            assertNothing(p.callFunction("test"));
         }
     }
 }

--- a/examples/test/qore/vars/reference.qtest
+++ b/examples/test/qore/vars/reference.qtest
@@ -11,6 +11,31 @@
 
 %exec-class ReferenceTest
 
+class T {
+    public {
+        static hash<auto> h();
+        static reference<auto> rs;
+        reference<auto> r;
+    }
+
+    constructor() {
+        r = \h;
+        rs = \h;
+    }
+
+    *hash<auto> test() {
+        return testCall(r);
+    }
+
+    *hash<auto> testStatic() {
+        return testCall(rs);
+    }
+
+    static private hash<auto> testCall(hash<auto> h) {
+        return h;
+    }
+}
+
 class A {
     private {
         reference<hash> x;
@@ -27,6 +52,7 @@ class A {
 
 class ReferenceTest inherits QUnit::Test {
     constructor() : Test("Reference Test", "1.0") {
+        addTestCase("member ref", \memberReferenceTest());
         addTestCase("issue 3417", \issue3417());
         addTestCase("issue 2891", \issue2891());
         addTestCase("Complex reference test", \testComplexReferences());
@@ -35,6 +61,12 @@ class ReferenceTest inherits QUnit::Test {
 
         # Return for compatibility with test harness that checks return value.
         set_return_value(main());
+    }
+
+    memberReferenceTest() {
+        T t();
+        assertEq({}, t.test());
+        assertEq({}, t.testStatic());
     }
 
     issue3417() {

--- a/include/qore/Restrictions.h
+++ b/include/qore/Restrictions.h
@@ -93,7 +93,6 @@
 #define PO_NO_REFLECTION                    (1LL << 53)  //!< disallow the use of reflection
 #define PO_NO_TRANSIENT                     (1LL << 54)  //!< disables the transient keyword
 #define PO_BROKEN_SPRINTF                   (1LL << 55)  //!< enables pre-0.9 broken sprintf handling
-#define PO_BROKEN_ABSTRACT                  (1LL << 56)  //!< enables pre-0.9.3 broken abstract handling
 
 // aliases for old defines
 #define PO_NO_SYSTEM_FUNC_VARIANTS          PO_NO_INHERIT_SYSTEM_FUNC_VARIANTS

--- a/include/qore/intern/QoreListNodeEvalOptionalRefHolder.h
+++ b/include/qore/intern/QoreListNodeEvalOptionalRefHolder.h
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -50,8 +50,7 @@ private:
         if (exp) {
             val = exp->evalList(needs_deref, xsink);
             //printd(0, "QoreListNodeEvalOptionalRefHolder::evalIntern() this: %p exp: %p '%s' (%d) val: %p '%s' (%d)\n", this, exp, exp ? get_full_type_name(exp) : "n/a", exp->size(), val, val ? get_full_type_name(val) : "n/a", val ? val->size() : 0);
-        }
-        else {
+        } else {
             val = nullptr;
             needs_deref = false;
         }

--- a/include/qore/intern/QoreTypeInfo.h
+++ b/include/qore/intern/QoreTypeInfo.h
@@ -1285,6 +1285,7 @@ private:
    }
 
    DLLLOCAL void concatName(std::string& str) const {
+      assert(!tname.empty());
       str.append(tname);
    }
 

--- a/lib/AbstractQoreNode.cpp
+++ b/lib/AbstractQoreNode.cpp
@@ -3,7 +3,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -106,52 +106,51 @@ bool AbstractQoreNode::derefImpl(ExceptionSink* xsink) {
 }
 
 void AbstractQoreNode::customRef() const {
-   assert(false);
+    assert(false);
 }
 
 void AbstractQoreNode::customDeref(ExceptionSink* xsink) {
-   assert(false);
+    assert(false);
 }
 
 void AbstractQoreNode::deref(ExceptionSink* xsink) {
    //QORE_TRACE("AbstractQoreNode::deref()");
 #ifdef DEBUG
 /*
-   if (test(this)) {
-      printd(0, "AbstractQoreNode::deref() %p type: %d %s (%d->%d)\n", this, type, getTypeName(), reference_count(), reference_count() - 1);
-      break_deref();
-   }
+    if (test(this)) {
+        printd(0, "AbstractQoreNode::deref() %p type: %d %s (%d->%d)\n", this, type, getTypeName(), reference_count(), reference_count() - 1);
+        break_deref();
+    }
 */
 #if TRACK_REFS
-   if (type == NT_OBJECT)
-      printd(REF_LVL, "QoreObject::deref() %p class: %s (%d->%d) %d\n", this, ((QoreObject*)this)->getClassName(), references.load(), references.load() - 1, custom_reference_handlers);
-   else
-      printd(REF_LVL, "AbstractQoreNode::deref() %p type: %d %s (%d->%d)\n", this, type, getTypeName(), references.load(), references.load() - 1);
+    if (type == NT_OBJECT)
+        printd(REF_LVL, "QoreObject::deref() %p class: %s (%d->%d) %d\n", this, ((QoreObject*)this)->getClassName(), references.load(), references.load() - 1, custom_reference_handlers);
+    else
+        printd(REF_LVL, "AbstractQoreNode::deref() %p type: %d %s (%d->%d)\n", this, type, getTypeName(), references.load(), references.load() - 1);
 
 #endif
-   if (references.load() > 10000000 || references.load() <= 0){
-      if (type == NT_STRING)
-         printd(0, "AbstractQoreNode::deref() WARNING, node %p references: %d (type: %s) (val=\"%s\")\n",
-                this, references.load(), getTypeName(), ((QoreStringNode*)this)->getBuffer());
-      else
-         printd(0, "AbstractQoreNode::deref() WARNING, node %p references: %d (type: %s)\n", this, references.load(), getTypeName());
-      assert(false);
-   }
+    if (references.load() > 10000000 || references.load() <= 0){
+        if (type == NT_STRING)
+            printd(0, "AbstractQoreNode::deref() WARNING, node %p references: %d (type: %s) (val=\"%s\")\n",
+                    this, references.load(), getTypeName(), ((QoreStringNode*)this)->getBuffer());
+        else
+            printd(0, "AbstractQoreNode::deref() WARNING, node %p references: %d (type: %s)\n", this, references.load(), getTypeName());
+        assert(false);
+    }
 #endif
-   assert(references.load() > 0);
+    assert(references.load() > 0);
 
-   if (there_can_be_only_one) {
-      assert(is_unique());
-      return;
-   }
+    if (there_can_be_only_one) {
+        assert(is_unique());
+        return;
+    }
 
-   if (custom_reference_handlers) {
-      customDeref(xsink);
-   }
-   else if (ROdereference()) {
-      if (type < NUM_SIMPLE_TYPES || derefImpl(xsink))
-         delete this;
-   }
+    if (custom_reference_handlers) {
+        customDeref(xsink);
+    } else if (ROdereference()) {
+        if (type < NUM_SIMPLE_TYPES || derefImpl(xsink))
+            delete this;
+    }
 }
 
 QoreValue AbstractQoreNode::eval(ExceptionSink* xsink) const {

--- a/lib/Function.cpp
+++ b/lib/Function.cpp
@@ -475,64 +475,63 @@ void UserSignature::pushParam(BarewordNode* b, bool needs_types, bool bare_refs)
 }
 
 void UserSignature::pushParam(VarRefNode* v, QoreValue defArg, bool needs_types) {
-   // check for duplicate name
-   for (name_vec_t::iterator i = names.begin(), e = names.end(); i != e; ++i)
-      if (*i == v->getName())
-         parse_error(*loc, "duplicate variable '%s' declared in parameter list", (*i).c_str());
+    // check for duplicate name
+    for (name_vec_t::iterator i = names.begin(), e = names.end(); i != e; ++i)
+        if (*i == v->getName())
+            parse_error(*loc, "duplicate variable '%s' declared in parameter list", (*i).c_str());
 
-   names.push_back(v->getName());
+    names.push_back(v->getName());
 
-   bool is_decl = v->isDecl();
-   if (needs_types && !is_decl)
-      parse_error(*loc, "parameter '%s' declared without type information, but parse options require all declarations to have type information", v->getName());
+    bool is_decl = v->isDecl();
+    if (needs_types && !is_decl)
+        parse_error(*loc, "parameter '%s' declared without type information, but parse options require all declarations to have type information", v->getName());
 
-   // see if this is a new object call
-   if (v->has_effect()) {
-      // here we make 4 virtual function calls when 2 would be enough, but no need to optimize for speed for an exception
-      parse_error(*loc, "parameter '%s' may not be declared with implicit constructor syntax; instead use: '%s %s = new %s()'", v->getName(), v->parseGetTypeName(), v->getName(), v->parseGetTypeName());
-   }
+    // see if this is a new object call
+    if (v->has_effect()) {
+        // here we make 4 virtual function calls when 2 would be enough, but no need to optimize for speed for an exception
+        parse_error(*loc, "parameter '%s' may not be declared with implicit constructor syntax; instead use: '%s %s = new %s()'", v->getName(), v->parseGetTypeName(), v->getName(), v->parseGetTypeName());
+    }
 
-   if (is_decl) {
-      VarRefDeclNode* vd = reinterpret_cast<VarRefDeclNode*>(v);
-      QoreParseTypeInfo* pti = vd->takeParseTypeInfo();
-      parseTypeList.push_back(pti);
-      const QoreTypeInfo* ti = vd->getTypeInfo();
-      typeList.push_back(ti);
+    if (is_decl) {
+        VarRefDeclNode* vd = reinterpret_cast<VarRefDeclNode*>(v);
+        QoreParseTypeInfo* pti = vd->takeParseTypeInfo();
+        parseTypeList.push_back(pti);
+        const QoreTypeInfo* ti = vd->getTypeInfo();
+        typeList.push_back(ti);
 
-      assert(!(pti && ti));
+        assert(!(pti && ti));
 
-      if (pti || QoreTypeInfo::hasType(ti)) {
-         ++num_param_types;
-         // only increment min_param_types if there is no default argument
-         if (!defArg)
-            ++min_param_types;
-      }
+        if (pti || QoreTypeInfo::hasType(ti)) {
+            ++num_param_types;
+            // only increment min_param_types if there is no default argument
+            if (!defArg)
+                ++min_param_types;
+        }
 
-      // add type name to signature
-      if (pti)
-         QoreParseTypeInfo::concatName(pti, str);
-      else
-         QoreTypeInfo::concatName(ti, str);
-   }
-   else {
-      parseTypeList.push_back(0);
-      typeList.push_back(0);
-      str.append(NO_TYPE_INFO);
-   }
+        // add type name to signature
+        if (pti)
+            QoreParseTypeInfo::concatName(pti, str);
+        else
+            QoreTypeInfo::concatName(ti, str);
+    } else {
+        parseTypeList.push_back(0);
+        typeList.push_back(0);
+        str.append(NO_TYPE_INFO);
+    }
 
-   str.append(" ");
-   str.append(v->getName());
+    str.append(" ");
+    str.append(v->getName());
 
-   defaultArgList.push_back(defArg);
-   if (defArg)
-      addDefaultArgument(defArg);
+    defaultArgList.push_back(defArg);
+    if (defArg)
+        addDefaultArgument(defArg);
 
-   if (v->explicitScope()) {
-      if (v->getType() == VT_LOCAL)
-         parse_error(*loc, "invalid local variable declaration in argument list; by default all variables declared in argument lists are local");
-      else if (v->getType() == VT_GLOBAL)
-         parse_error(*loc, "invalid global variable declaration in argument list; by default all variables declared in argument lists are local");
-   }
+    if (v->explicitScope()) {
+        if (v->getType() == VT_LOCAL)
+            parse_error(*loc, "invalid local variable declaration in argument list; by default all variables declared in argument lists are local");
+        else if (v->getType() == VT_GLOBAL)
+            parse_error(*loc, "invalid global variable declaration in argument list; by default all variables declared in argument lists are local");
+    }
 }
 
 void UserSignature::parseInitPushLocalVars(const QoreTypeInfo* classTypeInfo) {

--- a/lib/Function.cpp
+++ b/lib/Function.cpp
@@ -43,11 +43,11 @@
 #include <cstdio>
 
 static void duplicateSignatureException(const char* cname, const char* name, const UserSignature* sig) {
-   parseException(*sig->getParseLocation(), "DUPLICATE-SIGNATURE", "%s%s%s(%s) has already been declared", cname ? cname : "", cname ? "::" : "", name, sig->getSignatureText());
+    parseException(*sig->getParseLocation(), "DUPLICATE-SIGNATURE", "%s%s%s(%s) has already been declared", cname ? cname : "", cname ? "::" : "", name, sig->getSignatureText());
 }
 
 static void ambiguousDuplicateSignatureException(const char* cname, const char* name, const AbstractFunctionSignature* sig1, const UserSignature* sig2) {
-   parseException(*sig2->getParseLocation(), "DUPLICATE-SIGNATURE", "%s%s%s(%s) matches already declared variant %s(%s)", cname ? cname : "", cname ? "::" : "", name, sig2->getSignatureText(), name, sig1->getSignatureText());
+    parseException(*sig2->getParseLocation(), "DUPLICATE-SIGNATURE", "%s%s%s(%s) matches already declared variant %s(%s)", cname ? cname : "", cname ? "::" : "", name, sig2->getSignatureText(), name, sig1->getSignatureText());
 }
 
 QoreFunction* IList::getFunction(const qore_class_private* class_ctx, const qore_class_private*& last_class,
@@ -83,29 +83,15 @@ bool AbstractFunctionSignature::operator==(const AbstractFunctionSignature& sig)
         return false;
     }
 
-    // issue #3404: supports %broken-abstract
-    bool broken_abstract;
-    {
-        // there is no progrm context when initializing Qore
-        QoreProgram* pgm = getProgram();
-        if (pgm) {
-            broken_abstract = pgm->getParseOptions64() & PO_BROKEN_ABSTRACT;
-        } else {
-            broken_abstract = false;
-        }
-    }
-
     for (unsigned i = 0; i < typeList.size(); ++i) {
         const QoreTypeInfo* ti = sig.typeList.size() <= i
             ? nullptr
             : sig.typeList[i];
         bool match;
-        if (broken_abstract) {
-            match = (QoreTypeInfo::parseAccepts(typeList[i], ti) >= QTI_AMBIGUOUS)
-                || (QoreTypeInfo::parseAccepts(ti, typeList[i]) >= QTI_AMBIGUOUS);
-        } else {
-            match = QoreTypeInfo::isInputIdentical(typeList[i], ti);
-        }
+        match = (QoreTypeInfo::runtimeTypeMatch(typeList[i], ti) >= QTI_NEAR);
+
+        //printd(5, "AbstractFunctionSignature::operator==() param %d (%s =~ %s) %d\n", i, QoreTypeInfo::getName(typeList[i]), QoreTypeInfo::getName(ti), QoreTypeInfo::runtimeTypeMatch(typeList[i], ti));
+
         if (!match) {
             //printd(5, "AbstractFunctionSignature::operator==() param %d %s != %s\n", i, QoreTypeInfo::getName(typeList[i]), QoreTypeInfo::getName(sig.typeList[i]));
             return false;
@@ -117,7 +103,7 @@ bool AbstractFunctionSignature::operator==(const AbstractFunctionSignature& sig)
 }
 
 int64 AbstractQoreFunctionVariant::getParseOptions(int64 po) const {
-   return is_user ? getUserVariantBase()->getParseOptions(po) : po;
+    return is_user ? getUserVariantBase()->getParseOptions(po) : po;
 }
 
 void AbstractQoreFunctionVariant::parseResolveUserSignature() {
@@ -127,7 +113,7 @@ void AbstractQoreFunctionVariant::parseResolveUserSignature() {
 }
 
 bool AbstractQoreFunctionVariant::hasBody() const {
-   return is_user ? getUserVariantBase()->hasBody() : true;
+    return is_user ? getUserVariantBase()->hasBody() : true;
 }
 
 LocalVar* AbstractQoreFunctionVariant::getSelfId() const {
@@ -139,10 +125,10 @@ LocalVar* AbstractQoreFunctionVariant::getSelfId() const {
 }
 
 static void do_call_name(QoreString &desc, const QoreFunction* func) {
-   const char* class_name = func->className();
-   if (class_name)
-      desc.sprintf("%s::", class_name);
-   desc.sprintf("%s(", func->getName());
+    const char* class_name = func->className();
+    if (class_name)
+        desc.sprintf("%s::", class_name);
+    desc.sprintf("%s(", func->getName());
 }
 
 static void add_args(QoreStringNode &desc, const QoreListNode* args) {
@@ -970,8 +956,7 @@ const AbstractQoreFunctionVariant* QoreFunction::runtimeFindVariant(ExceptionSin
         desc->concat(") can be found; ");
         if (!cnt) {
             desc->concat("no variants were accessible in this execution context");
-        }
-        else {
+        } else {
             desc->concat("the following variants were tested:");
 
             last_class = 0;
@@ -1373,8 +1358,7 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
                                 // we are missing parse-time type information, we need to match at runtime
                                 variant_runtime_match = true;
                                 break;
-                            }
-                            else if (sig->hasDefaultArg(pi))
+                            } else if (sig->hasDefaultArg(pi))
                                 rc = QTI_IGNORE;
                             else
                                 a = nothingTypeInfo;
@@ -1438,8 +1422,7 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
                         variant = nullptr;
                         runtime_match = true;
                         break;
-                    }
-                    else {
+                    } else {
                         // only set variant if it's the longest absolute match and the
                         // longest potential match
                         pmatch = variant_pmatch;
@@ -1449,8 +1432,7 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
                         //printd(5, "QoreFunction::parseFindVariant() assigning variant %p %s(%s)\n", *i, getName(), sig->getSignatureText());
                         variant = *i;
                     }
-                }
-                else if (variant_pmatch && variant_pmatch >= pmatch) {
+                } else if (variant_pmatch && variant_pmatch >= pmatch) {
                     // if we could possibly match less than another variant
                     // then we have to match at runtime
                     variant = nullptr;
@@ -1525,8 +1507,7 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
             }
         }
         qore_program_private::makeParseException(getProgram(), *loc, "PARSE-TYPE-ERROR", desc);
-    }
-    else if (variant) {
+    } else if (variant) {
         int64 flags = variant->getFlags();
         if (flags & (QCF_NOOP | QCF_RUNTIME_NOOP)) {
             QoreStringNode* desc = getNoopError(this, aqf, variant);

--- a/lib/ParseOptionMap.cpp
+++ b/lib/ParseOptionMap.cpp
@@ -97,7 +97,6 @@ void ParseOptionMap::static_init() {
    DO_MAP("no-reflection",            PO_NO_REFLECTION);
    DO_MAP("no-transient",             PO_NO_TRANSIENT);
    DO_MAP("broken-sprintf",           PO_BROKEN_SPRINTF);
-   DO_MAP("broken-abstract",          PO_BROKEN_ABSTRACT);
 
    // the following are not useful from the command-line
    //DO_MAP("no-user-constants",        PO_NO_INHERIT_USER_CONSTANTS);

--- a/lib/QC_AbstractDatasource.qpp
+++ b/lib/QC_AbstractDatasource.qpp
@@ -1,31 +1,31 @@
 /* -*- mode: c++; indent-tabs-mode: nil -*- */
 /** @file QC_AbstractDatasource.qpp AbstractDatasource class (interface) definition */
 /*
-  Qore Programming Language
+    Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
 
-  Permission is hereby granted, free of charge, to any person obtaining a
-  copy of this software and associated documentation files (the "Software"),
-  to deal in the Software without restriction, including without limitation
-  the rights to use, copy, modify, merge, publish, distribute, sublicense,
-  and/or sell copies of the Software, and to permit persons to whom the
-  Software is furnished to do so, subject to the following conditions:
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
 
-  The above copyright notice and this permission notice shall be included in
-  all copies or substantial portions of the Software.
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
 
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-  DEALINGS IN THE SOFTWARE.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
 
-  Note that the Qore library is released under a choice of three open-source
-  licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
-  information.
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
 */
 
 #include <qore/Qore.h>
@@ -83,7 +83,7 @@ abstract auto AbstractDatasource::exec(string sql, ...);
 int rows = db.vexec("insert into example_table value (%v, %v, %v)", arg_list);
     @endcode
  */
-abstract auto AbstractDatasource::vexec(string sql, *softlist vargs);
+abstract auto AbstractDatasource::vexec(string sql, *softlist<auto> vargs);
 
 //! Executes an %SQL command on the server and returns either the row count (for example, for updates and inserts) or the data retrieved (for example, if a stored procedure is executed that returns values)
 /** This method does not do any variable binding, so it's useful for example for DDL statements etc
@@ -119,7 +119,7 @@ abstract auto AbstractDatasource::execRaw(string sql);
     @par Example:
     @code{.py}
 # bind a string and a date/time value by value in a query
-hash query = db.select("select * from table where varchar_column = %v and timestamp_column > %v", string, 2007-10-11T15:31:26.289);
+hash<auto> query = db.select("select * from table where varchar_column = %v and timestamp_column > %v", string, 2007-10-11T15:31:26.289);
 if (query.firstValue())
     printf("got results\n");
     @endcode
@@ -143,7 +143,7 @@ abstract auto AbstractDatasource::select(string sql, ...);
 
     @par Example:
     @code{.py}
-*hash h = db.selectRow("select * from example_table where id = 1");
+*list<auto> h = db.selectRow("select * from example_table where id = 1");
     @endcode
 
     @throw DBI-SELECT-ROW-ERROR more than 1 row retrieved from the server
@@ -166,7 +166,7 @@ abstract auto AbstractDatasource::selectRow(string sql, ...);
 
     @par Example:
     @code{.py}
-*list list = db.selectRows("select * from example_table");
+*list<auto> list = db.selectRows("select * from example_table");
     @endcode
 
     @see AbstractDatasource::select()
@@ -191,7 +191,7 @@ abstract auto AbstractDatasource::selectRows(string sql, ...);
 
     @par Example:
     @code{.py}
-hash query = db.vselect("select * from example_table where id = %v and name = %v", arg_list);
+hash<auto> query = db.vselect("select * from example_table where id = %v and name = %v", arg_list);
 if (query.firstValue())
     printf("got results\n");
     @endcode
@@ -200,7 +200,7 @@ if (query.firstValue())
 
     @note This method returns all the data available immediately; to process query data piecewise, use the SQLStatement class
  */
-abstract auto AbstractDatasource::vselect(string sql, *softlist vargs);
+abstract auto AbstractDatasource::vselect(string sql, *softlist<auto> vargs);
 
 //! Executes a select statement on the server and returns the first row as a hash (column names and values), taking a list for all bind arguments
 /** This method is the same as the AbstractDatasource::selectRow() method, except this method takes a single argument after the %SQL command giving the list of bind value parameters
@@ -217,12 +217,12 @@ abstract auto AbstractDatasource::vselect(string sql, *softlist vargs);
 
     @par Example:
     @code{.py}
-*hash h = db.vselectRow("select * from example_table where id = %v and type = %v", arg_list);
+*hash<auto> h = db.vselectRow("select * from example_table where id = %v and type = %v", arg_list);
     @endcode
 
     @see AbstractDatasource::selectRow()
  */
-abstract auto AbstractDatasource::vselectRow(string sql, *softlist vargs);
+abstract auto AbstractDatasource::vselectRow(string sql, *softlist<auto> vargs);
 
 //! Executes a select statement on the server and returns the results in a list (rows) of hashes (column names and values), taking a list for all bind arguments
 /** Same as the AbstractDatasource::selectRows() method, except this method takes a single argument after the %SQL command giving the list of bind value parameters.
@@ -243,14 +243,14 @@ abstract auto AbstractDatasource::vselectRow(string sql, *softlist vargs);
 
     @par Example:
     @code{.py}
-*list list = db.vselectRows("select * from example_table where id = %v and type = %v", arg_list);
+*list<auto> list = db.vselectRows("select * from example_table where id = %v and type = %v", arg_list);
     @endcode
 
     @see AbstractDatasource::selectRows()
 
     @note This method returns all the data available immediately; to process query data piecewise, use the SQLStatement class
  */
-abstract auto AbstractDatasource::vselectRows(string sql, *softlist vargs);
+abstract auto AbstractDatasource::vselectRows(string sql, *softlist<auto> vargs);
 
 //! Manually signals the start of transaction management on the AbstractDatasource
 /** This method should be called when the AbstractDatasource object will be shared between more than 1 thread, and a transaction will be started with a AbstractDatasource::select() method or the like.
@@ -383,14 +383,14 @@ abstract bool AbstractDatasource::inTransaction();
 //! Returns a @ref datasource_hash "datasource hash" describing the configuration of the current object
 /** @par Example:
     @code{.py}
-hash h = ds.getConfigHash();
+hash<auto> h = ds.getConfigHash();
     @endcode
 
     @return a @ref datasource_hash "datasource hash" describing the configuration of the current object
 
     @since %Qore 0.8.8
  */
-abstract hash AbstractDatasource::getConfigHash();
+abstract hash<auto> AbstractDatasource::getConfigHash();
 
 //! Returns a string giving the configuration of the current object in a format that can be parsed by parse_datasource()
 /** @par Example:

--- a/lib/QC_AbstractSQLStatement.qpp
+++ b/lib/QC_AbstractSQLStatement.qpp
@@ -1,31 +1,31 @@
 /* -*- mode: c++; indent-tabs-mode: nil -*- */
 /** @file QC_AbstractSQLStatement.qpp AbstractSQLStatement class (interface) definition */
 /*
-  Qore Programming Language
+    Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
 
-  Permission is hereby granted, free of charge, to any person obtaining a
-  copy of this software and associated documentation files (the "Software"),
-  to deal in the Software without restriction, including without limitation
-  the rights to use, copy, modify, merge, publish, distribute, sublicense,
-  and/or sell copies of the Software, and to permit persons to whom the
-  Software is furnished to do so, subject to the following conditions:
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
 
-  The above copyright notice and this permission notice shall be included in
-  all copies or substantial portions of the Software.
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
 
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-  DEALINGS IN THE SOFTWARE.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
 
-  Note that the Qore library is released under a choice of three open-source
-  licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
-  information.
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
 */
 
 #include <qore/Qore.h>
@@ -79,7 +79,7 @@ abstract nothing AbstractSQLStatement::prepareRaw(string sql);
     @par Example:
     @code{.py}
 stmt.prepare("insert into table (id, name) values (%v, %v)");
-foreach hash h in (l) {
+foreach hash<auto> h in (l) {
     stmt.bind(h.id, h.name);
     stmt.exec();
 }
@@ -107,8 +107,8 @@ abstract nothing AbstractSQLStatement::bind(...);
     @par Example:
     @code{.py}
 stmt.prepare("insert into table (id, name) values (%v, %v)");
-foreach hash h in (l) {
-    list args = (h.id, h.name);
+foreach hash<auto> h in (l) {
+    list<auto> args = (h.id, h.name);
     stmt.bindArgs(args);
     stmt.exec();
 }
@@ -120,7 +120,7 @@ foreach hash h in (l) {
 
     @see AbstractSQLStatement::bind(), AbstractSQLStatement::bindPlaceholders(), AbstractSQLStatement::bindPlaceholdersArgs(), AbstractSQLStatement::bindValues(), and AbstractSQLStatement::bindValuesArgs()
 */
-abstract nothing AbstractSQLStatement::bindArgs(softlist vargs);
+abstract nothing AbstractSQLStatement::bindArgs(softlist<auto> vargs);
 
 //! Binds placeholder buffer specifications to buffers defined in AbstractSQLStatement::prepare()
 /** If the statement has not previously been prepared with the DB API, it will be implicitly prepared by this method call. This means that this call will cause a connection to be dedicated from a DatasourcePool object or the transaction lock to be grabbed with a Datasource object, depending on the argument to AbstractSQLStatement::constructor().
@@ -164,7 +164,7 @@ abstract nothing AbstractSQLStatement::bindPlaceholders(...);
     @par Example:
     @code{.py}
 stmt.prepare("begin select sysdate into :sd from dual", Type::Date); end;
-list l = list(Type::Date);
+list<auto> l = list(Type::Date);
 stmt.bindPlaceholdersArgs(l);
 date d = stmt.getOutput().sd;
     @endcode
@@ -175,7 +175,7 @@ date d = stmt.getOutput().sd;
 
     @see AbstractSQLStatement::bind(), AbstractSQLStatement::bindArgs(), AbstractSQLStatement::bindPlaceholders(), AbstractSQLStatement::bindValues(), and AbstractSQLStatement::bindValuesArgs()
 */
-abstract nothing AbstractSQLStatement::bindPlaceholdersArgs(softlist vargs);
+abstract nothing AbstractSQLStatement::bindPlaceholdersArgs(softlist<auto> vargs);
 
 //! Binds values to value buffer specifications to buffers defined in AbstractSQLStatement::prepare()
 /** If the statement has not previously been prepared with the DB API, it will be implicitly prepared by this method call. This means that this call will cause a connection to be dedicated from a DatasourcePool object or the transaction lock to be grabbed with a Datasource object, depending on the argument to AbstractSQLStatement::constructor().
@@ -191,7 +191,7 @@ abstract nothing AbstractSQLStatement::bindPlaceholdersArgs(softlist vargs);
     @par Example:
     @code{.py}
 stmt.prepare("insert into table (id, name) values (%v, %v)");
-foreach hash h in (l) {
+foreach hash<auto> h in (l) {
     stmt.bindValues(h.id, h.name);
     stmt.exec();
 }
@@ -219,8 +219,8 @@ abstract nothing AbstractSQLStatement::bindValues(...);
     @par Example:
     @code{.py}
 stmt.prepare("insert into table (id, name) values (%v, %v)");
-foreach hash h in (l) {
-    list args = (h.id, h.name);
+foreach hash<auto> h in (l) {
+    list<auto> args = (h.id, h.name);
     stmt.bindValuesArgs(args);
     stmt.exec();
 }
@@ -230,7 +230,7 @@ foreach hash h in (l) {
 
     @note Exceptions could be thrown by the DBI driver when the statement is prepared or when attempting to bind the given arguments to buffer specifications; see the relevant DBI driver docs for more information
 */
-abstract nothing AbstractSQLStatement::bindValuesArgs(softlist vargs);
+abstract nothing AbstractSQLStatement::bindValuesArgs(softlist<auto> vargs);
 
 //! Executes the bound statement with any bound buffers, also optionally allows binding placeholder buffer specifications and values to buffers defined in AbstractSQLStatement::prepare() before executing the statement
 /** If the statement has not previously been prepared with the DB API, it will be implicitly prepared by this method call. This means that this call will cause a connection to be dedicated from a DatasourcePool object or the transaction lock to be grabbed with a Datasource object, depending on the argument to AbstractSQLStatement::constructor().
@@ -248,7 +248,7 @@ abstract nothing AbstractSQLStatement::bindValuesArgs(softlist vargs);
     @par Example:
     @code{.py}
 stmt.prepare("insert into table (id, name) values (%v, %v)");
-foreach hash h in (l) {
+foreach hash<auto> h in (l) {
     stmt.exec(h.id, h.name);
 }
     @endcode
@@ -277,8 +277,8 @@ abstract nothing AbstractSQLStatement::exec(...);
     @par Example:
     @code{.py}
 stmt.prepare("insert into table (id, name) values (%v, %v)");
-foreach hash h in (l) {
-    list args = (h.id, h.name);
+foreach hash<auto> h in (l) {
+    list<auto> args = (h.id, h.name);
     stmt.execArgs(args);
 }
     @endcode
@@ -289,7 +289,7 @@ foreach hash h in (l) {
 
     @see AbstractSQLStatement::exec()
 */
-abstract nothing AbstractSQLStatement::execArgs(softlist vargs);
+abstract nothing AbstractSQLStatement::execArgs(softlist<auto> vargs);
 
 //! Returns the number of rows affected by the last call to AbstractSQLStatement::exec()
 /** @return the number of rows affected by the last call to AbstractSQLStatement::exec()
@@ -310,28 +310,28 @@ abstract int AbstractSQLStatement::affectedRows();
 
     @par Example:
     @code{.py}
-hash h = stmt.getOutput();
+hash<auto> h = stmt.getOutput();
     @endcode
 
     @throw SQLSTATEMENT-ERROR No %SQL has been set with AbstractSQLStatement::prepare() or AbstractSQLStatement::prepareRaw()
 
     @note Exceptions could be thrown by the DBI driver when the statement is prepared or when attempting to bind the given arguments to buffer specifications or when the statement is executed or when output values are retrieved; see the relevant DBI driver docs for more information
 */
-abstract hash AbstractSQLStatement::getOutput();
+abstract hash<auto> AbstractSQLStatement::getOutput();
 
 //! Retrieves output buffers as a hash; result sets will be returned as lists of hashes
 /** @return Retrieves output buffers as a hash; result sets will be returned as lists of hashes. Each key in the hash is the same as the name given to the placeholder specification in the call to AbstractSQLStatement::prepare() or AbstractSQLStatement::prepareRaw()
 
     @par Example:
     @code{.py}
-hash h = stmt.getOutputRows();
+hash<auto> h = stmt.getOutputRows();
     @endcode
 
     @throw SQLSTATEMENT-ERROR No %SQL has been set with AbstractSQLStatement::prepare() or AbstractSQLStatement::prepareRaw()
 
     @note Exceptions could be thrown by the DBI driver when the statement is prepared or when attempting to bind the given arguments to buffer specifications or when the statement is executed or when output values are retrieved; see the relevant DBI driver docs for more information
 */
-abstract hash AbstractSQLStatement::getOutputRows();
+abstract hash<auto> AbstractSQLStatement::getOutputRows();
 
 //! Performs an explicit define operation on the SQLStatement
 /** It is not encessary to call this method manually; define operations are implicitly executed when needed when retrieving values from a select statement
@@ -347,7 +347,7 @@ abstract hash AbstractSQLStatement::getOutputRows();
     stmt.define();
     # note that the AbstractSQLStatement::next() would implicitly execute exec() and define()
     while (stmt.next()) {
-        hash row = stmt.fetchRow();
+        hash<auto> row = stmt.fetchRow();
         do_something(row);
     }
 }
@@ -403,7 +403,7 @@ abstract nothing AbstractSQLStatement::beginTransaction();
     @par Example:
     @code{.py}
 while (stmt.next()) {
-    hash h = stmt.fetchRow();
+    hash<auto> h = stmt.fetchRow();
 }
     @endcode
 
@@ -432,7 +432,7 @@ abstract bool AbstractSQLStatement::valid();
     @par Example:
     @code{.py}
 while (stmt.next()) {
-    hash h = stmt.fetchRow();
+    hash<auto> h = stmt.fetchRow();
 }
     @endcode
 
@@ -440,7 +440,7 @@ while (stmt.next()) {
 
     @note Exceptions could be thrown by the DBI driver when the statement is prepared or when attempting to bind the given arguments to buffer specifications or when the statement is executed or when row values are retrieved; see the relevant DBI driver docs for more information
 */
-abstract *hash AbstractSQLStatement::fetchRow();
+abstract *hash<auto> AbstractSQLStatement::fetchRow();
 
 //! Retrieves the current row as a hash where the keys are the column names and the values are the column values
 /** Use with AbstractSQLStatement::next() to iterate through the results of a select statement one row at a time
@@ -450,7 +450,7 @@ abstract *hash AbstractSQLStatement::fetchRow();
     @par Example:
     @code{.py}
 while (stmt.next()) {
-    hash h = stmt.getValue();
+    hash<auto> h = stmt.getValue();
 }
     @endcode
 
@@ -460,7 +460,7 @@ while (stmt.next()) {
     - Equivalent to AbstractSQLStatement::fetchRow()
     - Exceptions could be thrown by the DBI driver when the statement is prepared or when attempting to bind the given arguments to buffer specifications or when the statement is executed or when row values are retrieved; see the relevant DBI driver docs for more information
 */
-abstract *hash AbstractSQLStatement::getValue();
+abstract *hash<auto> AbstractSQLStatement::getValue();
 
 //! Retrieves a block of rows as a list of hashes with the maximum number of rows determined by the argument passed; automatically advances the row pointer; with this call it is not necessary to call AbstractSQLStatement::next()
 /** If the argument passed is omitted or less than or equal to zero, then all available rows from the current row position are retrieved, also if fewer rows are available than requested then only the rows available are retrieved.
@@ -471,7 +471,7 @@ abstract *hash AbstractSQLStatement::getValue();
 
     @par Example:
     @code{.py}
-list l = stmt.fetchRows(-1);
+list<auto> l = stmt.fetchRows(-1);
     @endcode
 
     @throw SQLSTATEMENT-ERROR No %SQL has been set with AbstractSQLStatement::prepare() or AbstractSQLStatement::prepareRaw()
@@ -480,7 +480,7 @@ list l = stmt.fetchRows(-1);
     - There is no need to call AbstractSQLStatement::next() when calling this method; the method automatically iterates through the given number of rows
     - Exceptions could be thrown by the DBI driver when the statement is prepared or when attempting to bind the given arguments to buffer specifications or when the statement is executed or when row values are retrieved; see the relevant DBI driver docs for more information
 */
-abstract list AbstractSQLStatement::fetchRows(softint rows = -1);
+abstract list<auto> AbstractSQLStatement::fetchRows(softint rows = -1);
 
 //! Retrieves a block of rows as a hash of lists with the maximum number of rows determined by the argument passed; automatically advances the row pointer; with this call it is not necessary to call AbstractSQLStatement::next().
 /** If the argument passed is omitted or less than or equal to zero, then all available rows from the current row position are retrieved, also if fewer rows are available than requested then only the rows available are retrieved.
@@ -491,7 +491,7 @@ abstract list AbstractSQLStatement::fetchRows(softint rows = -1);
 
     @par Example:
     @code{.py}
-hash h = stmt.fetchColumns(-1);
+hash<auto> h = stmt.fetchColumns(-1);
     @endcode
 
     @throw SQLSTATEMENT-ERROR No %SQL has been set with AbstractSQLStatement::prepare() or AbstractSQLStatement::prepareRaw()
@@ -500,7 +500,7 @@ hash h = stmt.fetchColumns(-1);
     - There is no need to call AbstractSQLStatement::next() when calling this method; the method automatically iterates through the given number of rows
     - Exceptions could be thrown by the DBI driver when the statement is prepared or when attempting to bind the given arguments to buffer specifications or when the statement is executed or when row values are retrieved; see the relevant DBI driver docs for more information
 */
-abstract hash AbstractSQLStatement::fetchColumns(softint rows = -1);
+abstract hash<auto> AbstractSQLStatement::fetchColumns(softint rows = -1);
 
 //! Describes columns in the statement result.
 /**
@@ -511,7 +511,7 @@ abstract hash AbstractSQLStatement::fetchColumns(softint rows = -1);
     - \c "native_type": (string) the database-specific name of the type
     - \c "internal_id": (integer) the database-specific type code of the type
 */
-abstract hash AbstractSQLStatement::describe();
+abstract hash<auto> AbstractSQLStatement::describe();
 
 //! Returns the current SQL string set with the call to AbstractSQLStatement::prepare() or AbstractSQLStatement::prepareRaw() or @ref nothing if no SQL has been set
 /** @return Returns the current SQL string set with the call to AbstractSQLStatement::prepare() or AbstractSQLStatement::prepareRaw() or @ref nothing if no SQL has been set

--- a/lib/QC_Datasource.qpp
+++ b/lib/QC_Datasource.qpp
@@ -367,7 +367,7 @@ Datasource db(DSPGSQL, "user", "pass", "database", "utf8", "localhost", 5432);
     @throw DATASOURCE-CONSTRUCTOR-ERROR port value is \<= 0
     @throw DBI-OPTION-ERROR unknown or unsupported option passed to driver
  */
-Datasource::constructor(string driver, *string user, *string pass, *string db, *string encoding, *string host, *softint port, *hash options, *Qore::Thread::Queue[Queue] queue, auto arg) {
+Datasource::constructor(string driver, *string user, *string pass, *string db, *string encoding, *string host, *softint port, *hash<auto> options, *Qore::Thread::Queue[Queue] queue, auto arg) {
    ReferenceHolder<Queue> q(queue, xsink);
 
    if (!port && driver->find('@') != -1) {
@@ -477,7 +477,7 @@ Datasource db(("type": DSPGSQL, "user": "username", "pass": "password", "db": "d
     @throw DATASOURCE-CONSTRUCTOR-ERROR missing or invalid \c "driver" key, other key name not assigned to a string; port value is \<= 0
     @throw DBI-OPTION-ERROR unknown or unsupported option passed to driver
  */
-Datasource::constructor(hash opts, *Qore::Thread::Queue[Queue] queue, auto arg) {
+Datasource::constructor(hash<auto> opts, *Qore::Thread::Queue[Queue] queue, auto arg) {
    ds_constructor_hash(opts, self, queue, arg, xsink);
 }
 
@@ -631,7 +631,7 @@ int rows = db.vexec("insert into example_table value (%v, %v, %v)", arg_list);
 
     @note see the documentation for the DBI driver being used for additional possible exceptions
  */
-auto Datasource::vexec(string sql, *softlist vargs) {
+auto Datasource::vexec(string sql, *softlist<auto> vargs) {
    return ds->exec(sql, vargs, xsink);
 }
 
@@ -711,7 +711,7 @@ auto Datasource::select(string sql, ...) {
 
     @par Example:
     @code{.py}
-*hash h = db.selectRow("select * from example_table where id = 1");
+*hash<auto> h = db.selectRow("select * from example_table where id = 1");
     @endcode
 
     @throw TRANSACTION-LOCK-TIMEOUT Timeout trying to acquire the transaction lock
@@ -719,7 +719,7 @@ auto Datasource::select(string sql, ...) {
 
     @note see the documentation for the DBI driver being used for additional possible exceptions
  */
-*hash Datasource::selectRow(string sql, ...) {
+*hash<auto> Datasource::selectRow(string sql, ...) {
    ReferenceHolder<QoreListNode> argl((args->size() > 1 ? args->copyListFrom(1) : 0), xsink);
    return ds->selectRow(sql, *argl, xsink);
 }
@@ -740,7 +740,7 @@ auto Datasource::select(string sql, ...) {
 
     @par Example:
     @code{.py}
-*list list = db.selectRows("select * from example_table");
+*list<auto> list = db.selectRows("select * from example_table");
     @endcode
 
     @throw TRANSACTION-LOCK-TIMEOUT Timeout trying to acquire the transaction lock
@@ -771,7 +771,7 @@ auto Datasource::selectRows(string sql, ...) {
 
     @par Example:
     @code{.py}
-hash query = db.vselect("select * from example_table where id = %v and name = %v", arg_list);
+hash<auto> query = db.vselect("select * from example_table where id = %v and name = %v", arg_list);
 if (query.firstValue())
     printf("got results\n");
     @endcode
@@ -787,7 +787,7 @@ if (query.firstValue())
     - <hash>::contextIterator()
     - @ref context
  */
-auto Datasource::vselect(string sql, *softlist vargs) {
+auto Datasource::vselect(string sql, *softlist<auto> vargs) {
    return ds->select(sql, vargs, xsink);
 }
 
@@ -805,7 +805,7 @@ auto Datasource::vselect(string sql, *softlist vargs) {
 
     @par Example:
     @code{.py}
-*hash h = db.vselectRow("select * from example_table where id = %v and type = %v", arg_list);
+*hash<auto> h = db.vselectRow("select * from example_table where id = %v and type = %v", arg_list);
     @endcode
 
     @throw TRANSACTION-LOCK-TIMEOUT Timeout trying to acquire the transaction lock
@@ -814,7 +814,7 @@ auto Datasource::vselect(string sql, *softlist vargs) {
 
     @see Datasource::selectRow()
  */
-*hash Datasource::vselectRow(string sql, *softlist vargs) {
+*hash<auto> Datasource::vselectRow(string sql, *softlist<auto> vargs) {
    return ds->selectRow(sql, vargs, xsink);
 }
 
@@ -836,7 +836,7 @@ auto Datasource::vselect(string sql, *softlist vargs) {
 
     @par Example:
     @code{.py}
-*list list = db.vselectRows("select * from example_table where id = %v and type = %v", arg_list);
+*list<auto> list = db.vselectRows("select * from example_table where id = %v and type = %v", arg_list);
     @endcode
 
     @throw TRANSACTION-LOCK-TIMEOUT Timeout trying to acquire the transaction lock
@@ -847,7 +847,7 @@ auto Datasource::vselect(string sql, *softlist vargs) {
 
     @see Datasource::selectRows()
  */
-auto Datasource::vselectRows(string sql, *softlist vargs) {
+auto Datasource::vselectRows(string sql, *softlist<auto> vargs) {
    return ds->selectRows(sql, vargs, xsink);
 }
 
@@ -868,7 +868,7 @@ auto Datasource::vselectRows(string sql, *softlist vargs) {
 
     @par Example:
     @code{.py}
-*hash h = db.describe("select * from example_table where id = 1");
+*hash<auto> h = db.describe("select * from example_table where id = 1");
     @endcode
 
     @throw TRANSACTION-LOCK-TIMEOUT Timeout trying to acquire the transaction lock
@@ -877,7 +877,7 @@ auto Datasource::vselectRows(string sql, *softlist vargs) {
 
     @since %Qore 0.8.9
  */
-*hash Datasource::describe(string sql, ...) {
+*hash<auto> Datasource::describe(string sql, ...) {
    ReferenceHolder<QoreListNode> argl((args->size() > 1 ? args->copyListFrom(1) : 0), xsink);
    return ds->describe(sql, *argl, xsink);
 }
@@ -940,7 +940,7 @@ foreach string cap in (db.getCapabilityList())
     printf("- %s\n", cap);
     @endcode
  */
-list Datasource::getCapabilityList() [flags=CONSTANT] {
+list<auto> Datasource::getCapabilityList() [flags=CONSTANT] {
    return ds->getCapabilityList();
 }
 
@@ -1286,7 +1286,7 @@ int Datasource::transactionTid() [flags=CONSTANT] {
 
     @since %Qore 0.8.6
  */
-hash Datasource::getOptionHash() [flags=RET_VALUE_ONLY] {
+hash<auto> Datasource::getOptionHash() [flags=RET_VALUE_ONLY] {
    return ds->getOptionHash(xsink);
 }
 
@@ -1322,7 +1322,7 @@ auto Datasource::getOption(string opt) [flags=RET_VALUE_ONLY] {
 //! Returns a @ref datasource_hash "datasource hash" describing the configuration of the current object
 /** @par Example:
     @code{.py}
-hash h = ds.getConfigHash();
+hash<auto> h = ds.getConfigHash();
     @endcode
 
     @return a @ref datasource_hash "datasource hash" describing the configuration of the current object
@@ -1332,7 +1332,7 @@ hash h = ds.getConfigHash();
 
     @since %Qore 0.8.8
  */
-hash Datasource::getConfigHash() [flags=CONSTANT] {
+hash<auto> Datasource::getConfigHash() [flags=CONSTANT] {
    return ds->getConfigHash(xsink);
 }
 

--- a/lib/QC_DatasourcePool.qpp
+++ b/lib/QC_DatasourcePool.qpp
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -298,14 +298,14 @@ DatasourcePool ds("pgsql:user/pass@db01(utf8)%localhost:5432");
     @since %Qore 0.8.6
  */
 DatasourcePool::constructor(string desc, *Qore::Thread::Queue[Queue] queue, auto arg) {
-   ReferenceHolder<Queue> q(queue, xsink);
-   ReferenceHolder<QoreHashNode> h(parseDatasource(desc->getBuffer(), xsink), xsink);
-   if (!h) {
-      assert(*xsink);
-      return;
-   }
+    ReferenceHolder<Queue> q(queue, xsink);
+    ReferenceHolder<QoreHashNode> h(parseDatasource(desc->getBuffer(), xsink), xsink);
+    if (!h) {
+        assert(*xsink);
+        return;
+    }
 
-   dsp_constructor_hash(*h, self, q.release(), arg, xsink);
+    dsp_constructor_hash(*h, self, q.release(), arg, xsink);
 }
 
 //! Creates a DatasourcePool object from a hash argument giving parameters for the constructor
@@ -330,7 +330,7 @@ Datasource db(("type": DSPGSQL, "user": "username", "pass": "password", "db": "d
     @throw DATASOURCEPOOL-CONSTRUCTOR-ERROR missing or invalid \c "driver" key, other key name not assigned to a string; \c "port" value is \<= 0; invalid \c "min" or \c "max" keys
     @throw DBI-OPTION-ERROR unknown or unsupported option passed to driver
  */
-DatasourcePool::constructor(hash opts, *Qore::Thread::Queue[Queue] queue, auto arg) {
+DatasourcePool::constructor(hash<auto> opts, *Qore::Thread::Queue[Queue] queue, auto arg) {
    dsp_constructor_hash(opts, self, queue, arg, xsink);
 }
 
@@ -420,7 +420,7 @@ int rows = db.vexec("insert into example_table value (%v, %v, %v)", arg_list);
 
     @note see the documentation for the DBI driver being used for additional possible exceptions
  */
-auto DatasourcePool::vexec(string sql, *softlist vargs) {
+auto DatasourcePool::vexec(string sql, *softlist<auto> vargs) {
    return ds->exec(sql, vargs, xsink);
 }
 
@@ -496,7 +496,7 @@ auto DatasourcePool::select(string sql, ...) {
 
     @par Example:
     @code{.py}
-*hash h = db.selectRow("select * from example_table where id = 1");
+*hash<auto> h = db.selectRow("select * from example_table where id = 1");
     @endcode
 
     @throw DBI-SELECT-ROW-ERROR more than 1 row retrieved from the server
@@ -524,7 +524,7 @@ auto DatasourcePool::selectRow(string sql, ...) {
 
     @par Example:
     @code{.py}
-*list list = db.selectRows("select * from example_table");
+*list<auto> list = db.selectRows("select * from example_table");
     @endcode
 
     @note see the documentation for the DBI driver being used for additional possible exceptions
@@ -551,7 +551,7 @@ auto DatasourcePool::selectRows(string sql, ...) {
 
     @par Example:
     @code{.py}
-hash query = db.vselect("select * from example_table where id = %v and name = %v", arg_list);
+hash<auto> query = db.vselect("select * from example_table where id = %v and name = %v", arg_list);
 if (query.firstValue())
     printf("got results\n");
     @endcode
@@ -565,7 +565,7 @@ if (query.firstValue())
     - <hash>::contextIterator()
     - @ref context
  */
-auto DatasourcePool::vselect(string sql, *softlist vargs) {
+auto DatasourcePool::vselect(string sql, *softlist<auto> vargs) {
    return ds->select(sql, vargs, xsink);
 }
 
@@ -583,14 +583,14 @@ auto DatasourcePool::vselect(string sql, *softlist vargs) {
 
     @par Example:
     @code{.py}
-*hash h = db.vselectRow("select * from example_table where id = %v and type = %v", arg_list);
+*hash<auto> h = db.vselectRow("select * from example_table where id = %v and type = %v", arg_list);
     @endcode
 
     @note see the documentation for the DBI driver being used for additional possible exceptions
 
     @see DatasourcePool::selectRow()
  */
-auto DatasourcePool::vselectRow(string sql, *softlist vargs) {
+auto DatasourcePool::vselectRow(string sql, *softlist<auto> vargs) {
    return ds->selectRow(sql, vargs, xsink);
 }
 
@@ -612,14 +612,14 @@ auto DatasourcePool::vselectRow(string sql, *softlist vargs) {
 
     @par Example:
     @code{.py}
-*list list = db.vselectRows("select * from example_table where id = %v and type = %v", arg_list);
+*list<auto> list = db.vselectRows("select * from example_table where id = %v and type = %v", arg_list);
     @endcode
 
     @note see the documentation for the DBI driver being used for additional possible exceptions
 
     @see DatasourcePool::selectRows()
  */
-auto DatasourcePool::vselectRows(string sql, *softlist vargs) {
+auto DatasourcePool::vselectRows(string sql, *softlist<auto> vargs) {
    return ds->selectRows(sql, vargs, xsink);
 }
 
@@ -870,7 +870,7 @@ bool DatasourcePool::currentThreadInTransaction() [flags=CONSTANT] {
 
     @since %Qore 0.8.6
  */
-hash DatasourcePool::getOptionHash() [flags=CONSTANT] {
+hash<auto> DatasourcePool::getOptionHash() [flags=CONSTANT] {
    return ds->getOptionHash();
 }
 
@@ -888,14 +888,14 @@ auto DatasourcePool::getOption(string opt) [flags=RET_VALUE_ONLY] {
 //! Returns a @ref datasource_hash "datasource hash" describing the configuration of the current object
 /** @par Example:
     @code{.py}
-hash h = ds.getConfigHash();
+hash<auto> h = ds.getConfigHash();
     @endcode
 
     @return a @ref datasource_hash "datasource hash" describing the configuration of the current object
 
     @since %Qore 0.8.8
  */
-hash DatasourcePool::getConfigHash() [flags=CONSTANT] {
+hash<auto> DatasourcePool::getConfigHash() [flags=CONSTANT] {
    return ds->getConfigHash(xsink);
 }
 
@@ -949,7 +949,7 @@ DatasourcePool::setWarningCallback(timeout ms, code callback, auto arg) {
 //! Returns a hash with usage information about the DatasourcePool object
 /** @par Example:
     @code{.py}
-hash h = ds.getUsageInfo();
+hash<auto> h = ds.getUsageInfo();
     @endcode
 
     @return a hash with the following keys (note that the \c callback, \c timeout, and optionally \c arg keys are only set if a warning callback is set):
@@ -964,7 +964,7 @@ hash h = ds.getUsageInfo();
 
     @since %Qore 0.8.9
 */
-*hash DatasourcePool::getUsageInfo() [flags=CONSTANT] {
+*hash<auto> DatasourcePool::getUsageInfo() [flags=CONSTANT] {
    return ds->getUsageInfo();
 }
 
@@ -1050,7 +1050,7 @@ foreach string cap in (db.getCapabilityList())
 
     @since %Qore 0.8.12
 */
-list DatasourcePool::getCapabilityList() [flags=CONSTANT] {
+list<auto> DatasourcePool::getCapabilityList() [flags=CONSTANT] {
    return ds->getCapabilityList();
 }
 

--- a/lib/QC_FileLineIterator.qpp
+++ b/lib/QC_FileLineIterator.qpp
@@ -100,15 +100,15 @@ FileLineIterator ni = i.copy();
     @throw ILLEGAL-EXPRESSION FileLineIterator::constructor() cannot be called with a TTY target when @ref no-terminal-io "%no-terminal-io" is set
  */
 FileLineIterator::copy() {
-   SimpleRefHolder<FileLineIterator> fli(new FileLineIterator(xsink, *i));
+    SimpleRefHolder<FileLineIterator> fli(new FileLineIterator(xsink, *i));
 
-   if (fli->isTty() && runtime_check_parse_option(PO_NO_TERMINAL_IO)) {
-      xsink->raiseException("ILLEGAL-EXPRESSION", "FileLineIterator::copy() cannot be called with a TTY target when 'no-terminal-io' is set");
-      return;
-   }
+    if (fli->isTty() && runtime_check_parse_option(PO_NO_TERMINAL_IO)) {
+        xsink->raiseException("ILLEGAL-EXPRESSION", "FileLineIterator::copy() cannot be called with a TTY target when 'no-terminal-io' is set");
+        return;
+    }
 
-   if (!*xsink)
-      self->setPrivate(CID_FILELINEITERATOR, fli.release());
+    if (!*xsink)
+        self->setPrivate(CID_FILELINEITERATOR, fli.release());
 }
 
 //! Moves the current position to the next line in the file; returns @ref False if there are no more lines to read; if the iterator is not pointing at a valid element before this call, the iterator will be positioned to the beginning of the file
@@ -127,9 +127,9 @@ while (i.next()) {
     @throw ITERATOR-THREAD-ERROR this exception is thrown if this method is called from any thread other than the thread that created the object
  */
 bool FileLineIterator::next() {
-   if (i->check(xsink))
-      return false;
-   return i->next(xsink);
+    if (i->check(xsink))
+        return false;
+    return i->next(xsink);
 }
 
 //! Returns the current line in the file or throws an \c ITERATOR-ERROR exception if the iterator is invalid
@@ -148,7 +148,7 @@ while (i.next()) {
     @see FileLineIterator::getLine()
  */
 string FileLineIterator::getValue() [flags=RET_VALUE_ONLY] {
-   return i->checkValid(xsink) ? 0 : i->getValue();
+    return i->checkValid(xsink) ? 0 : i->getValue();
 }
 
 //! Returns the current line in the file or throws an \c ITERATOR-ERROR exception if the iterator is invalid
@@ -167,7 +167,7 @@ while (i.next()) {
     @see FileLineIterator::getValue()
  */
 string FileLineIterator::getLine() [flags=RET_VALUE_ONLY] {
-   return i->checkValid(xsink) ? 0 : i->getValue();
+    return i->checkValid(xsink) ? 0 : i->getValue();
 }
 
 //! Returns @ref Qore::True "True" if the iterator is currently pointing at a valid element, @ref Qore::False "False" if not
@@ -180,7 +180,7 @@ if (i.valid())
     @endcode
  */
 bool FileLineIterator::valid() [flags=CONSTANT] {
-   return i->valid();
+    return i->valid();
 }
 
 //! Returns the current iterator line number in the file (the first line is line 1) or 0 if not pointing at a valid element
@@ -194,7 +194,7 @@ while (i.next()) {
     @endcode
  */
 int FileLineIterator::index() [flags=CONSTANT] {
-   return i->index();
+    return i->index();
 }
 
 //! Returns the @ref character_encoding "character encoding" for the %FileLineIterator
@@ -206,7 +206,7 @@ string encoding = f.getEncoding();
     @return the @ref character_encoding "character encoding" for the %FileLineIterator
  */
 string FileLineIterator::getEncoding() [flags=CONSTANT] {
-   return new QoreStringNode(i->getEncoding()->getCode());
+    return new QoreStringNode(i->getEncoding()->getCode());
 }
 
 //! Returns @ref Qore::True "True" if the FileLineIterator is connected to a terminal device, @ref Qore::False "False" if not
@@ -218,7 +218,7 @@ bool b = i.isTty();
     @endcode
 */
 bool FileLineIterator::isTty() [flags=CONSTANT] {
-   return i->isTty();
+    return i->isTty();
 }
 
 //! Returns the file path/name used to open the file
@@ -230,28 +230,28 @@ string fn = f.getFileName();
     @return the file path/name used to open the file
  */
 string FileLineIterator::getFileName() [flags=CONSTANT] {
-   return i->getFileName();
+    return i->getFileName();
 }
 
 //! Returns @ref stat_list of stat() of the underlying file
 /** If any errors occur, a \c FILE-HSTAT-ERROR exception is thrown
     @par Example:
     @code{.py}
-list l = f.stat();
+list<auto> l = f.stat();
     @endcode
 
     @return @ref stat_list of stat() of the underlying file
     @since %Qore 0.8.12
  */
-list FileLineIterator::stat() [flags=CONSTANT] {
-   return i->stat(xsink);
+list<auto> FileLineIterator::stat() [flags=CONSTANT] {
+    return i->stat(xsink);
 }
 
 //! Returns @ref StatInfo "StatInfo" hash of hstat() of the underlying file
 /** If any errors occur, a \c FILE-HSTAT-ERROR exception is thrown
     @par Example:
     @code{.py}
-hash h = f.hstat();
+hash<StatInfo> h = f.hstat();
     @endcode
 
     @return @ref StatInfo "StatInfo" hash of hstat() of the underlying file
@@ -259,7 +259,7 @@ hash h = f.hstat();
     @since %Qore 0.8.12
  */
 hash<StatInfo> FileLineIterator::hstat() [flags=CONSTANT] {
-   return i->hstat(xsink);
+    return i->hstat(xsink);
 }
 
 //! Reset the iterator instance to its initial state
@@ -273,6 +273,6 @@ i.reset();
     @throw ITERATOR-THREAD-ERROR this exception is thrown if this method is called from any thread other than the thread that created the object
  */
 FileLineIterator::reset() {
-   if (!i->check(xsink))
-      i->reset(xsink);
+    if (!i->check(xsink))
+        i->reset(xsink);
 }

--- a/lib/QC_HashIterator.qpp
+++ b/lib/QC_HashIterator.qpp
@@ -73,7 +73,7 @@ HashIterator::constructor(hash<auto> h) {
 //! Creates an empty hash iterator object
 /** @par Example:
     @code{.py}
-*hash h = get_hash_or_nothing();
+*hash<auto> h = get_hash_or_nothing();
 HashIterator hi(h);
     @endcode
  */

--- a/lib/QC_HashPairReverseIterator.qpp
+++ b/lib/QC_HashPairReverseIterator.qpp
@@ -77,7 +77,7 @@ qclass HashPairReverseIterator [arg=QoreHashReverseIterator* i; ns=Qore; vparent
 HashPairReverseIterator hi(h);
     @endcode
  */
-HashPairReverseIterator::constructor(hash h) {
+HashPairReverseIterator::constructor(hash<auto> h) {
     self->setPrivate(CID_HASHPAIRREVERSEITERATOR, new QoreHashReverseIterator(h));
 }
 
@@ -115,7 +115,7 @@ map printf("%s: %y\n", $1.key, $1.value), hash.pairIterator();
 
     @since %Qore 0.8.6.2
  */
-string HashPairReverseIterator::getValue() [flags=RET_VALUE_ONLY] {
+hash<auto> HashPairReverseIterator::getValue() [flags=RET_VALUE_ONLY] {
     if (i->check(xsink))
         return QoreValue();
     return i->getReferencedValuePair(xsink);

--- a/lib/QC_ListHashIterator.qpp
+++ b/lib/QC_ListHashIterator.qpp
@@ -37,9 +37,9 @@
 
     @par Example: ListHashIterator basic usage
     @code{.py}
-    list data = (
-             ( "column1" : 1, "column2" : "a"),
-             ( "column1" : 2, "column2" : "b"),
+    list<auto> data = (
+             {"column1": 1, "column2": "a"},
+             {"column1": 2, "column2": "b"},
         );
 
     ListHashIterator it(data);
@@ -47,8 +47,8 @@
         printf("iter %d: %n\n", it.index(), it.getValue());
     }
 
-    iter 0: hash: (column1 : 1, column2 : "a")
-    iter 1: hash: (column1 : 2, column2 : "b")
+    iter 0: hash: (column1: 1, column2: "a")
+    iter 1: hash: (column1: 2, column2: "b")
     @endcode
 
     @note
@@ -69,9 +69,9 @@ ListHashIterator i(l);
     @endcode
 
     @note the constructor's argument is @ref softlist_type "softlist" so that it can also accept @ref nothing
- */
+*/
 ListHashIterator::constructor(softlist<auto> l) {
-   self->setPrivate(CID_LISTHASHITERATOR, new QoreListHashIterator(l));
+    self->setPrivate(CID_LISTHASHITERATOR, new QoreListHashIterator(l));
 }
 
 //! Creates a copy of the ListHashIterator object, iterating the same object as the original and in the same position
@@ -79,9 +79,9 @@ ListHashIterator::constructor(softlist<auto> l) {
     @code{.py}
 ListHashIterator ni = i.copy();
     @endcode
- */
+*/
 ListHashIterator::copy() {
-   self->setPrivate(CID_LISTHASHITERATOR, new QoreListHashIterator(*i));
+    self->setPrivate(CID_LISTHASHITERATOR, new QoreListHashIterator(*i));
 }
 
 //! Moves the current position to the next element in the result list; returns @ref False if there are no more elements; if the iterator is not pointing at a valid element before this call, the iterator will be positioned on the first element in the list if the list is not empty
@@ -98,11 +98,11 @@ while (i.next()) {
     @endcode
 
     @throw ITERATOR-THREAD-ERROR this exception is thrown if this method is called from any thread other than the thread that created the object
- */
+*/
 bool ListHashIterator::next() {
-   if (i->check(xsink))
-      return false;
-   return i->next();
+    if (i->check(xsink))
+        return false;
+    return i->next();
 }
 
 //! Moves the current position to the previous element in the result list; returns @ref False if there are no more elements; if the iterator is not pointing at a valid element before this call, the iterator will be positioned on the last element in the list if the list is not empty
@@ -119,11 +119,11 @@ while (i.prev()) {
     @endcode
 
     @throw ITERATOR-THREAD-ERROR this exception is thrown if this method is called from any thread other than the thread that created the object
- */
+*/
 bool ListHashIterator::prev() {
-   if (i->check(xsink))
-      return false;
-   return i->prev();
+    if (i->check(xsink))
+        return false;
+    return i->prev();
 }
 
 //! returns @ref True if the result list is empty; @ref False if not
@@ -134,9 +134,9 @@ bool ListHashIterator::prev() {
 if (i.empty())
     printf("the result list is empty\n");
     @endcode
- */
+*/
 bool ListHashIterator::empty() [flags=CONSTANT] {
-   return i->empty();
+    return i->empty();
 }
 
 //! returns @ref True if on the first element of the list
@@ -149,7 +149,7 @@ while (i.next()) {
         printf("START:\n");
 }
     @endcode
- */
+*/
 bool ListHashIterator::first() [flags=CONSTANT] {
    return i->first();
 }
@@ -164,9 +164,9 @@ while (i.next()) {
         printf("END.\n");
 }
     @endcode
- */
+*/
 bool ListHashIterator::last() [flags=CONSTANT] {
-   return i->last();
+    return i->last();
 }
 
 //! returns the current row value as a hash or throws an \c INVALID-ITERATOR exception if the iterator is invalid
@@ -184,11 +184,11 @@ while (i.next()) {
 
     @throw ITERATOR-THREAD-ERROR this exception is thrown if this method is called from any thread other than the thread that created the object
     @throw INVALID-ITERATOR the iterator is not pointing at a valid element or the list being iterated does not contain a hash element at the current iterator position
- */
-hash ListHashIterator::getValue() [flags=RET_VALUE_ONLY] {
-   if (i->check(xsink))
-      return QoreValue();
-   return i->getRow(xsink);
+*/
+hash<auto> ListHashIterator::getValue() [flags=RET_VALUE_ONLY] {
+    if (i->check(xsink))
+        return QoreValue();
+    return i->getRow(xsink);
 }
 
 //! returns the current row value as a hash or throws an \c INVALID-ITERATOR exception if the iterator is invalid
@@ -205,11 +205,11 @@ while (i.next()) {
 
     @throw ITERATOR-THREAD-ERROR this exception is thrown if this method is called from any thread other than the thread that created the object
     @throw INVALID-ITERATOR the iterator is not pointing at a valid element or the list being iterated does not contain a hash element at the current iterator position
- */
-hash ListHashIterator::getRow() [flags=RET_VALUE_ONLY] {
-   if (i->check(xsink))
-      return QoreValue();
-   return i->getRow(xsink);
+*/
+hash<auto> ListHashIterator::getRow() [flags=RET_VALUE_ONLY] {
+    if (i->check(xsink))
+        return QoreValue();
+    return i->getRow(xsink);
 }
 
 //! returns the current iterator position in the list or -1 if not pointing at a valid element
@@ -221,9 +221,9 @@ while (i.next()) {
     printf("+ %d/%d: %y\n", i.index(), i.max(), i.getValue());
 }
     @endcode
- */
+*/
 int ListHashIterator::index() [flags=CONSTANT] {
-   return i->index();
+    return i->index();
 }
 
 //! returns the number of elements in the list
@@ -235,9 +235,9 @@ while (i.next()) {
     printf("+ %d/%d: %y\n", i.index(), i.max(), i.getValue());
 }
     @endcode
- */
+*/
 int ListHashIterator::max() [flags=CONSTANT] {
-   return i->max();
+    return i->max();
 }
 
 //! sets the new position in the result list; if the position is invalid then the method returns @ref False, meaning the iterator is not valid, otherwise it returns @ref True
@@ -252,11 +252,11 @@ if (!i.set(pos))
     @endcode
 
     @throw ITERATOR-THREAD-ERROR this exception is thrown if this method is called from any thread other than the thread that created the object
- */
+*/
 bool ListHashIterator::set(int pos) {
-   if (i->check(xsink))
-      return false;
-   return !i->set(pos);
+    if (i->check(xsink))
+        return false;
+    return !i->set(pos);
 }
 
 //! This method allows the iterator to be dereferenced directly as a hash for the current row being iterated, as memberGate methods are called implicitly when an unknown member is accessed from outside the class.
@@ -275,12 +275,12 @@ while (i.next()) {
     @throw INVALID-ITERATOR the iterator is not pointing at a valid element or the list being iterated does not contain a hash element at the current iterator position or the given hash key does not exist
 
     @note equivalent to ListHashIterator::getKeyValue() when called explicitly
- */
+*/
 auto ListHashIterator::memberGate(string key) [flags=RET_VALUE_ONLY] {
-   if (i->check(xsink))
-      return QoreValue();
+    if (i->check(xsink))
+        return QoreValue();
 
-   return i->getReferencedKeyValue(key->getBuffer(), xsink);
+    return i->getReferencedKeyValue(key->getBuffer(), xsink);
 }
 
 //! Returns the current value for the column given as an argument
@@ -299,12 +299,12 @@ while (i.next()) {
     @throw INVALID-ITERATOR the iterator is not pointing at a valid element or the list being iterated does not contain a hash element at the current iterator position or the given hash key does not exist
 
     @note ListHashIterator::memberGate() allows for the iterator to act as if it is a hash with members equal to the current row being iterated
- */
+*/
 auto ListHashIterator::getKeyValue(string key) [flags=RET_VALUE_ONLY] {
-   if (i->check(xsink))
-      return QoreValue();
+    if (i->check(xsink))
+        return QoreValue();
 
-   return i->getReferencedKeyValue(key->getBuffer(), xsink);
+    return i->getReferencedKeyValue(key->getBuffer(), xsink);
 }
 
 //! returns @ref Qore::True "True" if the iterator is currently pointing at a valid element, @ref Qore::False "False" if not
@@ -315,9 +315,9 @@ auto ListHashIterator::getKeyValue(string key) [flags=RET_VALUE_ONLY] {
 if (i.valid())
     printf("current value: %y\n", i.getValue());
     @endcode
- */
+*/
 bool ListHashIterator::valid() [flags=CONSTANT] {
-   return i->valid();
+    return i->valid();
 }
 
 //! Reset the iterator instance to its initial state
@@ -329,9 +329,9 @@ i.reset();
    @endcode
 
     @throw ITERATOR-THREAD-ERROR this exception is thrown if this method is called from any thread other than the thread that created the object
- */
+*/
 ListHashIterator::reset() {
-   if (i->check(xsink))
-       return QoreValue();
-   i->reset();
+    if (i->check(xsink))
+        return QoreValue();
+    i->reset();
 }

--- a/lib/QC_ListHashReverseIterator.qpp
+++ b/lib/QC_ListHashReverseIterator.qpp
@@ -54,7 +54,7 @@ public:
 
     @par Example: ListHashReverseIterator basic usage
     @code{.py}
-    list data = (
+    list<auto> data = (
              ( "column1" : 1, "column2" : "a"),
              ( "column1" : 2, "column2" : "b"),
         );

--- a/lib/QC_ObjectPairIterator.qpp
+++ b/lib/QC_ObjectPairIterator.qpp
@@ -1,31 +1,31 @@
 /* -*- mode: c++; indent-tabs-mode: nil -*- */
 /** @file QC_ObjectIterator.qpp ObjectIterator class definition */
 /*
-  Qore Programming Language
+    Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
 
-  Permission is hereby granted, free of charge, to any person obtaining a
-  copy of this software and associated documentation files (the "Software"),
-  to deal in the Software without restriction, including without limitation
-  the rights to use, copy, modify, merge, publish, distribute, sublicense,
-  and/or sell copies of the Software, and to permit persons to whom the
-  Software is furnished to do so, subject to the following conditions:
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
 
-  The above copyright notice and this permission notice shall be included in
-  all copies or substantial portions of the Software.
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
 
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-  DEALINGS IN THE SOFTWARE.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
 
-  Note that the Qore library is released under a choice of three open-source
-  licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
-  information.
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
 */
 
 #include <qore/Qore.h>
@@ -115,7 +115,7 @@ map printf("%s: %y\n", $1.key, $1.value), object.pairIterator();
 
     @since %Qore 0.8.6.2
  */
-hash ObjectPairIterator::getValue() [flags=RET_VALUE_ONLY] {
+hash<auto> ObjectPairIterator::getValue() [flags=RET_VALUE_ONLY] {
    if (i->check(xsink))
       return QoreValue();
    return i->getReferencedValuePair(xsink);

--- a/lib/QC_ObjectPairReverseIterator.qpp
+++ b/lib/QC_ObjectPairReverseIterator.qpp
@@ -1,31 +1,31 @@
 /* -*- mode: c++; indent-tabs-mode: nil -*- */
 /** @file QC_ObjectPairReverseIterator.qpp ObjectPairReverseIterator class definition */
 /*
-  Qore Programming Language
+    Qore Programming Language
 
-  Copyright (C) 2003 - 2015 David Nichols
+    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
 
-  Permission is hereby granted, free of charge, to any person obtaining a
-  copy of this software and associated documentation files (the "Software"),
-  to deal in the Software without restriction, including without limitation
-  the rights to use, copy, modify, merge, publish, distribute, sublicense,
-  and/or sell copies of the Software, and to permit persons to whom the
-  Software is furnished to do so, subject to the following conditions:
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
 
-  The above copyright notice and this permission notice shall be included in
-  all copies or substantial portions of the Software.
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
 
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-  DEALINGS IN THE SOFTWARE.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
 
-  Note that the Qore library is released under a choice of three open-source
-  licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
-  information.
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
 */
 
 #include <qore/Qore.h>
@@ -112,7 +112,7 @@ ObjectPairReverseIterator::copy() {
 
     @par Example:
     @code{.py}
-foreach hash h in (new ObjectPairReverseIterator(obj))
+foreach hash<auto> h in (new ObjectPairReverseIterator(obj))
     printf("%s: %y\n", h.key, h.value);
     @endcode
 
@@ -121,8 +121,8 @@ foreach hash h in (new ObjectPairReverseIterator(obj))
 
     @since %Qore 0.8.6.2
  */
-string ObjectPairReverseIterator::getValue() [flags=RET_VALUE_ONLY] {
-   if (i->check(xsink))
-      return QoreValue();
-   return i->getReferencedValuePair(xsink);
+hash<auto> ObjectPairReverseIterator::getValue() [flags=RET_VALUE_ONLY] {
+    if (i->check(xsink))
+        return QoreValue();
+    return i->getReferencedValuePair(xsink);
 }

--- a/lib/QC_Program.qpp
+++ b/lib/QC_Program.qpp
@@ -719,12 +719,6 @@ const PO_NO_TRANSIENT = PO_NO_TRANSIENT;
     @since %Qore 0.9
 */
 const PO_BROKEN_SPRINTF = PO_BROKEN_SPRINTF;
-
-//! Enables broken \c \b abstract method matching where types do not need to match exactly in an abstract method hierarchy
-/**
-    @since %Qore 0.9.3
-*/
-const PO_BROKEN_ABSTRACT = PO_BROKEN_ABSTRACT;
 //@}
 
 /** @defgroup warning_constants Warning Constants

--- a/lib/QC_SQLStatement.qpp
+++ b/lib/QC_SQLStatement.qpp
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -49,7 +49,7 @@ extern QoreClass* QC_ABSTRACTDATASOURCE;
     on_exit stmt.commit();
     stmt.prepare("select * from table");
     while (stmt.next()) {
-        hash row = stmt.fetchRow();
+        hash<auto> row = stmt.fetchRow();
         do_something(row);
     }
 }
@@ -215,7 +215,7 @@ nothing SQLStatement::prepareRaw(string sql) {
     @par Example:
     @code{.py}
 stmt.prepare("insert into table (id, name) values (%v, %v)");
-foreach hash h in (l) {
+foreach hash<auto> h in (l) {
     stmt.bind(h.id, h.name);
     stmt.exec();
 }
@@ -245,8 +245,8 @@ nothing SQLStatement::bind(...) {
     @par Example:
     @code{.py}
 stmt.prepare("insert into table (id, name) values (%v, %v)");
-foreach hash h in (l) {
-    list args = (h.id, h.name);
+foreach hash<auto> h in (l) {
+    list<auto> args = (h.id, h.name);
     stmt.bindArgs(args);
     stmt.exec();
 }
@@ -258,7 +258,7 @@ foreach hash h in (l) {
 
     @see SQLStatement::bind(), SQLStatement::bindPlaceholders(), SQLStatement::bindPlaceholdersArgs(), SQLStatement::bindValues(), and SQLStatement::bindValuesArgs()
  */
-nothing SQLStatement::bindArgs(softlist vargs) {
+nothing SQLStatement::bindArgs(softlist<auto> vargs) {
    stmt->bind(*vargs, xsink);
 }
 
@@ -306,7 +306,7 @@ nothing SQLStatement::bindPlaceholders(...) {
     @par Example:
     @code{.py}
 stmt.prepare("begin select sysdate into :sd from dual", Type::Date); end;
-list l = list(Type::Date);
+list<auto> l = list(Type::Date);
 stmt.bindPlaceholdersArgs(l);
 date d = stmt.getOutput().sd;
     @endcode
@@ -317,7 +317,7 @@ date d = stmt.getOutput().sd;
 
     @see SQLStatement::bind(), SQLStatement::bindArgs(), SQLStatement::bindPlaceholders(), SQLStatement::bindValues(), and SQLStatement::bindValuesArgs()
  */
-nothing SQLStatement::bindPlaceholdersArgs(softlist vargs) {
+nothing SQLStatement::bindPlaceholdersArgs(softlist<auto> vargs) {
    stmt->bindPlaceholders(*vargs, xsink);
 }
 
@@ -335,7 +335,7 @@ nothing SQLStatement::bindPlaceholdersArgs(softlist vargs) {
     @par Example:
     @code{.py}
 stmt.prepare("insert into table (id, name) values (%v, %v)");
-foreach hash h in (l) {
+foreach hash<auto> h in (l) {
     stmt.bindValues(h.id, h.name);
     stmt.exec();
 }
@@ -365,8 +365,8 @@ nothing SQLStatement::bindValues(...) {
     @par Example:
     @code{.py}
 stmt.prepare("insert into table (id, name) values (%v, %v)");
-foreach hash h in (l) {
-    list args = (h.id, h.name);
+foreach hash<auto> h in (l) {
+    list<auto> args = (h.id, h.name);
     stmt.bindValuesArgs(args);
     stmt.exec();
 }
@@ -376,7 +376,7 @@ foreach hash h in (l) {
 
     @note Exceptions could be thrown by the DBI driver when the statement is prepared or when attempting to bind the given arguments to buffer specifications; see the relevant DBI driver docs for more information
  */
-nothing SQLStatement::bindValuesArgs(softlist vargs) {
+nothing SQLStatement::bindValuesArgs(softlist<auto> vargs) {
    stmt->bindValues(*vargs, xsink);
 }
 
@@ -396,7 +396,7 @@ nothing SQLStatement::bindValuesArgs(softlist vargs) {
     @par Example:
     @code{.py}
 stmt.prepare("insert into table (id, name) values (%v, %v)");
-foreach hash h in (l) {
+foreach hash<auto> h in (l) {
     stmt.exec(h.id, h.name);
 }
     @endcode
@@ -427,8 +427,8 @@ nothing SQLStatement::exec(...) {
     @par Example:
     @code{.py}
 stmt.prepare("insert into table (id, name) values (%v, %v)");
-foreach hash h in (l) {
-    list args = (h.id, h.name);
+foreach hash<auto> h in (l) {
+    list<auto> args = (h.id, h.name);
     stmt.execArgs(args);
 }
     @endcode
@@ -439,7 +439,7 @@ foreach hash h in (l) {
 
     @see SQLStatement::exec()
  */
-nothing SQLStatement::execArgs(softlist vargs) {
+nothing SQLStatement::execArgs(softlist<auto> vargs) {
    stmt->exec(vargs, xsink);
 }
 
@@ -464,14 +464,14 @@ int SQLStatement::affectedRows() {
 
     @par Example:
     @code{.py}
-hash h = stmt.getOutput();
+hash<auto> h = stmt.getOutput();
     @endcode
 
     @throw SQLSTATEMENT-ERROR No %SQL has been set with SQLStatement::prepare() or SQLStatement::prepareRaw()
 
     @note Exceptions could be thrown by the DBI driver when the statement is prepared or when attempting to bind the given arguments to buffer specifications or when the statement is executed or when output values are retrieved; see the relevant DBI driver docs for more information
  */
-hash SQLStatement::getOutput() {
+hash<auto> SQLStatement::getOutput() {
    return stmt->getOutput(xsink);
 }
 
@@ -480,14 +480,14 @@ hash SQLStatement::getOutput() {
 
     @par Example:
     @code{.py}
-hash h = stmt.getOutputRows();
+hash<auto> h = stmt.getOutputRows();
     @endcode
 
     @throw SQLSTATEMENT-ERROR No %SQL has been set with SQLStatement::prepare() or SQLStatement::prepareRaw()
 
     @note Exceptions could be thrown by the DBI driver when the statement is prepared or when attempting to bind the given arguments to buffer specifications or when the statement is executed or when output values are retrieved; see the relevant DBI driver docs for more information
  */
-hash SQLStatement::getOutputRows() {
+hash<auto> SQLStatement::getOutputRows() {
    return stmt->getOutputRows(xsink);
 }
 
@@ -505,7 +505,7 @@ hash SQLStatement::getOutputRows() {
     stmt.define();
     # note that the SQLStatement::next() would implicitly execute exec() and define()
     while (stmt.next()) {
-        hash row = stmt.fetchRow();
+        hash<auto> row = stmt.fetchRow();
         do_something(row);
     }
 }
@@ -571,7 +571,7 @@ nothing SQLStatement::beginTransaction() {
     @par Example:
     @code{.py}
 while (stmt.next()) {
-    hash h = stmt.fetchRow();
+    hash<auto> h = stmt.fetchRow();
 }
     @endcode
 
@@ -604,7 +604,7 @@ bool SQLStatement::valid() [flags=CONSTANT] {
     @par Example:
     @code{.py}
 while (stmt.next()) {
-    hash h = stmt.fetchRow();
+    hash<auto> h = stmt.fetchRow();
 }
     @endcode
 
@@ -612,7 +612,7 @@ while (stmt.next()) {
 
     @note Exceptions could be thrown by the DBI driver when the statement is prepared or when attempting to bind the given arguments to buffer specifications or when the statement is executed or when row values are retrieved; see the relevant DBI driver docs for more information
  */
-*hash SQLStatement::fetchRow() {
+*hash<auto> SQLStatement::fetchRow() {
    return stmt->fetchRow(xsink);
 }
 
@@ -624,7 +624,7 @@ while (stmt.next()) {
     @par Example:
     @code{.py}
 while (stmt.next()) {
-    hash h = stmt.getValue();
+    hash<auto> h = stmt.getValue();
 }
     @endcode
 
@@ -636,7 +636,7 @@ while (stmt.next()) {
 
     @since %Qore 0.8.5
  */
-*hash SQLStatement::getValue() {
+*hash<auto> SQLStatement::getValue() {
    return stmt->fetchRow(xsink);
 }
 
@@ -649,7 +649,7 @@ while (stmt.next()) {
 
     @par Example:
     @code{.py}
-list l = stmt.fetchRows(-1);
+list<auto> l = stmt.fetchRows(-1);
     @endcode
 
     @throw SQLSTATEMENT-ERROR No %SQL has been set with SQLStatement::prepare() or SQLStatement::prepareRaw()
@@ -658,7 +658,7 @@ list l = stmt.fetchRows(-1);
     - There is no need to call SQLStatement::next() when calling this method; the method automatically iterates through the given number of rows
     - Exceptions could be thrown by the DBI driver when the statement is prepared or when attempting to bind the given arguments to buffer specifications or when the statement is executed or when row values are retrieved; see the relevant DBI driver docs for more information
  */
-list SQLStatement::fetchRows(softint rows = -1) {
+list<auto> SQLStatement::fetchRows(softint rows = -1) {
    return stmt->fetchRows((int)rows, xsink);
 }
 
@@ -671,7 +671,7 @@ list SQLStatement::fetchRows(softint rows = -1) {
 
     @par Example:
     @code{.py}
-hash h = stmt.fetchColumns(-1);
+hash<auto> h = stmt.fetchColumns(-1);
     @endcode
 
     @throw SQLSTATEMENT-ERROR No %SQL has been set with SQLStatement::prepare() or SQLStatement::prepareRaw()
@@ -680,7 +680,7 @@ hash h = stmt.fetchColumns(-1);
     - There is no need to call SQLStatement::next() when calling this method; the method automatically iterates through the given number of rows
     - Exceptions could be thrown by the DBI driver when the statement is prepared or when attempting to bind the given arguments to buffer specifications or when the statement is executed or when row values are retrieved; see the relevant DBI driver docs for more information
  */
-hash SQLStatement::fetchColumns(softint rows = -1) {
+hash<auto> SQLStatement::fetchColumns(softint rows = -1) {
    return stmt->fetchColumns((int)rows, xsink);
 }
 
@@ -693,7 +693,7 @@ hash SQLStatement::fetchColumns(softint rows = -1) {
     - \c "native_type": (string) the database-specific name of the type
     - \c "internal_id": (integer) the database-specific type code of the type
  */
-hash SQLStatement::describe() {
+hash<auto> SQLStatement::describe() {
     return stmt->describe(xsink);
 }
 

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -271,7 +271,7 @@ void AbstractMethod::add(MethodVariantBase* v) {
 }
 
 void AbstractMethod::override(MethodVariantBase* v) {
-    // see if there is already an committed variant matching this signature
+    // see if there is already a committed variant matching this signature
     // in this case it must be inherited
     const char* sig = v->getAbstractSignature();
     vmap_t::iterator vi = vlist.find(sig);

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -285,11 +285,13 @@ void AbstractMethod::checkAbstract(const char* cname, const char* mname, vmap_t&
     //printd(5, "AbstractMethod::checkAbstract() checking %s::%s() vlist: %d\n", cname, mname, !vlist.empty());
     if (!vlist.empty()) {
         if (!desc) {
-            desc = new QoreStringNodeMaker("class '%s' cannot be instantiated because it has the following unimplemented abstract variants:", cname);
+            desc = new QoreStringNodeMaker("class '%s' cannot be instantiated because it has the following " \
+                "unimplemented abstract variants:", cname);
         }
         for (auto& vi : vlist) {
             MethodVariantBase* v = vi.second;
-            desc->sprintf("\n * abstract %s %s::%s(%s);", QoreTypeInfo::getName(v->getReturnTypeInfo()), cname, mname, v->getSignature()->getSignatureText());
+            desc->sprintf("\n * abstract %s %s::%s(%s);", QoreTypeInfo::getName(v->getReturnTypeInfo()), cname, mname,
+                v->getSignature()->getSignatureText());
         }
     }
 }

--- a/lib/QoreListNode.cpp
+++ b/lib/QoreListNode.cpp
@@ -3,7 +3,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),

--- a/lib/QoreTypeInfo.cpp
+++ b/lib/QoreTypeInfo.cpp
@@ -707,8 +707,10 @@ qore_type_result_e QoreTypeSpec::match(const QoreTypeSpec& t, bool& may_not_matc
                     //printd(5, "pcr: '%s' '%s' eq: %d ss: %d\n", QoreTypeInfo::getName(t.u.ti), QoreTypeInfo::getName(u.ti), QoreTypeInfo::equal(u.ti, t.u.ti), QoreTypeInfo::outputSuperSetOf(t.u.ti, u.ti));
                     // the passed argument's type must be a superset or equal to the reference type's subtype
                     // that is; if the types are different, the reference type's subtype must be more restrictive than the passed type's
-                    if (QoreTypeInfo::equal(t.u.ti, u.ti))
-                        return QTI_IDENT;
+                    qore_type_result_e ref_res = QoreTypeInfo::runtimeTypeMatch(t.u.ti, u.ti);
+                    if (ref_res != QTI_NOT_EQUAL) {
+                        return ref_res;
+                    }
                     return QoreTypeInfo::outputSuperSetOf(t.u.ti, u.ti) ? QTI_AMBIGUOUS : QTI_NOT_EQUAL;
                 }
                 case QTS_TYPE:

--- a/lib/QoreValue.cpp
+++ b/lib/QoreValue.cpp
@@ -608,7 +608,6 @@ int ValueEvalRefHolder::evalIntern(const AbstractQoreNode* exp) {
 
     needs_deref = true;
     v = exp->eval(needs_deref, xsink);
-
     return xsink && *xsink ? -1 : 0;
 }
 

--- a/lib/SelfVarrefNode.cpp
+++ b/lib/SelfVarrefNode.cpp
@@ -54,7 +54,11 @@ const char *SelfVarrefNode::getTypeName() const {
 
 QoreValue SelfVarrefNode::evalImpl(bool &needs_deref, ExceptionSink *xsink) const {
     assert(runtime_get_stack_object());
-    return runtime_get_stack_object()->getReferencedMemberNoMethod(str, xsink);
+    assert(needs_deref);
+    // issue 3523: evaluate in case the value is a reference
+    ValueHolder val(runtime_get_stack_object()->getReferencedMemberNoMethod(str, xsink), xsink);
+    // the value here must always require a dereference
+    return val->needsEval() ? val->eval(xsink) : val.release();
 }
 
 char* SelfVarrefNode::takeString() {

--- a/lib/StaticClassVarRefNode.cpp
+++ b/lib/StaticClassVarRefNode.cpp
@@ -3,7 +3,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -57,7 +57,11 @@ const char *StaticClassVarRefNode::getTypeName() const {
 
 // evalImpl(): return value requires a deref(xsink) if not 0
 QoreValue StaticClassVarRefNode::evalImpl(bool &needs_deref, ExceptionSink *xsink) const {
-    return vi.getReferencedValue();
+    assert(needs_deref);
+    // issue 3523: evaluate in case the value is a reference
+    ValueHolder val(vi.getReferencedValue(), xsink);
+    // the value here must always require a dereference
+    return val->needsEval() ? val->eval(xsink) : val.release();
 }
 
 void StaticClassVarRefNode::parseInitImpl(QoreValue& val, LocalVar *oflag, int pflag, int &lvids, const QoreTypeInfo *&typeInfo) {

--- a/lib/VarRefNode.cpp
+++ b/lib/VarRefNode.cpp
@@ -106,41 +106,38 @@ void VarRefNode::resolve(const QoreTypeInfo* typeInfo) {
 }
 
 QoreValue VarRefNode::evalImpl(bool& needs_deref, ExceptionSink* xsink) const {
-   QoreValue v;
-   if (type == VT_LOCAL) {
-      v = ref.id->eval(needs_deref, xsink);
-      printd(5, "VarRefNode::evalImpl() this: %p lvar %p (%s) v: '%s'\n", this, ref.id, ref.id->getName(), v.getTypeName());
-   }
-   else if (type == VT_CLOSURE) {
-      printd(5, "VarRefNode::evalImpl() this: %p closure var %p (%s)\n", this, ref.id, ref.id->getName());
-      ClosureVarValue *val = thread_get_runtime_closure_var(ref.id);
-      v = val->eval(needs_deref, xsink);
-   }
-   else if (type == VT_LOCAL_TS) {
-      printd(5, "VarRefNode::evalImpl() this: %p local thread-safe var %p (%s)\n", this, ref.id, ref.id->getName());
-      ClosureVarValue *val = thread_find_closure_var(ref.id->getName());
-      v = val->eval(needs_deref, xsink);
-   }
-   else if (type == VT_IMMEDIATE)
-      v = ref.cvv->eval(needs_deref, xsink);
-   else {
-      assert(needs_deref);
-      printd(5, "VarRefNode::evalImpl() this: %p global var: %p (%s)\n", this, ref.var, ref.var->getName());
-      v = ref.var->eval();
-   }
+    QoreValue v;
+    if (type == VT_LOCAL) {
+        v = ref.id->eval(needs_deref, xsink);
+        printd(5, "VarRefNode::evalImpl() this: %p lvar %p (%s) v: '%s'\n", this, ref.id, ref.id->getName(), v.getTypeName());
+    } else if (type == VT_CLOSURE) {
+        printd(5, "VarRefNode::evalImpl() this: %p closure var %p (%s)\n", this, ref.id, ref.id->getName());
+        ClosureVarValue *val = thread_get_runtime_closure_var(ref.id);
+        v = val->eval(needs_deref, xsink);
+    } else if (type == VT_LOCAL_TS) {
+        printd(5, "VarRefNode::evalImpl() this: %p local thread-safe var %p (%s)\n", this, ref.id, ref.id->getName());
+        ClosureVarValue *val = thread_find_closure_var(ref.id->getName());
+        v = val->eval(needs_deref, xsink);
+    } else if (type == VT_IMMEDIATE)
+        v = ref.cvv->eval(needs_deref, xsink);
+    else {
+        assert(needs_deref);
+        printd(5, "VarRefNode::evalImpl() this: %p global var: %p (%s)\n", this, ref.var, ref.var->getName());
+        v = ref.var->eval();
+    }
 
-   AbstractQoreNode* n = v.getInternalNode();
-   if (n && n->getType() == NT_REFERENCE) {
-      ReferenceNode* r = reinterpret_cast<ReferenceNode*>(n);
-      bool nd;
-      QoreValue nv = r->eval(nd, xsink);
-      if (needs_deref)
-         discard(v.getInternalNode(), xsink);
-      needs_deref = nd;
-      return v = nv;
-   }
+    AbstractQoreNode* n = v.getInternalNode();
+    if (n && n->getType() == NT_REFERENCE) {
+        ReferenceNode* r = reinterpret_cast<ReferenceNode*>(n);
+        bool nd = true;
+        QoreValue nv = r->eval(nd, xsink);
+        if (needs_deref)
+            discard(v.getInternalNode(), xsink);
+        needs_deref = nd;
+        return v = nv;
+    }
 
-   return v;
+    return v;
 }
 
 void VarRefNode::parseInitIntern(LocalVar *oflag, int pflag, int &lvids, const QoreTypeInfo *typeInfo, bool is_new) {
@@ -209,42 +206,42 @@ void VarRefNode::makeGlobal() {
 }
 
 int VarRefNode::getLValue(LValueHelper& lvh, bool for_remove) const {
-   if (type == VT_LOCAL)
-      return ref.id->getLValue(lvh, for_remove, new_decl);
-   if (type == VT_CLOSURE)
-      return thread_get_runtime_closure_var(ref.id)->getLValue(lvh, for_remove);
-   if (type == VT_LOCAL_TS)
-      return thread_find_closure_var(ref.id->getName())->getLValue(lvh, for_remove);
-   if (type == VT_IMMEDIATE)
-      return ref.cvv->getLValue(lvh, for_remove);
-   assert(type == VT_GLOBAL);
-   return ref.var->getLValue(lvh, for_remove);
+    if (type == VT_LOCAL)
+        return ref.id->getLValue(lvh, for_remove, new_decl);
+    if (type == VT_CLOSURE)
+        return thread_get_runtime_closure_var(ref.id)->getLValue(lvh, for_remove);
+    if (type == VT_LOCAL_TS)
+        return thread_find_closure_var(ref.id->getName())->getLValue(lvh, for_remove);
+    if (type == VT_IMMEDIATE)
+        return ref.cvv->getLValue(lvh, for_remove);
+    assert(type == VT_GLOBAL);
+    return ref.var->getLValue(lvh, for_remove);
 }
 
 void VarRefNode::remove(LValueRemoveHelper& lvrh) {
-   if (type == VT_LOCAL)
-      return ref.id->remove(lvrh);
-   if (type == VT_CLOSURE)
-      return thread_get_runtime_closure_var(ref.id)->remove(lvrh);
-   if (type == VT_LOCAL_TS)
-      return thread_find_closure_var(ref.id->getName())->remove(lvrh);
-   if (type == VT_IMMEDIATE)
-      return ref.cvv->remove(lvrh);
-   assert(type == VT_GLOBAL);
-   return ref.var->remove(lvrh);
+    if (type == VT_LOCAL)
+        return ref.id->remove(lvrh);
+    if (type == VT_CLOSURE)
+        return thread_get_runtime_closure_var(ref.id)->remove(lvrh);
+    if (type == VT_LOCAL_TS)
+        return thread_find_closure_var(ref.id->getName())->remove(lvrh);
+    if (type == VT_IMMEDIATE)
+        return ref.cvv->remove(lvrh);
+    assert(type == VT_GLOBAL);
+    return ref.var->remove(lvrh);
 }
 
 bool VarRefNode::scanMembers(RSetHelper& rsh) {
-   if (type == VT_CLOSURE)
-      return rsh.checkNode(*thread_get_runtime_closure_var(ref.id));
-   if (type == VT_LOCAL_TS)
-      return rsh.checkNode(*thread_find_closure_var(ref.id->getName()));
-   if (type == VT_IMMEDIATE)
-      return rsh.checkNode(*ref.cvv);
-   // never called with type == VT_LOCAL
-   // we don't scan global vars; they are deleted explicitly when the program goes out of scope
-   assert(type == VT_GLOBAL);
-   return false;
+    if (type == VT_CLOSURE)
+        return rsh.checkNode(*thread_get_runtime_closure_var(ref.id));
+    if (type == VT_LOCAL_TS)
+        return rsh.checkNode(*thread_find_closure_var(ref.id->getName()));
+    if (type == VT_IMMEDIATE)
+        return rsh.checkNode(*ref.cvv);
+    // never called with type == VT_LOCAL
+    // we don't scan global vars; they are deleted explicitly when the program goes out of scope
+    assert(type == VT_GLOBAL);
+    return false;
 }
 
 GlobalVarRefNode::GlobalVarRefNode(const QoreProgramLocation* loc, char *n, const QoreTypeInfo* typeInfo) : VarRefNode(loc, n, 0, false, true) {

--- a/lib/scanner.lpp
+++ b/lib/scanner.lpp
@@ -786,8 +786,6 @@ RTIME           PT(-?[0-9]+(\.[0-9]+)?[HMSu])+
 ^%correct-references{WS}*$              parse_disable_parse_options(yylloc, PO_BROKEN_REFERENCES);
 ^%broken-sprintf{WS}*$                  parse_set_parse_options(yylloc, PO_BROKEN_SPRINTF);
 ^%correct-sprintf{WS}*$                 parse_disable_parse_options(yylloc, PO_BROKEN_SPRINTF);
-^%broken-abstract{WS}*$                 parse_set_parse_options(yylloc, PO_BROKEN_ABSTRACT);
-^%correct-abstract{WS}*$                parse_disable_parse_options(yylloc, PO_BROKEN_ABSTRACT);
 ^%allow-statement-no-effect{WS}*$       parse_set_parse_options(yylloc, PO_ALLOW_STATEMENT_NO_EFFECT);
 ^%no-reflection{WS}*$                   parse_set_parse_options(yylloc, PO_NO_REFLECTION);
 ^%no-transient{WS}*$                    parse_set_parse_options(yylloc, PO_NO_TRANSIENT);

--- a/qlib/AwsRestClient.qm
+++ b/qlib/AwsRestClient.qm
@@ -62,8 +62,10 @@ module AwsRestClient {
     All the public symbols in the module are defined in the AwsRestClient namespace.
 
     The main classes are:
-    - @ref AwsRestClient::AwsRestClient "AwsRestClient": this class provides the REST client API for communuication with <a href="http://www.Aws.net">Aws.net</a>'s RTLS Studio REST API; it also automates authentication and authorization to the target Connected App
-    - @ref AwsRestClient::AwsRestConnection "AwsRestConnection": provides a REST connection object to a <a href="http://www.Aws.net">Aws.net</a>'s RTLS Studio server (based on the @ref connectionproviderintro "ConnectionProvider" module)
+    - @ref AwsRestClient::AwsRestClient "AwsRestClient": this class provides the REST client API for communuication
+      with the AWS REST API; it also automates authentication and authorization
+    - @ref AwsRestClient::AwsRestConnection "AwsRestConnection": provides a REST connection object to a the AWS server
+      (based on the @ref connectionproviderintro "ConnectionProvider" module)
 
     @par Example:
     @code{.py}
@@ -140,7 +142,7 @@ public namespace AwsRestClient {
             string credential_scope_suffix;
         }
 
-        #! creates the object with the given options (which include the mandatory \c apikey option for <a href="http://www.Aws.net">Aws.net</a>'s RTLS Studio server authentication)
+        #! creates the object with the given options
         /**
             @par Example:
             @code{.py}
@@ -391,7 +393,8 @@ AwsRestClient rest({
     /** supports the following options:
         - \c "aws_keyid": (required) AWS key ID
         - \c "aws_region": (required) the AWS region to use (ex: \c "us-east-1")
-        - \c "aws_s3": (optional) set to True to flag this object for use with AWS S3, which requires special message encoding
+        - \c "aws_s3": (optional) set to True to flag this object for use with AWS S3, which requires special message
+          encoding
         - \c "aws_secret": (required) the AWS secret access key value
         - \c "aws_service": (required) the AWS service to use (ex: \c "iam")
         - \c "aws_token": (optional) a temporary session token from AWS Security Token Service for this HTTP session
@@ -468,12 +471,12 @@ AwsRestClient rest({
 
         private:internal constructorInit() {
             if (!opts.aws_keyid.val()) {
-                throw "AWSRESTCONNECTION-ERROR", sprintf("missing 'aws_keyid' option for connection %y with url %y (%s)",
-                    name, url, desc);
+                throw "AWSRESTCONNECTION-ERROR", sprintf("missing 'aws_keyid' option for connection %y with url "
+                    "%y (%s)", name, url, desc);
             }
             if (!opts.aws_secret.val()) {
-                throw "AWSRESTCONNECTION-ERROR", sprintf("missing 'aws_secret' option for connection %y with url %y (%s)",
-                    name, url, desc);
+                throw "AWSRESTCONNECTION-ERROR", sprintf("missing 'aws_secret' option for connection %y with url "
+                    "%y (%s)", name, url, desc);
             }
             real_opts = {"url": real_url} + urlh.("username", "password") + self.opts;
         }
@@ -502,24 +505,30 @@ AwsRestClient rest({
 
         #! gets options
         /** @return returns a hash with the following supported options:
-            - \c "apikey": the <a href="http://www.Aws.net">Aws.net</a>'s RTLS Studio API key in use
+            - \c "aws_keyid": (required) AWS key ID
+            - \c "aws_region": (required) the AWS region to use (ex: \c "us-east-1")
+            - \c "aws_s3": (optional) set to True to flag this object for use with AWS S3, which requires special
+              message encoding
+            - \c "aws_secret": (required) the AWS secret access key value
+            - \c "aws_service": (required) the AWS service to use (ex: \c "iam")
+            - \c "aws_token": (optional) a temporary session token from AWS Security Token Service for this HTTP
+              session
             - \c "connect_timeout": connection timeout to use in milliseconds
             - \c "content_encoding": this sets the send encoding (if the \c "send_encoding" option is not set) and the
               requested response encoding; for possible values, see
               @ref RestClient::RestClient::EncodingSupport "EncodingSupport"
-            - \c "data": see @ref RestClient::RestClient::DataSerializationOptions for possible values; the default is
-              \c "json"
-            - \c "error_passthru": if @ref Qore::True "True" then HTTP status codes indicating errors will not cause an
-              \c REST-RESPONSE-ERROR exception to be raised, rather such responses will be passed through to the caller
-              like any other response
+            - \c "error_passthru": if @ref Qore::True "True" then HTTP status codes indicating errors will not cause
+              an \c REST-RESPONSE-ERROR exception to be raised, rather such responses will be passed through to the
+              caller like any other response
             - \c "http_version": HTTP version to use (\c "1.0" or \c "1.1", defaults to \c "1.1")
             - \c "max_redirects": maximum redirects to support
             - \c "proxy": proxy URL to use
             - \c "redirect_passthru": if @ref Qore::True "True" then redirect responses will be passed to the called
               instead of processed
             - \c "send_encoding": a @ref RestClient::RestClient::EncodingSupport "send data encoding option" or the
-              value \c "auto" which means to use automatic encoding; if not present defaults to no content-encoding on
-              sent message bodies
+              value
+              \c "auto" which means to use automatic encoding; if not present defaults to no content-encoding on sent
+              message bodies
             - \c "timeout": transfer timeout to use in milliseconds
 
             @see @ref AwsRestClient::AwsRestClient::constructor() "AwsRestClient::constructor()" for more information

--- a/qlib/Mapper.qm
+++ b/qlib/Mapper.qm
@@ -270,6 +270,32 @@ m.mapData(input1);           # output record hash date_begin = start_date = time
 
 #! the Mapper namespace contains all the definitions in the Mapper module
 public namespace Mapper {
+    #! describes a runtime type
+    public hashdecl MapperRuntimeKeyInfo {
+        #! the type of value that must be assigned to this key
+        string value_type = "string";
+
+        #! hash of conflicting keys, if any
+        *hash<string, bool> conflicting_keys;
+
+        #! if the key requires in input field for the mapping
+        bool requires_input = False;
+
+        #! the code to handle the key at runtime
+        /** the signature of this closure or call reference depends on \a requires_input:
+            - \a requires_input == True: <tt>auto sub (auto arg, auto val) {}</tt>
+              - parameters:
+                - \c arg: the argument to the runtime key in the mapping
+                - \c val: the current value of the mapping, if any
+            - \a requires_input == False: <tt>auto sub (auto arg) {}</tt>
+              - parameters:
+                - \c arg: the argument to the runtime key in the mapping
+
+            In both cases the return value is the value to use for the field
+        */
+        code handler;
+    }
+
     #! this class is a base class for mapping data; see @ref mapperexamples for usage examples
     public class Mapper {
         public {
@@ -290,6 +316,7 @@ public namespace Mapper {
                 "number_format": "the default number format when parsing number fields from strings; ex: \".,\"",
                 "output": "a hash describing the output record",
                 "output_log": "a call reference / closure for input record logging",
+                "runtime_keys": "field key support provided as a Mapper option; format: hash<string, hash<MapperRuntimeKeyInfo>>",
                 "timezone": "the default output timezone for date/time values",
                 "runtime": "runtime options as a hash (see also setRuntime(), replaceRuntime())",
                 "empty_strings_to_nothing": "converts out record's empty strings and into NOTHING - actually the value is deleted",
@@ -413,6 +440,18 @@ public namespace Mapper {
 
             #! map of constant runtime fields
             hash<auto> rconsth;
+
+            #! map of field keys provided by the "runtime_keys" option
+            hash<string, hash<MapperRuntimeKeyInfo>> runtime_keys;
+
+            #! hash of runtime keys that provide independent mappings (where their "requires_input" values are False)
+            hash<string, hash<MapperRuntimeKeyInfo>> runtime_independent_keys;
+
+            #! hash of valid keys
+            hash<string, bool> valid_keys;
+
+            #! hash of valid types
+            hash<string, bool> valid_types;
         }
 
         #! builds the object based on a hash providing field mappings, data constraints, and optionally custom mapping logic
@@ -497,10 +536,15 @@ Mapper mapv(DataMap);
                 error("empty map passed to %s::constructor()", self.className());
 
             mapc = mapv;
-            hash<auto> ck = optionKeys();
-            foreach string k in (keys opts) {
-                if (!ck{k})
-                    error("unknown option key %y passed to %s::constructor(); recognized option keys: %y", getFieldName(k), self.className(), ck.keys());
+            {
+                # check for invalid option keys
+                list<string> all_keys = keys optionKeys();
+                *hash<auto> invalid_option_keys = opts - all_keys;
+                if (invalid_option_keys) {
+                    error("unknown option key%s %y passed to %s::constructor(); recognized option keys: %y",
+                        invalid_option_keys.size() == 1 ? "" : "s", keys invalid_option_keys, self.className(),
+                        all_keys);
+                }
             }
 
             if (opts.encoding)
@@ -526,7 +570,7 @@ Mapper mapv(DataMap);
             # runtime options
             if (opts.runtime) {
                 if (opts.runtime.typeCode() != NT_HASH) {
-                    error("input key 'runtime' passed to %s::constructor() assigned to type %y (value %y); expecting \"hash\"",
+                    error("option 'runtime' passed to %s::constructor() assigned to type %y (value %y); expecting \"hash\"",
                           self.className(), opts.runtime.type(), opts.runtime);
                 }
                 # the "{} + " construction is there to make sure m_runtime has type hash<auto>
@@ -536,6 +580,44 @@ Mapper mapv(DataMap);
             if (opts.empty_strings_to_nothing) {
                 m_empty_strings_to_nothing = parse_boolean(opts.empty_strings_to_nothing);
             }
+
+            # validate and set runtime types
+            if (opts.runtime_keys) {
+                if (opts.runtime_keys.typeCode() != NT_HASH) {
+                    error("option 'runtime_keys' passed to %s::constructor() assigned to type %y (value %y); "
+                        "expecting \"hash<string, hash<MapperRuntimeKeyInfo>>\"", self.className(),
+                        opts.runtime.type(), opts.runtime);
+                }
+                foreach hash<auto> i in (opts.runtime_keys.pairIterator()) {
+                    if (i.value.fullType() != "hash<MapperRuntimeKeyInfo>") {
+                        # try to cast for older code
+                        bool ok;
+                        if (i.value.typeCode() == NT_HASH) {
+                            try {
+                                if (i.value = cast<hash<MapperRuntimeKeyInfo>>(i.value)) {
+                                    ok = True;
+                                }
+                            } catch (hash<ExceptionInfo> ex) {
+                            }
+                        }
+
+                        if (!ok) {
+                            error("option 'runtime_keys' key %y passed to %s::constructor() has type %y; expecting "
+                                "\"hash<MapperRuntimeKeyInfo>\"", i.key, self.className(), i.value.fullType());
+                        }
+                    }
+                    runtime_keys{i.key} = i.value;
+                    if (!i.value.requires_input) {
+                        runtime_independent_keys{i.key} = i.value;
+                    }
+                }
+            }
+
+            # set valid keys
+            valid_keys = validKeys();
+
+            # set valid types
+            valid_types = validTypes();
         }
 
         #! verifies the input map in the constructor
@@ -626,7 +708,7 @@ Mapper mapv(DataMap);
             } else if (fh.runtime) {
                 if (!m_runtime.hasKey(fh.runtime))
                     error("output field %y requires unregistered runtime key %y", getFieldName(k), fh.runtime);
-            } else if (!fh.struct && input && !exists fh.constant && !fh.code && !exists fh.index)
+            } else if (!fh.struct && input && !exists fh.constant && !fh.code && !exists fh.index && !runtime_independent_keys{keys fh})
                 checkInputField(k, k);
             if (exists fh.constant && exists fh.index) {
                 error("output field %y has both 'constant' and 'index' which is not valid", getFieldName(k));
@@ -694,11 +776,42 @@ Mapper mapv(DataMap);
             if (fh.maxlen && !exists fh.trunc && trunc_all)
                 fh.trunc = True;
 
-            hash<auto> vk = validKeys();
-            hash<auto> vt = validTypes();
+            # check valid keys
+            {
+                hash<string, bool> all_valid_keys = valid_keys;
+                if (runtime_keys) {
+                    map all_valid_keys{$1} = True, keys runtime_keys;
+                }
+                *hash<auto> invalid_keys = fh - (keys all_valid_keys);
+                if (invalid_keys) {
+                    error("output field %y in map hash contains unknown key%s %y (valid keys: %y)",
+                        getFieldName(k), invalid_keys.size() == 1 ? "" : "s", keys invalid_keys, keys all_valid_keys);
+                }
+            }
 
-            map error("output field %y in map hash contains unknown key '%s' (valid keys: %y)",
-                getFieldName(k), $1, keys vk), keys fh, !vk{$1};
+            # check runtime keys
+            foreach hash<auto> i in (runtime_keys{keys fh}.pairIterator()) {
+                # check for conflicts
+                if (*hash<auto> conflicts = fh{keys i.value.conflicting_keys}) {
+                    error("output field %y contains key %y which conflicts with the following keys: %y",
+                        getFieldName(k), i.key, keys conflicts);
+                }
+
+                # check type
+                if (i.value.value_type != "any") {
+                    string type = i.value.value_type;
+                    if (i.value.value_type[0] == "*") {
+                        if (!exists fh{i.key}) {
+                            continue;
+                        }
+                        type = type[1..];
+                    }
+                    if (type != fh{i.key}.type()) {
+                        error("output field %y key %y has value %y with type %y which is not compatible with the "
+                            "expected type %y", getFieldName(k), i.key, fh{i.key}, fh{i.key}.type(), i.value.value_type);
+                    }
+                }
+            }
 
             # convert old "number" tag to new "type" tag
             if (fh.number) {
@@ -707,8 +820,8 @@ Mapper mapv(DataMap);
                 fh.type = "number";
                 delete fh.number;
             } else if (exists fh.type) {
-                if (!vt.(fh.type))
-                    error("output field %y contains an invalid type value '%s' (valid types: %y)", getFieldName(k), fh.type, vt.keys());
+                if (!valid_types.(fh.type))
+                    error("output field %y contains an invalid type value '%s' (valid types: %y)", getFieldName(k), fh.type, valid_types.keys());
                 switch (fh.type) {
                     case "date": {
                         if (!timezone)
@@ -884,14 +997,14 @@ Mapper mapv(DataMap);
         #! returns a list of valid field keys for this class (can be overridden in subclasses)
         /** @return a list of valid field keys for this class (can be overridden in subclasses)
         */
-        hash<auto> validKeys() {
+        hash<string, bool> validKeys() {
             return ValidKeys;
         }
 
         #! returns a list of valid field types for this class (can be overridden in subclasses)
         /** @return a list of valid types for this class (can be overridden in subclasses)
         */
-        hash<auto> validTypes() {
+        hash<string, bool> validTypes() {
             return ValidTypes;
         }
 
@@ -922,7 +1035,7 @@ Mapper mapv(DataMap);
             @throw STRING-TOO-LONG a field value exceeds the maximum value and the 'trunc' key is not set
             @throw INVALID-NUMBER the field is marked as numeric but the input value contains non-numeric data
         */
-        list<hash> mapAll(list recs) {
+        list<hash> mapAll(list<auto> recs) {
             return map mapData($1), recs;
         }
 
@@ -936,7 +1049,7 @@ Mapper mapv(DataMap);
             @throw STRING-TOO-LONG a field value exceeds the maximum value and the 'trunc' key is not set
             @throw INVALID-NUMBER the field is marked as numeric but the input value contains non-numeric data
         */
-        list<hash> mapAll(hash recs) {
+        list<hash> mapAll(hash<auto> recs) {
             return map mapData($1), recs.contextIterator();
         }
 
@@ -1081,6 +1194,14 @@ Mapper mapv(DataMap);
             # if the internal field was marked as needing processing by a subclass, then call the mapSubclass method
             if (m.subclass)
                 v = v_is_list ? (map mapSubclass(m, $1), v) : mapSubclass(m, v);
+
+            # process any runtime keys if present in the current field mapping
+            if (*hash<string, hash<MapperRuntimeKeyInfo>> current_runtime_keys = runtime_keys{keys m}) {
+                map v = $1.value.requires_input
+                    ? $1.value.handler(m{$1.key}, v)
+                    : $1.value.handler(m{$1.key}),
+                    current_runtime_keys.pairIterator();
+            }
 
             # execute any field filter if necessary
             if (m.code) {

--- a/qlib/RestHandler.qm
+++ b/qlib/RestHandler.qm
@@ -134,7 +134,7 @@ module RestHandler {
 
     In all cases, the signature for these methods looks like:
     @code{.py}
-    hash method(hash<auto> cx, *hash<auto> ah) {}
+    hash<auto> method(hash<auto> cx, *hash<auto> ah) {}
     @endcode
 
     The arguments passed to the REST action methods are as follows:
@@ -152,10 +152,10 @@ module RestHandler {
     @code{.py}
 class AbstractExampleInstanceBaseClass inherits AbstractRestClass {
     private {
-        hash h;
+        hash<auto> h;
     }
 
-    constructor(hash n_h) {
+    constructor(hash<auto> n_h) {
         h = n_h;
     }
 
@@ -224,10 +224,10 @@ class AbstractExampleInstanceBaseClass inherits AbstractRestClass {
 class WorkflowOrderRestClass inherits AbstractRestClass {
     private {
         # this holds the information or state of the REST object
-        hash wf;
+        hash<auto> wf;
     }
 
-    constructor(hash n_wf) {
+    constructor(hash<auto> n_wf) {
         wf = n_wf;
     }
 
@@ -245,7 +245,7 @@ class WorkflowOrderRestClass inherits AbstractRestClass {
     }
 
     # supports \c GET requests on the object
-    hash get(hash<auto> cx, *hash<auto> ah) {
+    hash<HttpHandlerResponseInfo> get(hash<auto> cx, *hash<auto> ah) {
         return RestHandler::makeResponse(200, wf);
     }
 }
@@ -253,10 +253,10 @@ class WorkflowOrderRestClass inherits AbstractRestClass {
 class WorkflowOrderInstanceRestClass inherits AbstractRestClass {
     private {
         # this holds the information or state of the REST object
-        hash oh;
+        hash<auto> oh;
     }
 
-    constructor(hash n_oh) {
+    constructor(hash<auto> n_oh) {
         oh = n_oh;
     }
 
@@ -266,12 +266,12 @@ class WorkflowOrderInstanceRestClass inherits AbstractRestClass {
     }
 
     # supports \c PUT requests where action=retry on the object
-    hash putRetry(hash<auto> cx, *hash<auto> ah) {
+    hash<HttpHandlerResponseInfo> putRetry(hash<auto> cx, *hash<auto> ah) {
         return RestHandler::makeResponse(200, api.retryOrder(oh.order_instanceid));
     }
 
     # supports \c GET requests on the object
-    hash get(hash<auto> cx, *hash<auto> ah) {
+    hash<HttpHandlerResponseInfo> get(hash<auto> cx, *hash<auto> ah) {
         return RestHandler::makeResponse(200, oh);
     }
 }
@@ -290,7 +290,7 @@ class WorkflowOrderInstanceRestClass inherits AbstractRestClass {
 
     REST action methods have the following signature:
     @code{.py}
-    hash method(hash<auto> cx, *hash<auto> ah) {}
+    hash<HttpHandlerResponseInfo> method(hash<auto> cx, *hash<auto> ah) {}
     @endcode
 
     In the usual case when only one of the above methods is used, then the argument information is copied to both
@@ -537,7 +537,7 @@ public namespace RestHandler {
 
             @note this method is called after the message body has been received
         */
-        abstract hash getResponseHeaderMessageImpl();
+        abstract hash<auto> getResponseHeaderMessageImpl();
 
         #! abstract callback method for receiving chunked data
         /**
@@ -550,7 +550,7 @@ public namespace RestHandler {
             - \c "hdr": this can be assigned to @ref nothing for the trailer hash if the data was not sent chunked or no trailers were included in a chunked message
             - \c "obj": this is the owning object (so socket parameters can be changed based on headers received, such as, for example, socket character encoding)
         */
-        abstract nothing recvImpl(hash v);
+        abstract nothing recvImpl(hash<auto> v);
 
         #! abstract callback method for sending chunked data
         /**
@@ -623,7 +623,7 @@ public namespace RestHandler {
             - \c "hdr": this can be assigned to @ref nothing for the trailer hash if the data was not sent chunked or no trailers were included in a chunked message
             - \c "obj": this is the owning object (so socket parameters can be changed based on headers received, such as, for example, socket character encoding)
         */
-        private nothing recvImpl(hash v) {
+        private nothing recvImpl(hash<auto> v) {
             stream.recv(v);
         }
 
@@ -1188,11 +1188,11 @@ public namespace RestHandler {
             ) : {};
             #path ? parse_uri_query(path) : {};
 
-            *hash args;
+            *hash<auto> args;
             if (ah.params) {
                 if (ah.params.typeCode() != NT_HASH)
                     return RestHandler::make400("cannot parse arguments in REST call %y, URI arguments must be key/value pairs with an 'action' key; got type %y instead (value: %y)", path, ah.params.type(), ah.params);
-                args = ah.params;
+                args = {} + ah.params;
             }
 
             if (exists body)
@@ -1251,7 +1251,7 @@ public namespace RestHandler {
 
             # make a hash of "accept" values
             *string astr = hdr.accept;
-            hash aih;
+            hash<auto> aih;
             if (astr) {
                 do {
                     astr =~ s/;[^,]*//;

--- a/qlib/SqlUtil.qm
+++ b/qlib/SqlUtil.qm
@@ -249,31 +249,31 @@ module SqlUtil {
     @par From the Primary Key
     To retrieve a single row based on a single primary key value, use @ref SqlUtil::AbstractTable::find(auto):
     @code{.py}
-*hash row = table.find(id);
+*hash<auto> row = table.find(id);
     @endcode
     If no primary key value matches the given argument, then @ref nothing is returned. A %Qore SQL statement like the following is generated from the above:
     @code{.py}
-*hash row = ds.selectRow("select * from schema.table where id = %v", id);
+*hash<auto> row = ds.selectRow("select * from schema.table where id = %v", id);
     @endcode
     \n
     To retrieve a single row based on a complex primary key value, or a single primary key value and extra criteria, use @ref SqlUtil::AbstractTable::find(hash):
     @code{.py}
-*hash row = table.find(("account_type": type, "name": name));
+*hash<auto> row = table.find(("account_type": type, "name": name));
     @endcode
     If no row value matches the given argument hash, then @ref nothing is returned. A %Qore SQL statement like the following is generated from the above:
     @code{.py}
-*hash row = ds.selectRow("select * from schema.table where account_type = %v and name = %v", type, name);
+*hash<auto> row = ds.selectRow("select * from schema.table where account_type = %v and name = %v", type, name);
     @endcode
 
     @par At Most One Matching Row From the Table
     To retrieve at most one matching row from the table, use @ref SqlUtil::AbstractTable::findSingle():
     @code{.py}
-*hash row = table.findSingle(("permission_type": op_between("US", "UX")));
+*hash<auto> row = table.findSingle(("permission_type": op_between("US", "UX")));
     @endcode
     This method can be used to efficiently check the table if at least one record matches the given \c where criteria; even if more rows match,
     only a single row is returned.  If no rows match, then @ref nothing is returned. A %Qore SQL statement like the following is generated from the above:
     @code{.py}
-*hash row = ds.selectRow("select * from schema.table where permission_type between %v and %v limit %v", "US", "UX", 1);
+*hash<auto> row = ds.selectRow("select * from schema.table where permission_type between %v and %v limit %v", "US", "UX", 1);
     @endcode
 
     @note handling the \c "limit" option depends on the underlying database; see @ref sql_paging for more information
@@ -297,7 +297,7 @@ module SqlUtil {
     @par From Complex Select Criteria
     To select a hash keyed by column name of lists (row values) based on complex select criteria, use @ref SqlUtil::AbstractTable::select():
     @code{.py}
-hash sh = (
+hash<auto> sh = (
     "columns": ("id", "name", "q.*"),
     "where": ("type": "user"),
     "limit": 100,
@@ -364,7 +364,7 @@ while (True) {
     - @ref SqlUtil::AbstractTable::upsertFromSelect()
     - @ref SqlUtil::AbstractTable::upsertFromSelectCommit()
 
-    SQL strings for select statements are constructed programmatically based on a select option hash described below.
+    SQL strings for select statements are constructed programmatically based on a select option hash<auto> described below.
 
     @par Select Option Hash Example:
     @code{.py}
@@ -398,7 +398,7 @@ hash soh = (
 
     <b>Alias Example:</b>
     @code{.py}
-hash sh = (
+hash<auto> sh = (
     "columns": ("t1.*", "t2.customer_name"),
     "join": join_inner(table2, "t2", ("id": "altid"))),
     "alias": "t1",
@@ -454,7 +454,7 @@ list columns = (
     <b>A String in Dot Notation</b>\n
     This format is for use with @ref select_option_join "joins"; ex: \c "q.name"
     @code{.py}
-hash sh = (
+hash<auto> sh = (
     "columns": ("t1.id", "t2.customer_name"),
     "join": join_inner(table2, "t2", ("id": "altid"))),
     "alias": "t1",
@@ -482,7 +482,7 @@ list columns = (
     <b>An \c "*" in Dot Notation</b>\n
     ex: \c "q.*"
     @code{.py}
-hash sh = (
+hash<auto> sh = (
     "columns": ("table.id", "t2.*"),
     "join": join_inner(table2, "t2", ("id": "altid")),
 );
@@ -499,7 +499,7 @@ hash sh = (
     @subsubsection select_option_orderby Select Option "orderby"
     <b>Orderby Example:</b>
     @code{.py}
-hash sh = (
+hash<auto> sh = (
     "where": (
         "account_type": "CUSTOMER",
     ),
@@ -518,7 +518,7 @@ hash sh = (
     @subsubsection select_option_desc Select Option "desc"
     <b>Desc Example:</b>
     @code{.py}
-hash sh = (
+hash<auto> sh = (
     "where": (
         "account_type": "CUSTOMER",
     ),
@@ -535,7 +535,7 @@ hash sh = (
     @subsubsection select_option_limit Select Option "limit"
     <b>Limit Example:</b>
     @code{.py}
-hash sh = (
+hash<auto> sh = (
     "where": ("type": "user"),
     "limit": 100,
     "offset": 200
@@ -550,7 +550,7 @@ hash sh = (
     @subsubsection select_option_offset Select Option "offset"
     <b>Offset Example:</b>
     @code{.py}
-hash sh = (
+hash<auto> sh = (
     "where": ("type": "user"),
     "limit": 100,
     "offset": 200
@@ -566,7 +566,7 @@ hash sh = (
     @subsubsection select_option_join Select Option "join"
     <b>Join Example:</b>
     @code{.py}
-hash sh = (
+hash<auto> sh = (
     "columns": (
         "name", "version", "id",
         cop_as("st.value", "source"),
@@ -585,7 +585,7 @@ hash sh = (
     @subsubsection select_option_groupby Select Option "groupby"
     <b>Groupby Example:</b>
     @code{.py}
-hash sh = (
+hash<auto> sh = (
     "columns": (
         cop_as(cop_max("service_type"), "type"),
         cop_count(),
@@ -601,7 +601,7 @@ hash sh = (
     @subsubsection select_option_having Select Option "having"
     <b>Having Example:</b>
     @code{.py}
-hash sh = (
+hash<auto> sh = (
     "columns": (
         cop_as(cop_max("service_type"), "type"),
         cop_count(),
@@ -619,7 +619,7 @@ hash sh = (
     @subsubsection select_option_superquery Select Option "superquery"
     <b>Superquery Example:</b>
     @code{.py}
-hash sh = (
+hash<auto> sh = (
     "columns": (
         "serviceid", "service_methodid",
         cop_as(cop_over(cop_max("service_methodid"), "serviceid"), "max_methodid"),
@@ -644,7 +644,7 @@ hash sh = (
 on_success ds.commit();
 on_error ds.rollback();
 
-hash sh = (
+hash<auto> sh = (
     "columns": ("serviceid", "service_methodid"),
     "forupdate": True,
 )
@@ -867,7 +867,7 @@ hash w = (
     that bind by value is used, so, if used in a context like the following:
     @code{.py}
 Table t(ds, "table");
-*hash qh = t.select(("where": w));
+*hash<auto> qh = t.select(("where": w));
     @endcode \n
     the complete query would look instead as follows:
     @code{.py}
@@ -888,7 +888,7 @@ hash w2 = (
     "id": op_ge(2500),
 );
 Table t(ds, "table");
-*hash qh = t.select(("where": (w1, w2)));
+*hash<auto> qh = t.select(("where": (w1, w2)));
     @endcode \n
     the complete query would look instead as follows:
     @code{.py}
@@ -898,11 +898,11 @@ ds.vselect("select * from table where (name = %v and account_type like %v and id
     @par Code Examples:
     Find a single row in the table where the \c "permission_type" column is a value between \c "US" and \c "UX":\n
     @code{.py}
-*hash row = table.findSingle(("permission_type": op_between("US", "UX")));
+*hash<auto> row = table.findSingle(("permission_type": op_between("US", "UX")));
     @endcode
     resulting in an internal SQL command that looks as follows (depending on the database):
     @code{.py}
-*hash row = ds.vselectRow("select * from table where permission_type between %v and %v limit %v", ("US", "UX", 1));
+*hash<auto> row = ds.vselectRow("select * from table where permission_type between %v and %v limit %v", ("US", "UX", 1));
     @endcode \n
     Delete all rows in the table where the \c "name" column is like \c "%Smith%":\n
     @code{.py}
@@ -969,7 +969,7 @@ if (l) {
 int upsert_strategy = verbose ? AbstractTable::UpsertSelectFirst : AbstractTable::UpsertAuto;
 
 # hash summarizing changes
-hash sh;
+hash<auto> sh;
 
 # get the rows to be inserted
 list l = get_table_rows();
@@ -982,7 +982,7 @@ if (l) {
     on_error ds.rollback();
 
     # loop through the reference data rows
-    foreach hash h in (l) {
+    foreach hash<auto> h in (l) {
         int code = upsert(h);
         if (code == AbstractTable::UR_Unchanged)
             continue;
@@ -1025,7 +1025,7 @@ int upsert_strategy = verbose ? AbstractTable::UpsertSelectFirst : AbstractTable
 # get the rows to be inserted
 list l = get_table_rows();
 
-code callback = sub (string table_name, hash row, int result) {
+code callback = sub (string table_name, hash<auto> row, int result) {
     if (result == AbstractTable::UR_Unchanged)
         return;
     string change = AbstractTable::UpsertResultMap{result};
@@ -1033,7 +1033,7 @@ code callback = sub (string table_name, hash row, int result) {
         printf("*** reference data %s: %y: %s\n", table_name, row, change);
 };
 
-hash sh = table.upsertFromIterator(l.iterator(), upsert_strategy, False, ("info_callback": callback, "commit_block": 5000));
+hash<auto> sh = table.upsertFromIterator(l.iterator(), upsert_strategy, False, ("info_callback": callback, "commit_block": 5000));
 if (sh)
     printf("*** reference data %s: %s\n", table.getName(), (foldl $1 + ", " + $2, (map sprintf("%s: %d", $1.key, $1.value), sh.pairIterator())));
 else
@@ -1058,7 +1058,7 @@ table.upsertFromSelect(table2, ("where": ("account_type": "CUSTOMER")));
 # set the upsert strategy depending on the use case
 int upsert_strategy = verbose ? AbstractTable::UpsertSelectFirst : AbstractTable::UpsertAuto;
 
-code callback = sub (string table_name, hash row, int result) {
+code callback = sub (string table_name, hash<auto> row, int result) {
     if (result == AbstractTable::UR_Unchanged)
         return;
     string change = AbstractTable::UpsertResultMap{result};
@@ -1066,7 +1066,7 @@ code callback = sub (string table_name, hash row, int result) {
         printf("*** reference data %s: %y: %s\n", table_name, row, change);
 };
 
-hash sh = table.upsertFromSelect(table2, ("where": ("account_type": "CUSTOMER")), upsert_strategy, False, ("info_callback": callback, "commit_block": 5000));
+hash<auto> sh = table.upsertFromSelect(table2, ("where": ("account_type": "CUSTOMER")), upsert_strategy, False, ("info_callback": callback, "commit_block": 5000));
 if (sh)
     printf("*** reference data %s: %s\n", table.getName(), (foldl $1 + ", " + $2, (map sprintf("%s: %d", $1.key, $1.value), sh.pairIterator())));
 else
@@ -1098,7 +1098,7 @@ int upsert_strategy = verbose ? AbstractTable::UpsertSelectFirst : AbstractTable
 # get the rows to be inserted
 list l = get_table_rows();
 
-code callback = sub (string table_name, hash row, int result) {
+code callback = sub (string table_name, hash<auto> row, int result) {
     if (result == AbstractTable::UR_Unchanged)
         return;
     string change = AbstractTable::UpsertResultMap{result};
@@ -1106,7 +1106,7 @@ code callback = sub (string table_name, hash row, int result) {
         printf("*** reference data %s: %y: %s\n", table_name, row, change);
 };
 
-hash sh = table.upsertFromSelect(table2, ("where": ("account_type": "CUSTOMER")), upsert_strategy, ("delete_others": True, "info_callback": callback, "commit_block": 5000));
+hash<auto> sh = table.upsertFromSelect(table2, ("where": ("account_type": "CUSTOMER")), upsert_strategy, ("delete_others": True, "info_callback": callback, "commit_block": 5000));
 if (sh)
     printf("*** reference data %s: %s\n", table.getName(), (foldl $1 + ", " + $2, (map sprintf("%s: %d", $1.key, $1.value), sh.pairIterator())));
 else
@@ -1611,7 +1611,7 @@ hash date_col_desc = (
 );
     @endcode
 
-    The above hash describes a column that will be have \c TIMESTAMP type on most databases, but \c DATE on Oracle.
+    The above hash<auto> describes a column that will be have \c TIMESTAMP type on most databases, but \c DATE on Oracle.
 
     @subsection pk_desc_hash Primary Key Description Hash
 
@@ -1744,7 +1744,7 @@ db.getAlignSql(schema, callback_opts);
     The \c "sqlarg_callback" @ref closure "closure" or @ref call_reference "call reference" is called with an SQL string and arguments for each SQL command that is executed
     during SQL data operations and can be specified as in the following example:
     @code{.py}
-code sqlarg_callback = sub (string str, *list args) {
+code sqlarg_callback = sub (string str, *list<auto> args) {
     if (verbose > 1)
         printf("SQL: %s\nargs: %y", str, args);
 };
@@ -1764,7 +1764,7 @@ table.insertFromIterator(i, sqlarg_callback);
 
     Here is an example of an upsert callback:
     @code{.py}
-code upsert_callback = sub (string table_name, hash row, int result) {
+code upsert_callback = sub (string table_name, hash<auto> row, int result) {
     # verbosity threshold
     int t = 0;
     if (result != AbstractTable::UR_Unchanged)
@@ -1786,7 +1786,7 @@ code upsert_callback = sub (string table_name, hash row, int result) {
     }
 };
 
-hash sh = table.upsertFromIterator(i, upsert_strategy, False, ("info_callback": upsert_callback));
+hash<auto> sh = table.upsertFromIterator(i, upsert_strategy, False, ("info_callback": upsert_callback));
     @endcode
 
     @subsection insert_info_callback Insert Info Callback
@@ -1880,7 +1880,7 @@ new Database(ds).rebuildIndex("ix_foo_bar");
     <b>Example:</b>
     Compute statistics for enumerated tables only.
     @code{.py}
-hash opts = (
+hash<auto> opts = (
     "tables": ("workflows", "workflow_instance"),
 );
 db.computeStatistics(opts);
@@ -2003,7 +2003,7 @@ public namespace SqlUtil {
         *hash jcols;          #!< the columns to use for the join, the keys will be columns in the source table and the values are columns in the \a table argument
         *hash cond;           #!< additional conditions for the join clause for the \a table argument; see @ref where_clauses for more information
         *string ta;           #!< optional table name or alias of the other table to join with when not joining with the primary table
-        *hash opt;            #!< optional join options (for example, to specify a partition for the join if supported)
+        *hash<auto> opt;            #!< optional join options (for example, to specify a partition for the join if supported)
     }
 
     /** @defgroup DBFeaturesConstants DB Features Constants
@@ -2516,7 +2516,7 @@ public namespace SqlUtil {
         Column operator functions can be nested as in the following example:
         @par Example:
         @code{.py}
-*hash rows = t.selectRows(("columns": cop_as(cop_lower("permission_type"), "perm"), "where": ("permission_type": "USER"), "limit": 100, "offset": 200));
+*list<auto> rows = t.selectRows(("columns": cop_as(cop_lower("permission_type"), "perm"), "where": ("permission_type": "USER"), "limit": 100, "offset": 200));
         @endcode
      */
     #@{
@@ -2653,7 +2653,7 @@ DatasourcePool ds("oracle:pvanek_omq/omq@xbox(al32utf8)");
 Database db(ds);
 Table t(ds, "dual");
 
-hash sh = (
+hash<auto> sh = (
     "columns" : (
         cop_as(cop_value(1), "as_int"),
         cop_as(cop_value(1.2), "as_float"),
@@ -2807,7 +2807,7 @@ sql: select 1 as as_int,1.2 as as_float,3.2 as as_numeric,to_timestamp('20150421
         @return a @ref ColumnOperatorInfo hash corresponding to the arguments for use in the @ref select_option_columns "columns" argument of a @ref select_option_hash "select option hash"
     */
     public hash<ColumnOperatorInfo> sub cop_over(auto column, *string partitionby, *string orderby) {
-        list args = (partitionby, orderby, );
+        list<auto> args = (partitionby, orderby, );
         return make_cop(COP_OVER, column, ("args" : args));
     }
 
@@ -3053,7 +3053,7 @@ const T_TestAnalyticFunctions = (
 );
 
 # select hash
-hash sh = (
+hash<auto> sh = (
         "columns" : cop_as(cop_over(cop_cume_dist(), "row_type", "id"), "cume_dist"),
     );
 
@@ -3086,7 +3086,7 @@ const T_TestAnalyticFunctions = (
 );
 
 # select hash
-hash sh = (
+hash<auto> sh = (
         "columns" : cop_as(cop_over(cop_dense_rank(), "row_type", "id"), "dense_rank"),
     );
 
@@ -3119,7 +3119,7 @@ const T_TestAnalyticFunctions = (
 );
 
 # select hash
-hash sh = (
+hash<auto> sh = (
         "columns" : cop_as(cop_over(cop_first_value("row_value"), "row_type", "id"), "first_value"),
     );
 
@@ -3152,7 +3152,7 @@ const T_TestAnalyticFunctions = (
 );
 
 # select hash
-hash sh = (
+hash<auto> sh = (
         "columns" : cop_as(cop_over(cop_last_value("row_value"), "row_type", "id"), "last_value"),
     );
 
@@ -3185,7 +3185,7 @@ const T_TestAnalyticFunctions = (
 );
 
 # select hash
-hash sh = (
+hash<auto> sh = (
         "columns" : cop_as(cop_over(cop_ntile(10), "row_type", "id"), "ntile"),
     );
 
@@ -3220,7 +3220,7 @@ const T_TestAnalyticFunctions = (
 );
 
 # select hash
-hash sh = (
+hash<auto> sh = (
         "columns" : cop_as(cop_over(cop_percent_rank(), "row_type", "id"), "percent_rank"),
     );
 
@@ -3253,7 +3253,7 @@ const T_TestAnalyticFunctions = (
 );
 
 # select hash
-hash sh = (
+hash<auto> sh = (
         "columns" : cop_as(cop_over(cop_rank(), "row_type", "id"), "rank"),
     );
 
@@ -3286,7 +3286,7 @@ const T_TestAnalyticFunctions = (
 );
 
 # select hash
-hash sh = (
+hash<auto> sh = (
         "columns" : cop_as(cop_over(cop_row_number(), "row_type", "id"), "row_number"),
     );
 
@@ -3644,7 +3644,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
     /**
         @note this function is normally not used directly, but rather is called by the other @ref sql_jop_funcs
     */
-    public hash<string, hash<JoinOperatorInfo>> sub make_jop(string jop, AbstractTable table, *string alias, *hash jcols, *hash cond, *string ta, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub make_jop(string jop, AbstractTable table, *string alias, *hash jcols, *hash cond, *string ta, *hash<auto> opt) {
         string hk = alias ? alias : table.getSqlName();
         return new hash<string, hash<JoinOperatorInfo>>((hk: cast<hash<JoinOperatorInfo>>(("jop": jop, "table": table, "jcols": jcols, "cond": cond, "alias": alias, "ta": ta, "opt": opt))));
     }
@@ -3654,7 +3654,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @note this function is normally not used directly, but rather is called by the other @ref sql_jop_funcs
     */
-    public hash<string, hash<JoinOperatorInfo>> sub make_jop(string jop, string table_name, *string alias, *hash jcols, *hash cond, *string ta, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub make_jop(string jop, string table_name, *string alias, *hash jcols, *hash cond, *string ta, *hash<auto> opt) {
         string hk = alias ? alias : table_name;
         return new hash<string, hash<JoinOperatorInfo>>((hk:  cast<hash<JoinOperatorInfo>>(("jop": jop, "table": table_name, "jcols": jcols, "cond": cond, "alias": alias, "ta": ta, "opt": opt))));
     }
@@ -3679,7 +3679,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @return a join description hash corresponding to the arguments for use in the @ref select_option_join "join" argument of a @ref select_option_hash "select option hash"
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_inner(AbstractTable table, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_inner(AbstractTable table, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_INNER, table, alias, jcols, cond, NOTHING, opt);
     }
 
@@ -3703,7 +3703,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @return a join description hash corresponding to the arguments for use in the @ref select_option_join "join" argument of a @ref select_option_hash "select option hash"
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_inner(Table table, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_inner(Table table, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_INNER, table.getTable(), alias, jcols, cond, NOTHING, opt);
     }
 
@@ -3727,7 +3727,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @return a join description hash corresponding to the arguments for use in the @ref select_option_join "join" argument of a @ref select_option_hash "select option hash"
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_inner(string table_name, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_inner(string table_name, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_INNER, table_name, alias, jcols, cond, NOTHING, opt);
     }
 
@@ -3754,7 +3754,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @since %SqlUtil 1.3
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_inner(string ta, AbstractTable table, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_inner(string ta, AbstractTable table, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_INNER, table, alias, jcols, cond, ta, opt);
     }
 
@@ -3779,7 +3779,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @return a join description hash corresponding to the arguments for use in the @ref select_option_join "join" argument of a @ref select_option_hash "select option hash"
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_inner(string ta, Table table, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_inner(string ta, Table table, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_INNER, table.getTable(), alias, jcols, cond, ta, opt);
     }
 
@@ -3806,7 +3806,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @since %SqlUtil 1.3
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_inner_alias(string ta, string table_name, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_inner_alias(string ta, string table_name, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_INNER, table_name, alias, jcols, cond, ta, opt);
     }
 
@@ -3830,7 +3830,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @return a join description hash corresponding to the arguments for use in the @ref select_option_join "join" argument of a @ref select_option_hash "select option hash"
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_left(AbstractTable table, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_left(AbstractTable table, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_LEFT, table, alias, jcols, cond, NOTHING, opt);
     }
 
@@ -3854,7 +3854,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @return a join description hash corresponding to the arguments for use in the @ref select_option_join "join" argument of a @ref select_option_hash "select option hash"
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_left(Table table, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_left(Table table, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_LEFT, table.getTable(), alias, jcols, cond, NOTHING, opt);
     }
 
@@ -3880,7 +3880,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @since %SqlUtil 1.3
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_left(string table_name, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_left(string table_name, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_LEFT, table_name, alias, jcols, cond, NOTHING, opt);
     }
 
@@ -3905,7 +3905,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @return a join description hash corresponding to the arguments for use in the @ref select_option_join "join" argument of a @ref select_option_hash "select option hash"
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_left(string ta, AbstractTable table, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_left(string ta, AbstractTable table, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_LEFT, table, alias, jcols, cond, ta, opt);
     }
 
@@ -3930,7 +3930,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @return a join description hash corresponding to the arguments for use in the @ref select_option_join "join" argument of a @ref select_option_hash "select option hash"
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_left(string ta, Table table, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_left(string ta, Table table, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_LEFT, table.getTable(), alias, jcols, cond, ta, opt);
     }
 
@@ -3957,7 +3957,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @since %SqlUtil 1.3
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_left_alias(string ta, string table_name, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_left_alias(string ta, string table_name, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_LEFT, table_name, alias, jcols, cond, ta, opt);
     }
 
@@ -3981,7 +3981,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @return a join description hash corresponding to the arguments for use in the @ref select_option_join "join" argument of a @ref select_option_hash "select option hash"
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_right(AbstractTable table, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_right(AbstractTable table, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_RIGHT, table, alias, jcols, cond, NOTHING, opt);
     }
 
@@ -4005,7 +4005,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @return a join description hash corresponding to the arguments for use in the @ref select_option_join "join" argument of a @ref select_option_hash "select option hash"
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_right(Table table, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_right(Table table, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_RIGHT, table.getTable(), alias, jcols, cond, NOTHING, opt);
     }
 
@@ -4031,7 +4031,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @since %SqlUtil 1.3
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_right(string table_name, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_right(string table_name, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_RIGHT, table_name, alias, jcols, cond, NOTHING, opt);
     }
 
@@ -4056,7 +4056,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @return a join description hash corresponding to the arguments for use in the @ref select_option_join "join" argument of a @ref select_option_hash "select option hash"
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_right(string ta, AbstractTable table, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_right(string ta, AbstractTable table, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_RIGHT, table, alias, jcols, cond, ta, opt);
     }
 
@@ -4081,7 +4081,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @return a join description hash corresponding to the arguments for use in the @ref select_option_join "join" argument of a @ref select_option_hash "select option hash"
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_right(string ta, Table table, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_right(string ta, Table table, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_RIGHT, table.getTable(), alias, jcols, cond, ta, opt);
     }
 
@@ -4108,7 +4108,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @since %SqlUtil 1.3
     */
-    public hash<string, hash<JoinOperatorInfo>> sub join_right_alias(string ta, string table_name, *string alias, *hash jcols, *hash cond, *hash opt) {
+    public hash<string, hash<JoinOperatorInfo>> sub join_right_alias(string ta, string table_name, *string alias, *hash jcols, *hash cond, *hash<auto> opt) {
         return make_jop(JOP_RIGHT, table_name, alias, jcols, cond, ta, opt);
     }
     #@}
@@ -4208,42 +4208,42 @@ int rows_updated = t.update(("counter": uop_divide(2)));
     #! a hash of valid operators for use in @ref where_clauses
     public const DefaultOpMap = (
         OP_LIKE: (
-            "code": string sub (object t, string cn, auto arg, reference<list> args, *hash<auto> jch,
+            "code": string sub (object t, string cn, auto arg, reference<list<auto>> args, *hash<auto> jch,
                 bool join = False, *hash<auto> ch, *hash<auto> psch) {
                 args += arg;
                 return sprintf("%s like %v", cn);
             },
         ),
         OP_LT: (
-            "code": string sub (object t, string cn, auto arg, reference<list> args, *hash<auto> jch,
+            "code": string sub (object t, string cn, auto arg, reference<list<auto>> args, *hash<auto> jch,
                 bool join = False, *hash<auto> ch, *hash<auto> psch) {
                 args += arg;
                 return sprintf("%s < %v", cn);
             },
         ),
         OP_LE: (
-            "code": string sub (object t, string cn, auto arg, reference<list> args, *hash<auto> jch,
+            "code": string sub (object t, string cn, auto arg, reference<list<auto>> args, *hash<auto> jch,
                 bool join = False, *hash<auto> ch, *hash<auto> psch) {
                 args += arg;
                 return sprintf("%s <= %v", cn);
             },
         ),
         OP_GT: (
-            "code": string sub (object t, string cn, auto arg, reference<list> args, *hash<auto> jch,
+            "code": string sub (object t, string cn, auto arg, reference<list<auto>> args, *hash<auto> jch,
                 bool join = False, *hash<auto> ch, *hash<auto> psch) {
                 args += arg;
                 return sprintf("%s > %v", cn);
             },
         ),
         OP_GE: (
-            "code": string sub (object t, string cn, auto arg, reference<list> args, *hash<auto> jch,
+            "code": string sub (object t, string cn, auto arg, reference<list<auto>> args, *hash<auto> jch,
                 bool join = False, *hash<auto> ch, *hash<auto> psch) {
                 args += arg;
                 return sprintf("%s >= %v", cn);
             },
         ),
         OP_NE: (
-            "code": string sub (object t, string cn, auto arg, reference<list> args, *hash<auto> jch,
+            "code": string sub (object t, string cn, auto arg, reference<list<auto>> args, *hash<auto> jch,
                 bool join = False, *hash<auto> ch, *hash<auto> psch) {
                 if (arg === NULL || !exists arg)
                     return sprintf("%s is not null", cn);
@@ -4252,7 +4252,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
             },
         ),
         OP_EQ: (
-            "code": string sub (object t, string cn, auto arg, reference<list> args, *hash<auto> jch,
+            "code": string sub (object t, string cn, auto arg, reference<list<auto>> args, *hash<auto> jch,
                 bool join = False, *hash<auto> ch, *hash<auto> psch) {
                 if (arg === NULL || !exists arg)
                     return sprintf("%s is null", cn);
@@ -4261,7 +4261,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
             },
         ),
         OP_BETWEEN: (
-            "code": string sub (object t, string cn, auto arg, reference<list> args, *hash<auto> jch,
+            "code": string sub (object t, string cn, auto arg, reference<list<auto>> args, *hash<auto> jch,
                 bool join = False, *hash<auto> ch, *hash<auto> psch) {
                 args += arg[0];
                 args += arg[1];
@@ -4269,7 +4269,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
             },
         ),
         OP_IN: (
-            "code": string sub (object t, string cn, auto arg, reference<list> args, *hash<auto> jch,
+            "code": string sub (object t, string cn, auto arg, reference<list<auto>> args, *hash<auto> jch,
                 bool join = False, *hash<auto> ch, *hash<auto> psch) {
                 *string ins = (foldl $1 + "," + $2, (map t.getSqlValue($1), arg));
                 return exists ins ? sprintf("%s in (%s)", cn, ins) : "1 != 1";
@@ -4277,55 +4277,55 @@ int rows_updated = t.update(("counter": uop_divide(2)));
         ),
         OP_NOT: (
             "recursive": True,
-            "code": string sub (object t, string cn, auto arg, reference<list> args, *hash<auto> jch,
+            "code": string sub (object t, string cn, auto arg, reference<list<auto>> args, *hash<auto> jch,
                 bool join = False, *hash<auto> ch, *hash<auto> psch) {
                 return sprintf("not (%s)", cn);
             },
         ),
         OP_CLT: (
             "argcolumn": True,
-            "code": string sub (object t, string cn, auto arg, reference<list> args, *hash<auto> jch,
+            "code": string sub (object t, string cn, auto arg, reference<list<auto>> args, *hash<auto> jch,
                 bool join = False, *hash<auto> ch, *hash<auto> psch) {
                 return sprintf("%s < %s", cn, arg);
             },
         ),
         OP_CLE: (
             "argcolumn": True,
-            "code": string sub (object t, string cn, auto arg, reference<list> args, *hash<auto> jch,
+            "code": string sub (object t, string cn, auto arg, reference<list<auto>> args, *hash<auto> jch,
                 bool join = False, *hash<auto> ch, *hash<auto> psch) {
                 return sprintf("%s <= %s", cn, arg);
             },
         ),
         OP_CGT: (
             "argcolumn": True,
-            "code": string sub (object t, string cn, auto arg, reference<list> args, *hash<auto> jch,
+            "code": string sub (object t, string cn, auto arg, reference<list<auto>> args, *hash<auto> jch,
                 bool join = False, *hash<auto> ch, *hash<auto> psch) {
                 return sprintf("%s > %s", cn, arg);
             },
         ),
         OP_CGE: (
             "argcolumn": True,
-            "code": string sub (object t, string cn, auto arg, reference<list> args, *hash<auto> jch,
+            "code": string sub (object t, string cn, auto arg, reference<list<auto>> args, *hash<auto> jch,
                 bool join = False, *hash<auto> ch, *hash<auto> psch) {
                 return sprintf("%s >= %s", cn, arg);
             },
         ),
         OP_CNE: (
             "argcolumn": True,
-            "code": string sub (object t, string cn, auto arg, reference<list> args, *hash<auto> jch,
+            "code": string sub (object t, string cn, auto arg, reference<list<auto>> args, *hash<auto> jch,
                 bool join = False, *hash<auto> ch, *hash<auto> psch) {
                 return sprintf("%s != %s", cn, arg);
             },
         ),
         OP_CEQ: (
             "argcolumn": True,
-            "code": string sub (object t, string cn, string arg, reference<list> args, *hash<auto> jch,
+            "code": string sub (object t, string cn, string arg, reference<list<auto>> args, *hash<auto> jch,
                 bool join = False, *hash<auto> ch, *hash<auto> psch) {
                 return sprintf("%s = %s", cn, arg);
             },
         ),
         OP_SUBSTR: (
-            "code": string sub (object t, string cn, auto arg, reference<list> args, *hash<auto> jch,
+            "code": string sub (object t, string cn, auto arg, reference<list<auto>> args, *hash<auto> jch,
                 bool join = False, *hash<auto> ch, *hash<auto> psch) {
                 args += arg[0]; # start
                 if (!exists arg[1]) {
@@ -4338,7 +4338,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
             },
         ),
         OP_OR: (
-            "code": string sub (object t, string cn, list<auto> arg, reference<list> args, *hash<auto> jch, bool join = False,
+            "code": string sub (object t, string cn, list<auto> arg, reference<list<auto>> args, *hash<auto> jch, bool join = False,
                 *hash<auto> ch, *hash<auto> psch) {
                 return t.getOrClause(arg, \args, jch, join, ch, psch);
             },
@@ -4534,7 +4534,7 @@ int rows_updated = t.update(("counter": uop_divide(2)));
 
         @note The argument list size may be constrained depending on the database server / driver used; passing a large number of arguments to this function may be a sign of an improper application or query design; consider using a join with a temporary table instead of passing a large number of arguments to this function
     */
-    public hash<OperatorInfo> sub op_in(list args) {
+    public hash<OperatorInfo> sub op_in(list<auto> args) {
         return make_op(OP_IN, args);
     }
 
@@ -4889,7 +4889,7 @@ c.clear();
         }
 
         #! returns the hash contained by this object
-        *hash getHash() {
+        *hash<auto> getHash() {
             return h;
         }
 
@@ -4915,7 +4915,7 @@ bool b = c.matchKeys(h);
             return True;
         }
 
-        #! returns @ref Qore::True "True" if the list argument has the same list of key strings as the keys in the object (in any order), @ref Qore::False "False" if not
+        #! returns @ref Qore::True "True" if the list<auto> argument has the same list of key strings as the keys in the object (in any order), @ref Qore::False "False" if not
         /** @par Example:
             @code{.py}
 bool b = c.matchKeys(l);
@@ -4923,7 +4923,7 @@ bool b = c.matchKeys(l);
 
             @param l the hash to compare
 
-            @return @ref Qore::True "True" if the list argument has the same list of key strings as the keys in the object (in any order), @ref Qore::False "False" if not
+            @return @ref Qore::True "True" if the list<auto> argument has the same list of key strings as the keys in the object (in any order), @ref Qore::False "False" if not
         */
         bool matchKeys(list<auto> l) {
             if (h.size() != l.size())
@@ -4973,7 +4973,7 @@ bool b = c.partialMatchKeys(h);
             return True;
         }
 
-        #! returns @ref Qore::True "True" if the list argument has at least the same keys (in any order, can have more keys), @ref Qore::False "False" if not
+        #! returns @ref Qore::True "True" if the list<auto> argument has at least the same keys (in any order, can have more keys), @ref Qore::False "False" if not
         /** @par Example:
             @code{.py}
 bool b = c.partialMatchKeys(l);
@@ -4981,7 +4981,7 @@ bool b = c.partialMatchKeys(l);
 
             @param l the list of strings to compare
 
-            @return @ref Qore::True "True" if the list argument has at least the same keys (in any order, can have more keys), @ref Qore::False "False" if not
+            @return @ref Qore::True "True" if the list<auto> argument has at least the same keys (in any order, can have more keys), @ref Qore::False "False" if not
         */
         bool partialMatchKeys(list<auto> l) {
             if (h.size() > l.size())
@@ -5171,7 +5171,7 @@ bool b = h.hasKeyValue(key);
             softlist l;
         }
 
-        #! creates the object with the list argument passed
+        #! creates the object with the list<auto> argument passed
         constructor(softlist nl) {
             l = nl;
         }
@@ -5202,7 +5202,7 @@ auto v = c.get(2);
         }
 
         #! returns the list contained by this object
-        list getList() {
+        list<auto> getList() {
             return l;
         }
 
@@ -5264,8 +5264,8 @@ int num = l.size();
         constructor() {
         }
 
-        #! creates and populates the object from a hash description
-        constructor(AbstractDatasource ds, hash tables, *hash opt) {
+        #! creates and populates the object from a hash<auto> description
+        constructor(AbstractDatasource ds, hash tables, *hash<auto> opt) {
             populate(ds, tables, opt);
         }
 
@@ -5299,8 +5299,8 @@ int num = l.size();
             return remove h{k};
         }
 
-        #! populates the object from a hash description
-        populate(AbstractDatasource ds, hash tables, *hash opt) {
+        #! populates the object from a hash<auto> description
+        populate(AbstractDatasource ds, hash tables, *hash<auto> opt) {
             delete h;
             AbstractDatabase::checkDriverOptions(\tables, ds.getDriverName());
             foreach string name in (tables.keyIterator()) {
@@ -5349,7 +5349,7 @@ int num = l.size();
 
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        *list getDropAllForeignConstraintsOnTableSql(string name, *hash opt) {
+        *list<auto> getDropAllForeignConstraintsOnTableSql(string name, *hash<auto> opt) {
             if (!h{name})
                 return;
 
@@ -5357,7 +5357,7 @@ int num = l.size();
 
             list l = ();
             foreach AbstractUniqueConstraint uk in (t.getUniqueConstraintIterator()) {
-                foreach hash sch in (uk.getSourceConstraintIterator()) {
+                foreach hash<auto> sch in (uk.getSourceConstraintIterator()) {
                     l += AbstractDatabase::doCallback(opt, sch.fk.getDropSql(sch.table), AbstractDatabase::AC_Drop, "foreign constraint", sch.fk.getName(), sch.table);
                     string tn = sch.table;
                     tn =~ s/.*\.//;
@@ -5432,7 +5432,7 @@ AbstractTable t = tables.table_name;
 
             @return an SQL string that can be used to rename the given table if it exists and the target does not exist, otherwise returns @ref nothing
          */
-        *string getRenameTableIfExistsSql(string old_name, string new_name, *hash opts) {
+        *string getRenameTableIfExistsSql(string old_name, string new_name, *hash<auto> opts) {
             if (!h{old_name} || h{new_name})
                 return;
 
@@ -5470,7 +5470,7 @@ tables.tableRenamed(old, newv);
 
             # search through all unique keys and rename foreign keys in source tables
             foreach AbstractUniqueConstraint uk in (t.getUniqueConstraintIterator()) {
-                foreach hash sch in (uk.getSourceConstraintIterator()) {
+                foreach hash<auto> sch in (uk.getSourceConstraintIterator()) {
                     sch.fk.target.table = t.getName();
                 }
             }
@@ -5505,7 +5505,7 @@ tables.tableRenamed(old, newv);
 
             @return an SQL string that can be used to drop an existing constraint on a table, if the table is not already cached or the constraint does not exist, then @ref nothing is returned
         */
-        *string getDropConstraintIfExistsSql(string tname, string cname, *hash opts) {
+        *string getDropConstraintIfExistsSql(string tname, string cname, *hash<auto> opts) {
             if (!h{tname})
                 return;
 
@@ -5526,7 +5526,7 @@ tables.tableRenamed(old, newv);
             return sql;
         }
 
-        list getCreateList() {
+        list<auto> getCreateList() {
             # foreign dependency hash: table -> hash: source table (ie table with foreign constraint on key)
             hash tdh;
             # source dependency hash: table -> list: foreign table (key has foreign constraint on value)
@@ -5570,7 +5570,7 @@ map $1.drop(), l;
 
             @return a list of cached table names in the order that can be used to drop the tables, taking into account foreign constraint dependencies
         */
-        list getDropList() {
+        list<auto> getDropList() {
             if (!h)
                 return ();
 
@@ -5684,7 +5684,7 @@ AbstractColumn c = cols.id;
             return AbstractHashContainer::memberGate(k);
         }
 
-        #! returns a subset of the current columns according to the list argument
+        #! returns a subset of the current columns according to the list<auto> argument
         Columns subset(softlist l) {
             hash nh = h{l};
             if (nh.size() != l.size())
@@ -5805,7 +5805,7 @@ list l = col.getAddColumnSql(t);
 
             @return a list of sql strings that can be used to add the column to an existing table
          */
-        abstract list getAddColumnSql(AbstractTable t);
+        abstract list<auto> getAddColumnSql(AbstractTable t);
 
         #! returns a string that can be used to drop the column from the table
         string getDropSql(string table_name) {
@@ -5826,7 +5826,7 @@ list l = col.getModifySql(t, newcol);
 
             @return a list of sql strings that can be used to modify the column to the new definition; if the column definitions are identical then an empty list is returned
          */
-        list getModifySql(AbstractTable t, AbstractColumn c, *hash opt) {
+        list<auto> getModifySql(AbstractTable t, AbstractColumn c, *hash<auto> opt) {
             list l = getModifySqlImpl(t, c, opt);
 
             # update existing rows with the new default column value if:
@@ -5886,7 +5886,7 @@ list l = col.getModifySql(t, newcol);
 
             @return a list of sql strings that can be used to modify the column to the new definition; if the column definitions are identical then an empty list is returned
          */
-        private abstract list getModifySqlImpl(AbstractTable t, AbstractColumn c, *hash opt);
+        private abstract list<auto> getModifySqlImpl(AbstractTable t, AbstractColumn c, *hash<auto> opt);
     }
 
     #! the base class to use to extend AbstractColumn to implement numeric columns
@@ -6002,7 +6002,7 @@ AbstractIndex ix = indexes.pk_jobs;
         }
 
         #! returns a string that can be used to create the index in the database
-        abstract string getCreateSql(string table_name, *hash opt);
+        abstract string getCreateSql(string table_name, *hash<auto> opt);
 
         #! returns a string that can be used to drop the index from the database
         string getDropSql(string table_name) {
@@ -6053,7 +6053,7 @@ AbstractIndex ix = indexes.pk_jobs;
         }
 
         #! returns a list of strings to drop and recreate the current index; if there are dependent constraints, the list contains commands to disable the constraints before dropping the index and also contains commands to re-enable the contraints after re-creating the index
-        list getRecreateSql(AbstractDatasource ds, string table_name, *hash opt) {
+        list<auto> getRecreateSql(AbstractDatasource ds, string table_name, *hash<auto> opt) {
             list l = ();
             list enl;
             # get drop SQL and disable any dependent constraints plus a list of strings to re-enable the constraints
@@ -6153,7 +6153,7 @@ AbstractConstraint ix = constraints.uk_jobs;
         }
 
         #! returns a string that can be used to create the constraint in the database
-        abstract string getCreateSql(string table_name, *hash opt);
+        abstract string getCreateSql(string table_name, *hash<auto> opt);
 
         #! returns a string that can be used to drop the constraint from the database
         string getDropSql(string table_name) {
@@ -6161,7 +6161,7 @@ AbstractConstraint ix = constraints.uk_jobs;
         }
 
         #! returns a list of SQL strings that can be used to rename the constraint in the database
-        abstract list getRenameSql(string table_name, string new_name);
+        abstract list<auto> getRenameSql(string table_name, string new_name);
 
         #! returns a string that can be used to temporarily disable the constraint from the database; if disabling constraints is not supported, then the constraint will be dropped
         string getDisableSql(string table_name) {
@@ -6169,7 +6169,7 @@ AbstractConstraint ix = constraints.uk_jobs;
         }
 
         #! returns a string that can be used to enable the constraint in the database; if disabling constraints is not supported, then the constraint will be dropped
-        string getEnableSql(string table_name, *hash opt) {
+        string getEnableSql(string table_name, *hash<auto> opt) {
             return getCreateSql(table_name, opt);
         }
 
@@ -6261,8 +6261,8 @@ AbstractConstraint ix = constraints.uk_jobs;
         }
 
         #! returns lists of SQL strings to disable this constraint plus any dependent constraints and another list of SQL strings to reenable the same constraints; used when updating indexes that depend on constraints
-        hash getDisableReenableSql(AbstractDatasource ds, string table_name, *hash opts) {
-            hash ch = (
+        hash<auto> getDisableReenableSql(AbstractDatasource ds, string table_name, *hash<auto> opts) {
+            hash<auto> ch = (
                 "disable": (),
                 "enable": (),
                 );
@@ -6371,7 +6371,7 @@ uk.addSourceConstraint(table_name, constraint_name);
         }
 
         #! returns a string that can be used to create the constraint in the database
-        abstract string getCreateSql(string table_name, *hash opts);
+        abstract string getCreateSql(string table_name, *hash<auto> opts);
     }
 
     #! represents a unique column constraint
@@ -6522,12 +6522,12 @@ AbstractForeignConstraint ix = fcs.fk_jobs_job_defs;
         }
 
         #! returns a string that can be used to create the sequence in the database
-        abstract string getCreateSql(*hash opt);
+        abstract string getCreateSql(*hash<auto> opt);
 
         #! returns a string that can be used to drop the sequence from the database
         /** @param opt drop options (if supported by the driver and object); in this generic base class method, this argument is ignored
          */
-        string getDropSql(*hash opt) {
+        string getDropSql(*hash<auto> opt) {
             return sprintf("drop sequence %s", name);
         }
 
@@ -6535,7 +6535,7 @@ AbstractForeignConstraint ix = fcs.fk_jobs_job_defs;
         /** @param new_name the new name of the object
             @param opt drop options (if supported by the driver and object)
          */
-        abstract softlist getRenameSql(string new_name, *hash opt);
+        abstract softlist<auto> getRenameSql(string new_name, *hash<auto> opt);
     }
 
     #! base class for views
@@ -6561,12 +6561,12 @@ AbstractForeignConstraint ix = fcs.fk_jobs_job_defs;
         }
 
         #! returns a string that can be used to create the view in the database
-        abstract string getCreateSql(*hash opt);
+        abstract string getCreateSql(*hash<auto> opt);
 
         #! returns a string that can be used to drop the view from the database
         /** @param opt drop options (if supported by the driver and object); in this generic base class method, this argument is ignored
          */
-        string getDropSql(*hash opt) {
+        string getDropSql(*hash<auto> opt) {
             return sprintf("drop view %s", name);
         }
 
@@ -6574,7 +6574,7 @@ AbstractForeignConstraint ix = fcs.fk_jobs_job_defs;
         /** @param new_name the new name of the object
             @param opt drop options (if supported by the driver and object)
          */
-        abstract softlist getRenameSql(string new_name, *hash opt);
+        abstract softlist<auto> getRenameSql(string new_name, *hash<auto> opt);
     }
 
     #! base class for function or objects with code
@@ -6609,7 +6609,7 @@ AbstractForeignConstraint ix = fcs.fk_jobs_job_defs;
         #! returns a string that can be used to drop the function from the database
         /** @param opt drop options (if supported by the driver and object); in this generic base class method, this argument is ignored
          */
-        string getDropSql(*hash opt) {
+        string getDropSql(*hash<auto> opt) {
             return sprintf("drop %s %s", type, name);
         }
 
@@ -6656,13 +6656,13 @@ AbstractForeignConstraint ix = fcs.fk_jobs_job_defs;
         }
 
         #! returns a list of SQL strings that can be used to create the function in the database
-        abstract list getCreateSql(*hash opt);
+        abstract list<auto> getCreateSql(*hash<auto> opt);
 
         #! returns a list of strings that can be used to rename the function in the database
         /** @param new_name the new name of the object
             @param opt drop options (if supported by the driver and object)
          */
-        abstract softlist getRenameSql(string new_name, *hash opt);
+        abstract softlist<auto> getRenameSql(string new_name, *hash<auto> opt);
 
         #! sets the new name of the object
         setName(string new_name) {
@@ -6717,13 +6717,13 @@ AbstractFunction f = funcs.func1;
         }
 
         #! returns a string that can be used to create the trigger in the database
-        abstract list getCreateSql(string table_name, *hash opt);
+        abstract list<auto> getCreateSql(string table_name, *hash<auto> opt);
 
         #! returns a string that can be used to rename the trigger in the database
-        abstract softlist getRenameSql(string table_name, string new_name);
+        abstract softlist<auto> getRenameSql(string table_name, string new_name);
 
         #! returns a string that can be used to drop the trigger in the database
-        abstract list getDropSql(string table_name);
+        abstract list<auto> getDropSql(string table_name);
     }
 
     #! trigger container class that throws an exception if an unknown trigger is accessed
@@ -6795,7 +6795,7 @@ Database db(ds);
             @throw DATABASE-DRIVER-ERROR no database-specific module can be loaded
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        constructor(AbstractDatasource ds, *hash opts) {
+        constructor(AbstractDatasource ds, *hash<auto> opts) {
             db = AbstractDatabase::getDatabase(ds, opts);
         }
 
@@ -6810,7 +6810,7 @@ AbstractDatabase db("pgsql:user/pass@db%host");
 
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        constructor(string ds, *hash opts) {
+        constructor(string ds, *hash<auto> opts) {
             db = AbstractDatabase::getDatabase(ds, opts);
         }
 
@@ -6833,7 +6833,7 @@ AbstractDatabase db("pgsql:user/pass@db%host");
 
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        constructor(hash ds, *hash opts) {
+        constructor(hash ds, *hash<auto> opts) {
             db = AbstractDatabase::getDatabase(ds, opts);
         }
 
@@ -6854,7 +6854,7 @@ AbstractDatabase db("pgsql:user/pass@db%host");
             #! datasource description
             string dsdesc;
             #! option hash
-            *hash opts;
+            *hash<auto> opts;
             #! the connection to the database server
             transient AbstractDatasource ds;
             #! mutex for atomic actions
@@ -7237,7 +7237,7 @@ AbstractDatabase db("pgsql:user/pass@db%host");
             /** The following keys can be set in @ref schema_desc_hash "schema description hashes":
                 - \c tables: a hash keyed by table name set to @ref table_desc_hash "table description hash" values
                 - \c table_map: a hash for automatically renaming tables; if the source name (key) exists and the target name (value) does not exist, then the source table is automatically renamed
-                - \c sequences: a hash keyed by sequence name set to @ref AbstractDatabase::SequenceDescriptionOptions "sequence hash description" values
+                - \c sequences: a hash keyed by sequence name set to @ref AbstractDatabase::SequenceDescriptionOptions "sequence hash<auto> description" values
                 - \c sequence_map: a hash for automatically renaming sequences; if the source name (key) exists and the target name (value) does not exist, then the source sequence is automatically renamed
                 - \c functions: a hash keyed by function name set to function source string values
                 - \c function_map: a hash for automatically renaming functions; if the source name (key) exists and the target name (value) does not exist, then the source function is automatically renamed
@@ -7311,7 +7311,7 @@ AbstractDatabase db("pgsql:user/pass@db%host");
             return featuresImpl();
         }
 
-        static doOkCallback(*hash opt, int ac, string type, string name, *string table, *string info) {
+        static doOkCallback(*hash<auto> opt, int ac, string type, string name, *string table, *string info) {
             if (opt.info_callback) {
                 bool c = (type == "column");
                 if (c)
@@ -7347,7 +7347,7 @@ AbstractDatabase db("pgsql:user/pass@db%host");
             info_callback(str, ac, type, name, table, new_name, info);
         }
 
-        static *string doCallback(*hash opt, *string sql, int ac, string type, string name, *string table, *string new_name, *string info) {
+        static *string doCallback(*hash<auto> opt, *string sql, int ac, string type, string name, *string table, *string new_name, *string info) {
             if (!sql)
                 return;
             if (opt.info_callback) {
@@ -7366,7 +7366,7 @@ AbstractDatabase db("pgsql:user/pass@db%host");
             return sql;
         }
 
-        static list doCallback(*hash opt, list sql, int ac, string type, string name, *string table, *string new_name, *string info) {
+        static list doCallback(*hash<auto> opt, list sql, int ac, string type, string name, *string table, *string new_name, *string info) {
             if (!sql)
                 return sql;
             if (opt.info_callback) {
@@ -7413,7 +7413,7 @@ t.tryExec("delete from tmp_table where id = %v and name = %v", arglist);
 
             @return any return value from the SQL command executed
          */
-        auto tryExecArgs(string sql, *softlist args) {
+        auto tryExecArgs(string sql, *softlist<auto> args) {
             return tryExecArgsImpl(sql, args);
         }
 
@@ -7448,7 +7448,7 @@ list l = db.getAlignSql(schema_hash);
             @throw SCHEMA-DESCRIPTION-ERROR the @ref schema_desc_hash "schema description hash" has an error or a required object does not exist
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        list getAlignSql(hash schema_hash, *hash opt, *Tables table_cache) {
+        list<auto> getAlignSql(hash schema_hash, *hash<auto> opt, *Tables table_cache) {
             validateOptionsIntern("SCHEMA-DESCRIPTION-ERROR", getSchemaDescriptionOptions(), \schema_hash);
             validateOptionsIntern("OPTION-ERROR", getAlignSchemaOptions(), \opt);
             validateHashKeysForWhitespaces(schema_hash);
@@ -7500,7 +7500,7 @@ list l = db.getAlignSql(schema_hash);
                                     name, i.getValue().type());
                 }
 
-                hash sh = i.getValue();
+                hash<auto> sh = i.getValue();
                 validateOptionsIntern("SEQUENCE-DESCRIPTION-ERROR", getSequenceDescriptionOptions(), \sh);
 
                 # see if sequence exists
@@ -7516,7 +7516,7 @@ list l = db.getAlignSql(schema_hash);
 
             # rename any tables
             AbstractDatabase::checkDriverOptions(\schema_hash.table_map, drv);
-            foreach hash th in (schema_hash.table_map) {
+            foreach hash<auto> th in (schema_hash.table_map) {
                 if (th.value.typeCode() != NT_STRING)
                     throw "SCHEMA-DESCRIPTION-ERROR", sprintf("table_map %y value is not a string in the schema description hash; got type %y instead (%y)", th.key, th.value.type(), th.value);
 
@@ -7572,7 +7572,7 @@ list l = db.getDropSchemaSql(schema_hash);
             @throw SCHEMA-DESCRIPTION-ERROR the @ref schema_desc_hash "schema description hash" has an error
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        list getDropSchemaSql(hash schema_hash, *hash opt) {
+        list<auto> getDropSchemaSql(hash schema_hash, *hash<auto> opt) {
             validateOptionsIntern("SCHEMA-DESCRIPTION-ERROR", getSchemaDescriptionOptions(), \schema_hash);
             validateOptionsIntern("OPTION-ERROR", getDropSchemaOptions(), \opt);
 
@@ -7625,7 +7625,7 @@ list l = db.getDropSchemaSql(schema_hash);
             return l;
         }
 
-        private list dropSqlUnlocked(string type, hash schema_hash, code get, code make, *hash opt, string make_arg_type) {
+        private list dropSqlUnlocked(string type, hash schema_hash, code get, code make, *hash<auto> opt, string make_arg_type) {
             list l = ();
             hash copt = getCreationOptions();
             string drv = getDriverName();
@@ -7650,7 +7650,7 @@ list l = db.getDropSchemaSql(schema_hash);
             return l;
         }
 
-        private list alignCodeUnlocked(string type, hash schema_hash, code get, code make, *hash opt, string make_arg_type) {
+        private list alignCodeUnlocked(string type, hash schema_hash, code get, code make, *hash<auto> opt, string make_arg_type) {
             list l = ();
             hash copt = getCreationOptions();
             string drv = getDriverName();
@@ -7725,13 +7725,13 @@ AbstractSequence seq = db.makeSequence("seq_queues");
             @throw OPTION-ERROR invalid or unsupported option passed
             @throw SEQUENCE-ERROR end not compatible with start and increment, increment is zero
         */
-        AbstractSequence makeSequence(string name, number start = 1, number increment = 1, *softnumber end, *hash opts) {
+        AbstractSequence makeSequence(string name, number start = 1, number increment = 1, *softnumber end, *hash<auto> opts) {
             validateOptionsIntern("OPTION-ERROR", getCreationOptions(), \opts);
 
             return makeSequenceImpl(name, start, increment, end, opts);
         }
 
-        AbstractSequence makeSequenceFromDescription(string name, *hash<auto> sh, *hash opts) {
+        AbstractSequence makeSequenceFromDescription(string name, *hash<auto> sh, *hash<auto> opts) {
             validateOptionsIntern("SEQUENCE-DESCRIPTION-ERROR", getSequenceDescriptionOptions(), \sh);
 
             return makeSequence(name, sh.start, sh.increment, sh.end);
@@ -7751,7 +7751,7 @@ AbstractTable table = db.makeTable("table", th);
 
             @see SqlUtil::AbstractTable::constructor()
         */
-        AbstractTable makeTable(string name, hash<auto> desc, *hash opts) {
+        AbstractTable makeTable(string name, hash<auto> desc, *hash<auto> opts) {
             AbstractTable t = AbstractTable::getTable(ds, name, opts);
             t.setupTable(desc, opts);
             return t;
@@ -7769,7 +7769,7 @@ AbstractFunction f = db.makeFunction("update_queue", src);
 
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        AbstractFunction makeFunction(string name, string src, *hash opts) {
+        AbstractFunction makeFunction(string name, string src, *hash<auto> opts) {
             validateOptionsIntern("OPTION-ERROR", getCreationOptions(), \opts);
 
             return makeFunctionImpl(name, src, opts);
@@ -7787,7 +7787,7 @@ AbstractFunction f = db.makeProcedure("get_queue_info", src);
 
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        AbstractFunction makeProcedure(string name, string src, *hash opt) {
+        AbstractFunction makeProcedure(string name, string src, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getCreationOptions(), \opt);
 
             return makeProcedureImpl(name, src, opt);
@@ -7806,7 +7806,7 @@ db.dropFunctionIfExists(name);
 
             @throw OPTION-ERROR invalid or unknown callback option
         */
-        bool dropFunctionIfExists(string name, *hash opt) {
+        bool dropFunctionIfExists(string name, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getDropSchemaOptions(), \opt);
             *AbstractFunction f = getFunction(name);
             if (!f)
@@ -7827,7 +7827,7 @@ db.dropProcedureIfExists(name);
 
             @throw OPTION-ERROR invalid or unknown callback option
         */
-        bool dropProcedureIfExists(string name, *hash opt) {
+        bool dropProcedureIfExists(string name, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getDropSchemaOptions(), \opt);
             *AbstractFunction f = getProcedure(name);
             if (!f)
@@ -7848,7 +7848,7 @@ db.dropSequenceIfExists(name);
 
             @throw OPTION-ERROR invalid or unknown callback option
         */
-        bool dropSequenceIfExists(string name, *hash opt) {
+        bool dropSequenceIfExists(string name, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getDropSchemaOptions(), \opt);
             *AbstractSequence seq = getSequence(name);
             if (!seq)
@@ -7869,7 +7869,7 @@ db.dropViewIfExists(name);
 
             @throw OPTION-ERROR invalid or unknown callback option
         */
-        bool dropViewIfExists(string name, *hash opt) {
+        bool dropViewIfExists(string name, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getDropSchemaOptions(), \opt);
             *AbstractView obj = getView(name);
             if (!obj)
@@ -7890,7 +7890,7 @@ db.dropTableIfExists(name);
 
             @throw OPTION-ERROR invalid or unknown callback option
         */
-        bool dropTableIfExists(string name, *hash opt) {
+        bool dropTableIfExists(string name, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getDropSchemaOptions(), \opt);
             *AbstractTable obj = getTable(name);
             if (!obj)
@@ -7912,7 +7912,7 @@ string sql = db.getDropFunctionSqlIfExists(name);
 
             @throw OPTION-ERROR invalid or unknown callback option
         */
-        *string getDropFunctionSqlIfExists(string name, *hash opt) {
+        *string getDropFunctionSqlIfExists(string name, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getDropSchemaOptions(), \opt);
             *AbstractFunction f = getFunction(name);
             if (!f)
@@ -7933,7 +7933,7 @@ string sql = db.getDropProcedureSqlIfExists(name);
 
             @throw OPTION-ERROR invalid or unknown callback option
         */
-        *string getDropProcedureSqlIfExists(string name, *hash opt) {
+        *string getDropProcedureSqlIfExists(string name, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getDropSchemaOptions(), \opt);
             *AbstractFunction f = getProcedure(name);
             if (!f)
@@ -7954,7 +7954,7 @@ string sql = db.getDropSequenceSqlIfExists(name);
 
             @throw OPTION-ERROR invalid or unknown callback option
         */
-        *string getDropSequenceSqlIfExists(string name, *hash opt) {
+        *string getDropSequenceSqlIfExists(string name, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getDropSchemaOptions(), \opt);
             *AbstractSequence obj = getSequence(name);
             if (!obj)
@@ -7975,7 +7975,7 @@ string sql = db.getDropTableSqlIfExists(name);
 
             @throw OPTION-ERROR invalid or unknown callback option
         */
-        *list getDropTableSqlIfExists(string name, *hash opt) {
+        *list<auto> getDropTableSqlIfExists(string name, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getDropSchemaOptions(), \opt);
             *AbstractTable t = getTable(name);
             if (!t)
@@ -7983,12 +7983,12 @@ string sql = db.getDropTableSqlIfExists(name);
             return t.getDropSql(opt);
         }
 
-        doDropSql(*softlist l, string type, string name, *hash opt) {
+        doDropSql(*softlist l, string type, string name, *hash<auto> opt) {
             if (l)
                 AbstractDatabase::doCallback(opt, l, AC_Drop, type, name);
         }
 
-        bool doDrop(*softlist l, string type, string name, *hash opt) {
+        bool doDrop(*softlist l, string type, string name, *hash<auto> opt) {
             if (l) {
                 AbstractDatabase::doCallback(opt, l, AC_Drop, type, name);
                 on_success ds.commit();
@@ -8012,7 +8012,7 @@ list l = db.getAlignFunctionSql(f);
 
             @throw OPTION-ERROR invalid or unsupported option passed
          */
-        list getAlignFunctionSql(AbstractFunction f, *hash opt) {
+        list<auto> getAlignFunctionSql(AbstractFunction f, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignSchemaOptions(), \opt);
 
             *AbstractFunction of = getFunctionImpl(f.name);
@@ -8043,7 +8043,7 @@ list l = db.getAlignProcedureSql(f);
 
             @throw OPTION-ERROR invalid or unsupported option passed
          */
-        list getAlignProcedureSql(AbstractFunction f, *hash opt) {
+        list<auto> getAlignProcedureSql(AbstractFunction f, *hash<auto> opt) {
             *AbstractFunction of = getProcedureImpl(f.name);
 
             list l = ();
@@ -8251,7 +8251,7 @@ string sql = t.getSqlFromList(list);
 
             @since %SqlUtil 1.2
          */
-        bool rebuildIndex(string name, *hash options) {
+        bool rebuildIndex(string name, *hash<auto> options) {
             validateOptionsIntern("REBUILD-INDEX-ERROR", getRebuildIndexOptions(), \options);
             return rebuildIndexImpl(name, options);
         }
@@ -8265,7 +8265,7 @@ string sql = t.getSqlFromList(list);
 
             @since %SqlUtil 1.2
          */
-        bool rebuildIndex(AbstractIndex index, *hash options) {
+        bool rebuildIndex(AbstractIndex index, *hash<auto> options) {
             validateOptionsIntern("REBUILD-INDEX-ERROR", getRebuildIndexOptions(), \options);
             return rebuildIndexImpl(index.name, options);
         }
@@ -8278,7 +8278,7 @@ string sql = t.getSqlFromList(list);
 
             @since %SqlUtil 1.2
          */
-        computeStatistics(*hash options) {
+        computeStatistics(*hash<auto> options) {
             validateOptionsIntern("COMPUTE-STATISTICS-ERROR", getComputeStatisticsOptions(), \options);
             computeStatisticsImpl(options);
         }
@@ -8291,7 +8291,7 @@ string sql = t.getSqlFromList(list);
 
             @since %SqlUtil 1.2
          */
-        reclaimSpace(*hash options) {
+        reclaimSpace(*hash<auto> options) {
             validateOptionsIntern("RECLAIM-SPACE-ERROR", getReclaimSpaceOptions(), \options);
             reclaimSpaceImpl(options);
         }
@@ -8318,7 +8318,7 @@ string sql = t.getSqlFromList(list);
             AbstractSqlUtilBase::validateOptionsIntern(err, ropt, \opt, tag);
         }
 
-        static AbstractDatabase getDatabase(AbstractDatasource nds, *hash opts) {
+        static AbstractDatabase getDatabase(AbstractDatasource nds, *hash<auto> opts) {
             string drv = nds.getDriverName();
 
             if (opts)
@@ -8342,12 +8342,12 @@ string sql = t.getSqlFromList(list);
             }
         }
 
-        static AbstractDatabase getDatabase(string dsstr, *hash opts) {
+        static AbstractDatabase getDatabase(string dsstr, *hash<auto> opts) {
             Datasource nds(dsstr);
             return AbstractDatabase::getDatabase(nds, opts);
         }
 
-        static AbstractDatabase getDatabase(hash<auto> dsh, *hash opts) {
+        static AbstractDatabase getDatabase(hash<auto> dsh, *hash<auto> opts) {
             Datasource nds(dsh);
             return AbstractDatabase::getDatabase(nds, opts);
         }
@@ -8361,57 +8361,57 @@ string sql = t.getSqlFromList(list);
         }
 
         #! override in subclasses to return driver-specific options
-        private hash getDatabaseOptions() {
+        private hash<auto> getDatabaseOptions() {
             return DatabaseOptions;
         }
 
         #! override in subclasses to return driver-specific options
-        private hash getCallbackOptions() {
+        private hash<auto> getCallbackOptions() {
             return CallbackOptions;
         }
 
         #! override in subclasses to return driver-specific options
-        private hash getCreationOptions() {
+        private hash<auto> getCreationOptions() {
             return CreationOptions;
         }
 
         #! override in subclasses to return driver-specific options
-        private hash getCacheOptions() {
+        private hash<auto> getCacheOptions() {
             return CacheOptions;
         }
 
         #! override in subclasses to return driver-specific options
-        private hash getAlignSchemaOptions() {
+        private hash<auto> getAlignSchemaOptions() {
             return AlignSchemaOptions;
         }
 
         #! override in subclasses to return driver-specific options
-        private hash getDropSchemaOptions() {
+        private hash<auto> getDropSchemaOptions() {
             return DropSchemaOptions;
         }
 
         #! override in subclasses to return driver-specific options
-        private hash getSchemaDescriptionOptions() {
+        private hash<auto> getSchemaDescriptionOptions() {
             return SchemaDescriptionOptions;
         }
 
         #! override in subclasses to return driver-specific options
-        private hash getSequenceDescriptionOptions() {
+        private hash<auto> getSequenceDescriptionOptions() {
             return SequenceDescriptionOptions;
         }
 
         #! override in subclasses to return driver-specific options
-        private hash getRebuildIndexOptions() {
+        private hash<auto> getRebuildIndexOptions() {
             return hash();
         }
 
         #! override in subclasses to return driver-specific options
-        private hash getComputeStatisticsOptions() {
+        private hash<auto> getComputeStatisticsOptions() {
             return ComputeStatisticsOptions;
         }
 
         #! override in subclasses to return driver-specific options
-        private hash getReclaimSpaceOptions() {
+        private hash<auto> getReclaimSpaceOptions() {
             return ReclaimSpaceOptions;
         }
 
@@ -8426,17 +8426,17 @@ string sql = t.getSqlFromList(list);
         }
 
         private abstract string getCreateSqlImpl(list l);
-        private abstract list getAlignSqlImpl(hash schema_hash, *hash opt);
-        private abstract list getDropSchemaSqlImpl(hash schema_hash, *hash opt);
+        private abstract list<auto> getAlignSqlImpl(hash schema_hash, *hash<auto> opt);
+        private abstract list<auto> getDropSchemaSqlImpl(hash schema_hash, *hash<auto> opt);
 
         private abstract *AbstractSequence getSequenceImpl(string name);
         private abstract *AbstractFunction getFunctionImpl(string name);
         private abstract *AbstractFunction getProcedureImpl(string name);
         private abstract *AbstractView getViewImpl(string name);
 
-        private abstract AbstractSequence makeSequenceImpl(string name, number start = 1, number increment = 1, *softnumber end, *hash opts);
-        private abstract AbstractFunction makeFunctionImpl(string name, string src, *hash opts);
-        private abstract AbstractFunction makeProcedureImpl(string name, string src, *hash opts);
+        private abstract AbstractSequence makeSequenceImpl(string name, number start = 1, number increment = 1, *softnumber end, *hash<auto> opts);
+        private abstract AbstractFunction makeFunctionImpl(string name, string src, *hash<auto> opts);
+        private abstract AbstractFunction makeProcedureImpl(string name, string src, *hash<auto> opts);
 
         private abstract list featuresImpl();
         private abstract list listTablesImpl();
@@ -8455,9 +8455,9 @@ string sql = t.getSqlFromList(list);
         private abstract bool supportsPackagesImpl();
         private abstract bool supportsTypesImpl();
 
-        private abstract bool rebuildIndexImpl(string name, *hash options);
-        private abstract computeStatisticsImpl(*hash options);
-        private abstract reclaimSpaceImpl(*hash options);
+        private abstract bool rebuildIndexImpl(string name, *hash<auto> options);
+        private abstract computeStatisticsImpl(*hash<auto> options);
+        private abstract reclaimSpaceImpl(*hash<auto> options);
         private abstract int getPhysicalSizeImpl();
     }
 
@@ -8497,7 +8497,7 @@ Table table(ds, "table");
             @throw TABLE-DRIVER-ERROR no database-specific module can be loaded
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        constructor(AbstractDatasource ds, string name, *hash opts) {
+        constructor(AbstractDatasource ds, string name, *hash<auto> opts) {
             t = AbstractTable::getTable(ds, name, opts);
         }
 
@@ -8514,7 +8514,7 @@ Table table("pgsql:user/pass@db%host", "table");
             @throw TABLE-DRIVER-ERROR no database-specific module can be loaded
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        constructor(string ds, string name, *hash opts) {
+        constructor(string ds, string name, *hash<auto> opts) {
             t = AbstractTable::getTable(ds, name, opts);
         }
 
@@ -8539,7 +8539,7 @@ Table table("pgsql:user/pass@db%host", "table");
             @throw TABLE-DRIVER-ERROR no database-specific module can be loaded
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        constructor(hash<auto> ds, string name, *hash opts) {
+        constructor(hash<auto> ds, string name, *hash<auto> opts) {
             t = AbstractTable::getTable(ds, name, opts);
         }
 
@@ -8552,7 +8552,7 @@ Table table("pgsql:user/pass@db%host", "table");
             @throw OPTION-ERROR invalid or unsupported option passed
             @throw DESCRIPTION-ERROR invalid or unsupported description hash value passed
         */
-        constructor(AbstractDatasource ds, hash<auto> desc, string name, *hash opts) {
+        constructor(AbstractDatasource ds, hash<auto> desc, string name, *hash<auto> opts) {
             t = AbstractTable::getTable(ds, name);
             t.setupTable(desc, opts);
         }
@@ -8674,12 +8674,12 @@ Table table("pgsql:user/pass@db%host", "table");
 
             #! Table description options
             /** this option is made up of the following keys:
-                - \c columns: (@ref column_desc_hash "column description hash") a hash describing the column
-                - \c primary_key : (@ref pk_desc_hash "primary key description hash") a hash describing the primary key for the table
-                - \c indexes: (@ref index_desc_hash "index description hashes") a hash describing the indexes on the table
+                - \c columns: (@ref column_desc_hash "column description hash") a hash<auto> describing the column
+                - \c primary_key : (@ref pk_desc_hash "primary key description hash") a hash<auto> describing the primary key for the table
+                - \c indexes: (@ref index_desc_hash "index description hashes") a hash<auto> describing the indexes on the table
                 - \c triggers: a hash of trigger information keyed by trigger name; the values are the trigger source code; since triggers are driver-dependent, a driver-independent table description would include trigger hashes under the \c drivers key and the driver key name under that
-                - \c foreign_constraints: (@ref fk_desc_hash "foreign constraint hashes") a hash describing the foreign constraints on the table
-                - \c unique_constraints: (@ref uk_desc_hash "unique constraint hashes") a hash describing the unique constraints on the table
+                - \c foreign_constraints: (@ref fk_desc_hash "foreign constraint hashes") a hash<auto> describing the foreign constraints on the table
+                - \c unique_constraints: (@ref uk_desc_hash "unique constraint hashes") a hash<auto> describing the unique constraints on the table
                 - \c table_cache: (@ref SqlUtil::Tables "Tables") an optional table cache for maintaining cached tables and foreign key relationships between tables
 
                 @see @ref table_desc_hash
@@ -9067,7 +9067,7 @@ table.dropCommit();
 
             @note The transaction is committed if successful or rolled back if an exception occurs; use @ref drop() to execute without any transaction management
          */
-        dropCommit(*hash opt) {
+        dropCommit(*hash<auto> opt) {
             on_exit ds.commit();
             on_error ds.rollback();
             drop(opt);
@@ -9085,13 +9085,13 @@ table.drop();
 
             @note Transaction management is normally not performed when dropping tables, however this method uses the Qore::SQL::AbstractDatasource::exec() method, which normally participates in acquiring a transaction lock for the underlying datasource object; therefore after this method executes normally the transaction lock will be dedicated to the calling thread.
          */
-        drop(*hash opt) {
+        drop(*hash<auto> opt) {
             map ds.execRaw($1), getDropSql(opt);
             inDb = False;
         }
 
         #! A legacy wrapper for drop()
-        deprecated dropNoCommit(*hash opt) {
+        deprecated dropNoCommit(*hash<auto> opt) {
             drop(opt);
         }
 
@@ -9122,7 +9122,7 @@ t.tryExec("delete from tmp_table where id = %v and name = %v", arglist);
 
             @return any return value from the SQL command executed
          */
-        auto tryExecArgs(string sql, *softlist args) {
+        auto tryExecArgs(string sql, *softlist<auto> args) {
             return tryExecArgsImpl(sql, args);
         }
 
@@ -9154,7 +9154,7 @@ list l = table.getDropSql();
 
             @throw OPTION-ERROR invalid or unknown callback option
         */
-        softlist getDropSql(*hash opt) {
+        softlist<auto> getDropSql(*hash<auto> opt) {
             cache();
             return AbstractDatabase::doCallback(opt, getDropSqlImpl(), AbstractDatabase::AC_Drop, "table", getSqlName());
         }
@@ -9207,7 +9207,7 @@ string sql = table.getTruncateSql();
 
             @note if the @ref sql_callback_executed "sql_callback_executed option" is @ref Qore::True "True" in \a opt, then the changes are also effected in the current object, if not, then they are not (see @ref sql_callback_executed for more information)
          */
-        string getTruncateSql(*hash opt) {
+        string getTruncateSql(*hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
             return AbstractDatabase::doCallback(opt, getTruncateSqlImpl(), AbstractDatabase::AC_Truncate, "table", name);
         }
@@ -9222,7 +9222,7 @@ table.createCommit();
 
             @note The transaction is committed if successful or rolled back if an exception occurs; use @ref create() to execute without any transaction management
          */
-        createCommit(*hash opt) {
+        createCommit(*hash<auto> opt) {
             on_exit ds.commit();
             on_error ds.rollback();
             create(opt);
@@ -9240,7 +9240,7 @@ table.create();
 
             @throw CREATE-TABLE-ERROR table has already been read from or created in the database
          */
-        create(*hash opt) {
+        create(*hash<auto> opt) {
             if (inDb)
                 throw "CREATE-TABLE-ERROR", sprintf("%s has already been read from or created in the database", getDesc());
 
@@ -9251,7 +9251,7 @@ table.create();
         }
 
         #! A legacy wrapper for create()
-        deprecated createNoCommit(*hash opt) {
+        deprecated createNoCommit(*hash<auto> opt) {
             create(opt);
         }
 
@@ -9337,7 +9337,7 @@ bool b = table.empty();
             @throw OPTION-ERROR invalid or unsupported option passed
             @throw DESCRIPTION-ERROR invalid or unsupported description hash value passed
         */
-        setupTable(hash<auto> desc, *hash opt) {
+        setupTable(hash<auto> desc, *hash<auto> opt) {
             # check description
             validateOptionsIntern("DESCRIPTION-ERROR", getTableDescriptionHashOptions(), \desc);
 
@@ -9355,7 +9355,7 @@ bool b = table.empty();
             on_exit l.unlock();
 
             if (!emptyUnlocked())
-                throw "DESCRIPTION-ERROR", sprintf("%s: cannot set up a non-empty table from a hash description", getDesc());
+                throw "DESCRIPTION-ERROR", sprintf("%s: cannot set up a non-empty table from a hash<auto> description", getDesc());
 
             # add current table to cache
             opt.table_cache.add(name, self);
@@ -9400,7 +9400,7 @@ bool b = table.empty();
 
             # add columns to table
             foreach string cn in (desc.columns.keyIterator()) {
-                hash ch = desc.columns{cn};
+                hash<auto> ch = desc.columns{cn};
                 softbool nullable = !exists ch.notnull ? True : !(remove ch.notnull);
                 # bug #1688: sqlutil: oracle: character_semantics can be
                 # different for each column. So the global options (oc)
@@ -9436,7 +9436,7 @@ bool b = table.empty();
                 if (desc.unique_constraints{un}.typeCode() != NT_HASH)
                     throw "DESCRIPTION-ERROR", sprintf("%s: value assigned to index key %y is not a hash, got type %y instead (%y)", getDesc(), un, desc.unique_constraints{un}.type(), desc.unique_constraints{un});
 
-                hash ch = desc.unique_constraints{un};
+                hash<auto> ch = desc.unique_constraints{un};
 
                 if (!ch.columns || !inlist(ch.columns.typeCode(), (NT_LIST, NT_STRING)))
                     throw "DESCRIPTION-ERROR", sprintf("%s: value assigned to \"columns\" key for unique constraint %y is not a list or a string, got type %y instead (%y)", getDesc(), un, ch.columns.type(), ch.columns);
@@ -9451,7 +9451,7 @@ bool b = table.empty();
                 if (desc.foreign_constraints{cn}.typeCode() != NT_HASH)
                     throw "DESCRIPTION-ERROR", sprintf("%s: value assigned to foreign constraint key %y is not a hash, got type %y instead (%y)", getDesc(), cn, desc.foreign_constraints{cn}.type(), desc.foreign_constraints{cn});
 
-                hash ch = desc.foreign_constraints{cn};
+                hash<auto> ch = desc.foreign_constraints{cn};
 
                 if (!ch.columns || !inlist(ch.columns.typeCode(), (NT_LIST, NT_STRING)))
                     throw "DESCRIPTION-ERROR", sprintf("%s: value assigned to \"columns\" key for foreign constraint %y is not a list or a string, got type %y instead (%y)", getDesc(), cn, ch.columns.type(), ch.columns);
@@ -9494,7 +9494,7 @@ table.addColumn("name", ("qore_type": Type::String, "size": 50), False);
             In case the table is already in the database, this method commits the transaction on success and rolls back the transaction if there's an error.
 
             @param cname the name of the column
-            @param opt a hash describing the column; the following keys are permitted (other column options may be supported depending on the underlying AbstractTable implementation):
+            @param opt a hash<auto> describing the column; the following keys are permitted (other column options may be supported depending on the underlying AbstractTable implementation):
             - \c qore_type: a qore type string that will be converted to a native DB type with some default conversion;
             - \c native_type: the native database column type; if both \c native_type and \c qore_type are given then \c native_type is used
             - \c size: for data types requiring a size component, the size; for numeric columns this represents the precision for example
@@ -9510,7 +9510,7 @@ table.addColumn("name", ("qore_type": Type::String, "size": 50), False);
 
             @see inDb() for a method that tells if the table is already in the database or not
          */
-        AbstractColumn addColumn(string cname, hash opt, bool nullable = True, *reference lsql) {
+        AbstractColumn addColumn(string cname, hash<auto> opt, bool nullable = True, *reference lsql) {
             l.lock();
             on_exit l.unlock();
 
@@ -9526,7 +9526,7 @@ list l = table.getAddColumnSql("name", ("qore_type": Type::String, "size": 50), 
             In case the table is already in the database, this method commits the transaction on success and rolls back the transaction if there's an error.
 
             @param cname the name of the column
-            @param copt a hash describing the column; the following keys are permitted (other column options may be supported depending on the underlying AbstractTable implementation):
+            @param copt a hash<auto> describing the column; the following keys are permitted (other column options may be supported depending on the underlying AbstractTable implementation):
             - \c qore_type: a qore type string that will be converted to a native DB type with some default conversion;
             - \c native_type: the native database column type; if both \c native_type and \c qore_type are given then \c native_type is used
             - \c size: for data types requiring a size component, the size; for numeric columns this represents the precision for example
@@ -9547,7 +9547,7 @@ list l = table.getAddColumnSql("name", ("qore_type": Type::String, "size": 50), 
 
             @see inDb() for a method that tells if the table is already in the database or not
          */
-        list getAddColumnSql(string cname, hash copt, bool nullable = True, *hash opt) {
+        list<auto> getAddColumnSql(string cname, hash copt, bool nullable = True, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
 
             list lsql;
@@ -9561,7 +9561,7 @@ list l = table.getAddColumnSql("name", ("qore_type": Type::String, "size": 50), 
             return AbstractDatabase::doCallback(opt, lsql, AbstractDatabase::AC_Add, "column", name, cname);
         }
 
-        private AbstractColumn addColumnUnlocked(string cname, hash opt, bool nullable = True, *reference lsql, bool do_exec = True, bool modify_table = True) {
+        private AbstractColumn addColumnUnlocked(string cname, hash<auto> opt, bool nullable = True, *reference lsql, bool do_exec = True, bool modify_table = True) {
             if (!columns)
                 columns = new Columns();
             else if (columns.hasKey(cname))
@@ -9600,7 +9600,7 @@ table.modifyColumn("name", ("qore_type": Type::String, "size": 240), False);
             In case the table is already in the database, this method commits the transaction on success and rolls back the transaction if there's an error.
 
             @param cname the name of the column
-            @param opt a hash describing the column; the following keys are permitted (other column options may be supported depending on the underlying AbstractTable implementation):
+            @param opt a hash<auto> describing the column; the following keys are permitted (other column options may be supported depending on the underlying AbstractTable implementation):
             - \c qore_type: a qore type string that will be converted to a native DB type with some default conversion;
             - \c native_type: the native database column type; if both \c native_type and \c qore_type are given then \c native_type is used
             - \c size: for data types requiring a size component, the size; for numeric columns this represents the precision for example
@@ -9617,7 +9617,7 @@ table.modifyColumn("name", ("qore_type": Type::String, "size": 240), False);
 
             @see inDb() for a method that tells if the table is already in the database or not
          */
-        AbstractColumn modifyColumn(string cname, hash opt, bool nullable = True, *reference lsql) {
+        AbstractColumn modifyColumn(string cname, hash<auto> opt, bool nullable = True, *reference lsql) {
             l.lock();
             on_exit l.unlock();
             getColumnsUnlocked();
@@ -9647,7 +9647,7 @@ list l = table.getModifyColumnSql("name", ("qore_type": Type::String, "size": 24
             @endcode
 
             @param cname the name of the column
-            @param copt a hash describing the column; the following keys are permitted (other column options may be supported depending on the underlying AbstractTable implementation):
+            @param copt a hash<auto> describing the column; the following keys are permitted (other column options may be supported depending on the underlying AbstractTable implementation):
             - \c qore_type: a qore type string that will be converted to a native DB type with some default conversion;
             - \c native_type: the native database column type; if both \c native_type and \c qore_type are given then \c native_type is used
             - \c size: for data types requiring a size component, the size; for numeric columns this represents the precision for example
@@ -9668,7 +9668,7 @@ list l = table.getModifyColumnSql("name", ("qore_type": Type::String, "size": 24
 
             @see inDb() for a method that tells if the table is already in the database or not
          */
-        list getModifyColumnSql(string cname, hash copt, bool nullable = True, *hash opt) {
+        list<auto> getModifyColumnSql(string cname, hash copt, bool nullable = True, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
 
             l.lock();
@@ -9745,7 +9745,7 @@ string sql = table.getRenameColumnSql("name", "family_name");
 
             @note if the @ref sql_callback_executed "sql_callback_executed option" is @ref Qore::True "True" in \a opt, then the changes are also effected in the current object, if not, then they are not (see @ref sql_callback_executed for more information)
         */
-        string getRenameColumnSql(string old_name, string new_name, *hash opt) {
+        string getRenameColumnSql(string old_name, string new_name, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
 
             l.lock();
@@ -9838,7 +9838,7 @@ printf("%s;\n", sql);
 
             @see inDb() for a method that tells if the table is already in the database or not
          */
-        AbstractPrimaryKey addPrimaryKey(string pkname, softlist cols, *hash opt, *reference<string> sql) {
+        AbstractPrimaryKey addPrimaryKey(string pkname, softlist cols, *hash<auto> opt, *reference<string> sql) {
             l.lock();
             on_exit l.unlock();
 
@@ -9868,7 +9868,7 @@ printf("%s;\n", sql);
 
             @note if the @ref sql_callback_executed "sql_callback_executed option" is @ref Qore::True "True" in \a opt, then the changes are also effected in the current object, if not, then they are not (see @ref sql_callback_executed for more information)
          */
-        string getAddPrimaryKeySql(string pkname, softlist cols, *hash pkopt, *hash opt) {
+        string getAddPrimaryKeySql(string pkname, softlist cols, *hash pkopt, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
             l.lock();
             on_exit l.unlock();
@@ -9886,14 +9886,14 @@ printf("%s;\n", sql);
             primaryKey = pk;
         }
 
-        private AbstractPrimaryKey addPrimaryKeyUnlocked(string pkname, softlist cols, *hash opt, *reference<string> sql) {
+        private AbstractPrimaryKey addPrimaryKeyUnlocked(string pkname, softlist cols, *hash<auto> opt, *reference<string> sql) {
             AbstractPrimaryKey pk = addPrimaryKeyUnlockedIntern(pkname, cols, opt, \sql);
             execSql(sql);
             setPrimaryKeyUnlocked(pk);
             return pk;
         }
 
-        private AbstractPrimaryKey addPrimaryKeyUnlockedIntern(string pkname, softlist cols, *hash opt, *reference<string> sql) {
+        private AbstractPrimaryKey addPrimaryKeyUnlockedIntern(string pkname, softlist cols, *hash<auto> opt, *reference<string> sql) {
             getColumnsUnlocked();
             if (!manual)
                 getIndexesUnlocked();
@@ -9907,7 +9907,7 @@ printf("%s;\n", sql);
             if (!cols)
                 throw "PRIMARY-KEY-ERROR", sprintf("%s add primary key %y: no column names passed to %s::addPrimaryKey()", getDesc(), pkname, self.className());
 
-            hash ch;
+            hash<auto> ch;
             while (cols) {
                 auto v = shift cols;
                 if (v.typeCode() != NT_STRING)
@@ -9946,7 +9946,7 @@ list l = table.getDropAllConstraintsAndIndexesOnColumnSql("status");
 
             @see inDb() for a method that tells if the table is already in the database or not
         */
-        list getDropAllConstraintsAndIndexesOnColumnSql(string cname, *hash opt) {
+        list<auto> getDropAllConstraintsAndIndexesOnColumnSql(string cname, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
 
             l.lock();
@@ -9955,7 +9955,7 @@ list l = table.getDropAllConstraintsAndIndexesOnColumnSql("status");
             return getDropAllConstraintsAndIndexesOnColumnSqlUnlocked(cname, opt);
         }
 
-        private list getDropAllConstraintsAndIndexesOnColumnSqlUnlocked(string cname, *hash opt) {
+        private list<auto> getDropAllConstraintsAndIndexesOnColumnSqlUnlocked(string cname, *hash<auto> opt) {
             getAllConstraintsUnlocked();
             getIndexesUnlocked();
 
@@ -10022,7 +10022,7 @@ list l = table.getDropPrimaryKeySql();
 
             @see inDb() for a method that tells if the table is already in the database or not
          */
-        list getDropPrimaryKeySql(*hash opt) {
+        list<auto> getDropPrimaryKeySql(*hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
 
             l.lock();
@@ -10099,7 +10099,7 @@ printf("%s;\n", sql);
 
             @see inDb() for a method that tells if the table is already in the database or not
          */
-        AbstractUniqueConstraint addUniqueConstraint(string cname, softlist cols, *hash opt, *reference<string> sql) {
+        AbstractUniqueConstraint addUniqueConstraint(string cname, softlist cols, *hash<auto> opt, *reference<string> sql) {
             l.lock();
             on_exit l.unlock();
             return addUniqueConstraintUnlocked(cname, cols, opt, \sql);
@@ -10126,7 +10126,7 @@ printf("%s;\n", sql);
 
             @note if the @ref sql_callback_executed "sql_callback_executed option" is @ref Qore::True "True" in \a opt, then the changes are also effected in the current object, if not, then they are not (see @ref sql_callback_executed for more information)
          */
-        string getAddUniqueConstraintSql(string cname, softlist cols, *hash ukopt, *hash opt) {
+        string getAddUniqueConstraintSql(string cname, softlist cols, *hash ukopt, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
 
             l.lock();
@@ -10144,7 +10144,7 @@ printf("%s;\n", sql);
             return AbstractDatabase::doCallback(opt, sql, AbstractDatabase::AC_Add, "unique constraint", cname, getSqlName());
         }
 
-        private AbstractUniqueConstraint addUniqueConstraintUnlocked(string cname, softlist cols, *hash opt, *reference<string> sql) {
+        private AbstractUniqueConstraint addUniqueConstraintUnlocked(string cname, softlist cols, *hash<auto> opt, *reference<string> sql) {
             AbstractUniqueConstraint uk = addUniqueConstraintUnlockedIntern(cname, cols, opt, \sql);
             # add foreign constraint to table in the DB if the table already exists in the DB
             execSql(sql);
@@ -10155,7 +10155,7 @@ printf("%s;\n", sql);
             return uk;
         }
 
-        private AbstractUniqueConstraint addUniqueConstraintUnlockedIntern(string cname, softlist cols, *hash opt, *reference<string> sql) {
+        private AbstractUniqueConstraint addUniqueConstraintUnlockedIntern(string cname, softlist cols, *hash<auto> opt, *reference<string> sql) {
             getColumnsUnlocked();
             if (!manual)
                 getIndexesUnlocked();
@@ -10166,7 +10166,7 @@ printf("%s;\n", sql);
             if (!cols)
                 throw "UNIQUE-CONSTRAINT-ERROR", sprintf("%s add unique constraint %y: no column names passed to %s::addUniqueConstraint()", getDesc(), cname, self.className());
 
-            hash ch;
+            hash<auto> ch;
             while (cols) {
                 auto v = shift cols;
                 if (v.typeCode() != NT_STRING)
@@ -10211,7 +10211,7 @@ printf("%s;\n", sql);
 
             @see inDb() for a method that tells if the table is already in the database or not
          */
-        AbstractIndex addIndex(string iname, bool unique, softlist cols, *hash opt, *reference<string> sql) {
+        AbstractIndex addIndex(string iname, bool unique, softlist cols, *hash<auto> opt, *reference<string> sql) {
             l.lock();
             on_exit l.unlock();
 
@@ -10240,7 +10240,7 @@ printf("%s;\n", sql);
 
             @note if the @ref sql_callback_executed "sql_callback_executed option" is @ref Qore::True "True" in \a opt, then the changes are also effected in the current object, if not, then they are not (see @ref sql_callback_executed for more information)
          */
-        string getAddIndexSql(string iname, bool unique, softlist cols, *hash ixopt, *hash opt) {
+        string getAddIndexSql(string iname, bool unique, softlist cols, *hash ixopt, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
 
             l.lock();
@@ -10256,7 +10256,7 @@ printf("%s;\n", sql);
             return AbstractDatabase::doCallback(opt, sql, AbstractDatabase::AC_Add, "index", iname, getSqlName());
         }
 
-        private AbstractIndex addIndexUnlocked(string iname, bool unique, softlist cols, *hash opt, *reference<string> sql) {
+        private AbstractIndex addIndexUnlocked(string iname, bool unique, softlist cols, *hash<auto> opt, *reference<string> sql) {
             AbstractIndex ix = addIndexUnlockedIntern(iname, unique, cols, opt, \sql);
             execSql(sql);
             # set as index for the table
@@ -10276,7 +10276,7 @@ printf("%s;\n", sql);
             return ix;
         }
 
-        private AbstractIndex addIndexUnlockedIntern(string iname, bool unique, softlist cols, *hash opt, *reference<string> sql) {
+        private AbstractIndex addIndexUnlockedIntern(string iname, bool unique, softlist cols, *hash<auto> opt, *reference<string> sql) {
             getColumnsUnlocked();
             if (inDb)
                 getIndexesUnlocked();
@@ -10289,7 +10289,7 @@ printf("%s;\n", sql);
             if (!cols)
                 throw "INDEX-ERROR", sprintf("%s: no column names passed to %s::addIndex()", getDesc(), self.className());
 
-            hash ch;
+            hash<auto> ch;
             while (cols) {
                 auto v = shift cols;
                 if (v.typeCode() != NT_STRING)
@@ -10413,7 +10413,7 @@ string sql = table.getDropIndexSql("uk_mytable_name");
 
             @see inDb() for a method that tells if the table is already in the database or not
          */
-        string getDropIndexSql(string iname, *hash opt) {
+        string getDropIndexSql(string iname, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
 
             l.lock();
@@ -10452,7 +10452,7 @@ printf("%s;\n", sql);
 
             @see inDb() for a method that tells if the table is already in the database or not
          */
-        AbstractForeignConstraint addForeignConstraint(string cname, softlist cols, string table, *softlist tcols, *hash opt, *reference<string> sql) {
+        AbstractForeignConstraint addForeignConstraint(string cname, softlist cols, string table, *softlist tcols, *hash<auto> opt, *reference<string> sql) {
             l.lock();
             on_exit l.unlock();
 
@@ -10482,7 +10482,7 @@ printf("%s;\n", sql);
 
             @note if the @ref sql_callback_executed "sql_callback_executed option" is @ref Qore::True "True" in \a opt, then the changes are also effected in the current object, if not, then they are not (see @ref sql_callback_executed for more information)
          */
-        string getAddForeignConstraintSql(string cname, softlist cols, string table, *softlist tcols, *hash fkopt, *hash opt) {
+        string getAddForeignConstraintSql(string cname, softlist cols, string table, *softlist tcols, *hash fkopt, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
 
             l.lock();
@@ -10519,7 +10519,7 @@ printf("%s;\n", sql);
             return t.describe();
         }
 
-        private AbstractForeignConstraint addForeignConstraintUnlocked(string cname, softlist cols, string table, *softlist tcols, *hash opt, *reference<string> sql) {
+        private AbstractForeignConstraint addForeignConstraintUnlocked(string cname, softlist cols, string table, *softlist tcols, *hash<auto> opt, *reference<string> sql) {
             AbstractForeignConstraint fk = addForeignConstraintUnlockedIntern(cname, cols, table, tcols, opt, \sql);
             execSql(sql);
 
@@ -10534,7 +10534,7 @@ printf("%s;\n", sql);
             return fk;
         }
 
-        private AbstractForeignConstraint addForeignConstraintUnlockedIntern(string cname, softlist cols, string table, *softlist tcols, *hash opt, *reference<string> sql) {
+        private AbstractForeignConstraint addForeignConstraintUnlockedIntern(string cname, softlist cols, string table, *softlist tcols, *hash<auto> opt, *reference<string> sql) {
             getColumnsUnlocked();
             # load constraints if needed, verify unique constraint name, validate/process options
             checkUniqueConstraintNameValidateOptions("FOREIGN-CONSTRAINT-ERROR", cname, getForeignConstraintOptions(), \opt);
@@ -10542,7 +10542,7 @@ printf("%s;\n", sql);
             if (!cols)
                 throw "FOREIGN-CONSTRAINT-ERROR", sprintf("%y: no column names passed to %s::addForeignConstraint()", getDesc(), self.className());
 
-            hash ch;
+            hash<auto> ch;
             while (cols) {
                 auto v = shift cols;
                 if (v.typeCode() != NT_STRING)
@@ -10657,7 +10657,7 @@ printf("%s;\n", sql);
 
             @see inDb() for a method that tells if the table is already in the database or not
          */
-        AbstractCheckConstraint addCheckConstraint(string cname, string src, *hash opt, *reference<string> sql) {
+        AbstractCheckConstraint addCheckConstraint(string cname, string src, *hash<auto> opt, *reference<string> sql) {
             l.lock();
             on_exit l.unlock();
             return addCheckConstraintUnlocked(cname, src, opt, \sql);
@@ -10686,7 +10686,7 @@ printf("%s;\n", sql);
 
             @note if the @ref sql_callback_executed "sql_callback_executed option" is @ref Qore::True "True" in \a opt, then the changes are also effected in the current object, if not, then they are not (see @ref sql_callback_executed for more information)
          */
-        string getAddCheckConstraintSql(string cname, string src, *hash copt, *hash opt) {
+        string getAddCheckConstraintSql(string cname, string src, *hash copt, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
 
             l.lock();
@@ -10704,7 +10704,7 @@ printf("%s;\n", sql);
             return AbstractDatabase::doCallback(opt, sql, AbstractDatabase::AC_Add, "check constraint", cname, getSqlName());
         }
 
-        private AbstractCheckConstraint addCheckConstraintUnlocked(string cname, string src, *hash opt, *reference<string> sql) {
+        private AbstractCheckConstraint addCheckConstraintUnlocked(string cname, string src, *hash<auto> opt, *reference<string> sql) {
             AbstractCheckConstraint cc = addCheckConstraintUnlockedIntern(cname, src, opt, \sql);
             execSql(sql);
 
@@ -10717,7 +10717,7 @@ printf("%s;\n", sql);
             return cc;
         }
 
-        private AbstractCheckConstraint addCheckConstraintUnlockedIntern(string cname, string src, *hash opt, *reference<string> sql) {
+        private AbstractCheckConstraint addCheckConstraintUnlockedIntern(string cname, string src, *hash<auto> opt, *reference<string> sql) {
             # load constraints if needed, verify unique constraint name, validate/process options
             checkUniqueConstraintNameValidateOptions("CHECK-CONSTRAINT-ERROR", cname, getConstraintOptions(), \opt);
 
@@ -10816,7 +10816,7 @@ string sql = table.getDropConstraintSql("uk_mytable_name");
 
             @see inDb() for a method that tells if the table is already in the database or not
          */
-        string getDropConstraintSql(string cname, *hash opt) {
+        string getDropConstraintSql(string cname, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
 
             l.lock();
@@ -10851,7 +10851,7 @@ string sql = table.getDropConstraintSql("uk_mytable_name");
 
             @see inDb() for a method that tells if the table is already in the database or not
          */
-        *string getDropConstraintIfExistsSql(string cname, *hash opt, *reference<AbstractConstraint> cref) {
+        *string getDropConstraintIfExistsSql(string cname, *hash<auto> opt, *reference<AbstractConstraint> cref) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
 
             l.lock();
@@ -10972,7 +10972,7 @@ printf("%s;\n", sql);
 
             @see inDb() for a method that tells if the table is already in the database or not
          */
-        AbstractTrigger addTrigger(string tname, string src, *hash opt, *reference lsql) {
+        AbstractTrigger addTrigger(string tname, string src, *hash<auto> opt, *reference lsql) {
             l.lock();
             on_exit l.unlock();
 
@@ -11002,7 +11002,7 @@ printf("%s;\n", sql);
 
             @note if the @ref sql_callback_executed "sql_callback_executed option" is @ref Qore::True "True" in \a opt, then the changes are also effected in the current object, if not, then they are not (see @ref sql_callback_executed for more information)
          */
-        list getAddTriggerSql(string tname, string src, *hash topt, *hash opt) {
+        list<auto> getAddTriggerSql(string tname, string src, *hash topt, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
 
             l.lock();
@@ -11021,7 +11021,7 @@ printf("%s;\n", sql);
             return AbstractDatabase::doCallback(opt, lsql, AbstractDatabase::AC_Add, "trigger", tname, getSqlName());
         }
 
-        private AbstractTrigger addTriggerUnlocked(string tname, string src, *hash opt, *reference lsql) {
+        private AbstractTrigger addTriggerUnlocked(string tname, string src, *hash<auto> opt, *reference lsql) {
             AbstractTrigger trig = addTriggerUnlockedIntern(tname, src, opt, \lsql);
             execSql(lsql);
 
@@ -11035,7 +11035,7 @@ printf("%s;\n", sql);
             return trig;
        }
 
-        private AbstractTrigger addTriggerUnlockedIntern(string tname, string src, *hash opt, *reference lsql) {
+        private AbstractTrigger addTriggerUnlockedIntern(string tname, string src, *hash<auto> opt, *reference lsql) {
             # load triggers if needed
             if (!manual)
                 getTriggersUnlocked();
@@ -11109,7 +11109,7 @@ string sql = table.getDropTriggerSql("trig_mytable");
 
             @see inDb() for a method that tells if the table is already in the database or not
          */
-        list getDropTriggerSql(string tname, *hash opt) {
+        list<auto> getDropTriggerSql(string tname, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
 
             l.lock();
@@ -11127,7 +11127,7 @@ string sql = table.getDropTriggerSql("trig_mytable");
             return AbstractDatabase::doCallback(opt, triggers{tname}.getDropSql(getSqlName()), AbstractDatabase::AC_Drop, "trigger", tname, getSqlName());
         }
 
-        private getAllConstraintsUnlocked(*hash opt) {
+        private getAllConstraintsUnlocked(*hash<auto> opt) {
             if (manual)
                 return;
 
@@ -11283,7 +11283,7 @@ string sql = table.getDropColumnSql("notes_2");
 
             @see inDb() for a method that tells if the table is already in the database or not
          */
-        list getDropColumnSql(string cname, *hash opt) {
+        list<auto> getDropColumnSql(string cname, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
 
             l.lock();
@@ -11313,7 +11313,7 @@ table.insertCommit(row);
 
             @throw COLUMN-ERROR an unknown column was referenced in the hash to be inserted
          */
-        *hash insertCommit(hash row) {
+        *hash insertCommit(hash<auto> row) {
             on_success ds.commit();
             on_error ds.rollback();
 
@@ -11325,7 +11325,7 @@ table.insertCommit(row);
             @param row a hash representing the row to insert; hash values can also be set with @ref sql_iop_funcs to insert values based on SQL operations to be used directly in the insert statement
             @param sql an optional reference to a string to return the SQL generated for the insert statement
          */
-        *hash insertCommit(hash row, reference<string> sql) {
+        *hash insertCommit(hash<auto> row, reference<string> sql) {
             on_success ds.commit();
             on_error ds.rollback();
 
@@ -11337,7 +11337,7 @@ table.insertCommit(row);
             @param row a hash representing the row to insert; hash values can also be set with @ref sql_iop_funcs to insert values based on SQL operations to be used directly in the insert statement
             @param opt optional insert options; see @ref AbstractTable::InsertOptions for more info
          */
-        *hash insertCommit(hash row, hash opt) {
+        *hash insertCommit(hash<auto> row, hash<auto> opt) {
             on_success ds.commit();
             on_error ds.rollback();
 
@@ -11350,7 +11350,7 @@ table.insertCommit(row);
             @param sql an optional reference to a string to return the SQL generated for the insert statement
             @param opt optional insert options; see @ref AbstractTable::InsertOptions for more info
          */
-        *hash insertCommit(hash row, reference<string> sql, hash opt) {
+        *hash insertCommit(hash<auto> row, reference<string> sql, hash<auto> opt) {
             on_success ds.commit();
             on_error ds.rollback();
 
@@ -11370,7 +11370,7 @@ table.insert(row);
 
             @throw COLUMN-ERROR an unknown column was referenced in the hash to be inserted
          */
-        *hash insert(hash row) {
+        *hash insert(hash<auto> row) {
             return insertIntern(row);
         }
 
@@ -11379,7 +11379,7 @@ table.insert(row);
             @param row a hash representing the row to insert; hash values can also be set with @ref sql_iop_funcs to insert values based on SQL operations to be used directly in the insert statement
             @param sql an optional reference to a string to return the SQL generated for the insert statement
          */
-        *hash insert(hash row, reference<string> sql) {
+        *hash insert(hash<auto> row, reference<string> sql) {
             return insertIntern(row, \sql);
         }
 
@@ -11388,7 +11388,7 @@ table.insert(row);
             @param row a hash representing the row to insert; hash values can also be set with @ref sql_iop_funcs to insert values based on SQL operations to be used directly in the insert statement
             @param opt optional insert options; see @ref AbstractTable::InsertOptions for more info
          */
-        *hash insert(hash row, hash opt) {
+        *hash insert(hash<auto> row, hash<auto> opt) {
             return insertIntern(row, NOTHING, opt);
         }
 
@@ -11398,21 +11398,21 @@ table.insert(row);
             @param sql an optional reference to a string to return the SQL generated for the insert statement
             @param opt optional insert options; see @ref AbstractTable::InsertOptions for more info
          */
-        *hash insert(hash row, reference<string> sql, hash opt) {
+        *hash insert(hash<auto> row, reference<string> sql, hash<auto> opt) {
             return insertIntern(row, \sql, opt);
         }
 
         #! A legacy wrapper for @ref SqlUtil::AbstractTable::insert()
-        deprecated *hash insertNoCommit(hash row, *reference<string> sql, *hash opt) {
+        deprecated *hash insertNoCommit(hash<auto> row, *reference<string> sql, *hash<auto> opt) {
             return insertIntern(row, \sql, opt);
         }
 
         #! A legacy wrapper for @ref SqlUtil::AbstractTable::insert()
-        deprecated *hash insertNoCommit(hash row, hash opt) {
+        deprecated *hash insertNoCommit(hash<auto> row, hash<auto> opt) {
             return insertIntern(row, NOTHING, opt);
         }
 
-        private *hash insertIntern(hash row, *reference<string> sql, *hash opt) {
+        private *hash insertIntern(hash<auto> row, *reference<string> sql, *hash<auto> opt) {
             # check data callback options if any
             validateOptionsIntern("OPTION-ERROR", getInsertOptions(), \opt);
 
@@ -11435,7 +11435,7 @@ table.insert(row);
             sql += (foldl $1 + "," + $2, vh.placeholders);
             sql += ")";
 
-            softlist args = vh.values;
+            softlist<auto> args = vh.values;
 
             # check for a bulk insert in case the driver does not support array binding
             if (!hasArrayBind()) {
@@ -11473,7 +11473,7 @@ table.insert(row);
             execData(opt, sql, args);
         }
 
-        private hash getPlaceholdersAndValues(hash row) {
+        private hash<auto> getPlaceholdersAndValues(hash<auto> row) {
             hash im;
             # placeholder list
             list phl = ();
@@ -11558,7 +11558,7 @@ int rows = table.insertFromSelectCommit(("id", "name", "created"), source_table,
 
             @note this method does not take insert options because it is executed entirely in the database server; use insertFromIterator() or insertFromIteratorCommit() to insert arbitrary data with insert options
         */
-        int insertFromSelectCommit(list cols, AbstractTable source, hash sh, reference<string> sql, hash opt) {
+        int insertFromSelectCommit(list cols, AbstractTable source, hash<auto> sh, reference<string> sql, hash<auto> opt) {
             on_success ds.commit();
             on_error ds.rollback();
 
@@ -11574,7 +11574,7 @@ int rows = table.insertFromSelectCommit(("id", "name", "created"), source_table,
         }
 
         #! @ref SqlUtil::AbstractTable::insertFromSelectCommit() variant
-        int insertFromSelectCommit(list cols, AbstractTable source, hash sh) {
+        int insertFromSelectCommit(list cols, AbstractTable source, hash<auto> sh) {
             on_success ds.commit();
             on_error ds.rollback();
 
@@ -11582,7 +11582,7 @@ int rows = table.insertFromSelectCommit(("id", "name", "created"), source_table,
         }
 
         #! @ref SqlUtil::AbstractTable::insertFromSelectCommit() variant
-        int insertFromSelectCommit(list cols, AbstractTable source, hash sh, reference<string> sql) {
+        int insertFromSelectCommit(list cols, AbstractTable source, hash<auto> sh, reference<string> sql) {
             on_success ds.commit();
             on_error ds.rollback();
 
@@ -11590,7 +11590,7 @@ int rows = table.insertFromSelectCommit(("id", "name", "created"), source_table,
         }
 
         #! @ref SqlUtil::AbstractTable::insertFromSelectCommit() variant
-        int insertFromSelectCommit(list cols, AbstractTable source, hash sh, hash opt) {
+        int insertFromSelectCommit(list cols, AbstractTable source, hash<auto> sh, hash<auto> opt) {
             on_success ds.commit();
             on_error ds.rollback();
 
@@ -11617,7 +11617,7 @@ int rows = table.insertFromSelect(("id", "name", "created"), source_table, (("co
 
             @note this method does not take insert options because it is executed entirely in the database server; use insertFromIterator() or insertFromIteratorCommit() to insert arbitrary data with insert options
         */
-        int insertFromSelect(list cols, AbstractTable source, hash sh, reference<string> sql, hash opt) {
+        int insertFromSelect(list cols, AbstractTable source, hash<auto> sh, reference<string> sql, hash<auto> opt) {
             return insertFromSelectIntern(cols, source, sh, \sql, opt);
         }
 
@@ -11627,27 +11627,27 @@ int rows = table.insertFromSelect(("id", "name", "created"), source_table, (("co
         }
 
         #! @ref SqlUtil::AbstractTable::insertFromSelectCommit() variant
-        int insertFromSelect(list cols, AbstractTable source, hash sh) {
+        int insertFromSelect(list cols, AbstractTable source, hash<auto> sh) {
             return insertFromSelectIntern(cols, source, sh);
         }
 
         #! @ref SqlUtil::AbstractTable::insertFromSelectCommit() variant
-        int insertFromSelect(list cols, AbstractTable source, hash sh, reference<string> sql) {
+        int insertFromSelect(list cols, AbstractTable source, hash<auto> sh, reference<string> sql) {
             return insertFromSelectIntern(cols, source, sh, \sql);
         }
 
         #! @ref SqlUtil::AbstractTable::insertFromSelectCommit() variant
-        int insertFromSelect(list cols, AbstractTable source, hash sh, hash opt) {
+        int insertFromSelect(list cols, AbstractTable source, hash<auto> sh, hash<auto> opt) {
             return insertFromSelectIntern(cols, source, sh, NOTHING, opt);
         }
 
         #! A legacy @ref SqlUtil::AbstractTable::insertFromSelect() wrapper
-        deprecated int insertFromSelectNoCommit(list cols, AbstractTable source, *hash sh, *reference<string> sql, *hash opt) {
+        deprecated int insertFromSelectNoCommit(list cols, AbstractTable source, *hash<auto> sh, *reference<string> sql, *hash<auto> opt) {
             return insertFromSelectIntern(cols, source, sh, \sql, opt);
         }
 
-        private int insertFromSelectIntern(list cols, AbstractTable source, *hash sh, *reference<string> sql, *hash opt) {
-            list args;
+        private int insertFromSelectIntern(list cols, AbstractTable source, *hash<auto> sh, *reference<string> sql, *hash<auto> opt) {
+            list<auto> args;
             string ssql = source.getSelectSql(sh, \args);
 
             # issue #3352: do not execute runtime DML while holding the lock
@@ -11690,7 +11690,7 @@ int rows = table.insertFromIteratorCommit(i);
             - upsertFromIterator()
             - upsertFromIteratorCommit()
         */
-        int insertFromIteratorCommit(Qore::AbstractIterator i, *hash opt) {
+        int insertFromIteratorCommit(Qore::AbstractIterator i, *hash<auto> opt) {
             on_success ds.commit();
             on_error ds.rollback();
 
@@ -11716,16 +11716,16 @@ int rows = table.insertFromIterator(i);
             - upsertFromIterator()
             - upsertFromIteratorCommit()
         */
-        int insertFromIterator(Qore::AbstractIterator i, *hash opt) {
+        int insertFromIterator(Qore::AbstractIterator i, *hash<auto> opt) {
             return insertFromIteratorIntern(i, opt - "commit_block");
         }
 
         #! A legacy @ref SqlUtil::AbstractTable::insertFromIterator() wrapper
-        deprecated int insertFromIteratorNoCommit(Qore::AbstractIterator i, *hash opt) {
+        deprecated int insertFromIteratorNoCommit(Qore::AbstractIterator i, *hash<auto> opt) {
             return insertFromIteratorIntern(i, opt - "commit_block");
         }
 
-        private int insertFromIteratorIntern(Qore::AbstractIterator i, *hash opt) {
+        private int insertFromIteratorIntern(Qore::AbstractIterator i, *hash<auto> opt) {
             # check upsert options
             validateOptionsIntern("OPTION-ERROR", getInsertFromIteratorOptions(), \opt);
 
@@ -11733,7 +11733,7 @@ int rows = table.insertFromIterator(i);
                 return 0;
 
             # get initial row
-            hash row = i.getValue();
+            hash<auto> row = i.getValue();
 
             # make insert statement template
             string sql = sprintf("insert into %s (%s) values (%s)", getSqlName(), (foldl $1 + "," + $2, (map getColumnSqlName($1), row.keyIterator())),
@@ -11777,7 +11777,7 @@ table.upsertCommit(row);
 
             @note if upserting multiple rows; it's better to use getBulkUpsertClosure(), getUpsertClosure(), or getUpsertClosureWithValidation() and execute the closure on each row; when using this method, the overhead for setting up the upsert is made for each row which is very inefficient
          */
-        int upsertCommit(hash row, int upsert_strategy = UpsertAuto, *hash opt) {
+        int upsertCommit(hash<auto> row, int upsert_strategy = UpsertAuto, *hash<auto> opt) {
             on_success ds.commit();
             on_error ds.rollback();
 
@@ -11801,12 +11801,12 @@ table.upsert(row);
 
             @note if upserting multiple rows; it's better to use getBulkUpsertClosure(), getUpsertClosure(), or getUpsertClosureWithValidation() and execute the closure on each row; when using this method, the overhead for setting up the upsert is made for each row which is very inefficient
          */
-        int upsert(hash row, int upsert_strategy = UpsertAuto, *hash opt) {
+        int upsert(hash<auto> row, int upsert_strategy = UpsertAuto, *hash<auto> opt) {
             return getUpsertClosure(row, upsert_strategy, opt)(row);
         }
 
         #! A legacy @ref SqlUtil::AbstractTable::upsert() wrapper
-        deprecated int upsertNoCommit(hash row, int upsert_strategy = UpsertAuto) {
+        deprecated int upsertNoCommit(hash<auto> row, int upsert_strategy = UpsertAuto) {
             return getUpsertClosure(row, upsert_strategy)(row);
         }
 
@@ -11825,14 +11825,14 @@ map upsert($1), row_list;
             @param upsert_strategy see @ref upsert_options for possible values for the upsert strategy
             @param opt a hash of options for the upsert operation; see @ref SqlUtil::AbstractTable::UpsertOptions for common options; each driver can support additional driver-specific options
 
-            @return a closure that can be executed given a hash argument representing a single row that will be updated or inserted in the database with the given upsert strategy; the closure returned does not check the input hash for validity; the closure has the following signature: @code{.py} int sub upsert(hash row) {} @endcode The return value of the closure is an integer code giving the result of the update; see @ref upsert_results for more information
+            @return a closure that can be executed given a hash argument representing a single row that will be updated or inserted in the database with the given upsert strategy; the closure returned does not check the input hash for validity; the closure has the following signature: @code{.py} int sub upsert(hash<auto> row) {} @endcode The return value of the closure is an integer code giving the result of the update; see @ref upsert_results for more information
 
             @throw COLUMN-ERROR an unknown column was referenced in the hash to be inserted
             @throw UPSERT-ERROR no primary key, unique constraint, or unique index for upsert; not all columns of the unique constraint/index are used in the upsert statement
 
             @note the row values passed to the closure for upserting are not checked if they match the example row passed to the getUpsertClosure() method; passing non-conforming data will cause errors; see @ref SqlUtil::AbstractTable::getUpsertClosureWithValidation() for a similar method that returns a validating closure; the closure returned by this method is faster than the one returned by @ref SqlUtil::AbstractTable::getUpsertClosure() since there is no validation
          */
-        code getUpsertClosure(hash row, int upsert_strategy = UpsertAuto, *hash opt) {
+        code getUpsertClosure(hash<auto> row, int upsert_strategy = UpsertAuto, *hash<auto> opt) {
             # check upsert options
             validateOptionsIntern("OPTION-ERROR", getUpsertOptions(), \opt);
 
@@ -11880,7 +11880,7 @@ upsert(row_hash);
             @param upsert_strategy see @ref upsert_options for possible values for the upsert strategy
             @param opt a hash of options for the upsert operation; see @ref SqlUtil::AbstractTable::UpsertOptions for common options; each driver can support additional driver-specific options
 
-            @return a closure that can be executed given a hash argument representing either a single row or a set of rows (where each key value is a list of column values) that will be updated or inserted in the database with the given upsert strategy; the closure returned does not check the input hash for validity; the closure has the following signature: @code{.py} int sub upsert(hash row) {} @endcode The return value of the closure is always @ref SqlUtil::AbstractTable::UR_Verified; see @ref upsert_results for more information
+            @return a closure that can be executed given a hash argument representing either a single row or a set of rows (where each key value is a list of column values) that will be updated or inserted in the database with the given upsert strategy; the closure returned does not check the input hash for validity; the closure has the following signature: @code{.py} int sub upsert(hash<auto> row) {} @endcode The return value of the closure is always @ref SqlUtil::AbstractTable::UR_Verified; see @ref upsert_results for more information
 
             @throw COLUMN-ERROR an unknown column was referenced in the hash to be inserted
             @throw UPSERT-ERROR no primary key, unique constraint, or unique index for upsert; not all columns of the unique constraint/index are used in the upsert statement
@@ -11893,7 +11893,7 @@ upsert(row_hash);
             - getUpsertClosure()
             - getUpsertClosureWithValidation()
          */
-        code getBulkUpsertClosure(hash example_row, int upsert_strategy = AbstractTable::UpsertAuto, *hash opt) {
+        code getBulkUpsertClosure(hash example_row, int upsert_strategy = AbstractTable::UpsertAuto, *hash<auto> opt) {
             code upsert = getUpsertClosure(example_row, upsert_strategy, opt);
             return int sub (hash h) {
                 map upsert($1), h.contextIterator();
@@ -11916,17 +11916,17 @@ map upsert($1), row_list;
             @param upsert_strategy see @ref upsert_options for possible values for the upsert strategy
             @param opt a hash of options for the upsert operation; see @ref SqlUtil::AbstractTable::UpsertOptions for common options; each driver can support additional driver-specific options
 
-            @return a closure that can be executed given a hash argument representing a single row that will be updated or inserted in the database with the given upsert strategy; the closure has the following signature: @code{.py} int sub upsert(hash row) {} @endcode The return value of the closure is an integer code giving the result of the update; see @ref upsert_results for more information
+            @return a closure that can be executed given a hash argument representing a single row that will be updated or inserted in the database with the given upsert strategy; the closure has the following signature: @code{.py} int sub upsert(hash<auto> row) {} @endcode The return value of the closure is an integer code giving the result of the update; see @ref upsert_results for more information
 
             @throw COLUMN-ERROR an unknown column was referenced in the hash to be inserted
             @throw UPSERT-ERROR no primary key, unique constraint, or unique index for upsert; not all columns of the unique constraint/index are used in the upsert statement
 
             @note the row values passed to the closure for upserting are checked if they match the example row passed to the getUpsertClosure() method; passing non-conforming data to the closure will cause the closure to throw an \c UPSERT-ERROR exception; see @ref SqlUtil::AbstractTable::getUpsertClosure() for a similar method that returns a non-validating closure; the closure returned by this method is a little slower than the one returned by @ref SqlUtil::AbstractTable::getUpsertClosure() since each row is validated
          */
-        code getUpsertClosureWithValidation(hash example_row, int upsert_strategy = UpsertAuto, *hash opt) {
+        code getUpsertClosureWithValidation(hash example_row, int upsert_strategy = UpsertAuto, *hash<auto> opt) {
             code upsert = getUpsertClosure(example_row, upsert_strategy, opt);
 
-            return int sub (hash row) {
+            return int sub (hash<auto> row) {
                 if (!row.compareKeys(example_row))
                     throw "UPSERT-ERROR", sprintf("%s: the keys in the row passed to the upsert closure (%y) do not match the keys passed to AbstractTable::getUpsertClosureWithValidation() (%y)", getDesc(), row.keys, example_row.keys());
                 return upsert(row);
@@ -11966,7 +11966,7 @@ hash h = table.upsertFromIterator(i, AbstractTable::UpsertUpdateFirst);
             - insertFromIteratorCommit()
             - insertFromIterator()
         */
-        *hash upsertFromIteratorCommit(Qore::AbstractIterator i, int upsert_strategy = AbstractTable::UpsertAuto, *hash opt) {
+        *hash upsertFromIteratorCommit(Qore::AbstractIterator i, int upsert_strategy = AbstractTable::UpsertAuto, *hash<auto> opt) {
             on_success ds.commit();
             on_error ds.rollback();
 
@@ -12006,16 +12006,16 @@ hash h = table.upsertFromIterator(i, AbstractTable::UpsertUpdateFirst);
             - insertFromIteratorCommit()
             - insertFromIterator()
         */
-        *hash upsertFromIterator(Qore::AbstractIterator i, int upsert_strategy = AbstractTable::UpsertAuto, *hash opt) {
+        *hash upsertFromIterator(Qore::AbstractIterator i, int upsert_strategy = AbstractTable::UpsertAuto, *hash<auto> opt) {
             return upsertFromIteratorIntern(i, upsert_strategy, opt - "commit_block");
         }
 
         #! A legacy SqlUtik::AbstractTable::upsertFromIterator() wrapper
-        deprecated *hash upsertFromIteratorNoCommit(Qore::AbstractIterator i, int upsert_strategy = AbstractTable::UpsertAuto, *hash opt) {
+        deprecated *hash upsertFromIteratorNoCommit(Qore::AbstractIterator i, int upsert_strategy = AbstractTable::UpsertAuto, *hash<auto> opt) {
             return upsertFromIteratorIntern(i, upsert_strategy, opt - "commit_block");
         }
 
-        private *hash upsertFromIteratorIntern(Qore::AbstractIterator i, int upsert_strategy = AbstractTable::UpsertAuto, *hash opt) {
+        private *hash upsertFromIteratorIntern(Qore::AbstractIterator i, int upsert_strategy = AbstractTable::UpsertAuto, *hash<auto> opt) {
             # check upsert options
             validateOptionsIntern("OPTION-ERROR", getUpsertOptions(), \opt);
 
@@ -12029,7 +12029,7 @@ hash h = table.upsertFromIterator(i, AbstractTable::UpsertUpdateFirst);
             # primary key value hash for "delete_others"
             hash pkh;
 
-            hash row = i.getValue();
+            hash<auto> row = i.getValue();
             code upsert = getUpsertClosure(row, upsert_strategy, opt);
 
             opt.change_count = 0;
@@ -12057,12 +12057,12 @@ hash h = table.upsertFromIterator(i, AbstractTable::UpsertUpdateFirst);
             return rh;
         }
 
-        private *hash doDeleteOthersIntern(hash pkh, *hash opt) {
+        private *hash<auto> doDeleteOthersIntern(hash pkh, *hash<auto> opt) {
             hash rh;
 
             # iterate through the table to find rows that do not belong and delete them
             list pkl = primaryKey.keys();
-            foreach hash row in (getStatement()) {
+            foreach hash<auto> row in (getStatement()) {
                 string k = foldl $1 + "-" + $2, (map row.$1.toString(), pkl);
                 if (pkh{k})
                     continue;
@@ -12123,7 +12123,7 @@ hash h = table.upsertFromSelectCommit(table2, ("where": ("account_type": "CUSTOM
             - upsertCommit()
             - getUpsertClosure()
         */
-        *hash upsertFromSelectCommit(AbstractTable t, *hash sh, int upsert_strategy = AbstractTable::UpsertAuto, *hash opt) {
+        *hash upsertFromSelectCommit(AbstractTable t, *hash<auto> sh, int upsert_strategy = AbstractTable::UpsertAuto, *hash<auto> opt) {
             on_success { ds.commit(); t.commit(); }
             on_error { ds.rollback(); t.rollback(); }
 
@@ -12131,7 +12131,7 @@ hash h = table.upsertFromSelectCommit(table2, ("where": ("account_type": "CUSTOM
         }
 
         #! @ref SqlUtil::AbstractTable::upsertFromSelectCommit() variant
-        *hash upsertFromSelectCommit(Table t, *hash sh, int upsert_strategy = AbstractTable::UpsertAuto, *hash opt) {
+        *hash upsertFromSelectCommit(Table t, *hash<auto> sh, int upsert_strategy = AbstractTable::UpsertAuto, *hash<auto> opt) {
             on_success { ds.commit(); t.commit(); }
             on_error { ds.rollback(); t.rollback(); }
 
@@ -12179,22 +12179,22 @@ hash h = table.upsertFromSelect(table2, ("where": ("account_type": "CUSTOMER")),
             - upsertCommit()
             - getUpsertClosure()
         */
-        *hash upsertFromSelect(AbstractTable t, *hash sh, int upsert_strategy = AbstractTable::UpsertAuto, *hash opt) {
+        *hash upsertFromSelect(AbstractTable t, *hash<auto> sh, int upsert_strategy = AbstractTable::UpsertAuto, *hash<auto> opt) {
             return upsertFromIteratorIntern(t.getStatement(sh), upsert_strategy, opt - "commit_block");
         }
 
         #! A legacy @ref SqlUtil::AbstractTable::upsertFromSelect() wrapper
-        deprecated *hash upsertFromSelectNoCommit(AbstractTable t, *hash sh, int upsert_strategy = AbstractTable::UpsertAuto, *hash opt) {
+        deprecated *hash upsertFromSelectNoCommit(AbstractTable t, *hash<auto> sh, int upsert_strategy = AbstractTable::UpsertAuto, *hash<auto> opt) {
             return upsertFromIteratorIntern(t.getStatement(sh), upsert_strategy, opt - "commit_block");
         }
 
         #! @ref SqlUtil::AbstractTable::upsertFromSelect() variant
-        deprecated *hash upsertFromSelect(Table t, *hash sh, int upsert_strategy = AbstractTable::UpsertAuto, *hash opt) {
+        deprecated *hash upsertFromSelect(Table t, *hash<auto> sh, int upsert_strategy = AbstractTable::UpsertAuto, *hash<auto> opt) {
             return upsertFromIteratorIntern(t.getStatement(sh), upsert_strategy, opt - "commit_block");
         }
 
         #! A legacy @ref SqlUtil::AbstractTable::upsertFromSelect() wrapper
-        deprecated *hash upsertFromSelectNoCommit(Table t, *hash sh, int upsert_strategy = AbstractTable::UpsertAuto, *hash opt) {
+        deprecated *hash upsertFromSelectNoCommit(Table t, *hash<auto> sh, int upsert_strategy = AbstractTable::UpsertAuto, *hash<auto> opt) {
             return upsertFromIteratorIntern(t.getStatement(sh), upsert_strategy, opt - "commit_block");
         }
 
@@ -12236,7 +12236,7 @@ SQLStatement i = table.getRowIterator(sh);
             @deprecated for getStatement(); if the underlying database connection object returns an @ref Qore::SQL::AbstractSQLStatement "AbstractSQLStatement" instead of an
             @ref Qore::SQL::SQLStatement "SQLStatement", then an exception will be raised; use getStatement() instead
          */
-        Qore::SQL::SQLStatement getRowIterator(*hash sh, *reference<string> sql, *hash opt) {
+        Qore::SQL::SQLStatement getRowIterator(*hash<auto> sh, *reference<string> sql, *hash<auto> opt) {
             return cast<SQLStatement>(getStatementIntern(sh, \sql, opt));
         }
 
@@ -12264,7 +12264,7 @@ SQLStatement i = table.getRowIteratorNoExec(sh);
             @deprecated for getStatementNoExec(); if the underlying database connection object returns an @ref Qore::SQL::AbstractSQLStatement "AbstractSQLStatement" instead of an
             @ref Qore::SQL::SQLStatement "SQLStatement", then an exception will be raised; use getStatementNoExec() instead
          */
-        Qore::SQL::SQLStatement getRowIteratorNoExec(*hash sh, *reference<string> sql, *hash opt) {
+        Qore::SQL::SQLStatement getRowIteratorNoExec(*hash<auto> sh, *reference<string> sql, *hash<auto> opt) {
             return getStatementIntern(sh, \sql, opt, True);
         }
 
@@ -12289,7 +12289,7 @@ SQLStatement i = table.getRowIterator();
             @deprecated for getStatement(); if the underlying database connection object returns an @ref Qore::SQL::AbstractSQLStatement "AbstractSQLStatement" instead of an
             @ref Qore::SQL::SQLStatement "SQLStatement", then an exception will be raised; use getStatement() instead
          */
-        Qore::SQL::SQLStatement getRowIterator(*hash sh, *hash opt) {
+        Qore::SQL::SQLStatement getRowIterator(*hash<auto> sh, *hash<auto> opt) {
             return cast<SQLStatement>(getStatementIntern(sh, NOTHING, opt));
         }
 
@@ -12316,7 +12316,7 @@ AbstractSQLStatement i = table.getStatement(sh);
 
             @since %SqlUtil 1.5
          */
-        Qore::SQL::AbstractSQLStatement getStatement(*hash sh, *reference<string> sql, *hash opt) {
+        Qore::SQL::AbstractSQLStatement getStatement(*hash<auto> sh, *reference<string> sql, *hash<auto> opt) {
             return getStatementIntern(sh, \sql, opt);
         }
 
@@ -12342,7 +12342,7 @@ AbstractSQLStatement i = table.getStatement();
 
             @since %SqlUtil 1.5
          */
-        Qore::SQL::AbstractSQLStatement getStatement(*hash sh, *hash opt) {
+        Qore::SQL::AbstractSQLStatement getStatement(*hash<auto> sh, *hash<auto> opt) {
             return getStatementIntern(sh, NOTHING, opt);
         }
 
@@ -12369,7 +12369,7 @@ AbstractSQLStatement i = table.getStatementNoExec(sh);
 
             @since %SqlUtil 1.5
          */
-        Qore::SQL::AbstractSQLStatement getStatementNoExec(*hash sh, *reference<string> sql, *hash opt) {
+        Qore::SQL::AbstractSQLStatement getStatementNoExec(*hash<auto> sh, *reference<string> sql, *hash<auto> opt) {
             return getStatementIntern(sh, \sql, opt, True);
         }
 
@@ -12395,14 +12395,14 @@ AbstractSQLStatement i = table.getStatement();
 
             @since %SqlUtil 1.5
          */
-        Qore::SQL::AbstractSQLStatement getStatementNoExec(*hash sh, *hash opt) {
+        Qore::SQL::AbstractSQLStatement getStatementNoExec(*hash<auto> sh, *hash<auto> opt) {
             return getStatementIntern(sh, NOTHING, opt, True);
         }
 
-        private Qore::SQL::AbstractSQLStatement getStatementIntern(*hash sh, *reference<string> sql, *hash opt, *bool no_exec) {
+        private Qore::SQL::AbstractSQLStatement getStatementIntern(*hash<auto> sh, *reference<string> sql, *hash<auto> opt, *bool no_exec) {
             validateOptionsIntern("OPTION-ERROR", getSelectOptions(), \sh);
 
-            list args;
+            list<auto> args;
             sql = getSelectSqlIntern(sh, \args, opt);
 
             AbstractSQLStatement stmt = ds.getSQLStatement();
@@ -12439,10 +12439,10 @@ AbstractSQLStatement i = table.getStatement();
             - if \c "offset" is supplied and no \c "orderby" is supplied, then if any primary key exists, the primary key columns will be used for the \c "orderby" option automatically
             - if the \c forupdate @ref select_option_hash "select option" is used, then after a successful select operation, the calling thread will own the thread transaction lock
          */
-        *hash selectRow(*hash sh, *reference<string> sql, *hash opt) {
+        *hash<auto> selectRow(*hash<auto> sh, *reference<string> sql, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getSelectOptions(), \sh);
 
-            list args;
+            list<auto> args;
             sql = getSelectSqlUnlocked(sh, \args, opt);
 
             bool rollback_on_error = False;
@@ -12475,10 +12475,10 @@ AbstractSQLStatement i = table.getStatement();
             - if \c "offset" is supplied and no \c "orderby" is supplied, then if any primary key exists, the primary key columns will be used for the \c "orderby" option automatically
             - if the \c forupdate @ref select_option_hash "select option" is used, then after a successful select operation, the calling thread will own the thread transaction lock
          */
-        *list selectRows(*hash sh, *reference<string> sql, *hash opt) {
+        *list selectRows(*hash<auto> sh, *reference<string> sql, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getSelectOptions(), \sh);
 
-            list args;
+            list<auto> args;
             sql = getSelectSqlUnlocked(sh, \args, opt);
 
             bool rollback_on_error = False;
@@ -12512,10 +12512,10 @@ AbstractSQLStatement i = table.getStatement();
             - if \c "offset" is supplied and no \c "orderby" is supplied, then if any primary key exists, the primary key columns will be used for the \c "orderby" option automatically
             - if the \c forupdate @ref select_option_hash "select option" is used, then after a successful select operation, the calling thread will own the thread transaction lock
          */
-        *hash select(*hash sh, *reference<string> sql, *hash opt) {
+        *hash<auto> select(*hash<auto> sh, *reference<string> sql, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getSelectOptions(), \sh);
 
-            list args;
+            list<auto> args;
             sql = getSelectSqlUnlocked(sh, \args, opt);
 
             bool rollback_on_error = False;
@@ -12549,12 +12549,12 @@ AbstractSQLStatement i = table.getStatement();
             - if \c "offset" is supplied and no \c "orderby" is supplied, then if any primary key exists, the primary key columns will be used for the \c "orderby" option automatically
             - if the \c forupdate @ref select_option_hash "select option" is used, then after a successful select operation, the calling thread will own the thread transaction lock
          */
-        *hash selectRow(*hash sh, *hash opt) {
+        *hash<auto> selectRow(*hash<auto> sh, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getSelectOptions(), \sh);
             # check data callback options if any
             validateOptionsIntern("OPTION-ERROR", getSqlDataCallbackOptions(), \opt);
 
-            list args;
+            list<auto> args;
             string sql = getSelectSqlUnlocked(sh, \args, opt);
 
             if (opt.sqlarg_callback)
@@ -12590,12 +12590,12 @@ AbstractSQLStatement i = table.getStatement();
             - if \c "offset" is supplied and no \c "orderby" is supplied, then if any primary key exists, the primary key columns will be used for the \c "orderby" option automatically
             - if the \c forupdate @ref select_option_hash "select option" is used, then after a successful select operation, the calling thread will own the thread transaction lock
          */
-        *list selectRows(*hash sh, *hash opt) {
+        *list selectRows(*hash<auto> sh, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getSelectOptions(), \sh);
             # check data callback options if any
             validateOptionsIntern("OPTION-ERROR", getSqlDataCallbackOptions(), \opt);
 
-            list args;
+            list<auto> args;
             string sql = getSelectSqlUnlocked(sh, \args, opt);
 
             if (opt.sqlarg_callback)
@@ -12631,12 +12631,12 @@ AbstractSQLStatement i = table.getStatement();
             - if \c "offset" is supplied and no \c "orderby" is supplied, then if any primary key exists, the primary key columns will be used for the \c "orderby" option automatically
             - if the \c forupdate @ref select_option_hash "select option" is used, then after a successful select operation, the calling thread will own the thread transaction lock
          */
-        *hash select(*hash sh, *hash opt) {
+        *hash<auto> select(*hash<auto> sh, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getSelectOptions(), \sh);
             # check data callback options if any
             validateOptionsIntern("OPTION-ERROR", getSqlDataCallbackOptions(), \opt);
 
-            list args;
+            list<auto> args;
             string sql = getSelectSqlUnlocked(sh, \args, opt);
 
             if (opt.sqlarg_callback)
@@ -12657,7 +12657,7 @@ AbstractSQLStatement i = table.getStatement();
         #! returns the SQL string to be executed corresponding to the argument hash with an output parameter for the select bind arguments
         /** @par Example:
             @code{.py}
-list args;
+list<auto> args;
 string sql = table.getSelectSql(sh, \args);
             @endcode
 
@@ -12673,7 +12673,7 @@ string sql = table.getSelectSql(sh, \args);
             - the select string is specific to the arguments passed (for example @ref null arguments will have clauses like 'is null')
             - if \c "offset" is supplied and no \c "orderby" is supplied, then if any primary key exists, the primary key columns will be used for the \c "orderby" option automatically
          */
-        string getSelectSql(*hash sh, *reference<list> args) {
+        string getSelectSql(*hash<auto> sh, *reference<list<auto>> args) {
             validateOptionsIntern("OPTION-ERROR", getSelectOptions(), \sh);
 
             args = ();
@@ -12696,14 +12696,14 @@ string sql = table.getSelectSql(sh, \args);
             }
         }
 
-        string getSelectSqlIntern(*hash qh, reference<list> args, *hash opt) {
+        string getSelectSqlIntern(*hash<auto> qh, reference<list<auto>> args, *hash<auto> opt) {
             l.lock();
             on_exit l.unlock();
 
             return getSelectSqlUnlocked(qh, \args, opt);
         }
 
-        string getSelectSqlUnlocked(*hash qh, reference<list> args, *hash opt) {
+        string getSelectSqlUnlocked(*hash<auto> qh, reference<list<auto>> args, *hash<auto> opt) {
             # we first get column & table info in case we are referencing a table through a synonym
             # so the getSelectSqlName() will refer to the proper schema owner
             getColumnsUnlocked();
@@ -12711,9 +12711,9 @@ string sql = table.getSelectSql(sh, \args);
         }
 
         # column & table information must be retrieved before calling this function
-        string getSelectSqlUnlockedIntern(*hash qh, string from, reference<list> args, *hash ch, *hash opt) {
+        string getSelectSqlUnlockedIntern(*hash<auto> qh, string from, reference<list<auto>> args, *hash<auto> ch, *hash<auto> opt) {
             # get pseudo-column hash
-            *hash psch = getPseudoColumnHash();
+            *hash<auto> psch = getPseudoColumnHash();
 
             if (qh.hasKey("offset")) {
                 if (!qh.orderby) {
@@ -12738,7 +12738,7 @@ string sql = table.getSelectSql(sh, \args);
             }
 
             # make a hash of aliases to tables when using joins
-            hash jch = map {$1.alias ?? $1.table.getName(): $1.table}, qh.join.iterator();
+            hash<auto> jch = map {$1.alias ?? $1.table.getName(): $1.table}, qh.join.iterator();
 
             # issue #1909: add an alias for the main table if present
             if (qh.alias) {
@@ -12847,7 +12847,7 @@ string sql = table.getSelectSql(sh, \args);
 
                 # create "join on" clause
                 # the join clause expression list
-                list jel = ();
+                list<string> jel = ();
                 if (jh.jcols) {
                     if (jh.jcols.typeCode() != NT_HASH)
                         throw "SELECT-ERROR", sprintf("%s: join clause error; expecting a hash assigned to the \"jcols\" key; got %y instead", getDesc(), jh.jcols.type());
@@ -12861,8 +12861,7 @@ string sql = table.getSelectSql(sh, \args);
                             throw "SELECT-ERROR", sprintf("%s: cannot join on unknown column %y.%y; known columns: %y", getDesc(), t.getSqlName(), value, t.columns.keys());
                         jel += sprintf("%s.%s = %s.%s", jtn, key, an, value);
                     }
-                }
-                else {
+                } else {
                     *hash fkh;
                     if (!jt.primaryKey.empty()) {
                         # see if there is a foreign constraint from table -> pk of self
@@ -12912,18 +12911,18 @@ string sql = table.getSelectSql(sh, \args);
                 getColumnsUnlocked();
                 hash cm = getColumnOperatorMap();
 
-                list hl = ();
+                list<auto> hl = ();
 
                 HashIterator i(qh.having);
                 while (i.next()) {
                     string key = i.getKey();
                     auto value = i.getValue();
                     if (value.typeCode() != NT_LIST)
-                        throw "SELECT-ERROR", sprintf("%s: expecting a list argument to the \"having\" condition for column %y; got type %y instead (value: %y)", getDesc(), key, value.type(), value);
+                        throw "SELECT-ERROR", sprintf("%s: expecting a list<auto> argument to the \"having\" condition for column %y; got type %y instead (value: %y)", getDesc(), key, value.type(), value);
                     if (value[0].typeCode() != NT_STRING)
                         throw "SELECT-ERROR", sprintf("%s: expecting a string argument to the \"having\" condition in the first position giving the column operator code for column %y; got type %y instead (value: %y)", getDesc(), key, value[0].type(), value[0]);
 
-                    *hash psch_copy = psch;
+                    *hash<auto> psch_copy = psch;
                     string hstr = doColumnOperatorIntern(value[0], NOTHING, getColumnExpressionIntern(key, jch, boolean(qh.join), ch, psch), cm, jch, boolean(qh.join), ch, psch);
                     if (psch_copy != psch)
                         throw "HAVING-ERROR", sprintf("%s: cannot use column operator functions in the having clause with column alias specifications", getDesc());
@@ -12967,19 +12966,19 @@ string sql = table.getSelectSql(sh, \args);
             return sql;
         }
 
-        private string getFromIntern(string from, *hash qh) {
+        private string getFromIntern(string from, *hash<auto> qh) {
             return from;
         }
 
-        private list getGroupByListUnlocked(hash qh, *hash jch, *hash ch, *hash psch, list coll) {
+        private list<auto> getGroupByListUnlocked(hash<auto> qh, *hash<auto> jch, *hash<auto> ch, *hash<auto> psch, list coll) {
             return getGroupOrderByListUnlocked("groupby", qh, jch, ch, psch, coll);
         }
 
-        private list getOrderByListUnlocked(hash qh, *hash jch, *hash ch, *hash psch, list coll) {
+        private list<auto> getOrderByListUnlocked(hash<auto> qh, *hash<auto> jch, *hash<auto> ch, *hash<auto> psch, list coll) {
             return getGroupOrderByListUnlocked("orderby", qh, jch, ch, psch, coll);
         }
 
-        private list getGroupOrderByListUnlocked(string key, hash qh, *hash jch, *hash ch, *hash psch, list coll) {
+        private list<auto> getGroupOrderByListUnlocked(string key, hash<auto> qh, *hash<auto> jch, *hash<auto> ch, *hash<auto> psch, list coll) {
             list ce = ();
 
             code do_int = sub (int cv) {
@@ -13028,11 +13027,11 @@ string sql = table.getSelectSql(sh, \args);
             sql += " for update";
         }
 
-        private string getSelectSqlName(*hash qh) {
+        private string getSelectSqlName(*hash<auto> qh) {
             return getSqlName();
         }
 
-        private string getColumnExpressionIntern(auto cvc, *hash jch, bool join, *hash ch, *hash psch) {
+        private string getColumnExpressionIntern(auto cvc, *hash<auto> jch, bool join, *hash<auto> ch, *hash<auto> psch) {
             switch (cvc.typeCode()) {
                 case NT_HASH:
                     return doColumnOperatorIntern(cvc, jch, join, ch, psch);
@@ -13042,11 +13041,11 @@ string sql = table.getSelectSql(sh, \args);
             throw "SELECT-ERROR", sprintf("%s: column operator hash %y has an invalid \"column\" key; expecting a string column specification or a column operator description hash", getDesc(), cvc);
         }
 
-        private string doColumnOperatorIntern(hash cvc, *hash jch, bool join, *hash ch, *hash psch, *reference psch_ref) {
+        private string doColumnOperatorIntern(hash cvc, *hash<auto> jch, bool join, *hash<auto> ch, *hash<auto> psch, *reference psch_ref) {
             return doColumnOperatorIntern(cvc.cop, cvc.arg, (cvc.column ? getColumnExpressionIntern(cvc.column, jch, join, ch, psch) : NOTHING), getColumnOperatorMap(), jch, join, ch, psch, \psch_ref);
         }
 
-        private string doColumnOperatorIntern(auto cop, auto arg, *string cve, hash cm, *hash jch, bool join, *hash ch, *hash psch, *reference psch_ref) {
+        private string doColumnOperatorIntern(auto cop, auto arg, *string cve, hash cm, *hash<auto> jch, bool join, *hash<auto> ch, *hash<auto> psch, *reference psch_ref) {
             if (cop.typeCode() != NT_STRING)
                 throw "SELECT-ERROR", sprintf("%s: invalid column operator code %y; use column operator functions to create valid column specifications with supported column operators", getDesc(), cop);
 
@@ -13110,7 +13109,7 @@ string sql = table.getSelectSql(sh, \args);
              }
         }
 
-        private string getColumnNameIntern(string cv, *hash jch, bool join, *hash ch, *hash psch) {
+        private string getColumnNameIntern(string cv, *hash<auto> jch, bool join, *hash<auto> ch, *hash<auto> psch) {
             # remove any disposable unique prefix
             cv =~ s/^[0-9]+://;
             # return the name if it's a "technical name" (starts with "_")
@@ -13158,29 +13157,29 @@ string sql = table.getSelectSql(sh, \args);
             return False;
         }
 
-        private getSelectWhereSqlUnlocked(reference<string> sql, reference<list> args, *hash qh, *hash jch, bool join = False, *hash ch, *hash psch) {
+        private getSelectWhereSqlUnlocked(reference<string> sql, reference<list<auto>> args, *hash<auto> qh, *hash<auto> jch, bool join = False, *hash<auto> ch, *hash<auto> psch) {
             if (qh."where")
                 sql += getWhereClauseUnlocked(qh."where", \args, NOTHING, jch, join, ch, psch);
         }
 
-        private *string getWhereClause(*hash cond, reference<list> args, *string cprefix, *hash jch, bool join = False) {
+        private *string getWhereClause(*hash cond, reference<list<auto>> args, *string cprefix, *hash<auto> jch, bool join = False) {
             l.lock();
             on_exit l.unlock();
             return getWhereClauseUnlocked(cond, \args, cprefix, jch, join, NOTHING, getPseudoColumnHash());
         }
 
-        private *string getWhereClause(list cond, reference<list> args, *string cprefix, *hash jch, bool join = False) {
+        private *string getWhereClause(list cond, reference<list<auto>> args, *string cprefix, *hash<auto> jch, bool join = False) {
             l.lock();
             on_exit l.unlock();
             return getWhereClauseUnlocked(cond, \args, cprefix, jch, join, NOTHING, getPseudoColumnHash());
         }
 
-        private *string getWhereClauseUnlocked(list cond, reference<list> args, *string cprefix, *hash jch, bool join = False, *hash pch, *hash psch) {
+        private *string getWhereClauseUnlocked(list cond, reference<list<auto>> args, *string cprefix, *hash<auto> jch, bool join = False, *hash pch, *hash<auto> psch) {
             getColumnsUnlocked();
             list al = ();
             if (!exists args)
                 args = ();
-            foreach hash ch in (cond) {
+            foreach hash<auto> ch in (cond) {
                 *list wl = getWhereClauseIntern(ch, \args, cprefix, jch, join, pch, psch);
                 if (wl)
                     al += "(" + (foldl $1 + " and " + $2, wl) + ")";
@@ -13189,7 +13188,7 @@ string sql = table.getSelectSql(sh, \args);
                 return " where " + (foldl $1 + " or " + $2, al);
         }
 
-        private *string getWhereClauseUnlocked(*hash cond, reference<list> args, *string cprefix, *hash jch, bool join = False, *hash pch, *hash psch) {
+        private *string getWhereClauseUnlocked(*hash cond, reference<list<auto>> args, *string cprefix, *hash<auto> jch, bool join = False, *hash pch, *hash<auto> psch) {
             getColumnsUnlocked();
             if (!exists args)
                 args = ();
@@ -13198,18 +13197,18 @@ string sql = table.getSelectSql(sh, \args);
                 return " where " + (foldl $1 + " and " + $2, wl);
         }
 
-        private *list getWhereClauseIntern(*hash cond, reference<list> args, *string cprefix, *hash jch, bool join = False, *hash ch, *hash psch) {
+        private *list<auto> getWhereClauseIntern(*hash cond, reference<list<auto>> args, *string cprefix, *hash<auto> jch, bool join = False, *hash<auto> ch, *hash<auto> psch) {
             if (!cond)
                 return;
 
             return map doWhereExpressionIntern(cprefix ? sprintf("%s.%s", cprefix, $1.key) : getColumnNameIntern($1.key, jch, join, ch, psch), $1.value, \args, jch, join, ch, psch), cond.pairIterator();
         }
 
-        private string doWhereExpressionIntern(string cn, auto we, reference<list> args, *hash jch, bool join = False, *hash ch, *hash psch) {
+        private string doWhereExpressionIntern(string cn, auto we, reference<list<auto>> args, *hash<auto> jch, bool join = False, *hash<auto> ch, *hash<auto> psch) {
             int wt = we.typeCode();
             if (wt == NT_HASH) {
                 if (we.hasKey("cop")) {
-                    *hash psch_copy = psch;
+                    *hash<auto> psch_copy = psch;
                     string val = doColumnOperatorIntern(we, jch, join, ch, psch, \psch_copy);
                     if (psch_copy != psch)
                         throw "WHERE-ERROR", sprintf("%s: cannot use column operator function %y in the where clause with column alias specifications", getDesc(), we.cop);
@@ -13243,9 +13242,9 @@ string sql = table.getSelectSql(sh, \args);
             return sprintf("%s = %v", cn);
         }
 
-        string getOrClause(list arglist, reference<list> args, *hash jch, bool join = False, *hash ch, *hash psch) {
+        string getOrClause(list<auto> arglist, reference<list<auto>> args, *hash<auto> jch, bool join = False, *hash<auto> ch, *hash<auto> psch) {
             list l = ();
-            foreach hash h in (arglist) {
+            foreach hash<auto> h in (arglist) {
                 string str = getOrClause(h, \args, jch, join, ch, psch);
                 if (str)
                     l += str;
@@ -13253,12 +13252,12 @@ string sql = table.getSelectSql(sh, \args);
             return l ? ("(" + (foldl $1 + " or " + $2, l) + ")") : "";
         }
 
-        string getOrClause(hash arg, reference<list> args, *hash jch, bool join = False, *hash ch, *hash psch) {
+        string getOrClause(hash arg, reference<list<auto>> args, *hash<auto> jch, bool join = False, *hash<auto> ch, *hash<auto> psch) {
             *list wl = getWhereClauseIntern(arg, \args, NOTHING, jch, join, ch, psch);
             return wl ? ("(" + (foldl $1 + " and " + $2, wl) + ")") : "";
         }
 
-        private doSelectOrderBySqlUnlocked(reference<string> sql, reference<list> args, *hash qh, *hash jch, *hash ch, *hash psch, list coll) {
+        private doSelectOrderBySqlUnlocked(reference<string> sql, reference<list<auto>> args, *hash<auto> qh, *hash<auto> jch, *hash<auto> ch, *hash<auto> psch, list coll) {
             list ce = getOrderByListUnlocked(qh, jch, ch, psch, coll);
 
             sql += " order by " + (foldl $1 + ", " + $2, (map $1 + (qh.desc || qh.orderbydesc.$1 ? " desc" : ""), ce));
@@ -13280,14 +13279,14 @@ int dcnt = table.delCommit(("name": name));
 
             @see delete(*hash)
          */
-        int delCommit(hash cond, reference<string> sql, hash opt) {
+        int delCommit(hash cond, reference<string> sql, hash<auto> opt) {
             on_success ds.commit();
             on_error ds.rollback();
             return delIntern(cond, \sql, opt);
         }
 
         #! @ref SqlUtil::AbstractTable::delCommit() variant
-        int delCommit(hash cond, hash opt) {
+        int delCommit(hash cond, hash<auto> opt) {
             on_success ds.commit();
             on_error ds.rollback();
             return delIntern(cond, NOTHING, opt);
@@ -13331,12 +13330,12 @@ int dcnt = table.del(("name": name));
 
             @see delCommit(*hash)
          */
-        int del(hash cond, reference<string> sql, hash opt) {
+        int del(hash cond, reference<string> sql, hash<auto> opt) {
             return delIntern(cond, \sql, opt);
         }
 
         #! @ref SqlUtil::AbstractTable::del() variant
-        int del(hash cond, hash opt) {
+        int del(hash cond, hash<auto> opt) {
             return delIntern(cond, NOTHING, opt);
         }
 
@@ -13360,10 +13359,10 @@ int dcnt = table.del(("name": name));
             return del(cond, \sql);
         }
 
-        private int delIntern(*hash cond, *reference<string> sql, *hash opt) {
+        private int delIntern(*hash cond, *reference<string> sql, *hash<auto> opt) {
             # make query
             sql = sprintf("delete from %s", getSqlName());
-            list args;
+            list<auto> args;
             if (cond)
                 sql += getWhereClause(cond, \args);
 
@@ -13388,7 +13387,7 @@ int ucnt = table.updateCommit(("id": id), ("name": name));
 
             @see update()
          */
-        int updateCommit(hash set, hash cond, reference<string> sql, hash opt) {
+        int updateCommit(hash set, hash cond, reference<string> sql, hash<auto> opt) {
             on_success ds.commit();
             on_error ds.rollback();
             return updateIntern(set, cond, \sql, opt);
@@ -13402,7 +13401,7 @@ int ucnt = table.updateCommit(("id": id), ("name": name));
         }
 
         #! A @ref SqlUtil::AbstractTable::updateCommit() variant
-        int updateCommit(hash set, hash cond, hash opt) {
+        int updateCommit(hash set, hash cond, hash<auto> opt) {
             on_success ds.commit();
             on_error ds.rollback();
             return updateIntern(set, cond, NOTHING, opt);
@@ -13440,7 +13439,7 @@ int ucnt = table.update(("id": id), ("name": name));
 
             @see updateCommit()
          */
-        int update(hash set, hash cond, reference<string> sql, hash opt) {
+        int update(hash set, hash cond, reference<string> sql, hash<auto> opt) {
             return updateIntern(set, cond, \sql, opt);
         }
 
@@ -13450,7 +13449,7 @@ int ucnt = table.update(("id": id), ("name": name));
         }
 
         #! A @ref SqlUtil::AbstractTable::update() variant
-        int update(hash set, hash cond, hash opt) {
+        int update(hash set, hash cond, hash<auto> opt) {
             return updateIntern(set, cond, NOTHING, opt);
         }
 
@@ -13470,18 +13469,18 @@ int ucnt = table.update(("id": id), ("name": name));
         }
 
         #! A legacy @ref SqlUtil::AbstractTable::update() wrapper
-        deprecated int updateNoCommit(hash set, *hash cond, *hash opt) {
+        deprecated int updateNoCommit(hash set, *hash cond, *hash<auto> opt) {
             return updateIntern(set, cond, NOTHING, opt);
         }
 
-        private int updateIntern(hash<auto> set, *hash<auto> cond, *reference<string> sql, *hash opt) {
+        private int updateIntern(hash<auto> set, *hash<auto> cond, *reference<string> sql, *hash<auto> opt) {
             # make query
             sql = sprintf("update %s set ", getSqlName());
 
             if (!set)
                 throw "UPDATE-ERROR", sprintf("%s: the set hash is empty", getDesc());
 
-            list args;
+            list<auto> args;
 
             list sl = ();
             HashIterator i(set);
@@ -13550,12 +13549,12 @@ int ucnt = table.update(("id": id), ("name": name));
         }
 
         private bool emptyDataIntern() {
-            list args;
+            list<auto> args;
             string sql = getSelectSql(("limit": 1), \args);
             return boolean(ds.vselectRow(sql, args));
         }
 
-        private Columns checkUpsertRow(hash row, reference<int> upsert_strategy) {
+        private Columns checkUpsertRow(hash<auto> row, reference<int> upsert_strategy) {
             # unique column source
             string csrc;
 
@@ -13582,12 +13581,12 @@ int ucnt = table.update(("id": id), ("name": name));
             return cols;
         }
 
-        private code getUpsertInsertFirst(Columns cols, hash example_row, *hash opt) {
+        private code getUpsertInsertFirst(Columns cols, hash example_row, *hash<auto> opt) {
             string insert_sql = getUpsertInsertSql(example_row);
             list updc = ();
             string update_sql = getUpsertUpdateSql(example_row, cols, \updc, opt);
 
-            return int sub (hash row) {
+            return int sub (hash<auto> row) {
                 if (tryInsertImpl(insert_sql, row))
                     return UR_Inserted;
 
@@ -13596,12 +13595,12 @@ int ucnt = table.update(("id": id), ("name": name));
             };
         }
 
-        private code getUpsertUpdateFirst(Columns cols, hash example_row, *hash opt) {
+        private code getUpsertUpdateFirst(Columns cols, hash example_row, *hash<auto> opt) {
             list updc = ();
             string update_sql = getUpsertUpdateSql(example_row, cols, \updc, opt);
             string insert_sql = getUpsertInsertSql(example_row);
 
-            return int sub (hash row) {
+            return int sub (hash<auto> row) {
                 if (tryUpdate(update_sql, row, cols, updc))
                     return UR_Verified;
 
@@ -13610,15 +13609,15 @@ int ucnt = table.update(("id": id), ("name": name));
             };
         }
 
-        private code getUpsertSelectFirst(Columns cols, hash example_row, *hash opt) {
+        private code getUpsertSelectFirst(Columns cols, hash example_row, *hash<auto> opt) {
             #printf("getUpsertSelectFirst() %s: %y\n", name, cols.keys());
             list<string> updc();
             string select_sql = getUpsertSelectSql(example_row, cols, \updc);
             string insert_sql = getUpsertInsertSql(example_row);
             string update_sql = getUpsertUpdateSql(example_row, cols, \updc, opt);
 
-            return int sub (hash row) {
-                list args = row.(cols.keys()).values();
+            return int sub (hash<auto> row) {
+                list<auto> args = row.(cols.keys()).values();
                 #printf("select_sql: %s args: %y\n", select_sql, args);
                 *hash dbrow = ds.vselectRow(select_sql, args);
                 if (!dbrow) {
@@ -13635,19 +13634,19 @@ int ucnt = table.update(("id": id), ("name": name));
             };
         }
 
-        private code getUpsertInsertOnly(Columns cols, hash example_row, *hash opt) {
+        private code getUpsertInsertOnly(Columns cols, hash example_row, *hash<auto> opt) {
             string insert_sql = getUpsertInsertSql(example_row);
 
-            return int sub (hash row) {
+            return int sub (hash<auto> row) {
                 return tryInsertImpl(insert_sql, row) ? UR_Inserted : UR_Unchanged;
             };
         }
 
-        private code getUpsertUpdateOnly(Columns cols, hash example_row, *hash opt) {
+        private code getUpsertUpdateOnly(Columns cols, hash example_row, *hash<auto> opt) {
             list updc = ();
             string update_sql = getUpsertUpdateSql(example_row, cols, \updc, opt);
 
-            return int sub (hash row) {
+            return int sub (hash<auto> row) {
                 return tryUpdate(update_sql, row, cols, updc) ? UR_Verified : UR_Unchanged;
             };
         }
@@ -13693,7 +13692,7 @@ int ucnt = table.update(("id": id), ("name": name));
             return cols;
         }
 
-        private string getUpsertSelectSql(hash row, Columns cols, reference<list<string>> updc) {
+        private string getUpsertSelectSql(hash<auto> row, Columns cols, reference<list<string>> updc) {
             if (cols.size() != row.size()) {
                 # make list of columns not in unique key
                 map updc += $1, row.keyIterator(), !cols.hasKey($1);
@@ -13708,7 +13707,7 @@ int ucnt = table.update(("id": id), ("name": name));
                 );
         }
 
-        private string getUpsertInsertSql(hash row) {
+        private string getUpsertInsertSql(hash<auto> row) {
             string sql = sprintf("insert into %s (", getSqlName());
             sql += (foldl $1 + "," + $2, (map getColumnSqlName($1), row.keyIterator()));
             sql += ") values (";
@@ -13717,7 +13716,7 @@ int ucnt = table.update(("id": id), ("name": name));
             return sql;
         }
 
-        private string getUpsertUpdateSql(hash row, Columns cols, reference updc, *hash opt) {
+        private string getUpsertUpdateSql(hash<auto> row, Columns cols, reference updc, *hash<auto> opt) {
             # make list of columns not in unique key if necessary
             if (!updc) {
                 # hash of columns to skip on update if applicable
@@ -13734,8 +13733,8 @@ int ucnt = table.update(("id": id), ("name": name));
             return sql;
         }
 
-        private softbool tryUpdate(string sql, hash row, Columns cols, list updc) {
-            list args = row{updc}.values() + row{cols.keys()}.values();
+        private softbool tryUpdate(string sql, hash<auto> row, Columns cols, list updc) {
+            list<auto> args = row{updc}.values() + row{cols.keys()}.values();
             return ds.vexec(sql, args);
         }
 
@@ -13799,7 +13798,7 @@ string sql = t.getSqlFromList(list);
 
             @return an SQL string corresponding to the list of commands in the argument
         */
-        string getSqlFromList(list l) {
+        string getSqlFromList(list<auto> l) {
             return getCreateSqlImpl(l);
         }
 
@@ -13836,7 +13835,7 @@ table.cache();
 
             @param opts cache options; see @ref SqlUtil::AbstractTable::CacheOptions for common options; each driver can support additional driver-specific options
         */
-        cache(*hash opts) {
+        cache(*hash<auto> opts) {
             l.lock();
             on_exit l.unlock();
             cacheUnlocked(opts);
@@ -13937,7 +13936,7 @@ Indexes ix = table.getIndexes();
         }
 
         #! returns a ForeignConstraints object describing the foreign constraints that the table has on other tables
-        ForeignConstraints getForeignConstraints(*hash opt) {
+        ForeignConstraints getForeignConstraints(*hash<auto> opt) {
             l.lock();
             on_exit l.unlock();
             getForeignConstraintsUnlocked(opt);
@@ -13992,7 +13991,7 @@ string sql = table.getRenameSql("new_name");
             - rename()
             - inDb() for a method that tells if the table is already in the database or not
          */
-        string getRenameSql(string new_name, *hash opt) {
+        string getRenameSql(string new_name, *hash<auto> opt) {
             validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
 
             l.lock();
@@ -14014,7 +14013,7 @@ printf("%s\n", table.getCreateSql());
 
             @return an SQL string that could be used to create the table and all known properties of the table
         */
-        string getCreateSqlString(*hash opt) {
+        string getCreateSqlString(*hash<auto> opt) {
             # convert table alignment omission options to a hash and check
             if (opt.omit) opt.omit = getCheckOmissionOptions(opt.omit, "CREATE-TABLE-ERROR");
 
@@ -14037,7 +14036,7 @@ map printf("$1;\n", $1), table.getCreateSql();
 
             @return a list of SQL strings that could be used to create the table and all known properties of the table
         */
-        list getCreateSql(*hash opt) {
+        list<auto> getCreateSql(*hash<auto> opt) {
             # convert table alignment omission options to a hash and check
             if (opt.omit) opt.omit = getCheckOmissionOptions(opt.omit, "CREATE-TABLE-ERROR");
 
@@ -14060,7 +14059,7 @@ string sql = table.getCreateTableSql();
 
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        string getCreateTableSql(*hash opt) {
+        string getCreateTableSql(*hash<auto> opt) {
             # convert table alignment omission options to a hash and check
             if (opt.omit) opt.omit = getCheckOmissionOptions(opt.omit, "CREATE-TABLE-ERROR");
 
@@ -14083,12 +14082,12 @@ string sql = table.getCreateTableSql();
             return checkExistenceImpl();
         }
 
-        private *hash getCheckOmissionOptions(*softlist ol, string err) {
+        private *hash<string, bool> getCheckOmissionOptions(*softlist<softstring> ol, string err) {
             # convert table alignment omission options to a hash and check
             if (!ol)
                 return;
 
-            hash oh;
+            hash<string, bool> oh;
             foreach string ostr in (ol) {
                 if (!TableOmissionOptions{ostr})
                     throw err, sprintf("omission option %y is unknown; known omission options: %y", ostr, TableOmissionOptions.keys());
@@ -14113,11 +14112,11 @@ list l = table.getAlignSql(table2);
 
             @note if the @ref sql_callback_executed "sql_callback_executed option" is @ref Qore::True "True" in \a opt, then the changes are also effected in the current object, if not, then they are not (see @ref sql_callback_executed for more information)
         */
-        list getAlignSql(AbstractTable t, *hash opt) {
+        list<auto> getAlignSql(AbstractTable t, *hash<auto> opt) {
             if (self.className() != t.className())
                 throw "ALIGN-TABLE-ERROR", sprintf("cannot align %s of class %y with %s of class %y", getDesc(), self.className(), t.getDesc(), t.className());
 
-            hash ato = getAlignTableOptions();
+            hash<auto> ato = getAlignTableOptions();
 
             validateOptionsIntern("OPTION-ERROR", ato, \opt);
 
@@ -14140,7 +14139,7 @@ list l = table.getAlignSql(table2);
                     return t.getCreateSqlUnlocked(opt, False);
 
                 # use db_table_cache for table_cache when caching DB objects
-                *hash db_opt = opt;
+                *hash<auto> db_opt = {} + opt;
                 db_opt.table_cache = remove db_opt.db_table_cache;
                 cacheUnlocked(db_opt);
             }
@@ -14156,8 +14155,8 @@ list l = table.getAlignSql(table2);
             return this.getAlignSqlUnlocked(t, opt);
         }
 
-        private list getAlignSqlUnlocked(AbstractTable t, *hash opt) {
-            list l = ();
+        private list<auto> getAlignSqlUnlocked(AbstractTable t, *hash<auto> opt) {
+            list<auto> l = ();
 
             # check name
             if (name != t.name) {
@@ -14549,7 +14548,7 @@ string sql = table.getAlignSqlString(table2);
             @throw ALIGN-TABLE-ERROR the argument must be of the same class as the current object; template table has no columns
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        string getAlignSqlString(AbstractTable t, *hash opt) {
+        string getAlignSqlString(AbstractTable t, *hash<auto> opt) {
             return getCreateSqlImpl(getAlignSql(t, opt));
         }
 
@@ -14566,7 +14565,7 @@ string sql = table.getAlignSqlString(table2);
 
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        *list getCreateIndexesSql(*hash opt, bool cache = True) {
+        *list<auto> getCreateIndexesSql(*hash<auto> opt, bool cache = True) {
             validateOptionsIntern("OPTION-ERROR", getIndexOptions(), \opt);
             l.lock();
             on_exit l.unlock();
@@ -14586,7 +14585,7 @@ string sql = table.getAlignSqlString(table2);
 
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        *string getCreatePrimaryKeySql(*hash opt, bool cache = True) {
+        *string getCreatePrimaryKeySql(*hash<auto> opt, bool cache = True) {
             validateOptionsIntern("OPTION-ERROR", getConstraintOptions(), \opt);
             l.lock();
             on_exit l.unlock();
@@ -14606,7 +14605,7 @@ string sql = table.getAlignSqlString(table2);
 
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        *list getCreateForeignConstraintsSql(*hash opt, bool cache = True) {
+        *list<auto> getCreateForeignConstraintsSql(*hash<auto> opt, bool cache = True) {
             validateOptionsIntern("OPTION-ERROR", getForeignConstraintOptions(), \opt);
             l.lock();
             on_exit l.unlock();
@@ -14628,7 +14627,7 @@ string sql = table.getAlignSqlString(table2);
 
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        *list getCreateConstraintsSql(*hash opt, bool cache = True) {
+        *list<auto> getCreateConstraintsSql(*hash<auto> opt, bool cache = True) {
             validateOptionsIntern("OPTION-ERROR", getConstraintOptions(), \opt);
             l.lock();
             on_exit l.unlock();
@@ -14648,7 +14647,7 @@ string sql = table.getAlignSqlString(table2);
 
             @throw OPTION-ERROR invalid or unsupported option passed
         */
-        *list getCreateMiscSql(*hash opt, bool cache = True) {
+        *list<auto> getCreateMiscSql(*hash<auto> opt, bool cache = True) {
             validateOptionsIntern("OPTION-ERROR", getTableCreationOptions(), \opt);
             l.lock();
             on_exit l.unlock();
@@ -14670,7 +14669,7 @@ string sql = table.getAlignSqlString(table2);
 
             @see getCreateTriggersSql()
         */
-        *list getCreateTriggersSql(*hash opt, bool cache = True) {
+        *list<auto> getCreateTriggersSql(*hash<auto> opt, bool cache = True) {
             validateOptionsIntern("OPTION-ERROR", getTableCreationOptions(), \opt);
             l.lock();
             on_exit l.unlock();
@@ -14680,7 +14679,7 @@ string sql = table.getAlignSqlString(table2);
         #! finds a row in the table with the given primary key value; if no row matches the primary key value passed then @ref nothing is returned
         /** @par Example:
             @code{.py}
-*hash row = table.find(id);
+*hash<auto> row = table.find(id);
             @endcode
 
             @throw PRIMARY-KEY-ERROR the table has no primary key or the primary key has more than one column
@@ -14709,7 +14708,7 @@ string sql = table.getAlignSqlString(table2);
             if (!ids)
                 return;
 
-            list args;
+            list<auto> args;
             hash cond{cname} = op_in(ids);
             string sql = getSelectSqlIntern(("where": cond), \args);
 
@@ -14730,7 +14729,7 @@ string sql = table.getAlignSqlString(table2);
         #! finds a row in the table with the given primary key value given as a hash; if no row matches the primary key value passed then @ref nothing is returned
         /** @par Example:
             @code{.py}
-*hash row = table.find(("account_type": type, "name": name));
+*hash<auto> row = table.find(("account_type": type, "name": name));
             @endcode
 
             @param row a hash giving the primary key value to find; other columns may also appear in the hash, however at least all columns of the primary key must be present
@@ -14741,7 +14740,7 @@ string sql = table.getAlignSqlString(table2);
 
             @note a table with a primary key with a single column can also be used with this method; just pass a hash with one key
          */
-        *hash find(hash row) {
+        *hash<auto> find(hash<auto> row) {
             Columns cols;
             {
                 l.lock();
@@ -14767,7 +14766,7 @@ string sql = table.getAlignSqlString(table2);
         #! finds a single row in the table that match the row condition passed; multiple rows may match, but only one row will be returned from the database; if no row matches the condition hash passed then @ref nothing is returned
         /** @par Example:
             @code{.py}
-*hash row = table.findSingle(h);
+*hash<auto> row = table.findSingle(h);
             @endcode
 
             @param cond a hash giving the column values to find; see @ref where_clauses for the format of this argument
@@ -14778,14 +14777,14 @@ string sql = table.getAlignSqlString(table2);
 
             @note this is equivalent to calling selectRow() with \c where = \c cond and \c limit = 1
          */
-        *hash findSingle(*hash cond) {
+        *hash<auto> findSingle(*hash<auto> cond) {
             return selectRows(("where": cond, "limit": 1))[0];
         }
 
         #! finds all rows in the table with the given column values; a list of hashes is returned representing the rows returned
         /** @par Example:
             @code{.py}
-*list rows = table.findAll(h);
+*list<auto> rows = table.findAll(h);
             @endcode
 
             @param cond a hash giving the column values to find; see @ref where_clauses for the format of this argument
@@ -14796,7 +14795,7 @@ string sql = table.getAlignSqlString(table2);
 
             @note this is equivalent to calling selectRows() with \c where = \c cond
          */
-        *list findAll(*hash cond) {
+        *list<auto> findAll(*hash<auto> cond) {
             return selectRows(("where": cond));
         }
 
@@ -14825,7 +14824,7 @@ string sql = table.getAlignSqlString(table2);
         }
 
         #! returns a list of column names for use in SQL strings; subclasses can process the argument list in case a column name is a reserved word
-        list getColumnSqlNames(softlist cols) {
+        list<auto> getColumnSqlNames(softlist cols) {
             return cols;
         }
 
@@ -14842,139 +14841,139 @@ string sql = table.getAlignSqlString(table2);
         #! returns the table options for this driver
         /** override in subclasses to return driver-specific options
         */
-        private hash getTableOptions() {
+        private hash<auto> getTableOptions() {
             return TableOptions;
         }
 
         #! return the foreign constraint options for this driver
         /** override in subclasses to return driver-specific options
         */
-        private hash getForeignConstraintOptions() {
+        private hash<auto> getForeignConstraintOptions() {
             return ForeignConstraintOptions;
         }
 
         #! returns the constraint options for this driver
         /** override in subclasses to return driver-specific options
         */
-        private hash getConstraintOptions() {
+        private hash<auto> getConstraintOptions() {
             return ConstraintOptions;
         }
 
         #! returns the cache options for this driver
         /** override in subclasses to return driver-specific options
         */
-        private hash getCacheOptions() {
+        private hash<auto> getCacheOptions() {
             return CacheOptions;
         }
 
         #! returns the table creation options for this driver
         /** override in subclasses to return driver-specific options
         */
-        private hash getTableCreationOptions() {
+        private hash<auto> getTableCreationOptions() {
             return TableCreationOptions;
         }
 
         #! returns the align table options for this driver
         /** override in subclasses to return driver-specific options
         */
-        private hash getAlignTableOptions() {
+        private hash<auto> getAlignTableOptions() {
             return AlignTableOptions;
         }
 
-        #! returns the table description hash options for this driver
+        #! returns the table description hash<auto> options for this driver
         /** override in subclasses to return driver-specific options
         */
-        private hash getTableDescriptionHashOptions() {
+        private hash<auto> getTableDescriptionHashOptions() {
             return TableDescriptionHashOptions;
         }
 
         #! returns the column options for this driver
         /** override in subclasses to return driver-specific options
         */
-        private hash getColumnOptions() {
+        private hash<auto> getColumnOptions() {
             return ColumnOptions;
         }
 
         #! returns the column description options for this driver
         /** override in subclasses to return driver-specific options
         */
-        private hash getColumnDescOptions() {
+        private hash<auto> getColumnDescOptions() {
             return ColumnDescOptions;
         }
 
         #! returns the table column description options for this driver
         /** override in subclasses to return driver-specific options
         */
-        private hash getTableColumnDescOptions() {
+        private hash<auto> getTableColumnDescOptions() {
             return getColumnDescOptions() + AdditionalColumnDescOptions;
         }
 
         #! returns the index options for this driver
         /** override in subclasses to return driver-specific options
         */
-        private hash getIndexOptions() {
+        private hash<auto> getIndexOptions() {
             return IndexOptions;
         }
 
         #! returns the trigger options for this driver
         /** override in subclasses to return driver-specific options
         */
-        private hash getTriggerOptions() {
+        private hash<auto> getTriggerOptions() {
             return TriggerOptions;
         }
 
         #! returns the select options for this driver
         /** override in subclasses to return driver-specific options
         */
-        private hash getSelectOptions() {
+        private hash<auto> getSelectOptions() {
             return SelectOptions;
         }
 
         #! returns the upsert options for this driver
         /** override in subclasses to return driver-specific options
         */
-        private hash getUpsertOptions() {
+        private hash<auto> getUpsertOptions() {
             return UpsertOptions;
         }
 
         #! returns the insert options for this driver
         /** override in subclasses to return driver-specific options
         */
-        private hash getInsertOptions() {
+        private hash<auto> getInsertOptions() {
             return InsertOptions;
         }
 
         #! returns the insert from iterator options for this driver
         /** override in subclasses to return driver-specific options
         */
-        private hash getInsertFromIteratorOptions() {
+        private hash<auto> getInsertFromIteratorOptions() {
             return InsertFromIteratorOptions;
         }
 
         #! returns the sql data operation callback options for this driver
         /** override in subclasses to return driver-specific options
         */
-        private hash getSqlDataCallbackOptions() {
+        private hash<auto> getSqlDataCallbackOptions() {
             return SqlDataCallbackOptions;
         }
 
         #! returns the "where" operator map for this object
         /** override in subclasses to return driver-specific options
         */
-        private hash getWhereOperatorMap() {
+        private hash<auto> getWhereOperatorMap() {
             return DefaultOpMap;
         }
 
         #! returns the column operator map for this object
         /** subclasses should to implement getColumnOperatorMapImpl() to return driver-specific options
         */
-        private hash getColumnOperatorMap() {
+        private hash<auto> getColumnOperatorMap() {
             return DefaultCopMap + getColumnOperatorMapImpl()
                                  + m_customCopMap;
         }
 
         #! Reimplement in subclasses to provide driver specific column operators
-        private *hash getColumnOperatorMapImpl() {
+        private *hash<auto> getColumnOperatorMapImpl() {
         }
 
         #! register custom user column operator for this table object
@@ -14991,7 +14990,7 @@ string sql = table.getAlignSqlString(table2);
             @code{.py}
 # t is a AbstractTable/Table object
 # custom operator hash
-hash to_char = (
+hash<auto> to_char = (
     "code" : string sub(string arg1, auto arg) {
                  return sprintf("to_char(%s, '%s')", arg1, arg);
              },
@@ -14999,7 +14998,7 @@ hash to_char = (
 # operator registration
 t.addCustomCopOperator("to_char", to_char);
 # example usage
-hash sh = (
+hash<auto> sh = (
     "columns" : cop_as(SqlUtil::make_cop("to_char", "d", "yyyymmddhh24miss"), "string_fmt_date"),
     "limit" : 1,
 );
@@ -15014,8 +15013,8 @@ any res = t.selectRows(sh, \sql);
 # SQL> select to_char(d, 'yyyymmddhh24miss') as string_fmt_date from test_schema.t
             @endcode
         */
-        addCustomCopOperator(string name, hash operator) {
-            hash ops = getColumnOperatorMap();
+        addCustomCopOperator(string name, hash<auto> operator) {
+            hash<auto> ops = getColumnOperatorMap();
             if (ops.hasKey(name)) {
                 throw "CUSTOM-OPERATOR-ERROR",
                       sprintf("Operator '%s' is already registered as: %y", name, ops{name});
@@ -15025,13 +15024,10 @@ any res = t.selectRows(sh, \sql);
             if (!operator.hasKey("code")) {
                 throw "CUSTOM-OPERATOR-ERROR",
                       "Operator hash must contain key 'code'";
-            }
-            else if (operator."code".typeCode() != NT_CLOSURE
-                     && operator."code".typeCode() != NT_CALLREF
-                    )
-            {
+            } else if (!operator."code".callp()) {
                 throw "CUSTOM-OPERATOR-ERROR",
-                      sprintf("Operator hash must contain key 'code' with a value of type 'closure' or 'callref', got: %s", operator."code".type());
+                      sprintf("Operator hash must contain key 'code' with a callable value; got type: %s",
+                        operator."code".type());
             }
 
             m_customCopMap{name} = operator;
@@ -15040,15 +15036,15 @@ any res = t.selectRows(sh, \sql);
         #! returns the insert operator map for this object
         /** override in subclasses to return driver-specific options
         */
-        private hash getInsertOperatorMap() {
+        private hash<auto> getInsertOperatorMap() {
             return DefaultIopMap;
         }
 
         #! returns the update operator map for this object
         /** override in subclasses to return driver-specific options
         */
-        private hash getUpdateOperatorMap() {
-            hash uom = getRawUpdateOperatorMap();
+        private hash<auto> getUpdateOperatorMap() {
+            hash<auto> uom = getRawUpdateOperatorMap();
             return getColumnOperatorMap().(uom.keys())
                 + (map {$1.key: $1.value}, uom.pairIterator(), $1.value.typeCode() == NT_HASH);
         }
@@ -15056,22 +15052,22 @@ any res = t.selectRows(sh, \sql);
         #! returns the raw (default) update operator map for this object
         /** override in subclasses to return driver-specific options
         */
-        private hash getRawUpdateOperatorMap() {
+        private hash<auto> getRawUpdateOperatorMap() {
             return DefaultUopMap;
         }
 
         #! returns a hash of valid pseudocolumns
         /** override in subclasses to return driver-specific pseudocolumns; by default this method returns @ref nothing
         */
-        private *hash getPseudoColumnHash() {
+        private *hash<auto> getPseudoColumnHash() {
         }
 
-        private string getCreateTableSqlUnlocked(*hash opt) {
+        private string getCreateTableSqlUnlocked(*hash<auto> opt) {
             getColumnsUnlocked();
             return AbstractDatabase::doCallback(opt, getCreateTableSqlImpl(opt), AbstractDatabase::AC_Create, "table", name);
         }
 
-        private *list getCreateIndexesSqlUnlocked(*hash opt, bool cache = True) {
+        private *list<auto> getCreateIndexesSqlUnlocked(*hash<auto> opt, bool cache = True) {
             if (cache)
                 getIndexesUnlocked();
             if (!indexes)
@@ -15080,7 +15076,7 @@ any res = t.selectRows(sh, \sql);
             return map AbstractDatabase::doCallback(opt, $1.getCreateSql(name, opt), AbstractDatabase::AC_Add, "index", $1.name, name), indexes.iterator();
         }
 
-        private *string getCreatePrimaryKeySqlUnlocked(*hash opt, bool cache = True) {
+        private *string getCreatePrimaryKeySqlUnlocked(*hash<auto> opt, bool cache = True) {
             if (cache)
                 getPrimaryKeyUnlocked();
             if (primaryKey.empty())
@@ -15088,7 +15084,7 @@ any res = t.selectRows(sh, \sql);
             return AbstractDatabase::doCallback(opt, primaryKey.getCreateSql(name, opt), AbstractDatabase::AC_Add, "primary key", primaryKey.getName(), name);
         }
 
-        private *list getCreateConstraintsSqlUnlocked(*hash opt, bool cache = True) {
+        private *list<auto> getCreateConstraintsSqlUnlocked(*hash<auto> opt, bool cache = True) {
             if (cache)
                 getConstraintsUnlocked();
             if (constraints.empty())
@@ -15097,7 +15093,7 @@ any res = t.selectRows(sh, \sql);
             return map AbstractDatabase::doCallback(opt, $1.getCreateSql(name, opt), AbstractDatabase::AC_Add, "constraint", $1.getName(), name), constraints.iterator(), !ix || !$1.getIndex();
         }
 
-        private *list getCreateForeignConstraintsSqlUnlocked(*hash opt, bool cache = True) {
+        private *list<auto> getCreateForeignConstraintsSqlUnlocked(*hash<auto> opt, bool cache = True) {
             if (cache)
                 getForeignConstraintsUnlocked(opt);
             if (foreignConstraints.empty())
@@ -15105,22 +15101,22 @@ any res = t.selectRows(sh, \sql);
             return map AbstractDatabase::doCallback(opt, $1.getCreateSql(name, opt), AbstractDatabase::AC_Add, "foreign constraint", $1.getName(), name), foreignConstraints.iterator();
         }
 
-        private *list getCreateMiscSqlUnlocked(*hash opt, bool cache = True) {
+        private *list<auto> getCreateMiscSqlUnlocked(*hash<auto> opt, bool cache = True) {
             return getCreateMiscSqlImpl(opt, cache);
         }
 
-        private *list getCreateTriggersSqlUnlocked(*hash opt, bool cache = True) {
+        private *list<auto> getCreateTriggersSqlUnlocked(*hash<auto> opt, bool cache = True) {
             if (cache)
                 getTriggersUnlocked();
             if (triggers.empty())
                 return;
 
-            list l = ();
+            list<auto> l = ();
             map l += AbstractDatabase::doCallback(opt, $1.getCreateSql(name, opt), AbstractDatabase::AC_Add, "trigger", $1.name, name), triggers.iterator();
             return l;
         }
 
-        private list getCreateSqlUnlocked(*hash opt, bool cache = True) {
+        private list<auto> getCreateSqlUnlocked(*hash<auto> opt, bool cache = True) {
             # make sure driver options take precedence over generic options
             if (opt) {
                 string dn = getDriverName();
@@ -15129,7 +15125,7 @@ any res = t.selectRows(sh, \sql);
 
             # mark in options that the entire table is being created
             opt.create_table_all = True;
-            list l += getCreateTableSqlUnlocked(opt);
+            list<auto> l += getCreateTableSqlUnlocked(opt);
             *list tl;
             if (!opt.omit.indexes) {
                 tl = getCreateIndexesSqlUnlocked(opt, cache);
@@ -15151,7 +15147,7 @@ any res = t.selectRows(sh, \sql);
             return l;
         }
 
-        private cacheUnlocked(*hash opt) {
+        private cacheUnlocked(*hash<auto> opt) {
             getColumnsUnlocked();
             getPrimaryKeyUnlocked();
             getIndexesUnlocked();
@@ -15160,19 +15156,19 @@ any res = t.selectRows(sh, \sql);
             getTriggersUnlocked();
         }
 
-        private auto execData(*hash opt, string sql, *list args) {
+        private auto execData(*hash<auto> opt, string sql, *list<auto> args) {
             if (opt.sqlarg_callback)
                 opt.sqlarg_callback(sql, args);
             return ds.vexec(sql, args);
         }
 
-        private execData(AbstractSQLStatement stmt, *hash opt, *list args) {
+        private execData(AbstractSQLStatement stmt, *hash<auto> opt, *list<auto> args) {
             if (opt.sqlarg_callback)
                 opt.sqlarg_callback(stmt.getSQL(), args);
             stmt.execArgs(args);
         }
 
-        static AbstractTable getTable(AbstractDatasource nds, string nname, *hash opts) {
+        static AbstractTable getTable(AbstractDatasource nds, string nname, *hash<auto> opts) {
             string drv = nds.getDriverName();
 
             # generate module and module namespace name
@@ -15195,12 +15191,12 @@ any res = t.selectRows(sh, \sql);
             }
         }
 
-        static AbstractTable getTable(string dsstr, string nname, *hash opts) {
+        static AbstractTable getTable(string dsstr, string nname, *hash<auto> opts) {
             Datasource nds(dsstr);
             return AbstractTable::getTable(nds, nname, opts);
         }
 
-        static AbstractTable getTable(hash dsh, string nname, *hash opts) {
+        static AbstractTable getTable(hash<auto> dsh, string nname, *hash<auto> opts) {
             Datasource nds(dsh);
             return AbstractTable::getTable(nds, nname, opts);
         }
@@ -15252,7 +15248,7 @@ any res = t.selectRows(sh, \sql);
             inDb = True;
         }
 
-        private getForeignConstraintsUnlocked(*hash opt) {
+        private getForeignConstraintsUnlocked(*hash<auto> opt) {
             if (foreignConstraints)
                 return;
             if (manual) {
@@ -15339,7 +15335,7 @@ any res = t.selectRows(sh, \sql);
             return True;
         }
 
-        private softlist getDropSqlImpl() {
+        private softlist<auto> getDropSqlImpl() {
             return sprintf("drop table %s", getSqlName());
         }
 
@@ -15348,7 +15344,7 @@ any res = t.selectRows(sh, \sql);
         }
 
         #! tries to execute a command so that if an error occurs the current transaction status is not lost
-        private auto tryExecArgsImpl(string sql, *softlist args) {
+        private auto tryExecArgsImpl(string sql, *softlist<auto> args) {
             return ds.vexec(sql, args);
         }
 
@@ -15361,10 +15357,10 @@ any res = t.selectRows(sh, \sql);
         private clearImpl() {
         }
 
-        private preSetupTableImpl(reference desc, *hash opt) {
+        private preSetupTableImpl(reference desc, *hash<auto> opt) {
         }
 
-        private abstract *hash doReturningImpl(hash opt, reference<string> sql, list args);
+        private abstract *hash<auto> doReturningImpl(hash<auto> opt, reference<string> sql, list<auto> args);
 
         private abstract bool emptyImpl();
 
@@ -15386,44 +15382,44 @@ any res = t.selectRows(sh, \sql);
         #! returns @ref Qore::True "True" if the database automatically creates a unique constraint when a unique index is created (ex: mysql)
         private abstract bool uniqueIndexCreatesConstraintImpl();
 
-        private abstract setupTableImpl(hash desc, *hash opt);
+        private abstract setupTableImpl(hash<auto> desc, *hash<auto> opt);
 
         private abstract Columns describeImpl();
         private abstract AbstractPrimaryKey getPrimaryKeyImpl();
         private abstract Indexes getIndexesImpl();
-        private abstract ForeignConstraints getForeignConstraintsImpl(*hash opt);
+        private abstract ForeignConstraints getForeignConstraintsImpl(*hash<auto> opt);
         private abstract Constraints getConstraintsImpl();
         private abstract Triggers getTriggersImpl();
 
-        private abstract string getCreateTableSqlImpl(*hash opt);
-        private abstract *list getCreateMiscSqlImpl(*hash opt, bool cache);
-        private abstract string getCreateSqlImpl(list l);
+        private abstract string getCreateTableSqlImpl(*hash<auto> opt);
+        private abstract *list<auto> getCreateMiscSqlImpl(*hash<auto> opt, bool cache);
+        private abstract string getCreateSqlImpl(list<auto> l);
         private abstract string getRenameSqlImpl(string new_name);
-        private abstract *list getAlignSqlImpl(AbstractTable t, *hash opt);
+        private abstract *list<auto> getAlignSqlImpl(AbstractTable t, *hash<auto> opt);
 
-        private abstract AbstractColumn addColumnImpl(string cname, hash opt, bool nullable = True);
-        private abstract AbstractPrimaryKey addPrimaryKeyImpl(string cname, hash ch, *hash opt);
-        private abstract AbstractIndex addIndexImpl(string iname, bool enabled, hash ch, *hash opt);
-        private abstract AbstractForeignConstraint addForeignConstraintImpl(string cname, hash ch, string table, hash tch, *hash opt);
-        private abstract AbstractCheckConstraint addCheckConstraintImpl(string cname, string src, *hash opt);
-        private abstract AbstractUniqueConstraint addUniqueConstraintImpl(string cname, hash ch, *hash opt);
+        private abstract AbstractColumn addColumnImpl(string cname, hash<auto> opt, bool nullable = True);
+        private abstract AbstractPrimaryKey addPrimaryKeyImpl(string cname, hash<auto> ch, *hash<auto> opt);
+        private abstract AbstractIndex addIndexImpl(string iname, bool enabled, hash<auto> ch, *hash<auto> opt);
+        private abstract AbstractForeignConstraint addForeignConstraintImpl(string cname, hash<auto> ch, string table, hash<auto> tch, *hash<auto> opt);
+        private abstract AbstractCheckConstraint addCheckConstraintImpl(string cname, string src, *hash<auto> opt);
+        private abstract AbstractUniqueConstraint addUniqueConstraintImpl(string cname, hash<auto> ch, *hash<auto> opt);
 
-        private abstract AbstractTrigger addTriggerImpl(string tname, string src, *hash opt);
+        private abstract AbstractTrigger addTriggerImpl(string tname, string src, *hash<auto> opt);
 
         #! tries to insert a row, if there is a duplicate key, then it returns @ref Qore::False "False", if successful, returns @ref Qore::True "True"
-        private abstract bool tryInsertImpl(string sql, hash row);
+        private abstract bool tryInsertImpl(string sql, hash<auto> row);
 
         #! returns the qore type -> column type map
-        private abstract hash getQoreTypeMapImpl();
+        private abstract hash<auto> getQoreTypeMapImpl();
 
         #! returns the type name -> type description hash
-        private abstract hash getTypeMapImpl();
+        private abstract hash<auto> getTypeMapImpl();
 
         #! processes a string for use in SQL select statements when there is an "order by" and "offset" argument
-        private abstract doSelectOrderByWithOffsetSqlUnlockedImpl(reference<string> sql, reference<list> args, *hash qh, *hash jch, *hash ch, *hash psch, list coll);
+        private abstract doSelectOrderByWithOffsetSqlUnlockedImpl(reference<string> sql, reference<list<auto>> args, *hash<auto> qh, *hash<auto> jch, *hash<auto> ch, *hash<auto> psch, list coll);
 
         #! processes a string for use in SQL select statements when there is a "limit" argument, but no "orderby" or "offset" arguments
-        private abstract doSelectLimitOnlyUnlockedImpl(reference<string> sql, reference<list> args, *hash qh);
+        private abstract doSelectLimitOnlyUnlockedImpl(reference<string> sql, reference<list<auto>> args, *hash<auto> qh);
 
         #! db-specific copy actions
         private abstract copyImpl(AbstractTable old);

--- a/qlib/TableMapper.qm
+++ b/qlib/TableMapper.qm
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! @file TableMapper.qm provides mapping functionality to an SQL Table target
 
-/*  TableMapper.qm Copyright 2014 - 2018 Qore Technologies, s.r.o.
+/*  TableMapper.qm Copyright 2014 - 2019 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -594,18 +594,18 @@ InboundTableMapper mapper(table, DbMapper);
         #! returns a list of valid field types for this class (can be overridden in subclasses)
         /** @return a list of valid types for this class (can be overridden in subclasses)
         */
-        hash validTypes() {
+        hash<string, bool> validTypes() {
             return ValidTypes + (has_returning ? ("sequence": True, "sequence_currval": True) : NOTHING);
         }
 
         #! returns a list of valid field keys for this class (can be overridden in subclasses)
         /** @return a list of valid field keys for this class (can be overridden in subclasses)
         */
-        hash validKeys() {
-            return Mapper::ValidKeys + (
+        hash<string, bool> validKeys() {
+            return Mapper::ValidKeys + {
                 "sequence": True,
                 "sequence_currval": True,
-                );
+            };
         }
 
         #! returns a list of valid constructor options for this class (can be overridden in subclasses)
@@ -626,7 +626,7 @@ InboundTableMapper mapper(table, DbMapper);
             @throw STRING-TOO-LONG a field value exceeds the maximum value and the 'trunc' key is not set
             @throw INVALID-NUMBER the field is marked as numeric but the input value contains non-numeric data
         */
-        hash insertRow(hash rec) {
+        hash insertRow(hash<auto> rec) {
             hash h = mapDataIntern(rec);
 
             if (upsert) {
@@ -637,9 +637,8 @@ InboundTableMapper mapper(table, DbMapper);
                         upsert_code = table.getUpsertClosure(h);
                     upsert_code(h);
                 }
-            }
-            else {
-                *hash rh;
+            } else {
+                *hash<auto> rh;
                 if (unstable_input || (insert_block == 1))
                     rh = table.insert(h, ("returning": getReturning()));
                 else {
@@ -650,8 +649,7 @@ InboundTableMapper mapper(table, DbMapper);
                         rh = table.insert(h, \sql, ("returning": getReturning()));
                         stmt = table.getDatasource().getSQLStatement();
                         stmt.prepare(sql);
-                    }
-                    else {
+                    } else {
                         # remove sequences
                         map remove h.$1, ret_args;
                         # execute the SQLStatement on the args


### PR DESCRIPTION
…accept near (QTI_NEAR) matches for abstract method overrides, update abstract base classes to use hash<auto> and list<auto> instead of hash and list, ensure that hash <=> hash<auto and list <=> list<auto> are near matches as well as similar types; this will allow for maximum performance without type stripping while not breaking backwards compatibility

refs #3523 fixed reference handling when assigned to class members
refs #3535 implemented runtime field key handling for the Mapper class