### PR TITLE
refs #3939 fixed a bug in closure-bound lvar reference handling; a "s…

### DIFF
--- a/bin/rest
+++ b/bin/rest
@@ -3,7 +3,7 @@
 
 # @file rest example program for the RestClient module
 
-/*  Copyright 2013 - 2019 Qore Technologies, s.r.o.
+/*  Copyright 2013 - 2020 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -23,6 +23,8 @@
       - fixed a bug handling external runtime keys with bulk input for keys that do not require the current input
         value
         (<a href="https://github.com/qorelanguage/qore/issues/3931">issue 3931</a>)
+    - fixed a race condition in closure-bound variable reference handling that could result in a runtime crash
+      (<a href="https://github.com/qorelanguage/qore/issues/3939">issue 3939</a>)
 
     @section qore_0944 Qore 0.9.4.4
 

--- a/examples/test/qlib/SqlUtil/BulkPgsqlSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/BulkPgsqlSqlUtil.qtest
@@ -135,11 +135,6 @@ class PgsqlTest inherits SqlTestBase {
             "oid": 1234, # should not be used
 
             "date": 2016-01-11,
-            "abstime": 2016-01-11T09:26:14,
-            "reltime": (
-                "value": 5M + 71D + 19h + 245m + 51s,
-                "expect": PT5327H5M51S,
-            ),
             "interval": 6M + 3D + 2h + 45m + 15s,
             "time": 09:26:52,
             "time with time zone": 09:27:03-06,

--- a/examples/test/qore/classes/ThreadPool/ThreadPool.qtest
+++ b/examples/test/qore/classes/ThreadPool/ThreadPool.qtest
@@ -12,11 +12,62 @@
 
 %exec-class ThreadPoolTest
 
+class RefTest {
+    test(reference<hash<auto>> val) {
+        ThreadPool thread_pool();
+        foreach string key in (keys val) {
+            string ckey = key;
+            thread_pool.submit(sub() {
+                ++val{ckey};
+                ++val.i;
+            });
+        }
+        thread_pool.stopWait();
+        check(\val);
+    }
+
+    private check(reference<hash<auto>> val) {
+        val.other = 3;
+    }
+}
+
 class ThreadPoolTest inherits QUnit::Test {
+    private {
+        hash<auto> val;
+    }
+
     constructor() : QUnit::Test("ThreadPool", "1.0") {
+        addTestCase("ref test", \refTest());
         addTestCase("stopWait() test", \stopWaitTest());
         addTestCase("ThreadPoolTest", \ThreadPoolTest());
         set_return_value(main());
+    }
+
+    # issue #3939
+    refTest() {
+        val = {
+            "test-1": 1,
+            "test-2": 1,
+        };
+        RefTest rt();
+        rt.test(\val);
+        assertEq(2, val.i);
+    }
+
+    private doRef(reference<hash<auto>> val) {
+        ThreadPool thread_pool();
+        foreach string key in (keys val) {
+            thread_pool.submit(sub() {
+                ++val{key};
+                ++val.i;
+            });
+        }
+        thread_pool.stopWait();
+        check(\val);
+    }
+
+    private check(reference<hash<auto>> val) {
+        val.other = 3;
     }
 
     # issue #3897

--- a/include/qore/intern/ThreadClosureVariableStack.h
+++ b/include/qore/intern/ThreadClosureVariableStack.h
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -113,9 +113,9 @@ public:
             while (p) {
                 --p;
                 ClosureVarValue* rv = w->var[p];
-                printd(5, "ThreadClosureVariableStack::find(%p '%s') this: %p checking %p '%s' skip: %d\n", id, id, this, rv ? rv->id : nullptr, rv ? rv->id : "n/a", rv ? rv->skip : false);
-                if (rv && rv->id == id && !rv->skip) {
-                    printd(5, "ThreadClosureVariableStack::find(%p '%s') this: %p returning: %p\n", id, id, this, rv);
+                //printd(5, "ThreadClosureVariableStack::find(%p '%s') this: %p checking %p '%s'\n", id, id, this, rv ? rv->id : nullptr, rv ? rv->id : "n/a");
+                if (rv && rv->id == id) {
+                    //printd(5, "ThreadClosureVariableStack::find(%p '%s') this: %p returning: %p\n", id, id, this, rv);
                     return rv;
                 }
             }
@@ -123,18 +123,22 @@ public:
 #ifdef DEBUG
             if (!w) {
                 printd(0, "ThreadClosureVariableStack::find() this: %p no closure-bound local variable '%s' (%p) on stack (pgm: %p) p: %d curr->prev: %p\n", this, id, id, getProgram(), p, curr->prev);
-                p = curr->pos - 1;
-                while (p >= 0) {
-                    ClosureVarValue* cvv = w->var[p];
-                    printd(0, "var p: %d: %s (%p) (skip: %d)\n", p, cvv ? cvv->id : "frame boundary", cvv ? cvv->id : nullptr, cvv ? cvv->skip : false);
-                    --p;
+                w = curr;
+                while (w) {
+                    p = w->pos;
+                    while (p) {
+                        --p;
+                        ClosureVarValue* cvv = w->var[p];
+                        printd(0, "var p: %d: %s (%p)\n", p, cvv ? cvv->id : "frame boundary", cvv ? cvv->id : nullptr);
+                    }
+                    w = w->prev;
                 }
             }
 #endif
             assert(w);
         }
         // to avoid a warning on most compilers - note that this generates a warning on aCC!
-        return 0;
+        return nullptr;
     }
 
     DLLLOCAL cvv_vec_t* getAll() const {

--- a/include/qore/intern/ThreadLocalVariableData.h
+++ b/include/qore/intern/ThreadLocalVariableData.h
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -101,16 +101,16 @@ public:
             while (p) {
                 --p;
                 LocalVarValue* var = &w->var[p];
-                if (var->id == id && !var->skip && !var->frame_boundary)
+                if (var->id == id && !var->frame_boundary)
                     return var;
             }
             w = w->prev;
 #ifdef DEBUG
             if (!w) {
-                printd(0, "ThreadLocalVariableData::find() this: %p no local variable '%s' (%p) on stack (pgm: %p) p: %d\n", this, id, id, getProgram(), p);
                 p = curr->pos - 1;
+                printd(0, "ThreadLocalVariableData::find() this: %p no local variable '%s' (%p) on stack (pgm: %p) p: %d\n", this, id, id, getProgram(), p);
                 while (p >= 0) {
-                    printd(0, "var p: %d: %s (%p) (skip: %d frame_boundary: %d)\n", p, curr->var[p].id, curr->var[p].id, curr->var[p].skip, curr->var[p].frame_boundary);
+                    printd(0, "var p: %d: %s (%p) (frame_boundary: %d)\n", p, curr->var[p].id, curr->var[p].id, curr->var[p].frame_boundary);
                     --p;
                 }
             }

--- a/lib/ThreadLocalVariableData.cpp
+++ b/lib/ThreadLocalVariableData.cpp
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -34,34 +34,34 @@
 #include "qore/intern/LocalVar.h"
 
 int ThreadLocalVariableData::getFrame(int frame, Block*& w, int& p) {
-   assert(frame >= 0);
+    assert(frame >= 0);
 
-   if (!frame) {
-      w = curr;
-      p = w->pos;
-      return 0;
-   }
+    if (!frame) {
+        w = curr;
+        p = w->pos;
+        return 0;
+    }
 
-   // find requested frame
-   int cframe = 0;
+    // find requested frame
+    int cframe = 0;
 
-   w = curr;
-   while (true) {
-      p = w->pos;
-      while (p) {
-         --p;
-         const LocalVarValue& var = w->var[p];
-         if (var.frame_boundary) {
-            if (frame == ++cframe)
-               return 0;
-            continue;
-         }
-      }
-      w = w->prev;
-      if (!w)
-         break;
-   }
-   return -1;
+    w = curr;
+    while (true) {
+        p = w->pos;
+        while (p) {
+            --p;
+            const LocalVarValue& var = w->var[p];
+            if (var.frame_boundary) {
+                if (frame == ++cframe)
+                    return 0;
+                continue;
+            }
+        }
+        w = w->prev;
+        if (!w)
+            break;
+    }
+    return -1;
 }
 
 void ThreadLocalVariableData::getLocalVars(QoreHashNode& h, int frame, ExceptionSink* xsink) {
@@ -77,12 +77,10 @@ void ThreadLocalVariableData::getLocalVars(QoreHashNode& h, int frame, Exception
             if (var.frame_boundary)
                 return;
 
-            if (!var.skip) {
-                ReferenceHolder<QoreHashNode> v(new QoreHashNode(autoTypeInfo), xsink);
-                v->setKeyValue("type", new QoreStringNode("local"), xsink);
-                v->setKeyValue("value", var.eval(xsink), xsink);
-                h.setKeyValue(var.id, v.release(), xsink);
-            }
+            ReferenceHolder<QoreHashNode> v(new QoreHashNode(autoTypeInfo), xsink);
+            v->setKeyValue("type", new QoreStringNode("local"), xsink);
+            v->setKeyValue("value", var.eval(xsink), xsink);
+            h.setKeyValue(var.id, v.release(), xsink);
         }
         w = w->prev;
         if (!w)
@@ -93,30 +91,30 @@ void ThreadLocalVariableData::getLocalVars(QoreHashNode& h, int frame, Exception
 
 // returns 0 = OK, 1 = no such variable, -1 exception setting variable
 int ThreadLocalVariableData::setVarValue(int frame, const char* name, const QoreValue& val, ExceptionSink* xsink) {
-   Block* w;
-   int p;
-   if (getFrame(frame, w, p))
-      return 1;
+    Block* w;
+    int p;
+    if (getFrame(frame, w, p))
+        return 1;
 
-   while (true) {
-      while (p) {
-         --p;
-         const LocalVarValue& var = w->var[p];
-         if (var.frame_boundary)
-            return 1;
+    while (true) {
+        while (p) {
+            --p;
+            const LocalVarValue& var = w->var[p];
+            if (var.frame_boundary)
+                return 1;
 
-         if (!var.skip && !strcmp(var.id, name)) {
-            LValueHelper lvh(xsink);
-            if (var.getLValue(lvh, false, nullptr, nullptr))
-               return -1;
+            if (!strcmp(var.id, name)) {
+                LValueHelper lvh(xsink);
+                if (var.getLValue(lvh, false, nullptr, nullptr))
+                    return -1;
 
-            return lvh.assign(val.refSelf(), "<API assignment>");
-         }
-      }
-      w = w->prev;
-      if (!w)
-         break;
-      p = w->pos;
-   }
-   return 1;
+                return lvh.assign(val.refSelf(), "<API assignment>");
+            }
+        }
+        w = w->prev;
+        if (!w)
+            break;
+        p = w->pos;
+    }
+    return 1;
 }

--- a/lib/Variable.cpp
+++ b/lib/Variable.cpp
@@ -1787,7 +1787,6 @@ int LocalVarValue::getLValue(LValueHelper& lvh, bool for_remove, const QoreTypeI
 
 void LocalVarValue::remove(LValueRemoveHelper& lvrh, const QoreTypeInfo* typeInfo) {
     if (val.getType() == NT_REFERENCE) {
-        VarStackPointerHelper<LocalVarValue> helper(const_cast<LocalVarValue*>(this));
         ReferenceNode* ref = reinterpret_cast<ReferenceNode*>(val.v.n);
         lvrh.doRemove(lvalue_ref::get(ref)->vexp);
         return;
@@ -1830,8 +1829,6 @@ void ClosureVarValue::remove(LValueRemoveHelper& lvrh) {
     if (val.getType() == NT_REFERENCE) {
         ReferenceHolder<ReferenceNode> ref(reinterpret_cast<ReferenceNode*>(val.v.n->refSelf()), lvrh.getExceptionSink());
         sl.unlock();
-        // skip this entry in case it's a recursive reference
-        VarStackPointerHelper<ClosureVarValue> helper(const_cast<ClosureVarValue*>(this));
         lvrh.doRemove(lvalue_ref::get(*ref)->vexp);
         return;
     }


### PR DESCRIPTION
…kip" flag was set to avoid processing recursive references, but in multithreaded contexts, this could lead to the variable being invisible in other threads leading to a crash.  In any case, recursive references are caught on assignment, so the "skip" flag (and associated logic) was removed

removed a test for a removed type in BulkPgsqlSqlUtil.qtest