### PR TITLE
refs #3152 raise a warning when the catch var has no type and types a…

### DIFF
--- a/bin/qdbg-server
+++ b/bin/qdbg-server
@@ -5,10 +5,11 @@
 %new-style
 %allow-debugger
 
-%requires qore >= 0.8.13
+%requires qore >= 1.0
 %requires HttpServer
 %requires DebugProgramControl
 %requires DebugHandler
+%requires Logger
 
 %exec-class DebugWrapper
 
@@ -73,12 +74,21 @@ class DebugWrapper {
             wsHandler.logger = logger;
 
             logger.log(DUV_DEBUG, "create HttpServer");
-            mServer = new HttpServer(\httplog(), \httperr(), logger.verbose >= DUV_DEBUG);
+
+            Logger http_logger("my-logger", LoggerLevel::getLevelInfo());
+            if (logger.verbose >= DUV_DEBUG) {
+                http_logger.addAppender(new MyAppender());
+            }
+            hash<HttpServerOptionInfo> http_opts = <HttpServerOptionInfo>{
+                "logger": http_logger,
+                "debug": True,
+            };
+            mServer = new HttpServer(http_opts);
             mServer.setHandler("ws-handler", opt.path ?? "", wsHandler.getContentType(), wsHandler);
             mServer.setDefaultHandler("ws-handler", wsHandler);
             if (opt.listen) {
                 foreach string l in (opt.listen) {
-                    mServer.addListener(l);
+                    mServer.addListener(http_get_listener_options_from_bind(l));
                     logger.log(DUV_INFO, "started debug server listener: %s", l);
                 }
             } else {
@@ -128,5 +138,19 @@ class DebugWrapper {
     }
 
     public dummy() {
+    }
+}
+
+class MyAppender inherits LoggerAppenderWithLayout {
+    constructor() : LoggerAppenderWithLayout("test", new LoggerLayoutPattern("%d T%t [%p]: %m%n")) {
+        open();
+    }
+
+    processEventImpl(int type, auto params) {
+        switch (type) {
+            case EVENT_LOG:
+                print(params);
+                break;
+        }
     }
 }

--- a/doxygen/lang/195_statements.dox.tmpl
+++ b/doxygen/lang/195_statements.dox.tmpl
@@ -299,7 +299,10 @@ Skips the rest of a loop and jumps right to the evaluation of the iteration expr
     @section context context Statements
 
     @par Synopsis
-    To easily iterate through multiple rows in a hash of arrays (such as a query result set returned by the Qore::SQL::Datasource::select() or Qore::SQL::SQLStatement::fetchColumns() methods), the <tt><b>context</b></tt> statement can be used. Column names can be referred to directly in expressions in the scope of the context statement by preceding the name with a \c "%" character.
+    To easily iterate through multiple rows in a hash of arrays (such as a query result set returned by the
+    Qore::SQL::Datasource::select() or Qore::SQL::SQLStatement::fetchColumns() methods), the <tt><b>context</b></tt>
+    statement can be used. Column names can be referred to directly in expressions in the scope of the context
+    statement by preceding the name with a \c "%" character, while the current row can be referenced with \c %%.
 
     @par Syntax
     <tt><b>context</b></tt> <em>[name]</em> <tt>(</tt><em>@ref expressions "data_expression"</em><tt>)</tt>\n
@@ -312,19 +315,31 @@ Skips the rest of a loop and jumps right to the evaluation of the iteration expr
     <em>@ref expressions "data_expression"</em>\n
     This must evaluate to a hash of arrays in order for the <tt><b>context</b></tt> statement to execute.\n\n
     <em>@ref expressions "where_expression"</em>\n
-    An optional <b><tt>where</tt></b> expression may be given, in which case for each row in the hash, the expression will be executed, and if the where expression evaluates to @ref True "True", the row will be iterated in the context loop. If this expression evaluates to @ref False "False", then the row will not be iterated. This option is given so the programmer can create multiple views of a single data structure (such as a query result set) in memory rather than build different data structures by hand (or retrieve the data multiple times from a database).\n\n
+    An optional <b><tt>where</tt></b> expression may be given, in which case for each row in the hash, the expression
+    will be executed, and if the where expression evaluates to @ref True "True", the row will be iterated in the
+    context loop. If this expression evaluates to @ref False "False", then the row will not be iterated. This option
+    is given so the programmer can create multiple views of a single data structure (such as a query result set) in
+    memory rather than build different data structures by hand (or retrieve the data multiple times from a
+    database).\n\n
     <em>@ref expressions "sort_expression"</em>\n
-    An optional <tt><b>sortBy</b></tt> expression may also be given. In this case, the expression will be evaluated for each row of the query given, and then the result set will be sorted in ascending order by the results of the expressions according to the resulting type of the evaluated expression (i.e. if the result of the evaluation of the expression gives a string, then string order is used to sort, if the result of the evaluation is an integer, then integer order is used, etc).\n\n
+    An optional <tt><b>sortBy</b></tt> expression may also be given. In this case, the expression will be evaluated
+    for each row of the query given, and then the result set will be sorted in ascending order by the results of the
+    expressions according to the resulting type of the evaluated expression (i.e. if the result of the evaluation of
+    the expression gives a string, then string order is used to sort, if the result of the evaluation is an integer,
+    then integer order is used, etc).\n\n
     <em>@ref expressions "sort_descending_expression"</em>\n
-    Another optional modifier to the <tt><b>context</b></tt> statement that behaves the same as above except that the results are sorted in descending order.
+    Another optional modifier to the <tt><b>context</b></tt> statement that behaves the same as above except that the
+    results are sorted in descending order.
 
     @par Example
     @code{.py}
 # note that "%service_type" and "%effective_start_date" represent values
 # in the service_history hash of arrays.
 context (service_history) where (%service_type == "voice")
-sortBy (%effective_start_date) {
-   printf("%s: start date: %s\n", %msisdn, format_date("YYYY-MM-DD HH:mm:SS", %effective_start_date));
+        sortBy (%effective_start_date) {
+    # %% is a hash of the current row
+    check_row(%%);
+    printf("%s: start date: %s\n", %msisdn, format_date("YYYY-MM-DD HH:mm:SS", %effective_start_date));
 }
     @endcode
 

--- a/doxygen/lang/250_warnings.dox.tmpl
+++ b/doxygen/lang/250_warnings.dox.tmpl
@@ -25,6 +25,7 @@
     - @ref duplicate-hash-key
     - @ref duplicate-local-vars
     - @ref excess-args
+    - @ref invalid-catch
     - @ref invalid-operation
     - @ref module-only
     - @ref non-existent-method-call
@@ -78,6 +79,11 @@
     @section excess-args excess-args
     Raised when a function or method call is made with more arguments than are used by the function or method
     @since %Qore 0.8.0
+
+    <hr>
+    @section invalid-catch invalid-catch
+    Raised when a @ref try "catch block" exception variable has no type declaration, but types are required
+    @since %Qore 1.0
 
     <hr>
     @section invalid-operation invalid-operation

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -7,12 +7,23 @@
     @par Release Summary
     Bugfix release; see below for more information
 
+    @subsection qore_1_0_compatibility Fixes That Can Affect Backwards-Compatibility
+    - Some server-side APIs have changed due to the integration of the
+      <a href="../../modules/Logger/html/index.html">Logger</a> module in the
+      <a href="../../modules/HttpServer/html/index.html">HttpServer</a> and the
+      <a href="../../modules/HttpServerUtil/html/index.html">HttpServerUtil</a> modules, in particular the
+      \a errorlogger listener option has been removed, and the type of the \a logger listener option has been
+      updated to require a \c Logger object.  Additionally, deprecated APIs have been removed from these modules.
+    - Implemented the @ref invalid-catch "invalid-catch" warning when types are required by parse options, byt the
+      exception variable declaration has no type, and added this to the default warning mask for modules
+
     @subsection qore_1_0_new_features New Features in Qore
     - added support for <a href="https://alpinelinux.org/">Alpine Linux</a>
     - added support for @ref thread_local_variables "thread-local global variables"; see the
       @ref thread_local "thread_local" keyword
     - new constants:
       - @ref Qore::PO_NO_INHERIT_PROGRAM_DATA "PO_NO_INHERIT_PROGRAM_DATA"
+      - @ref Qore::WARN_INVALID_CATCH "WARN_INVALID_CATCH"
     - updated methods:
       - @ref <value>::fullType()
     - type errors with function and method resolution will report the full namespace paths of class and hashdecl
@@ -34,18 +45,10 @@
           directly to @ref Logger::Logger "Logger" objects
           (<a href="https://github.com/qorelanguage/qore/issues/4164">issue 4164</a>)
 
-    @subsection qore_1_0_compatibility Fixes That Can Affect Backwards-Compatibility
-    - Some server-side APIs have changed due to the integration of the
-      <a href="../../modules/Logger/html/index.html">Logger</a> module in the
-      <a href="../../modules/HttpServer/html/index.html">HttpServer</a> and the
-      <a href="../../modules/HttpServerUtil/html/index.html">HttpServerUtil</a> modules, in particular the
-      \a errorlogger listener option has been removed, and the type of the \a logger listener option has been
-      updated to require a \c Logger object.  Additionally, deprecated APIs have been removed from these modules.
-
     @subsection qore_1_0_bug_fixes Bug Fixes in Qore
     - <a href="../../modules/Qdx/html/index.html">Qdx</a> module
       - fixed stripping the final \c "\" character in multi-line entries in tables
-        (<a href="https://github.com/qorelanguage/qore/issues/4195>issue 4195</a>)
+        (<a href="https://github.com/qorelanguage/qore/issues/4195">issue 4195</a>)
     - fixed a bug handling @ref softlist_complex_type "complex softlist<...>" values where illegal matches were
       allowed under some circumstances leading to runtime errors
       (<a href="https://github.com/qorelanguage/qore/issues/4184">issue 4184</a>)

--- a/examples/test/qore/vars/string.qtest
+++ b/examples/test/qore/vars/string.qtest
@@ -57,6 +57,13 @@ class StringTest inherits QUnit::Test {
             Program p(PO_NEW_STYLE | PO_STRICT_TYPES);
             assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("string str = 'a'; str += {};", ""));
         };
+        {
+            Program p(PO_NEW_STYLE);
+            *hash<ExceptionInfo> warn = p.parse("auto sub test() { string str = 'a'; *list<auto> v = (); return str + v; }", "",
+                -1);
+            assertNothing(warn.err);
+            assertEq(("a",), p.callFunction("test"));
+        }
     }
 
     testWidth() {

--- a/include/qore/QoreProgram.h
+++ b/include/qore/QoreProgram.h
@@ -59,9 +59,10 @@
 #define QP_WARN_DUPLICATE_BLOCK_VARS     (1 << 14)  //!< when a variable is declared more than once in the same block; this would normally be an error, but for backwards-compatibility it's just a warning unless parse option 'assume-local' is set, in which case it's an error
 #define QP_WARN_MODULE_ONLY              (1 << 15)  //!< when qualifiers that are only valid in modules are given when not parsing a module
 #define QP_WARN_BROKEN_LOGIC_PRECEDENCE  (1 << 16)  //!< warning about expressions that are affected by broken-logic-precedence
+#define QP_WARN_INVALID_CATCH            (1 << 17)  //!< when a catch block is missing a type declaration when %require-types is in effect
 #define QP_WARN_ALL                      -1         //!< for all possible warnings
 
-#define QP_WARN_MODULES (QP_WARN_UNREACHABLE_CODE|QP_WARN_NONEXISTENT_METHOD_CALL|QP_WARN_INVALID_OPERATION|QP_WARN_CALL_WITH_TYPE_ERRORS|QP_WARN_RETURN_VALUE_IGNORED|QP_WARN_DUPLICATE_HASH_KEY|QP_WARN_DUPLICATE_BLOCK_VARS|QP_WARN_BROKEN_LOGIC_PRECEDENCE)
+#define QP_WARN_MODULES (QP_WARN_UNREACHABLE_CODE|QP_WARN_NONEXISTENT_METHOD_CALL|QP_WARN_INVALID_OPERATION|QP_WARN_CALL_WITH_TYPE_ERRORS|QP_WARN_RETURN_VALUE_IGNORED|QP_WARN_DUPLICATE_HASH_KEY|QP_WARN_DUPLICATE_BLOCK_VARS|QP_WARN_BROKEN_LOGIC_PRECEDENCE|QP_WARN_INVALID_CATCH)
 
 #define QP_WARN_DEFAULT (QP_WARN_UNKNOWN_WARNING|QP_WARN_MODULES|QP_WARN_DEPRECATED)
 

--- a/lib/QC_GetOpt.qpp
+++ b/lib/QC_GetOpt.qpp
@@ -461,6 +461,13 @@ hash<auto> GetOpt::parse3(softlist<auto> pgm_args) [dom=PROCESS] {
 //! Parses the given options and returns a hash of the parsed options
 /** @par Example:
     @code{.py}
+const Opts = {
+     "url"  : "u,url=s",
+     "xml"  : "x,xml",
+     "lxml" : "X,literal-xml",
+     "verb" : "v,verbose",
+     "help" : "h,help",
+};
 hash<auto> o = GetOpt::parse(Opts, \ARGV);
 if (exists o."_ERRORS_") {
     foreach string err in (o."_ERRORS_")
@@ -469,6 +476,20 @@ if (exists o."_ERRORS_") {
 }
     @endcode
 
+    @param opts a hash where each key defines the key value for the return hash if any arguments are given
+    corresponding to the string value of the key; The string value of each hash key follows the following pattern:\n
+    <em>opts</em><tt>[(=|:)</tt><em>type</em><tt>[</tt><em>modifier</em><tt>]]</tt>\n
+    Where the meaning of the above placeholders in italics is:\n
+    - <em>opts</em>: At least one short option and/or a long option name; if both are present, then they must be
+      separated by a comma. The short option must be a single character.
+    - <tt>(=|:)</tt><em>type</em>: if \c "=" is used, then the option takes a mandatory argument, if \c ":" is used,
+      then the argument is optional. Types are specified as follows:
+      - <em>s</em>: string
+      - <em>i</em>: integer
+      - <em>f</em>: float
+      - <em>d</em>: date
+      - <em>b</em>: boolean
+    - <em>modifier</em>: \c "@" specifies a list, \c "+" an additive value (sum; must be integer or float type)
     @param pgm_args The reference should point to a list of arguments to process (normally <tt>ARGV</tt>); any
     argument accepted by the object will be removed from the list
 
@@ -510,9 +531,30 @@ static hash<auto> GetOpt::parse(hash<auto> opts, reference<list<string>> pgm_arg
 //! Parses the given options and returns a hash of the parsed options and throws and exception if there are any errors
 /** @par Example:
     @code{.py}
+const Opts = {
+     "url"  : "u,url=s",
+     "xml"  : "x,xml",
+     "lxml" : "X,literal-xml",
+     "verb" : "v,verbose",
+     "help" : "h,help",
+};
 hash<auto> o = GetOpt::parseEx(Opts, \ARGV);
     @endcode
 
+    @param opts a hash where each key defines the key value for the return hash if any arguments are given
+    corresponding to the string value of the key; The string value of each hash key follows the following pattern:\n
+    <em>opts</em><tt>[(=|:)</tt><em>type</em><tt>[</tt><em>modifier</em><tt>]]</tt>\n
+    Where the meaning of the above placeholders in italics is:\n
+    - <em>opts</em>: At least one short option and/or a long option name; if both are present, then they must be
+      separated by a comma. The short option must be a single character.
+    - <tt>(=|:)</tt><em>type</em>: if \c "=" is used, then the option takes a mandatory argument, if \c ":" is used,
+      then the argument is optional. Types are specified as follows:
+      - <em>s</em>: string
+      - <em>i</em>: integer
+      - <em>f</em>: float
+      - <em>d</em>: date
+      - <em>b</em>: boolean
+    - <em>modifier</em>: \c "@" specifies a list, \c "+" an additive value (sum; must be integer or float type)
     @param pgm_args The reference should point to a list of arguments to process (normally <tt>ARGV</tt>); any
     argument accepted by the object will be removed from the list
 
@@ -526,8 +568,8 @@ hash<auto> o = GetOpt::parseEx(Opts, \ARGV);
     @throw GETOPT-ERROR error parsing arguments
 
     @see
-    - Qore::GetOpt::parse() "GetOpt::parse(hash<auto>, reference<list<string>>)"
-    - Qore::GetOpt::parseExit() "GetOpt::parseExit(hash<auto>, reference<list<string>>)"
+    - @ref Qore::GetOpt::parse() "GetOpt::parse(hash<auto>, reference<list<string>>)"
+    - @ref Qore::GetOpt::parseExit() "GetOpt::parseExit(hash<auto>, reference<list<string>>)"
 */
 static hash<auto> GetOpt::parseEx(hash<auto> opts, reference<list<string>> pgm_args) {
     SimpleRefHolder<GetOpt> g(GETOPT_constructor_intern(opts, xsink));
@@ -556,9 +598,30 @@ static hash<auto> GetOpt::parseEx(hash<auto> opts, reference<list<string>> pgm_a
 //! Parses the given options and returns a hash of the parsed options; prints out an error message and exits the program if there are any errors
 /** @par Example:
     @code{.py}
+const Opts = {
+     "url"  : "u,url=s",
+     "xml"  : "x,xml",
+     "lxml" : "X,literal-xml",
+     "verb" : "v,verbose",
+     "help" : "h,help",
+};
 hash<auto> o = GetOpt::parseExit(Opts, \ARGV);
     @endcode
 
+    @param opts a hash where each key defines the key value for the return hash if any arguments are given
+    corresponding to the string value of the key; The string value of each hash key follows the following pattern:\n
+    <em>opts</em><tt>[(=|:)</tt><em>type</em><tt>[</tt><em>modifier</em><tt>]]</tt>\n
+    Where the meaning of the above placeholders in italics is:\n
+    - <em>opts</em>: At least one short option and/or a long option name; if both are present, then they must be
+      separated by a comma. The short option must be a single character.
+    - <tt>(=|:)</tt><em>type</em>: if \c "=" is used, then the option takes a mandatory argument, if \c ":" is used,
+      then the argument is optional. Types are specified as follows:
+      - <em>s</em>: string
+      - <em>i</em>: integer
+      - <em>f</em>: float
+      - <em>d</em>: date
+      - <em>b</em>: boolean
+    - <em>modifier</em>: \c "@" specifies a list, \c "+" an additive value (sum; must be integer or float type)
     @param pgm_args The reference should point to a list of arguments to process (normally <tt>ARGV</tt>); any
     argument accepted by the object will be removed from the list
 
@@ -569,8 +632,8 @@ hash<auto> o = GetOpt::parseExit(Opts, \ARGV);
     All arguments parsed will be removed from \a pgm_args, leaving only unparsed arguments (for example, file names).
 
     @see
-    - Qore::GetOpt::parse() "GetOpt::parse(hash<auto>, reference<list<string>>)"
-    - Qore::GetOpt::parseEx() "GetOpt::parseEx(hash<auto>, reference<list<string>>)"
+    - @ref Qore::GetOpt::parse() "GetOpt::parse(hash<auto>, reference<list<string>>)"
+    - @ref Qore::GetOpt::parseEx() "GetOpt::parseEx(hash<auto>, reference<list<string>>)"
 */
 static hash<auto> GetOpt::parseExit(hash<auto> opts, reference<list<string>> pgm_args) [dom=PROCESS] {
     SimpleRefHolder<GetOpt> g(GETOPT_constructor_intern(opts, xsink));

--- a/lib/QC_Program.qpp
+++ b/lib/QC_Program.qpp
@@ -779,6 +779,7 @@ const WARN_CALL_WITH_TYPE_ERRORS = QP_WARN_CALL_WITH_TYPE_ERRORS;
     - @ref WARN_DUPLICATE_HASH_KEY
     - @ref WARN_DUPLICATE_BLOCK_VARS
     - @ref WARN_BROKEN_LOGIC_PRECEDENCE
+    - @ref WARN_INVALID_CATCH
 */
 const WARN_DEFAULT = QP_WARN_DEFAULT;
 
@@ -827,6 +828,7 @@ const WARN_INVALID_OPERATION = QP_WARN_INVALID_OPERATION;
     - @ref WARN_DUPLICATE_HASH_KEY
     - @ref WARN_DUPLICATE_BLOCK_VARS
     - @ref WARN_BROKEN_LOGIC_PRECEDENCE
+    - @ref WARN_INVALID_CATCH
 */
 const WARN_MODULES = QP_WARN_MODULES;
 
@@ -872,10 +874,19 @@ const WARN_WARNING_MASK_UNCHANGED = QP_WARN_WARNING_MASK_UNCHANGED;
 
 //! This warns before expressions affected by @ref broken-logic-precedence "%broken-logic-precedence"
 /** @see @ref warning-broken-logic-precedence
- *
+
     @since %Qore 0.8.12.11
 */
 const WARN_BROKEN_LOGIC_PRECEDENCE = QP_WARN_BROKEN_LOGIC_PRECEDENCE;
+
+//! This warns when the catch variable has no type definition and types are required
+/** @see @ref invalid-catch
+
+    @note This is an error when @ref strict-types "%strict-types" is in effect
+
+    @since %Qore 1.0
+*/
+const WARN_INVALID_CATCH = QP_WARN_INVALID_CATCH;
 //@}
 
 //! Program objects allow %Qore programs to support subprograms with the option to restrict capabilities, for example, to support user-defined logic for application actions

--- a/lib/QC_Socket.qpp
+++ b/lib/QC_Socket.qpp
@@ -6,7 +6,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2021 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -79,7 +79,7 @@ static int check_response_code(int status_code, ExceptionSink* xsink) {
 }
 
 //! Socket poll info hash
-/** for use with @ref Qore::Sockett::poll() "Socket::poll()""
+/** for use with @ref Qore::Socket::poll() "Socket::poll()""
 */
 hashdecl Qore::SocketPollInfo {
     //! Socket poll type; see @ref socket_poll_constants for possible values to be combined with binary or; on input, these are the events to check, on output, this value gives the events found in the timeout period
@@ -88,7 +88,7 @@ hashdecl Qore::SocketPollInfo {
     Socket socket;
 }
 
-/** @defgroup zsocket_poll_constants ZSocket Poll Constants
+/** @defgroup socket_poll_constants Socket Poll Constants
 */
 //@{
 //! (input and output) for polling for read events
@@ -3313,7 +3313,7 @@ list<hash<SocketPollInfo>> l(
 l = Socket::poll(l, 2s);
     @endcode
 
-    @param item list of @ref SocketPollInfo hashes of sockets with events in the timeoutt period
+    @param items list of @ref SocketPollInfo hashes of sockets with events in the timeoutt period
     @param timeout_ms the poll timeout period; -1 = never timeout
 
     @return a list of sockets with events in the timeout period

--- a/lib/QorePlusOperatorNode.cpp
+++ b/lib/QorePlusOperatorNode.cpp
@@ -217,8 +217,9 @@ void QorePlusOperatorNode::parseInitImpl(QoreValue& val, LocalVar* oflag, int pf
             returnTypeInfo = listTypeInfo;
         }
     }
-    // otherwise only set return type if return types on both sides are known at parse time
-    else if (QoreTypeInfo::hasType(leftTypeInfo) && QoreTypeInfo::hasType(rightTypeInfo)) {
+    // otherwise only set return type if return types on both sides are known at parse time and neither can be a list
+    else if (QoreTypeInfo::hasType(leftTypeInfo) && QoreTypeInfo::hasType(rightTypeInfo)
+        && !QoreTypeInfo::parseReturns(leftTypeInfo, NT_LIST) && !QoreTypeInfo::parseReturns(rightTypeInfo, NT_LIST)) {
         // issue #3157: try to handle timeout + date specially
         if (QoreTypeInfo::equal(leftTypeInfo, timeoutTypeInfo)
             && QoreTypeInfo::parseReturns(rightTypeInfo, NT_DATE)) {

--- a/lib/QoreProgram.cpp
+++ b/lib/QoreProgram.cpp
@@ -72,6 +72,7 @@ static const char* qore_warnings_l[] = {
     "duplicate-block-vars",
     "module-only",
     "broken-logic-precedence",
+    "invalid-catch",
 };
 #define NUM_WARNINGS (sizeof(qore_warnings_l)/sizeof(const char* ))
 

--- a/lib/parser.ypp
+++ b/lib/parser.ypp
@@ -2481,7 +2481,9 @@ try_statement:
             char* param = 0;
             const QoreTypeInfo* typeInfo = nullptr;
             QoreParseTypeInfo* parseTypeInfo = nullptr;
-            const QoreProgramLocation* loc = qore_program_private::get(*getProgram())->getLocation(@1.first_line, @7.last_line);
+            const QoreProgramLocation* loc =
+                qore_program_private::get(*getProgram())->getLocation(@1.first_line, @7.last_line);
+            bool missing_type_decl = true;
             if ($5.getType() == NT_VARREF) {
                 VarRefNode* varRefNode = $5.get<VarRefNode>();
                 param = varRefNode->takeName();
@@ -2490,13 +2492,32 @@ try_statement:
                     parseTypeInfo = varRefDeclNode->takeParseTypeInfo();
                     if (!parseTypeInfo)
                         typeInfo = varRefDeclNode->getTypeInfo();
+                    missing_type_decl = false;
                 }
             } else if ($5.getType() == NT_BAREWORD) {
                 param = $5.get<BarewordNode>()->takeString();
                 if (!parse_check_parse_option(PO_ALLOW_BARE_REFS))
-                    parse_error(*loc, "local variable '%s' in catch parameter list declared without '$' prefix, but parse option 'allow-bare-refs' is not set", param);
+                    parse_error(*loc, "local variable '%s' in catch parameter list declared without '$' prefix, but " \
+                        "parse option 'allow-bare-refs' is not set", param);
             } else if ($5) {
                 parse_error(*loc, "only one parameter accepted in catch block for exception hash");
+                missing_type_decl = false;
+            }
+            if ($5 && missing_type_decl) {
+                int64 po = parse_get_parse_options();
+                if (po & (PO_STRICT_TYPES|PO_REQUIRE_TYPES)) {
+                    SimpleRefHolder<QoreStringNode> desc(new QoreStringNodeMaker("the catch block is missing a " \
+                        "type declaration; the exception argument should be declared as 'hash<ExceptionInfo>' or " \
+                        "with a compatible type"));
+                    // issue #2943: raise an error for mixing string and non-scalar values with %strict-types
+                    if (po & PO_STRICT_TYPES) {
+                        desc->concat("; this is an error when %strict-types is in effect");
+                        qore_program_private::makeParseException(getProgram(), *loc, "PARSE-TYPE-ERROR", desc.release());
+                    } else {
+                        qore_program_private::makeParseWarning(getProgram(), *loc, QP_WARN_INVALID_CATCH,
+                            "INVALID-CATCH", desc.release());
+                    }
+                }
             }
             $5.discard(nullptr);
             const QoreProgramLocation* vloc = qore_program_private::get(*getProgram())->getLocation($5 ? @5.first_line : 0, $5 ? @5.last_line : 0);

--- a/qlib/FilePoller.qm
+++ b/qlib/FilePoller.qm
@@ -1,6 +1,6 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-/*  FilePoller.qm Copyright (C) 2014 - 2017 Qore Technologies s.r.o.
+/*  FilePoller.qm Copyright (C) 2014 - 2021 Qore Technologies s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -423,7 +423,7 @@ public namespace FilePoller {
                     if (runOnce())
                         continue;
                     fileSleep(poll_interval);
-                } catch (ex) {
+                } catch (hash<ExceptionInfo> ex) {
                     logInfo("cannot get file list from %y: %s: %s", path, ex.desc, ex.err);
                     runflag = False;
                     break;

--- a/qlib/Pop3Client.qm
+++ b/qlib/Pop3Client.qm
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! @file Pop3Client.qm POP3 client module definition
 
-/*  Pop3Client.qm Copyright 2013 - 2020 Qore Technologies, s.r.o.
+/*  Pop3Client.qm Copyright 2013 - 2021 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 */
 
 # minimum qore version
-%requires qore >= 0.9.5
+%requires qore >= 1.0
 
 # need mime definitions
 %requires Mime >= 1.0
@@ -304,8 +304,7 @@ Pop3Client pop3("pop3s://user@gmail.com:password@pop.gmail.com");
     destructor() {
         try {
             disconnect();
-        }
-        catch (hash<ExceptionInfo> ex) {
+        } catch (hash<ExceptionInfo> ex) {
             logDbg("Pop3Client disconnect: %s: %s", ex.err, ex.desc);
         }
     }
@@ -1009,8 +1008,7 @@ pop3.setEventQueue();
         if (isConnected()) {
             try {
                 disconnectIntern();
-            }
-            catch(ex) {
+            } catch() {
                 # ignore
             }
         }

--- a/qlib/RestSchemaValidator.qm
+++ b/qlib/RestSchemaValidator.qm
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! @file RestSchemaValidator.qm an abstract API for validating REST schemas
 
-/*  RestSchemaValidator.qm Copyright (C) 2017 - 2020 Qore Technologies, s.r.o.
+/*  RestSchemaValidator.qm Copyright (C) 2017 - 2021 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -556,7 +556,7 @@ public namespace RestSchemaValidator {
 
             const DataSerializationSupportList = keys DataSerializationSupport;
 
-%ifndef NoYaml
+%ifndef NoYamls
             const DeserializeYaml = (
                 "code": "yaml",
                 "in": \parse_yaml(),

--- a/qlib/VscDebugAdapter.qm
+++ b/qlib/VscDebugAdapter.qm
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! @file VscDebugAdapter Visual Studio Code debug adapter
 
-/*  VscDebugAdapter.qm Copyright 2013 - 2020 Qore Technologies, s.r.o.
+/*  VscDebugAdapter.qm Copyright 2013 - 2021 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -106,7 +106,7 @@ public namespace VscDebugAdapter {
                     } else {
                         m_file.open2(m_filename, O_CREAT | O_TRUNC | O_WRONLY);
                     }
-                } catch (ex) {
+                } catch (hash<ExceptionInfo> ex) {
                     stderr.printf("%y\n", ex);
                     m_logging = False;
                 }


### PR DESCRIPTION
…re required; raise an error if strict-types is declared

refs #2943 fixed an error where invalid warnings/errors were raised with *list types and the + operator with strings