### PR TITLE
refs #4444 dropped the deprecated c++ gettid() API to fix compilation…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,12 +688,12 @@ endif (WIN32 OR MINGW OR MSYS)
 
 set_target_properties(libqore PROPERTIES OUTPUT_NAME qore)
 if (APPLE)
-    set_target_properties(libqore PROPERTIES VERSION 7)
-    set_target_properties(libqore PROPERTIES SOVERSION 7)
+    set_target_properties(libqore PROPERTIES VERSION 12)
+    set_target_properties(libqore PROPERTIES SOVERSION 12)
     set_target_properties(libqore PROPERTIES INSTALL_NAME_DIR ${CMAKE_INSTALL_FULL_LIBDIR})
 else (APPLE)
-    set_target_properties(libqore PROPERTIES VERSION 7.4.2)
-    set_target_properties(libqore PROPERTIES SOVERSION 7)
+    set_target_properties(libqore PROPERTIES VERSION 12.0.0)
+    set_target_properties(libqore PROPERTIES SOVERSION 12)
 endif (APPLE)
 
 # prepare qore target

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -35,9 +35,11 @@
     - <a href="../../modules/Util/html/index.html">Util</a> module
       - \c parse_uri_query() fails if the string has newlines in it
         (<a href="https://github.com/qorelanguage/qore/issues/4429">issue 4429</a>)
+    - Fixed building on the latest versions of Alpine (v3.15)
+      (<a href="https://github.com/qorelanguage/qore/issues/4444">issue 4444</a>)
     - Support for OpenSSL 3+ added; when %Qore is compiled with OpenSS 3 or greater, all cipher and digest algorithms
       known to the encryption library are supported with dynamic APIs
-      (<a href="https://github.com/qorelanguage/qore/issues/4494">issue 4494</a>)
+      (<a href="https://github.com/qorelanguage/qore/issues/4394">issue 4394</a>)
     - Removed code that generated unnecessary \c ILLEGAL-CALL exceptions at parse time
       (<a href="https://github.com/qorelanguage/qore/issues/4404">issue 4404</a>)
 

--- a/include/qore/ModuleManager.h
+++ b/include/qore/ModuleManager.h
@@ -43,7 +43,7 @@
  */
 
 #define QORE_MODULE_API_MAJOR 1  //!< the major number of the Qore module API implemented
-#define QORE_MODULE_API_MINOR 2  //!< the minor number of the Qore module API implemented
+#define QORE_MODULE_API_MINOR 3  //!< the minor number of the Qore module API implemented
 
 #define QORE_MODULE_COMPAT_API_MAJOR QORE_MODULE_API_MAJOR  //!< the major number of the earliest recommended Qore module API
 #define QORE_MODULE_COMPAT_API_MINOR QORE_MODULE_API_MINOR  //!< the minor number of the earliest recommended Qore module API

--- a/include/qore/qore_thread.h
+++ b/include/qore/qore_thread.h
@@ -66,9 +66,6 @@ typedef void (*q_thread_t)(ExceptionSink* xsink, void* arg);
  */
 DLLEXPORT bool is_valid_qore_thread();
 
-//! @deprecated due to symbol conflicts; use q_gettid() instead
-DLLEXPORT int gettid() noexcept;
-
 //! returns the current TID number
 /** @since %Qore 0.9.5.1
 */

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -11,7 +11,7 @@ dummy:
 	echo "Build started!"
 
 EXTRA_INCLUDES = -I$(top_srcdir)/include -I$(top_builddir)/include -I$(top_builddir)/lib
-libqore_la_LDFLAGS = -version-info 11:2:4 -no-undefined ${QORE_LIB_LDFLAGS}
+libqore_la_LDFLAGS = -version-info 12:0:0 -no-undefined ${QORE_LIB_LDFLAGS}
 AM_CPPFLAGS = $(EXTRA_INCLUDES) ${QORE_LIB_CPPFLAGS}
 AM_CXXFLAGS = ${QORE_LIB_CXXFLAGS}
 AM_YFLAGS = -d

--- a/lib/ModuleManager.cpp
+++ b/lib/ModuleManager.cpp
@@ -61,9 +61,7 @@
 #include <vector>
 
 static const qore_mod_api_compat_s qore_mod_api_list_l[] = {
-    {1, 2},
-    {1, 1},
-    {1, 0},
+    {1, 3},
 };
 #define QORE_MOD_API_LEN (sizeof(qore_mod_api_list_l)/sizeof(struct qore_mod_api_compat_s))
 
@@ -804,7 +802,7 @@ int QoreModuleManager::loadModuleIntern(ExceptionSink& xsink, ExceptionSink& wsi
         if (i == module_load_map.end()) {
             break;
         }
-        if (i->second == gettid()) {
+        if (i->second == q_gettid()) {
             xsink.raiseException("LOAD-MODULE-ERROR", "module '%s' has a circular dependency back to itself",
                 name);
             return -1;
@@ -2015,7 +2013,7 @@ char version_list_t::set(const char* v) {
 
 ModuleLoadMapHelper::ModuleLoadMapHelper(const char* feature) {
     assert(QMM.module_load_map.find(feature) == QMM.module_load_map.end());
-    i = QMM.module_load_map.insert(QoreModuleManager::module_load_map_t::value_type(feature, gettid())).first;
+    i = QMM.module_load_map.insert(QoreModuleManager::module_load_map_t::value_type(feature, q_gettid())).first;
 
     // run initialization unlocked
     QMM.mutex.unlock();

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -1322,11 +1322,6 @@ bool is_valid_qore_thread() {
    return (bool)thread_data.get();
 }
 
-// deprecated due to potential symbol conflicts; use q_gettid() instead
-int gettid() noexcept {
-    return q_gettid();
-}
-
 int q_gettid() noexcept {
     // when destroying objects in the static namespace, this function is called after thread data is destroyed
     // to grab locks; therefore in such cases we return TID 0

--- a/qore.spec-fedora
+++ b/qore.spec-fedora
@@ -32,9 +32,7 @@ development but is also useful as a general purpose language.
 
 %package -n libqore
 Summary: The libraries for the qore runtime and qore clients
-Provides: qore-module(abi)%{?_isa} = 1.2
-Provides: qore-module(abi)%{?_isa} = 1.1
-Provides: qore-module(abi)%{?_isa} = 1.0
+Provides: qore-module(abi)%{?_isa} = 1.3
 
 %description -n libqore
 Qore is a scripting language supporting threading and embedded logic, designed
@@ -45,8 +43,8 @@ This package provides the qore library required for all clients using qore
 functionality.
 
 %files -n libqore
-%{_libdir}/libqore.so.7.4.2
-%{_libdir}/libqore.so.7
+%{_libdir}/libqore.so.12.0.0
+%{_libdir}/libqore.so.12
 %license COPYING.LGPL COPYING.GPL COPYING.MIT README-LICENSE
 %doc README.md README-MODULES RELEASE-NOTES AUTHORS ABOUT
 
@@ -177,6 +175,8 @@ make check
 %changelog
 * Wed Feb 9 2022 David Nichols <david@qore.org> 1.4.0-1
 - updated version to 1.4.0-1
+- updated libqore version to 12.0.0
+- added support for module-abi 1.3, dropped support for all previous versions
 
 * Fri Jan 28 2022 David Nichols <david@qore.org> 1.3.0-1
 - updated version to 1.3.0-1

--- a/qore.spec-multi
+++ b/qore.spec-multi
@@ -93,9 +93,7 @@ development but is also useful as a general purpose language.
 %package -n %{libname}
 Summary: The libraries for the qore runtime and qore clients
 Group: System Environment/Libraries
-Provides: qore-module(abi)%{?_isa} = 1.2
-Provides: qore-module(abi)%{?_isa} = 1.1
-Provides: qore-module(abi)%{?_isa} = 1.0
+Provides: qore-module(abi)%{?_isa} = 1.3
 %if "%{libname}" == "libqore"
 Provides: libqore7 = %{version}
 Obsoletes: libqore7 < %{version}
@@ -114,8 +112,8 @@ functionality.
 
 %files -n %{libname}
 %defattr(-,root,root,-)
-%{_libdir}/libqore.so.7.4.2
-%{_libdir}/libqore.so.7
+%{_libdir}/libqore.so.12.0.0
+%{_libdir}/libqore.so.12
 %doc COPYING.LGPL COPYING.GPL COPYING.MIT README.md README-LICENSE README-MODULES RELEASE-NOTES AUTHORS ABOUT
 
 %post -n %{libname}
@@ -282,6 +280,8 @@ rm -rf $RPM_BUILD_ROOT
 %changelog
 * Wed Feb 9 2022 David Nichols <david@qore.org> 1.4.0
 - updated version to 1.4.0
+- updated libqore version to 12.0.0
+- added support for module-abi 1.3, dropped support for all previous versions
 
 * Fri Jan 28 2022 David Nichols <david@qore.org> 1.3.0
 - updated version to 1.3.0

--- a/qore.spec-opensuse
+++ b/qore.spec-opensuse
@@ -56,9 +56,7 @@ development but is also useful as a general purpose language.
 Summary:        The libraries for the qore runtime and qore clients
 License:        LGPL-2.0+ or GPL-2.0+ or MIT
 Group:          Development/Languages/Other
-Provides:       qore-module(abi)%{?_isa} = 1.2
-Provides:       qore-module(abi)%{?_isa} = 1.1
-Provides:       qore-module(abi)%{?_isa} = 1.0
+Provides:       qore-module(abi)%{?_isa} = 1.3
 
 %description -n libqore7
 Qore is a scripting language supporting threading and embedded logic, designed
@@ -70,7 +68,7 @@ functionality.
 
 %files -n libqore7
 %defattr(-,root,root,-)
-%{_libdir}/libqore.so.7.4.2
+%{_libdir}/libqore.so.12.0.0
 %{_libdir}/libqore.so.7
 %doc COPYING.LGPL COPYING.GPL COPYING.MIT README-LICENSE
 


### PR DESCRIPTION
… issues on Alpine (use q_gettid() instead)