### PR TITLE
refs #4505 fixed parse_datasource() to accept strings with pathnames …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8.12)
 # NOTE: Qore should always use semantic versioning: https://semver.org/
 set(VERSION_MAJOR 1)
 set(VERSION_MINOR 7)
-set(VERSION_SUB 1)
+set(VERSION_SUB 2)
 #set(VERSION_PATCH 0)
 
 # support <pkg>_ROOT in find_package
@@ -692,7 +692,7 @@ if (APPLE)
     set_target_properties(libqore PROPERTIES SOVERSION 12)
     set_target_properties(libqore PROPERTIES INSTALL_NAME_DIR ${CMAKE_INSTALL_FULL_LIBDIR})
 else (APPLE)
-    set_target_properties(libqore PROPERTIES VERSION 12.0.0)
+    set_target_properties(libqore PROPERTIES VERSION 12.0.1)
     set_target_properties(libqore PROPERTIES SOVERSION 12)
 endif (APPLE)
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 
 # AC_PREREQ(2.59)
 # NOTE: Qore should always use semantic versioning: https://semver.org/
-AC_INIT([qore], [1.7.1],
+AC_INIT([qore], [1.7.2],
         [David Nichols <david@qore.org>],
         [qore])
 AM_INIT_AUTOMAKE([no-dist-gzip dist-bzip2 tar-ustar subdir-objects])

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -2,6 +2,16 @@
 
     @tableofcontents
 
+    @section qore_1_7_2 Qore 1.7.2
+
+    @par Release Summary
+    Bugfix release; see below for more information
+
+    @subsection qore_1_7_2_bug_fixes Bug Fixes in Qore
+    - Fixed @ref Qore::parse_datasource() "parse_datasource()" to parse datasource strings with a DB name as a path or
+      with \c ':' chars in the DB or host name
+      (<a href="https://github.com/qorelanguage/qore/issues/4505">issue 4505</a>)
+
     @section qore_1_7_1 Qore 1.7.1
 
     @par Release Summary

--- a/examples/test/qore/functions/parse_datasource.qtest
+++ b/examples/test/qore/functions/parse_datasource.qtest
@@ -22,22 +22,54 @@ public class ParseDatasourceTest inherits QUnit::Test {
     }
 
     test() {
-        hash dh = (
-            "user"    : "user",
-            "pass"    : "123pass@word",
-            "db"      : "dbname",
-            "charset" : "utf8",
-            "host"    : "hostname",
+        {
+            hash<auto> dh = (
+                "user"    : "user",
+                "pass"    : "123pass@word",
+                "db"      : "dbname",
+                "charset" : "utf8",
+                "host"    : "hostname",
             );
-        string ds = "user/123pass@word@dbname(utf8)%hostname";
+            string ds = "user/123pass@word@dbname(utf8)%hostname";
 
-        assertEq(dh, parse_datasource(ds));
+            assertEq(dh, parse_datasource(ds));
+        }
+        assertEq({
+            "type": "sqlite3",
+            "db": "/tmp/my-db.sqlite",
+        }, parse_datasource("sqlite3:@/tmp/my-db.sqlite"));
+
+        assertEq({
+            "type": "sqlite3",
+            "db": ":memory:",
+        }, parse_datasource("sqlite3:@:memory:"));
+        assertEq({
+            "type": "test",
+            "user": "a",
+            "db": "b:x",
+            "host": "c:x",
+        }, parse_datasource("test:a@b:x%c:x"));
+        assertEq({
+            "type": "test",
+            "user": "a",
+            "db": "b",
+            "host": "c:x",
+        }, parse_datasource("test:a@b%c:x"));
+        assertEq({
+            "user": "a",
+            "db": "b:x",
+            "host": "c:x",
+        }, parse_datasource("a@b:x%c:x"));
+        assertEq({
+            "user": "a",
+            "db": "b",
+            "host": "c:x",
+        }, parse_datasource("a@b%c:x"));
 
         assertThrows("DATASOURCE-PARSE-ERROR", "empty text", sub() { parse_datasource(""); });
         assertThrows("DATASOURCE-PARSE-ERROR", "missing closing parenthesis", sub() { parse_datasource("a@b("); });
         assertThrows("DATASOURCE-PARSE-ERROR", "missing hostname", sub() { parse_datasource("a@b%"); });
         assertThrows("DATASOURCE-PARSE-ERROR", "missing hostname", sub() { parse_datasource("a@b%{}"); });
-        assertThrows("DATASOURCE-PARSE-ERROR", "invalid port", sub() { parse_datasource("a@b%c:x"); });
         assertThrows("DATASOURCE-PARSE-ERROR", "invalid characters present", sub() { parse_datasource("a@b%c:12x2"); });
         assertThrows("DATASOURCE-PARSE-ERROR", "missing closing curly bracket", sub() { parse_datasource("a@b{"); });
         assertThrows("DATASOURCE-PARSE-ERROR", "unrecognized characters at end", sub() { parse_datasource("a@b{x=y}dfgf"); });

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -11,7 +11,7 @@ dummy:
 	echo "Build started!"
 
 EXTRA_INCLUDES = -I$(top_srcdir)/include -I$(top_builddir)/include -I$(top_builddir)/lib
-libqore_la_LDFLAGS = -version-info 12:0:0 -no-undefined ${QORE_LIB_LDFLAGS}
+libqore_la_LDFLAGS = -version-info 12:1:0 -no-undefined ${QORE_LIB_LDFLAGS}
 AM_CPPFLAGS = $(EXTRA_INCLUDES) ${QORE_LIB_CPPFLAGS}
 AM_CXXFLAGS = ${QORE_LIB_CXXFLAGS}
 AM_YFLAGS = -d

--- a/qore.spec-fedora
+++ b/qore.spec-fedora
@@ -2,7 +2,7 @@
 %global user_module_dir %{_datadir}/qore-modules/
 
 Name: qore
-Version: 1.7.1
+Version: 1.7.2
 Release: 1%{?dist}
 Summary: Multithreaded Programming Language
 
@@ -43,7 +43,7 @@ This package provides the qore library required for all clients using qore
 functionality.
 
 %files -n libqore
-%{_libdir}/libqore.so.12.0.0
+%{_libdir}/libqore.so.12.0.1
 %{_libdir}/libqore.so.12
 %license COPYING.LGPL COPYING.GPL COPYING.MIT README-LICENSE
 %doc README.md README-MODULES RELEASE-NOTES AUTHORS ABOUT
@@ -173,6 +173,9 @@ make check
 %{_mandir}/man1/qore.1.*
 
 %changelog
+* Mon May 2 2022 David Nichols <david@qore.org> 1.7.2-1
+- updated version to 1.7.2-1
+
 * Mon Apr 18 2022 David Nichols <david@qore.org> 1.7.1-1
 - updated version to 1.7.1-1
 

--- a/qore.spec-multi
+++ b/qore.spec-multi
@@ -31,7 +31,7 @@
 
 Summary: Multithreaded Programming Language
 Name: qore
-Version: 1.7.1
+Version: 1.7.2
 Release: 1%{dist}
 %if 0%{?suse_version}
 License: LGPL-2.0+ or GPL-2.0+ or MIT
@@ -112,7 +112,7 @@ functionality.
 
 %files -n %{libname}
 %defattr(-,root,root,-)
-%{_libdir}/libqore.so.12.0.0
+%{_libdir}/libqore.so.12.0.1
 %{_libdir}/libqore.so.12
 %doc COPYING.LGPL COPYING.GPL COPYING.MIT README.md README-LICENSE README-MODULES RELEASE-NOTES AUTHORS ABOUT
 
@@ -278,6 +278,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 
 %changelog
+* Mon May 2 2022 David Nichols <david@qore.org> 1.7.2
+- updated version to 1.7.2
+
 * Mon Apr 18 2022 David Nichols <david@qore.org> 1.7.1
 - updated version to 1.7.1
 

--- a/qore.spec-opensuse
+++ b/qore.spec-opensuse
@@ -19,7 +19,7 @@
 
 %define module_dir %{_libdir}/qore-modules
 Name:           qore
-Version:        1.7.1
+Version:        1.7.2
 Release:        0
 Summary:        Multithreaded Programming Language
 License:        LGPL-2.1+ or GPL-2.0+ or MIT
@@ -68,7 +68,7 @@ functionality.
 
 %files -n libqore12
 %defattr(-,root,root,-)
-%{_libdir}/libqore.so.12.0.0
+%{_libdir}/libqore.so.12.0.1
 %{_libdir}/libqore.so.12
 %doc COPYING.LGPL COPYING.GPL COPYING.MIT README-LICENSE
 


### PR DESCRIPTION
…as the db name and with the ':' char in the dbname and in the hostname