### PR TITLE
refs #4379 added regex subst APIs to the QoreString* classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 2.8.12)
 
 # NOTE: Qore should always use semantic versioning: https://semver.org/
 set(VERSION_MAJOR 1)
-set(VERSION_MINOR 0)
-set(VERSION_SUB 13)
+set(VERSION_MINOR 1)
+set(VERSION_SUB 0)
 #set(VERSION_PATCH 0)
 
 # support <pkg>_ROOT in find_package
@@ -690,7 +690,7 @@ if (APPLE)
     set_target_properties(libqore PROPERTIES SOVERSION 7)
     set_target_properties(libqore PROPERTIES INSTALL_NAME_DIR ${CMAKE_INSTALL_FULL_LIBDIR})
 else (APPLE)
-    set_target_properties(libqore PROPERTIES VERSION 7.3.0)
+    set_target_properties(libqore PROPERTIES VERSION 7.4.0)
     set_target_properties(libqore PROPERTIES SOVERSION 7)
 endif (APPLE)
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 
 # AC_PREREQ(2.59)
 # NOTE: Qore should always use semantic versioning: https://semver.org/
-AC_INIT([qore], [1.0.13],
+AC_INIT([qore], [1.1.0],
         [David Nichols <david@qore.org>],
         [qore])
 AM_INIT_AUTOMAKE([no-dist-gzip dist-bzip2 tar-ustar subdir-objects])

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -9,6 +9,11 @@
 
     @subsection qore_1_1_0_new_features New Features in Qore
 
+    - fixed bugs tagging functions and constants provided by builtin modules with their module name; required to
+      consistently provide unique binary names when imported into Java, for example
+      (<a href="https://github.com/qorelanguage/qore/issues/4383">issue 4383</a>)
+    - fixed a bug initializing constant values that could result in spurious errors
+      (<a href="https://github.com/qorelanguage/qore/issues/4382">issue 4382</a>)
     - added regex APIs to the C++ string class
       (<a href="https://github.com/qorelanguage/qore/issues/4379">issue 4379</a>)
 

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -2,6 +2,16 @@
 
     @tableofcontents
 
+    @section qore_1_1_0 Qore 1.1.0
+
+    @par Release Summary
+    Minor new features added to %Qore
+
+    @subsection qore_1_1_0_new_features New Features in Qore
+
+    - added regex APIs to the C++ string class
+      (<a href="https://github.com/qorelanguage/qore/issues/4379">issue 4379</a>)
+
     @section qore_1_0_13 Qore 1.0.13
 
     @par Release Summary

--- a/examples/test/qore/stack/exception-location.qtest
+++ b/examples/test/qore/stack/exception-location.qtest
@@ -27,10 +27,9 @@ class ExceptionLocationTest inherits QUnit::Test {
     testExceptionLocation() {
         *int line;
         try {
-            hash h = do_loc1();
+            hash<auto> h = do_loc1();
             delete h;
-        }
-        catch (hash<auto> ex) {
+        } catch (hash<auto> ex) {
             line = ex.line;
         }
 
@@ -85,7 +84,7 @@ class ExceptionLocationTest inherits QUnit::Test {
 
             ex = getEx(\p.parse(), Code1 + "class B1 inherits B {} class B inherits\nB1 {}\n", "K");
             assertEq(4, ex.line);
-            assertEq(4, ex.endline);
+            assertEq(5, ex.endline);
             assertEq("K", ex.file);
 
             ex = getEx(\p.parse(), Code1 + "class B1 {\n} class B inherits\nB1, private B1 {}\n", "L");

--- a/include/qore/ModuleManager.h
+++ b/include/qore/ModuleManager.h
@@ -43,7 +43,7 @@
  */
 
 #define QORE_MODULE_API_MAJOR 1  //!< the major number of the Qore module API implemented
-#define QORE_MODULE_API_MINOR 1  //!< the minor number of the Qore module API implemented
+#define QORE_MODULE_API_MINOR 2  //!< the minor number of the Qore module API implemented
 
 #define QORE_MODULE_COMPAT_API_MAJOR QORE_MODULE_API_MAJOR  //!< the major number of the earliest recommended Qore module API
 #define QORE_MODULE_COMPAT_API_MINOR QORE_MODULE_API_MINOR  //!< the minor number of the earliest recommended Qore module API

--- a/include/qore/QoreClass.h
+++ b/include/qore/QoreClass.h
@@ -1075,35 +1075,11 @@ public:
     */
     DLLEXPORT QoreValue getReferencedKeyValue(const char* key) const;
 
-    // used when parsing, finds committed non-static methods within the entire class hierarchy
-    /** (local class plus base classes)
-    */
-    DLLLOCAL const QoreMethod* parseFindCommittedMethod(const char* nme);
+    //! returns true if the class has one or more parent classes
+    DLLEXPORT bool hasParentClass() const;
 
-    // returns 0 for success, -1 for error
-    DLLLOCAL int parseAddBaseClassArgumentList(BCAList* bcal);
-    // only called when parsing, sets the name of the class
-    DLLLOCAL void setName(const char* n);
-
-    DLLLOCAL qore_classid_t getIDForMethod() const;
-    // get base class list to add virtual class indexes for private data
-    DLLLOCAL BCSMList* getBCSMList() const;
-
-    DLLLOCAL bool parseHasPublicMembersInHierarchy() const;
-    DLLLOCAL bool runtimeHasPublicMembersInHierarchy() const;
-
-    // returns true if the class has one or more parent classes
-    DLLLOCAL bool hasParentClass() const;
-    DLLLOCAL bool hasPrivateCopyMethod() const;
-    // returns the status including the pending variant (if any)
-    DLLLOCAL bool parseHasPrivateCopyMethod() const;
-    DLLLOCAL const QoreMethod* parseGetConstructor() const;
-    // returns true if the class implements a "methodGate" method, also in pending uncommitted methods
-    DLLLOCAL bool parseHasMethodGate() const;
-    // called when there is an empty public member declaration or a "no_public" declaration
-    DLLLOCAL void parseSetEmptyPublicMemberDeclaration();
-    // unsets the public member flag for builtin classes
-    DLLLOCAL void unsetPublicMemberFlag();
+    //! returns true if the class has any publicly-declared members
+    DLLEXPORT bool hasPublicMembersInHierarchy() const;
 
 protected:
     //! Deletes the object and frees all memory
@@ -1113,35 +1089,10 @@ protected:
     DLLEXPORT QoreClass();
 
 private:
-    //! this function is not implemented; it is here as a private function in order to prohibit it from being used
     QoreClass& operator=(const QoreClass&) = delete;
 
     //! private implementation of the class
     class qore_class_private* priv;
-
-    DLLLOCAL void insertMethod(QoreMethod* o);
-    DLLLOCAL void insertStaticMethod(QoreMethod* o);
-    DLLLOCAL QoreValue evalMethodGate(QoreObject* self, const char* nme, const QoreListNode* args, ExceptionSink* xsink) const;
-    DLLLOCAL const QoreMethod* parseResolveSelfMethodIntern(const char* nme);
-
-    //! evaluates a method on an object and returns the result
-    /** if the method name is not valid or is private (and the call is made outside the object)
-        then an exception will be raised and no value (NOTHING) will be returned.
-        This function must only be called from QoreObject!
-
-        @param self the object to execute the method on
-        @param method_name the name of the method to execute
-        @param args the arguments for the method
-        @param xsink Qore-language exception information is added here
-
-        @return the value returned by the method, can be 0
-    */
-    DLLLOCAL QoreValue evalMethod(QoreObject* self, const char* method_name, const QoreListNode* args, ExceptionSink* xsink) const;
-
-    // This function must only be called from QoreObject
-    DLLLOCAL void execMemberNotification(QoreObject* self, const char* mem, ExceptionSink* xsink) const;
-    // This function must only be called from QoreObject
-    DLLLOCAL void execDestructor(QoreObject* self, ExceptionSink* xsink) const;
 };
 
 //! To be used to iterate through a class's normal (non-static) methods

--- a/include/qore/QoreString.h
+++ b/include/qore/QoreString.h
@@ -73,6 +73,18 @@ class BinaryNode;
 #define CD_ALL (CD_XHTML | CD_NUM_REF)
 //@}
 
+//! @defgroup StringRegexOpts String Regular Expression Options
+/**
+*/
+//@{
+//! global substitutions
+#define QS_RE_GLOBAL    (1 << 0)
+#define QS_RE_CASELESS  (1 << 1)
+#define QS_RE_DOTALL    (1 << 2)
+#define QS_RE_EXTENDED  (1 << 3)
+#define QS_RE_MULTILINE (1 << 4)
+//@}
+
 //! Qore's string type supported by the QoreEncoding class
 /** A QoreString is implemented by a char pointer, a byte length, and a QoreEncoding pointer.
     For the equivalent Qore parse tree/value type, see QoreStringNode
@@ -605,12 +617,53 @@ public:
 
     //! returns a new string consisting of "length" characters from the current string starting with character position "offset"
     /** offset and length spoecify characters, not bytes
-         @param offset the offset in characters from the beginning of the string (starting with 0)
+        @param offset the offset in characters from the beginning of the string (starting with 0)
         @param length the number of characters for the substring
         @param xsink invalid multi-byte encodings can cause an exception to be thrown
-        @return the new string; an empty string is returned if the arguments cannot be satisfied; 0 is returned only if a Qore-language exception is thrown due to character encoding conversion errors
+
+        @return the new string; an empty string is returned if the arguments cannot be satisfied; nullptr is returned
+        only if a Qore-language exception is thrown due to character encoding conversion errors
     */
     DLLEXPORT QoreString* substr(qore_offset_t offset, qore_offset_t length, ExceptionSink* xsink) const;
+
+    //! performs perl5-compatible regular expression substitution
+    /** @param match the pattern to match
+        @param subst the substitution string
+        @param opts regex options combined with binary or; see @ref StringRegexOpts for options
+        @param xsink invalid multi-byte encodings can cause an exception to be thrown
+
+        @return the new string if the operation was successful
+
+        @since %Qore 1.1.0
+    */
+    DLLEXPORT QoreString* regexSubst(QoreString& match, QoreString& subst, int opts, ExceptionSink* xsink) const;
+
+    //! performs perl5-compatible regular expression substitution
+    /** @param output the string where the output will be written
+        @param match the pattern to match
+        @param subst the substitution string
+        @param opts regex options combined with binary or; see @ref StringRegexOpts for options
+        @param xsink invalid multi-byte encodings can cause an exception to be thrown
+
+        @return 0 = OK, -1 = error raised
+
+        @since %Qore 1.1.0
+    */
+    DLLEXPORT int regexSubst(QoreString& output, QoreString& match, QoreString& subst, int opts,
+            ExceptionSink* xsink) const;
+
+    //! performs perl5-compatible regular expression substitution to the current string
+    /**
+        @param match the pattern to match
+        @param subst the substitution string
+        @param opts regex options combined with binary or; see @ref StringRegexOpts for options
+        @param xsink invalid multi-byte encodings can cause an exception to be thrown
+
+        @return 0 = OK, -1 = error raised
+
+        @since %Qore 1.1.0
+    */
+    DLLEXPORT int regexSubstInPlace(QoreString& match, QoreString& subst, int opts, ExceptionSink* xsink) const;
 
     //! removes a single \\n\\r or \\n from the end of the string and returns the number of characters removed
     DLLEXPORT size_t chomp();

--- a/include/qore/QoreStringNode.h
+++ b/include/qore/QoreStringNode.h
@@ -207,6 +207,18 @@ public:
     //! return a QoreStringNode with the characters reversed
     DLLEXPORT QoreStringNode* reverse() const;
 
+    //! performs perl5-compatible regular expression substitution
+    /** @param match the pattern to match
+        @param subst the substitution string
+        @param opts regex options
+        @param xsink invalid multi-byte encodings can cause an exception to be thrown
+
+        @return the new string if the operation was successful
+
+        @since %Qore 1.1.0
+    */
+    DLLEXPORT QoreStringNode* regexSubst(QoreString& match, QoreString& subst, int opts, ExceptionSink* xsink) const;
+
     // copy function
     DLLEXPORT QoreStringNode* copy() const;
 

--- a/include/qore/intern/ConstantList.h
+++ b/include/qore/intern/ConstantList.h
@@ -197,15 +197,6 @@ protected:
 
     DLLLOCAL void del(ExceptionSink* xsink);
     DLLLOCAL void del(QoreListNode& l);
-
-    DLLLOCAL void setModuleName() {
-        assert(from_module.empty());
-        const char* mod_name = get_module_context_name();
-        if (mod_name) {
-            from_module = mod_name;
-        }
-        //printd(5, "qore_ns_private::setModuleName() this: %p mod: %s\n", this, mod_name ? mod_name : "n/a");
-    }
 };
 
 class ConstantEntryInitHelper {

--- a/include/qore/intern/Function.h
+++ b/include/qore/intern/Function.h
@@ -741,6 +741,10 @@ public:
         all_priv(true) {
         ilist.push_back(INode(this, Public));
         //printd(5, "QoreFunction::QoreFunction() this: %p %s\n", this, name.c_str());
+        const char* mod_name = get_module_context_name();
+        if (mod_name) {
+            from_module = mod_name;
+        }
     }
 
     // copy constructor (used by method functions when copied)
@@ -763,7 +767,8 @@ public:
             check_parse(false),
             has_priv(old.has_priv),
             all_priv(old.all_priv),
-            nn_uniqueReturnType(old.nn_uniqueReturnType) {
+            nn_uniqueReturnType(old.nn_uniqueReturnType),
+            from_module(old.from_module) {
         bool no_user = po & PO_NO_INHERIT_USER_FUNC_VARIANTS;
         bool no_builtin = po & PO_NO_SYSTEM_FUNC_VARIANTS;
 
@@ -799,12 +804,6 @@ public:
         // the rest of ilist is copied in method base class
         // do not copy pending variants
         //printd(5, "QoreFunction::QoreFunction() this: %p %s\n", this, name.c_str());
-
-        if (!old.from_module.empty()) {
-            from_module = old.from_module;
-        } else {
-            setModuleName();
-        }
     }
 
 #if 0
@@ -1079,15 +1078,6 @@ protected:
     const QoreTypeInfo* nn_uniqueReturnType = nullptr;
 
     std::string from_module;
-
-    DLLLOCAL void setModuleName() {
-        assert(from_module.empty());
-        const char* mod_name = get_module_context_name();
-        if (mod_name) {
-            from_module = mod_name;
-        }
-        //printd(5, "qore_ns_private::setModuleName() this: %p mod: %s\n", this, mod_name ? mod_name : "n/a");
-    }
 
     DLLLOCAL int parseCheckReturnType() {
         if (parse_rt_done)

--- a/include/qore/intern/FunctionList.h
+++ b/include/qore/intern/FunctionList.h
@@ -147,7 +147,7 @@ public:
 
 typedef HASH_MAP<const char*, FunctionEntry*, qore_hash_str, eqstr> fl_map_t;
 #else
-typedef std::map<const char*, FunctionEntry*, ltstr> fl_map_t;
+typedef std::map<const char*, FunctionEntry*> fl_map_t;
 #endif
 
 class FunctionList : public fl_map_t {

--- a/include/qore/intern/QoreClassIntern.h
+++ b/include/qore/intern/QoreClassIntern.h
@@ -1142,7 +1142,8 @@ public:
 protected:
     DLLLOCAL int checkFinalized(ExceptionSink* xsink) const {
         if (finalized) {
-            xsink->raiseException("DESTRUCTOR-ERROR", "illegal class static variable assignment after second phase of variable destruction");
+            xsink->raiseException("DESTRUCTOR-ERROR", "illegal class static variable assignment after second phase "
+                "of variable destruction");
             return -1;
         }
         return 0;
@@ -3289,10 +3290,6 @@ public:
 
     DLLLOCAL static int runtimeCheckInstantiateClass(const QoreClass& qc, ExceptionSink* xsink) {
         return qc.priv->runtimeCheckInstantiateClass(xsink);
-    }
-
-    DLLLOCAL static int parseInit(QoreClass& qc) {
-        return qc.priv->parseInit();
     }
 
     DLLLOCAL static int parseInitPartial(QoreClass& qc) {

--- a/include/qore/intern/QoreClassIntern.h
+++ b/include/qore/intern/QoreClassIntern.h
@@ -1532,15 +1532,20 @@ public:
     DLLLOCAL int initialize(QoreClass* thisclass);
 
     // inaccessible methods are ignored
-    DLLLOCAL const QoreMethod* parseResolveSelfMethod(const QoreProgramLocation* loc, const char* name, const qore_class_private* class_ctx, bool allow_internal);
+    DLLLOCAL const QoreMethod* parseResolveSelfMethod(const QoreProgramLocation* loc, const char* name,
+            const qore_class_private* class_ctx, bool allow_internal);
 
     // inaccessible methods are ignored
-    DLLLOCAL const QoreMethod* parseFindNormalMethod(const char* name, const qore_class_private* class_ctx, bool allow_internal);
+    DLLLOCAL const QoreMethod* parseFindNormalMethod(const char* name, const qore_class_private* class_ctx,
+            bool allow_internal);
     // inaccessible methods are ignored
-    DLLLOCAL const QoreMethod* parseFindStaticMethod(const char* name, const qore_class_private* class_ctx, bool allow_internal);
+    DLLLOCAL const QoreMethod* parseFindStaticMethod(const char* name, const qore_class_private* class_ctx,
+            bool allow_internal);
 
-    DLLLOCAL const QoreMethod* runtimeFindCommittedMethod(const char* name, ClassAccess& access, const qore_class_private* class_ctx, bool allow_internal) const;
-    DLLLOCAL const QoreMethod* runtimeFindCommittedStaticMethod(const char* name, ClassAccess& access, const qore_class_private* class_ctx, bool allow_internal) const;
+    DLLLOCAL const QoreMethod* runtimeFindCommittedMethod(const char* name, ClassAccess& access,
+            const qore_class_private* class_ctx, bool allow_internal) const;
+    DLLLOCAL const QoreMethod* runtimeFindCommittedStaticMethod(const char* name, ClassAccess& access,
+            const qore_class_private* class_ctx, bool allow_internal) const;
 
     DLLLOCAL bool match(const QoreClass* cls);
     DLLLOCAL void execConstructors(QoreObject* o, BCEAList* bceal, ExceptionSink* xsink) const;
@@ -1549,9 +1554,11 @@ public:
 
     DLLLOCAL bool parseCheckHierarchy(const QoreClass* cls, ClassAccess& access, bool toplevel) const;
 
-    DLLLOCAL const QoreMemberInfo* parseFindMember(const char* mem, const qore_class_private*& qc, ClassAccess& n_access, bool toplevel) const;
+    DLLLOCAL const QoreMemberInfo* parseFindMember(const char* mem, const qore_class_private*& qc,
+            ClassAccess& n_access, bool toplevel) const;
 
-    DLLLOCAL const QoreVarInfo* parseFindVar(const char* vname, const qore_class_private*& qc, ClassAccess& access, bool toplevel) const;
+    DLLLOCAL const QoreVarInfo* parseFindVar(const char* vname, const qore_class_private*& qc, ClassAccess& access,
+            bool toplevel) const;
 
     DLLLOCAL bool parseHasPublicMembersInHierarchy() const;
 
@@ -1573,9 +1580,11 @@ public:
 
     DLLLOCAL void parseResolveAbstract();
 
-    DLLLOCAL QoreValue parseFindConstantValue(const char* cname, const QoreTypeInfo*& typeInfo, bool& found, const qore_class_private* class_ctx, bool allow_internal) const;
+    DLLLOCAL QoreValue parseFindConstantValue(const char* cname, const QoreTypeInfo*& typeInfo, bool& found,
+            const qore_class_private* class_ctx, bool allow_internal) const;
 
-    DLLLOCAL QoreVarInfo* parseFindStaticVar(const char* vname, const QoreClass*& qc, ClassAccess& access, bool check, bool toplevel) const;
+    DLLLOCAL QoreVarInfo* parseFindStaticVar(const char* vname, const QoreClass*& qc, ClassAccess& access, bool check,
+            bool toplevel) const;
 
     DLLLOCAL void resolveCopy();
 
@@ -1634,29 +1643,29 @@ typedef vector_map_t<qore_classid_t, BCEANode*> bceamap_t;
 */
 class BCEAList : public bceamap_t {
 protected:
-   DLLLOCAL ~BCEAList() {
-      assert(empty());
-   }
+    DLLLOCAL ~BCEAList() {
+        assert(empty());
+    }
 
 public:
-   DLLLOCAL void deref(ExceptionSink* xsink);
-   // evaluates arguments, returns -1 if an exception was thrown
-   DLLLOCAL int add(qore_classid_t classid, const QoreListNode* arg, const AbstractQoreFunctionVariant* variant, const QoreProgramLocation* loc, ExceptionSink* xsink);
-   DLLLOCAL QoreListNode* findArgs(qore_classid_t classid, bool* aexeced, const AbstractQoreFunctionVariant*& variant, const QoreProgramLocation*& loc);
-   /*
-   DLLLOCAL bool initMembers(qore_classid_t classid) {
-      bceamap_t::iterator i = lower_bound(classid);
-      if (i == end() || i->first != classid) {
-         insert(i, bceamap_t::value_type(classid, new BCEANode(false, true)));
-         return false;
-      }
-      if (!i->second->member_init_done) {
-         i->second->member_init_done = true;
-         return false;
-      }
-      return true;
-   }
-   */
+    DLLLOCAL void deref(ExceptionSink* xsink);
+    // evaluates arguments, returns -1 if an exception was thrown
+    DLLLOCAL int add(qore_classid_t classid, const QoreListNode* arg, const AbstractQoreFunctionVariant* variant, const QoreProgramLocation* loc, ExceptionSink* xsink);
+    DLLLOCAL QoreListNode* findArgs(qore_classid_t classid, bool* aexeced, const AbstractQoreFunctionVariant*& variant, const QoreProgramLocation*& loc);
+    /*
+    DLLLOCAL bool initMembers(qore_classid_t classid) {
+        bceamap_t::iterator i = lower_bound(classid);
+        if (i == end() || i->first != classid) {
+            insert(i, bceamap_t::value_type(classid, new BCEANode(false, true)));
+            return false;
+        }
+        if (!i->second->member_init_done) {
+            i->second->member_init_done = true;
+            return false;
+        }
+        return true;
+    }
+    */
 };
 
 struct SelfInstantiatorHelper {
@@ -1950,6 +1959,11 @@ public:
         return from_module.empty() ? nullptr : from_module.c_str();
     }
 
+    // get base class list to add virtual class indexes for private data
+    DLLLOCAL BCSMList* getBCSMList() const {
+        return scl ? &scl->sml : nullptr;
+    }
+
     DLLLOCAL void pgmRef() const {
         refs.ROreference();
         var_refs.ROreference();
@@ -1995,6 +2009,13 @@ public:
 
     DLLLOCAL bool hasAbstract() const {
         return !ahm.empty();
+    }
+
+    DLLLOCAL void parseSetEmptyPublicMemberDeclaration() {
+        pending_has_public_memdecl = true;
+        if (!has_new_user_changes) {
+            has_new_user_changes = true;
+        }
     }
 
     DLLLOCAL int runtimeCheckInstantiateClass(ExceptionSink* xsink) const {
@@ -2793,6 +2814,22 @@ public:
         hm_method_t::const_iterator i = shm.find(nme);
         return (i != shm.end()) ? i->second : nullptr;
     }
+
+    DLLLOCAL const QoreMethod* parseGetConstructor() const {
+        const_cast<qore_class_private*>(this)->initialize();
+        if (constructor) {
+            return constructor;
+        }
+        return parseFindLocalMethod("constructor");
+    }
+
+    DLLLOCAL void unsetPublicMemberFlag() {
+        assert(has_public_memdecl);
+        has_public_memdecl = false;
+    }
+
+    // This function must only be called from QoreObject
+    DLLLOCAL void execMemberNotification(QoreObject* self, const char* mem, ExceptionSink* xsink) const;
 
     // returns a non-static method if it exists in the local class and has been committed to the class
     DLLLOCAL QoreMethod* findLocalCommittedMethod(const char* nme);

--- a/include/qore/intern/QoreClassList.h
+++ b/include/qore/intern/QoreClassList.h
@@ -52,10 +52,11 @@ struct cl_rec_t {
 };
 
 // we use a vector map as the number of classes is generally relatively small
-#include <qore/vector_map>
-typedef vector_map_t<const char*, cl_rec_t> hm_qc_t;
-/*
-#ifdef HAVE_QORE_HASH_MAP
+//#include <qore/vector_map>
+//typedef vector_map_t<const char*, cl_rec_t> hm_qc_t;
+
+///*
+#ifdef HAVE_QORE_HASH_MAPX
 //#warning compiling with hash_map
 #include <qore/hash_map_include.h>
 #include "qore/intern/xxhash.h"
@@ -65,7 +66,7 @@ typedef HASH_MAP<const char*, cl_rec_t, qore_hash_str, eqstr> hm_qc_t;
 #include <map>
 typedef std::map<const char*, cl_rec_t, ltstr> hm_qc_t;
 #endif
-*/
+//*/
 
 class QoreNamespaceList;
 

--- a/include/qore/intern/qore_string_private.h
+++ b/include/qore/intern/qore_string_private.h
@@ -433,16 +433,14 @@ public:
             pos = str.len + pos;
             if (pos < 0)
                 pos = 0;
-        }
-        else if (pos >= (qore_offset_t)str.len)
+        } else if (pos >= (qore_offset_t)str.len)
             return;
 
         if (plen < 0) {
             plen = str.len + plen;
             if (plen <= 0)
                 return;
-        }
-        else if (plen > (qore_offset_t)str.len)
+        } else if (plen > (qore_offset_t)str.len)
             plen = str.len;
 
         concat_intern(str.buf + pos, plen);
@@ -614,6 +612,10 @@ public:
         concat(ns->priv);
         return 0;
     }
+
+    DLLLOCAL void setRegexBaseOpts(QoreRegexBase& re, int opts);
+
+    DLLLOCAL void setRegexOpts(QoreRegexSubst& re, int opts);
 
     DLLLOCAL void splice_simple(size_t offset, size_t length, QoreString* extract = nullptr);
     DLLLOCAL void splice_simple(size_t offset, size_t length, const char* str, size_t str_len,

--- a/include/qore/intern/xxhash.h
+++ b/include/qore/intern/xxhash.h
@@ -150,16 +150,26 @@ and therefore get some new hashes, by calling again XXHnn_digest().
 When you are done, don't forget to free XXH state space, using typically XXHnn_freeState().
 */
 
-   struct qore_hash_str {
-      DLLLOCAL size_t operator()(const char* s1) const {
+struct qore_hash_str {
+    DLLLOCAL size_t operator()(const char* s1) const {
 #if TARGET_BITS == 64
-	return XXH64(s1, strlen(s1), 0);
+return XXH64(s1, strlen(s1), 0);
 #else
-	return XXH32(s1, strlen(s1), 0);
+return XXH32(s1, strlen(s1), 0);
 #endif
-      }
-   };
-  
+    }
+};
+
+struct qore_hash_stdstr {
+    DLLLOCAL size_t operator()(const std::string& s1) const {
+#if TARGET_BITS == 64
+return XXH64(s1.c_str(), s1.size(), 0);
+#else
+return XXH32(s1.c_str(), s1.size(), 0);
+#endif
+    }
+};
+
 #if defined (__cplusplus)
 }
 #endif

--- a/lib/ConstantList.cpp
+++ b/lib/ConstantList.cpp
@@ -52,6 +52,11 @@ ConstantEntry::ConstantEntry(const QoreProgramLocation* loc, const char* n, Qore
     if (pgm)
         pwo = qore_program_private::getParseWarnOptions(pgm);
 
+    const char* mod_name = get_module_context_name();
+    if (mod_name) {
+        from_module = mod_name;
+    }
+
     //printd(5, "ConstantEntry::ConstantEntry() this: %p '%s' ti: '%s' nti: '%s'\n", this, n,
     //  QoreTypeInfo::getName(typeInfo), QoreTypeInfo::getName(val.getTypeInfo()));
 }
@@ -61,16 +66,9 @@ ConstantEntry::ConstantEntry(const ConstantEntry& old)
         typeInfo(old.typeInfo), val(old.val.refSelf()),
         in_init(false), pub(old.builtin), init(true), builtin(old.builtin),
         saved_node(old.saved_node ? old.saved_node->refSelf() : nullptr),
-        access(old.access) {
+        access(old.access), from_module(old.from_module) {
     assert(!old.in_init);
     assert(old.init);
-
-    if (!old.from_module.empty()) {
-        from_module = old.from_module;
-    } else {
-        setModuleName();
-    }
-
     //printd(5, "ConstantEntry::ConstantEntry() this: %p copy '%s' ti: '%s' nti: '%s'\n", this, name.c_str(),
     //  QoreTypeInfo::getName(typeInfo), QoreTypeInfo::getName(val.getTypeInfo()));
 }

--- a/lib/Function.cpp
+++ b/lib/Function.cpp
@@ -1889,6 +1889,7 @@ QoreValue UserVariantBase::evalIntern(ReferenceHolder<QoreListNode>& argv, QoreO
             signature.selfid->instantiateSelf(self);
 
         // instantiate argv and push id on stack
+        assert(signature.argvid);
         signature.argvid->instantiate(argv ? argv->refSelf() : nullptr);
 
         {

--- a/lib/FunctionCallNode.cpp
+++ b/lib/FunctionCallNode.cpp
@@ -171,7 +171,7 @@ int FunctionCallBase::parseArgsVariant(const QoreProgramLocation* loc, QoreParse
         // expressions for immediate evaluation)
         const QoreClass* qc = func->getClass();
         if (qc) {
-            if (qore_class_private::parseInitPartial(*const_cast<QoreClass*>(qc)) && !err) {
+            if (qore_class_private::get(*const_cast<QoreClass*>(qc))->parseInit() && !err) {
                 err = -1;
             }
         } else {

--- a/lib/FunctionCallNode.cpp
+++ b/lib/FunctionCallNode.cpp
@@ -171,7 +171,7 @@ int FunctionCallBase::parseArgsVariant(const QoreProgramLocation* loc, QoreParse
         // expressions for immediate evaluation)
         const QoreClass* qc = func->getClass();
         if (qc) {
-            if (qore_class_private::parseInit(*const_cast<QoreClass*>(qc)) && !err) {
+            if (qore_class_private::parseInitPartial(*const_cast<QoreClass*>(qc)) && !err) {
                 err = -1;
             }
         } else {
@@ -627,7 +627,7 @@ int ScopedObjectCallNode::parseInitImpl(QoreValue& val, QoreParseContext& parse_
     else assert(oc);
 #endif
 
-    const QoreMethod* constructor = oc ? oc->parseGetConstructor() : nullptr;
+    const QoreMethod* constructor = oc ? qore_class_private::get(*oc)->parseGetConstructor() : nullptr;
     if (parseArgs(parse_context,
         constructor
             ? qore_method_private::get(*constructor)->getFunction()

--- a/lib/HashDeclList.cpp
+++ b/lib/HashDeclList.cpp
@@ -80,7 +80,7 @@ TypedHashDecl* HashDeclList::find(const char* name) {
     return i != hm.end() ? i->second : nullptr;
 }
 
-const TypedHashDecl* HashDeclList::find(const char *name) const {
+const TypedHashDecl* HashDeclList::find(const char* name) const {
     hm_qth_t::const_iterator i = hm.find(name);
     return i != hm.end() ? i->second : nullptr;
 }

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -11,7 +11,7 @@ dummy:
 	echo "Build started!"
 
 EXTRA_INCLUDES = -I$(top_srcdir)/include -I$(top_builddir)/include -I$(top_builddir)/lib
-libqore_la_LDFLAGS = -version-info 10:0:3 -no-undefined ${QORE_LIB_LDFLAGS}
+libqore_la_LDFLAGS = -version-info 11:0:4 -no-undefined ${QORE_LIB_LDFLAGS}
 AM_CPPFLAGS = $(EXTRA_INCLUDES) ${QORE_LIB_CPPFLAGS}
 AM_CXXFLAGS = ${QORE_LIB_CXXFLAGS}
 AM_YFLAGS = -d

--- a/lib/ModuleManager.cpp
+++ b/lib/ModuleManager.cpp
@@ -61,6 +61,7 @@
 #include <vector>
 
 static const qore_mod_api_compat_s qore_mod_api_list_l[] = {
+    {1, 2},
     {1, 1},
     {1, 0},
 };

--- a/lib/QoreClassList.cpp
+++ b/lib/QoreClassList.cpp
@@ -160,8 +160,10 @@ void QoreClassList::resolveCopy() {
 int QoreClassList::parseInit() {
     int err = 0;
     for (auto& i : hm) {
-        //printd(5, "QoreClassList::parseInit() this: %p initializing %p '%s'\n", this, i.second, i.first);
-        if (qore_class_private::parseInit(*(i.second.cls)) && !err) {
+        printd(5, "QoreClassList::parseInit() this: %p initializing %p '%s' (%s)\n", this, i.second.cls, i.first,
+            i.second.cls->getName());
+
+        if (qore_class_private::get(*(i.second.cls))->parseInit() && !err) {
             err = -1;
         }
     }

--- a/lib/QoreDotEvalOperatorNode.cpp
+++ b/lib/QoreDotEvalOperatorNode.cpp
@@ -180,7 +180,7 @@ int QoreDotEvalOperatorNode::parseInitImpl(QoreValue& val, QoreParseContext& par
 
     if (!meth) {
         // if there is no method, then check for a methodGate() method or a pseudo-method
-        if (!is_abstract && !qc->parseHasMethodGate()) {
+        if (!is_abstract && !qore_class_private::get(*qc)->parseHasMethodGate()) {
             // check if it could be a pseudo-method call
             meth = pseudo_classes_find_method(NT_OBJECT, mname, qc);
             if (meth) {

--- a/lib/QoreNamespace.cpp
+++ b/lib/QoreNamespace.cpp
@@ -2669,13 +2669,12 @@ int qore_ns_private::parseAddPendingClass(const QoreProgramLocation* loc, QoreCl
         parse_error(*loc, "class '%s' is already defined in namespace '%s::'", oc->getName(), name.c_str());
         return -1;
     }
+    och.release();
 
     qore_class_private::get(*oc)->setNamespace(this);
-    och.release();
-    if (!strcmp(oc->getName(), "AbstractSqlUtilBase")) {
-        //printd(5, "qore_ns_private::parseAddPendingClass() added class %p '%s' ns: %p '%s' parent: %p\n", oc,
-        //  oc->getName(), this, name.c_str(), parent);
-    }
+
+    //printd(5, "qore_ns_private::parseAddPendingClass() added class %p '%s' ns: %p '%s' parent: %p\n", oc,
+    //    oc->getName(), this, name.c_str(), parent);
 
     return 0;
 }

--- a/lib/QoreStringNode.cpp
+++ b/lib/QoreStringNode.cpp
@@ -221,6 +221,13 @@ QoreStringNode *QoreStringNode::reverse() const {
     return str;
 }
 
+QoreStringNode* QoreStringNode::regexSubst(QoreString& match, QoreString& subst, int opts,
+        ExceptionSink* xsink) const {
+    QoreRegexSubst regex(&match, 0, xsink);
+    priv->setRegexOpts(regex, opts);
+    return *xsink ? nullptr : regex.exec(this, &subst, xsink);
+}
+
 QoreStringNode *QoreStringNode::parseBase64ToString(const QoreEncoding* qe, ExceptionSink* xsink) const {
     SimpleRefHolder<BinaryNode> b(::parseBase64(priv->buf, priv->len, xsink));
     if (!b)

--- a/lib/VarRefNode.cpp
+++ b/lib/VarRefNode.cpp
@@ -364,7 +364,7 @@ int VarRefNewObjectNode::parseInitConstructorCall(const QoreProgramLocation* loc
     }
 
     // FIXME: make common code with ScopedObjectCallNode
-    const QoreMethod* constructor = qc ? qc->parseGetConstructor() : nullptr;
+    const QoreMethod* constructor = qc ? qore_class_private::get(*qc)->parseGetConstructor() : nullptr;
     int e = parseArgsVariant(loc, parse_context, constructor
         ? qore_method_private::get(*constructor)->getFunction()
         : nullptr, nullptr);

--- a/lib/qpp.cpp
+++ b/lib/qpp.cpp
@@ -3983,6 +3983,10 @@ public:
             lname.insert(0, "Pseudo");
         }
 
+        if (upm) {
+            fprintf(fp, "#include \"qore/intern/QoreClassIntern.h\"\n");
+        }
+
         fprintf(fp, "qore_classid_t CID_%s;\nQoreClass* QC_%s;\n\n", UC.c_str(), UC.c_str());
 
         for (mmap_t::const_iterator i = normal_mmap.begin(), e = normal_mmap.end(); i != e; ++i) {
@@ -4064,7 +4068,7 @@ public:
         }
 
         if (upm)
-            fprintf(fp, "\n    QC_%s->unsetPublicMemberFlag();\n", UC.c_str());
+            fprintf(fp, "\n    qore_class_private::get(*QC_%s)->unsetPublicMemberFlag();\n", UC.c_str());
 
         if (is_final)
             fprintf(fp, "\n    QC_%s->setFinal();\n", UC.c_str());

--- a/qore.spec-fedora
+++ b/qore.spec-fedora
@@ -2,7 +2,7 @@
 %global user_module_dir %{_datadir}/qore-modules/
 
 Name: qore
-Version: 1.0.13
+Version: 1.1.0
 Release: 1%{?dist}
 Summary: Multithreaded Programming Language
 
@@ -45,7 +45,7 @@ This package provides the qore library required for all clients using qore
 functionality.
 
 %files -n libqore
-%{_libdir}/libqore.so.7.3.0
+%{_libdir}/libqore.so.7.4.0
 %{_libdir}/libqore.so.7
 %license COPYING.LGPL COPYING.GPL COPYING.MIT README-LICENSE
 %doc README.md README-MODULES RELEASE-NOTES AUTHORS ABOUT
@@ -175,6 +175,10 @@ make check
 %{_mandir}/man1/qore.1.*
 
 %changelog
+* Sun Jan 9 2022 David Nichols <david@qore.org> 1.1.0-1
+- updated version to 1.1.0-1
+- updated libqore version to 7.4.0
+
 * Wed Dec 15 2021 David Nichols <david@qore.org> 1.0.13-1
 - updated version to 1.0.13-1
 - updated libqore version to 7.3.0

--- a/qore.spec-multi
+++ b/qore.spec-multi
@@ -31,7 +31,7 @@
 
 Summary: Multithreaded Programming Language
 Name: qore
-Version: 1.0.13
+Version: 1.1.0
 Release: 1%{dist}
 %if 0%{?suse_version}
 License: LGPL-2.0+ or GPL-2.0+ or MIT
@@ -114,7 +114,7 @@ functionality.
 
 %files -n %{libname}
 %defattr(-,root,root,-)
-%{_libdir}/libqore.so.7.3.0
+%{_libdir}/libqore.so.7.4.0
 %{_libdir}/libqore.so.7
 %doc COPYING.LGPL COPYING.GPL COPYING.MIT README.md README-LICENSE README-MODULES RELEASE-NOTES AUTHORS ABOUT
 
@@ -278,6 +278,10 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 
 %changelog
+* Sun Jan 9 2022 David Nichols <david@qore.org> 1.1.0
+- updated version to 1.1.0
+- updated libqore version to 7.4.0
+
 * Wed Dec 15 2021 David Nichols <david@qore.org> 1.0.13
 - updated version to 1.0.13
 - updated libqore version to 7.3.0

--- a/qore.spec-opensuse
+++ b/qore.spec-opensuse
@@ -19,7 +19,7 @@
 
 %define module_dir %{_libdir}/qore-modules
 Name:           qore
-Version:        1.0.13
+Version:        1.1.0
 Release:        0
 Summary:        Multithreaded Programming Language
 License:        LGPL-2.1+ or GPL-2.0+ or MIT
@@ -70,7 +70,7 @@ functionality.
 
 %files -n libqore7
 %defattr(-,root,root,-)
-%{_libdir}/libqore.so.7.3.0
+%{_libdir}/libqore.so.7.4.0
 %{_libdir}/libqore.so.7
 %doc COPYING.LGPL COPYING.GPL COPYING.MIT README-LICENSE
 


### PR DESCRIPTION
refs #4380 cleaned up the QoreClass API - removed private functions from public header