### PR TITLE
refs #3893 fixed issues with nested mapper option handling

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -12,8 +12,9 @@
     - <a href="../../modules/Mapper/html/index.html">Mapper</a> module updates:
       - added support for mapper context in mapper field key handlers
         (<a href="https://github.com/qorelanguage/qore/issues/3893">issue 3893</a>)
-      - added support for nested mappers
+      - added support for nested mappers and the \c submappers option
         (<a href="https://github.com/qorelanguage/qore/issues/3414">issue 3414</a>)
+      - implemented the \c output_create_ignore_duplicates option
     - added support for freestanding expression evaluation:
       - @ref Qore::Expression "Expression" class
       - @ref Qore::Program::getExpression() "Program::getExpression()" method
@@ -22,6 +23,8 @@
     - <a href="../../modules/CsvUtil/html/index.html">CsvUtil</a> module updates:
       - fixed \c FixedLengthWriteDataProvider to return the record created with the \c createRecord() call
         (<a href="https://github.com/qorelanguage/qore/issues/3914">issue 3914</a>)
+    - <a href="../../modules/DataProvider/html/index.html">DataProvider</a> module updates:
+      - added the \c DUPLICATE-RECORD exception documentation for \c AbstractDataProvider::createRecord()
     - <a href="../../modules/FixedLengthUtil/html/index.html">FixedLengthUtil</a> module updates:
       - fixed \c CsvWriteDataProvider to return the record created with the \c createRecord() call
         (<a href="https://github.com/qorelanguage/qore/issues/3914">issue 3914</a>)
@@ -33,6 +36,8 @@
       - fixed \c Mapper::mapAuto() to return @ref NOTHING with no input
         (<a href="https://github.com/qorelanguage/qore/issues/3872">issue 3872</a>)
     - <a href="../../modules/SalesforceRestDataProvider/html/index.html">SalesforceRestDataProvider</a> module updates:
+      - fixed a bug deleting records with no matches
+        (<a href="https://github.com/qorelanguage/qore/issues/3921">issue 3921</a>)
       - fixed serializing \c DATE fields
         (<a href="https://github.com/qorelanguage/qore/issues/3908">issue 3908</a>)
     - fixed a bug in class copy methods with \c private:internal members

--- a/qlib/DataProvider/AbstractDataProvider.qc
+++ b/qlib/DataProvider/AbstractDataProvider.qc
@@ -238,6 +238,8 @@ public class AbstractDataProvider {
         @return the data written to the data provider
 
         @throw INVALID-OPERATION the data provider does not support record creation
+        @throw DUPLICATE-RECORD this exception should be thrown if the provider fails due to an attempt to create a
+        duplicate record
     */
     *hash<auto> createRecord(hash<auto> rec, *hash<auto> create_options) {
         checkCreate();
@@ -1029,6 +1031,9 @@ public class AbstractDataProvider {
         @param create_options the create options after processing by validateCreateOptions()
 
         @return the data written to the data provider
+
+        @throw DUPLICATE-RECORD this exception should be thrown if the provider fails due to an attempt to create a
+        duplicate record
     */
     private *hash<auto> createRecordImpl(hash<auto> rec, *hash<auto> create_options) {
         throwUnimplementedException();

--- a/qlib/DataProvider/DataProvider.qm
+++ b/qlib/DataProvider/DataProvider.qm
@@ -177,6 +177,8 @@ $env:QORE_DATA_PROVIDERS="MyConnectionProvider;OtherConnectionProvider"
       - @ref DataProvider::DataProviderPipeline "DataProviderPipeline"
       .
       (<a href="https://github.com/qorelanguage/qore/issues/3876">issue 3876</a>)
+    - added the \c DUPLICATE-RECORD exception documentation for
+      @ref DataProvider::AbstractDataProvider::createRecord() "AbstractDataProvider::createRecord()"
 
     @subsection dataprovider_v1_0_1 DataProvider v1.0.1
     - implemented callbacks to allow for dynamic elements of request-response data providers (such as URI paths) to be

--- a/qlib/Mapper.qm
+++ b/qlib/Mapper.qm
@@ -304,13 +304,14 @@ m.mapData(input1);           # output record hash date_begin = start_date = time
 
     @subsection mapperv1_5_2 Mapper v1.5.2
     - added the @ref Mapper::Mapper::mapAutoInput() "Mapper::mapAutoInput()" method
+    - added the following \c output_create_ignore_duplicates option
     - fixed a bug where mapper output data was not logged in case of an error in an output provider
       (<a href="https://github.com/qorelanguage/qore/issues/3909">issue 3909</a>)
     - added support for mapper context in mapper field key handlers
       (<a href="https://github.com/qorelanguage/qore/issues/3893">issue 3893</a>)
     - fixed @ref Mapper::Mapper::mapAuto() "Mapper::mapAuto()" to return @ref NOTHING with no input
       (<a href="https://github.com/qorelanguage/qore/issues/3872">issue 3872</a>)
-    - implemented support for nested mappers
+    - implemented support for nested mappers including the \c submappers option
       (<a href="https://github.com/qorelanguage/qore/issues/3414">issue 3414</a>)
 
     @subsection mapperv1_5_1 Mapper v1.5.1
@@ -495,6 +496,12 @@ public class Mapper inherits AbstractDataProcessor {
                 "desc": "any options to output providers using the request/response API",
             },
 
+            "output_create_ignore_duplicates": <MapperOptionInfo>{
+                "type": "bool",
+                "desc": "a flag that indicates that duplicate records should be ignored when creating records with "
+                    "an output data provider",
+            },
+
             "runtime": <MapperOptionInfo>{
                 "type": "hash",
                 "desc": "defines key-value pairs lookups for the \"runtime\" field mapping key",
@@ -647,6 +654,9 @@ public class Mapper inherits AbstractDataProcessor {
         /** if so then allow_output_dot cannot be set
         */
         bool structured_output;
+
+        #! flag indicating that duplicate records should be ignored when creating records with an output mapper
+        bool output_create_ignore_duplicates;
 
         #! count of records mapped
         int count = 0;
@@ -1077,6 +1087,10 @@ Mapper mapv(DataMap);
                 $1.value.type(), $1.value), opts.submappers.pairIterator(), $1.value.typeCode() != NT_HASH;
 
             global_submappers = opts.submappers;
+        }
+
+        if (opts.output_create_ignore_duplicates) {
+            output_create_ignore_duplicates = True;
         }
 
         # set global transform options
@@ -2125,7 +2139,7 @@ Mapper mapv(DataMap);
                     if (output_do_request) {
                         map output_provider.doRequest($1, output_request_options), dh.contextIterator();
                     } else {
-                        map output_provider.createRecord($1), dh.contextIterator();
+                        map doCreateRecordIntern($1), dh.contextIterator();
                     }
                 }
             }
@@ -2176,6 +2190,7 @@ Mapper mapv(DataMap);
         # iterate through dynamic target fields
         map mapFieldIntern(\h, $1, rec, False, 0), keys mapd;
 
+        # log output before any output provider
         if (do_log_output) {
             logOutput(h);
         }
@@ -2190,7 +2205,7 @@ Mapper mapv(DataMap);
                 if (output_do_request) {
                     output_provider.doRequest(h, output_request_options);
                 } else {
-                    h = output_provider.createRecord(h);
+                    h = doCreateRecordIntern(h);
                 }
             }
         }
@@ -2205,6 +2220,21 @@ Mapper mapv(DataMap);
         ++count;
 
         return h;
+    }
+
+    #! Creates a record with the output data provider
+    private *hash<auto> doCreateRecordIntern(hash<auto> rec) {
+        try {
+            return output_provider.createRecord(rec);
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.err == "DUPLICATE-RECORD" && output_create_ignore_duplicates) {
+                if (info_log) {
+                    info_log("duplicate record: %y; returning %y", rec, ex.arg);
+                }
+                return ex.arg;
+            }
+            rethrow;
+        }
     }
 
     #! Swap the mapper thread context
@@ -2384,17 +2414,21 @@ Mapper mapv(DataMap);
                 "output-key": key,
                 "input": rec,
             };
-            if (do_list) {
-                foreach hash<auto> i in (current_runtime_keys.pairIterator()) {
-                    v = map i.value.requires_roles.value
-                    ? i.value.handler(m{i.key}, $1, ctx)
-                    : i.value.handler(m{i.key}, ctx), v;
+            try {
+                if (do_list) {
+                    foreach hash<auto> i in (current_runtime_keys.pairIterator()) {
+                        v = map i.value.requires_roles.value
+                        ? i.value.handler(m{i.key}, $1, ctx)
+                        : i.value.handler(m{i.key}, ctx), v;
+                    }
+                } else {
+                    map v = $1.value.requires_roles.value
+                        ? $1.value.handler(m{$1.key}, v, ctx, \missing)
+                        : $1.value.handler(m{$1.key}, ctx, \missing),
+                        current_runtime_keys.pairIterator();
                 }
-            } else {
-                map v = $1.value.requires_roles.value
-                    ? $1.value.handler(m{$1.key}, v, ctx, \missing)
-                    : $1.value.handler(m{$1.key}, ctx, \missing),
-                    current_runtime_keys.pairIterator();
+            } catch (hash<ExceptionInfo> ex) {
+                error2(ex.err, "%s (field %y)", ex.desc, key);
             }
         }
 
@@ -2411,7 +2445,7 @@ Mapper mapv(DataMap);
                     v = m.code(v, rec);
                 }
             } catch (hash<ExceptionInfo> ex) {
-                ex.desc = sprintf("field %y closure: %s", key, ex.desc);
+                ex.desc = sprintf("%y mapper field %y closure: %s", name, key, ex.desc);
                 throw ex.err, ex.desc, ex.arg;
             }
         }

--- a/qlib/SalesforceRestDataProvider/SalesforceRestDataProvider.qm
+++ b/qlib/SalesforceRestDataProvider/SalesforceRestDataProvider.qm
@@ -90,6 +90,8 @@ module SalesforceRestDataProvider {
     @section salesforcerestdataprovider_relnotes Release Notes
 
     @subsection salesforcerestdataprovider_v1_0 SalesforceRestDataProvider v1.0.1
+    - fixed a bug deleting records with no matches
+      (<a href="https://github.com/qorelanguage/qore/issues/3921">issue 3921</a>)
     - fixed serializing \c DATE fields
       (<a href="https://github.com/qorelanguage/qore/issues/3908">issue 3908</a>)
 

--- a/qlib/SalesforceRestDataProvider/SalesforceRestObjectDataProvider.qc
+++ b/qlib/SalesforceRestDataProvider/SalesforceRestObjectDataProvider.qc
@@ -182,6 +182,9 @@ public class SalesforceRestObjectDataProvider inherits AbstractDataProvider {
         @param create_options the create options after processing by validateCreateOptions()
 
         @return the data written to the data provider with the \c "id" field of the new record
+
+        @throw DUPLICATE-RECORD this exception should be thrown if the provider fails due to an attempt to create a
+        duplicate record
     */
     private *hash<auto> createRecordImpl(hash<auto> rec, *hash<auto> create_options) {
         rec = fixSalesforceRecord(rec);
@@ -194,6 +197,13 @@ public class SalesforceRestObjectDataProvider inherits AbstractDataProvider {
         } catch (hash<ExceptionInfo> ex) {
             # ensure that any error response body is included in the exception
             hash<auto> ex_arg = info{"request-uri", "response-code", "response-body"};
+            # check for duplicate record error
+            if (info."response-body"[0].errorCode == "DUPLICATE_VALUE"
+                && (*string id = (info."response-body"[0].message =~ x/record with id: ([0-9a-zA-Z]+)/)[0])) {
+                ex.desc = sprintf("%s: %s", ex.err, ex.desc);
+                ex.err = "DUPLICATE-RECORD";
+                ex_arg.id = id;
+            }
             throw ex.err, ex.desc, ex_arg;
         }
         if (!resp.body.success) {
@@ -271,7 +281,7 @@ public class SalesforceRestObjectDataProvider inherits AbstractDataProvider {
         }
         where_cond = fixSalesforceRecord(where_cond);
         AbstractDataProviderRecordIterator i = searchRecords(where_cond, search_options);
-        int count;
+        int count = 0;
         map (deleteSingleRecord(i.getValue().Id), ++count), i;
         return count;
     }


### PR DESCRIPTION
refs #3921 fixed a bug in the SalesforceRestDataProvider module deleting records with no matches
implemented support for detecting duplicate record errors in DataProvider createRecord() API calls