### PR TITLE
refs #4314 added <string>::splitRegex() to allow splitting a string b…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -7,10 +7,17 @@
     @par Release Summary
     Bugfix release; see below for more information
 
+    @subsection qore_1_0_7_new_feature New Features
+    - new pseudo-methods:
+      - <string>::splitRegex()
+
     @subsection qore_1_0_7_bug_fixes Bug Fixes in Qore
     - <a href="../../modules/HttpServer/html/index.html">HttpServer</a> module
       - \c HttpServer::addListeners() has no mechanism for returning errors to the caller
         (<a href="https://github.com/qorelanguage/qore/issues/4312">issue 4312</a>)
+    - <a href="../../modules/Mapper/html/index.html">Mapper</a> module
+      - fixed bugs handling escaped \c "." characters in field names
+        (<a href="https://github.com/qorelanguage/qore/issues/4315">issue 4315</a>)
 
     @section qore_1_0_6 Qore 1.0.6
 

--- a/examples/test/qlib/DataProvider/DataProvider.qtest
+++ b/examples/test/qlib/DataProvider/DataProvider.qtest
@@ -805,6 +805,12 @@ public class DataProviderTest inherits QUnit::Test {
             Counter thread_cnt(1);
             Queue abort_queue();
             code submit = sub () {
+                if (m_options.verbose > 2) {
+                    printf("TID %d: infinite submission thread started\n", gettid());
+                }
+                on_exit if (m_options.verbose > 2) {
+                    printf("TID %d: infinite submission thread exiting\n", gettid());
+                }
                 try {
                     thread_cnt.dec();
                     pipe.submit(record_provider);
@@ -826,13 +832,32 @@ public class DataProviderTest inherits QUnit::Test {
                 sleep(50ms);
             }
 
+            if (m_options.verbose > 2) {
+                printf("TID %d: record processor0 size: %d; about to abort\n", gettid(), record_processor0.recs.size());
+                hash<auto> stacks = get_all_thread_call_stacks();
+                hash<auto> tmap;
+                foreach hash<auto> i in (stacks.pairIterator()) {
+                    splice i.value, 0, 2;
+                    tmap{i.key} = map $1.type != "new-thread" ? sprintf("%s %s()", get_ex_pos($1), $1.function) : "new-thread", i.value;
+                }
+                printf("all threads: %N\n", tmap);
+            }
+
             pipe.abort();
             assertEq(PS_ABORTED, pipe.getInfo().status);
-            #printf("%N\n", pipe.getInfo());
             assertThrows("PIPELINE-ERROR", \pipe.submit(), {});
+
+            if (m_options.verbose > 2) {
+                printf("TID %d: pipeline info: %N\n", gettid(), pipe.getInfo());
+            }
 
             *hash<ExceptionInfo> ex_info = abort_queue.get();
             assertEq("PIPELINE-SUBMISSION-ABORTED", ex_info.err);
+
+            if (m_options.verbose > 2) {
+                printf("TID %d: infinite submission exception: %s: %s\n", gettid(), ex_info.err, ex_info.desc);
+
+            }
 
             pipe.reset();
             pipe.submit({"a": 1});

--- a/examples/test/qlib/DataProvider/DataProvider.qtest
+++ b/examples/test/qlib/DataProvider/DataProvider.qtest
@@ -771,6 +771,11 @@ public class DataProviderTest inherits QUnit::Test {
                 #"debug_log": sub (string fmt) { vprintf(fmt + "\n", argv); },
                 #"error_log": sub (string fmt) { vprintf(fmt + "\n", argv); },
             });
+            if (Platform.CPU == "aarch64") {
+                opts.info_log = sub (string fmt) { vprintf(fmt + "\n", argv); };
+                opts.debug_log = sub (string fmt) { vprintf(fmt + "\n", argv); };
+                opts.error_log = sub (string fmt) { vprintf(fmt + "\n", argv); };
+            }
             DataProviderPipeline pipe(opts);
 
             TestRecordProcessor record_processor0("A");
@@ -825,6 +830,10 @@ public class DataProviderTest inherits QUnit::Test {
             assertEq(PS_ABORTED, pipe.getInfo().status);
             #printf("%N\n", pipe.getInfo());
             assertThrows("PIPELINE-ERROR", \pipe.submit(), {});
+
+            *hash<ExceptionInfo> ex_info = abort_queue.get();
+            assertEq("PIPELINE-SUBMISSION-ABORTED", ex_info.err);
+
             pipe.reset();
             pipe.submit({"a": 1});
             pipe.waitDone();

--- a/examples/test/qlib/DataProvider/DataProvider.qtest
+++ b/examples/test/qlib/DataProvider/DataProvider.qtest
@@ -788,11 +788,39 @@ public class DataProviderTest inherits QUnit::Test {
             pipe.submit({"a": 1});
             assertEq(PS_RUNNING, pipe.getInfo().status);
 
+            # wait for record count = 1
+            while (True) {
+                int size = record_processor0.recs.size();
+                if (size == 1) {
+                    break;
+                }
+                sleep(50ms);
+            }
+
             Counter thread_cnt(1);
-            code submit = sub () { try { thread_cnt.dec(); pipe.submit(record_provider); } catch (hash<ExceptionInfo> ex) {}};
+            Queue abort_queue();
+            code submit = sub () {
+                try {
+                    thread_cnt.dec();
+                    pipe.submit(record_provider);
+                    abort_queue.push();
+                } catch (hash<ExceptionInfo> ex) {
+                    abort_queue.push(ex);
+                }
+            };
             background submit();
             thread_cnt.waitForZero();
-            sleep(500ms);
+
+            # issue #4317: do not abort before we know the infinite record provider is in progress
+            # wait for record count >= 2
+            while (True) {
+                int size = record_processor0.recs.size();
+                if (size >= 2) {
+                    break;
+                }
+                sleep(50ms);
+            }
+
             pipe.abort();
             assertEq(PS_ABORTED, pipe.getInfo().status);
             #printf("%N\n", pipe.getInfo());

--- a/examples/test/qlib/DataProvider/DataProvider.qtest
+++ b/examples/test/qlib/DataProvider/DataProvider.qtest
@@ -771,11 +771,6 @@ public class DataProviderTest inherits QUnit::Test {
                 #"debug_log": sub (string fmt) { vprintf("TID " + gettid() + " " + fmt + "\n", argv); },
                 #"error_log": sub (string fmt) { vprintf("TID " + gettid() + " " + fmt + "\n", argv); },
             });
-            if (Platform.CPU == "aarch64") {
-                opts.info_log = sub (string fmt) { vprintf("TID " + gettid() + " " + fmt + "\n", argv); };
-                opts.debug_log = sub (string fmt) { vprintf("TID " + gettid() + " " + fmt + "\n", argv); };
-                opts.error_log = sub (string fmt) { vprintf("TID " + gettid() + " " + fmt + "\n", argv); };
-            }
             DataProviderPipeline pipe(opts);
 
             TestRecordProcessor record_processor0("A");

--- a/examples/test/qlib/DataProvider/DataProvider.qtest
+++ b/examples/test/qlib/DataProvider/DataProvider.qtest
@@ -767,14 +767,14 @@ public class DataProviderTest inherits QUnit::Test {
             InfiniteRecordProvider record_provider();
             hash<PipelineOptionInfo> opts({
                 "name": "test-pipeline-3",
-                #"info_log": sub (string fmt) { vprintf(fmt + "\n", argv); },
-                #"debug_log": sub (string fmt) { vprintf(fmt + "\n", argv); },
-                #"error_log": sub (string fmt) { vprintf(fmt + "\n", argv); },
+                #"info_log": sub (string fmt) { vprintf("TID " + gettid() + " " + fmt + "\n", argv); },
+                #"debug_log": sub (string fmt) { vprintf("TID " + gettid() + " " + fmt + "\n", argv); },
+                #"error_log": sub (string fmt) { vprintf("TID " + gettid() + " " + fmt + "\n", argv); },
             });
             if (Platform.CPU == "aarch64") {
-                opts.info_log = sub (string fmt) { vprintf(fmt + "\n", argv); };
-                opts.debug_log = sub (string fmt) { vprintf(fmt + "\n", argv); };
-                opts.error_log = sub (string fmt) { vprintf(fmt + "\n", argv); };
+                opts.info_log = sub (string fmt) { vprintf("TID " + gettid() + " " + fmt + "\n", argv); };
+                opts.debug_log = sub (string fmt) { vprintf("TID " + gettid() + " " + fmt + "\n", argv); };
+                opts.error_log = sub (string fmt) { vprintf("TID " + gettid() + " " + fmt + "\n", argv); };
             }
             DataProviderPipeline pipe(opts);
 
@@ -876,19 +876,55 @@ public class DataProviderTest inherits QUnit::Test {
             assertEq(0s, info2.duration);
             assertEq(0.0, info2.duration_secs);
             assertEq(0.0, info2.recs_per_sec);
+
+            # clear record processor cache
+            record_processor0.clear();
+
             pipe1.submit({"a": 1});
             assertEq(PS_RUNNING, pipe1.getInfo().status);
 
+            # wait for record count = 1
+            while (True) {
+                int size = record_processor0.recs.size();
+                if (size == 1) {
+                    break;
+                }
+                sleep(50ms);
+            }
+
             assertEq(0, thread_cnt.getCount());
+            assertEq(0, abort_queue.size());
             thread_cnt.inc();
-            submit = sub () { try { thread_cnt.dec(); pipe1.submit(record_provider); } catch (hash<ExceptionInfo> ex) {}};
+            submit = sub () {
+                try {
+                    thread_cnt.dec();
+                    pipe1.submit(record_provider);
+                    abort_queue.push();
+                } catch (hash<ExceptionInfo> ex) {
+                    abort_queue.push(ex);
+                }
+            };
             background submit();
             thread_cnt.waitForZero();
-            sleep(500ms);
+
+            # issue #4317: do not abort before we know the infinite record provider is in progress
+            # wait for record count >= 2
+            while (True) {
+                int size = record_processor0.recs.size();
+                if (size >= 2) {
+                    break;
+                }
+                sleep(50ms);
+            }
+
             pipe1.abort();
             assertEq(PS_ABORTED, pipe1.getInfo().status);
             #printf("%N\n", pipe.getInfo());
             assertThrows("PIPELINE-ERROR", \pipe1.submit(), {});
+
+            ex_info = abort_queue.get();
+            assertEq("PIPELINE-SUBMISSION-ABORTED", ex_info.err);
+
             pipe1.reset();
             pipe1.submit({"a": 1});
             pipe1.waitDone();
@@ -914,19 +950,55 @@ public class DataProviderTest inherits QUnit::Test {
             assertEq(0s, info2.duration);
             assertEq(0.0, info2.duration_secs);
             assertEq(0.0, info2.recs_per_sec);
+
+            # clear record processor cache
+            record_processor0.clear();
+
             pipe2.submit({"a": 1});
             assertEq(PS_RUNNING, pipe2.getInfo().status);
 
+            # wait for record count = 1
+            while (True) {
+                int size = record_processor0.recs.size();
+                if (size == 1) {
+                    break;
+                }
+                sleep(50ms);
+            }
+
             assertEq(0, thread_cnt.getCount());
+            assertEq(0, abort_queue.size());
             thread_cnt.inc();
-            submit = sub () { try { thread_cnt.dec(); pipe2.submit(record_provider); } catch (hash<ExceptionInfo> ex) {}};
+            submit = sub () {
+                try {
+                    thread_cnt.dec();
+                    pipe2.submit(record_provider);
+                    abort_queue.push();
+                } catch (hash<ExceptionInfo> ex) {
+                    abort_queue.push(ex);
+                }
+            };
             background submit();
             thread_cnt.waitForZero();
-            sleep(500ms);
+
+            # issue #4317: do not abort before we know the infinite record provider is in progress
+            # wait for record count >= 2
+            while (True) {
+                int size = record_processor0.recs.size();
+                if (size >= 2) {
+                    break;
+                }
+                sleep(50ms);
+            }
+
             pipe2.abort();
             assertEq(PS_ABORTED, pipe2.getInfo().status);
             #printf("%N\n", pipe.getInfo());
             assertThrows("PIPELINE-ERROR", \pipe2.submit(), {});
+
+            ex_info = abort_queue.get();
+            assertEq("PIPELINE-SUBMISSION-ABORTED", ex_info.err);
+
             pipe2.reset();
             pipe2.submit({"a": 1});
             pipe2.waitDone();

--- a/examples/test/qlib/Mapper/mapper.qtest
+++ b/examples/test/qlib/Mapper/mapper.qtest
@@ -247,6 +247,12 @@ public class MapperTest inherits QUnit::Test {
             ("output.1": 456, "output.2": "xyz", "output.3": 2),
         );
 
+        const DotMap2 = {
+            "output\\.1": "input\\.2",
+            "output\\.2": "input\\.1",
+            "output\\.3": {"struct": ("a", "b")},
+        };
+
         const OStructMap = (
             "a.id": "input.2",
             "a.other": "input.1",
@@ -1106,6 +1112,19 @@ public class MapperTest inherits QUnit::Test {
 
             # test for hash of lists format
             hash h = map {$1: ()}, DotInput[0].keyIterator();
+            map (map h{$1.key} += $1.value, $1.pairIterator()), DotInput;
+            assertEq(DotOutput, m.mapAll(h));
+            assertEq(4, m.getCount());
+        }
+
+        {
+            Mapper m(DotMap2);
+            list<auto> l = m.mapAll(DotInput);
+            assertEq(DotOutput, l);
+            assertEq(2, m.getCount());
+
+            # test for hash of lists format
+            hash<string, list<auto>> h = map {$1: ()}, keys DotInput[0];
             map (map h{$1.key} += $1.value, $1.pairIterator()), DotInput;
             assertEq(DotOutput, m.mapAll(h));
             assertEq(4, m.getCount());

--- a/examples/test/qore/vars/string.qtest
+++ b/examples/test/qore/vars/string.qtest
@@ -76,11 +76,11 @@ class StringTest inherits QUnit::Test {
         assertEq("list<string>", a.fullType());
         assertEq(("field", "1.field", "2\\.with\\.dots.field", "3"), a);
 
-        str.upr();
-        a = str.splitRegex("FIELD", RE_Caseless, True);
+        str = str.upr();
+        a = str.splitRegex("field", RE_Caseless, True);
         assertEq(True, a.complexType());
         assertEq("list<string>", a.fullType());
-        assertEq(("FIELD", "1.FIELD", "2\\.with\\.dots.FIELD", "3"), a);
+        assertEq(("FIELD", "1.FIELD", "2\\.WITH\\.DOTS.FIELD", "3"), a);
     }
 
     nonScalarTest() {

--- a/examples/test/qore/vars/string.qtest
+++ b/examples/test/qore/vars/string.qtest
@@ -16,6 +16,7 @@
 
 class StringTest inherits QUnit::Test {
     constructor() : QUnit::Test("String test", "1.0") {
+        addTestCase("split regex", \splitRegexTest());
         addTestCase("non scalar test", \nonScalarTest());
         addTestCase("width test", \testWidth());
         addTestCase("Basic functions test", \testBasics());
@@ -34,6 +35,52 @@ class StringTest inherits QUnit::Test {
         addTestCase("String conversion test", \testConversions());
         addTestCase("trim", \testTrim());
         set_return_value(main());
+    }
+
+    splitRegexTest() {
+        string str = "gee this is a long string";
+        list<string> a = str.splitRegex(" ");
+        assertEq(True, a.complexType());
+        assertEq("list<string>", a.fullType());
+        assertEq("is", a[2]);
+        assertEq("string", a[5]);
+
+        a = str.splitRegex(" ", True);
+        assertEq(True, a.complexType());
+        assertEq("list<string>", a.fullType());
+        assertEq("is ", a[2]);
+        assertEq("string", a[5]);
+
+        str = "field1.field2\\.with\\.dots.field3";
+        a = str.splitRegex("(?<!\\\\)\\.");
+        assertEq(True, a.complexType());
+        assertEq("list<string>", a.fullType());
+        assertEq(("field1", "field2\\.with\\.dots", "field3"), a);
+
+        a = str.splitRegex("(?<!\\\\)\\.", True);
+        assertEq(True, a.complexType());
+        assertEq("list<string>", a.fullType());
+        assertEq(("field1.", "field2\\.with\\.dots.", "field3"), a);
+
+        a = str.splitRegex("xxx");
+        assertTrue(a.size() == 1);
+        assertTrue(a[0] == str);
+
+        a = str.splitRegex("FIELD", RE_Caseless);
+        assertEq(True, a.complexType());
+        assertEq("list<string>", a.fullType());
+        assertEq(("", "1.", "2\\.with\\.dots.", "3"), a);
+
+        a = str.splitRegex("FIELD", RE_Caseless, True);
+        assertEq(True, a.complexType());
+        assertEq("list<string>", a.fullType());
+        assertEq(("field", "1.field", "2\\.with\\.dots.field", "3"), a);
+
+        str.upr();
+        a = str.splitRegex("FIELD", RE_Caseless, True);
+        assertEq(True, a.complexType());
+        assertEq("list<string>", a.fullType());
+        assertEq(("FIELD", "1.FIELD", "2\\.with\\.dots.FIELD", "3"), a);
     }
 
     nonScalarTest() {

--- a/include/qore/intern/QoreLibIntern.h
+++ b/include/qore/intern/QoreLibIntern.h
@@ -1020,7 +1020,8 @@ DLLLOCAL extern QoreString YamlNullString;
 
 DLLLOCAL extern bool q_disable_gc;
 
-DLLLOCAL QoreValue qore_parse_get_define_value(const QoreProgramLocation* loc, const char* str, QoreString& arg, bool& ok);
+DLLLOCAL QoreValue qore_parse_get_define_value(const QoreProgramLocation* loc, const char* str, QoreString& arg,
+    bool& ok);
 
 #ifndef HAVE_INET_NTOP
 DLLLOCAL const char* inet_ntop(int af, const void* src, char* dst, size_t size);
@@ -1040,15 +1041,21 @@ DLLLOCAL void ignore_return_value(QoreSimpleValue& n);
 
 DLLLOCAL void qore_string_init();
 
-DLLLOCAL QoreListNode* split_intern(const char* pattern, size_t pl, const char* str, size_t sl, const QoreEncoding* enc, bool with_separator = false);
-DLLLOCAL QoreStringNode* join_intern(const QoreStringNode* p0, const QoreListNode* l, int offset, ExceptionSink* xsink);
+DLLLOCAL QoreListNode* split_regex_intern(QoreRegex& regex, const char* str, size_t sl, const QoreEncoding* enc,
+    bool with_separator = false);
+DLLLOCAL QoreListNode* split_intern(const char* pattern, size_t pl, const char* str, size_t sl,
+    const QoreEncoding* enc, bool with_separator = false);
+DLLLOCAL QoreStringNode* join_intern(const QoreStringNode* p0, const QoreListNode* l, int offset,
+    ExceptionSink* xsink);
 DLLLOCAL QoreListNode* split_with_quote(ExceptionSink* xsink, const QoreString* sep, const QoreString* str,
     const QoreString* quote, bool trim_unquoted, AbstractIteratorHelper* h = nullptr,
     const QoreString* eol = nullptr);
 DLLLOCAL bool inlist_intern(const QoreValue arg, const QoreListNode* l, ExceptionSink* xsink);
 DLLLOCAL QoreStringNode* format_float_intern(const QoreString& fmt, double num, ExceptionSink* xsink);
-DLLLOCAL QoreStringNode* format_float_intern(int prec, const QoreString& dsep, const QoreString& tsep, double num, ExceptionSink* xsink);
-DLLLOCAL DateTimeNode* make_date_with_mask(const AbstractQoreZoneInfo* tz, const QoreString& dtstr, const QoreString& mask, ExceptionSink* xsink);
+DLLLOCAL QoreStringNode* format_float_intern(int prec, const QoreString& dsep, const QoreString& tsep, double num,
+    ExceptionSink* xsink);
+DLLLOCAL DateTimeNode* make_date_with_mask(const AbstractQoreZoneInfo* tz, const QoreString& dtstr,
+    const QoreString& mask, ExceptionSink* xsink);
 DLLLOCAL QoreHashNode* date_info(const DateTime& d);
 DLLLOCAL void init_charmaps();
 DLLLOCAL int do_unaccent(QoreString& str, const QoreString& src, ExceptionSink* xsink);

--- a/include/qore/intern/QoreRegex.h
+++ b/include/qore/intern/QoreRegex.h
@@ -2,7 +2,7 @@
 /*
     QoreRegex.h
 
-    Copyright (C) 2003 - 2019 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2021 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -64,6 +64,8 @@ public:
     DLLLOCAL bool exec(const QoreString* target, ExceptionSink* xsink) const;
     DLLLOCAL bool exec(const char* str, size_t len) const;
     DLLLOCAL QoreListNode* extractSubstrings(const QoreString* target, ExceptionSink* xsink) const;
+    DLLLOCAL QoreListNode* extractWithPattern(const QoreString& target, bool include_pattern,
+            ExceptionSink* xsink) const;
     // caller owns QoreString returned
     DLLLOCAL QoreString* getString();
 

--- a/lib/Pseudo_QC_String.qpp
+++ b/lib/Pseudo_QC_String.qpp
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2021 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -362,7 +362,7 @@ int <string>::toInt(int base=10) [flags=RET_VALUE_ONLY] {
         return xsink -> raiseException("INVALID-BASE", "base " QLLD " is invalid; base must be 0 or 2 - 36 inclusive", base);
     if (!str->getEncoding()->isAsciiCompat())
         return xsink -> raiseException("UNSUPPORTED-ENCODING", "cannot convert string in non-ASCII-compatible encoding \"%s\" to an integer", str->getEncoding()->getCode());
-    return strtoll(str -> getBuffer(), 0, (int)base);
+    return strtoll(str -> c_str(), 0, (int)base);
 }
 
 //! Returns @ref True by default
@@ -450,12 +450,12 @@ list<string> list = str.split(":"); # returns ("some", "text", "here")
     @since %Qore 0.8.5
  */
 list<string> <string>::split(string sep, bool with_separator = False) [flags=RET_VALUE_ONLY] {
-   // convert pattern encoding to string if necessary
-   TempEncodingHelper temp(sep, str->getEncoding(), xsink);
-   if (*xsink)
-      return QoreValue();
+    // convert pattern encoding to string if necessary
+    TempEncodingHelper temp(sep, str->getEncoding(), xsink);
+    if (*xsink)
+        return QoreValue();
 
-   return split_intern(temp->getBuffer(), temp->strlen(), str->getBuffer(), str->strlen(), str->getEncoding(), with_separator);
+    return split_intern(temp->c_str(), temp->strlen(), str->c_str(), str->strlen(), str->getEncoding(), with_separator);
 }
 
 //! Splits a string into a list of components based on a separator string and a quote character
@@ -474,7 +474,8 @@ list<string> <string>::split(string sep, bool with_separator = False) [flags=RET
 list<string> list = "some,'text with spaces, and commas, here is another one! ,',here".split(",", "'"); # returns ("some", ", and commas, here is another one! ,", "here")
     @endcode
 
-    @throw ENCODING-CONVERSION-ERROR this exception could be thrown if the string arguments have different @ref character_encoding "character encodings" and an error occurs during encoding conversion
+    @throw ENCODING-CONVERSION-ERROR this exception could be thrown if the string arguments have different @ref character_encoding "character encodings" and an error occurs during encoding conversion   return split_with_quote(xsink, sep, str, quote, trim_unquoted);
+
     @throw SPLIT-ERROR field missing closing quote character; extra text following quoted field
 
     @note equivalent to @ref Qore::split(string, string, string, bool)
@@ -484,11 +485,77 @@ list<string> list = "some,'text with spaces, and commas, here is another one! ,'
     - %Qore 0.8.6 added the \c trim_unquoted parameter
  */
 list<string> <string>::split(string sep, string quote, bool trim_unquoted = False) [flags=RET_VALUE_ONLY] {
-   return split_with_quote(xsink, sep, str, quote, trim_unquoted);
+    return split_with_quote(xsink, sep, str, quote, trim_unquoted);
+}
+
+//! Splits a string into a list of components based on a separator regular expression
+/**
+    @par Example:
+    @code{.py}
+string str = "some\\:text:here";
+list<string> list = str.splitRegex("(?<!\\\\)\\:"); # returns ("some\\:text", "here")
+    @endcode
+
+    @param regex_sep the separator regular expression; if the separator regular expression is not matched in the
+    string to split, then a list with only one element containing the entire string argument is returned'; if this
+    string has a different @ref character_encoding "character encoding" than \a str, then it will be converted to
+    <em>str</em>'s @ref character_encoding "character encoding"
+    @param options regular expression options; see @ref regex_constants for possible values
+    @param with_separator include the separator string in every element
+
+    @return a list of each component of a string separated by a separator regular expression, with the separator
+    removed; the separator pattern will not be included in the elements of the list returned unless the
+    \a with_separator argument is @ref True; the strings in the return value are always returned in UTF-8 encoding
+
+    @throw ENCODING-CONVERSION-ERROR this exception could be thrown if the string arguments have different
+    @ref character_encoding "character encodings" and an error occurs during encoding conversion
+
+    @since %Qore 1.0.7
+ */
+list<string> <string>::splitRegex(string regex_sep, int options = 0, bool with_separator = False) [flags=RET_VALUE_ONLY] {
+    QoreRegex qr(*regex_sep, options, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    return qr.extractWithPattern(*str, with_separator, xsink);
+}
+
+//! Splits a string into a list of components based on a separator regular expression
+/**
+    @par Example:
+    @code{.py}
+string str = "some\\:text:here";
+list<string> list = str.splitRegex("(?<!\\\\)\\:"); # returns ("some\\:text", "here")
+    @endcode
+
+    @param regex_sep the separator regular expression; if the separator regular expression is not matched in the
+    string to split, then a list with only one element containing the entire string argument is returned'; if this
+    string has a different @ref character_encoding "character encoding" than \a str, then it will be converted to
+    <em>str</em>'s @ref character_encoding "character encoding"
+    @param with_separator include the separator string in every element
+
+    @return a list of each component of a string separated by a separator regular expression, with the separator
+    removed; the separator pattern will not be included in the elements of the list returned unless the
+    \a with_separator argument is @ref True; the strings in the return value are always returned in UTF-8 encoding
+
+    @throw ENCODING-CONVERSION-ERROR this exception could be thrown if the string arguments have different
+    @ref character_encoding "character encodings" and an error occurs during encoding conversion
+
+    @since %Qore 1.0.7
+ */
+list<string> <string>::splitRegex(string regex_sep, bool with_separator = False) [flags=RET_VALUE_ONLY] {
+    QoreRegex qr(*regex_sep, 0, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    return qr.extractWithPattern(*str, with_separator, xsink);
 }
 
 //! Returns @ref True if the regular expression matches the string passed, otherwise returns @ref False
-/** Strings are converted to UTF-8 for pattern-matching; if any invalid encodings are encountered, an ENCODING-CONVERSION-ERROR is raised
+/** Strings are converted to UTF-8 for pattern-matching; if any invalid encodings are encountered, an
+    \c ENCODING-CONVERSION-ERROR is raised
 
     @param regex the regular expression pattern
     @param options regular expression options; see @ref regex_constants for possible values
@@ -502,7 +569,8 @@ bool b = "hello".regex("^hel"); # returns True
 
     @throw REGEX-COMPILATION-ERROR There was an error compiling the regular expression
     @throw REGEX-OPTION-ERROR the option argument contains invalid option bits
-    @throw ENCODING-CONVERSION-ERROR this exception could be thrown if an encoding error is encountered when converting the given strings to UTF-8
+    @throw ENCODING-CONVERSION-ERROR this exception could be thrown if an encoding error is encountered when
+    converting the given strings to UTF-8
 
     @note equivalent to @ref Qore::regex(string, string, int)
 
@@ -511,20 +579,23 @@ bool b = "hello".regex("^hel"); # returns True
     @since %Qore 0.8.5
  */
 bool <string>::regex(string regex, int options = 0) [flags=RET_VALUE_ONLY] {
-   QoreRegex qr(*regex, options, xsink);
-   if (*xsink)
-      return QoreValue();
+    QoreRegex qr(*regex, options, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
 
-   return qr.exec(str, xsink);
+    return qr.exec(str, xsink);
 }
 
 //! Returns a list of substrings in a string based on matching patterns defined by a regular expression
-/** Strings are converted to UTF-8 for pattern-matching; if any invalid encodings are encountered, an ENCODING-CONVERSION-ERROR is raised
+/** Strings are converted to UTF-8 for pattern-matching; if any invalid encodings are encountered, an
+    \c ENCODING-CONVERSION-ERROR is raised
 
     @param regex the regular expression to use for matching, elements should be given in parentheses
     @param options regular expression options; see @ref regex_constants for possible values
 
-    @return a list of substrings in a string based on matching patterns defined by a regular expression or @ref nothing if no match was made
+    @return a list of substrings in a string based on matching patterns defined by a regular expression or
+    @ref nothing if no match was made
 
     @par Example:
     @code{.py}
@@ -534,7 +605,8 @@ string str = "ns:element";
 
     @throw REGEX-COMPILATION-ERROR There was an error compiling the regular expression
     @throw REGEX-OPTION-ERROR the option argument contains invalid option bits
-    @throw ENCODING-CONVERSION-ERROR this exception could be thrown if an encoding error is encountered when converting the given strings to UTF-8
+    @throw ENCODING-CONVERSION-ERROR this exception could be thrown if an encoding error is encountered when
+    converting the given strings to UTF-8
 
     @note equivalent Qore::regex_extract(string, string, int)
 
@@ -542,14 +614,15 @@ string str = "ns:element";
 
     @since %Qore 0.8.5
 
-    @since %Qore 0.8.8 this function accepts the @ref Qore::RE_Global option to extract all occurrences of the pattern(s) in a string
+    @since %Qore 0.8.8 this function accepts the @ref Qore::RE_Global option to extract all occurrences of the
+    pattern(s) in a string
  */
 *list<*string> <string>::regexExtract(string regex, int options = 0) [flags=RET_VALUE_ONLY] {
-   QoreRegex qr(*regex, options, xsink);
-   if (*xsink)
-      return QoreValue();
+    QoreRegex qr(*regex, options, xsink);
+    if (*xsink)
+        return QoreValue();
 
-   return qr.extractSubstrings(str, xsink);
+    return qr.extractSubstrings(str, xsink);
 }
 
 //! Returns the <a href="http://en.wikipedia.org/wiki/MD5">MD5 message digest</a> of the string as a hex string
@@ -862,7 +935,7 @@ int <string>::comparePartial(string ostr) [flags=RET_VALUE_ONLY] {
    if (*xsink)
       return QoreValue();
 
-   int rc = strncmp(str->getBuffer(), temp->getBuffer(), temp->size());
+   int rc = strncmp(str->c_str(), temp->c_str(), temp->size());
    return !rc ? 0 : (rc < 0 ? -1 : 1);
 }
 
@@ -987,10 +1060,10 @@ bool <string>::sizep() [flags=CONSTANT] {
 
    int64 strsize = 0;
 
-   const char* start = str->getBuffer() + offset;
+   const char* start = str->c_str() + offset;
    SimpleRefHolder<QoreStringNode> rv(new QoreStringNode(str->getEncoding()));
    if (eolstr) {
-      const char* p = strstr(start, eolstr->getBuffer());
+      const char* p = strstr(start, eolstr->c_str());
       if (p) {
          strsize = p - start + eolstr->size();
          if (trim) {

--- a/lib/ql_string.qpp
+++ b/lib/ql_string.qpp
@@ -1,32 +1,32 @@
 /* -*- mode: c++; indent-tabs-mode: nil -*- */
 /*
-  ql_string.qpp
+    ql_string.qpp
 
-  Qore Programming Language
+    Qore Programming Language
 
-  Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2021 Qore Technologies, s.r.o.
 
-  Permission is hereby granted, free of charge, to any person obtaining a
-  copy of this software and associated documentation files (the "Software"),
-  to deal in the Software without restriction, including without limitation
-  the rights to use, copy, modify, merge, publish, distribute, sublicense,
-  and/or sell copies of the Software, and to permit persons to whom the
-  Software is furnished to do so, subject to the following conditions:
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
 
-  The above copyright notice and this permission notice shall be included in
-  all copies or substantial portions of the Software.
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
 
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-  DEALINGS IN THE SOFTWARE.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
 
-  Note that the Qore library is released under a choice of three open-source
-  licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
-  information.
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
 */
 
 #include <qore/Qore.h>
@@ -90,7 +90,8 @@ static const char* memstr(const char* str, const char* pattern, size_t pl, size_
         if (!p)
             return nullptr;
 
-        //printd(5, "memstr() pattern: %s str: %p p: %p len: %d pl: %d remaining: %d (%c %c %c)\n", pattern, str, p, len, pl, len-(p-str), p[1], p[2], p[3]);
+        //printd(5, "memstr() pattern: %s str: %p p: %p len: %d pl: %d remaining: %d (%c %c %c)\n", pattern, str, p,
+        //  len, pl, len-(p-str), p[1], p[2], p[3]);
 
         // if there is not enough string left for the pattern, then return
         if ((len - (p - str)) < pl)
@@ -115,17 +116,18 @@ static const char* memstr(const char* str, const char* pattern, size_t pl, size_
     return nullptr;
 }
 
-static void split_add_element(QoreListNode* l, const char* str, unsigned len, const QoreEncoding *enc) {
-    if (enc)
+static void split_add_element(QoreListNode* l, const char* str, unsigned len, const QoreEncoding* enc) {
+    if (enc) {
         l->push(new QoreStringNode(str, len, enc), nullptr);
-    else {
+    } else {
         BinaryNode* b = new BinaryNode;
         b->append(str, len);
         l->push(b, nullptr);
     }
 }
 
-QoreListNode* split_intern(const char* pattern, size_t pl, const char* str, size_t sl, const QoreEncoding *enc, bool with_separator) {
+QoreListNode* split_intern(const char* pattern, size_t pl, const char* str, size_t sl, const QoreEncoding* enc,
+        bool with_separator) {
     QoreListNode* l = new QoreListNode(enc ? stringTypeInfo : binaryTypeInfo);
     const char* ostr = str;
     while (const char* p = memstr(str, pattern, pl, sl - (str - ostr))) {
@@ -1737,7 +1739,7 @@ string column = trunc_str(str, 80, dsp.getOSEncoding());
     @throw ENCODING-CONVERSION-ERROR this exception could be thrown if an explicit @ref character_encoding "character encoding" was given and an error occurs during encoding conversion
  */
 string trunc_str(softstring str, softint len, *string encoding) [flags=RET_VALUE_ONLY] {
-   const QoreEncoding *enc = encoding ? QEM.findCreate(encoding) : str->getEncoding();
+   const QoreEncoding* enc = encoding ? QEM.findCreate(encoding) : str->getEncoding();
    if (len <= 0)
       return new QoreStringNode(enc);
 

--- a/qlib/DataProvider/AbstractDataProcessor.qc
+++ b/qlib/DataProvider/AbstractDataProcessor.qc
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! Qore AbstractDataProcessor class definition
 
-/** AbstractDataProcessor.qc Copyright 2019 - 2020 Qore Technologies, s.r.o.
+/** AbstractDataProcessor.qc Copyright 2019 - 2021 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),

--- a/qlib/DataProvider/DataProviderPipeline.qc
+++ b/qlib/DataProvider/DataProviderPipeline.qc
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! Qore DataProviderPipeline class definition
 
-/** DataProviderPipeline.qc Copyright 2019 - 2020 Qore Technologies, s.r.o.
+/** DataProviderPipeline.qc Copyright 2019 - 2021 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),

--- a/qlib/Mapper.qm
+++ b/qlib/Mapper.qm
@@ -41,7 +41,7 @@
 %requires(reexport) DataProvider
 
 module Mapper {
-    version = "1.5.5";
+    version = "1.5.6";
     desc = "user module providing basic data mapping infrastructure";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -301,6 +301,10 @@ m.mapData(input1);           # output record hash date_begin = start_date = time
     Note that the @ref Mapper::Mapper::setRuntime() "Mapper::setRuntime()" and @ref Mapper::Mapper::replaceRuntime() "Mapper::replaceRuntime()" methods are deprecated - please use @ref Mapper::Mapper "Mapper" construction options to set runtime values instead. The methods are deprecated since runtime options duplicate existing functionality and are confusing and error-prone to use.
 
     @section mapperrelnotes Release Notes
+
+    @subsection mapperv1_5_6 Mapper v1.5.6
+    - respect escaped dots in field names (\.) when separating field names
+      (<a href="https://github.com/qorelanguage/qore/issues/4315">issue 4315</a>)
 
     @subsection mapperv1_5_5 Mapper v1.5.5
     - fixed handling automatically-acquired input and output data structions with dots in field names; un-deprecated
@@ -1284,6 +1288,8 @@ Mapper mapv(DataMap);
 
     #! raises an error if an invalid fields in structured input data are declared; sets "struct"
     private processStructuredInputField(string k, string name, reference<list<string>> struct) {
+        # convert any escaped dots in "name" to a dot
+        name =~ s/\\\././g;
         struct = ();
         *hash<string, AbstractDataField> current_fields = input;
         string current_name = name;
@@ -1314,7 +1320,7 @@ Mapper mapv(DataMap);
             }
             if (!found) {
                 # resolve the rest of the fields directly
-                struct += allow_dot ? current_name : current_name.split(".");
+                struct += allow_dot ? current_name : splitDottedFields(current_name);
                 break;
             }
         }
@@ -1326,6 +1332,11 @@ Mapper mapv(DataMap);
         if (!input{n})
             error("output field %y requires unknown input field %y; valid input fields are: %y", getFieldName(k),
                 name, keys input);
+    }
+
+    #! Splits a dotted field and replaces escaped (\.) dots with plain dots (.)
+    static list<string> splitDottedFields(string k) {
+        return map regex_subst($1, "\\\\.", ".", RE_Global), k.splitRegex("(?<!\\\\)\\.");
     }
 
     #! perform per-field pre-processing on the passed map in the constructor
@@ -1352,10 +1363,11 @@ Mapper mapv(DataMap);
                 *string basename = (k =~ x/([^\.]+)/)[0];
                 if (exists basename && (field = output{basename}) && field.isAssignableFrom(HashType)) {
                     # set key path for hash output fields
-                    fh.output_key_path = k.split(".");
+                    fh.output_key_path = splitDottedFields(k);
                     k = basename;
                 } else {
-                    error("output field %y is not a defined output field; known output fields: %y", getFieldName(k), keys output);
+                    error("output field %y is not a defined output field; known output fields: %y", getFieldName(k),
+                        keys output);
                 }
             }
             if (!field) {
@@ -1377,17 +1389,19 @@ Mapper mapv(DataMap);
         # process "name" key
         if (fh.name) {
             if (fh.struct)
-                error("output field %y has both 'name' (%y) and 'struct' (%y) values; only one can be given to identify the input field", getFieldName(k), fh.name, fh.struct);
-            if (input && !fh.hasKey("constant") && !fh.code && !exists fh.index && !exists fh.input_record
+                error("output field %y has both 'name' (%y) and 'struct' (%y) values; only one can be given to "
+                    "identify the input field", getFieldName(k), fh.name, fh.struct);
+            if (input && !fh.hasKey("constant") && !fh."code" && !exists fh.index && !exists fh.input_record
                 && !structured_input)
                 checkInputField(k, fh.name);
-            if (!allow_dot && !structured_input && fh.name =~ /\./)
-                fh.struct = (remove fh.name).split(".");
+            if (!allow_dot && (!structured_input || fh.name =~ /\\\./) && fh.name =~ /\./)
+                fh.struct = splitDottedFields(remove fh.name);
             else if (structured_input) {
                 processStructuredInputField(k, fh.name, \fh.struct);
             } else {
                 # add to ident list if the input and output fields are identical
-                if (fh.name == k && !fh.date_format && !fh.number_format && !fh.trunc && !trunc_all && !fh.subclass && !fh.code)
+                if (fh.name == k && !fh.date_format && !fh.number_format && !fh.trunc && !trunc_all && !fh.subclass
+                    && !fh.code)
                     identh{k} = True;
             }
         } else if (fh.runtime) {
@@ -1405,7 +1419,7 @@ Mapper mapv(DataMap);
             case NT_NOTHING:
                 break;
             case NT_STRING:
-                fh.struct = fh.struct.split("."); # then fall down to next case
+                fh.struct = splitDottedFields(fh.struct); # then fall down to next case
             case NT_LIST: {
                 if (!fh.struct)
                     error("output field %y has an empty 'struct' key", getFieldName(k));
@@ -1627,7 +1641,7 @@ Mapper mapv(DataMap);
 
         # check if the output field should be a hash
         if (!allow_output_dot && k =~ /\./) {
-            fh.ostruct = k.split(".");
+            fh.ostruct = splitDottedFields(k);
             mapo{fh.ostruct[0]} = NOTHING;
         } else {
             # add to consth if a constant value is included

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -169,7 +169,11 @@ for test in $TESTS; do
     if [ $MEASURE_TIME -eq 1 ]; then
         eval $TIME_CMD $QORE $test $TEST_OUTPUT_FORMAT
     else
-        $QORE $test $TEST_OUTPUT_FORMAT
+        if [ "${HOSTTYPE}" = "aarch64" -a -n "`echo $test|grep DataProvider`" ]; then
+            $QORE $test $TEST_OUTPUT_FORMAT
+        else
+            $QORE $test $TEST_OUTPUT_FORMAT
+        fi
     fi
 
     if [ $? -eq 0 ]; then

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -170,7 +170,7 @@ for test in $TESTS; do
         eval $TIME_CMD $QORE $test $TEST_OUTPUT_FORMAT
     else
         if [ "${HOSTTYPE}" = "aarch64" -a -n "`echo $test|grep DataProvider`" ]; then
-            $QORE $test $TEST_OUTPUT_FORMAT
+            $QORE $test -vvv $TEST_OUTPUT_FORMAT
         else
             $QORE $test $TEST_OUTPUT_FORMAT
         fi

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -169,11 +169,7 @@ for test in $TESTS; do
     if [ $MEASURE_TIME -eq 1 ]; then
         eval $TIME_CMD $QORE $test $TEST_OUTPUT_FORMAT
     else
-        if [ "`uname -m`" = "aarch64" -a -n "`echo $test|grep DataProvider`" ]; then
-            $QORE $test -vvv $TEST_OUTPUT_FORMAT
-        else
-            $QORE $test $TEST_OUTPUT_FORMAT
-        fi
+        $QORE $test $TEST_OUTPUT_FORMAT
     fi
 
     if [ $? -eq 0 ]; then

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -169,8 +169,7 @@ for test in $TESTS; do
     if [ $MEASURE_TIME -eq 1 ]; then
         eval $TIME_CMD $QORE $test $TEST_OUTPUT_FORMAT
     else
-        if [ -n "`echo $test|grep DataProvider`" ]; then
-            echo hosttype: ${HOSTTYPE}
+        if [ "`uname -m`" = "aarch64" -a -n "`echo $test|grep DataProvider`" ]; then
             $QORE $test -vvv $TEST_OUTPUT_FORMAT
         else
             $QORE $test $TEST_OUTPUT_FORMAT

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -169,7 +169,8 @@ for test in $TESTS; do
     if [ $MEASURE_TIME -eq 1 ]; then
         eval $TIME_CMD $QORE $test $TEST_OUTPUT_FORMAT
     else
-        if [ "${HOSTTYPE}" = "aarch64" -a -n "`echo $test|grep DataProvider`" ]; then
+        if [ -n "`echo $test|grep DataProvider`" ]; then
+            echo hosttype: ${HOSTTYPE}
             $QORE $test -vvv $TEST_OUTPUT_FORMAT
         else
             $QORE $test $TEST_OUTPUT_FORMAT


### PR DESCRIPTION
…ased on a regular expression

refs #4315 implemented support for escaped "." characters in mapper fields