### PR TITLE
refs #4257 fixed a potential crash when raising a large number of exc…

### DIFF
--- a/doxygen/lang/225_exception_handling.dox.tmpl
+++ b/doxygen/lang/225_exception_handling.dox.tmpl
@@ -2,19 +2,35 @@
 
     @tableofcontents
 
-    Exceptions are errors that can only be handled using a @ref try "try catch block". Any exception that is thrown in a @ref try "try block" will immediately cause execution of that thread to begin with the first statement of the @ref try "catch block", regardless of the position of the program pointer of the running thread, even if nested function or object method calls have been made.
+    Exceptions are errors that can only be handled using a @ref try "try catch block". Any exception that is thrown in
+    a @ref try "try block" will immediately cause execution of that thread to begin with the first statement of the
+    @ref try "catch block", regardless of the position of the program pointer of the running thread, even if nested
+    function or object method calls have been made.
 
-    Exceptions can be thrown by the %Qore system for a number of reasons, see the documentation for each function and object method for details.
+    Exceptions can be thrown by the %Qore system for a number of reasons, see the documentation for each function and
+    object method for details.
 
-    Programmers can also throw exceptions explicitly by using the @ref throw "throw" and @ref rethrow "rethrow" statements.
+    Programmers can also throw exceptions explicitly by using the @ref throw "throw" and @ref rethrow "rethrow"
+    statements.
 
-    Information about the exception, including the context in which the exception occurred, is saved in the exception hash, which can be retrieved by using a parameter variable in the @ref try "catch block".
+    Information about the exception, including the context in which the exception occurred, is saved in the exception
+    hash, which can be retrieved by using a parameter variable in the @ref try "catch block".
 
     The exception hash is defined in the @ref Qore::ExceptionInfo "ExceptionInfo" @ref hashdecl "hashdecl".
 
-    System exceptions always throw at least 2 values, populating the \c "err" and \c "desc" keys of the exception hash, giving the exception string code and the exception description string, respectively, and occassionally, depending on the function, the \c "arg" key may be populated with supporting information. User exceptions have no restrictions, any values given in the @ref throw "throw statement" will be mapped to exception keys as per the table above.
+    System exceptions always throw at least 2 values, populating the \c "err" and \c "desc" keys of the exception hash,
+    giving the exception string code and the exception description string, respectively, and occassionally, depending
+    on the function, the \c "arg" key may be populated with supporting information. User exceptions have no
+    restrictions, any values given in the @ref throw "throw statement" will be mapped to exception keys as per the
+    table above.
 
-    See the @ref on_exit "on_exit", @ref on_success "on_success" statement, and @ref on_error "on_error" statement for statements that allow for exception-safe and exception-dependent cleanup in %Qore code.
+    See the @ref on_exit "on_exit", @ref on_success "on_success" statement, and @ref on_error "on_error" statement for
+    statements that allow for exception-safe and exception-dependent cleanup in %Qore code.
 
-    Classes that assist in exception-safe lock handling are the @ref Qore::Thread::AutoLock "AutoLock class", the @ref Qore::Thread::AutoGate "AutoGate class", the @ref Qore::Thread::AutoReadLock "AutoReadLock class", and the @ref Qore::Thread::AutoWriteLock "AutoWriteLock class".
+    Classes that assist in exception-safe lock handling are the @ref Qore::Thread::AutoLock "AutoLock class", the
+    @ref Qore::Thread::AutoGate "AutoGate class", the @ref Qore::Thread::AutoReadLock "AutoReadLock class", and the
+    @ref Qore::Thread::AutoWriteLock "AutoWriteLock class".
+
+    @note A maximum limit of 20 exceptions can be raised at any time; excess exceptions over this limit will be
+    ignored.
 */

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -11,6 +11,9 @@
     - <a href="../../modules/DataProvider/html/index.html">DataProvider</a>
       - fixed a bug where the @ref data_type "data" type was not supported correctly as a data provider type
         (<a href="https://github.com/qorelanguage/qore/issues/4232">issue 4232</a>)
+    - fixed a potential crash when raising a large number of exceptions or parse warnings that can cause an unprotected
+      stack exhaustion error; max 20 exceptions can be raised at any one time; the rest are ignored
+      (<a href="https://github.com/qorelanguage/qore/issues/4257">issue 4257</a>)
     - fixed a potential deadlock loading user modules with complex initialization code
       (<a href="https://github.com/qorelanguage/qore/issues/4254">issue 4254</a>)
     - fixed a bug where SSL errors were not properly cleared before I/O operations in all cases, leading to incorrect

--- a/examples/test/qore/threads/background.qtest
+++ b/examples/test/qore/threads/background.qtest
@@ -117,7 +117,8 @@ class T {
             background extract str, 0; #13", "bg");
         };
 
-        *hash ex = testAssertion("background negative test", c, NOTHING, new TestResultExceptionType("PARSE-EXCEPTION"));
+        *hash<auto> ex = testAssertion("background negative test", c, NOTHING, new TestResultExceptionType("PARSE-EXCEPTION"));
+        printf("%N\n", ex);
 
         # count exceptions
         while (ex) {

--- a/include/qore/intern/QoreException.h
+++ b/include/qore/intern/QoreException.h
@@ -4,7 +4,7 @@
 
     Qore programming language exception handling support
 
-    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2021 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -107,7 +107,7 @@ public:
 
     // called for generic exceptions
     DLLLOCAL QoreHashNode* makeExceptionObjectAndDelete(ExceptionSink *xsink);
-    DLLLOCAL QoreHashNode* makeExceptionObject() const;
+    DLLLOCAL QoreHashNode* makeExceptionObject(int level = 0) const;
 
     // called for runtime exceptions
     DLLLOCAL QoreException(const char *n_err, QoreValue n_desc, QoreValue n_arg = QoreValue())

--- a/lib/QoreException.cpp
+++ b/lib/QoreException.cpp
@@ -148,7 +148,7 @@ QoreHashNode* QoreException::makeExceptionObject(int level) const {
 
     // add chained exceptions with this "chain reaction" call
     if (next) {
-         if (++level < QORE_MAX_EXCEPTIONS) {
+         if (level < QORE_MAX_EXCEPTIONS) {
              ph->setKeyValueIntern("next", next->makeExceptionObject(level + 1));
          }
     }


### PR DESCRIPTION
…eptions or parse warnings that can cause an unprotected stack exhaustion error; max 20 exceptions can be raised at any one time; the rest are ignored