### PR TITLE
refs #3546 fixed a bug where false positive parse-time matches with a…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -7,6 +7,20 @@
     @par Release Summary
     TDB
 
+    @section qore_0931 Qore 0.9.3.1
+
+    @par Release Summary
+
+    Bugfix release; see details below
+
+    @subsection qore_0931_bug_fixes Bug Fixes in Qore
+    - <a href="../../modules/RestSchemaValidator/html/index.html">RestSchemaValidator</a>: fixed a bug where REST
+      serialization errors in server responses were ignored and a <tt>200 OK</tt> response was sent instead
+      (<a href="https://github.com/qorelanguage/qore/issues/3547">issue 3547</a>)
+    - fixed a bug where false positive parse-time matches with a complex list or hash type could be made with
+      incompatible types
+      (<a href="https://github.com/qorelanguage/qore/issues/3546">issue 3546</a>)
+
     @section qore_093 Qore 0.9.3
 
     @par Release Summary

--- a/examples/test/qore/misc/reflection.qtest
+++ b/examples/test/qore/misc/reflection.qtest
@@ -98,6 +98,7 @@ class CTestComplex {
 
 class ReflectionTest inherits QUnit::Test {
     constructor() : QUnit::Test("ReflectionTest", "1.0") {
+        addTestCase("type tests", \typeTests());
         addTestCase("pgm tests", \pgmTests());
         addTestCase("issue 3145", \issue3145Test());
         addTestCase("issue 3141", \issue3141Test());
@@ -107,6 +108,10 @@ class ReflectionTest inherits QUnit::Test {
         addTestCase("pseudo-class tests", \pseudoClassTests());
         addTestCase("program tests", \programTests());
         set_return_value(main());
+    }
+
+    typeTests() {
+        assertFalse(AutoListType.isOutputCompatible(IntType));
     }
 
     pgmTests() {

--- a/include/qore/intern/QoreTypeInfo.h
+++ b/include/qore/intern/QoreTypeInfo.h
@@ -626,8 +626,9 @@ public:
     // if second's return type is compatible with first's return type
     // static version of method, checking for null pointer
     DLLLOCAL static bool isOutputCompatible(const QoreTypeInfo* first, const QoreTypeInfo* second) {
-        if (hasType(first) && hasType(second))
-            return first->isOutputCompatible(second);
+        if (hasType(first) && hasType(second)) {
+            return parseAccepts(first, second);
+        }
         return true;
     }
 
@@ -935,17 +936,6 @@ protected:
         for (auto& at : accept_vec) {
             if (at.map && at.spec.matchType(n.getType()) != QTI_NOT_EQUAL)
                 return true;
-        }
-        return false;
-    }
-
-    // if the argument's return type is compatible with "this"'s return type
-    DLLLOCAL bool isOutputCompatible(const QoreTypeInfo* typeInfo) const {
-        for (auto& rt : typeInfo->return_vec) {
-            for (auto& at : accept_vec) {
-                if (at.spec.match(rt.spec))
-                    return true;
-            }
         }
         return false;
     }

--- a/lib/QoreTypeInfo.cpp
+++ b/lib/QoreTypeInfo.cpp
@@ -657,7 +657,7 @@ qore_type_result_e QoreTypeSpec::match(const QoreTypeSpec& t, bool& may_not_matc
                         ? QTI_NEAR
                         : QTI_NOT_EQUAL;
                 case QTS_TYPE:
-                    if (u.ti == autoTypeInfo) {
+                    if (t.getType() == NT_HASH && u.ti == autoTypeInfo) {
                         return QTI_NEAR;
                     }
                     // NOTE: with %strict-types, anything with may_not_match = true must return QTI_NOT_EQUAL
@@ -685,7 +685,7 @@ qore_type_result_e QoreTypeSpec::match(const QoreTypeSpec& t, bool& may_not_matc
                 case QTS_EMPTYLIST:
                     return QTI_NEAR;
                 case QTS_TYPE:
-                    if (u.ti == autoTypeInfo) {
+                    if (t.getType() == NT_LIST && u.ti == autoTypeInfo) {
                         return QTI_NEAR;
                     }
                     // NOTE: with %strict-types, anything with may_not_match = true must return QTI_NOT_EQUAL

--- a/qlib/RestSchemaValidator.qm
+++ b/qlib/RestSchemaValidator.qm
@@ -28,7 +28,7 @@
 %strict-args
 
 # make sure we have the required qore version
-%requires qore >= 0.8.13
+%requires qore >= 0.9.3
 
 # requires the HttpServerUtil module
 %requires(reexport) HttpServerUtil >= 0.3.12
@@ -49,7 +49,7 @@
 %endtry
 
 module RestSchemaValidator {
-    version = "1.1.1";
+    version = "1.1.2";
     desc = "RestSchemaValidator module providing an abstract REST schema validation API";
     author = "David Nichols <david.nichols@qoretechnologies.com>";
     url = "http://qore.org";
@@ -69,6 +69,11 @@ module RestSchemaValidator {
     - @ref RestSchemaValidator::NullRestSchemaValidator "NullRestSchemaValidator"
 
     @section restschemavalidator_relnotes RestSchemaValidator Module Release Notes
+
+    @subsection restschemavalidator_1_1_2 RestSchemaValidator v1.1.2
+    - fixed \c NullRestSchemaValidator to report serialization errors instead of ignoring them and returning about
+      <tt>200 OK</tt> response
+      (<a href="https://github.com/qorelanguage/qore/issues/3547">issue 3547</a>)
 
     @subsection restschemavalidator_1_1_1 RestSchemaValidator v1.1.1
     - fixed \c NullRestSchemaValidator not respecting set Content-Type header from RestClass
@@ -451,7 +456,12 @@ public namespace RestSchemaValidator {
                         case NT_BINARY:
                             return s;
                         default:
-                            return sprintf("%s", s);
+                            # issue #3547: send as a YAML-serialized string if possible to catch unserialiable data
+%ifndef NoYaml
+                            return make_yaml(s);
+%else
+                            throw "TEXT-SERIALIZATION-ERROR", sprintf("cannot serialize type %y without YAML support", s.type());
+%endif
                     }
                 },
                 MimeTypeOctetStream: binary sub (auto s) {
@@ -461,7 +471,12 @@ public namespace RestSchemaValidator {
                         case NT_BINARY:
                             return s;
                         default:
-                            return binary(sprintf("%s", s));
+                            # issue #3547: send as a YAML-serialized string if possible to catch unserialiable data
+%ifndef NoYaml
+                            return binary(make_yaml(s));
+%else
+                            throw "BINARY-SERIALIZATION-ERROR", sprintf("cannot serialize type %y without YAML support", s.type());
+%endif
                     }
                 },
             };
@@ -472,7 +487,7 @@ public namespace RestSchemaValidator {
             const DeserializeYaml = (
                 "code": "yaml",
                 "in": \parse_yaml(),
-                );
+            );
 %endif
 %ifndef NoXml
             const DeserializeXml = (
@@ -493,7 +508,7 @@ public namespace RestSchemaValidator {
                         rethrow;
                     }
                 },
-                );
+            );
 %endif
 
             #! Data deserialization support MIME types to codes and de/serialization functions


### PR DESCRIPTION
… complex list or hash type could be made with incompatible types

refs #3547 fixed a bug in NullRestSchemaValidator in RestSchemaValidator where REST serialization errors in server responses were ignored and a 200 OK response was sent instead