### PR TITLE
refs #3570 fixed a crash handling recursive user module dependencies …

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -9,9 +9,11 @@
     Bugfix release; see details below
 
     @subsection qore_0931_bug_fixes Bug Fixes in Qore
-    - fixed crical error handling thread resources where if an exception was thrown handling thread resources, user
-      thread resource handlers queued afterwards were not executed
+    - fixed a critical error handling thread resources where if an exception was thrown handling thread resources,
+      user thread resource handlers queued afterwards were not executed
       (<a href="https://github.com/qorelanguage/qore/issues/3571">issue 3571</a>)
+    - fixed a crash handling recursive user module dependencies with directory-based (split) user modules
+      (<a href="https://github.com/qorelanguage/qore/issues/3570">issue 3570</a>)
     - fixed an error handling aborted chunked HTTP transfers that can result in a long timeout stalling the I/O thread
       (<a href="https://github.com/qorelanguage/qore/issues/3564">issue 3564</a>)
     - added library option constants and functions to allow the TLS v1.3 protocol to be disabled when the library is

--- a/examples/test/qore/misc/module-loader/RD1/RD1.qm
+++ b/examples/test/qore/misc/module-loader/RD1/RD1.qm
@@ -1,0 +1,13 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+
+module RD1 {
+    version = "1.0";
+    desc = "Test Module RD1";
+    author = "Qore Technologies, s.r.o.";
+    url = "http://qore.org";
+    license = "MIT";
+}
+
+%requires ./RD2

--- a/examples/test/qore/misc/module-loader/RD2/RD2.qm
+++ b/examples/test/qore/misc/module-loader/RD2/RD2.qm
@@ -1,0 +1,13 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+
+module RD2 {
+    version = "1.0";
+    desc = "Test Module RD2";
+    author = "Qore Technologies, s.r.o.";
+    url = "http://qore.org";
+    license = "MIT";
+}
+
+%requires ./RD1

--- a/examples/test/qore/misc/module-loader/recursive-dependency.qtest
+++ b/examples/test/qore/misc/module-loader/recursive-dependency.qtest
@@ -11,6 +11,10 @@
 %exec-class RecursiveDependencyTest
 
 class RecursiveDependencyTest inherits QUnit::Test {
+    private {
+        const Scripts = ("recursive-load.q", "recursive-load-dir.q");
+    }
+
     constructor() : Test("Recursive dependency test", "1.0") {
         addTestCase("RD Test", \test());
 
@@ -19,6 +23,12 @@ class RecursiveDependencyTest inherits QUnit::Test {
 
     test() {
         assertThrows('LOAD-MODULE-ERROR', sub() {load_module("./R1.qm");});
+
+        string dir = get_script_dir();
+        foreach string script in (Scripts) {
+            string loc = dir + DirSep + script;
+            assertRegex("LOAD-MODULE-ERROR", backquote("qore " + loc + " 2>&1"), script);
+        }
     }
 }
 

--- a/examples/test/qore/misc/module-loader/recursive-load-dir.q
+++ b/examples/test/qore/misc/module-loader/recursive-load-dir.q
@@ -1,0 +1,7 @@
+#!/usr/bin/env qore
+
+%new-style
+
+%requires ./RD1
+
+our int i;

--- a/examples/test/qore/misc/module-loader/recursive-load.q
+++ b/examples/test/qore/misc/module-loader/recursive-load.q
@@ -1,0 +1,7 @@
+#!/usr/bin/env qore
+
+%new-style
+
+%requires ./R1.qm
+
+our int i;

--- a/lib/ModuleManager.cpp
+++ b/lib/ModuleManager.cpp
@@ -925,6 +925,12 @@ QoreAbstractModule* QoreModuleManager::loadSeparatedModule(ExceptionSink& xsink,
     QoreProgram* path_pgm, unsigned load_opt, int warning_mask) {
     assert(feature);
     printd(5, "QoreModuleManager::loadSeparatedModule() path: %s, feature: %s, pgm: %p, reexport: %d, mpgm: %p, path_pgm: %p, load_opt: %d warning_mask: %d\n", path.c_str(), feature, pgm, reexport, mpgm, path_pgm, load_opt, warning_mask);
+    if (module_load_check(feature)) {
+        xsink.raiseException("LOAD-MODULE-ERROR", "cannot load user module '%s'; recursive module dependency detected", feature);
+        return nullptr;
+    }
+    ON_BLOCK_EXIT(module_load_clear, feature);
+
     QoreParseCountContextHelper pcch;
     // parse options for the module
     int64 parseOptions = USER_MOD_PO;


### PR DESCRIPTION
…… (#3575)

* refs #3570 fixed a crash handling recursive user module dependencies with split modules

* refs #3570 fixed new test when not run from the same directory