### PR TITLE
refs #3829 fixed AbstractDataProviderType::get() to return the correc…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -26,6 +26,9 @@
 
     @subsection qore_0942_bug_fixes Bug Fixes in Qore
 
+    - <a href="../../modules/DataProvider/html/index.html">DataProvider</a> module:
+      - fixed \c AbstractDataProviderType::get() to return the correct type with all string arguments
+        (<a href="https://github.com/qorelanguage/qore/issues/3829">issue 3829</a>)
     - <a href="../../modules/SmtpClient/html/index.html">SmtpClient</a> module:
       - fixed type errors sending mails
         (<a href="https://github.com/qorelanguage/qore/issues/3813">issue 3813</a>)

--- a/examples/test/qlib/DataProvider/DataProvider.qtest
+++ b/examples/test/qlib/DataProvider/DataProvider.qtest
@@ -119,6 +119,15 @@ public class DataProviderTest inherits QUnit::Test {
 
     dataProviderTest() {
         {
+            assertEq("hash<auto>", AbstractDataProviderType::get("hash<auto>").getName());
+            assertEq("hash<string, bool>", AbstractDataProviderType::get("hash<string, bool>").getName());
+            assertEq("*hash<auto>", AbstractDataProviderType::get("*hash<auto>").getName());
+            assertEq("*hash<string, bool>", AbstractDataProviderType::get("*hash<string, bool>").getName());
+            assertThrows("UNKNOWN-TYPE", "xyz", \AbstractDataProviderType::get(), "xyz");
+            assertThrows("UNKNOWN-TYPE", "hash<string>", \AbstractDataProviderType::get(), "hash<string>");
+        }
+
+        {
             AbstractDataProviderType type = DataProvider::getType("/qore/ftp/event");
             assertEq(AutoHashType, type.getValueType());
             type = DataProvider::getType("qore/ftp/event");

--- a/qlib/DataProvider/AbstractDataProviderType.qc
+++ b/qlib/DataProvider/AbstractDataProviderType.qc
@@ -428,9 +428,11 @@ public class AbstractDataProviderType inherits Serializable {
     }
 
     #! returns an appropriate object for the given type
+    /** @param typename the name of the type; should be a valid Qore type string
+        @param options type options for the data type object
+    */
     static AbstractDataProviderType get(string typename, *hash<auto> options) {
-        return AbstractDataProviderType::get(DataTypeMap{typename}
-            ?? AbstractDataProviderType::anyType, options);
+        return AbstractDataProviderType::get(DataTypeMap{typename} ?? new Type(typename), options);
     }
 
     #! sets the given option without any validation of the option


### PR DESCRIPTION
…t type with all string arguments