### PR TITLE
refs #487 aligned astparser with new scanner/parser changes

### DIFF
--- a/command-line.cpp
+++ b/command-line.cpp
@@ -7,7 +7,7 @@
 
     it should offer POSIX style command-line handling on any platform...
 
-    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -509,7 +509,7 @@ static void show_build_options(const char* arg) {
 }
 
 static void do_version(const char* arg) {
-   printf("QORE for %s %s (%d-bit build), Copyright (C) 2003 - 2019 David Nichols\n", qore_target_os, qore_target_arch, qore_target_bits);
+   printf("QORE for %s %s (%d-bit build), Copyright (C) 2003 - 2020 David Nichols\n", qore_target_os, qore_target_arch, qore_target_bits);
 
    printf("version %s", qore_version_string);
    FeatureList::iterator i = qoreFeatureList.begin();

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -50,6 +50,8 @@
     - support for Unicode character matching in regular expressions:
       - the \c <tt>/u</tt> option in @ref qore_regex_options
       - the @ref Qore::RE_Unicode "RE_Unicode" constant
+      - the \c "%w" string format code that uses character widths with field widths (ex: \c "%5w" specifies a field 5
+        characters wide; see @ref format_specification for more information)
     - new constants:
       - @ref Qore::EVENT_HTTP_CHUNKED_DATA_READ "EVENT_HTTP_CHUNKED_DATA_READ"
       - @ref Qore::EVENT_HTTP_CHUNKED_DATA_SENT "EVENT_HTTP_CHUNKED_DATA_SENT"
@@ -65,15 +67,7 @@
     - pseudo-methods now run in the same class context as the caller
     - new functions
       - @ref Qore::char_width()
-      - @ref Qore::f_vwprintf()
-      - @ref Qore::f_vwsprintf()
-      - @ref Qore::f_wprintf()
-      - @ref Qore::f_wsprintf()
       - @ref Qore::get_call_reference()
-      - @ref Qore::vwprintf()
-      - @ref Qore::vwsprintf()
-      - @ref Qore::wprintf()
-      - @ref Qore::wsprintf()
     - new methods:
       - @ref Qore::Program::getCallReference() "Program::getCallReference()"
     - updated methods:

--- a/examples/test/qore/vars/string.qtest
+++ b/examples/test/qore/vars/string.qtest
@@ -40,10 +40,10 @@ class StringTest inherits QUnit::Test {
         assertEq(6, str.length());
         assertEq(12, str.width());
         assertEq(18, str.size());
-        assertEq(str + " ", wsprintf("%-13s", str));
-        assertEq(str + " ", vwsprintf("%-13s", str));
-        assertEq("ステ.", f_wsprintf("%-5s", str));
-        assertEq("ステ.", f_vwsprintf("%-5s", str));
+        assertEq(str + " ", sprintf("%-13w", str));
+        assertEq(str + " ", vsprintf("%-13w", str));
+        assertEq("ステ.", f_sprintf("%-5w", str));
+        assertEq("ステ.", f_vsprintf("%-5w", str));
     }
 
     testBasics() {

--- a/include/qore/QoreLib.h
+++ b/include/qore/QoreLib.h
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -152,13 +152,7 @@ DLLEXPORT QoreStringNode* q_sprintf(const QoreListNode* params, int field, int o
 DLLEXPORT QoreStringNode* q_vsprintf(const QoreListNode* params, int field, int offset, ExceptionSink* xsink);
 
 //! a string formatting function that works with Qore data structures
-DLLEXPORT QoreStringNode* q_vsprintf(ExceptionSink* xsink, const QoreListNode* params, int field, int offset, bool char_width);
-
-//! a string formatting function that works with Qore data structures
 DLLEXPORT QoreStringNode* q_sprintf(const QoreListNode* params, int field, int offset, ExceptionSink* xsink);
-
-//! a string formatting function that works with Qore data structures
-DLLEXPORT QoreStringNode* q_sprintf(ExceptionSink* xsink, const QoreListNode* params, int field, int offset, bool char_width);
 
 //! thread-safe version of "localtime()"
 DLLEXPORT struct tm* q_localtime(const time_t* clock, struct tm* tms);

--- a/lib/QoreLib.cpp
+++ b/lib/QoreLib.cpp
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -560,14 +560,65 @@ FeatureList::FeatureList() {
 FeatureList::~FeatureList() {
 }
 
+// process a string argument from a *printf*-style string format specification
+static void process_opt_string(QoreString& tbuf, QoreValue qv, int type, int opts, bool char_width, int width, ExceptionSink* xsink) {
+    QoreStringValueHelper astr(qv);
+    // use the character width and not the byte length for formatting fields if applicable
+    int length = char_width ? astr->getCharWidth(xsink) : astr->size();
+    //printd(5, "process_opt_string() astr: '%s' len: %d width: %d type: %d\n", astr->c_str(), length, width, type);
+    if ((width != -1) && (length > width) && !type) {
+        width = length;
+    }
+    if ((width != -1) && (length > width)) {
+        if (char_width && type) {
+            // count of positions
+            int c = 0;
+            UnicodeCharacterIterator i(**astr);
+            while (i.next(xsink) && c < width) {
+                int ucs = i.getValue();
+                int w = qore_get_unicode_character_width(ucs);
+                if ((c + w) > width) {
+                    // pad with dots
+                    while (c < width) {
+                        tbuf.concat('.');
+                        ++c;
+                    }
+                    break;
+                }
+
+                c += w;
+                tbuf.concatUnicode(ucs, xsink);
+                if (*xsink) {
+                    break;
+                }
+            }
+        } else {
+            tbuf.concat(*astr, (size_t)width, xsink); // string encodings are converted here if necessary
+        }
+    } else {
+        if ((width != -1) && (opts & P_JUSTIFY_LEFT)) {
+            tbuf.concat(*astr, xsink);
+            while (width > length) {
+                tbuf.concat(' ');
+                --width;
+            }
+        } else {
+            while (width > length) {
+                tbuf.concat(' ');
+                --width;
+            }
+            tbuf.concat(*astr, xsink);
+        }
+    }
+}
+
 // if type = 0 then field widths are soft limits, otherwise they are hard
-static int process_opt(QoreString *cstr, char* param, QoreValue qv, int type, bool& arg_used, int char_width, ExceptionSink* xsink) {
+static int process_opt(QoreString *cstr, char* param, QoreValue qv, int type, bool& arg_used, ExceptionSink* xsink) {
     assert(arg_used == true);
     char* str = param;
     int opts = 0;
     int width = -1;
     int decimals = -1;
-    int length;
     char fmt[20], *f;
     QoreString tbuf(cstr->getEncoding());
 
@@ -609,53 +660,11 @@ static int process_opt(QoreString *cstr, char* param, QoreValue qv, int type, bo
     char p = *param;
     switch (*param) {
         case 's': {
-            QoreStringValueHelper astr(qv);
-            // use the character width and not the byte length for formatting fields if applicable
-            length = char_width ? astr->getCharWidth(xsink) : astr->size();
-            //printd(5, "process_opt() astr: '%s' len: %d width: %d type: %d\n", astr->c_str(), length, width, type);
-            if ((width != -1) && (length > width) && !type)
-                width = length;
-            if ((width != -1) && (length > width)) {
-                if (char_width && type) {
-                    // count of positions
-                    int c = 0;
-                    UnicodeCharacterIterator i(**astr);
-                    while (i.next(xsink) && c < width) {
-                        int ucs = i.getValue();
-                        int w = qore_get_unicode_character_width(ucs);
-                        if ((c + w) > width) {
-                            // pad with dots
-                            while (c < width) {
-                                tbuf.concat('.');
-                                ++c;
-                            }
-                            break;
-                        }
-
-                        c += w;
-                        tbuf.concatUnicode(ucs, xsink);
-                        if (*xsink) {
-                            break;
-                        }
-                    }
-                } else {
-                    tbuf.concat(*astr, (size_t)width, xsink); // string encodings are converted here if necessary
-                }
-            } else {
-                if ((width != -1) && (opts & P_JUSTIFY_LEFT)) {
-                    tbuf.concat(*astr, xsink);
-                    while (width > length) {
-                        tbuf.concat(' ');
-                        --width;
-                    }
-                } else {
-                    while (width > length) {
-                        tbuf.concat(' ');
-                        --width;
-                    }
-                    tbuf.concat(*astr, xsink);
-                }
-            }
+            process_opt_string(tbuf, qv, type, opts, false, width, xsink);
+            break;
+        }
+        case 'w': {
+            process_opt_string(tbuf, qv, type, opts, true, width, xsink);
             break;
         }
         case 'p':
@@ -773,7 +782,7 @@ static int process_opt(QoreString *cstr, char* param, QoreValue qv, int type, bo
 
 static QoreStringNode* qore_sprintf_intern(ExceptionSink* xsink, const QoreStringNode* fmt,
     const QoreListNode* arg_list, size_t arg_offset, int field, int last_arg = -1,
-    bool ignore_broken_sprintf = false, bool char_width = false) {
+    bool ignore_broken_sprintf = false) {
     SimpleRefHolder<QoreStringNode> buf(new QoreStringNode(fmt->getEncoding()));
 
     bool broken_sprintf = ignore_broken_sprintf
@@ -798,7 +807,7 @@ static QoreStringNode* qore_sprintf_intern(ExceptionSink* xsink, const QoreStrin
             } else {
                 use_arg = false;
             }
-            i += process_opt(*buf, (char*)&pstr[i], param_value, field, arg_used, char_width, xsink);
+            i += process_opt(*buf, (char*)&pstr[i], param_value, field, arg_used, xsink);
             if (*xsink) {
                 return nullptr;
             }
@@ -816,7 +825,7 @@ static QoreStringNode* qore_sprintf_intern(ExceptionSink* xsink, const QoreStrin
     return buf.release();
 }
 
-QoreStringNode* q_sprintf(ExceptionSink* xsink, const QoreListNode* params, int field, int offset, bool char_width) {
+QoreStringNode* q_sprintf(const QoreListNode* params, int field, int offset, ExceptionSink* xsink) {
     assert(xsink);
 
     QoreValue pv = get_param_value(params, offset);
@@ -824,14 +833,10 @@ QoreStringNode* q_sprintf(ExceptionSink* xsink, const QoreListNode* params, int 
         return new QoreStringNode;
     }
 
-    return qore_sprintf_intern(xsink, pv.get<const QoreStringNode>(), params, offset + 1, field, -1, false, char_width);
+    return qore_sprintf_intern(xsink, pv.get<const QoreStringNode>(), params, offset + 1, field, -1, false);
 }
 
-QoreStringNode* q_sprintf(const QoreListNode* params, int field, int offset, ExceptionSink* xsink) {
-    return q_sprintf(xsink, params, field, offset, false);
-}
-
-QoreStringNode* q_vsprintf(ExceptionSink* xsink, const QoreListNode* params, int field, int offset, bool char_width) {
+QoreStringNode* q_vsprintf(const QoreListNode* params, int field, int offset, ExceptionSink* xsink) {
     assert(xsink);
     QoreValue pv = get_param_value(params, offset);
     if (pv.getType() != NT_STRING) {
@@ -864,11 +869,7 @@ QoreStringNode* q_vsprintf(ExceptionSink* xsink, const QoreListNode* params, int
         }
     }
 
-    return qore_sprintf_intern(xsink, fmt, arg_list, arg_offset, field, last_arg, ignore_broken_sprintf, char_width);
-}
-
-QoreStringNode* q_vsprintf(const QoreListNode* params, int field, int offset, ExceptionSink* xsink) {
-    return q_vsprintf(xsink, params, field, offset, false);
+    return qore_sprintf_intern(xsink, fmt, arg_list, arg_offset, field, last_arg, ignore_broken_sprintf);
 }
 
 static QoreValue do_method_intern(QoreObject* self, const QoreMethod* meth, ClassAccess access, const char* name, const qore_class_private* pcls, ExceptionSink* xsink) {

--- a/lib/parser.ypp
+++ b/lib/parser.ypp
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),

--- a/lib/ql_string.qpp
+++ b/lib/ql_string.qpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -417,7 +417,7 @@ const RE_Unicode = PCRE_UCP;
     @note The percent sign \c "%" always starts a format specification unless it is followed by another \c "%" sign,
     in this case only one \c "%" is output (ie \c "%%" in the format string is output as a single \c "%")
 
-    @subsection format_specification Format Specification
+    @subsection format_specification String Format Specification
 
     After the \c "%" sign, there can be zero or more formatting flags as in the following table:
 
@@ -433,18 +433,9 @@ const RE_Unicode = PCRE_UCP;
     arguments longer than the width specified are truncated to the specified width.
 
     @note String fields are padded based on the byte length of characters by default; to do string padding based on
-    character width; use one of the following functions instead:
-    - @ref Qore::f_vwprintf()
-    - @ref Qore::f_vwsprintf()
-    - @ref Qore::f_wprintf()
-    - @ref Qore::f_wsprintf()
-    - @ref Qore::vwprintf()
-    - @ref Qore::vwsprintf()
-    - @ref Qore::wprintf()
-    - @ref Qore::wsprintf()
-    .
+    character width; use the \c "%w" specifier instead of \c "%s" (ex: \c "%10w");
     for "field" functions, if a multi-position character cannot fit in the space left in the field, the field is
-    padded with \c "." characters; ex: @code f_wsprintf("%-5s", str) == "ステ." @endcode
+    padded with \c "." characters; ex: @code f_sprintf("%-5w", str) == "ステ." @endcode
 
     For floating-point arguments, a precision specifier may be given by including a period "." and another digit
     string, which indicates the number of digits to appear after the decimal point.
@@ -453,17 +444,18 @@ const RE_Unicode = PCRE_UCP;
 
     <b>Printf Formatting Characters</b>
     |!Character|!Description
-    |\c s|string
+    |\c s|String where field width specify the number of characters regardless of their width
     |\c d|Integer, output in base 10 format
     |\c o|Integer, output in base 8 (octal) format
     |\c f|Literal floating point value
     |\c F|Literat floating point value
     |\c a|Hexadecimal floating-point output with lower-case \c "0x" and \c "abcdef"
     |\c A|Hexadecimal floating-point output with upper-case \c "0X" and \c "ABCDEF"
-    |\c g|compact floating-point output using a lower-case \c "e" for exponential output when necessary
-    |\c G|compact floating-point output using an upper-case \c "E" for exponential output when necessary
+    |\c g|Compact floating-point output using a lower-case \c "e" for exponential output when necessary
+    |\c G|Compact floating-point output using an upper-case \c "E" for exponential output when necessary
     |\c n|Any %Qore value, formatted as a string, without any line breaks
     |\c N|Any %Qore value, formatted as a string, with line breaks and whitespace formatting for complex objects
+    |\c w|String where field widths specify actual character widths instead of the number of characters (ex: the character width of \c "ス" is 2)
     |\c x|Integer, output in base 16 (hexadecimal) format with lower-case a-f
     |\c X|Integer, output in base 16 (hexadecimal) format with upper-case A-F
     |\c y|Any %Qore value, formatted as a pseudo-YAML string, without any line breaks; this format option is similar to \c "%n", but uses a YAML-like format.  Note that the output is not guaranteed to be parsed by the yaml module's parseYAML() function; it is for display purposes only; to get real YAML functionality, use the yaml module.
@@ -1839,30 +1831,6 @@ string f_sprintf() [flags=NOOP] {
    return null_string();
 }
 
-//! Returns a formatted string based on a @ref string_formatting "format string" and other arguments; enforces field widths on arguments larger than the given field width and uses the actual character width when formatting string fields
-/**
-    This function will truncate output longer than any field width given in the @ref string_formatting "format string"
-
-    @param fmt the @ref string_formatting "format string"
-    @param ... the argument(s) corresponding to format specifiers in the format string
-
-    @return a formatted string corresponding to the arguments given
-
-    @par Example:
-    @code{.py}
-string str = f_wsprintf("%5s", "a long string"); # will return "a lon"
-    @endcode
-
-    @see
-    - @ref string_formatting for information on the formatting string
-    - wsprintf() for a similar function that does not enforce field widths
-
-    @since %Qore 0.9.4
- */
-string f_wsprintf(string[doc] fmt, ...) [flags=CONSTANT] {
-   return q_sprintf(xsink, args, 1, 0, true);
-}
-
 //! Returns a formatted string based on a @ref string_formatting "format string" and other arguments; does not enforce field widths on arguments larger than the given field width
 /**
     This function will not truncate output longer than any field width given in the @ref string_formatting "format string"
@@ -1883,30 +1851,6 @@ string str = sprintf("%5s", "a long string"); # will return "a long string"
  */
 string sprintf(string[doc] fmt, ...) [flags=CONSTANT] {
    return q_sprintf(args, 0, 0, xsink);
-}
-
-//! Returns a formatted string based on a @ref string_formatting "format string" and other arguments; does not enforce field widths on arguments larger than the given field width; uses the actual character width when formatting string fields
-/**
-    This function will not truncate output longer than any field width given in the @ref string_formatting "format string"
-
-    @param fmt the @ref string_formatting "format string"
-    @param ... the argument(s) corresponding to format specifiers in the format string
-
-    @return a formatted string corresponding to the arguments given
-
-    @par Example:
-    @code{.py}
-string str = wsprintf("%5s", "a long string"); # will return "a long string"
-    @endcode
-
-    @see
-    - @ref string_formatting for information on the formatting string
-    - f_wsprintf() for a similar function that enforces field widths
-
-    @since %Qore 0.9.4
- */
-string wsprintf(string[doc] fmt, ...) [flags=CONSTANT] {
-   return q_sprintf(xsink, args, 0, 0, true);
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
@@ -1940,30 +1884,6 @@ string f_vsprintf(string[doc] fmt, auto[doc] varg) [flags=CONSTANT] {
    return q_vsprintf(args, 1, 0, xsink);
 }
 
-//! Returns a formatted string based on a @ref string_formatting "format string" and other arguments given as a list after the format string; enforces field widths on arguments larger than the given field width; uses the actual character width when formatting string fields
-/**
-    This function will truncate output longer than any field width given in the @ref string_formatting "format string"
-
-    @param fmt the @ref string_formatting "format string"
-    @param varg the argument(s) corresponding to format specifiers in the format string
-
-    @return a formatted string corresponding to the arguments given
-
-    @par Example:
-    @code{.py}
-string str = f_vwsprintf("%5s %3d\n", ("a long string", 500)); # will return "a lon 500"
-    @endcode
-
-    @see
-    - @ref string_formatting for information on the formatting string
-    - vwsprintf() for a similar function that does not enforce field widths
-
-    @since %Qore 0.9.4
-*/
-string f_vwsprintf(string[doc] fmt, auto[doc] varg) [flags=CONSTANT] {
-   return q_vsprintf(xsink, args, 1, 0, true);
-}
-
 //! Returns a formatted string based on a @ref string_formatting "format string" and other arguments given as a list after the format string; does not enforce field widths on arguments larger than the given field width
 /**
     This function will not truncate output longer than any field width given in the @ref string_formatting "format string"
@@ -1984,30 +1904,6 @@ string str = vsprintf("%5s %3d\n", ("a long string", 5000)); # will return "a lo
  */
 string vsprintf(string[doc] fmt, auto[doc] varg) [flags=CONSTANT] {
    return q_vsprintf(args, 0, 0, xsink);
-}
-
-//! Returns a formatted string based on a @ref string_formatting "format string" and other arguments given as a list after the format string; does not enforce field widths on arguments larger than the given field width; uses the actual character width when formatting string fields
-/**
-    This function will not truncate output longer than any field width given in the @ref string_formatting "format string"
-
-    @param fmt the @ref string_formatting "format string"
-    @param varg the argument(s) corresponding to format specifiers in the format string
-
-    @return a formatted string corresponding to the arguments given
-
-    @par Example:
-    @code{.py}
-string str = vwsprintf("%5s %3d\n", ("a long string", 5000)); # will return "a long string 5000"
-    @endcode
-
-    @see
-    - @ref string_formatting for information on the formatting string
-    - f_vwsprintf() for a similar function that enforces field widths
-
-    @since %Qore 0.9.4
-*/
-string vwsprintf(string[doc] fmt, auto[doc] varg) [flags=CONSTANT] {
-   return q_vsprintf(xsink, args, 0, 0, true);
 }
 
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
@@ -2041,32 +1937,6 @@ string f_printf(string[doc] fmt, ...) [dom=TERMINAL_IO] {
    return node;
 }
 
-//! Outputs the string passed to standard output, using the first argument as a @ref string_formatting "format string"; enforces field widths on arguments larger than the given field width; uses the actual character width when formatting string fields
-/**
-    This function will truncate output longer than any field width given in the @ref string_formatting "format string"
-
-    @param fmt the @ref string_formatting "format string"
-    @param ... the argument(s) corresponding to format specifiers in the format string
-
-    @return the formatted string output corresponding to the arguments given
-
-    @par Example:
-    @code{.py}
-f_wprintf("%5s", "a long string"); # will print out "a lon"
-    @endcode
-
-    @see
-    - @ref string_formatting for information on the formatting string
-    - wprintf() for a similar function that does not enforce field widths
-
-    @since %Qore 0.9.4
- */
-string f_wprintf(string[doc] fmt, ...) [dom=TERMINAL_IO] {
-   AbstractQoreNode* node;
-   print_node(stdout, node = q_sprintf(xsink, args, 1, 0, true));
-   return node;
-}
-
 //! This function variant does nothing at all; it is only included for backwards-compatibility with qore prior to version 0.8.0 for functions that would ignore type errors in arguments
 /**
  */
@@ -2095,32 +1965,6 @@ printf("%5s", "a long string"); # will print out "a long string"
 string printf(string[doc] fmt, ...) [dom=TERMINAL_IO] {
    AbstractQoreNode* node;
    print_node(stdout, node = q_sprintf(args, 0, 0, xsink));
-   return node;
-}
-
-//! Outputs the string passed to standard output, using the first argument as a @ref string_formatting "format string"; does not enforce field widths on arguments larger than the given field width; uses the actual character width when formatting string fields
-/**
-    This function will not truncate output longer than any field width given in the @ref string_formatting "format string"
-
-    @param fmt the @ref string_formatting "format string"
-    @param ... the argument(s) corresponding to format specifiers in the format string
-
-    @return the formatted string output corresponding to the arguments given
-
-    @par Example:
-    @code{.py}
-wprintf("%5s", "a long string"); # will print out "a long string"
-    @endcode
-
-    @see
-    - @ref string_formatting for information on the formatting string
-    - f_wprintf() for a similar function that enforces field widths
-
-    @since %Qore 0.9.4
- */
-string wprintf(string[doc] fmt, ...) [dom=TERMINAL_IO] {
-   AbstractQoreNode* node;
-   print_node(stdout, node = q_sprintf(xsink, args, 0, 0, true));
    return node;
 }
 
@@ -2157,32 +2001,6 @@ string f_vprintf(string[doc] fmt, auto[doc] varg) [dom=TERMINAL_IO] {
    return node;
 }
 
-//! Outputs the string passed to standard output, using the first argument as a @ref string_formatting "format string" and a second argument giving a list or a single argument to the format string; enforces field widths on arguments larger than the given field width; uses the actual character width when formatting string fields
-/**
-    This function will truncate output longer than any field width given in the @ref string_formatting "format string"
-
-    @param fmt the @ref string_formatting "format string"
-    @param varg the argument(s) corresponding to format specifiers in the format string
-
-    @return the formatted string output corresponding to the arguments given
-
-    @par Example:
-    @code{.py}
-f_vwprintf("%5s %3d", ("a long string", 5000)); # will print out "a lon 500"
-    @endcode
-
-    @see
-    - @ref string_formatting for information on the formatting string
-    - vwprintf() for a similar function that does not enforce field widths
-
-    @since %Qore 0.9.4
- */
-string f_vwprintf(string[doc] fmt, auto[doc] varg) [dom=TERMINAL_IO] {
-   AbstractQoreNode* node;
-   print_node(stdout, node = q_vsprintf(xsink, args, 1, 0, true));
-   return node;
-}
-
 //! Outputs the string passed to standard output, using the first argument as a @ref string_formatting "format string" and a second argument giving a list or a single argument to the format string; does not enforce field widths on arguments larger than the given field width
 /**
     This function will not truncate output longer than any field width given in the @ref string_formatting "format string"
@@ -2204,32 +2022,6 @@ vprintf("%5s %3d", ("a long string", 5000)); # will print out "a long string 500
 string vprintf(string[doc] fmt, auto[doc] varg) [dom=TERMINAL_IO] {
    AbstractQoreNode* node;
    print_node(stdout, node = q_vsprintf(args, 0, 0, xsink));
-   return node;
-}
-
-//! Outputs the string passed to standard output, using the first argument as a @ref string_formatting "format string" and a second argument giving a list or a single argument to the format string; does not enforce field widths on arguments larger than the given field width; uses the actual character width when formatting string fields
-/**
-    This function will not truncate output longer than any field width given in the @ref string_formatting "format string"
-
-    @param fmt the @ref string_formatting "format string"
-    @param varg the argument(s) corresponding to format specifiers in the format string
-
-    @return the formatted string output corresponding to the arguments given
-
-    @par Example:
-    @code{.py}
-vwprintf("%5s %3d", ("a long string", 5000)); # will print out "a long string 5000"
-    @endcode
-
-    @see
-    - @ref string_formatting for information on the formatting string
-    - f_vwprintf() for a similar function that enforces field widths
-
-    @since %Qore 0.9.4
- */
-string vwprintf(string[doc] fmt, auto[doc] varg) [dom=TERMINAL_IO] {
-   AbstractQoreNode* node;
-   print_node(stdout, node = q_vsprintf(xsink, args, 0, 0, true));
    return node;
 }
 

--- a/lib/scanner.lpp
+++ b/lib/scanner.lpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),

--- a/modules/astparser/src/ast/expressions/ASTLiteralExpression.h
+++ b/modules/astparser/src/ast/expressions/ASTLiteralExpression.h
@@ -4,7 +4,7 @@
 
   Qore AST Parser
 
-  Copyright (C) 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2017 - 2020 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -44,11 +44,15 @@ enum ALEKind {
     ALEK_Int,
     ALEK_Number,
     ALEK_String,
+    ALEK_Nothing,
+    ALEK_Null,
+    ALEK_Bool,
 };
 
 class ASTLiteralExpression : public ASTExpression {
 public:
     union ALEData {
+        bool b;
         int64_t i;
         double d;
         char* str;
@@ -91,6 +95,13 @@ public:
         value.stdstr = val;
     }
 
+    ASTLiteralExpression(bool b) :
+        ASTExpression(),
+        kind(ALEK_Bool)
+    {
+        value.b = b;
+    }
+
     virtual ~ASTLiteralExpression() {
         if (kind == ALEK_Binary || kind == ALEK_Date || kind == ALEK_Number)
             free(value.str);
@@ -100,6 +111,22 @@ public:
 
     virtual ASTExpressionKind getKind() const override {
         return ASTExpressionKind::AEK_Literal;
+    }
+
+protected:
+    ASTLiteralExpression(ALEKind k) : kind(k) {
+    }
+};
+
+class ASTNothing : public ASTLiteralExpression {
+public:
+    ASTNothing() : ASTLiteralExpression(ALEK_Nothing) {
+    }
+};
+
+class ASTNull : public ASTLiteralExpression {
+public:
+    ASTNull() : ASTLiteralExpression(ALEK_Null) {
     }
 };
 

--- a/modules/astparser/src/ast_parser.ypp
+++ b/modules/astparser/src/ast_parser.ypp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2017 - 2018 Qore Technologies, s.r.o.
+  Copyright (C) 2017 - 2020 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -178,6 +178,10 @@ void yyerror(YYLTYPE *loc, yyscan_t scanner, AstParseErrorLog* errorLog, ASTTree
 %token TOK_ABSTRACT "abstract"
 %token TOK_HASHDECL "hashdecl"
 %token TOK_TRANSIENT "transient"
+%token TOK_NULL "NULL"
+%token TOK_NOTHING "NOTHING"
+%token TOK_TRUE "True"
+%token TOK_FALSE "False"
 
 // currently unused tokens
 %token TOK_UNREFERENCE "unreference"
@@ -2739,11 +2743,15 @@ string:
         ;
 
 scalar:
-        QFLOAT      { $$ = new ASTLiteralExpression(ALEKind::ALEK_Float, $1); $$->loc = @1; }
-        | INTEGER   { $$ = new ASTLiteralExpression(ALEKind::ALEK_Int, $1); $$->loc = @1; }
-        | string    { $$ = new ASTLiteralExpression(ALEKind::ALEK_String, $1); $$->loc = @1; }
-        | DATETIME  { $$ = new ASTLiteralExpression(ALEKind::ALEK_Date, $1); $$->loc = @1; }
-        | NUMBER    { $$ = new ASTLiteralExpression(ALEKind::ALEK_Number, $1); $$->loc = @1; }
+        QFLOAT        { $$ = new ASTLiteralExpression(ALEKind::ALEK_Float, $1); $$->loc = @1; }
+        | INTEGER     { $$ = new ASTLiteralExpression(ALEKind::ALEK_Int, $1); $$->loc = @1; }
+        | string      { $$ = new ASTLiteralExpression(ALEKind::ALEK_String, $1); $$->loc = @1; }
+        | DATETIME    { $$ = new ASTLiteralExpression(ALEKind::ALEK_Date, $1); $$->loc = @1; }
+        | NUMBER      { $$ = new ASTLiteralExpression(ALEKind::ALEK_Number, $1); $$->loc = @1; }
+        | TOK_NOTHING { $$ = new ASTNothing; }
+        | TOK_NULL    { $$ = new ASTNull; }
+        | TOK_TRUE    { $$ = new ASTLiteralExpression(true); }
+        | TOK_FALSE   { $$ = new ASTLiteralExpression(false); }
         ;
 
 %%

--- a/modules/astparser/src/ast_parser.ypp
+++ b/modules/astparser/src/ast_parser.ypp
@@ -2748,10 +2748,10 @@ scalar:
         | string      { $$ = new ASTLiteralExpression(ALEKind::ALEK_String, $1); $$->loc = @1; }
         | DATETIME    { $$ = new ASTLiteralExpression(ALEKind::ALEK_Date, $1); $$->loc = @1; }
         | NUMBER      { $$ = new ASTLiteralExpression(ALEKind::ALEK_Number, $1); $$->loc = @1; }
-        | TOK_NOTHING { $$ = new ASTNothing; }
-        | TOK_NULL    { $$ = new ASTNull; }
-        | TOK_TRUE    { $$ = new ASTLiteralExpression(true); }
-        | TOK_FALSE   { $$ = new ASTLiteralExpression(false); }
+        | TOK_NOTHING { $$ = new ASTNothing; $$->loc = @1; }
+        | TOK_NULL    { $$ = new ASTNull; $$->loc = @1; }
+        | TOK_TRUE    { $$ = new ASTLiteralExpression(true); $$->loc = @1; }
+        | TOK_FALSE   { $$ = new ASTLiteralExpression(false); $$->loc = @1; }
         ;
 
 %%

--- a/modules/astparser/src/ast_scanner.lpp
+++ b/modules/astparser/src/ast_scanner.lpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2017 - 2018 Qore Technologies, s.r.o.
+  Copyright (C) 2017 - 2020 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -778,6 +778,10 @@ foldr                                   return TOK_FOLDR;
 foldl                                   return TOK_FOLDL;
 select                                  return TOK_SELECT;
 static                                  return TOK_STATIC;
+(::(Qore::)?)?NOTHING                   return TOK_NOTHING;
+(::(Qore::)?)?NULL                      return TOK_NULL;
+(::(Qore::)?)?True                      return TOK_TRUE;
+(::(Qore::)?)?False                     return TOK_FALSE;
 hashdecl                                return TOK_HASHDECL;
 transient                               {
                                             if (PO_NO_TRANSIENT) {


### PR DESCRIPTION
refs #3673 use %w as a printf format specifier instead of implementing a great number of new functions