### PR TITLE
refs #3688 BinaryInputStream accepts strings as well as binary values

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -55,6 +55,7 @@
     - new methods:
       - @ref Qore::Program::getCallReference() "Program::getCallReference()"
     - updated methods:
+      - @ref Qore::BinaryInputStream::constructor() "BinaryInputStream::constructor()" accepts strings as well as binary values
       - @ref Qore::Program::loadApplyToUserModule() "Program::loadApplyToUserModule()": added the \c reexport argument
       - @ref Qore::Program::loadApplyToUserModuleWarn() "Program::loadApplyToUserModuleWarn()": added the \c reexport argument
     - <a href="../../modules/reflection/html/index.html">reflection</a> module updates:

--- a/examples/test/qore/streams/binary-input.qtest
+++ b/examples/test/qore/streams/binary-input.qtest
@@ -35,6 +35,14 @@ public class BinaryInputStreamTest inherits QUnit::Test {
         assertEq(<03>, bis.read(2));
         assertEq(NOTHING, bis.read(2));
         assertEq(NOTHING, bis.read(10));
+
+        bis = new BinaryInputStream("abc");
+        assertThrows("INPUT-STREAM-ERROR", sub() { bis.read(0); });
+        assertThrows("INPUT-STREAM-ERROR", sub() { bis.read(-2); });
+        assertEq(<6162>, bis.read(2));
+        assertEq(<63>, bis.read(2));
+        assertEq(NOTHING, bis.read(2));
+        assertEq(NOTHING, bis.read(10));
     }
 
     peekTest() {

--- a/include/qore/ReferenceHolder.h
+++ b/include/qore/ReferenceHolder.h
@@ -114,7 +114,7 @@ public:
    return *xsink ? str.release() : 0;
    @endcode
 */
-template<typename T>
+template<typename T = class SimpleQoreNode>
 class SimpleRefHolder {
 private:
    DLLLOCAL SimpleRefHolder(const SimpleRefHolder&); // not implemented

--- a/lib/QC_BinaryInputStream.qpp
+++ b/lib/QC_BinaryInputStream.qpp
@@ -61,9 +61,11 @@ qclass BinaryInputStream [arg=BinaryInputStream* is; ns=Qore; vparent=InputStrea
 
 //! Creates the BinaryInputStream based on the \ref binary given
 /**
-    @param src the \ref binary to read bytes from
+    @param src the \ref binary or string to read bytes from
+
+    @since %Qore 0.9.4 this constructor also accepts strings
  */
-BinaryInputStream::constructor(binary src) {
+BinaryInputStream::constructor(data src) {
    SimpleRefHolder<BinaryInputStream> bis(new BinaryInputStream(src));
    self->setPrivate(CID_BINARYINPUTSTREAM, bis.release());
 }


### PR DESCRIPTION
refs #3689 cmake-based external modules can now use split user modules, and they will be correctly installed