### PR TITLE
refs #4360 fixed a bug in RestClient performing URL encoding - remove…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -19,6 +19,9 @@
     - <a href="../../modules/PgsqlSqlUtil/html/index.html">PgsqlSqlUtil</a> module
       - fixed handling column names that use reserved words
         (<a href="https://github.com/qorelanguage/qore/issues/4348">issue 4348</a>)
+    - <a href="../../modules/RestClient/html/index.html">RestClient</a> module
+      - removed erroneous / extraneous URI encoding on REST paths before sending
+        (<a href="https://github.com/qorelanguage/qore/issues/4360">issue 4360</a>)
     - <a href="../../modules/SqlUtil/html/index.html">SqlUtil</a> module
       - fixed upsert usage with unique constraints and indices when there is a non-matching PK
         (<a href="https://github.com/qorelanguage/qore/issues/4347">issue 4347</a>)
@@ -34,6 +37,9 @@
     - <a href="../../modules/Util/html/index.html">Util</a> module
       - fixed a bug in \c parse_to_qore_value() with floats and numbers with trailing zeros
         (<a href="https://github.com/qorelanguage/qore/issues/4349">issue 4349</a>)
+    - fixed issues encoding URLs in the @ref Qore::HTTPClient "HTTPClient" class according to
+      <a href="https://datatracker.ietf.org/doc/html/rfc1738#section-2.2">RFC 1738 section 2.2</a>
+      (<a href="https://github.com/qorelanguage/qore/issues/4361">issue 4361</a>)
     - fixed a bug parsing URLs with a query after the port (ex: \c "http://host:1234?query=true")
       (<a href="https://github.com/qorelanguage/qore/issues/4358">issue 4358</a>)
     - fixed a crashing bug when sorting large lists in background threads caused by excessive recursion and stack

--- a/include/qore/QoreHTTPClient.h
+++ b/include/qore/QoreHTTPClient.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2006 - 2019 Qore Technologies, s.r.o.
+  Copyright (C) 2006 - 2021 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -63,7 +63,8 @@ public:
     DLLEXPORT const QoreEncoding* getEncoding() const;
 
     DLLEXPORT int connect(ExceptionSink* xsink);
-    DLLEXPORT QoreHashNode* send(const char* meth, const char* path, const QoreHashNode* headers, const void* data, unsigned size, bool getbody, QoreHashNode* info, ExceptionSink* xsink);
+    DLLEXPORT QoreHashNode* send(const char* meth, const char* path, const QoreHashNode* headers, const void* data,
+            unsigned size, bool getbody, QoreHashNode* info, ExceptionSink* xsink);
 
     DLLEXPORT void setEventQueue(Queue* cbq, ExceptionSink* xsink);
 

--- a/include/qore/intern/QoreHttpClientObjectIntern.h
+++ b/include/qore/intern/QoreHttpClientObjectIntern.h
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2006 - 2020 Qore Technologies, s.r.o.
+    Copyright (C) 2006 - 2021 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),

--- a/qlib/RestClient.qm
+++ b/qlib/RestClient.qm
@@ -23,7 +23,7 @@
 */
 
 # minimum qore version
-%requires qore >= 0.9.7
+%requires qore >= 1.0
 
 # require type definitions everywhere
 %require-types
@@ -54,7 +54,7 @@
 %endtry
 
 module RestClient {
-    version = "1.7.3";
+    version = "1.7.4";
     desc = "user module for calling REST services";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -125,6 +125,10 @@ printf("%N\n", ans.body);
     could lead to compatibility problems; see @ref httpclient_get_with_body for more information
 
     @section restclientrelnotes Release Notes
+
+    @subsection restclientv1_7_4 RestClient v1.7.4
+    - removed erroneous / extraneous URI encoding on REST paths before sending
+      (<a href="https://github.com/qorelanguage/qore/issues/4360">issue 4360</a>)
 
     @subsection restclientv1_7_3 RestClient v1.7.3
     - additional fixes to REST path handling with schema validators with a base path
@@ -423,7 +427,9 @@ RestClient rest({"url": "http://localhost:8001/rest"});
         - %RestClient 1.2 the \a send_encoding option was added
         - %RestClient 1.4 the \a validator and \a swagger options were added
     */
-    constructor(*hash opts, *softbool do_not_connect) : HTTPClient(opts + ((opts.url || !opts.validator) ? NOTHING : ("url": opts.validator.getTargetUrl()))) {
+    constructor(*hash opts, *softbool do_not_connect) : HTTPClient(opts + ((opts.url || !opts.validator)
+            ? NOTHING
+            : {"url": opts.validator.getTargetUrl()})) {
         setSerialization(opts.data);
         if (opts.send_encoding)
             setSendEncoding(opts.send_encoding);
@@ -432,7 +438,8 @@ RestClient rest({"url": "http://localhost:8001/rest"});
             if (!opts.send_encoding)
                 setSendEncoding(opts.content_encoding);
             else if (!EncodingSupport.(opts.content_encoding))
-                throw "RESTCLIENT-ERROR", sprintf("content encoding option %y is unknown; valid options: %y", opts.content_encoding, EncodingSupport.keys());
+                throw "RESTCLIENT-ERROR", sprintf("content encoding option %y is unknown; valid options: %y",
+                    opts.content_encoding, EncodingSupport.keys());
             opts.headers."Accept-Encoding" = opts.content_encoding;
         }
 
@@ -442,7 +449,8 @@ RestClient rest({"url": "http://localhost:8001/rest"});
         # set validator
         if (opts.validator) {
             if (!(opts.validator instanceof AbstractRestSchemaValidator))
-                throw "RESTCLIENT-ERROR", sprintf("validator object expected to be an instance of AbstractRestSchemaValidator; got %y instead", opts.validator.type());
+                throw "RESTCLIENT-ERROR", sprintf("validator object expected to be an instance of "
+                    "AbstractRestSchemaValidator; got %y instead", opts.validator.type());
             validator = opts.validator;
         } else {
             if (opts.swagger) {
@@ -489,13 +497,16 @@ rest.setSerialization("yaml");
     */
     setSerialization(string data = "auto") {
         if (!DataSerializationOptions{data})
-            throw "RESTCLIENT-ERROR", sprintf("data serialization option %y is unknown; valid options: %y", data, DataSerializationOptions.keys());
+            throw "RESTCLIENT-ERROR", sprintf("data serialization option %y is unknown; valid options: %y", data,
+                DataSerializationOptions.keys());
 
         if (data == "auto" && DataSerializationSupport) {
             delete sct;
         } else {
             if (!DataSerializationSupport{data})
-                throw "RESTCLIENT-ERROR", sprintf("data serialization option %y is not supported because the required module could not be loaded; currently supported options: %y", data, DataSerializationSupport.keys());
+                throw "RESTCLIENT-ERROR", sprintf("data serialization option %y is not supported because the "
+                    "required module could not be loaded; currently supported options: %y", data,
+                    keys DataSerializationSupport);
             sct = DataSerializationSupport{data};
         }
 
@@ -858,7 +869,8 @@ hash<auto> ans = rest.del("/orders/1");
     }
 
     #! sets up the Content-Type header and encodes any body for sending
-    private nothing prepareMsg(string method, string path, reference<auto> body, reference<hash<auto>> hdr, string ct = "Content-Type") {
+    private nothing prepareMsg(string method, string path, reference<auto> body, reference<hash<auto>> hdr,
+            string ct = "Content-Type") {
         # use {} + ... here to ensure that hdr stays "hash<auto>"
         hdr = {} + headers + hdr;
 
@@ -906,7 +918,7 @@ hash<auto> ans = rest.del("/orders/1");
             splice path, 0, 0, "/";
         }
 
-        path = encode_uri_request(path);
+        # NOTE: Qore will perform URL encoding on the URL + path
     }
 
     #! sends an HTTP request to the REST server and returns the response
@@ -970,7 +982,8 @@ hash<auto> ans = rest.doRequest("DELETE", "/orders/1");
         - @ref RestClient::RestClient::setSerialization() "RestClient::setSerialization()"
         - @ref httpclient_get_with_body
     */
-    hash<auto> doRequest(string m, string path, auto body, *reference<hash<auto>> info, softbool decode_errors = True, *hash<auto> hdr) {
+    hash<auto> doRequest(string m, string path, auto body, *reference<hash<auto>> info, softbool decode_errors = True,
+            *hash<auto> hdr) {
         prepareMsg(m, path, \body, \hdr);
 
         on_exit if (exists body) {
@@ -989,7 +1002,8 @@ hash<auto> ans = rest.doRequest("DELETE", "/orders/1");
     #! The same as doRequest() except no schema validation is performed on the request
     /** @since RestClient 1.7.2
     */
-    hash<auto> doValidatedRequest(string m, string path, auto body, *reference<hash<auto>> info, softbool decode_errors = True, *hash<auto> hdr) {
+    hash<auto> doValidatedRequest(string m, string path, auto body, *reference<hash<auto>> info,
+            softbool decode_errors = True, *hash<auto> hdr) {
         # use {} + ... here to ensure that hdr stays "hash<auto>"
         hdr = {} + headers + hdr;
 
@@ -1004,7 +1018,8 @@ hash<auto> ans = rest.doRequest("DELETE", "/orders/1");
     }
 
     #! sends the outgoing HTTP message and recodes the response to data
-    private hash<auto> sendAndDecodeResponse(*data body, string m, string path, hash<auto> hdr, *reference<hash<auto>> info, *softbool decode_errors) {
+    private hash<auto> sendAndDecodeResponse(*data body, string m, string path, hash<auto> hdr,
+            *reference<hash<auto>> info, *softbool decode_errors) {
         hash<auto> h;
         try {
             h = send(body, m, path, hdr, False, \info);


### PR DESCRIPTION
…d erroneous / extraneous URI encoding before sending a msg

refs #4361 fixed a bug in the HTTPClient class where insufficient URL encoding was performed