### PR TITLE
refs #4773 initial GoogleDataProvider with simple calendarList support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -951,6 +951,7 @@ qore_user_module("qlib/EmpathicBuildingDataProvider" "RestClient;DataProvider" "
 # base 8 modules
 qore_user_module("qlib/SalesforceRestDataProvider" "RestClient;SalesforceRestClient;DataProvider")
 qore_user_module("qlib/AwsRestClientDataProvider" "RestClient;DataProvider;RestClientDataProvider")
+qore_user_module("qlib/GoogleDataProvider" "GoogleRestClient;RestClient;DataProvider")
 
 # print info
 message(STATUS "")

--- a/Makefile.am
+++ b/Makefile.am
@@ -98,7 +98,8 @@ DOX_SPLIT_MODULES = \
     qlib/FileDataProvider \
     qlib/FtpClientDataProvider \
     qlib/HttpClientDataProvider \
-    qlib/AwsRestClientDataProvider
+    qlib/AwsRestClientDataProvider \
+    qlib/GoogleDataProvider
 
 SqlUtil_modverdir = $(modverdir)/SqlUtil
 ConnectionProvider_modverdir = $(modverdir)/ConnectionProvider
@@ -116,6 +117,7 @@ RestClientDataProvider_modverdir = $(modverdir)/RestClientDataProvider
 AwsRestClientDataProvider_modverdir = $(modverdir)/AwsRestClientDataProvider
 FileDataProvider_modverdir = $(modverdir)/FileDataProvider
 FtpClientDataProvider_modverdir = $(modverdir)/FtpClientDataProvider
+GoogleDataProvider_modverdir = $(modverdir)/GoogleDataProvider
 HttpClientDataProvider_modverdir = $(modverdir)/HttpClientDataProvider
 ElasticSearchDataProvider_modverdir = $(modverdir)/ElasticSearchDataProvider
 EmpathicBuildingDataProvider_modverdir = $(modverdir)/EmpathicBuildingDataProvider
@@ -136,6 +138,7 @@ dist_RestClientDataProvider_modver_DATA = $(wildcard qlib/RestClientDataProvider
 dist_AwsRestClientDataProvider_modver_DATA = $(wildcard qlib/AwsRestClientDataProvider/*.q[cm])
 dist_FileDataProvider_modver_DATA = $(wildcard qlib/FileDataProvider/*.q[cm])
 dist_FtpClientDataProvider_modver_DATA = $(wildcard qlib/FtpClientDataProvider/*.q[cm])
+dist_GoogleDataProvider_modver_DATA = $(wildcard qlib/GoogleDataProvider/*.q[cm])
 dist_HttpClientDataProvider_modver_DATA = $(wildcard qlib/HttpClientDataProvider/*.q[cm])
 dist_ElasticSearchDataProvider_modver_DATA = $(wildcard qlib/ElasticSearchDataProvider/*.q[cm])
 dist_EmpathicBuildingDataProvider_modver_DATA = $(wildcard qlib/EmpathicBuildingDataProvider/*.q[cm])

--- a/doxygen/lang/120_modules.dox.tmpl
+++ b/doxygen/lang/120_modules.dox.tmpl
@@ -99,6 +99,8 @@ ModuleName/
         remote directory with the FTP protocol
     |user|<a href="../../modules/FtpPollerUtil/html/index.html">FtpPollerUtil</a>|Provides definitions for the \
         <a href="../../modules/FtpPoller/html/index.html">FtpPoller</a> module
+    |user|<a href="../../modules/GoogleDataProvider/html/index.html">GoogleDataProvider</a>|Provides a \
+        <a href="../../modules/DataProvider/html/index.html">data provider</a> API for Google REST API cloud services
     |user|<a href="../../modules/GoogleRestClient/html/index.html">GoogleRestClient</a>|providing APIs for \
         communicating with Google cloud REST APIs
     |user|<a href="../../modules/HttpClientDataProvider/html/index.html">HttpClientDataProvider</a>|Provides a \

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -11,6 +11,8 @@
     - New user modules:
       - <a href="../../modules/GoogleRestClient/html/index.html">GoogleRestClient</a>
         (<a href="https://github.com/qorelanguage/qore/issues/4773">issue 4773</a>)
+      - <a href="../../modules/GoogleRestClient/html/index.html">GoogleRestClient</a>
+        (<a href="https://github.com/qorelanguage/qore/issues/4773">issue 4773</a>)
     - <a href="../../modules/ConnectionProvider/html/index.html">ConnectionProvider</a> module
       - added a connection-defined feature list to connection info
         (<a href="https://github.com/qorelanguage/qore/issues/4771">issue 4771</a>)

--- a/examples/test/qlib/GoogleDataProvider/GoogleDataProvider.qtest
+++ b/examples/test/qlib/GoogleDataProvider/GoogleDataProvider.qtest
@@ -1,0 +1,95 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+%allow-injection
+
+%requires ../../../../qlib/Util.qm
+%requires ../../../../qlib/QUnit.qm
+%requires ../../../../qlib/Logger.qm
+%requires ../../../../qlib/DataProvider
+%requires ../../../../qlib/ConnectionProvider
+%requires ../../../../qlib/RestClient.qm
+%requires ../../../../qlib/GoogleRestClient.qm
+%requires ../../../../qlib/GoogleDataProvider
+
+%exec-class GoogleDataProviderTest
+
+public class GoogleDataProviderTest inherits QUnit::Test {
+    private {
+        GoogleDataProvider gdp;
+
+        # command-line options
+        const MyOpts = Opts + {
+            "conn": "c,connection=s",
+        };
+
+        const OptionColumn = 22;
+    }
+
+    constructor() : Test("GoogleDataProviderTest Test", "1.0", \ARGV, MyOpts) {
+        addTestCase("test", \googleDataProviderTest());
+        addTestCase("calendar test", \googleCalendarTest());
+
+        try {
+            setupConnection();
+        } catch (hash<ExceptionInfo> ex) {
+            if (m_options.verbose > 2) {
+                printf("%s\n", get_exception_string(ex));
+            } else if (m_options.verbose) {
+                printf("%s: %s\n", ex.err, ex.desc);
+            }
+        }
+
+        # Return for compatibility with test harness that checks return value.
+        set_return_value(main());
+    }
+
+    googleDataProviderTest() {
+        if (!gdp) {
+            testSkip("no connection");
+        }
+
+        assertEq("google", gdp.getName());
+    }
+
+    googleCalendarTest() {
+        if (!gdp) {
+            testSkip("no connection");
+        }
+
+        AbstractDataProvider prov = gdp.getChildProviderEx("calendar");
+        assertEq("calendar", prov.getName());
+        prov = prov.getChildProviderEx("calendarList");
+        assertEq("calendarList", prov.getName());
+        prov = prov.getChildProviderEx("list");
+        assertEq("list", prov.getName());
+        hash<auto> h = prov.doRequest();
+        assertEq(Type::String, h.etag.type());
+    }
+
+    private usageIntern() {
+        TestReporter::usageIntern(OptionColumn);
+        printOption("-c,--connection=ARG", "set connection name", OptionColumn);
+    }
+
+    private error(string fmt) {
+        throw "OPTION-ERROR", sprintf("%s: ERROR: %s", get_script_name(), vsprintf(fmt, argv));
+    }
+
+    private setupConnection() {
+        *string conn_name = m_options.conn ?? ENV.GOOGLE_CONNECTION;
+        if (!conn_name.val()) {
+            error("missing -c,--connection option or GOOGLE_CONNECTION environment variable");
+        }
+
+        AbstractConnection conn = get_connection(conn_name);
+        if (!(conn instanceof GoogleRestConnection)) {
+            error("connection %y is type %y; expecting \"GoogleRestConnection\"", conn_name, conn.className());
+        }
+        gdp = conn.getDataProvider();
+    }
+}

--- a/examples/test/qlib/RestClient/RestClient.qtest
+++ b/examples/test/qlib/RestClient/RestClient.qtest
@@ -477,7 +477,8 @@ public class Main inherits QUnit::Test {
             string uri = rc.getAuthorizationCodeRequest();
             assertTrue(uri.equalPartialPath(auth_uri));
             hash<ConnectionInfo> cinfo = rc.getInfo();
-            assertEq((RestConnection::RCF_UPDATE_TOKEN, RestConnection::RCF_OAUTH2_AUTH_CODE,), cinfo.features);
+            assertTrue(cinfo.features{RestConnection::RCF_UPDATE_TOKEN});
+            assertTrue(cinfo.features{RestConnection::RCF_OAUTH2_AUTH_CODE});
         }
 
         {
@@ -500,7 +501,8 @@ public class Main inherits QUnit::Test {
             assertRegex("&access_type=offline", uri);
             assertRegex("&include_granted_scopes=true", uri);
             hash<ConnectionInfo> cinfo = rc.getInfo();
-            assertEq((RestConnection::RCF_UPDATE_TOKEN, RestConnection::RCF_OAUTH2_AUTH_CODE,), cinfo.features);
+            assertTrue(cinfo.features{RestConnection::RCF_UPDATE_TOKEN});
+            assertTrue(cinfo.features{RestConnection::RCF_OAUTH2_AUTH_CODE});
         }
     }
 

--- a/examples/test/qlib/RestClient/RestClient.qtest
+++ b/examples/test/qlib/RestClient/RestClient.qtest
@@ -477,7 +477,7 @@ public class Main inherits QUnit::Test {
             string uri = rc.getAuthorizationCodeRequest();
             assertTrue(uri.equalPartialPath(auth_uri));
             hash<ConnectionInfo> cinfo = rc.getInfo();
-            assertEq((RestConnection::RCF_OAUTH2_AUTH_CODE,), cinfo.features);
+            assertEq((RestConnection::RCF_UPDATE_TOKEN, RestConnection::RCF_OAUTH2_AUTH_CODE,), cinfo.features);
         }
 
         {
@@ -500,7 +500,7 @@ public class Main inherits QUnit::Test {
             assertRegex("&access_type=offline", uri);
             assertRegex("&include_granted_scopes=true", uri);
             hash<ConnectionInfo> cinfo = rc.getInfo();
-            assertEq((RestConnection::RCF_OAUTH2_AUTH_CODE,), cinfo.features);
+            assertEq((RestConnection::RCF_UPDATE_TOKEN, RestConnection::RCF_OAUTH2_AUTH_CODE,), cinfo.features);
         }
     }
 

--- a/qlib/ConnectionProvider/AbstractConnection.qc
+++ b/qlib/ConnectionProvider/AbstractConnection.qc
@@ -280,7 +280,7 @@ public class AbstractConnection inherits Qore::Serializable {
     #! Returns a list of connection-defined features
     /** @since ConnectionProvider 1.10
     */
-    *list<string> getFeatures() {
+    *hash<string, bool> getFeatures() {
         return getFeaturesImpl();
     }
 
@@ -670,12 +670,12 @@ scheme://user:pass@hostname:port/path
         setChildCapabilities();
     }
 
-    #! Returns a list of connection-defined features
+    #! Returns a hash of connection-defined features
     /** This method returns no value; override in child classes to return features
 
         @since ConnectionProvider 1.10
     */
-    private *list<string> getFeaturesImpl() {
+    private *hash<string, bool> getFeaturesImpl() {
     }
 
     #! Override to set child data provider capabilities once per child class

--- a/qlib/ConnectionProvider/ConnectionProvider.qm
+++ b/qlib/ConnectionProvider/ConnectionProvider.qm
@@ -323,8 +323,8 @@ public hashdecl ConnectionInfo {
     #! user-defined key-value pairs associated with the connection
     hash<auto> tags;
 
-    #! connection-defined feature list
-    *list<string> features;
+    #! connection-defined feature hash
+    *hash<string, bool> features;
 
     #! if the connection supports the data provider API
     bool has_provider = False;

--- a/qlib/DataProvider/DataProvider.qc
+++ b/qlib/DataProvider/DataProvider.qc
@@ -44,6 +44,7 @@ public class DataProvider {
             "fixedlengthwrite": "FixedLengthUtil",
             "ftpclient": "FtpClientDataProvider",
             "ftppoller": "FtpPoller",
+            "google": "GoogleDataProvider",
             "httpclient": "HttpClientDataProvider",
             "mqtt": "MqttDataProvider",
             "restclient": "RestClientDataProvider",

--- a/qlib/GoogleDataProvider/GoogleCalendarDataProvider.qc
+++ b/qlib/GoogleDataProvider/GoogleCalendarDataProvider.qc
@@ -1,0 +1,106 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GoogleDataProvider module definition
+
+/** GoogleCalendarDataProvider.qc Copyright 2023 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GoogleDataProvider module
+public namespace GoogleDataProvider {
+#! The parent class for Google calendar REST APIs
+public class GoogleCalendarDataProvider inherits DataProvider::AbstractDataProvider {
+    public {
+        #! REST client connection
+        GoogleRestClient::GoogleRestClient rest;
+
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "calendar",
+            "desc": "Google calendar data provider; parent provider for APIs related to calendars",
+            "type": "GoogleCalendarDataProvider",
+            "constructor_options": GoogleDataProvider::ConstructorOptions,
+            "supports_children": True,
+            "children_can_support_apis": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+    }
+
+    private {
+        const ChildMap = {
+            "calendarList": Class::forName("GoogleDataProvider::GoogleCalendarListDataProvider"),
+        };
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", GoogleDataProvider::ConstructorOptions, options);
+        rest = GoogleDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(GoogleRestClient::GoogleRestClient rest) {
+        self.rest = rest;
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Google data %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Return data provider summary info
+    *list<hash<DataProvider::DataProviderSummaryInfo>> getChildProviderSummaryInfo() {
+        return map $1.getConstant("ProviderSummaryInfo").getValue(), ChildMap.iterator();
+    }
+
+    #! Returns a list of child data provider names, if any
+    /** @return a list of child data provider names, if any
+    */
+    private *list<string> getChildProviderNamesImpl() {
+        return keys ChildMap;
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    /** @return the given child provider or @ref nothing if the given child is unknown
+
+        @see getChildProviderEx()
+    */
+    private *DataProvider::AbstractDataProvider getChildProviderImpl(string name) {
+        *Class cls = ChildMap{name};
+        if (!cls) {
+            return;
+        }
+        return cls.newObject(rest);
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/GoogleDataProvider/GoogleCalendarListDataProvider.qc
+++ b/qlib/GoogleDataProvider/GoogleCalendarListDataProvider.qc
@@ -1,0 +1,106 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GoogleDataProvider module definition
+
+/** GoogleCalendarListDataProvider.qc Copyright 2023 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GoogleDataProvider module
+public namespace GoogleDataProvider {
+#! The parent class for Google calendarList REST APIs
+public class GoogleCalendarListDataProvider inherits DataProvider::AbstractDataProvider {
+    public {
+        #! REST client connection
+        GoogleRestClient::GoogleRestClient rest;
+
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "calendarList",
+            "desc": "Google calendarList data provider; parent provider for APIs related to calendarLists",
+            "type": "GoogleCalendarListDataProvider",
+            "constructor_options": GoogleDataProvider::ConstructorOptions,
+            "supports_children": True,
+            "children_can_support_apis": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+    }
+
+    private {
+        const ChildMap = {
+            "list": Class::forName("GoogleDataProvider::GoogleCalendarListListDataProvider"),
+        };
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", GoogleDataProvider::ConstructorOptions, options);
+        rest = GoogleDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(GoogleRestClient::GoogleRestClient rest) {
+        self.rest = rest;
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Google data %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Return data provider summary info
+    *list<hash<DataProvider::DataProviderSummaryInfo>> getChildProviderSummaryInfo() {
+        return map $1.getConstant("ProviderSummaryInfo").getValue(), ChildMap.iterator();
+    }
+
+    #! Returns a list of child data provider names, if any
+    /** @return a list of child data provider names, if any
+    */
+    private *list<string> getChildProviderNamesImpl() {
+        return keys ChildMap;
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    /** @return the given child provider or @ref nothing if the given child is unknown
+
+        @see getChildProviderEx()
+    */
+    private *DataProvider::AbstractDataProvider getChildProviderImpl(string name) {
+        *Class cls = ChildMap{name};
+        if (!cls) {
+            return;
+        }
+        return cls.newObject(rest);
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/GoogleDataProvider/GoogleCalendarListListDataProvider.qc
+++ b/qlib/GoogleDataProvider/GoogleCalendarListListDataProvider.qc
@@ -1,0 +1,318 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GoogleDataProvider module definition
+
+/** GoogleCalendarListListDataProvider.qc Copyright 2023 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GoogleDataProvider module
+public namespace GoogleDataProvider {
+#! The Empathic Building measurements create API data provider
+/** This API allows the caller to create Empathic Building measurements
+*/
+public class GoogleCalendarListListDataProvider inherits DataProvider::AbstractDataProvider {
+    public {
+        #! REST client connection
+       GoogleRestClient::GoogleRestClient rest;
+
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "list",
+            "desc": "Google calendarList list API data provider",
+            "type": "GoogleCalendarListListDataProvider",
+            "constructor_options": GoogleDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new GoogleCalendarListRequestType();
+
+        #! Response type
+        const ResponseType = new GoogleCalendarListResponseType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", GoogleDataProvider::ConstructorOptions, options);
+        rest = GoogleDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(GoogleRestClient::GoogleRestClient rest) {
+        self.rest = rest;
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Google calendarList %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string query_args;
+        map (query_args += ((query_args ? "&" : "?") + sprintf("%s=%s", $1.key, $1.value))), req.pairIterator();
+        hash<auto> info;
+        try {
+            return rest.get("/calendar/v3/users/me/calendarList" + query_args, NOTHING, \info).body;
+        } catch (hash<ExceptionInfo> ex) {
+            # ensure that any error response body is included in the exception
+            hash<auto> ex_arg = info{"request-uri", "response-code", "response-body"};
+            rethrow ex.err, ex.desc, ex.arg + ex_arg;
+        }
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Google calenderList request data type
+public class GoogleCalendarListRequestType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            # query parameters
+            "maxResults": {
+                "type": AbstractDataProviderTypeMap."int",
+                "desc": "Maximum number of entries returned on one result page. By default the value is 100 entries. "
+                    "The page size can never be larger than 250 entries",
+                "default_value": 100,
+            },
+            "minAccessRole": {
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "The minimum access role for the user in the returned entries. Optional. The default is no "
+                    "restriction\n"
+                    "Acceptable values are:\n"
+                    "- `freeBusyReader`: The user can read free/busy information\n"
+                    "- `owner`: The user can read and modify events and access control lists\n"
+                    "- `reader`: The user can read events that are not private\n"
+                    "- `writer`: The user can read and modify events",
+                "allowed_values": (
+                    "freeBusyReader",
+                    "owner",
+                    "reader",
+                    "writer",
+                ),
+            },
+            "pageToken": {
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "Token specifying which result page to return",
+            },
+            "showDeleted": {
+                "type": SoftBoolDataProviderStringType,
+                "desc": "Whether to include deleted calendar list entries in the result",
+                "default_value": False,
+            },
+            "showHidden": {
+                "type": SoftBoolDataProviderStringType,
+                "desc": "Whether to show hidden entries",
+                "default_value": False,
+            },
+            "syncToken": {
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "Token obtained from the nextSyncToken field returned on the last page of results from the "
+                    "previous list request. It makes the result of this list request contain only entries that have "
+                    "changed since then. If only read-only fields such as calendar properties or ACLs have changed, "
+                    "the entry won't be returned. All entries deleted and hidden since the previous list request "
+                    "will always be in the result set and it is not allowed to set showDeleted neither showHidden to "
+                    "`False`. To ensure client state consistency, the `minAccessRole` query parameter cannot be "
+                    "specified together with `nextSyncToken`.\n"
+                    "If the `syncToken` expires, the server will respond with a `410 GONE` response code and the "
+                    "client should clear its storage and perform a full synchronization without any `syncToken`.\n"
+                    "The default is to return all entries",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        map addField(new QoreDataField($1.key, $1.value.desc, $1.value.type, $1.value.default_value,
+            $1.value.allowed_values)), Fields.pairIterator();
+    }
+}
+
+#! Google calender list type
+public class GoogleCalendarElementType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "kind": {
+                "type": AbstractDataProviderTypeMap."string",
+                "desc": "Type of the resource (`calendar#calendarListEntry`)",
+            },
+            "etag": {
+                "type": AbstractDataProviderTypeMap."string",
+                "desc": "A hash that indicates a specific version of the object definition",
+            },
+            "id": {
+                "type": AbstractDataProviderTypeMap."string",
+                "desc": "Identifier of the calendar",
+            },
+            "summary": {
+                "type": AbstractDataProviderTypeMap."string",
+                "desc": "Title of the calendar",
+            },
+            "description": {
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "Description of the calendar",
+            },
+            "timeZone": {
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "The time zone of the calendar",
+            },
+            "summaryOverride": {
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "The summary that the authenticated user has set for this calendar",
+            },
+            "colorId": {
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "The color of the calendar. This is an ID referring to an entry in the calendar section of "
+                    "the colors definition (see the colors endpoint). This property is superseded by the "
+                    "`backgroundColor` and `foregroundColor` properties and can be ignored when using these "
+                    "properties",
+            },
+            "foregroundColor": {
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "The foreground color of the calendar in the hexadecimal format `#ffffff`. This property "
+                    "supersedes the index-based colorId property. To set or change this property, you need to "
+                    "specify `colorRgbFormat=true` in the parameters of the insert, update and patch methods",
+            },
+            "backgroundColor": {
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "The background color of the calendar in the hexadecimal format `#ffffff`. This property "
+                    "supersedes the index-based colorId property. To set or change this property, you need to "
+                    "specify `colorRgbFormat=true` in the parameters of the insert, update and patch methods",
+            },
+            "selected": {
+                "type": AbstractDataProviderTypeMap."*bool",
+                "desc": "Whether the calendar content shows up in the calendar UI",
+            },
+            "deleted": {
+                "type": AbstractDataProviderTypeMap."*bool",
+                "desc": "Whether this calendar list entry has been deleted from the calendar list",
+            },
+            "primary": {
+                "type": AbstractDataProviderTypeMap."*bool",
+                "desc": "Whether the calendar is the primary calendar of the authenticated user",
+            },
+            "accessRole": {
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "The effective access role that the authenticated user has on the calendar. Read-only. "
+                    "Possible values are:\n"
+                    "- `freeBusyReader`: Provides read access to free/busy information\n"
+                    "- `reader`: Provides read access to the calendar. Private events will appear to users with "
+                        "reader access, but event details will be hidden\n"
+                    "- `writer`: Provides read and write access to the calendar. Private events will appear to users "
+                        "with writer access, and event details will be visible\n"
+                    "- `owner`: Provides ownership of the calendar. This role has all of the permissions of the "
+                        "writer role with the additional ability to see and manipulate ACLs",
+            },
+            "defaultReminders": {
+                "type": AbstractDataProviderTypeMap."*list",
+                "desc": "The default reminders that the authenticated user has for this calendar",
+            },
+            "conferenceProperties": {
+                "type": AbstractDataProviderTypeMap."*hash",
+                "desc": "The types of conference solutions that are supported for this calendar.\n"
+                    "The possible values are:\n"
+                    "- `eventHangout`\n"
+                    "- `eventNamedHangout`\n"
+                    "- `hangoutsMeet`",
+            },
+            "location": {
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "Geographic location of the calendar as free-form text",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        map addField(new QoreDataField($1.key, $1.value.desc, $1.value.type, $1.value.default_value)),
+            Fields.pairIterator();
+    }
+}
+
+#! Create measurements request data type
+public class GoogleCalendarListResponseType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "kind": {
+                "type": AbstractDataProviderTypeMap."string",
+                "desc": "The type of the collection",
+            },
+            "etag": {
+                "type": AbstractDataProviderTypeMap."string",
+                "desc": "A hash that indicates a specific version of the object definition",
+            },
+            "nextPageToken": {
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "Token used to access the next page of this result. Omitted if no further results are "
+                    "available, in which case `nextSyncToken` is provided",
+            },
+            "nextSyncToken": {
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "A synchronization token for the data",
+            },
+            "items": {
+                "type": new ListDataType("*GoogleCalendarElementType", new GoogleCalendarElementType(), True),
+                "desc": "response items",
+            }
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        map addField(new QoreDataField($1.key, $1.value.desc, $1.value.type, $1.value.default_value)),
+            Fields.pairIterator();
+    }
+}
+}

--- a/qlib/GoogleDataProvider/GoogleDataProvider.qc
+++ b/qlib/GoogleDataProvider/GoogleDataProvider.qc
@@ -1,0 +1,189 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GoogleDataProvider module definition
+
+/** GoogleDataProvider.qc Copyright 2023 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GoogleDataProvider module
+public namespace GoogleDataProvider {
+#! The Google data provider class
+public class GoogleDataProvider inherits DataProvider::AbstractDataProvider {
+    public {
+        #! The REST client object for API calls
+        *GoogleRestClient::GoogleRestClient rest;
+
+        #! current URI path
+        string uri_path = "/";
+
+        #! The value to returns as the name of the object
+        string display_name;
+
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "type": "GoogleDataProvider",
+            "supports_children": True,
+            "constructor_options": ConstructorOptions,
+            "children_can_support_apis": True,
+        };
+
+        #! Constructor options
+        const ConstructorOptions = {
+            "restclient": <DataProviderOptionInfo>{
+                "type": AbstractDataProviderType::get(new Type("GoogleRestClient")),
+                "desc": "The GoogleRestClient object",
+            },
+            "restclient_options": <DataProviderOptionInfo>{
+                "type": AbstractDataProviderTypeMap."*hash",
+                "desc": "Options to the GoogleRestClient constructor; only used if a GoogleRestClient object is "
+                    "created for a call",
+            },
+            "oauth2_client_id": <DataProviderOptionInfo>{
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "The OAuth2 client ID",
+            },
+            "oauth2_client_secret": <DataProviderOptionInfo>{
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "The OAuth2 client secret",
+            },
+            "oauth2_refresh_token": <DataProviderOptionInfo>{
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "The OAuth2 refresh token, if known",
+            },
+            "token": <DataProviderOptionInfo>{
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "The OAuth2 token, if known",
+            },
+        };
+    }
+
+    private {
+        const ChildMap = {
+            "calendar": Class::forName("GoogleDataProvider::GoogleCalendarDataProvider"),
+        };
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        *hash<auto> copts = checkOptions("CONSTRUCTOR-ERROR", ConstructorOptions, options);
+        rest = GoogleDataProvider::getRestConnection(copts);
+    }
+
+    #! Creates the object from a GoogleRestClient
+    constructor(GoogleRestClient rest) {
+        rest.setConnectionPath("/");
+        self.rest = rest;
+    }
+
+    static RestClient::RestClient getRestConnection(*hash<auto> options) {
+        RestClient rest;
+        if (options.restclient) {
+            rest = options.restclient;
+        } else {
+            if (!options.oauth2_client_id) {
+                throw "CONSTRUCTOR-ERROR", "no 'restclient' or 'ouath2_client_id' option passed; "
+                    "cannot create REST client to Google instance without authentication information";
+            }
+            if (!options.oauth2_client_secret) {
+                throw "CONSTRUCTOR-ERROR", "no 'restclient', 'oauth2_client_secret' option passed; "
+                    "cannot create REST client to Google instance without authentication information";
+            }
+            if (!options.token) {
+                throw "CONSTRUCTOR-ERROR", "no 'restclient', 'token' option passed; "
+                    "cannot create REST client to Google instance without authentication information";
+            }
+
+            hash<auto> opts;
+            opts += options.restclient_options + options{
+                "oauth2_client_id",
+                "oauth2_client_secret",
+                "token",
+                "oauth2_refresh_token",
+            };
+            rest = new GoogleRestClient(opts);
+        }
+        rest.setConnectionPath("/");
+        return rest;
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return "google";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Google  REST API data provider for `%s`", rest.getSafeURL());
+    }
+
+    #! Return data provider summary info
+    *list<hash<DataProvider::DataProviderSummaryInfo>> getChildProviderSummaryInfo() {
+        return map $1.getConstant("ProviderSummaryInfo").getValue(), ChildMap.iterator();
+    }
+
+    #! Returns a list of child data provider names, if any
+    /** @return a list of child data provider names, if any
+    */
+    private *list<string> getChildProviderNamesImpl() {
+        return keys ChildMap;
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    /** @return the given child provider or @ref nothing if the given child is unknown
+
+        @see getChildProviderEx()
+    */
+    private *DataProvider::AbstractDataProvider getChildProviderImpl(string name) {
+        *Class cls = ChildMap{name};
+        if (!cls) {
+            return;
+        }
+        return cls.newObject(rest);
+    }
+
+    #! Returns data provider static info
+    private hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Boolean string type for query parameters
+public const SoftBoolStringType = new SoftBoolStringType();
+
+#! Boolean data provider string type for query parameters
+public const SoftBoolDataProviderStringType = AbstractDataProviderType::get(SoftBoolStringType);
+
+#! Boolean string type
+public class SoftBoolStringType inherits Qore::Reflection::Type {
+    #! Creates the object
+    constructor() : Type("*softstring") {
+    }
+
+    #! Returns the value after any conversions by the type
+    auto acceptsValue(auto value) {
+        return parse_boolean(value) ? "true" : "false";
+    }
+
+    #! Returns the default value for the type or NOTHING if the type has no default value
+    auto getDefaultValue() {
+        return "false";
+    }
+}
+}

--- a/qlib/GoogleDataProvider/GoogleDataProvider.qm
+++ b/qlib/GoogleDataProvider/GoogleDataProvider.qm
@@ -1,0 +1,79 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GoogleDataProvider module definition
+
+/*  GoogleDataProvider.qm Copyright 2023 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+# minimum required Qore version
+%requires qore >= 1.19
+# assume local scope for variables, do not use "$" signs
+%new-style
+# require type definitions everywhere
+%require-types
+# strict argument handling
+%strict-args
+# enable all warnings
+%enable-all-warnings
+
+%requires(reexport) DataProvider
+%requires(reexport) GoogleRestClient
+
+module GoogleDataProvider {
+    version = "1.0";
+    desc = "user module providing a data provider API for Google REST cloud services";
+    author = "David Nichols <david@qore.org>";
+    url = "http://qore.org";
+    license = "MIT";
+    init = sub () {
+        # register the data provider factory
+        DataProvider::registerFactory(new GoogleDataProviderFactory());
+    };
+}
+
+/** @mainpage GoogleDataProvider Module
+
+    @tableofcontents
+
+    @section eoogledataproviderintro Introduction to the GoogleDataProvider Module
+
+    The %GoogleDataProvider module provides a @ref dataproviderintro "data provider" API for Google cloud REST API
+    services.
+
+    This data provider provides Google API access to:
+    - <b><tt>@ref GoogleDataProvider::GoogleCalendarDataProvider "calendar"</tt></b>
+
+    @section googledataprovider_factory Google Data Provider Factory
+
+    The name of the Google data provider factory is <b><tt>google</tt></b>.
+
+    @section googledataprovider_examples Google Data Provider Examples
+
+    These examples are with \c qdp, the command-line interface to the Data Provider API.
+
+    @section googledataprovider_relnotes Release Notes
+
+    @subsection googledataprovider_v1_0 GoogleDataProvider v1.0
+    - initial release of the module
+*/
+
+#! Contains all public definitions in the GoogleDataProvider module
+public namespace GoogleDataProvider {
+}

--- a/qlib/GoogleDataProvider/GoogleDataProviderFactory.qc
+++ b/qlib/GoogleDataProvider/GoogleDataProviderFactory.qc
@@ -1,0 +1,60 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GoogleDataProviderFactory class definition
+
+/** GoogleDataProviderFactory.qc Copyright 2019 - 2023 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GoogleDataProvider module
+public namespace GoogleDataProvider {
+#! The Google data provider factory: \c google
+public class GoogleDataProviderFactory inherits DataProvider::AbstractDataProviderFactory {
+    private {
+        #! Data provider type info
+        static Class cls = new Class("GoogleDataProvider");
+
+        #! Factory info
+        const FactoryInfo = <DataProviderFactoryInfo>{
+            "name": "google",
+            "desc": "Google REST API data provider factory",
+            "children_can_support_apis": True,
+        };
+    }
+
+    #! Returns static factory information without \a provider_info
+    /** @return static factory information without \a provider_info which is provided by @ref getProviderInfo()
+    */
+    private hash<DataProvider::DataProviderFactoryInfo> getInfoImpl() {
+        return FactoryInfo;
+    }
+
+    #! Returns static provider information
+    /** @note the \c name and \c children attributes are not returned as they are dynamic attributes
+    */
+    private hash<DataProvider::DataProviderInfo> getProviderInfoImpl() {
+        return GoogleDataProvider::ProviderInfo;
+    }
+
+    #! Returns the class for the data provider object
+    private Qore::Reflection::Class getClassImpl() {
+        return cls;
+    }
+}
+}

--- a/qlib/GoogleRestClient.qm
+++ b/qlib/GoogleRestClient.qm
@@ -270,10 +270,10 @@ public class GoogleRestConnection inherits RestClient::RestConnection {
     /** @return a data provider object for this connection
     */
     DataProvider::AbstractDataProvider getDataProvider() {
-        # to avoid circular dependencies, this object loads the GoogleRestDataProvider and creates the data provider
+        # to avoid circular dependencies, this object loads the GoogleDataProvider and creates the data provider
         # object dynamically
-        load_module("GoogleRestDataProvider");
-        return create_object("GoogleRestDataProvider", get());
+        load_module("GoogleDataProvider");
+        return create_object("GoogleDataProvider", get());
     }
 
     #! Called to start a non-blocking polling ping operation on the Google REST server

--- a/qlib/RestClient.qm
+++ b/qlib/RestClient.qm
@@ -2013,8 +2013,8 @@ public class RestConnection inherits ConnectionProvider::HttpBasedConnection {
     }
 
     private {
-        #! List of supported features
-        list<string> feature_list;
+        #! Hash of supported features
+        hash<string, bool> features;
     }
 
     #! creates the RestConnection connection object
@@ -2037,11 +2037,11 @@ public class RestConnection inherits ConnectionProvider::HttpBasedConnection {
 
         # setup feature list appropriately
         if (opts.oauth2_grant_type) {
-            feature_list += RCF_UPDATE_TOKEN;
+            features{RCF_UPDATE_TOKEN} = True;
         }
         if (opts.oauth2_grant_type == "authorization_code"
             && (opts{OAuth2AuthRequestOptions}.size() == OAuth2AuthRequestOptions.size())) {
-            feature_list += RCF_OAUTH2_AUTH_CODE;
+            features{RCF_OAUTH2_AUTH_CODE} = True;
         }
     }
 
@@ -2250,8 +2250,8 @@ public class RestConnection inherits ConnectionProvider::HttpBasedConnection {
     #! Returns a list of connection-defined features
     /** @since RestClient 2.0
     */
-    private *softlist<string> getFeaturesImpl() {
-        return feature_list;
+    private *hash<string, bool> getFeaturesImpl() {
+        return features;
     }
 
     #! Sets child data provider capabilities

--- a/qlib/RestClient.qm
+++ b/qlib/RestClient.qm
@@ -468,6 +468,15 @@ public class RestClient inherits Qore::HTTPClient {
         string refresh_token;
         #! If OAuth2 tokens should be automatically refreshed
         bool oauth2_auto_refresh = True;
+
+        #! Closure or call reference to be called when an access token is automatically acquired
+        /** The closure or call reference must have the following signature:
+            <tt><update_token(*string token_type, string token, *string oauth2_refresh_token) /tt>
+
+            This closure will only be called when the token is automatically acquired in blocking I/O; it will not be
+            called when setToken() is called externally, for example
+        */
+        *code update_token;
     }
 
     #! calls the base class HTTPClient constructor and optionally connects to the REST server
@@ -1244,6 +1253,9 @@ hash<auto> ans = rest.doRequest("DELETE", "/orders/1");
                 if (refresh_token) {
                     # get a new token with the refresh token
                     oauth2Auth(getOAuth2RefreshInfo(), \info);
+                    if (token && (*code update_token = self.update_token)) {
+                        update_token(token_type, token, refresh_token);
+                    }
                 } else {
                     # try to get a new token
                     loginIntern(\info);
@@ -1356,13 +1368,23 @@ hash<auto> ans = rest.doRequest("DELETE", "/orders/1");
         return h;
     }
 
+    #! Can be called to set or clear a closure or call reference to be called when the authentication token is updated
+    /** The closure or call reference must have the following signature:
+        <tt><update_token(*string token_type, string token, *string oauth2_refresh_token) /tt>
+
+        @since %RestClient 2.0
+    */
+    setUpdateTokenCode(*code update_token) {
+        self.update_token = update_token;
+    }
+
     #! Sets up authentication info
     /** @since %RestClient 2.0
     */
     private setupAuth(hash<auto> opts) {
         # set any token
         if (opts.token) {
-            setToken(opts.token_type ?? "Bearer", opts.token);
+            setToken(opts.token_type ?? "Bearer", opts.token, opts.oauth2_refresh_token);
         } else {
             if (!exists getUsername() && !exists getPassword() && exists opts.username && exists opts.password) {
                 setUserPassword(opts.username, opts.password);
@@ -1980,6 +2002,19 @@ public class RestConnection inherits ConnectionProvider::HttpBasedConnection {
             flow
         */
         const RCF_OAUTH2_AUTH_CODE = "oauth2-auth-code";
+
+        #! RestClient feature: Update Token support
+        /** Returned as a connection feature indicating that this object supports setting a closure to update the
+            access token in external systems (in blocking I/O calls)
+
+            @see @ref RestClient::setUpdateTokenCode()
+        */
+        const RCF_UPDATE_TOKEN = "oauth2-update-token";
+    }
+
+    private {
+        #! List of supported features
+        list<string> feature_list;
     }
 
     #! creates the RestConnection connection object
@@ -1999,6 +2034,15 @@ public class RestConnection inherits ConnectionProvider::HttpBasedConnection {
     constructor(string name, string description, string url, hash<auto> attributes = {}, hash<auto> options = {})
             : HttpBasedConnection(name, description, url, attributes, RestConnection::processOptions(options)) {
         real_opts = {"url": real_url} + opts;
+
+        # setup feature list appropriately
+        if (opts.oauth2_grant_type) {
+            feature_list += RCF_UPDATE_TOKEN;
+        }
+        if (opts.oauth2_grant_type == "authorization_code"
+            && (opts{OAuth2AuthRequestOptions}.size() == OAuth2AuthRequestOptions.size())) {
+            feature_list += RCF_OAUTH2_AUTH_CODE;
+        }
     }
 
     #! Returns an unconnected object for a non-blocking poll operation
@@ -2207,10 +2251,7 @@ public class RestConnection inherits ConnectionProvider::HttpBasedConnection {
     /** @since RestClient 2.0
     */
     private *softlist<string> getFeaturesImpl() {
-        if (opts.oauth2_grant_type == "authorization_code"
-            && (opts{OAuth2AuthRequestOptions}.size() == OAuth2AuthRequestOptions.size())) {
-            return RCF_OAUTH2_AUTH_CODE;
-        }
+        return feature_list;
     }
 
     #! Sets child data provider capabilities


### PR DESCRIPTION
added the ability for RestConnections to update the token and other information in external systems