### PR TITLE
refs #4421 fixed variant resolution to detect ambiguities at parse ti…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -8,6 +8,9 @@
     Bugfix release; see below for more information
 
     @subsection qore_1_2_1_bug_fixes Bug Fixes in Qore
+    - fixed bugs in variant matching that could lead to unexpected results at runtime as well as errors with inherited
+      Java code
+      (<a href="https://github.com/qorelanguage/qore/issues/4421">issue 4421</a>)
     - fixed a bug dispatching method and function calls at runtime in certain cases
       (<a href="https://github.com/qorelanguage/qore/issues/4419">issue 4419</a>)
 

--- a/examples/test/qore/misc/classes.qtest
+++ b/examples/test/qore/misc/classes.qtest
@@ -753,11 +753,25 @@ class Issue_4419_B0;
 class Issue_4419_C0 inherits Issue_4419_B0;
 
 class Issue_4419_T {
-    t(auto x) {
+    t0(auto x) {
         throw "X";
     }
 
-    t(Issue_4419_B0 x) {
+    t0(Issue_4419_B0 x) {
+    }
+
+    t1(hash<auto> x) {
+        throw "X";
+    }
+
+    t1(hash<string, Issue_4419_B0> x) {
+    }
+
+    t2(list<auto> x) {
+        throw "X";
+    }
+
+    t2(list<Issue_4419_B0> x) {
     }
 }
 
@@ -797,8 +811,21 @@ public class ClassesTest inherits QUnit::Test {
 
     issue4419() {
         Issue_4419_T t();
-        auto x = new Issue_4419_C0();
-        assertNothing(t.t(x));
+        Issue_4419_C0 v();
+        {
+            auto x = v;
+            assertNothing(t.t0(x));
+        }
+        {
+            hash<auto> x = {
+                "a": v,
+            };
+            assertNothing(t.t1(x));
+        }
+        {
+            list<auto> x = (v,);
+            assertNothing(t.t2(x));
+        }
     }
 
     initTest() {

--- a/examples/test/qore/vars/overload.qtest
+++ b/examples/test/qore/vars/overload.qtest
@@ -130,12 +130,34 @@ int sub f10(softint i) {
     return 1;
 }
 
+sub issue_4419_t0(auto x) {
+    throw "X";
+}
+
+sub issue_4419_t0(Mutex x) {
+}
+
+sub issue_4419_t1(hash<auto> x) {
+    throw "X";
+}
+
+sub issue_4419_t1(hash<string, Mutex> x) {
+}
+
+sub issue_4419_t2(list<auto> x) {
+    throw "X";
+}
+
+sub issue_4419_t2(list<Mutex> x) {
+}
+
 public class OverloadTest inherits QUnit::Test {
     public {
         const Api = "hash sub p() { return {}; }*hash sub p(string a) {return {};}any sub p(string a, string b) { return 1; }";
     }
 
     constructor() : Test("Overload test", "1.0") {
+        addTestCase("issue 4419", \issue4419());
         addTestCase("softlist overload test", \softlistOverloadTest());
         addTestCase("issue 3861", \issue3861());
         addTestCase("issue 3441", \issue3441());
@@ -146,6 +168,24 @@ public class OverloadTest inherits QUnit::Test {
 
         # Return for compatibility with test harness that checks return value.
         set_return_value(main());
+    }
+
+    issue4419() {
+        Mutex m();
+        {
+            auto x = m;
+            assertNothing(issue_4419_t0(x));
+        }
+        {
+            hash<auto> x = {
+                "a": m,
+            };
+            assertNothing(issue_4419_t1(x));
+        }
+        {
+            list<auto> x = (m,);
+            assertNothing(issue_4419_t2(x));
+        }
     }
 
     softlistOverloadTest() {
@@ -265,12 +305,12 @@ public class OverloadTest inherits QUnit::Test {
         assertEq(4, f6(1, NOTHING, NOTHING, NOTHING));
         assertEq(4, f6(1, a, a, a));
         # check overload resolution with complex types
-        assertEq(1, f7({}));
+        assertEq(2, f7({}));
         assertEq(2, f7(("a": 1)));
         assertEq(2, f7(cast<hash<string, int>>(("a": 1))));
         assertEq(3, f7(new hash<MyHash>()));
         assertEq(0, f8());
-        assertEq(1, f8({}));
+        assertEq(2, f8({}));
         assertEq(2, f8(("a": 1)));
         assertEq(1, f8(("a": "1")));
         # check overload resolution against "any" and "auto"
@@ -297,12 +337,12 @@ public class OverloadTest inherits QUnit::Test {
         assertEq(4, call_function(\f6(), 1, a, a, {}));
         assertEq(4, call_function(\f6(), 1, NOTHING, NOTHING, NOTHING));
         assertEq(4, call_function(\f6(), 1, a, a, a));
-        assertEq(1, call_function(\f7(), {}));
+        assertEq(2, call_function(\f7(), {}));
         assertEq(2, call_function(\f7(), ("a": 1)));
         assertEq(2, call_function(\f7(), cast<hash<string, int>>(("a": 1))));
         assertEq(3, call_function(\f7(), new hash<MyHash>()));
         assertEq(0, call_function(\f8()));
-        assertEq(1, call_function(\f8(), {}));
+        assertEq(2, call_function(\f8(), {}));
         assertEq(2, call_function(\f8(), ("a": 1)));
         assertEq(1, call_function(\f8(), ("a": "1")));
         assertEq(0, call_function(\f9()));

--- a/include/qore/intern/QoreTypeInfo.h
+++ b/include/qore/intern/QoreTypeInfo.h
@@ -93,7 +93,8 @@ public:
         u.hd = hd;
     }
 
-    DLLLOCAL qore_type_result_e checkMatchType(const QoreTypeSpec& t, bool& may_not_match) const;
+    DLLLOCAL qore_type_result_e checkMatchType(const QoreTypeSpec& t, bool& may_not_match,
+            qore_type_result_e& max_result) const;
 
     DLLLOCAL qore_type_result_e tryMatchReferenceType(const QoreTypeSpec& t, bool& may_not_match) const;
 
@@ -245,7 +246,8 @@ public:
     DLLLOCAL qore_type_result_e match(const QoreTypeSpec& t) const {
         bool may_not_match = false;
         bool may_need_filter = false;
-        return match(t, may_not_match, may_need_filter);
+        qore_type_result_e max_result = QTI_NOT_EQUAL;
+        return match(t, may_not_match, may_need_filter, max_result);
     }
 
     // this is the "expecting" type, t is the type to match
@@ -253,13 +255,23 @@ public:
     // ex: this = NT_OBJECT, t = class, result = IDENT
     DLLLOCAL qore_type_result_e match(const QoreTypeSpec& t, bool& may_not_match) const {
         bool may_need_filter = false;
-        return match(t, may_not_match, may_need_filter);
+        qore_type_result_e max_result = QTI_NOT_EQUAL;
+        return match(t, may_not_match, may_need_filter, max_result);
     }
 
     // this is the "expecting" type, t is the type to match
     // ex: this = class, t = NT_OBJECT, result = AMBIGU`OUS
     // ex: this = NT_OBJECT, t = class, result = IDENT
-    DLLLOCAL qore_type_result_e match(const QoreTypeSpec& t, bool& may_not_match, bool& may_need_filter) const;
+    DLLLOCAL qore_type_result_e match(const QoreTypeSpec& t, bool& may_not_match, bool& may_need_filter) const {
+        qore_type_result_e max_result = QTI_NOT_EQUAL;
+        return match(t, may_not_match, may_need_filter, max_result);
+    }
+
+    // this is the "expecting" type, t is the type to match
+    // ex: this = class, t = NT_OBJECT, result = AMBIGU`OUS
+    // ex: this = NT_OBJECT, t = class, result = IDENT
+    DLLLOCAL qore_type_result_e match(const QoreTypeSpec& t, bool& may_not_match, bool& may_need_filter,
+            qore_type_result_e& max_result) const;
 
     DLLLOCAL qore_type_result_e runtimeAcceptsValue(const QoreValue& n, bool exact) const;
 
@@ -456,26 +468,42 @@ public:
     DLLLOCAL static qore_type_result_e parseAccepts(const QoreTypeInfo* first, const QoreTypeInfo* second) {
         bool may_not_match = false;
         bool may_need_filter = false;
-        return parseAccepts(first, second, may_not_match, may_need_filter);
+        qore_type_result_e max_result = QTI_NOT_EQUAL;
+        return parseAccepts(first, second, may_not_match, may_need_filter, max_result);
     }
 
     // static version of method, checking for null pointer
-    DLLLOCAL static qore_type_result_e parseAccepts(const QoreTypeInfo* first, const QoreTypeInfo* second, bool& may_not_match) {
+    DLLLOCAL static qore_type_result_e parseAccepts(const QoreTypeInfo* first, const QoreTypeInfo* second,
+            bool& may_not_match) {
         bool may_need_filter = false;
-        return parseAccepts(first, second, may_not_match, may_need_filter);
+        qore_type_result_e max_result = QTI_NOT_EQUAL;
+        return parseAccepts(first, second, may_not_match, may_need_filter, max_result);
+    }
+
+    DLLLOCAL static qore_type_result_e parseAccepts(const QoreTypeInfo* first, const QoreTypeInfo* second,
+            bool& may_not_match, bool& may_need_filter) {
+        qore_type_result_e max_result = QTI_NOT_EQUAL;
+        return parseAccepts(first, second, may_not_match, may_need_filter, max_result);
     }
 
     // static version of method, checking for null pointer
-    DLLLOCAL static qore_type_result_e parseAccepts(const QoreTypeInfo* first, const QoreTypeInfo* second, bool& may_not_match, bool& may_need_filter) {
+    DLLLOCAL static qore_type_result_e parseAccepts(const QoreTypeInfo* first, const QoreTypeInfo* second,
+            bool& may_not_match, bool& may_need_filter, qore_type_result_e& max_result) {
+        /*
         if (first == second) {
+            // issue
+            max_result = QTI_IDENT;
             return QTI_IDENT;
         }
+        */
         if (first == autoTypeInfo) {
+            max_result = QTI_WILDCARD;
             return QTI_WILDCARD;
         }
         if (!hasType(first)) {
             if (!may_need_filter && isComplex(second))
                 may_need_filter = true;
+            max_result = QTI_WILDCARD;
             return QTI_WILDCARD;
         }
         if (!hasType(second)) {
@@ -490,12 +518,14 @@ public:
             }
             // if the type may not match at runtime, then return no match with %strict-types
             if (parse_get_parse_options() & PO_STRICT_TYPES) {
+                max_result = QTI_NOT_EQUAL;
                 return QTI_NOT_EQUAL;
             }
+            max_result = QTI_IDENT;
             may_not_match = true;
             return QTI_AMBIGUOUS;
         }
-        return first->parseAccepts(second, may_not_match, may_need_filter);
+        return first->parseAccepts(second, may_not_match, may_need_filter, max_result);
     }
 
     // static version of method, checking for null pointer
@@ -1151,11 +1181,13 @@ protected:
         return false;
     }
 
-    DLLLOCAL qore_type_result_e parseAccepts(const QoreTypeInfo* typeInfo, bool& may_not_match, bool& may_need_filter) const {
+    DLLLOCAL qore_type_result_e parseAccepts(const QoreTypeInfo* typeInfo, bool& may_not_match,
+            bool& may_need_filter, qore_type_result_e& max_result) const {
         //printd(5, "QoreTypeInfo::parseAccepts() '%s' <- '%s'\n", tname.c_str(), typeInfo->tname.c_str());
         if (typeInfo->return_vec.size() > accept_vec.size()) {
             // if the type may not match at runtime, then return no match with %strict-types
             if (parse_get_parse_options() & PO_STRICT_TYPES) {
+                max_result = QTI_NOT_EQUAL;
                 return QTI_NOT_EQUAL;
             }
             may_not_match = true;
@@ -1165,13 +1197,18 @@ protected:
         for (auto& rt : typeInfo->return_vec) {
             bool t_no_match = true;
             for (auto& at : accept_vec) {
-                qore_type_result_e res = parseAcceptsIntern(at, rt, may_not_match, may_need_filter, t_no_match, ok);
-                if (res == QTI_IDENT)
+                qore_type_result_e t_max_result = QTI_NOT_EQUAL;
+                qore_type_result_e res = parseAcceptsIntern(at, rt, may_not_match, may_need_filter, t_no_match, ok,
+                    t_max_result);
+                if (res == QTI_IDENT) {
+                    max_result = t_max_result;
                     return res;
-                else if (res == QTI_AMBIGUOUS || res == QTI_NEAR || res == QTI_WILDCARD) {
+                } else if (res == QTI_AMBIGUOUS || res == QTI_NEAR || res == QTI_WILDCARD) {
+                    max_result = t_max_result;
                     assert(ok);
-                    if (may_not_match)
+                    if (may_not_match) {
                         return res;
+                    }
                     break;
                 }
             }
@@ -1179,16 +1216,19 @@ protected:
                 if (!may_not_match) {
                     // if the type may not match at runtime, then return no match with %strict-types
                     if (parse_get_parse_options() & PO_STRICT_TYPES) {
+                        max_result = QTI_NOT_EQUAL;
                         return QTI_NOT_EQUAL;
                     }
                     may_not_match = true;
-                    if (ok)
+                    if (ok) {
                         return QTI_AMBIGUOUS;
+                    }
                 }
             }
         }
-        if (ok)
+        if (ok) {
             return QTI_AMBIGUOUS;
+        }
         may_not_match = false;
         return QTI_NOT_EQUAL;
     }
@@ -1260,28 +1300,33 @@ protected:
     // returns true if there is no type or if the type can be converted to a scalar (numeric, bool, int, string, etc) value, false true if otherwise
     DLLLOCAL virtual bool canConvertToScalarImpl() const = 0;
 
-    DLLLOCAL static qore_type_result_e parseAcceptsIntern(const QoreAcceptSpec& at, const QoreReturnSpec& rt, bool& may_not_match, bool& may_need_filter, bool& t_no_match, bool& ok) {
-        //printd(5, "QoreTypeInfo::parseAcceptsIntern() at: %d rt: %d rc: %d\n", (int)at.spec.getTypeSpec(), (int)rt.spec.getTypeSpec(), at.spec.match(rt.spec, may_not_match, may_need_filter));
-        qore_type_result_e res = at.spec.match(rt.spec, may_not_match, may_need_filter);
+    DLLLOCAL static qore_type_result_e parseAcceptsIntern(const QoreAcceptSpec& at, const QoreReturnSpec& rt,
+            bool& may_not_match, bool& may_need_filter, bool& t_no_match, bool& ok, qore_type_result_e& max_result) {
+        //printd(5, "QoreTypeInfo::parseAcceptsIntern() at: %d rt: %d rc: %d\n", (int)at.spec.getTypeSpec(),
+        //    (int)rt.spec.getTypeSpec(), at.spec.match(rt.spec, may_not_match, may_need_filter));
+        qore_type_result_e res = at.spec.match(rt.spec, may_not_match, may_need_filter, max_result);
         switch (res) {
             case QTI_IDENT:
                 if (at.exact && rt.exact) {
-                    if (at.map && !may_need_filter)
+                    if (at.map && !may_need_filter) {
                         may_need_filter = true;
+                    }
                     return QTI_IDENT;
                 }
             // fall down to next case
             case QTI_NEAR:
             case QTI_AMBIGUOUS:
             case QTI_WILDCARD:
-                if (at.map && !may_need_filter)
+                if (at.map && !may_need_filter) {
                     may_need_filter = true;
+                }
                 if (t_no_match) {
                     t_no_match = false;
                     if (!ok) {
                         ok = true;
-                        if (may_not_match)
+                        if (may_not_match) {
                             return res;
+                        }
                     }
                 }
 

--- a/lib/Function.cpp
+++ b/lib/Function.cpp
@@ -101,18 +101,20 @@ bool AbstractFunctionSignature::compare(const AbstractFunctionSignature& sig, bo
             : sig.typeList[i];
         bool match;
         if (relaxed_match) {
-            match = QoreTypeInfo::parseAccepts(typeList[i], ti) >= QTI_AMBIGUOUS;
+            //printd(5, "AbstractFunctionSignature::compare() param %d (%s =~ %s) %d\n", i,
+            //    QoreTypeInfo::getName(typeList[i]), QoreTypeInfo::getName(ti),
+            //    QoreTypeInfo::parseAccepts(typeList[i], ti));
+            match = QoreTypeInfo::parseAccepts(typeList[i], ti) >= QTI_WILDCARD;
         } else {
+            //printd(5, "AbstractFunctionSignature::compare() param %d (%s =~ %s) %d\n", i,
+            //    QoreTypeInfo::getName(typeList[i]), QoreTypeInfo::getName(ti),
+            //    QoreTypeInfo::runtimeTypeMatch(typeList[i], ti));
             match = QoreTypeInfo::runtimeTypeMatch(typeList[i], ti) >= QTI_NEAR;
         }
 
-        //printd(5, "AbstractFunctionSignature::compare() param %d (%s =~ %s) %d\n", i,
-        //  QoreTypeInfo::getName(typeList[i]), QoreTypeInfo::getName(ti),
-        //  QoreTypeInfo::runtimeTypeMatch(typeList[i], ti));
-
         if (!match) {
             //printd(5, "AbstractFunctionSignature::compare() param %d %s != %s\n", i,
-            //    QoreTypeInfo::getName(typeList[i]), QoreTypeInfo::getName(sig.typeList[i]));
+            //    QoreTypeInfo::getName(typeList[i]), QoreTypeInfo::getName(ti));
             return false;
         }
     }
@@ -925,9 +927,9 @@ QoreListNode* QoreFunction::runtimeGetCallVariants() const {
 // finds a variant at runtime
 const AbstractQoreFunctionVariant* QoreFunction::runtimeFindVariant(ExceptionSink* xsink, const QoreListNode* args,
         bool only_user, const qore_class_private* class_ctx) const {
-    // the lowest match length with the highest score wins
-    int match_len = -1;
-    int match = -1;
+    // the lowest score length with the highest score wins
+    int score_len = -1;
+    int score = -1;
     const AbstractQoreFunctionVariant* variant = nullptr;
     //const AbstractQoreFunctionVariant* saved_variant = nullptr;
 
@@ -986,8 +988,9 @@ const AbstractQoreFunctionVariant* QoreFunction::runtimeFindVariant(ExceptionSin
             int64 vflags = (*i)->getFlags();
 
             // ignore "runtime noop" variants if necessary
-            if (strict_args && (vflags & QCF_RUNTIME_NOOP))
+            if (strict_args && (vflags & QCF_RUNTIME_NOOP)) {
                 continue;
+            }
 
             // does the variant accept extra arguments?
             bool uses_extra_args = vflags & QCF_USES_EXTRA_ARGS;
@@ -997,7 +1000,10 @@ const AbstractQoreFunctionVariant* QoreFunction::runtimeFindVariant(ExceptionSin
             sig = (*i)->getSignature();
             assert(sig);
 
-            //printd(5, "QoreFunction::runtimeFindVariant() this: %p %s(%s) args: %p (%d) class: %s class_ctx: %p '%s' nargs: %d nparams: %d\n", this, getName(), sig->getSignatureText(), args, args ? args->size() : 0, aqf->className() ? aqf->className() : "n/a", class_ctx, class_ctx ? class_ctx->name.c_str() : "n/a", nargs, sig->numParams());
+            //printd(5, "QoreFunction::runtimeFindVariant() this: %p %s(%s) args: %p (%d) class: %s class_ctx: %p '%s' "
+            //    "nargs: %d nparams: %d\n", this, getName(), sig->getSignatureText(), args, args ? args->size() : 0,
+            //    aqf->className() ? aqf->className() : "n/a", class_ctx, class_ctx ? class_ctx->name.c_str() : "n/a",
+            //    nargs, sig->numParams());
 
             // issue 1507: ensure that calls with no arguments and no params are considered a perfect match
             if (!nargs && !sig->numParams()) {
@@ -1006,40 +1012,48 @@ const AbstractQoreFunctionVariant* QoreFunction::runtimeFindVariant(ExceptionSin
             }
 
             // skip variants with signatures with fewer possible elements than the best match already
-            if ((int)(sig->getParamTypes() * QTI_IDENT) < match)
+            if ((int)(sig->getParamTypes() * QTI_IDENT) < score) {
                 continue;
+            }
 
-            int count = 0;
+            int pscore = 0;
             bool ok = true;
             for (unsigned pi = 0; pi < sig->numParams(); ++pi) {
                 const QoreTypeInfo* t = sig->getParamTypeInfo(pi);
                 QoreValue n;
-                if (args)
+                if (args) {
                     n = args->retrieveEntry(pi);
+                }
 
-                //printd(5, "QoreFunction::runtimeFindVariant() this: %p %s(%s) i: %d param: %s arg: %s\n", this, getName(), sig->getSignatureText(), pi, QoreTypeInfo::getName(t), n.getFullTypeName());
+                //printd(5, "QoreFunction::runtimeFindVariant() this: %p %s(%s) i: %d param: %s arg: %s\n", this,
+                //    getName(), sig->getSignatureText(), pi, QoreTypeInfo::getName(t), n.getFullTypeName());
 
                 int rc;
-                if (n.isNothing() && sig->hasDefaultArg(pi))
+                if (n.isNothing() && sig->hasDefaultArg(pi)) {
                     rc = QTI_IGNORE;
-                else {
+                } else {
                     rc = QoreTypeInfo::runtimeAcceptsValue(t, n);
-                    //printd(5, "QoreFunction::runtimeFindVariant() this: %p %s(%s) i: %d param: %s arg: %s rc: %d\n", this, getName(), sig->getSignatureText(), pi, QoreTypeInfo::getName(t), n.getFullTypeName(), rc);
+                    //printd(5, "QoreFunction::runtimeFindVariant() this: %p %s(%s) i: %d param: %s arg: %s rc: %d\n",
+                    //    this, getName(), sig->getSignatureText(), pi, QoreTypeInfo::getName(t), n.getFullTypeName(),
+                    //    rc);
                     if (rc == QTI_NOT_EQUAL) {
                         ok = false;
                         break;
                     }
                     // do not count default matches with non-existent arguments
-                    if (pi >= nargs)
+                    if (pi >= nargs) {
                         rc = QTI_IGNORE;
+                    }
                 }
 
                 // only increment for actual type matches (t may be NULL)
-                if (t && rc != QTI_IGNORE)
-                    count += rc;
+                if (t && rc != QTI_IGNORE) {
+                    pscore += rc;
+                }
             }
-            if (!ok)
+            if (!ok) {
                 continue;
+            }
 
             // check for extra args
             if ((sig->numParams() < nargs) && strict_args && !uses_extra_args) {
@@ -1050,22 +1064,25 @@ const AbstractQoreFunctionVariant* QoreFunction::runtimeFindVariant(ExceptionSin
                         break;
                     }
                 }
-                if (has_arg)
+                if (has_arg) {
                     continue;
+                }
             }
 
-            //printd(5, "QoreFunction::runtimeFindVariant() count: %d match: %d match_len: %d np: %d v: %p\n", count, match, match_len, sig->numParams(), variant);
+            //printd(5, "QoreFunction::runtimeFindVariant() pscore: %d score: %d score_len: %d np: %d v: %p\n", pscore,
+            //    score, score_len, sig->numParams(), variant);
 
-            if (count > match || (count == match && (match_len == -1 || (sig->numParams() < (unsigned)match_len)))) {
-                match = count;
+            if (pscore > score || (pscore == score && (score_len == -1 || (sig->numParams() < (unsigned)score_len)))) {
+                score = pscore;
                 variant = *i;
 
-                match_len = sig->numParams();
+                score_len = sig->numParams();
             }
         }
         // issue 1229: stop searching the class hierarchy if a match found
-        if (stop || variant)
+        if (stop || variant) {
             break;
+        }
     }
     /*
     if (saved_variant) {
@@ -1128,7 +1145,9 @@ const AbstractQoreFunctionVariant* QoreFunction::runtimeFindVariant(ExceptionSin
             // check parse options
             int64 vflags = variant->getFunctionality();
             // check restrictive flags
-            //printd(5, "QoreFunction::runtimeFindVariant() this: %p %s() returning %p %s(%s) vflags: " QLLD " po: " QLLD " neg: " QLLD "\n", this, getName(), variant, getName(), variant ? variant->getSignature()->getSignatureText() : "n/a", (vflags & po & ~PO_POSITIVE_OPTIONS));
+            //printd(5, "QoreFunction::runtimeFindVariant() this: %p %s() returning %p %s(%s) vflags: " QLLD " po: " QLLD
+            //    " neg: " QLLD "\n", this, getName(), variant, getName(),
+            //    variant ? variant->getSignature()->getSignatureText() : "n/a", (vflags & po & ~PO_POSITIVE_OPTIONS));
             if ((vflags & po & ~PO_POSITIVE_OPTIONS) || ((vflags & PO_POSITIVE_OPTIONS) && (((vflags & PO_POSITIVE_OPTIONS) & po) != (vflags & PO_POSITIVE_OPTIONS)))) {
                 //printd(5, "QoreFunction::runtimeFindVariant() this: %p %s(%s) getProgram(): %p getProgram()->getParseOptions64(): %x variant->getFunctionality(): %x\n", this, getName(), variant->getSignature()->getSignatureText(), getProgram(), getProgram()->getParseOptions64(), variant->getFunctionality());
                 if (!only_user) {
@@ -1418,9 +1437,11 @@ const AbstractQoreFunctionVariant* QoreFunction::runtimeFindExactVariant(Excepti
 const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProgramLocation* loc,
         const type_vec_t& argTypeInfo, const qore_class_private* class_ctx, int& err) const {
     // the lowest match length with the highest score wins
-    int match_len = -1;
-    // the number of parameters * 2 matched to arguments (compatible but not perfect match = 1, perfect match = 2)
-    int match = -1;
+    int score_len = -1;
+    // the score for the match of the variant
+    int score = -1;
+    // the maximum score for the match of the variant
+    int max_score = -1;
     // the number of possible matches at runtime (due to missing types at parse time); number of parameters
     int pmatch = -1;
     // the number of arguments matched perfectly in case of a tie score
@@ -1454,8 +1475,9 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
     for (ilist_t::const_iterator aqfi = ilist.begin(), aqfe = ilist.end(); aqfi != aqfe; ++aqfi) {
         bool stop;
         aqf = ilist.getFunction(class_ctx, last_class, aqfi, internal_access, stop);
-        if (!aqf)
+        if (!aqf) {
             break;
+        }
         printd(5, "QoreFunction::parseFindVariant() %p %s testing function %p\n", this, getName(), aqf);
         assert(!aqf->vlist.empty());
 
@@ -1474,8 +1496,9 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
             bool strict_args = (*i)->getParseOptions(po) & (PO_REQUIRE_TYPES|PO_STRICT_ARGS);
 
             // ignore "noop" variants if necessary
-            if (strict_args && (vflags & (QCF_NOOP | QCF_RUNTIME_NOOP)))
+            if (strict_args && (vflags & (QCF_NOOP | QCF_RUNTIME_NOOP))) {
                 continue;
+            }
 
             // does the variant accept extra arguments?
             bool uses_extra_args = vflags & QCF_USES_EXTRA_ARGS;
@@ -1483,8 +1506,8 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
             ++cnt;
 
             printd(5, "QoreFunction::parseFindVariant() this: %p checking committed %s(%s) variant: %p sig->pt: %d " \
-                "sig->mpt: %d match: %d, args: %d\n", this, getName(), sig->getSignatureText(), variant,
-                sig->getParamTypes(), sig->getMinParamTypes(), match, num_args);
+                "sig->mpt: %d score: %d, args: %d\n", this, getName(), sig->getSignatureText(), variant,
+                sig->getParamTypes(), sig->getMinParamTypes(), score, num_args);
 
             // issue 1507: ensure that calls with no arguments and no params are considered a perfect match
             if (!num_args && !sig->numParams()) {
@@ -1493,9 +1516,10 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
             }
 
             // skip variants with signatures with fewer possible elements than the best match already
-            if ((int)(sig->numParams() * QTI_IDENT) > match) {
+            if ((int)(sig->numParams() * QTI_IDENT) >= score) {
                 int variant_pmatch = 0;
-                int count = 0;
+                int pscore = 0;
+                int max_pscore = 0;
                 int variant_nperfect = 0;
                 bool variant_runtime_match = false;
                 bool ok = true;
@@ -1513,63 +1537,76 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
                         num_args, QoreTypeInfo::getName(t), QoreTypeInfo::hasType(t), QoreTypeInfo::getName(a), a,
                         QoreTypeInfo::parseAccepts(t, a));
 
-                    int rc = QTI_UNASSIGNED;
+                    qore_type_result_e rc = QTI_UNASSIGNED;
+                    qore_type_result_e max_rc = QTI_UNASSIGNED;
                     if (QoreTypeInfo::hasType(t)) {
                         if (!QoreTypeInfo::hasType(a)) {
                             if (pi < num_args) {
                                 // we are missing parse-time type information, we need to match at runtime
                                 variant_runtime_match = true;
                                 break;
-                            } else if (sig->hasDefaultArg(pi))
-                                rc = QTI_IGNORE;
-                            else
+                            } else if (sig->hasDefaultArg(pi)) {
+                                rc = max_rc = QTI_IGNORE;
+                            } else {
                                 a = nothingTypeInfo;
-                        } else if (QoreTypeInfo::isType(a, NT_NOTHING) && sig->hasDefaultArg(pi))
-                            rc = QTI_IDENT;
+                            }
+                        } else if (QoreTypeInfo::isType(a, NT_NOTHING) && sig->hasDefaultArg(pi)) {
+                            rc = max_rc = QTI_IDENT;
+                        }
                     }
 
                     if (rc == QTI_UNASSIGNED) {
                         bool may_not_match = false;
-                        rc = QoreTypeInfo::parseAccepts(t, a, may_not_match);
-                        printd(5, "QoreFunction::parseFindVariant() %s(%s) pi: %d (%s <= %s) rc: %d may_not_match: %d\n",
-                            getName(), sig->getSignatureText(), pi, QoreTypeInfo::getName(t), QoreTypeInfo::getName(a),
-                            rc, may_not_match);
+                        bool may_need_filter = false;
+                        rc = QoreTypeInfo::parseAccepts(t, a, may_not_match, may_need_filter, max_rc);
+                        //printd(5, "QoreFunction::parseFindVariant() %s(%s) pi: %d (%s <= %s) rc: %d max_rc: %d "
+                        //    "may_not_match: %d\n", getName(), sig->getSignatureText(), pi, QoreTypeInfo::getName(t),
+                        //    QoreTypeInfo::getName(a), rc, max_rc, may_not_match);
                         // if we might not match, we need to match at runtime
                         if (may_not_match) {
                             variant_runtime_match = true;
                             continue;
                         }
-                        if (rc == QTI_IDENT)
+                        if (rc == QTI_IDENT) {
                             ++variant_nperfect;
+                        }
                     }
 
                     if (rc == QTI_NOT_EQUAL) {
                         ok = false;
                         // raise a detailed parse exception immediately if there is only one variant
-                        if (ilist.size() == 1 && aqf->vlist.singular() && getProgram()->getParseExceptionSink())
+                        if (ilist.size() == 1 && aqf->vlist.singular() && getProgram()->getParseExceptionSink()) {
                             return doSingleVariantTypeException(loc, pi + 1, aqf->className(), getName(),
                                 sig->getSignatureText(), t, a);
+                        }
                         break;
                     }
                     ++variant_pmatch;
-                    if (rc != QTI_IGNORE && pos_has_arg)
-                        count += rc;
+                    if (rc != QTI_IGNORE && pos_has_arg) {
+                        pscore += rc;
+                        if (max_rc == QTI_UNASSIGNED) {
+                            max_rc = rc;
+                        }
+                        max_pscore += max_rc;
+                    }
                 }
 
                 // stop searching if we need to match at runtime
                 if (variant_runtime_match) {
                     runtime_match = true;
-                    if (variant)
+                    if (variant) {
                         variant = nullptr;
+                    }
                     break;
                 }
 
-                printd(5, "QoreFunction::parseFindVariant() this: %p tested %s(%s) ok: %d count: %d match: %d " \
-                    "variant_pmatch: %d variant_nperfect: %d nperfect: %d variant_runtime_match: %d\n", this,
-                    getName(), sig->getSignatureText(), ok, count, match, variant_pmatch, variant_nperfect, nperfect,
-                    variant_runtime_match);
-                if (!ok)
+                //printd(5, "QoreFunction::parseFindVariant() this: %p tested %s(%s) ok: %d pscore: %d max_pscore: %d "
+                //    "score: %d max_score: %d variant_pmatch: %d variant_nperfect: %d nperfect: %d "
+                //    "variant_runtime_match: %d\n", this, getName(), sig->getSignatureText(), ok, pscore, max_pscore,
+                //    score, max_score, variant_pmatch, variant_nperfect, nperfect, variant_runtime_match);
+                if (!ok) {
                     continue;
+                }
 
                 // now check if additional args are present
                 if ((sig->numParams() < num_args) && !uses_extra_args && strict_args &&
@@ -1577,17 +1614,19 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
                     continue;
                 }
 
-                if (!npv)
+                if (!npv) {
                     pvariant = variant;
-                else
+                } else {
                     pvariant = nullptr;
+                }
 
                 ++npv;
 
-                if (count > match
-                    || (count == match && (variant_nperfect > nperfect
-                                            || (variant_nperfect == nperfect
-                                                && (match_len == -1 || sig->numParams() < (unsigned)match_len))))) {
+                if ((pscore > score && max_pscore >= max_score)
+                    || (pscore == score
+                        && (variant_nperfect > nperfect
+                            || (variant_nperfect == nperfect
+                                && (score_len == -1 || sig->numParams() < (unsigned)score_len))))) {
                     // if we could possibly match less than another variant
                     // then we have to match at runtime
                     if (variant_pmatch < pmatch) {
@@ -1598,19 +1637,19 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
                         // only set variant if it's the longest absolute match and the
                         // longest potential match
                         pmatch = variant_pmatch;
-                        match = count;
+                        score = pscore;
                         nperfect = variant_nperfect;
-                        match_len = sig->numParams();
+                        score_len = sig->numParams();
                         printd(5, "QoreFunction::parseFindVariant() assigning variant %p %s(%s)\n", *i, getName(),
                             sig->getSignatureText());
                         variant = *i;
                     }
-                } else if (variant_pmatch && variant_pmatch >= pmatch) {
+                } else if (variant_pmatch && (variant_pmatch >= pmatch || max_pscore >= max_score)) {
                     // if we could possibly match less than another variant
                     // then we have to match at runtime
                     variant = nullptr;
                     pmatch = variant_pmatch;
-                    match_len = -1;
+                    score_len = -1;
                 }
             }
         }
@@ -1622,13 +1661,15 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
         }
 
         if (runtime_match) {
-            if (variant)
+            if (variant) {
                 variant = nullptr;
+            }
             break;
         }
         // issue 1229: stop searching the class hierarchy if a match found
-        if (stop || variant)
+        if (stop || variant) {
             break;
+        }
     }
 
     assert(!(runtime_match && variant));
@@ -1653,29 +1694,34 @@ const AbstractQoreFunctionVariant* QoreFunction::parseFindVariant(const QoreProg
             for (ilist_t::const_iterator aqfi = ilist.begin(), aqfe = ilist.end(); aqfi != aqfe; ++aqfi) {
                 bool stop;
                 aqf = ilist.getFunction(class_ctx, last_class, aqfi, internal_access, stop);
-                if (!aqf)
+                if (!aqf) {
                     break;
+                }
                 const char* class_name = aqf->className();
 
                 for (vlist_t::const_iterator i = aqf->vlist.begin(), e = aqf->vlist.end(); i != e; ++i) {
                     // skip if the variant is not accessible
-                    if (last_class && skip_method_variant(*i, class_ctx, internal_access))
+                    if (last_class && skip_method_variant(*i, class_ctx, internal_access)) {
                         continue;
+                    }
 
                     // if we should ignore "noop" variants
                     bool strict_args = (*i)->getParseOptions(po) & (PO_REQUIRE_TYPES|PO_STRICT_ARGS);
 
                     // ignore "noop" variants if necessary
-                    if (strict_args && ((*i)->getFlags() & (QCF_NOOP | QCF_RUNTIME_NOOP)))
+                    if (strict_args && ((*i)->getFlags() & (QCF_NOOP | QCF_RUNTIME_NOOP))) {
                         continue;
+                    }
 
                     desc->concat("\n   ");
-                    if (class_name)
+                    if (class_name) {
                         desc->sprintf("%s::", class_name);
+                    }
                     desc->sprintf("%s(%s)", getName(), (*i)->getSignature()->getSignatureText());
                 }
-                if (stop)
+                if (stop) {
                     break;
+                }
             }
         }
         qore_program_private::makeParseException(getProgram(), *loc, "PARSE-TYPE-ERROR", desc);

--- a/lib/FunctionCallNode.cpp
+++ b/lib/FunctionCallNode.cpp
@@ -51,13 +51,14 @@ QoreValue AbstractMethodCallNode::exec(QoreObject* o, const char* c_str, const q
         //    method->getClassName(), method->getName(), qc->getName(), o->getClass()->getName(), variant);
         assert(method);
         if (!o->isValid()) {
-            if (variant)
+            if (variant) {
                 xsink->raiseException("OBJECT-ALREADY-DELETED", "cannot call %s::%s(%s) on an object that has " \
                     "already been deleted", qc->getName(), method->getName(),
                     variant->getSignature()->getSignatureText());
-            else
+            } else {
                 xsink->raiseException("OBJECT-ALREADY-DELETED", "cannot call %s::%s() on an object that has " \
                     "already been deleted", qc->getName(), method->getName());
+            }
             return QoreValue();
         }
 

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -201,25 +201,26 @@ void AbstractMethod::parseMergeBase(AbstractMethod& m, bool committed) {
 
 // merge changes from parent class method of the same name during parse initialization
 void AbstractMethod::parseMergeBase(AbstractMethod& m, MethodFunctionBase* f, bool committed) {
-    //printd(5, "AbstractMethod::parseMergeBase(m: %p, f: %p %s::%s) this: %p m.pending_save: %d m.vlist: %d\n", &m, f, f ? f->getClassName() : "n/a", f ? f->getName() : "n/a", this, !m.pending_save.empty(), !m.vlist.empty());
+    //printd(5, "AbstractMethod::parseMergeBase(m: %p, f: %p %s::%s) this: %p m.pending_save: %d m.vlist: %d\n", &m,
+    //    f, f ? f->getClassName() : "n/a", f ? f->getName() : "n/a", this, !m.pending_save.empty(),
+    //    !m.vlist.empty());
     // move pending committed variants from our vlist that are in parent's pending_save list to our pending_save
     for (auto& i : m.pending_save) {
         const char* sig = i.second->getAbstractSignature();
         vmap_t::iterator vi = vlist.find(sig);
         if (vi != vlist.end()) {
-            /*
-            pending_save.insert(vmap_t::value_type(sig, i.second));
-            */
-
             pending_save.insert(vmap_t::value_type(sig, vi->second));
             vlist.erase(vi);
         }
     }
 
-    // add new abstract methods from parent to our list - if they are not already in our vlist or in our pending_save list
+    // add new abstract methods from parent to our list - if they are not already in our vlist or in our pending_save
+    // list
     for (auto& i : m.vlist) {
         const char* sig = i.second->getAbstractSignature();
-        //printd(5, "AbstractMethod::parseMergeBase(m: %p, f: %p %s::%s) this: %p checking parent: '%s' (f: %p: %d) '%s'\n", &m, f, f ? f->getClassName() : "n/a", f ? f->getName() : "n/a", this, sig, f, f && f->parseHasVariantWithSignature(i.second), sig);
+        //printd(5, "AbstractMethod::parseMergeBase(m: %p, f: %p %s::%s) this: %p checking parent: '%s' (f: %p: %d "
+        //    "rm: %d) '%s'\n", &m, f, f ? f->getClassName() : "n/a", f ? f->getName() : "n/a", this, sig, f,
+        //    f && f->parseHasVariantWithSignature(i.second, relaxed_match), relaxed_match, sig);
 
         if (f && f->parseHasVariantWithSignature(i.second, relaxed_match)) {
             // add to our pending_save
@@ -234,7 +235,8 @@ void AbstractMethod::parseMergeBase(AbstractMethod& m, MethodFunctionBase* f, bo
         if (vlist.find(sig) != vlist.end()) {
             continue;
         }
-        //printd(5, "AbstractMethod::parseMergeBase(m: %p, f: %p %s::%s) this: %p adding to vlist from parent: '%s'\n", &m, f, f ? f->getClassName() : "n/a", f ? f->getName() : "n/a", this, sig);
+        //printd(5, "AbstractMethod::parseMergeBase(m: %p, f: %p %s::%s) this: %p adding to vlist from parent: "
+        //    '%s'\n", &m, f, f ? f->getClassName() : "n/a", f ? f->getName() : "n/a", this, sig);
         i.second->ref();
         vlist.insert(vmap_t::value_type(sig, i.second));
     }
@@ -319,13 +321,15 @@ void AbstractMethod::checkAbstract(const char* cname, const char* mname, vmap_t&
     }
 }
 
-// try to find match non-abstract variants in base classes (allows concrete variants to be inherited from another parent class)
+// try to find match non-abstract variants in base classes (allows concrete variants to be inherited from another
+// parent class)
 void AbstractMethodMap::parseInit(qore_class_private& qc, BCList* scl) {
     //printd(5, "AbstractMethodMap::parseInit() this: %p cname: %s scl: %p ae: %d\n", this, qc.name.c_str(), scl,
     //    empty());
     for (amap_t::iterator i = begin(), e = end(); i != e;) {
         for (vmap_t::iterator vi = i->second->vlist.begin(), ve = i->second->vlist.end(); vi != ve;) {
-            // if there is a matching non-abstract variant in any parent class, then move the variant from vlist to pending_save
+            // if there is a matching non-abstract variant in any parent class, then move the variant from vlist to
+            // pending_save
             MethodVariantBase* v = scl->matchNonAbstractVariant(i->first, vi->second);
             if (v) {
                 const char* sig = vi->second->getAbstractSignature();
@@ -362,11 +366,12 @@ void AbstractMethodMap::parseAddAbstractVariant(const char* name, MethodVariantB
         f->ref();
         const char* sig = f->getAbstractSignature();
         m->vlist.insert(vmap_t::value_type(sig, f));
-        //printd(5, "AbstractMethodMap::parseAddAbstractVariant(name: '%s', v: %p) this: %p first (%s)\n", name, f, this, sig);
+        printd(5, "AbstractMethodMap::parseAddAbstractVariant(name: '%s', v: %p) this: %p first (%s)\n", name, f,
+            this, sig);
         insert(amap_t::value_type(name, m));
         return;
     }
-    //printd(5, "AbstractMethodMap::parseAddAbstractVariant(name: '%s', v: %p) this: %p additional\n", name, f, this);
+    printd(5, "AbstractMethodMap::parseAddAbstractVariant(name: '%s', v: %p) this: %p additional\n", name, f, this);
     i->second->parseAdd(f);
 }
 
@@ -384,18 +389,21 @@ void AbstractMethodMap::addAbstractVariant(const char* name, MethodVariantBase* 
         // already referenced for "normal" insertion, ref again for abstract method insertion
         f->ref();
         m->vlist.insert(vmap_t::value_type(f->getAbstractSignature(), f));
-        //printd(5, "AbstractMethodMap::addAbstractVariant(name: xxx::%s asig: %s, v: %p) this: %p (new)\n", name, f->getAbstractSignature(), f, this);
+        //printd(5, "AbstractMethodMap::addAbstractVariant(name: xxx::%s asig: %s, v: %p) this: %p (new)\n", name,
+        //    f->getAbstractSignature(), f, this);
         insert(amap_t::value_type(name, m));
         return;
     }
-    //printd(5, "AbstractMethodMap::addAbstractVariant(name: xxx::%s asig: %s, v: %p) this: %p\n", name, f->getAbstractSignature(), f, this);
+    //printd(5, "AbstractMethodMap::addAbstractVariant(name: xxx::%s asig: %s, v: %p) this: %p\n", name,
+    //    f->getAbstractSignature(), f, this);
     i->second->add(f);
 }
 
 void AbstractMethodMap::overrideAbstractVariant(const char* name, MethodVariantBase* f) {
     amap_t::iterator i = amap_t::find(name);
-    if (i == end())
+    if (i == end()) {
         return;
+    }
     i->second->override(f);
     if (i->second->empty()) {
         delete i->second;
@@ -843,7 +851,7 @@ const QoreMethod* qore_class_private::doParseMethodAccess(const QoreMethod* m, c
 
 int qore_class_private::initialize() {
     //printd(5, "qore_class_private::initialize() this: %p '%s' initialized: %d scl: %p\n", this, name.c_str(), initialized, scl);
-    if (initialized) {
+    if (initialized || sys) {
         return 0;
     }
 
@@ -1106,10 +1114,13 @@ void qore_class_private::mergeAbstract() {
                 hm_method_t::iterator mi = hm.find(j.first);
 
                 // merge committed parent abstract variants with any pending local variants
-                m->parseMergeBase((*j.second), mi == hm.end() ? 0 : qore_method_private::get(*mi->second)->getFunction(), true);
+                m->parseMergeBase((*j.second), mi == hm.end()
+                    ? nullptr
+                    : qore_method_private::get(*mi->second)->getFunction(), true);
                 if (!m->empty()) {
                     ahm.insert(amap_t::value_type(j.first, m.release()));
-                    //printd(5, "qore_class_private::initializeIntern() this: %p '%s' insert abstract method variant %s::%s()\n", this, name.c_str(), (*i).sclass->getName(), j.first.c_str());
+                    //printd(5, "qore_class_private::initializeIntern() this: %p '%s' insert abstract method variant "
+                    //    "%s::%s()\n", this, name.c_str(), (*i).sclass->getName(), j.first.c_str());
                 }
             }
         }
@@ -1538,10 +1549,11 @@ void qore_class_private::addBuiltinMethod(const char* mname, MethodVariantBase* 
 
     nm->priv->addBuiltinVariant(variant);
 
-    if (variant->isAbstract())
+    if (variant->isAbstract()) {
         ahm.addAbstractVariant(mname, variant);
-    else
+    } else {
         ahm.overrideAbstractVariant(mname, variant);
+    }
 }
 
 void qore_class_private::addBuiltinStaticMethod(const char* mname, MethodVariantBase* variant) {
@@ -2132,8 +2144,9 @@ void BCList::parseResolveAbstract() {
 }
 
 void BCList::rescanParents(QoreClass* cls) {
-    if (rescanned)
+    if (rescanned) {
         return;
+    }
     rescanned = true;
     // iterate sml for all virtual parent classes; must iterate with offsets;
     // the vector can be reallocated during this operation
@@ -3229,7 +3242,8 @@ static const QoreClass* getStackClass() {
     return qc ? qc->cls : nullptr;
 }
 
-void QoreClass::addMember(const char* mname, ClassAccess access, const QoreTypeInfo* n_typeInfo, QoreValue initial_value) {
+void QoreClass::addMember(const char* mname, ClassAccess access, const QoreTypeInfo* n_typeInfo,
+        QoreValue initial_value) {
     priv->addMember(mname, access, n_typeInfo, initial_value);
 }
 
@@ -3251,36 +3265,44 @@ void BCSMList::processMemberInitializationList(const QoreMemberMap& members, mem
     for (auto& i : *this) {
         assert(i.first);
 
-        //printd(5, "BCSMList::processMemberInitializationList() processing %p '%s'\n", i.first->priv, i.first->getName());
+        //printd(5, "BCSMList::processMemberInitializationList() processing %p '%s'\n", i.first->priv,
+        //    i.first->getName());
         for (auto& mi : i.first->priv->members.member_list) {
             // skip imported members
             if (!mi.second->local()) {
-                //printd(5, "BCSMList::processMemberInitializationList() %p '%s::%s' NOT LOCAL\n", i.first->priv, i.first->getName(), mi.first);
+                //printd(5, "BCSMList::processMemberInitializationList() %p '%s::%s' NOT LOCAL\n", i.first->priv,
+                //    i.first->getName(), mi.first);
                 continue;
             }
             // find corresponding member in derived class
             const QoreMemberInfo* info = members.find(mi.first);
             if (!info) {
-                //printd(5, "BCSMList::processMemberInitializationList() %p '%s::%s' NOT FOUND\n", i.first->priv, i.first->getName(), mi.first);
+                //printd(5, "BCSMList::processMemberInitializationList() %p '%s::%s' NOT FOUND\n", i.first->priv,
+                //    i.first->getName(), mi.first);
                 // in case of dependency injections, the member may not be found in the class
                 continue;
             }
 
             const qore_class_private* member_class_ctx = info->getClassContext(i.first->priv);
-            //printd(5, "BCSMList::processMemberInitializationList() adding '%s::%s' ctx: %p '%s'\n", i.first->getName(), mi.first, member_class_ctx, member_class_ctx ? member_class_ctx->name.c_str() : "n/a");
+            //printd(5, "BCSMList::processMemberInitializationList() adding '%s::%s' ctx: %p '%s'\n",
+            //    i.first->getName(), mi.first, member_class_ctx,
+            //    member_class_ctx ? member_class_ctx->name.c_str() : "n/a");
             // insert this entry with the class context for saving against the object
             member_init_list.push_back(member_init_entry_t(mi.first, mi.second.get(), member_class_ctx));
         }
-        //printd(5, "BCSMList::processMemberInitializationList() done processing %p '%s'\n", i.first->priv, i.first->getName());
+        //printd(5, "BCSMList::processMemberInitializationList() done processing %p '%s'\n", i.first->priv,
+        //    i.first->getName());
     }
 }
 
 void BCSMList::alignBaseClassesInSubclass(QoreClass* thisclass, QoreClass* child, bool is_virtual) {
-    //printd(5, "BCSMList::alignBaseClassesInSubclass(this: %s, sc: %s) size: %d\n", thisclass->getName(), sc->getName());
+    //printd(5, "BCSMList::alignBaseClassesInSubclass(this: %s, sc: %s) size: %d\n", thisclass->getName(),
+    //    sc->getName());
     // we must iterate with offsets, because the vector can be reallocated during this iteration
     for (unsigned i = 0; i < (*this).size(); ++i) {
         bool virt = is_virtual || (*this)[i].second;
-        //printd(5, "BCSMList::alignBaseClassesInSubclass() %s child: %s virt: %d\n", thisclass->getName(), sc->getName(), virt);
+        //printd(5, "BCSMList::alignBaseClassesInSubclass() %s child: %s virt: %d\n", thisclass->getName(),
+        //    sc->getName(), virt);
         child->priv->scl->sml.align(child, (*this)[i].first, virt);
     }
 }
@@ -3290,14 +3312,16 @@ void BCSMList::align(QoreClass* thisclass, QoreClass* qc, bool is_virtual) {
 
     // see if class already exists in vector
     for (auto& i : *this) {
-        if (i.first->getID() == qc->getID())
+        if (i.first->getID() == qc->getID()) {
             return;
+        }
         assert(i.first->getID() != thisclass->getID());
     }
     qc->priv->ref();
 
     // append to the end of the vector
-    //printd(5, "BCSMList::align() adding %p '%s' (virt: %d) as a base class of %p '%s'\n", qc, qc->getName(), is_virtual, thisclass, thisclass->getName());
+    //printd(5, "BCSMList::align() adding %p '%s' (virt: %d) as a base class of %p '%s'\n", qc, qc->getName(),
+    //    is_virtual, thisclass, thisclass->getName());
     push_back(std::make_pair(qc, is_virtual));
 }
 
@@ -4192,7 +4216,7 @@ QoreListNode* QoreClass::getStaticMethodList() const {
 }
 
 int qore_class_private::parseInitPartial() {
-    if (parse_init_partial_called) {
+    if (parse_init_partial_called || sys) {
         return 0;
     }
 
@@ -4281,7 +4305,7 @@ int qore_class_private::parseInit() {
 
     //printd(5, "qore_class_private::parseInit() this: %p '%s' parse_init_called: %d parse_init_partial_called: %d\n",
     //  this, name.c_str(), parse_init_called, parse_init_partial_called);
-    if (parse_init_called) {
+    if (parse_init_called || sys) {
         return err;
     }
 
@@ -4689,8 +4713,9 @@ void QoreClass::addBuiltinStaticVar(const char* name, QoreValue value, ClassAcce
 
 void QoreClass::rescanParents() {
     // rebuild parent class data
-    if (priv->scl)
+    if (priv->scl) {
         priv->scl->rescanParents(this);
+    }
 }
 
 void QoreClass::setPublicMemberFlag() {
@@ -4931,7 +4956,8 @@ void MethodFunctionBase::replaceAbstractVariantIntern(MethodVariantBase* variant
             return;
         }
     }
-    //printd(5, "MethodFunctionBase::replaceAbstractVariantIntern() this: %p adding %p ::%s%s to vlist\n", this, variant, getName(), variant->getAbstractSignature());
+    //printd(5, "MethodFunctionBase::replaceAbstractVariantIntern() this: %p adding %p ::%s%s to vlist\n", this,
+    //    variant, getName(), variant->getAbstractSignature());
     vlist.push_back(variant);
     if (is_abstract) {
         is_abstract = false;
@@ -4960,8 +4986,9 @@ MethodVariantBase* MethodFunctionBase::parseHasVariantWithSignature(MethodVarian
     AbstractFunctionSignature& sig = *(v->getSignature());
     for (vlist_t::const_iterator i = vlist.begin(), e = vlist.end(); i != e; ++i) {
         (*i)->parseResolveUserSignature();
-        if ((*i)->isSignatureIdentical(sig, relaxed_match))
+        if ((*i)->isSignatureIdentical(sig, relaxed_match)) {
             return reinterpret_cast<MethodVariantBase*>(*i);
+        }
     }
     return nullptr;
 }


### PR DESCRIPTION
…me and force runtime resolution, fixed variant resolution to detect "auto" as a wildcard (low-priority) match, fixed variant matching with relaxed rules enabled (ex: Java inheritance) to accept wildcard matches or better