### PR TITLE
refs #4656 implemented support for pre-encoded URLs in the HTTPClient…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -8,7 +8,22 @@
     Bugfix release; see below for more information
 
     @subsection qore_1_12_4_bug_fixes Bug Fixes in Qore
-    - fixed building on s390x and ppc64 architectures
+    - <a href="../../modules/ConnectionProvider/html/index.html">ConnectionProvider</a> module
+      - added support for the \c pre_encoded_urls option in the \c HttpConnection class
+        (<a href="https://github.com/qorelanguage/qore/issues/4656">issue 4656</a>)
+    - <a href="../../modules/HttpClientDataProvider/html/index.html">HttpClientDataProvider</a> module
+      - added support for the \c pre_encoded_urls option in the \c HttpConnection class
+        (<a href="https://github.com/qorelanguage/qore/issues/4656">issue 4656</a>)
+    - <a href="../../modules/RestClientDataProvider/html/index.html">RestClientDataProvider</a> module
+      - added support for the \c pre_encoded_urls option in the \c HttpConnection class
+        (<a href="https://github.com/qorelanguage/qore/issues/4656">issue 4656</a>)
+    - added the \c pre_encoded_urls option to the @ref Qore::HTTPClient "HTTPClient" class as well as the following
+      methods:
+      - @ref Qore::HTTPClient::setPreEncodedUrls() "HTTPClient::setPreEncodedUrls()"
+      - @ref Qore::HTTPClient::getPreEncodedUrls() "HTTPClient::getPreEncodedUrls()"
+      \n
+      (<a href="https://github.com/qorelanguage/qore/issues/4656">issue 4656</a>)
+    - fixed building and stack guard on s390x and ppc64 architectures
       (<a href="https://github.com/qorelanguage/qore/issues/4655">issue 4655</a>)
 
     @section qore_1_12_3 Qore 1.12.3

--- a/examples/test/qlib/HttpClientDataProvider/HttpClientDataProvider.qtest
+++ b/examples/test/qlib/HttpClientDataProvider/HttpClientDataProvider.qtest
@@ -75,5 +75,15 @@ public class HttpClientDataProviderTest inherits QUnit::Test {
         assertEq("patch", sinfo.name);
         assertEq(Type::String, sinfo.desc.type());
         assertEq("patch", prov.getName());
+
+        parent = new HttpClientDataProvider({
+            "url": "localhost",
+            "pre_encoded_urls": True,
+        });
+        prov = parent.getChildProviderEx("call");
+        sinfo = prov.getSummaryInfo();
+        assertEq("call", sinfo.name);
+        assertEq(Type::String, sinfo.desc.type());
+        assertEq("call", prov.getName());
     }
 }

--- a/examples/test/qlib/RestClientDataProvider/RestClientDataProvider.qtest
+++ b/examples/test/qlib/RestClientDataProvider/RestClientDataProvider.qtest
@@ -198,5 +198,17 @@ public class RestClientDataProviderTest inherits QUnit::Test {
             assertEq(Type::String, sinfo.desc.type());
             assertEq("put", prov.getName());
         }
+
+        {
+            RestClientDataProvider parent({
+                "url": "http://localhost:" + port,
+                "pre_encoded_urls": True,
+            });
+            AbstractDataProvider prov = parent.getChildProviderEx("put");
+            hash<DataProviderSummaryInfo> sinfo = prov.getSummaryInfo();
+            assertEq("put", sinfo.name);
+            assertEq(Type::String, sinfo.desc.type());
+            assertEq("put", prov.getName());
+        }
     }
 }

--- a/examples/test/qlib/RestHandler/RestHandler.qtest
+++ b/examples/test/qlib/RestHandler/RestHandler.qtest
@@ -324,6 +324,7 @@ public class RestHandlerTest inherits QUnit::Test {
     }
 
     constructor() : Test("RestHandlerTest", "1.0") {
+        addTestCase("pre-encoded-URLs test", \preEncodedUrlsTest());
         addTestCase("test bad request", \badRequestTest());
         addTestCase("Test direct interface", \directTest());
         addTestCase("Test external serialization", \serializationTest());
@@ -369,6 +370,55 @@ public class RestHandlerTest inherits QUnit::Test {
     globalTearDown() {
         mServer.stop();
         delete mServer;
+    }
+
+    preEncodedUrlsTest() {
+        {
+            RestClient rest({
+                "url": mClient.getURL(),
+                "pre_encoded_urls": True,
+            });
+
+            assertEq({"arg": "hello"}, rest.put("/test/echo?arg=hello").body);
+            assertEq({"arg": "[hello]"}, rest.put("/test/echo?arg=%5Bhello%5D").body);
+            assertEq({"arg": "{hello}"}, rest.put("/test/echo?arg=%7Bhello%7D").body);
+            assertEq({"arg": "hello|0"}, rest.put("/test/echo?arg=hello%7C0").body);
+            assertEq({"arg": "hello\\0"}, rest.put("/test/echo?arg=hello%5C0").body);
+            assertEq({"arg": "hello~0"}, rest.put("/test/echo?arg=hello%7E0").body);
+            assertEq({"arg": "hello`0"}, rest.put("/test/echo?arg=hello%600").body);
+            assertEq({"arg": "hello^0"}, rest.put("/test/echo?arg=hello%5E0").body);
+
+            assertThrows("URL-ENCODING-ERROR", "path\\[0\\]", \rest.get(), "path[0]");
+            assertThrows("URL-ENCODING-ERROR", \rest.get(), "path{0}");
+            assertThrows("URL-ENCODING-ERROR", \rest.get(), "path|0");
+            assertThrows("URL-ENCODING-ERROR", \rest.get(), "path\\0");
+            assertThrows("URL-ENCODING-ERROR", \rest.get(), "path~0");
+            assertThrows("URL-ENCODING-ERROR", \rest.get(), "path`0");
+            assertThrows("URL-ENCODING-ERROR", \rest.get(), "path^0");
+        }
+
+        {
+            RestClient rest({
+                "url": mClient.getURL(),
+            });
+
+            assertEq({"arg": "hello"}, rest.put("/test/echo?arg=hello").body);
+            assertEq({"arg": "%5Bhello%5D"}, rest.put("/test/echo?arg=%5Bhello%5D").body);
+            assertEq({"arg": "%7Bhello%7D"}, rest.put("/test/echo?arg=%7Bhello%7D").body);
+            assertEq({"arg": "hello%7C0"}, rest.put("/test/echo?arg=hello%7C0").body);
+            assertEq({"arg": "hello%5C0"}, rest.put("/test/echo?arg=hello%5C0").body);
+            assertEq({"arg": "hello%7E0"}, rest.put("/test/echo?arg=hello%7E0").body);
+            assertEq({"arg": "hello%600"}, rest.put("/test/echo?arg=hello%600").body);
+            assertEq({"arg": "hello%5E0"}, rest.put("/test/echo?arg=hello%5E0").body);
+
+            assertEq("path[0]", rest.get("test/echo?arg=path[0]").body.arg);
+            assertEq("path{0}", rest.get("test/echo?arg=path{0}").body.arg);
+            assertEq("path|0", rest.get("test/echo?arg=path|0").body.arg);
+            assertEq("path\\0", rest.get("test/echo?arg=path\\0").body.arg);
+            assertEq("path~0", rest.get("test/echo?arg=path~0").body.arg);
+            assertEq("path`0", rest.get("test/echo?arg=path`0").body.arg);
+            assertEq("path^0", rest.get("test/echo?arg=path^0").body.arg);
+        }
     }
 
     badRequestTest() {

--- a/examples/test/qore/classes/HTTPClient/HTTPClient.qtest
+++ b/examples/test/qore/classes/HTTPClient/HTTPClient.qtest
@@ -113,7 +113,7 @@ class TestStreamRequest inherits AbstractStreamRequest {
             hdr."Transfer-Encoding" = "chunked";
         }
         if (!data) {
-            data = "OK";
+            data = (self.hdr.path =~ x/\?(.*)/)[0] ?* "OK";
         }
         hash<HttpHandlerResponseInfo> rv = <HttpHandlerResponseInfo>{
             "code": 200,
@@ -379,6 +379,7 @@ I45SPdad6fpziP1EtT5rfrC0ZH7cMU8edg==
         if (m_options.verbose) {
             verbose = m_options.verbose;
         }
+        addTestCase("pre-encoded-urls", \preEncodedUrlsTest());
         addTestCase("poll proxy test", \pollProxyTest());
         addTestCase("poll test", \pollTest());
         addTestCase("chunked HEAD test", \chunkedHeadTest());
@@ -397,6 +398,30 @@ I45SPdad6fpziP1EtT5rfrC0ZH7cMU8edg==
    private usageIntern() {
         TestReporter::usageIntern(OptionColumn);
         printOption("-P,--proxy=ARG", "the proxy to use for proxy tests", OptionColumn);
+    }
+
+    preEncodedUrlsTest() {
+        RealTestHttpServer serv();
+        on_exit delete serv;
+
+        HTTPClient hc({
+            "url": "http://localhost:" + serv.getPort(),
+            "pre_encoded_urls": True,
+        });
+        hc.connect();
+
+        assertTrue(hc.getPreEncodedUrls());
+
+        assertEq("hello[]", hc.send(NOTHING, "PUT", "?hello%5B%5D").body);
+
+        assertThrows("URL-ENCODING-ERROR", "\\?hello\\[\\]", \hc.send(), (NOTHING, "PUT", "?hello[]"));
+
+        assertTrue(hc.setPreEncodedUrls());
+        assertTrue(hc.setPreEncodedUrls(False));
+        assertFalse(hc.getPreEncodedUrls());
+
+        assertEq("hello[]", hc.send(NOTHING, "PUT", "?hello[]").body);
+        assertEq("hello%5B%5D", hc.send(NOTHING, "PUT", "?hello%5B%5D").body);
     }
 
     pollProxyTest() {

--- a/include/qore/QoreHttpClientObject.h
+++ b/include/qore/QoreHttpClientObject.h
@@ -491,6 +491,16 @@ public:
     */
     DLLEXPORT QoreStringNode* getAssumedEncoding() const;
 
+    //! sets the new and returns the old pre_encoded_urls flag
+    /** @since %Qore 1.13.0
+     */
+    DLLEXPORT bool setPreEncodedUrls(bool set);
+
+    //! returns the current pre_encoded_urls flag
+    /** @since %Qore 1.13.0
+     */
+    DLLEXPORT bool getPreEncodedUrls() const;
+
     DLLLOCAL static void static_init();
 
     DLLLOCAL void cleanup(ExceptionSink* xsink);

--- a/lib/QC_HTTPClient.qpp
+++ b/lib/QC_HTTPClient.qpp
@@ -193,6 +193,10 @@ HTTPClient httpclient(("url":"http://hostname:8080/path"));
     - \c http_version: Either \c "1.0" or \c "1.1" for the claimed HTTP protocol version compliancy in outgoing
       message headers
     - \c max_redirects: The maximum number of redirects before throwing an exception (the default is 5)
+    - \c pre_encoded_urls: If @ref True "True" then all URI paths in URLs are assumed to be already
+      <a href="https://en.wikipedia.org/wiki/Percent-encoding">percent encoded</a>; if this flag is set and any
+      unencoded characters are sent in a URL with a new request, an exception is raised.  Characters that must require
+      percent encoding are: \c "{", \c "}", \c "|", \c "\\", \c "^", \c "~", \c "[", \c "]", and \c "`"
     - \c protocols: A hash describing new protocols, the key is the protocol name and the value is either an integer
       giving the default port number or a hash with \c "port" and \c "ssl" keys giving the default port number and a
       boolean value to indicate that an SSL connection should be established
@@ -251,6 +255,8 @@ HTTPClient httpclient(("url":"http://hostname:8080/path"));
     - %Qore 1.10 added the following options:
       - \c ssl_cert_data
       - \c ssl_key_data
+    - %Qore 1.13 added the following option:
+      - \c pre_encoded_urls
  */
 HTTPClient::constructor(hash<auto> opts) {
     ReferenceHolder<QoreHttpClientObject> client(new QoreHttpClientObject, xsink);
@@ -527,6 +533,8 @@ hash<auto> msg = httpclient.send(body, "POST", "/path", ("Content-Type":"applica
     period
     @throw SOCKET-SSL-ERROR There was an SSL error while reading data from the socket
     @throw SOCKET-HTTP-ERROR Invalid HTTP data was received
+    @throw URL-ENCODING-ERROR Thrown if the \c pre_encoded_urls option is set, and the URL has at least one unencoded
+    character that requires URL percent encoding
 
     @note For possible exceptions when implicitly establishing a connection, see the Socket::connect() method (or
     Socket::connectSSL() for secure connections)
@@ -587,6 +595,8 @@ hash<auto> msg = httpclient.send(body, "POST", "/path", ("Content-Type":"applica
     @throw SOCKET-TIMEOUT Data transmission or reception for a single send() or recv() action exceeded the timeout period
     @throw SOCKET-SSL-ERROR There was an SSL error while reading data from the socket
     @throw SOCKET-HTTP-ERROR Invalid HTTP data was received
+    @throw URL-ENCODING-ERROR Thrown if the \c pre_encoded_urls option is set, and the URL has at least one unencoded
+    character that requires URL percent encoding
 
     @note For possible exceptions when implicitly establishing a connection, see the Socket::connect() method (or Socket::connectSSL() for secure connections)
 
@@ -648,6 +658,8 @@ hash<auto> msg = httpclient.sendWithSendCallback(callback, "POST", "/path", ("Co
     @throw SOCKET-TIMEOUT Data transmission or reception for a single send() or recv() action exceeded the timeout period
     @throw SOCKET-SSL-ERROR There was an SSL error while reading data from the socket
     @throw SOCKET-HTTP-ERROR Invalid HTTP data was received
+    @throw URL-ENCODING-ERROR Thrown if the \c pre_encoded_urls option is set, and the URL has at least one unencoded
+    character that requires URL percent encoding
 
     @note
     - The \c "Transfer-Encoding: chunked" header is automatically set with this method if no \c "Transfer-Encoding" header is already present
@@ -719,6 +731,8 @@ httpclient.sendWithRecvCallback(rcv_callback, data, "POST", "/path", ("Content-T
     @throw SOCKET-TIMEOUT Data transmission or reception for a single send() or recv() action exceeded the timeout period
     @throw SOCKET-SSL-ERROR There was an SSL error while reading data from the socket
     @throw SOCKET-HTTP-ERROR Invalid HTTP data was received
+    @throw URL-ENCODING-ERROR Thrown if the \c pre_encoded_urls option is set, and the URL has at least one unencoded
+    character that requires URL percent encoding
 
     @note For possible exceptions when implicitly establishing a connection, see the Socket::connect() method (or Socket::connectSSL() for secure connections)
 
@@ -791,6 +805,8 @@ httpclient.sendWithRecvCallback(rcv_callback, data, "POST", "/path", ("Content-T
     @throw SOCKET-TIMEOUT Data transmission or reception for a single send() or recv() action exceeded the timeout period
     @throw SOCKET-SSL-ERROR There was an SSL error while reading data from the socket
     @throw SOCKET-HTTP-ERROR Invalid HTTP data was received
+    @throw URL-ENCODING-ERROR Thrown if the \c pre_encoded_urls option is set, and the URL has at least one unencoded
+    character that requires URL percent encoding
 
     @note For possible exceptions when implicitly establishing a connection, see the Socket::connect() method (or Socket::connectSSL() for secure connections)
 
@@ -854,6 +870,8 @@ httpclient.send(output_stream, data, "POST", "/path", ("Content-Type":"applicati
     @throw SOCKET-TIMEOUT Data transmission or reception for a single send() or recv() action exceeded the timeout period
     @throw SOCKET-SSL-ERROR There was an SSL error while reading data from the socket
     @throw SOCKET-HTTP-ERROR Invalid HTTP data was received
+    @throw URL-ENCODING-ERROR Thrown if the \c pre_encoded_urls option is set, and the URL has at least one unencoded
+    character that requires URL percent encoding
 
     @note For possible exceptions when implicitly establishing a connection, see the Socket::connect() method (or Socket::connectSSL() for secure connections)
 
@@ -933,6 +951,8 @@ httpclient.sendChunked(output_stream, input_stream, "POST", "/path", ("Content-T
     @throw SOCKET-TIMEOUT Data transmission or reception for a single send() or recv() action exceeded the timeout period
     @throw SOCKET-SSL-ERROR There was an SSL error while reading data from the socket
     @throw SOCKET-HTTP-ERROR Invalid HTTP data was received
+    @throw URL-ENCODING-ERROR Thrown if the \c pre_encoded_urls option is set, and the URL has at least one unencoded
+    character that requires URL percent encoding
 
     @note For possible exceptions when implicitly establishing a connection, see the Socket::connect() method (or Socket::connectSSL() for secure connections)
 
@@ -1007,6 +1027,8 @@ httpclient.sendWithCallbacks(send_callback, rcv_callback, "POST", "/path", ("Con
     @throw SOCKET-TIMEOUT Data transmission or reception for a single send() or recv() action exceeded the timeout period
     @throw SOCKET-SSL-ERROR There was an SSL error while reading data from the socket
     @throw SOCKET-HTTP-ERROR Invalid HTTP data was received
+    @throw URL-ENCODING-ERROR Thrown if the \c pre_encoded_urls option is set, and the URL has at least one unencoded
+    character that requires URL percent encoding
 
     @note
     - The \c "Transfer-Encoding: chunked" header is automatically set with this method if no \c "Transfer-Encoding" header is already present
@@ -2052,4 +2074,44 @@ string str = httpclient.getAssumedEncoding();
 */
 string HTTPClient::getAssumedEncoding() [flags=RET_VALUE_ONLY] {
     return client->getAssumedEncoding();
+}
+
+//! set the pre-encoded URL flag
+/** @par Example:
+    @code{.py}
+httpclient.setPreEncodedUrls();
+    @endcode
+
+    @param set if @ref True "True" then all URI paths in URLs are assumed to be already
+    <a href="https://en.wikipedia.org/wiki/Percent-encoding">percent encoded</a>; if this flag is set and any
+    unencoded characters are sent in a URL with a new request, an exception is raised.
+
+    @return the old \c pre_encoded_urls value
+
+    If @ref True "True" then all URI paths in URLs are assumed to be already
+    <a href="https://en.wikipedia.org/wiki/Percent-encoding">percent encoded</a>; if this flag is set and any
+    unencoded characters are sent in a URL with a new request, an exception is raised.
+
+    @since %Qore 1.13.0
+*/
+bool HTTPClient::setPreEncodedUrls(bool set = True) {
+    return client->setPreEncodedUrls(set);
+}
+
+//! get the pre-encoded URL flag
+/** @par Example:
+    @code{.py}
+bool b = httpclient.getPreEncodedUrls();
+    @endcode
+
+    @return the current \c pre_encoded_urls value
+
+    If @ref True "True" then all URI paths in URLs are assumed to be already
+    <a href="https://en.wikipedia.org/wiki/Percent-encoding">percent encoded</a>; if this flag is set and any
+    unencoded characters are sent in a URL with a new request, an exception is raised.
+
+    @since %Qore 1.13.0
+*/
+bool HTTPClient::getPreEncodedUrls() [flags=CONSTANT] {
+    return client->getPreEncodedUrls();
 }

--- a/lib/QoreHttpClientObject.cpp
+++ b/lib/QoreHttpClientObject.cpp
@@ -276,7 +276,9 @@ struct qore_httpclient_priv {
         // redirect messages will not be processed but rather passed to the caller
         redirect_passthru = false,
         // known content encodings are not decoded when set
-        encoding_passthru = false
+        encoding_passthru = false,
+        // if URLs are pre-encoded
+        pre_encoded_urls = false
         ;
 
     int default_port = HTTPCLIENT_DEFAULT_PORT,
@@ -289,6 +291,13 @@ struct qore_httpclient_priv {
     int connect_timeout_ms = -1;
 
     method_map_t additional_methods_map;
+
+    // characters that must be encoded when pre_encoded_urls is enabled
+    static constexpr const char* must_encode_chars = "{}|\\^~[]`";
+
+    // characters subject to percent encoding by Qore
+    typedef std::map<char, const char*> pct_encoding_map_t;
+    static pct_encoding_map_t pct_encoding_map;
 
     DLLLOCAL qore_httpclient_priv(my_socket_priv* ms) :
             msock(ms),
@@ -755,7 +764,8 @@ struct qore_httpclient_priv {
         int& code, bool& aborted, bool path_already_encoded, ExceptionSink* xsink);
 
     // called locked
-    DLLLOCAL const char* getMsgPath(const char* mpath, QoreString &pstr, bool already_encoded = false) {
+    DLLLOCAL const char* getMsgPath(ExceptionSink* xsink, const char* mpath, QoreString &pstr,
+            bool already_encoded = false) {
         pstr.clear();
 
         // use default path if no path is set
@@ -783,44 +793,24 @@ struct qore_httpclient_priv {
 
         if (already_encoded) {
             pstr.concat(mpath);
+        } else if (pre_encoded_urls) {
+            const char* p = strchrs(mpath, must_encode_chars);
+            if (p) {
+                xsink->raiseException("URL-ENCODING-ERROR", "URI path '%s' contains at least one unencoded character "
+                    "('%c'), when the 'pre_encoded_urls' option is set, URLs must be already encoded with percent "
+                    "encoding", mpath, *p);
+                return nullptr;
+            }
+            pstr.concat(mpath);
         } else {
             // concat mpath to pstr, performing minimal URL encoding until '?'
             const char* p = mpath;
             while (*p) {
-                // RFC-1738: encode space, <, >, ", #, %, {, }, |, \, ^, ~, [, ], `
-                if (*p == ' ') {
-                    pstr.concat("%20");
-                } else if (*p == '<') {
-                    pstr.concat("%3C");
-                } else if (*p == '>') {
-                    pstr.concat("%3E");
-                } else if (*p == '"') {
-                    pstr.concat("%22");
-                } else if (*p == '#') {
-                    pstr.concat("%23");
-                } else if (*p == '%') {
-                    pstr.concat("%25");
-                } else if (*p == '{') {
-                    pstr.concat("%7B");
-                } else if (*p == '}') {
-                    pstr.concat("%7D");
-                } else if (*p == '|') {
-                    pstr.concat("%7C");
-                } else if (*p == '\\') {
-                    pstr.concat("%5C");
-                } else if (*p == '^') {
-                    pstr.concat("%5E");
-                } else if (*p == '~') {
-                    pstr.concat("%7E");
-                } else if (*p == '[') {
-                    pstr.concat("%5B");
-                } else if (*p == ']') {
-                    pstr.concat("%5D");
-                } else if (*p == '`') {
-                    pstr.concat("%60");
-                } else {
-                    // according to RFC 3986 it's not necessary to encode non-ascii characters
+                pct_encoding_map_t::const_iterator i = pct_encoding_map.find(*p);
+                if (i == pct_encoding_map.end()) {
                     pstr.concat(*p);
+                } else {
+                    pstr.concat(i->second);
                 }
                 ++p;
             }
@@ -1168,6 +1158,25 @@ struct qore_httpclient_priv {
     DLLLOCAL static const qore_httpclient_priv* get(const QoreHttpClientObject& client) {
         return client.http_priv;
     }
+};
+
+// RFC-1738: encode space, <, >, ", #, %, {, }, |, \, ^, ~, [, ], `
+qore_httpclient_priv::pct_encoding_map_t qore_httpclient_priv::pct_encoding_map = {
+    {' ', "%20"},
+    {'<', "%3C"},
+    {'>', "%3E"},
+    {'"', "%22"},
+    {'#', "%23"},
+    {'%', "%25"},
+    {'{', "%7B"},
+    {'}', "%7D"},
+    {'|', "%7C"},
+    {'\\', "%5C"},
+    {'^', "%5E"},
+    {'~', "%7E"},
+    {'[', "%5B"},
+    {']', "%5D"},
+    {'`', "%60"},
 };
 
 constexpr int HS_NONE = 0;
@@ -2277,7 +2286,10 @@ int HttpClientConnectSendRecvPollOperation::startSend(ExceptionSink* xsink) {
             }
 
             QoreString pathstr(spriv->enc);
-            client->http_priv->getMsgPath(path.c_str(), pathstr, path_already_encoded);
+            client->http_priv->getMsgPath(xsink, path.c_str(), pathstr, path_already_encoded);
+            if (*xsink) {
+                return -1;
+            }
             QoreString hdr(spriv->enc);
             spriv->getSendHttpMessageHeaders(hdr, *info, method.c_str(),
                 pathstr.c_str(), client->http_priv->http11 ? "1.1" : "1.0", *request_headers, size,
@@ -2665,23 +2677,28 @@ int QoreHttpClientObject::setOptions(const QoreHashNode* opts, ExceptionSink* xs
     }
 
     n = opts->getKeyValue("ssl_verify_cert");
-    if (!n.isNothing() && n.getAsBool()) {
+    if (n.getAsBool()) {
         priv->socket->setSslVerifyMode(SSL_VERIFY_PEER);
     }
 
     n = opts->getKeyValue("error_passthru");
-    if (!n.isNothing() && n.getAsBool()) {
+    if (n.getAsBool()) {
         http_priv->error_passthru = true;
     }
 
     n = opts->getKeyValue("redirect_passthru");
-    if (!n.isNothing() && n.getAsBool()) {
+    if (n.getAsBool()) {
         http_priv->redirect_passthru = true;
     }
 
     n = opts->getKeyValue("encoding_passthru");
-    if (!n.isNothing() && n.getAsBool()) {
+    if (n.getAsBool()) {
         http_priv->encoding_passthru = true;
+    }
+
+    n = opts->getKeyValue("pre_encoded_urls");
+    if (n.getAsBool()) {
+        http_priv->pre_encoded_urls = true;
     }
 
     // issue #3978: allow the output encoding to be set as an option
@@ -2739,11 +2756,11 @@ QoreStringNode* QoreHttpClientObject::getSafeURL() {
 int QoreHttpClientObject::setHTTPVersion(const char* version, ExceptionSink* xsink) {
     int rc = 0;
     SafeLocker sl(priv->m);
-    if (!strcmp(version, "1.0"))
+    if (!strcmp(version, "1.0")) {
         http_priv->http11 = false;
-    else if (!strcmp(version, "1.1"))
+    } else if (!strcmp(version, "1.1")) {
         http_priv->http11 = true;
-    else {
+    } else {
         xsink->raiseException("HTTP-VERSION-ERROR", "only '1.0' and '1.1' are valid (value passed: '%s')", version);
         rc = -1;
     }
@@ -2849,7 +2866,10 @@ QoreHashNode* qore_httpclient_priv::sendMessageAndGetResponse(const char* mname,
     }
 
     QoreString pathstr(msock->socket->getEncoding());
-    const char* msgpath = with_connect ? mpath : getMsgPath(mpath, pathstr, path_already_encoded);
+    const char* msgpath = with_connect ? mpath : getMsgPath(xsink, mpath, pathstr, path_already_encoded);
+    if (*xsink) {
+        return nullptr;
+    }
 
     if (!msock->socket->isOpen()) {
         if (persistent) {
@@ -3700,4 +3720,18 @@ void QoreHttpClientObject::setAssumedEncoding(const char* enc) {
 QoreStringNode* QoreHttpClientObject::getAssumedEncoding() const {
     AutoLocker al(priv->m);
     return new QoreStringNode(qore_socket_private::get(*priv->socket)->getAssumedEncoding());
+}
+
+bool QoreHttpClientObject::setPreEncodedUrls(bool set) {
+    AutoLocker al(priv->m);
+    bool rv = http_priv->pre_encoded_urls;
+    if (rv != set) {
+        http_priv->pre_encoded_urls = set;
+    }
+    return rv;
+}
+
+bool QoreHttpClientObject::getPreEncodedUrls() const {
+    AutoLocker al(priv->m);
+    return http_priv->pre_encoded_urls;
 }

--- a/qlib/ConnectionProvider/AbstractConnectionWithInfo.qc
+++ b/qlib/ConnectionProvider/AbstractConnectionWithInfo.qc
@@ -29,7 +29,7 @@ public namespace ConnectionProvider {
 #! abstract base class for connections
 /** this class can be specialized to provide for user-defined connection types
 */
-public class AbstractConnectionWithInfo inherits Qore::Serializable, AbstractConnection {
+public class AbstractConnectionWithInfo inherits AbstractConnection {
     #! creates the AbstractConnection object
     /** @param name the name of the connection
         @param description connection description

--- a/qlib/ConnectionProvider/ConnectionProvider.qm
+++ b/qlib/ConnectionProvider/ConnectionProvider.qm
@@ -23,7 +23,7 @@
 */
 
 # minimum required Qore module
-%requires qore >= 1.0
+%requires qore >= 1.12.4
 
 %require-types
 %enable-all-warnings
@@ -35,7 +35,7 @@
 %requires(reexport) DataProvider
 
 module ConnectionProvider {
-    version = "1.7.1";
+    version = "1.7.2";
     desc    = "API for pluggable connection providers to Qore";
     author  = "David Nichols <david.nichols@qoretechnologies.com>";
     url     = "http://qore.org";
@@ -112,6 +112,13 @@ $env:QORE_CONNECTION_PROVIDERS="MyConnectionProvider;OtherConnectionProvider"
     @endverbatim
 
     @section connectionproviderrelnotes Release Notes
+
+    @subsection connectionprovider_1_7_2 ConnectionProvider 1.7.2
+    - removed unnecessary extraneous inheritance of @ref Qore::Serializable "Serializable" from the
+      @ref ConnectionProvider::AbstractConnectionWithInfo "AbstractConnectionWithInfo" class
+    - added support for the \c pre_encoded_urls option in the @ref ConnectionProvider::HttpConnection "HttpConnection"
+      class
+      (<a href="https://github.com/qorelanguage/qore/issues/4656">issue 4656</a>)
 
     @subsection connectionprovider_1_7_1 ConnectionProvider 1.7.1
     - non-blocking polling fixes

--- a/qlib/ConnectionProvider/HttpConnection.qc
+++ b/qlib/ConnectionProvider/HttpConnection.qc
@@ -40,6 +40,9 @@ public namespace ConnectionProvider {
         like any other response
     - \c "http_version": HTTP version to use (\c "1.0" or \c "1.1", defaults to \c "1.1")
     - \c "max_redirects": maximum redirects to support
+    - \c "pre_encoded_urls": If @ref True "True" then all URI paths in URLs are assumed to be already
+      <a href="https://en.wikipedia.org/wiki/Percent-encoding">percent encoded</a>; if this flag is set and any
+      unencoded characters are sent in a URL with a new request, an exception is raised
     - \c "proxy": proxy URL to use
     - \c "redirect_passthru": if @ref True "True" then redirect responses will be passed to the caller instead of
         processed
@@ -81,6 +84,12 @@ public class HttpConnection inherits AbstractConnectionWithInfo {
                 "max_redirects": <ConnectionOptionInfo>{
                     "type": "int",
                     "desc": "maximum redirects to support",
+                },
+                "pre_encoded_urls": <ConnectionOptionInfo>{
+                    "type": "bool",
+                    "desc": "if `true` then all URI paths in URLs are assumed to be already "
+                        "[percent encoded](https://en.wikipedia.org/wiki/Percent-encoding); if this flag is set and "
+                        "any unencoded characters are sent in a URL with a new request, an exception is raised",
                 },
                 "proxy": <ConnectionOptionInfo>{
                     "type": "string",

--- a/qlib/HttpClientDataProvider/HttpClientDataProvider.qc
+++ b/qlib/HttpClientDataProvider/HttpClientDataProvider.qc
@@ -73,6 +73,13 @@ public class HttpClientDataProvider inherits AbstractDataProvider {
                 "type": AbstractDataProviderType::get(IntType),
                 "desc": "Maximum redirects to support",
             },
+            "pre_encoded_urls": <DataProviderOptionInfo>{
+                "type": AbstractDataProviderType::get(BoolType),
+                "desc": "if `true` then all URI paths in URLs are assumed to be already "
+                    "[percent encoded](https://en.wikipedia.org/wiki/Percent-encoding); if this flag is set and "
+                    "any unencoded characters are sent in a URL with a new request, an exception is raised",
+                "default_value": False,
+            },
             "proxy": <DataProviderOptionInfo>{
                 "type": AbstractDataProviderType::get(StringType),
                 "desc": "The proxy URL to use",

--- a/qlib/HttpClientDataProvider/HttpClientDataProvider.qm
+++ b/qlib/HttpClientDataProvider/HttpClientDataProvider.qm
@@ -23,7 +23,7 @@
 */
 
 # minimum required Qore version
-%requires qore >= 1.10
+%requires qore >= 1.12.4
 # assume local scope for variables, do not use "$" signs
 %new-style
 # require type definitions everywhere
@@ -37,7 +37,7 @@
 %requires FileLocationHandler
 
 module HttpClientDataProvider {
-    version = "1.0";
+    version = "1.0.1";
     desc = "user module providing a data provider API for HTTP servers";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -74,6 +74,10 @@ module HttpClientDataProvider {
     - @ref HttpClientDataProvider::HttpClientPutDataProvider "HttpClientPutDataProvider"
 
     @section httpclientdataprovider_relnotes Release Notes
+
+    @subsection httpclientdataprovider_v1_0_1 HttpClientDataProvider v1.0.1
+    - added support for the \c pre_encoded_urls option
+      (<a href="https://github.com/qorelanguage/qore/issues/4656">issue 4656</a>)
 
     @subsection httpclientdataprovider_v1_0 HttpClientDataProvider v1.0
     - initial release of the module

--- a/qlib/RestClientDataProvider/RestClientDataProvider.qc
+++ b/qlib/RestClientDataProvider/RestClientDataProvider.qc
@@ -137,6 +137,13 @@ public class RestClientDataProvider inherits AbstractDataProvider {
                 "type": AbstractDataProviderType::get(BoolType),
                 "desc": "If `True` no charset will be added to the `Content-Type` header",
             },
+            "pre_encoded_urls": <DataProviderOptionInfo>{
+                "type": AbstractDataProviderType::get(BoolType),
+                "desc": "if `true` then all URI paths in URLs are assumed to be already "
+                    "[percent encoded](https://en.wikipedia.org/wiki/Percent-encoding); if this flag is set and "
+                    "any unencoded characters are sent in a URL with a new request, an exception is raised",
+                "default_value": False,
+            },
             "proxy": <DataProviderOptionInfo>{
                 "type": AbstractDataProviderType::get(StringType),
                 "desc": "The proxy URL to use",

--- a/qlib/RestClientDataProvider/RestClientDataProvider.qm
+++ b/qlib/RestClientDataProvider/RestClientDataProvider.qm
@@ -23,7 +23,7 @@
 */
 
 # minimum required Qore version
-%requires qore >= 1.10
+%requires qore >= 1.12.4
 # assume local scope for variables, do not use "$" signs
 %new-style
 # require type definitions everywhere
@@ -38,7 +38,7 @@
 %requires FileLocationHandler
 
 module RestClientDataProvider {
-    version = "1.0";
+    version = "1.0.1";
     desc = "user module providing a data provider API for REST servers";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -75,6 +75,10 @@ module RestClientDataProvider {
     - @ref RestClientDataProvider::RestClientPutDataProvider "RestClientPutDataProvider"
 
     @section restclientdataprovider_relnotes Release Notes
+
+    @subsection restclientdataprovider_v1_0_1 RestClientDataProvider v1.0.1
+    - added support for the \c pre_encoded_urls option
+      (<a href="https://github.com/qorelanguage/qore/issues/4656">issue 4656</a>)
 
     @subsection restclientdataprovider_v1_0 RestClientDataProvider v1.0
     - initial release of the module


### PR DESCRIPTION
… class and all inherited classes to support integration with languages and APIs that pre-encode URI paths (like Ruby on Rails)