### PR TITLE
refs #4471 fixed a bug where DataProvider types based on string that …

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -23,6 +23,9 @@
 
     @subsection qore_1_6_0_bug_fixes Bug Fixes in Qore
     - <a href="../../modules/DataProvider/html/index.html">DataProvider</a> module
+      - fixed a bug where %DataProvider types based on string that accept multiple input types with conversions but
+        are not soft types threw spurious errors at runtime with non-string types
+        (<a href="https://github.com/qorelanguage/qore/issues/4471">issue 4471</a>)
       - fixed a bug where hash types incorrectly claimed compatibility with incompatible hashes
         (<a href="https://github.com/qorelanguage/qore/issues/4463">issue 4463</a>)
     - <a href="../../modules/Mapper/html/index.html">Mapper</a> module

--- a/examples/test/qlib/DataProvider/DataProvider.qtest
+++ b/examples/test/qlib/DataProvider/DataProvider.qtest
@@ -232,8 +232,20 @@ class TestIntProcessor inherits AbstractDataProcessor {
     }
 }
 
+class StringTestType inherits Type {
+    #! Creates the object
+    constructor() : Type("softstring") {
+    }
+
+    #! Returns the type name
+    string getName() {
+        return "teststring";
+    }
+}
+
 public class DataProviderTest inherits QUnit::Test {
     constructor() : Test("DataProvider Test", "1.0") {
+        addTestCase("string test", \stringTest());
         addTestCase("data test", \dataTest());
         addTestCase("compat test", \compatTest());
         addTestCase("pipeline test", \pipelineTest());
@@ -242,6 +254,11 @@ public class DataProviderTest inherits QUnit::Test {
 
         # Return for compatibility with test harness that checks return value.
         set_return_value(main());
+    }
+
+    stringTest() {
+        AbstractDataProviderType t = AbstractDataProviderType::get(new StringTestType());
+        assertEq("1", t.acceptsValue(1));
     }
 
     dataTest() {

--- a/qlib/DataProvider/DataProvider.qm
+++ b/qlib/DataProvider/DataProvider.qm
@@ -203,6 +203,9 @@ $env:QORE_DATA_PROVIDERS="MyConnectionProvider;OtherConnectionProvider"
     @section dataprovider_relnotes Release Notes
 
     @subsection dataprovider_v2_1_2 DataProvider v2.1.2
+    - fixed a bug where %DataProvider types based on string that accept multiple input types with conversions but are
+      not soft types threw spurious errors at runtime with non-string types
+      (<a href="https://github.com/qorelanguage/qore/issues/4471">issue 4471</a>)
     - added the \c desc key supporting a markdown description to data provider info
       (<a href="https://github.com/qorelanguage/qore/issues/4465">issue 4465</a>)
     - fixed a bug where hash types incorrectly claimed compatibility with incompatible hashes

--- a/qlib/DataProvider/QoreStringDataTypeBase.qc
+++ b/qlib/DataProvider/QoreStringDataTypeBase.qc
@@ -86,8 +86,8 @@ public class QoreStringDataTypeBase inherits QoreDataType {
     */
     auto acceptsValue(auto value) {
         if (exists value && value !== NULL) {
-            if ((value.typeCode() != NT_STRING)) {
-                if (!soft_type || !value.strp()) {
+            if (value.typeCode() != NT_STRING) {
+                if (!accept_type_hash{value.type()}) {
                     throw "RUNTIME-TYPE-ERROR", sprintf("value of type %y cannot be converted to type %y",
                         value.type(), getName());
                 }


### PR DESCRIPTION
…accept multiple input types with conversions but are not soft types threw spurious errors at runtime with non-string types