### PR TITLE
refs #3879 fixed HTTP responses with no message body to include a Con…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -24,6 +24,10 @@
         (<a href="https://github.com/qorelanguage/qore/issues/3876">issue 3876</a>)
 
     @subsection qore_0943_bug_fixes Bug Fixes in Qore
+    - fixed HTTP responses with no message body and no \c Transfer-Encoding header to include a
+      <tt>Content-Length: 0</tt> header to correctly support
+      <a href="http://tools.ietf.org/html/rfc2616#section-4.4">RFC-2616</a>
+      (<a href="https://github.com/qorelanguage/qore/issues/3879">issue 3879</a>)
     - fixed a crash in handling reference arguments in call references in mixed class contexts
       (<a href="https://github.com/qorelanguage/qore/issues/3869">issue 3869</a>)
     - fixed a memory leak in the code that manages remote client certificates in the @ref Qore::Socket "Socket" class

--- a/examples/test/qlib/RestClient/RestClient.qtest
+++ b/examples/test/qlib/RestClient/RestClient.qtest
@@ -76,6 +76,8 @@ class SimpleStringHandler inherits AbstractHttpRequestHandler {
             return makeResponse(200, m_data ?? binary(body), {"Content-Type": m_mime});
         } else if (hdr.method == "DELETE") {
             return makeResponse(404, m_data ?? binary(body), {"Content-Type": m_mime});
+        } else if (hdr.method == "OPTIONS") {
+            return makeResponse(200, m_data ?? binary(body), {"Content-Type": m_mime});
         }
     }
 }
@@ -94,6 +96,7 @@ public class Main inherits QUnit::Test {
     constructor() : Test("RestClientTest", "1.0") {
         addTestCase("issue 3472", \issue3472());
         addTestCase("connection tests", \connectionTests());
+        addTestCase("OPTIONS tests", \methodOptionsTest());
         addTestCase("DELETE tests", \methodDeleteTest());
         addTestCase("GET tests", \methodGetTest());
         addTestCase("PUT tests", \methodPutTest());
@@ -125,6 +128,13 @@ public class Main inherits QUnit::Test {
         hash<auto> msg = rest.get("/api_text", NOTHING, NOTHING, {"Do-Error": True});
         assertEq(404, msg.status_code);
         assertEq("test error", msg.body);
+    }
+
+    methodOptionsTest() {
+        RestClient rest({"url": "http://localhost:" + port});
+        hash<auto> info;
+        rest.doRequest("OPTIONS", "/api_bin", NOTHING, \info);
+        assertEq("0", info."response-headers"."content-length");
     }
 
     methodDeleteTest() {

--- a/examples/test/qlib/RestHandler/RestHandler.qtest
+++ b/examples/test/qlib/RestHandler/RestHandler.qtest
@@ -450,7 +450,7 @@ public class RestHandlerTest inherits QUnit::Test {
             h = mClient.doRequest("OPTIONS", "test", NOTHING, \info);
             assertEq(200, h.status_code);
             assertNothing(h.body);
-            assertNothing(h."content-length");
+            assertEq("0", h."content-length");
 
             # issue #3373 exception test
             assertThrows("EXCEPTION-TEST-ERROR", "exception test error", \mClient.doRequest(), ("PUT", "test/ex", NOTHING, \info));

--- a/examples/test/qore/classes/Socket/Socket.qtest
+++ b/examples/test/qore/classes/Socket/Socket.qtest
@@ -478,7 +478,7 @@ class SocketTest inherits QUnit::Test {
         m = s.readHTTPHeader(-1, \info);
         assertEq(Type::Hash, info."headers-raw".type());
         assertEq("GET", m.method, who + " HTTP header method");
-        assertNothing(m."content-length");
+        assertEq("0", m."content-length");
 
         StringInputStream input_stream("OK");
         s.sendHTTPResponse(200, "OK", "1.1", http_headers + {"Transfer-Encoding": "chunked"}, input_stream, NOTHING, \info);


### PR DESCRIPTION
…… (#3880)

* refs #3879 fixed HTTP responses with no message body to include a Content-Length: 0 header

* refs #3879 fixed tests, do not send a Content-Type header when sending a chunked reply

* refs #3879 fixed Socket.qtest