### PR TITLE
Make more PowerPC platforms use the PowerPC macros

### DIFF
--- a/include/qore/macros.h
+++ b/include/qore/macros.h
@@ -40,7 +40,7 @@
 #include <qore/macros-sparc.h>
 #elif defined(__ppc64) || defined(__ppc64__) || defined(__powerpc64__) || defined(_ARCH_PPC64) || defined(__PPC64__)
 #include <qore/macros-ppc64.h>
-#elif defined(__ppc) || defined(__ppc__)
+#elif defined(__ppc) || defined(__ppc__) || defined(__powerpc__) || defined(_ARCH_PPC) || defined(__PPC__)
 #include <qore/macros-powerpc.h>
 #elif defined(__hppa)
 #include <qore/macros-parisc.h>


### PR DESCRIPTION
Make more PowerPC platforms use the PowerPC macros. The macros are only used if __ppc or __ppc__ is
defined check for more PowerPC defines so that they are used on more platforms.
NetBSD for 32-bit PowerPC does only define
__powerpc__ not __ppc or __ppc__ .
Fixes issue #4711 .