### PR TITLE
refs #3558 fixed a bug where different connections on the same Socket…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -14,6 +14,10 @@
     Bugfix release; see details below
 
     @subsection qore_0931_bug_fixes Bug Fixes in Qore
+    - fixed a bug where different connections on the same @ref Qore::Socket "Socket" object could not be identified;
+      code that relied on @ref Qore::Socket::getSocket() "Socket::getSocket()" is unreliable as the same descriptor
+      can be reassigned
+      (<a href="https://github.com/qorelanguage/qore/issues/3558">issue 3558</a>)
     - fixed a core dump in @ref Qore::FileLineIterator::getFileName() "FileLineIterator::getFileName()"
       (<a href="https://github.com/qorelanguage/qore/issues/3555">issue 3555</a>)
     - fixed a race condition in thread resource cleanups where a spurious exception could be raised

--- a/examples/test/qore/classes/Socket/Socket.qtest
+++ b/examples/test/qore/classes/Socket/Socket.qtest
@@ -94,12 +94,21 @@ class SocketTest inherits QUnit::Test {
     constructor() : QUnit::Test("Socket test", "1.0") {
         process_command_line();
 
+        addTestCase("connection ID", \connectionIdTest());
         addTestCase("Client/Server Socket tests", \clientServerSocketTest());
         addTestCase("Unconnected Socket tests", \unconnectedSocketTest());
         addTestCase("Random Port tests", \randomPortSocketTest());
         addTestCase("SSL read test", \sslReadTest());
         addTestCase("SSL write disconnect test", \sslWriteDisconnectTest());
         set_return_value(main());
+    }
+
+    connectionIdTest() {
+        Socket s();
+        assertEq(0, s.getConnectionId());
+        s.bind(0);
+        s.close();
+        assertEq(1, s.getConnectionId());
     }
 
     sslWriteDisconnectTest() {
@@ -118,12 +127,11 @@ class SocketTest inherits QUnit::Test {
         # accept a new connection
         Socket ns = s.acceptSSL(15s);
 
-        hash ex1;
+        hash<ExceptionInfo> ex1;
         while (True) {
             try {
                 ns.send(TestCert);
-            }
-            catch (hash ex) {
+            } catch (hash<ExceptionInfo> ex) {
                 ex1 = ex;
                 break;
             }

--- a/include/qore/QoreSocket.h
+++ b/include/qore/QoreSocket.h
@@ -1764,6 +1764,13 @@ public:
     */
     DLLEXPORT QoreObject* getRemoteCertificate() const;
 
+    //! returns a connection ID to help identifying when new connections are made
+    /** @return a connection ID to help identifying when new connections are made
+
+        @since %Qore 0.9.3.1
+    */
+    DLLEXPORT int64 getConnectionId() const;
+
     DLLLOCAL static void doException(int rc, const char* meth, int timeout_ms, ExceptionSink* xsink);
 
     //! sets the event queue (not part of the library's pubilc API), must be already referenced before call

--- a/include/qore/QoreSocketObject.h
+++ b/include/qore/QoreSocketObject.h
@@ -209,6 +209,7 @@ public:
    DLLEXPORT bool getAcceptAllCertificates() const;
    DLLEXPORT bool captureRemoteCertificates(bool set);
    DLLEXPORT QoreObject* getRemoteCertificate() const;
+   DLLEXPORT int64 getConnectionId() const;
 };
 
 #endif // _QORE_QORE_SOCKET_OBJECT_H

--- a/include/qore/intern/qore_socket_private.h
+++ b/include/qore/intern/qore_socket_private.h
@@ -216,6 +216,10 @@ struct qore_socket_private {
     static thread_local qore_socket_private* current_socket;
 
     int sock, sfamily, port, stype, sprot;
+
+    // issue #3558: connection sequence to show when a connection has been reestablished
+    int64 connection_id = 0;
+
     const QoreEncoding* enc;
 
     std::string socketname;
@@ -329,10 +333,14 @@ struct qore_socket_private {
                 socketname.clear();
             }
             do_close_event();
+            // issue #3558: increment the connection sequence here. so the connection sequence is different as soon as
+            // it's closed
+            ++connection_id;
+
             return close_and_reset();
-        }
-        else
+        } else {
             return 0;
+        }
     }
 
     DLLLOCAL int getSendTimeout() const {

--- a/lib/QC_Socket.qpp
+++ b/lib/QC_Socket.qpp
@@ -3003,3 +3003,19 @@ bool Socket::captureRemoteCertificates(bool set = True) {
 *SSLCertificate Socket::getRemoteCertificate() {
     return s->getRemoteCertificate();
 }
+
+//! Returns an integer connection ID that is incremented every time the socket is disconnected
+/** @par Example:
+    @code{.py}
+int conn_id = sock.getConnectionId();
+    @endcode
+
+    @return an integer connection ID that is incremented every time the socket is disconnected
+
+    This number can be used to identify new connections
+
+    @since %Qore 0.9.3.1
+*/
+int Socket::getConnectionId() [flags=CONSTANT] {
+    return s->getConnectionId();
+}

--- a/lib/QoreSocket.cpp
+++ b/lib/QoreSocket.cpp
@@ -2269,6 +2269,10 @@ QoreObject* QoreSocket::getRemoteCertificate() const {
     return nullptr;
 }
 
+int64 QoreSocket::getConnectionId() const {
+    return priv->connection_id;
+}
+
 QoreSocketTimeoutHelper::QoreSocketTimeoutHelper(QoreSocket& s, const char* op) : priv(new PrivateQoreSocketTimeoutHelper(qore_socket_private::get(s), op)) {
 }
 

--- a/lib/QoreSocketObject.cpp
+++ b/lib/QoreSocketObject.cpp
@@ -644,3 +644,10 @@ QoreObject* QoreSocketObject::getRemoteCertificate() const {
     AutoLocker al(priv->m);
     return priv->socket->getRemoteCertificate();
 }
+
+int64 QoreSocketObject::getConnectionId() const {
+    AutoLocker al(priv->m);
+    return priv->socket->getConnectionId();
+}
+
+


### PR DESCRIPTION
… object could not be identified; code that relied on Socket::getSocket() is unreliable as the same descriptor can be reassigned