### PR TITLE
refs #485 disallow deprecated "returns" to declare the return type

### DIFF
--- a/doxygen/lang/245_parse_directives.dox.tmpl
+++ b/doxygen/lang/245_parse_directives.dox.tmpl
@@ -15,8 +15,9 @@
     <b>Parse Directives</b>
     |!Directive|!Description
     |@ref allow-bare-refs "%allow-bare-refs"|Prohibits the use of the \c "$" character in variable names, method calls, and object member references. This makes %Qore scripts appear superficially more like C++ or Java programs.<br><br>This parse option is set by default with @ref new-style "%new-style".<br><br>Name resolution is made in the following order when this option is set: local variables, class constants and static class vars (when parsing in class code), global variables, and (non-class) constants.<br><br>Note that @ref implicit_arguments "implicit arguments" are still referenced with the \c "$" character even when this parse option is set; see also @ref require-dollar "%require-dollar" <br><br>Since %Qore 0.8.1
-    |@ref allow-debugger "%allow-debugger"|Allows debugging actions that could be insecure such as reading the thread local variable stack <br><br>Since %Qore 0.8.13
+    |@ref allow-debugger "%allow-debugger"|Allows debugging actions that could be insecure such as reading the thread local variable stack<br><br>Since %Qore 0.8.13
     |@ref allow-injection "%allow-injection"|Allows code and dependency injections into the given @ref Qore::Program "Program" object
+    |@ref allow-returns "%allow-returns"|Allows the use of the deprecated \c returns keyword<br><br>Since %Qore 0.9.4
     |@ref allow-weak-references "%allow-weak-references"|Allows the use of the @ref weak_assignment_operator "weak assignment operator (:=)"<br><br>Since %Qore 0.8.13
     |@ref append-include-path "%append-include-path"|Appends the given directories to qore's include path; also performs environment variable substitution
     |@ref append-module-path "%append-module-path"|Appends the given directories to qore's module path; also performs environment variable substitution <br><br>Since %Qore 0.8.6
@@ -54,6 +55,7 @@
     |@ref lock-options "%lock-options"|Prohibits further changes to parse options (equivalent to the <tt>-</tt><tt>-lock-options</tt> command line option)
     |@ref lock-warnings "%lock-warnings"|Prohibits further changes to the warning mask (equivalent to the <tt>-</tt><tt>-lock-warnings</tt> command line option)
     |@ref loose-args "%loose-args"|reverts the effect of the @ref strict-args "%strict-args" parse options
+    |@ref loose-types "%loose-types"|reverts the effect of the @ref strict-types "%strict-types" parse options
     |@ref new-style "%new-style"|Sets both @ref allow-bare-refs "%allow-bare-refs" and @ref assume-local "%assume-local". These two options together make programming in %Qore superficially more like programming in C++ or Java programs; use this if you dislike programming with the \c "$" sign, for example; see also @ref old-style "%old-style" <br><br>Since %Qore 0.8.1
     |@ref old-style "%old-style"|Resets default %Qore parsing behavior by setting @ref require-dollar "%require-dollar" and @ref assume-global "%assume-global"; this option is the opposite of @ref new-style "%new-style" <br><br>Since %Qore 0.8.4
     |@ref no-debugging "%no-debugging"|Forbids debugging of the current @ref Qore::Program "Program" object <br><br>Since %Qore 0.8.13
@@ -94,6 +96,7 @@
     |@ref set-time-zone "%set-time-zone"|Sets the time zone for the current program from a UTC offset (with format \c "+/-[00[:00[:00]]"; \c ":" characters are optional) or a time zone region name (ex: \c "Europe/Prague") <br><br>Since %Qore 0.8.3
     |@ref strict-args "%strict-args"|Prohibits access to builtin functions and methods flagged with @ref RUNTIME_NOOP and also causes errors to be raised if excess arguments are given to functions that do not access excess arguments and if a non-list lvalue is passed to the @ref push, @ref pop, or @ref shift <br><br>Since %Qore 0.8.0
     |@ref strict-bool-eval "%strict-bool-eval"|Sets qore's default strict mathematic boolean evaluation mode, where any value converted to 0 is @ref False "False" and otherwise it's is @ref True "True"; this was how qore behaved by default prior to v0.8.6. <br><br>Equivalent to parse option @ref Qore::PO_STRICT_BOOLEAN_EVAL and the <tt>-pstrict-bool-eval</tt> command line option. <br><br>See also @ref perl-bool-eval "%perl-bool-eval"<br><br>Since %Qore 0.8.6
+    |@ref strict-types "%strict-types"|Sets strict type checking and automatically sets default values for lvalues with type restrictions that have default values
     |@ref strong-encapsulation "%strong-encapsulation"|Disallows out-of-line class and namespace declarations. <br><br>Since %Qore 0.8.13
     |@ref try-module "%try-module" [(@ref variable_declarations "var_decl")] <em>feature</em> <tt>[\<\|\<=\|=\|\>=\|\></tt> <em>version</em><tt>]</tt>|If the named feature is not already present in %Qore, then the \c QORE_MODULE_DIR environment variable is used to provide a list of directories to seach for a module with the same name (<em>feature</em><tt>[-api-</tt><em>x</em><tt>.</tt><em>y</em><tt>].qmod</tt> for binary modules or <em>feature</em><tt>.qm</tt> for user modules). If the module is not found, then the qore default module directory is checked.<br><br>If an error occurs loading the module, then the @ref variable_declarations "variable" declared after <tt>%%try-module</tt> is instantiated with the exception information, and the code up to the @ref endtry "%endtry" parse declaration is parsed into the program, allowing for the qore script/program to handle module loading errors at parse time for modules that must be loaded at parse time.<br><br>If version information is provided, then it is compared with the module's version information, and if it does not match a parse exception is raised that is handled like any other load error.<br><br>See also @ref Qore::load_module() for a function providing run-time module loading and @ref requires "%requires" for a similar declaration that does not allow for parse-time module loading error handling.<br><br>Since %Qore 0.8.6
     |@ref try-reexport-module "%try-reexport-module" [(@ref variable_declarations "var_decl")] <em>feature</em> <tt>[\<\|\<=\|=\|\>=\|\></tt> <em>version</em><tt>]</tt>|The same as @ref try-module "%try-module" except that if used in a @ref user_modules "user module", the module is reexported to the importing code<br><br>Since %Qore 0.8.13
@@ -170,6 +173,23 @@
     - @ref Qore::load_user_module_with_program()
 
     @since %Qore 0.8.12
+
+    <hr>
+    @section allow-returns %allow-returns
+
+    @par Parse Directive:
+    <tt>%%allow-returns</tt>
+
+    @par Command Line:
+    <tt>-pallow-returns</tt>
+
+    @par Parse Option Constant:
+    @ref Qore::PO_ALLOW_RETURNS
+
+    @par Description:
+    Allows the use of the deprecated \c returns keyword.
+
+    @since %Qore 0.9.4
 
     <hr>
     @section allow-weak-references %allow-weak-references
@@ -856,7 +876,7 @@ i+ =4;
     @section loose-args %loose-args
 
     @par Parse Directive:
-    n/a
+    <tt>%%loose-args</tt>
 
     @par Command Line:
     n/a
@@ -868,6 +888,22 @@ i+ =4;
     Reverts the effect of the @ref strict-args "%strict-args" parse option.
 
     @see @ref loose-args "%loose-args"
+
+    <hr>
+    @section loose-types %loose-types
+
+    @par Parse Directive:
+    <tt>%%loose-types</tt>
+
+    @par Parse Option Constant:
+    n/a
+
+    @par Description:
+    Reverts the effect of the @ref strict-types "%strict-types" parse option.
+
+    @see strict-types "%strict-types"
+
+    @since %Qore 0.9.4
 
     <hr>
     @section new-style %new-style
@@ -1706,6 +1742,26 @@ if (str)
     @see @ref perl-bool-eval "perl-bool-eval"
 
     @since %Qore 0.8.6
+
+    <hr>
+    @section strict-types %strict-types
+
+    @par Parse Directive:
+    <tt>%%strict-types</tt>
+
+    @par Command Line:
+    <tt>-pstrict-types</tt>
+
+    @par Parse Option Constant:
+    @ref Qore::PO_STRICT_TYPES
+
+    @par Description:
+    Sets strict type checking and automatically sets default values for lvalues with type restrictions that have
+    default values.
+
+    @see loose-types "%loose-types"
+
+    @since %Qore 0.9.4
 
     <hr>
     @section strong-encapsulation %strong-encapsulation

--- a/doxygen/lang/255_keywords.dox.tmpl
+++ b/doxygen/lang/255_keywords.dox.tmpl
@@ -58,7 +58,7 @@
     |@ref NULL "NULL"|Soft 3|represents an SQL NULL value
     |@ref rethrow "rethrow"|Soft 3|for the @ref rethrow "rethrow statement"
     |@ref return "return"|Soft 3|for the @ref return "return statement"
-    |\b returns|Soft 3|used when using the deprecated syntax for declaring method or function return types
+    |\b returns|Soft 3|used when using the deprecated syntax for declaring method or function return types (see @ref allow-returns "%allow-returns")
     |@ref select "select"|Soft 1|for the @ref select "select operator"
     |@ref shift "shift"|Soft 1|for the @ref shift "shift operator"
     |\b sortBy|Soft 3|used with @ref context "context", @ref summarize "summarize", and @ref subcontext "subcontext" statements

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -17,6 +17,8 @@
     - fixed broken @ref cast "cast<>" operator handling; in previous releases, @ref cast "cast<>" would accept and
       return @ref nothing without raising an error with type specifications that did not accept or return
       @ref nothing.  To get the old behavior, use the @ref broken-cast "%broken-cast" parse directive.
+    - disallowed the use of the deprecated \c returns keyword by default.  To get the old behavior, use the
+      @ref allow-returns "%allow-returns" parse directive.
     - classes inheriting \c AbstractConneciton must be serializable; the \c AbstractConnection::getConstructorInfo()
       and \c AbstractConnection::getConstructorInfoImpl() methods have been removed and are ignored in child classes
     - the following are now reserved words in Qore to prohibit them from being redefined:
@@ -64,6 +66,9 @@
       - @ref Qore::EVENT_SOCKET_DATA_SENT "EVENT_SOCKET_DATA_SENT"
       - @ref Qore::NT_ALL "NT_ALL"
       - @ref Qore::RE_Unicode "RE_Unicode"
+      - @ref Qore::PO_ALLOW_RETURNS "PO_ALLOW_RETURNS"
+      - @ref Qore::PO_BROKEN_CAST "PO_BROKEN_CAST"
+      - @ref Qore::PO_STRICT_TYPES "PO_STRICT_TYPES"
     - new pseudo-methods:
       - <object>::getCallReference()
       - <string>::width()
@@ -80,10 +85,15 @@
       - @ref Qore::FtpClient::setDataEventQueue() "FtpClient::setDataEventQueue()": added the \a arg and \a with_data options
       - @ref Qore::FtpClient::setEventQueue() "FtpClient::setEventQueue()": added the \a arg and \a with_data options
       - @ref Qore::HTTPClient::setEventQueue() "HTTPClient::setEventQueue()": added the \a arg and \a with_data options
-      - @ref Qore::Program::loadApplyToUserModule() "Program::loadApplyToUserModule()": added the \c reexport argument
-      - @ref Qore::Program::loadApplyToUserModuleWarn() "Program::loadApplyToUserModuleWarn()": added the \c reexport argument
+      - @ref Qore::Program::loadApplyToUserModule() "Program::loadApplyToUserModule()": added the \a reexport argument
+      - @ref Qore::Program::loadApplyToUserModuleWarn() "Program::loadApplyToUserModuleWarn()": added the \a reexport argument
       - @ref Qore::ReadOnlyFile::setEventQueue() "ReadOnlyFile::setEventQueue()": added the \a arg and \a with_data options
       - @ref Qore::Socket::setEventQueue() "Socket::setEventQueue()": added the \a arg and \a with_data options
+    - new parse options:
+      - @ref allow-returns "%allow-returns"
+      - @ref broken-cast "%broken-cast"
+      - @ref loose-types "%loose-types"
+      - @ref strict-types "%strict-types"
     - <a href="../../modules/reflection/html/index.html">reflection</a> module updates:
       - added \c Type::isAssignableFrom() methods
       - added a working \c Type::constructor() method

--- a/examples/test/qore/misc/parse_directives.qtest
+++ b/examples/test/qore/misc/parse_directives.qtest
@@ -14,6 +14,8 @@
 public class ParseDirectiveTest inherits QUnit::Test {
 
     constructor() : Test("ParseDirectiveTest", "1.0") {
+        addTestCase("strict-types test", \strictTypesTest());
+        addTestCase("returns test", \returnsTest());
         addTestCase("missing arg to %append-include-path", \missingArgAppendIncludePath());
         addTestCase("missing arg to %append-module-path", \missingArgAppendModulePath());
         addTestCase("missing arg to %set-time-zone", \missingArgSetTimeZone());
@@ -33,6 +35,306 @@ public class ParseDirectiveTest inherits QUnit::Test {
 
         # Return for compatibility with test harness that checks return value.
         set_return_value(main());
+    }
+
+    strictTypesTest() {
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("*int v0 = 0; int v1 = v0;", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("*float v0 = 0.0; float v1 = v0;", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("*number v0 = 0n; number v1 = v0;", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("*string v0 = ''; string v1 = v0;", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("*binary v0 = <00>; binary v1 = v0;", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("*date v0 = 1970-01-01Z; date v1 = v0;", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("*hash<auto> v0 = {}; hash<auto> v1 = v0;", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("*list<auto> v0 = (); list<auto> v1 = v0;", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("int sub t() { *int v0 = 0; return v0; }", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("float sub t() { *float v0 = 0.0; return v0; }", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("number sub t() { *number v0 = 0n; return v0; }", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("string sub t() { *string v0 = ''; return v0; }", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("binary sub t() { *binary v0 = <00>; return v0; }", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("date sub t() { *date v0 = 1970-01-01Z; return v0; }", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("hash<auto> sub t() { *hash<auto> v0 = {}; return v0; }", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("list<auto> sub t() { *list<auto> v0 = (); return v0; }", ""));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            p.parse("auto sub t() { bool b; return b; }", "");
+            assertEq(False, p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            p.parse("auto sub t() { int i; return i; }", "");
+            assertEq(0, p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            p.parse("auto sub t() { float f; return f; }", "");
+            assertEq(0.0, p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            p.parse("auto sub t() { number n; return n; }", "");
+            assertEq(0n, p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            p.parse("auto sub t() { string str; return str; }", "");
+            assertEq("", p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            p.parse("auto sub t() { binary b; return b; }", "");
+            assertEq(binary(), p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            p.parse("auto sub t() { date d; return d; }", "");
+            assertEq(1970-01-01Z, p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            p.parse("auto sub t() { hash<auto> h; return h; }", "");
+            assertEq("hash<auto>", p.callFunction("t").fullType());
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            p.parse("auto sub t() { hash h; return h; }", "");
+            assertEq("hash", p.callFunction("t").fullType());
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            p.parse("auto sub t() { list<auto> l; return l; }", "");
+            assertEq("list<auto>", p.callFunction("t").fullType());
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            p.parse("auto sub t() { list l; return l; }", "");
+            assertEq("list", p.callFunction("t").fullType());
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            p.parse("auto sub t() { object o; return o; }", "");
+            assertNothing(p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
+            p.parse("auto sub t() { Mutex m; return m; }", "");
+            assertNothing(p.callFunction("t"));
+        }
+
+        # negative tests
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("int sub t() { *int v0 = 0; return v0; }", "");
+            assertEq(0, p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("float sub t() { *float v0 = 0.0; return v0; }", "");
+            assertEq(0.0, p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("number sub t() { *number v0 = 0n; return v0; }", "");
+            assertEq(0n, p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("string sub t() { *string v0 = ''; return v0; }", "");
+            assertEq("", p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("binary sub t() { *binary v0 = <00>; return v0; }", "");
+            assertEq(<00>, p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("date sub t() { *date v0 = 1970-01-01Z; return v0; }", "");
+            assertEq(1970-01-01Z, p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("hash<auto> sub t() { *hash<auto> v0 = {}; return v0; }", "");
+            assertEq("hash<auto>", p.callFunction("t").fullType());
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("list<auto> sub t() { *list<auto> v0 = (); return v0; }", "");
+            assertEq("list<auto>", p.callFunction("t").fullType());
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("auto sub t() { bool b; return b; }", "");
+            assertNothing(p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("auto sub t() { int i; return i; }", "");
+            assertNothing(p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("auto sub t() { float f; return f; }", "");
+            assertNothing(p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("auto sub t() { number n; return n; }", "");
+            assertNothing(p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("auto sub t() { string str; return str; }", "");
+            assertNothing(p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("auto sub t() { binary b; return b; }", "");
+            assertNothing(p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("auto sub t() { date d; return d; }", "");
+            assertNothing(p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("auto sub t() { hash<auto> h; return h; }", "");
+            assertNothing(p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("auto sub t() { hash h; return h; }", "");
+            assertNothing(p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("auto sub t() { list<auto> l; return l; }", "");
+            assertNothing(p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("auto sub t() { list l; return l; }", "");
+            assertNothing(p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("auto sub t() { object o; return o; }", "");
+            assertNothing(p.callFunction("t"));
+        }
+
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse("auto sub t() { Mutex m; return m; }", "");
+            assertNothing(p.callFunction("t"));
+        }
+    }
+
+    returnsTest() {
+        {
+            Program p();
+            assertThrows("PARSE-EXCEPTION", \p.parse(), ("sub t() returns int { return 1; }", ""));
+        }
+
+        {
+            Program p(PO_ALLOW_RETURNS);
+            p.parse("sub t() returns int { return 1; }", "");
+            assertEq(1, p.callFunction("t"));
+        }
     }
 
     missingArgAppendIncludePath() {

--- a/include/qore/Restrictions.h
+++ b/include/qore/Restrictions.h
@@ -4,7 +4,7 @@
 
     QORE programming language
 
-    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -94,13 +94,15 @@
 #define PO_NO_TRANSIENT                     (1LL << 54)  //!< disables the transient keyword
 #define PO_BROKEN_SPRINTF                   (1LL << 55)  //!< enables pre-0.9 broken sprintf handling
 #define PO_BROKEN_CAST                      (1LL << 56)  //!< enables pre-0.9.4 broken cast<> operator handling
+#define PO_ALLOW_RETURNS                    (1LL << 57)  //!< allows the use of the deprecated "returns" keyword
+#define PO_STRICT_TYPES                     (1LL << 58)  //!< enforce strict type checking and setting default values
 
 // aliases for old defines
 #define PO_NO_SYSTEM_FUNC_VARIANTS          PO_NO_INHERIT_SYSTEM_FUNC_VARIANTS
 #define PO_NO_SYSTEM_CLASSES                PO_NO_INHERIT_SYSTEM_CLASSES
 #define PO_NO_USER_CLASSES                  PO_NO_INHERIT_USER_CLASSES
 
-#define PO_DEFAULT                     0            //!< no parse options set by default
+#define PO_DEFAULT 0            //!< no parse options set by default
 
 //! all options that are set by the system
 #define PO_SYSTEM_OPS (PO_IN_MODULE)

--- a/include/qore/intern/QoreHashNodeIntern.h
+++ b/include/qore/intern/QoreHashNodeIntern.h
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -424,11 +424,9 @@ public:
 
     DLLLOCAL void setKeyValueIntern(const char* key, QoreValue v) {
         hash_assignment_priv ha(*this, key);
-#ifdef DEBUG
-        assert(ha.swap(v).isNothing());
-#else
-        ha.swap(v);
-#endif
+        // in case of assigning keys to an initialized hashdecl, the key may already have a value
+        // if the value is an object of a class that throws an exception in the destructor, then a crash will result
+        ValueHolder old(ha.swap(v), nullptr);
     }
 
     DLLLOCAL void setKeyValue(const char* key, QoreValue val, ExceptionSink* xsink) {

--- a/include/qore/intern/QoreTypeInfo.h
+++ b/include/qore/intern/QoreTypeInfo.h
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -455,6 +455,10 @@ public:
                         break;
                     }
                 }
+            }
+            // if the type may not match at runtime, then return no match with %strict-types
+            if (getProgram()->getParseOptions64() & PO_STRICT_TYPES) {
+                return QTI_NOT_EQUAL;
             }
             may_not_match = true;
             return QTI_AMBIGUOUS;
@@ -1102,6 +1106,10 @@ protected:
     DLLLOCAL qore_type_result_e parseAccepts(const QoreTypeInfo* typeInfo, bool& may_not_match, bool& may_need_filter) const {
         //printd(5, "QoreTypeInfo::parseAccepts() '%s' <- '%s'\n", tname.c_str(), typeInfo->tname.c_str());
         if (typeInfo->return_vec.size() > accept_vec.size()) {
+            // if the type may not match at runtime, then return no match with %strict-types
+            if (getProgram()->getParseOptions64() & PO_STRICT_TYPES) {
+                return QTI_NOT_EQUAL;
+            }
             may_not_match = true;
         }
 
@@ -1121,6 +1129,10 @@ protected:
             }
             if (t_no_match) {
                 if (!may_not_match) {
+                    // if the type may not match at runtime, then return no match with %strict-types
+                    if (getProgram()->getParseOptions64() & PO_STRICT_TYPES) {
+                        return QTI_NOT_EQUAL;
+                    }
                     may_not_match = true;
                     if (ok)
                         return QTI_AMBIGUOUS;
@@ -1576,8 +1588,7 @@ public:
     DLLLOCAL QoreComplexHashTypeInfo(const QoreTypeInfo* vti) : QoreTypeInfo(q_accept_vec_t {{QoreComplexHashTypeSpec(vti), nullptr, true}}, q_return_vec_t {{QoreComplexHashTypeSpec(vti), true}}) {
         if (vti == autoTypeInfo) {
             tname = "hash<auto>";
-        }
-        else {
+        } else {
             tname.sprintf("hash<string, %s>", QoreTypeInfo::getName(vti));
         }
     }

--- a/include/qore/intern/typed_hash_decl_private.h
+++ b/include/qore/intern/typed_hash_decl_private.h
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),

--- a/lib/ParseOptionMap.cpp
+++ b/lib/ParseOptionMap.cpp
@@ -3,7 +3,7 @@
 
     Qore Programming language
 
-    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -40,111 +40,113 @@ static ParseOptionMap parse_option_map;
 #define DO_MAP(a, b) map[(a)] = (b); rmap[(b)] = (a);
 
 ParseOptionMap::ParseOptionMap() {
-   static_init();
+    static_init();
 }
 
 void ParseOptionMap::static_init() {
-   DO_MAP("no-global-vars",           PO_NO_GLOBAL_VARS);
-   DO_MAP("no-subroutine-defs",       PO_NO_SUBROUTINE_DEFS);
-   DO_MAP("no-thread-control",        PO_NO_THREAD_CONTROL);
-   DO_MAP("no-thread-classes",        PO_NO_THREAD_CLASSES);
-   DO_MAP("no-top-level",             PO_NO_TOP_LEVEL_STATEMENTS);
-   DO_MAP("no-class-defs",            PO_NO_CLASS_DEFS);
-   DO_MAP("no-namespace-defs",        PO_NO_NAMESPACE_DEFS);
-   DO_MAP("no-constant-defs",         PO_NO_CONSTANT_DEFS);
-   DO_MAP("no-new",                   PO_NO_NEW);
-   DO_MAP("no-system-classes",        PO_NO_INHERIT_SYSTEM_CLASSES);
-   DO_MAP("no-user-classes",          PO_NO_INHERIT_USER_CLASSES);
-   DO_MAP("no-child-restrictions",    PO_NO_CHILD_PO_RESTRICTIONS);
-   DO_MAP("no-external-access",       PO_NO_EXTERNAL_ACCESS);
-   DO_MAP("no-external-info",         PO_NO_EXTERNAL_INFO);
-   DO_MAP("no-external-process",      PO_NO_EXTERNAL_PROCESS);
-   DO_MAP("require-our",              PO_REQUIRE_OUR);
-   DO_MAP("no-process-control",       PO_NO_PROCESS_CONTROL);
-   DO_MAP("no-network",               PO_NO_NETWORK);
-   DO_MAP("no-filesystem",            PO_NO_FILESYSTEM);
-   DO_MAP("no-database",              PO_NO_DATABASE);
-   DO_MAP("no-gui",                   PO_NO_GUI);
-   DO_MAP("no-terminal-io",           PO_NO_TERMINAL_IO);
-   DO_MAP("require-types",            PO_REQUIRE_TYPES);
-   DO_MAP("no-thread-info",           PO_NO_THREAD_INFO);
-   DO_MAP("no-locale-control",        PO_NO_LOCALE_CONTROL);
-   DO_MAP("no-io",                    PO_NO_IO);
-   DO_MAP("no-modules",               PO_NO_MODULES);
-   DO_MAP("lockdown",                 PO_LOCKDOWN);
-   DO_MAP("no-embedded-logic",        PO_NO_EMBEDDED_LOGIC);
-   DO_MAP("strict-bool-eval",         PO_STRICT_BOOLEAN_EVAL);
-   DO_MAP("allow-injection",          PO_ALLOW_INJECTION);
-   DO_MAP("no-user-api",              PO_NO_USER_API);
-   DO_MAP("no-system-api",            PO_NO_SYSTEM_API);
-   DO_MAP("no-api",                   PO_NO_API);
-   DO_MAP("no-system-constants",      PO_NO_INHERIT_SYSTEM_CONSTANTS);
-   DO_MAP("broken-list-parsing",      PO_BROKEN_LIST_PARSING);
-   DO_MAP("broken-logic-precedence",  PO_BROKEN_LOGIC_PRECEDENCE);
-   DO_MAP("broken-int-assignments",   PO_BROKEN_INT_ASSIGNMENTS);
-   DO_MAP("broken-operators",         PO_BROKEN_OPERATORS);
-   DO_MAP("broken-loop-statement",    PO_BROKEN_LOOP_STATEMENT);
-   DO_MAP("strong-encapsulation",     PO_STRONG_ENCAPSULATION);
-   DO_MAP("no-uncontrolled-apis",     PO_NO_UNCONTROLLED_APIS);
-   DO_MAP("no-debugging",             PO_NO_DEBUGGING);
-   DO_MAP("broken-references",        PO_BROKEN_REFERENCES);
-   DO_MAP("no-system-classes",        PO_NO_INHERIT_SYSTEM_CLASSES);
-   DO_MAP("no-system-functions",      PO_NO_INHERIT_SYSTEM_FUNC_VARIANTS);
-   DO_MAP("no-system-hashdecls",      PO_NO_INHERIT_SYSTEM_HASHDECLS);
-   DO_MAP("allow-weak-references",    PO_ALLOW_WEAK_REFERENCES);
-   DO_MAP("allow-debugger",           PO_ALLOW_DEBUGGER);
-   DO_MAP("allow-statement-no-effect",PO_ALLOW_STATEMENT_NO_EFFECT);
-   DO_MAP("no-reflection",            PO_NO_REFLECTION);
-   DO_MAP("no-transient",             PO_NO_TRANSIENT);
-   DO_MAP("broken-sprintf",           PO_BROKEN_SPRINTF);
-   DO_MAP("broken-cast",              PO_BROKEN_CAST);
+    DO_MAP("no-global-vars",           PO_NO_GLOBAL_VARS);
+    DO_MAP("no-subroutine-defs",       PO_NO_SUBROUTINE_DEFS);
+    DO_MAP("no-thread-control",        PO_NO_THREAD_CONTROL);
+    DO_MAP("no-thread-classes",        PO_NO_THREAD_CLASSES);
+    DO_MAP("no-top-level",             PO_NO_TOP_LEVEL_STATEMENTS);
+    DO_MAP("no-class-defs",            PO_NO_CLASS_DEFS);
+    DO_MAP("no-namespace-defs",        PO_NO_NAMESPACE_DEFS);
+    DO_MAP("no-constant-defs",         PO_NO_CONSTANT_DEFS);
+    DO_MAP("no-new",                   PO_NO_NEW);
+    DO_MAP("no-system-classes",        PO_NO_INHERIT_SYSTEM_CLASSES);
+    DO_MAP("no-user-classes",          PO_NO_INHERIT_USER_CLASSES);
+    DO_MAP("no-child-restrictions",    PO_NO_CHILD_PO_RESTRICTIONS);
+    DO_MAP("no-external-access",       PO_NO_EXTERNAL_ACCESS);
+    DO_MAP("no-external-info",         PO_NO_EXTERNAL_INFO);
+    DO_MAP("no-external-process",      PO_NO_EXTERNAL_PROCESS);
+    DO_MAP("require-our",              PO_REQUIRE_OUR);
+    DO_MAP("no-process-control",       PO_NO_PROCESS_CONTROL);
+    DO_MAP("no-network",               PO_NO_NETWORK);
+    DO_MAP("no-filesystem",            PO_NO_FILESYSTEM);
+    DO_MAP("no-database",              PO_NO_DATABASE);
+    DO_MAP("no-gui",                   PO_NO_GUI);
+    DO_MAP("no-terminal-io",           PO_NO_TERMINAL_IO);
+    DO_MAP("require-types",            PO_REQUIRE_TYPES);
+    DO_MAP("no-thread-info",           PO_NO_THREAD_INFO);
+    DO_MAP("no-locale-control",        PO_NO_LOCALE_CONTROL);
+    DO_MAP("no-io",                    PO_NO_IO);
+    DO_MAP("no-modules",               PO_NO_MODULES);
+    DO_MAP("lockdown",                 PO_LOCKDOWN);
+    DO_MAP("no-embedded-logic",        PO_NO_EMBEDDED_LOGIC);
+    DO_MAP("strict-bool-eval",         PO_STRICT_BOOLEAN_EVAL);
+    DO_MAP("allow-injection",          PO_ALLOW_INJECTION);
+    DO_MAP("no-user-api",              PO_NO_USER_API);
+    DO_MAP("no-system-api",            PO_NO_SYSTEM_API);
+    DO_MAP("no-api",                   PO_NO_API);
+    DO_MAP("no-system-constants",      PO_NO_INHERIT_SYSTEM_CONSTANTS);
+    DO_MAP("broken-list-parsing",      PO_BROKEN_LIST_PARSING);
+    DO_MAP("broken-logic-precedence",  PO_BROKEN_LOGIC_PRECEDENCE);
+    DO_MAP("broken-int-assignments",   PO_BROKEN_INT_ASSIGNMENTS);
+    DO_MAP("broken-operators",         PO_BROKEN_OPERATORS);
+    DO_MAP("broken-loop-statement",    PO_BROKEN_LOOP_STATEMENT);
+    DO_MAP("strong-encapsulation",     PO_STRONG_ENCAPSULATION);
+    DO_MAP("no-uncontrolled-apis",     PO_NO_UNCONTROLLED_APIS);
+    DO_MAP("no-debugging",             PO_NO_DEBUGGING);
+    DO_MAP("broken-references",        PO_BROKEN_REFERENCES);
+    DO_MAP("no-system-classes",        PO_NO_INHERIT_SYSTEM_CLASSES);
+    DO_MAP("no-system-functions",      PO_NO_INHERIT_SYSTEM_FUNC_VARIANTS);
+    DO_MAP("no-system-hashdecls",      PO_NO_INHERIT_SYSTEM_HASHDECLS);
+    DO_MAP("allow-weak-references",    PO_ALLOW_WEAK_REFERENCES);
+    DO_MAP("allow-debugger",           PO_ALLOW_DEBUGGER);
+    DO_MAP("allow-statement-no-effect",PO_ALLOW_STATEMENT_NO_EFFECT);
+    DO_MAP("no-reflection",            PO_NO_REFLECTION);
+    DO_MAP("no-transient",             PO_NO_TRANSIENT);
+    DO_MAP("broken-sprintf",           PO_BROKEN_SPRINTF);
+    DO_MAP("broken-cast",              PO_BROKEN_CAST);
+    DO_MAP("allow-returns",            PO_ALLOW_RETURNS);
+    DO_MAP("strict-types",             PO_STRICT_TYPES);
 
-   // the following are not useful from the command-line
-   //DO_MAP("no-user-constants",        PO_NO_INHERIT_USER_CONSTANTS);
-   //DO_MAP("no-user-classes",          PO_NO_INHERIT_USER_CLASSES);
-   //DO_MAP("no-user-functions",        PO_NO_INHERIT_USER_FUNC_VARIANTS);
-   //DO_MAP("no-user-hashdecls",        PO_NO_INHERIT_USER_HASHDECLS);
+    // the following are not useful from the command-line
+    //DO_MAP("no-user-constants",        PO_NO_INHERIT_USER_CONSTANTS);
+    //DO_MAP("no-user-classes",          PO_NO_INHERIT_USER_CLASSES);
+    //DO_MAP("no-user-functions",        PO_NO_INHERIT_USER_FUNC_VARIANTS);
+    //DO_MAP("no-user-hashdecls",        PO_NO_INHERIT_USER_HASHDECLS);
 }
 
 int ParseOptionMap::find_code(const char *name) {
-   opt_map_t::iterator i = map.find(name);
-   //printd(5, "find_code(%s) returning %p\n", name, i == map.end() ? -1 : i->second);
-   return (int)(i == map.end() ? -1 : i->second);
+    opt_map_t::iterator i = map.find(name);
+    //printd(5, "find_code(%s) returning %p\n", name, i == map.end() ? -1 : i->second);
+    return (int)(i == map.end() ? -1 : i->second);
 }
 
 int64 ParseOptionMap::find_code64(const char *name) {
-   opt_map_t::iterator i = map.find(name);
-   //printd(5, "find_code(%s) returning %p\n", name, i == map.end() ? -1 : i->second);
-   return (i == map.end() ? -1 : i->second);
+    opt_map_t::iterator i = map.find(name);
+    //printd(5, "find_code(%s) returning %p\n", name, i == map.end() ? -1 : i->second);
+    return (i == map.end() ? -1 : i->second);
 }
 
 const char *ParseOptionMap::find_name(int code) {
-   rev_opt_map_t::iterator i = rmap.find(code);
-   return (i == rmap.end() ? 0 : i->second);
+    rev_opt_map_t::iterator i = rmap.find(code);
+    return (i == rmap.end() ? 0 : i->second);
 }
 
 void ParseOptionMap::list_options() {
-   for (auto& i : map)
-      printf("%s\n", i.first);
+    for (auto& i : map)
+        printf("%s\n", i.first);
 }
 
 QoreHashNode* ParseOptionMap::getCodeToStringMap() {
-   QoreHashNode* h = new QoreHashNode(autoTypeInfo);
-   QoreString key;
-   for (auto& i : rmap) {
-      key.clear();
-      key.sprintf(QLLD, i.first);
-      h->setKeyValue(key.c_str(), new QoreStringNode(i.second), 0);
-   }
-   return h;
+    QoreHashNode* h = new QoreHashNode(autoTypeInfo);
+    QoreString key;
+    for (auto& i : rmap) {
+        key.clear();
+        key.sprintf(QLLD, i.first);
+        h->setKeyValue(key.c_str(), new QoreStringNode(i.second), nullptr);
+    }
+    return h;
 }
 
 QoreHashNode* ParseOptionMap::getStringToCodeMap() {
-   QoreHashNode* h = new QoreHashNode(autoTypeInfo);
-   for (auto& i : map) {
-      h->setKeyValue(i.first, i.second, 0);
-   }
-   return h;
+    QoreHashNode* h = new QoreHashNode(autoTypeInfo);
+    for (auto& i : map) {
+        h->setKeyValue(i.first, i.second, nullptr);
+    }
+    return h;
 }
 
 

--- a/lib/QC_Program.qpp
+++ b/lib/QC_Program.qpp
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -720,12 +720,26 @@ const PO_NO_TRANSIENT = PO_NO_TRANSIENT;
 */
 const PO_BROKEN_SPRINTF = PO_BROKEN_SPRINTF;
 
-//! allows for old pre-%Qore 0.9.4 broken @ref cast "cast<>" operator behavior where @ref nothing was silently accepted
+//! Allows for old pre-%Qore 0.9.4 broken @ref cast "cast<>" operator behavior where @ref nothing was silently accepted
 /** @see @ref broken-cast "%broken-cast"
 
     @since %Qore 0.9.4
 */
 const PO_BROKEN_CAST = PO_BROKEN_CAST;
+
+//! Allows the use of the deprecated \c returns keyword
+/** @see @ref allow-returns "%allow-returns"
+
+    @since %Qore 0.9.4
+*/
+const PO_ALLOW_RETURNS = PO_ALLOW_RETURNS;
+
+//! Sets strict type checking and automatically sets default values for lvalues with type restrictions for types with default values
+/** @see @ref strict-types "%strict-types"
+
+    @since %Qore 0.9.4
+*/
+const PO_STRICT_TYPES = PO_STRICT_TYPES;
 //@}
 
 /** @defgroup warning_constants Warning Constants

--- a/lib/QoreTypeInfo.cpp
+++ b/lib/QoreTypeInfo.cpp
@@ -3,7 +3,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -598,6 +598,11 @@ const char* getBuiltinTypeName(qore_type_t type) {
 static qore_type_result_e match_type(const QoreTypeInfo* this_type, const QoreTypeInfo* that_type, bool& may_not_match, bool& may_need_filter) {
     //printd(5, "QoreTypeSpec::match() '%s' <- '%s'\n", QoreTypeInfo::getName(this_type), QoreTypeInfo::getName(that_type));
     qore_type_result_e res = QoreTypeInfo::parseAccepts(this_type, that_type, may_not_match, may_need_filter);
+    // if the type may not match at runtime, then return no match with %strict-types
+    if (may_not_match && getProgram()->getParseOptions64() & PO_STRICT_TYPES) {
+        return QTI_NOT_EQUAL;
+    }
+
     // with strict-types, may not match must be interpreted as no match
     // however if we interpret "may not match" as "no match" here, then we introduce an incompatibility with
     // non-complex types
@@ -633,9 +638,12 @@ qore_type_result_e QoreTypeSpec::match(const QoreTypeSpec& t, bool& may_not_matc
                 case QTS_CLASS:
                     return qore_class_private::get(*t.u.qc)->parseCheckCompatibleClass(*qore_class_private::get(*u.qc), may_not_match);
                 default: {
-                    // NOTE: with %strict-types, anything with may_not_match = true must return QTI_NOT_EQUAL
                     qore_type_t tt = t.getType();
                     if (tt == NT_ALL || tt == NT_OBJECT) {
+                        // if the type may not match at runtime, then return no match with %strict-types
+                        if (getProgram()->getParseOptions64() & PO_STRICT_TYPES) {
+                            return QTI_NOT_EQUAL;
+                        }
                         may_not_match = true;
                         return QTI_AMBIGUOUS;
                     }
@@ -653,8 +661,11 @@ qore_type_result_e QoreTypeSpec::match(const QoreTypeSpec& t, bool& may_not_matc
                 case QTS_HASHDECL:
                     return typed_hash_decl_private::get(*t.u.hd)->parseEqual(*typed_hash_decl_private::get(*u.hd)) ? QTI_IDENT : QTI_NOT_EQUAL;
                 case QTS_TYPE:
-                    // NOTE: with %strict-types, anything with may_not_match = true must return QTI_NOT_EQUAL
                     if (t.getType() == NT_ALL || t.getType() == NT_HASH) {
+                        // if the type may not match at runtime, then return no match with %strict-types
+                        if (getProgram()->getParseOptions64() & PO_STRICT_TYPES) {
+                            return QTI_NOT_EQUAL;
+                        }
                         may_not_match = true;
                         return QTI_AMBIGUOUS;
                     }
@@ -683,8 +694,11 @@ qore_type_result_e QoreTypeSpec::match(const QoreTypeSpec& t, bool& may_not_matc
                     if (t.getType() == NT_HASH && u.ti == autoTypeInfo) {
                         return QTI_NEAR;
                     }
-                    // NOTE: with %strict-types, anything with may_not_match = true must return QTI_NOT_EQUAL
                     if (t.getType() == NT_ALL) {
+                        // if the type may not match at runtime, then return no match with %strict-types
+                        if (getProgram()->getParseOptions64() & PO_STRICT_TYPES) {
+                            return QTI_NOT_EQUAL;
+                        }
                         may_not_match = true;
                         return QTI_AMBIGUOUS;
                     }
@@ -711,8 +725,11 @@ qore_type_result_e QoreTypeSpec::match(const QoreTypeSpec& t, bool& may_not_matc
                     if (t.getType() == NT_LIST && u.ti == autoTypeInfo) {
                         return QTI_NEAR;
                     }
-                    // NOTE: with %strict-types, anything with may_not_match = true must return QTI_NOT_EQUAL
                     if (t.getType() == NT_ALL) {
+                        // if the type may not match at runtime, then return no match with %strict-types
+                        if (getProgram()->getParseOptions64() & PO_STRICT_TYPES) {
+                            return QTI_NOT_EQUAL;
+                        }
                         may_not_match = true;
                         return QTI_AMBIGUOUS;
                     }
@@ -740,6 +757,10 @@ qore_type_result_e QoreTypeSpec::match(const QoreTypeSpec& t, bool& may_not_matc
                 case QTS_EMPTYLIST:
                 case QTS_EMPTYHASH:
                     if (t.getType() == NT_REFERENCE) {
+                        // if the type may not match at runtime, then return no match with %strict-types
+                        if (getProgram()->getParseOptions64() & PO_STRICT_TYPES) {
+                            return QTI_NOT_EQUAL;
+                        }
                         may_not_match = true;
                         return QTI_AMBIGUOUS;
                     }
@@ -756,8 +777,11 @@ qore_type_result_e QoreTypeSpec::match(const QoreTypeSpec& t, bool& may_not_matc
             if (u.t == NT_ALL) {
                 return QTI_WILDCARD;
             }
-            // NOTE: with %strict-types, anything with may_not_match = true must return QTI_NOT_EQUAL
             if (ot == NT_ALL) {
+                // if the type may not match at runtime, then return no match with %strict-types
+                if (getProgram()->getParseOptions64() & PO_STRICT_TYPES) {
+                    return QTI_NOT_EQUAL;
+                }
                 may_not_match = true;
                 return QTI_AMBIGUOUS;
             }

--- a/lib/TypedHashDecl.cpp
+++ b/lib/TypedHashDecl.cpp
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -319,19 +319,16 @@ int typed_hash_decl_private::initHashIntern(QoreHashNode* h, const QoreHashNode*
             if (needs_scan(v)) {
                 h_priv->incScanCount(1);
             }
-        }
-#ifdef QORE_ENFORCE_DEFAULT_LVALUE
-        else {
+        } else if (getProgram()->getParseOptions64() & PO_STRICT_TYPES) {
             qore_hash_private* h_priv = qore_hash_private::get(*h);
             QoreValue& v = h_priv->getValueRef(i.first);
             assert(v.isNothing());
-            v = QoreTypeInfo::getDefaultQoreValue.second->getTypeInfo());
+            v = QoreTypeInfo::getDefaultQoreValue(i.second->getTypeInfo());
             // issue #3481: maintain DGC counts
             if (needs_scan(v)) {
                 h_priv->incScanCount(1);
             }
         }
-#endif
     }
 
     return 0;

--- a/lib/parser.ypp
+++ b/lib/parser.ypp
@@ -3114,12 +3114,17 @@ method_modifier:
 
 return_value:
         TOK_RETURNS qtypedef {
+            // see if the deprecated "returns" keyword can be used
+            if (!parse_check_parse_option(PO_ALLOW_RETURNS)) {
+                const QoreProgramLocation* loc = qore_program_private::get(*getProgram())->getLocation(@1.first_line, @2.last_line);
+                parse_error(*loc, "illegal use of the depcreated \"returns\" keyword (enable by setting parse option PO_ALLOW_RETURNS)");
+            }
+
             if (!$2) {
                 const QoreProgramLocation* loc = qore_program_private::get(*getProgram())->getLocation(@1.first_line, @2.last_line);
                 parse_error(*loc, "missing type declaration after 'returns'");
                 $$ = 0;
-            }
-            else {
+            } else {
                 $$ = new RetTypeInfo(ParserTypeStruct::getParseTypeInfo($2), ParserTypeStruct::getTypeInfo($2));
                 delete $2;
             }

--- a/lib/scanner.lpp
+++ b/lib/scanner.lpp
@@ -794,7 +794,10 @@ RTIME           PT(-?[0-9]+(\.[0-9]+)?[HMSu])+
 ^%correct-sprintf{WS}*$                 parse_disable_parse_options(yylloc, PO_BROKEN_SPRINTF);
 ^%broken-cast{WS}*$                     parse_set_parse_options(yylloc, PO_BROKEN_CAST);
 ^%correct-cast{WS}*$                    parse_disable_parse_options(yylloc, PO_BROKEN_CAST);
+^%allow-returns{WS}*$                   parse_set_parse_options(yylloc, PO_ALLOW_RETURNS);
 ^%allow-statement-no-effect{WS}*$       parse_set_parse_options(yylloc, PO_ALLOW_STATEMENT_NO_EFFECT);
+^%strict-types{WS}*$                    parse_set_parse_options(yylloc, PO_STRICT_TYPES);
+^%loose-types{WS}*$                     parse_disable_parse_options(yylloc, PO_STRICT_TYPES);
 ^%no-reflection{WS}*$                   parse_set_parse_options(yylloc, PO_NO_REFLECTION);
 ^%no-transient{WS}*$                    parse_set_parse_options(yylloc, PO_NO_TRANSIENT);
 ^%push-parse-options{WS}*$              push_parse_options();


### PR DESCRIPTION
refs #488 implementation of the "%strict-types" parse directive