### PR TITLE
refs #4666 RestHandler will always set the socketobject request conte…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -8,6 +8,11 @@
     Bugfix release with minor new features; see below for more information
 
     @subsection qore_1_13_new_features New Features in Qore
+    - <a href="../../modules/FileLocationHandler/html/index.html">FileLocationHandler</a> module
+      - added support for \c rest:// and \c rests:// locations
+        (<a href="https://github.com/qorelanguage/qore/issues/4669">issue 4669</a>)
+      - added support for runtime extensibility from an environment variable (\c QORE_FILE_LOCATION_HANDLERS)
+        (<a href="https://github.com/qorelanguage/qore/issues/4667">issue 4667</a>)
     - <a href="../../modules/RestClient/html/index.html">RestClient</a> module
       - apply the \c swagger_base_path argument to all REST validators
         (<a href="https://github.com/qorelanguage/qore/issues/4663">issue 4663</a>)
@@ -37,6 +42,9 @@
     - <a href="../../modules/RestClientDataProvider/html/index.html">RestClientDataProvider</a> module
       - added support for the \c pre_encoded_urls option in the \c HttpConnection class
         (<a href="https://github.com/qorelanguage/qore/issues/4656">issue 4656</a>)
+    - <a href="../../modules/RestHandler/html/index.html">RestHandler</a> module
+      - always set the \c socketobject request context property
+        (<a href="https://github.com/qorelanguage/qore/issues/4666">issue 4666</a>)
     - fixed a race condition in deadlock detection where a deadlock could occur due to the lack of atomic reads of a
       critical attribute
       (<a href="https://github.com/qorelanguage/qore/issues/4658">issue 4658</a>)

--- a/examples/test/qlib/FileLocationHandler/FileLocationHandler.qtest
+++ b/examples/test/qlib/FileLocationHandler/FileLocationHandler.qtest
@@ -14,10 +14,50 @@
 %requires ../../../../qlib/HttpServerUtil.qm
 %requires ../../../../qlib/HttpServer.qm
 %requires ../../../../qlib/WebUtil.qm
+%requires ../../../../qlib/RestClient.qm
+%requires ../../../../qlib/RestHandler.qm
 
 %include  ../../qore/classes/FtpServer.qc
 
+%try-module xml >= 1.3
+%define NoXml
+%endtry
+
+%try-module json
+%define NoJson
+%endtry
+
+%try-module yaml
+%define NoYaml
+%endtry
+
 %exec-class FileLocationHandlerTest
+
+class TestRestClass inherits AbstractRestClass {
+    private {
+        data info = "hello";
+    }
+
+    string name() {
+        return "test";
+    }
+
+    hash<HttpHandlerResponseInfo> get(hash<auto> cx, *hash<auto> ah) {
+        return RestHandler::makeResponse(200, info);
+    }
+
+    hash<HttpHandlerResponseInfo> post(hash<auto> cx, *hash<auto> ah) {
+        on_error printf("%s: ah: %y\n", get_exception_string($1), ah);
+        info = cx.body;
+        return RestHandler::makeResponse(200, "OK");
+    }
+}
+
+class MyRestHandler inherits RestHandler {
+    constructor() {
+        addClass(new TestRestClass());
+    }
+}
 
 class RealTestHttpServer inherits HttpServer {
     private:internal {
@@ -81,6 +121,18 @@ class MyFileHandler inherits FileHandler {
 public class FileLocationHandlerTest inherits QUnit::Test {
     public {
         static int verbose = 0;
+
+        const RestMap = {
+%ifndef NoJson
+            "json": True,
+%endif
+%ifndef NoXml
+            "xml": True,
+%endif
+%ifndef NoYaml
+            "yaml": True,
+%endif
+        };
     }
 
     constructor() : Test("FileLocationHandlerTest", "1.0") {
@@ -91,6 +143,7 @@ public class FileLocationHandlerTest inherits QUnit::Test {
         addTestCase("file tests", \fileTests());
         addTestCase("ftp tests", \ftpTests());
         addTestCase("http tests", \httpTests());
+        addTestCase("rest tests", \restTests());
         addTestCase("sftp tests", \sftpTests());
 
         # Return for compatibility with test harness that checks return value
@@ -178,6 +231,22 @@ public class FileLocationHandlerTest inherits QUnit::Test {
         doTests(url);
     }
 
+    private restTests() {
+        if (!RestMap) {
+            testSkip("no data serialization modules are present");
+        }
+
+        RealTestHttpServer serv();
+        on_exit delete serv;
+
+        MyRestHandler mHandler();
+        serv.setHandler("rest-handler", "/test", MimeTypeHtml, mHandler, NOTHING, False);
+        int port = serv.getPort();
+
+        string url = "rest://127.0.0.1:" + port + "/test";
+        doTests(url, True);
+    }
+
     private sftpTests() {
         *string sftp_loc;
         if (!(sftp_loc = ENV.QORE_SFTP_LOCATION)) {
@@ -187,7 +256,7 @@ public class FileLocationHandlerTest inherits QUnit::Test {
         doTests(sftp_loc);
     }
 
-    private doTests(string url) {
+    private doTests(string url, *bool no_write_stream) {
         on_error printf("ERROR URL: %y\n", url);
 
         string random_content = get_random_string(512);
@@ -205,6 +274,9 @@ public class FileLocationHandlerTest inherits QUnit::Test {
         d0 = stream.read(d0.size() * 2);
         assertEq(random_content.toBinary(), d0);
 
+        if (no_write_stream) {
+            return;
+        }
         # write new file data
         random_content = get_random_string(512);
         OutputStreamWrapper os = FileLocationHandler::getOutputStreamForLocation(url);

--- a/qlib/FileLocationHandler/FileLocationHandler.qc
+++ b/qlib/FileLocationHandler/FileLocationHandler.qc
@@ -218,6 +218,23 @@ public class FileLocationHandler {
 
         #! The location handler lock to ensure atomic operations
         static Mutex handler_lock();
+
+        #! Flag for dynamic initialization
+        static bool dynamic_init;
+    }
+
+    #! Initializes default handlers
+    static init() {
+        # register default handlers
+        FileLocationHandler::registerHandler("data", new FileLocationHandlerData());
+        FileLocationHandler::registerHandler("file", new FileLocationHandlerFile());
+        FileLocationHandler::registerHandler("ftp", new FileLocationHandlerFtp());
+        FileLocationHandler::registerHandler("ftps", new FileLocationHandlerFtp());
+        FileLocationHandler::registerHandler("http", new FileLocationHandlerHttp());
+        FileLocationHandler::registerHandler("https", new FileLocationHandlerHttp());
+        FileLocationHandler::registerHandler("rest", new FileLocationHandlerRest());
+        FileLocationHandler::registerHandler("rests", new FileLocationHandlerRest());
+        FileLocationHandler::registerHandler("sftp", new FileLocationHandlerSftp());
     }
 
     #! Register a new location handler
@@ -228,8 +245,13 @@ public class FileLocationHandler {
         @throw LOCATION-HANDLER-ERROR the given location handler scheme has already been registered
     */
     static registerHandler(string scheme, AbstractFileLocationHandler handler) {
-        handler_lock.lock();
-        on_exit handler_lock.unlock();
+        bool has_lock = handler_lock.lockOwner();
+        if (!has_lock) {
+            handler_lock.lock();
+        }
+        on_exit if (!has_lock) {
+            handler_lock.unlock();
+        }
 
         if (cache{scheme}) {
             throw "LOCATION-HANDLER-ERROR", sprintf("a location handler for scheme %y has already been registered",
@@ -239,10 +261,36 @@ public class FileLocationHandler {
         cache{scheme} = handler;
     }
 
+    #! Tries to register a new location handler; if the scheme is already registered, the method returns @ref False
+    /** @param scheme the scheme for the location
+        @param handler the handler for the location, must have the signature:
+
+        @return @ref True if the handler was registered, @ref False if not (scheme already has a handler)
+
+        @code{.py} data sub (string scheme, bool text, string location) {} @endcode
+    */
+    static bool tryRegisterHandler(string scheme, AbstractFileLocationHandler handler) {
+        bool has_lock = handler_lock.lockOwner();
+        if (!has_lock) {
+            handler_lock.lock();
+        }
+        on_exit if (!has_lock) {
+            handler_lock.unlock();
+        }
+
+        if (cache{scheme}) {
+            return False;
+        }
+
+        cache{scheme} = handler;
+        return True;
+    }
+
     #! Retuns a list of supported schemes
     /** @return a list of supported schemes
     */
     static list<string> getSupportedSchemes() {
+        FileLocationHandler::checkDynamicInit();
         return keys cache;
     }
 
@@ -252,6 +300,7 @@ public class FileLocationHandler {
         @return True if the scheme is supported
     */
     static bool isSchemeSupported(string scheme) {
+        FileLocationHandler::checkDynamicInit();
         return exists cache{scheme};
     }
 
@@ -351,6 +400,7 @@ public class FileLocationHandler {
         hash<LocationInfo> info = <LocationInfo>{
             "scheme": scheme ?? "file",
         };
+        FileLocationHandler::checkDynamicInit();
         *AbstractFileLocationHandler handler = cache{info.scheme};
         if (!handler) {
             throw "LOCATION-ERROR", sprintf("unknown location scheme %y in location %y; known location schemes: %y",
@@ -413,9 +463,38 @@ public class FileLocationHandler {
             if (!v.strp()) {
                 throw "LOCATION-ERROR", sprintf("option value in %y cannot be parsed", location);
             }
-            return {v: True};
+            v = {v: True};
         }
-        return v;
+        # strip types before returning
+        return {} + v;
+    }
+
+    #! Checks for dynamic initialization
+    private static checkDynamicInit() {
+        if (dynamic_init) {
+            return;
+        }
+
+        handler_lock.lock();
+        on_exit handler_lock.unlock();
+
+        # must check again inside the lock
+        if (dynamic_init) {
+            return;
+        }
+
+        dynamic_init = True;
+
+        # try to register handlers from the environment
+        if (*string handlers = ENV.QORE_FILE_LOCATION_HANDLERS) {
+            foreach string handler in (handlers.split(PathSep)) {
+                try {
+                    load_module(handler);
+                } catch (hash<ExceptionInfo> ex) {
+                    stderr.printf("error loading FileLocationHandler module %y: %s\n", handler, get_exception_string(ex));
+                }
+            }
+        }
     }
 }
 }

--- a/qlib/FileLocationHandler/FileLocationHandler.qm
+++ b/qlib/FileLocationHandler/FileLocationHandler.qm
@@ -22,7 +22,7 @@
 */
 
 # minimum required Qore version
-%requires qore >= 1.0
+%requires qore >= 1.13
 # assume local scope for variables, do not use "$" signs
 %new-style
 # require type definitions everywhere
@@ -35,20 +35,14 @@
 %requires Util
 
 module FileLocationHandler {
-    version = "2.1";
+    version = "2.2";
     desc = "user module for reading and writing file data based on URL-like location strings";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
     license = "MIT";
     init = sub () {
-        # register default handlers
-        FileLocationHandler::registerHandler("data", new FileLocationHandlerData());
-        FileLocationHandler::registerHandler("file", new FileLocationHandlerFile());
-        FileLocationHandler::registerHandler("ftp", new FileLocationHandlerFtp());
-        FileLocationHandler::registerHandler("ftps", new FileLocationHandlerFtp());
-        FileLocationHandler::registerHandler("http", new FileLocationHandlerHttp());
-        FileLocationHandler::registerHandler("https", new FileLocationHandlerHttp());
-        FileLocationHandler::registerHandler("sftp", new FileLocationHandlerSftp());
+        # setup default handlers
+        FileLocationHandler::init();
     };
 }
 
@@ -70,8 +64,9 @@ module FileLocationHandler {
     - @ref FileLocationHandler::FileLocationHandler::writeFileToLocation() "FileLocationHandler::writeFileToLocation()"
     - @ref FileLocationHandler::FileLocationHandler::getOutputStreamForLocation() "FileLocationHandler::getOutputStreamForLocation()"
 
-    To register a location handler based on a scheme, call:
+    To register a location handler based on a scheme, call one of:
     - @ref FileLocationHandler::FileLocationHandler::registerHandler() "FileLocationHandler::registerHandler()"
+    - @ref FileLocationHandler::FileLocationHandler::tryRegisterHandler() "FileLocationHandler::tryRegisterHandler()"
 
     This module provides the following classes:
     - @ref FileLocationHandler::AbstractFileLocationHandler "AbstractFileLocationHandler": the abstract API class
@@ -84,12 +79,31 @@ module FileLocationHandler {
       \c "ftps://" locations
     - @ref FileLocationHandler::FileLocationHandlerHttp "FileLocationHandlerHttp": class handling \c "http://" and
       \c "https://" locations
-    - @ref FileLocationHandler::FileLocationHandlerFtp "FileLocationHandlerSftp": class handling \c "sftp://"
+    - @ref FileLocationHandler::FileLocationHandlerRest "FileLocationHandlerRest": class handling \c "rest://" and
+      \c "rests://" locations
+    - @ref FileLocationHandler::FileLocationHandlerSftp "FileLocationHandlerSftp": class handling \c "sftp://"
       locations
     - @ref FileLocationHandler::OutputStreamWrapper "OutputStreamWrapper": output stream wrapper class for handling
       background I/O operations
 
+    @section filelocationhandler_env FileLocationHandler Environment variable
+
+    The \c QORE_FILE_LOCATION_HANDLERS environment variable will be read to initialize modules that provide support
+    for custom URL schemes; multiple modules can be separated by the OS-specific path separator (\c : on Linux / UNIX,
+    \c ; on Windows).
+
+    Each module listed in this environment variable should call either
+    @ref FileLocationHandler::FileLocationHandler::registerHandler() "FileLocationHandler::registerHandler()" or
+    @ref FileLocationHandler::FileLocationHandler::tryRegisterHandler() "FileLocationHandler::tryRegisterHandler()" in
+    its \c init code to register a handler for a new scheme.
+
     @section filelocationhandler_relnotes Release Notes
+
+    @subsection filelocationhandler_v2_2 FileLocationHandler v2.2
+    - added support for \c rest:// and \c rests:// locations
+      (<a href="https://github.com/qorelanguage/qore/issues/4669">issue 4669</a>)
+    - added support for runtime extensibility from environment variables
+      (<a href="https://github.com/qorelanguage/qore/issues/4667">issue 4667</a>)
 
     @subsection filelocationhandler_v2_1 FileLocationHandler v2.1
     - added support for immediate <tt>data://</tt> locations

--- a/qlib/FileLocationHandler/FileLocationHandlerRest.qc
+++ b/qlib/FileLocationHandler/FileLocationHandlerRest.qc
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
-#! @file FileLocationHandlerHttp.qc module for returning file data from a URL-like location string
+#! @file FileLocationHandlerRest.qc module for returning file data from a URL-like location string
 
-/*  FileLocationHandlerHttp Copyright 2021 - 2022 Qore Technologies, s.r.o.
+/*  FileLocationHandlerRest Copyright 2021 - 2022 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -25,37 +25,47 @@
 #! Contains all public definitions in the FileLocationHandler module
 public namespace FileLocationHandler {
 #! The class for handling file locations
-class FileLocationHandlerHttp inherits AbstractFileLocationHandler {
+class FileLocationHandlerRest inherits AbstractFileLocationHandler {
     public {
-        #! Valid HTTP location options
-        /** @see @ref Qore::HTTPClient::constructor() "HTTPClient::constructor()" for supported options
+        #! Valid REST location options
+        /** @see @ref RestClient::RestClient::constructor() "RestClient::constructor()" for supported options
         */
-        const HttpClientLocationOpts = {
+        const RestClientLocationOpts = {
             "connect_timeout": <FileHandlerOptionInfo>{
                 "type": "int",
-                "desc": "connection timeout in milliseconds",
+                "desc": "Connection timeout in milliseconds",
             },
-            "encoding": <FileHandlerOptionInfo>{
+            "content_encoding": <FileHandlerOptionInfo>{
                 "type": "string",
-                "desc": "the string encoding for any strings returned or sent",
+                "desc": "The content encoding (compression algorithm) for sending (if `send_encoding` is not set) "
+                    "and receiving",
             },
-            "encoding_passthru": <FileHandlerOptionInfo>{
-                "type": "bool",
-                "desc": "do not decode known content-encodings but rather pass the body through as-is",
+            "data": <FileHandlerOptionInfo>{
+                "type": "string",
+                "desc": "The data serialization option to use",
+                "default_value": "auto",
             },
             "error_passthru": <FileHandlerOptionInfo>{
                 "type": "bool",
-                "desc": "HTTP status codes indicating errors will not cause an `HTTP-CLIENT-RECEIVE-ERROR` exception "
-                    "to be raised",
+                "desc": "Error responses will be passed to the caller instead of causing an exception to be raised",
+            },
+            "headers": <FileHandlerOptionInfo>{
+                "type": "hash",
+                "desc": "An optional hash of headers to send with the request",
             },
             "http_version": <FileHandlerOptionInfo>{
                 "type": "string",
-                "desc": "Either `1.0` or `1.1` for the claimed HTTP protocol version compliancy in outgoing message "
-                    "headers",
+                "desc": "The HTTP version to use",
+                "default_value": "1.1",
+            },
+            "max_redirects": <FileHandlerOptionInfo>{
+                "type": "int",
+                "desc": "The maximum number of redirect responses to process",
+                "default_value": 5,
             },
             "method": <FileHandlerOptionInfo>{
                 "type": "string",
-                "desc": "the HTTP method to use; if not given then `GET` is used for reads, and `POST` is used for "
+                "desc": "The HTTP method to use; if not given then `GET` is used for reads, and `POST` is used for "
                     "writes",
             },
             "proxy": <FileHandlerOptionInfo>{
@@ -64,37 +74,50 @@ class FileLocationHandlerHttp inherits AbstractFileLocationHandler {
             },
             "redirect_passthru": <FileHandlerOptionInfo>{
                 "type": "bool",
-                "desc": "redirect responses will be passed to the caller instead of followed",
+                "desc": "Redirect responses will be passed to the caller instead of followed",
+            },
+            "send_encoding": <FileHandlerOptionInfo>{
+                "type": "string",
+                "desc": "The content encoding (compression algorithm) to use when sending data",
             },
             "ssl_cert_data": <FileHandlerOptionInfo>{
                 "type": "data",
-                "desc": "the X.509 certificate data in PEM format (string) or in DER format (binary); if this "
+                "desc": "The X.509 certificate data in PEM format (string) or in DER format (binary); if this "
                     "option is set, then `ssl_cert_path` is ignored",
             },
             "ssl_cert_path": <FileHandlerOptionInfo>{
                 "type": "string",
-                "desc": "a path to an X.509 client certificate file in PEM format; if this option is used, then the "
+                "desc": "A path to an X.509 client certificate file in PEM format; if this option is used, then the "
                     "calling context must not be restricted with sandbox restriction `PO_NO_FILESYSTEM` which is "
                     "checked at runtime",
             },
             "ssl_key_data": <FileHandlerOptionInfo>{
                 "type": "data",
-                "desc": "the X.509 private key data in PEM format (string) or in DER format (binary); if this "
+                "desc": "The X.509 private key data in PEM format (string) or in DER format (binary); if this "
                     "option is set, then `ssl_key_path` is ignored",
             },
             "ssl_key_path": <FileHandlerOptionInfo>{
                 "type": "string",
-                "desc": "a path to a private key file in PEM format; if this option is used, then the "
+                "desc": "A path to a private key file in PEM format; if this option is used, then the "
                     "calling context must not be restricted with sandbox restriction `PO_NO_FILESYSTEM` which is "
                     "checked at runtime",
             },
             "ssl_key_password": <FileHandlerOptionInfo>{
                 "type": "string",
-                "desc": "the password to the private key given with `ssl_key_path`",
+                "desc": "The password to the private key given with `ssl_key_path`",
             },
             "ssl_verify_cert": <FileHandlerOptionInfo>{
                 "type": "bool",
-                "desc": "the server's certificate will only be accepted if it's verified",
+                "desc": "The server's certificate will only be accepted if it's verified",
+            },
+            "swagger": <FileHandlerOptionInfo>{
+                "type": "string",
+                "desc": "The location of a Swagger schema to use for message validation",
+            },
+            "swagger_base_path": <FileHandlerOptionInfo>{
+                "type": "string",
+                "desc": "In case a REST validator is used, the base path in the schema can be overridden "
+                    "with this option (applies to any REST validator; not just Swagger validators)",
             },
             "timeout": <FileHandlerOptionInfo>{
                 "type": "int",
@@ -118,8 +141,8 @@ class FileLocationHandlerHttp inherits AbstractFileLocationHandler {
         if (!opts.headers.Accept) {
             opts.headers.Accept = "*/*";
         }
-        HTTPClient hc = getHttpClient(scheme, location, opts, \path);
-        return hc.send(NOTHING, opts.method ? opts.method.upr() : "GET", path).body ?? "";
+        object hc = getRestClient(scheme, location, opts, \path);
+        return hc.doRequest(opts.method ? opts.method.upr() : "GET", path).body ?? "";
     }
 
     #! Retrieves a binary file from the given location
@@ -133,8 +156,8 @@ class FileLocationHandlerHttp inherits AbstractFileLocationHandler {
     */
     private binary getBinaryFileImpl(string scheme, string location, *hash<auto> opts) {
         string path;
-        HTTPClient hc = getHttpClient(scheme, location, opts, \path);
-        *string body = hc.send(NOTHING, opts.method ? opts.method.upr() : "GET", path).body;
+        object client = getRestClient(scheme, location, opts, \path);
+        *string body = client.doRequest(opts.method ? opts.method.upr() : "GET", path).body;
         return exists body ? body.toBinary() : binary();
     }
 
@@ -146,22 +169,7 @@ class FileLocationHandlerHttp inherits AbstractFileLocationHandler {
         @return a stream reader for the file's contents, if it can be retrieved
     */
     private Qore::StreamReader getStreamReaderImpl(string scheme, string location, *hash<auto> opts) {
-        string path;
-        HTTPClient hc = getHttpClient(scheme, location, opts, \path);
-
-        StreamPipe pipe(False);
-
-        # run the I/O operation in the background
-        background sub () {
-            try {
-                OutputStream os = pipe.getOutputStream();
-                hc.send(os, NOTHING, opts.method ? opts.method.upr() : "GET", path);
-                os.close();
-            } catch (hash<ExceptionInfo> ex) {
-            }
-        }();
-
-        return new StreamReader(pipe.getInputStream(), opts.encoding);
+        return new StreamReader(getBinaryStreamImpl(scheme, location, opts));
     }
 
     #! Retrieves a binary file from the given location
@@ -172,22 +180,7 @@ class FileLocationHandlerHttp inherits AbstractFileLocationHandler {
         @return an input stream of the file's contents, if it can be retrieved
     */
     private Qore::InputStream getBinaryStreamImpl(string scheme, string location, *hash<auto> opts) {
-        string path;
-        HTTPClient hc = getHttpClient(scheme, location, opts, \path);
-
-        StreamPipe pipe(False);
-
-        # run the I/O operation in the background
-        background sub () {
-            try {
-                OutputStream os = pipe.getOutputStream();
-                hc.send(os, NOTHING, opts.method ? opts.method.upr() : "GET", path);
-                os.close();
-            } catch (hash<ExceptionInfo> ex) {
-            }
-        }();
-
-        return pipe.getInputStream();
+        return new BinaryInputStream(getBinaryFileImpl(scheme, location, opts));
     }
 
     #! Writes data to a file at the given location
@@ -198,8 +191,8 @@ class FileLocationHandlerHttp inherits AbstractFileLocationHandler {
     */
     private writeFileImpl(string scheme, string location, data contents, *hash<auto> opts) {
         string path;
-        HTTPClient hc = getHttpClient(scheme, location, opts, \path);
-        hc.send(contents, opts.method ? opts.method.upr() : "POST", path);
+        object client = getRestClient(scheme, location, opts, \path);
+        client.doRequest(opts.method ? opts.method.upr() : "POST", path, contents);
     }
 
     #! Returns an output stream for writing data to the given location
@@ -216,59 +209,48 @@ class FileLocationHandlerHttp inherits AbstractFileLocationHandler {
           been written to the target, call OutputStreamWrapper::waitForIo()
     */
     private OutputStreamWrapper getOutputStreamImpl(string scheme, string location, *hash<auto> opts) {
-        string path;
-        HTTPClient hc = getHttpClient(scheme, location, opts, \path);
-
-        StreamPipe pipe(False);
-
-        Counter io_counter(1);
-        OutputStreamWrapper rv(pipe.getOutputStream(), io_counter);
-
-        # run the I/O operation in the background
-        background sub () {
-            try {
-                on_exit io_counter.dec();
-
-                Qore::InputStream is = pipe.getInputStream();
-                hc.sendChunked(new BinaryOutputStream(), is, opts.method ? opts.method.upr() : "POST", NOTHING, path);
-                is.close();
-            } catch (hash<ExceptionInfo> ex) {
-            }
-        }();
-
-        return rv;
+        throw "STREAM-WRITE-ERROR", sprintf("rest:// locations do not support writing with an output stream; use "
+            "http(s):// locations instead");
     }
 
     #! Gets supported read options
     /** @return supported read options
     */
     private hash<string, hash<FileHandlerOptionInfo>> getReadOptionsImpl() {
-        return HttpClientLocationOpts;
+        return RestClientLocationOpts;
     }
 
     #! Gets supported write options
     /** @return supported write options
     */
     private hash<string, hash<FileHandlerOptionInfo>> getWriteOptionsImpl() {
-        return HttpClientLocationOpts;
+        return RestClientLocationOpts;
     }
 
-    #! Returns an HTTP client for the given location
-    private HTTPClient getHttpClient(string scheme, string location, *hash<auto> opts, reference<string> path) {
-        location = scheme + "://" + location;
+    #! Returns a RestClient object for the given location
+    private object getRestClient(string scheme, string location, *hash<auto> opts, reference<string> path) {
+        # dynamically load the module to avoid a circular module dependency
+        load_module("RestClient");
+
+        location = (scheme == "rests" ? "https" : "http") + "://" + location;
 
         hash<UrlInfo> url_info = parse_url(location);
         if (url_info.path) {
             path = url_info.path;
         }
         if (!exists path) {
-            throw "LOCATION-ERROR", sprintf("HTTP location %y missing URI path", location);
+            throw "LOCATION-ERROR", sprintf("REST location %y missing URI path", location);
         }
-        HTTPClient h({
-            "url": location,
-        } + opts);
-        h.connect();
-        return h;
+        location = sprintf("%s://%s", url_info.protocol, url_info.host);
+        if (url_info.port) {
+            location += ":" + url_info.port;
+        }
+        object client = create_object("RestClient", {
+                "url": location,
+            } + opts
+        );
+        client.connect();
+        return client;
     }
 }
 }

--- a/qlib/RestHandler.qm
+++ b/qlib/RestHandler.qm
@@ -42,7 +42,7 @@
 %requires reflection
 
 module RestHandler {
-    version = "1.6.1";
+    version = "1.6.2";
     desc = "user module for implementing REST services with the Qore HTTP server";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -374,6 +374,10 @@ Content-Length: 16
 
     @section resthandler_relnotes RestHandler Release Notes
 
+    @subsection rh_1_6_2 RestHandler v1.6.2
+    - always set the \c socketobject request context property
+      (<a href="https://github.com/qorelanguage/qore/issues/4666">issue 4666</a>)
+
     @subsection rh_1_6_1 RestHandler v1.6.1
     - implemented the @ref RestHandler::RestHandler::errorResponseHeaders() to allow subclasses to return custom
       headers in error responses, such as when a request cannot be deserialized
@@ -536,14 +540,23 @@ public namespace RestHandler {
 
         #! this method provides the callback method for receiving chunked data by calling recvImpl()
         /**
-            @param v the first time this method is called with a hash of the message headers in the \c "hdr" key, and then with any message body in the \c "data"; if a chunked HTTP message is received, then this method is called once for each chunk; when the message has been received, then this method is called with a hash representing any trailer data received in a chunked transfer or @ref nothing if the data was received in a normal message body or if there was no trailer data in a chunked transfer.  The argument to this callback is always a hash; data calls have the following keys:
-            - \c "data": the string or binary data, or, in the case of a non-chunked request, the already decoded and deserialized request body, in which case the \c "deserialized" key will be @ref True
+            @param v the first time this method is called with a hash of the message headers in the \c "hdr" key, and
+            then with any message body in the \c "data"; if a chunked HTTP message is received, then this method is
+            called once for each chunk; when the message has been received, then this method is called with a hash
+            representing any trailer data received in a chunked transfer or @ref nothing if the data was received in a
+            normal message body or if there was no trailer data in a chunked transfer.  The argument to this callback
+            is always a hash; data calls have the following keys:
+            - \c "data": the string or binary data, or, in the case of a non-chunked request, the already decoded and
+              deserialized request body, in which case the \c "deserialized" key will be @ref True
             - \c "chunked": @ref True if the data was received with chunked transfer encoding, @ref False if not
-            - \c "deserialized": present and set to @ref True if a non-chunked request was received, and the body has already been deserialized
+            - \c "deserialized": present and set to @ref True if a non-chunked request was received, and the body has
+              already been deserialized
             .
             Header or trailer data is placed in a hash with the following keys:
-            - \c "hdr": this can be assigned to @ref nothing for the trailer hash if the data was not sent chunked or no trailers were included in a chunked message
-            - \c "obj": this is the owning object (so socket parameters can be changed based on headers received, such as, for example, socket character encoding)
+            - \c "hdr": this can be assigned to @ref nothing for the trailer hash if the data was not sent chunked or
+              no trailers were included in a chunked message
+            - \c "obj": this is the owning object (so socket parameters can be changed based on headers received, such
+              as, for example, socket character encoding)
         */
         nothing recv(hash<auto> v) {
             try {
@@ -556,7 +569,9 @@ public namespace RestHandler {
 
         #! this method provides the callback method for sending chunked data by calling sendImpl()
         /**
-            @return The chunked HTTP data to send; this method must return either a string or a binary value each time it is called to give the chunked data to send; when all data has been sent, then a hash of message trailers can be returned or simply @ref nothing which will close the chunked message
+            @return The chunked HTTP data to send; this method must return either a string or a binary value each time
+            it is called to give the chunked data to send; when all data has been sent, then a hash of message
+            trailers can be returned or simply @ref nothing which will close the chunked message
         */
         auto send() {
             try {
@@ -793,11 +808,13 @@ public namespace RestHandler {
             if (!args && cx.body.typeCode() == NT_HASH) {
                 args = cx.body - "action";
             }
+            cx.socketobject = s;
             if (cl) {
                 string cname = shift cl;
                 *AbstractRestClass cls = subClass(cname, cx, args);
                 if (!cls) {
-                    # issue #2994: if we are on the last class and there is no "action" argument; see if we can find an action method instead
+                    # issue #2994: if we are on the last class and there is no "action" argument; see if we can find
+                    # an action method instead
                     if (!cl && !args.action) {
                         string mname = sprintf("%s%s%s", mn, cname[0].upr(), cname[1..]);
                         if (self.hasCallableMethod(mname)) {
@@ -805,11 +822,13 @@ public namespace RestHandler {
                         }
                     }
 
-                    rh.logDebug("REST DBG: class %y: unknown subclass %y: method %y args: %y", name(), cname, mn, args);
+                    rh.logDebug("REST DBG: class %y: unknown subclass %y: method %y args: %y", name(), cname, mn,
+                        args);
                     return unknownSubClassError(cname, cx, args);
                 }
 
-                rh.logDebug("REST DBG: class %y: dispatching to subclass %y: method %y args: %y", name(), cname, mn, args);
+                rh.logDebug("REST DBG: class %y: dispatching to subclass %y: method %y args: %y", name(), cname, mn,
+                    args);
                 return cls.handleRequest(listener, rh, s, cl, mn, cx, args);
             }
 
@@ -825,7 +844,6 @@ public namespace RestHandler {
             string sn = "stream" + mn[0].upr() + mn.substr(1);
             AbstractRestStreamRequestHandler rsh;
             try {
-                cx.socketobject = s;
                 rsh = call_object_method_args(self, sn, (cx, ah));
             } catch (hash<ExceptionInfo> ex) {
                 if (ex.err == "METHOD-DOES-NOT-EXIST" && ex.desc.find(sn) != -1) {
@@ -1295,8 +1313,9 @@ public namespace RestHandler {
             }
 
             # reflect body in arguments if body is a hash
-            if (body.typeCode() == NT_HASH)
+            if (body.typeCode() == NT_HASH) {
                 map args.$1 = body.$1, keys body, !exists args.$1;
+            }
 
             if (!Methods.(hdr.method))
                 return AbstractHttpRequestHandler::make400("unsupported HTTP method %y given in REST call %y",

--- a/qlib/Swagger.qm
+++ b/qlib/Swagger.qm
@@ -889,6 +889,13 @@ public class SwaggerLoader {
         @throws XML-MODULE-MISSING trying to parse an XML %Swagger specification with the xml module unavailable
     */
     static SwaggerSchema fromUrl(string url, *bool json) {
+        if (!exists json) {
+            if (url =~ /\.yaml$/i) {
+                json = False;
+            } else if (url =~ /\.json$/i) {
+                json = True;
+            }
+        }
         return SwaggerLoader::fromString(FileLocationHandler::getTextFileFromLocation(url), json);
     }
 


### PR DESCRIPTION
…xt property

refs #4667 added support for runtime extensibility to the FileLocationHandler module from the QORE_FILE_LOCATION_HANDLERS environment variable refs #4668 RestHandler will no longer silently ignore non-hash message bodies refs #4669 FileLocationHandler now supports rest:// and rests:// locations