### PR TITLE
refs #4798 Fix build on illumos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,11 +342,15 @@ qore_iconv_translit_check()
 qore_openssl_checks()
 qore_mpfr_checks()
 
-qore_check_headers_cxx(arpa/inet.h cxxabi.h dlfcn.h fcntl.h getopt.h glob.h grp.h iconv.h inttypes.h memory.h netdb.h
+qore_check_headers_cxx(arpa/inet.h cxxabi.h dlfcn.h fcntl.h getopt.h glob.h grp.h iconv.h inttypes.h linux/if_packet.h memory.h netdb.h
     netinet/in.h netinet/tcp.h poll.h pwd.h stdbool.h stddef.h stdint.h stdlib.h string.h strings.h sys/select.h
     sys/socket.h sys/socket.h sys/stat.h sys/statvfs.h sys/time.h sys/types.h sys/un.h sys/wait.h termios.h umem.h
     unistd.h vfork.h winsock2.h ws2tcpip.h
 )
+
+# net/if_dl.h is not self-contained
+include(CheckIncludeFiles)
+check_include_files("sys/types.h;sys/socket.h;net/if_dl.h" HAVE_NET_IF_DL_H)
 
 qore_search_libs(LIBQORE_LIBS setsockopt socket)
 qore_search_libs(LIBQORE_LIBS gethostbyname nsl)
@@ -357,7 +361,7 @@ qore_check_funcs(
     access alarm atoll bzero chown clock_gettime doprnt exp2 floor fork fsync getaddrinfo getegid geteuid
     getgid getgrgid_r getgrnam_r getgroups gethostbyaddr gethostbyname gethostname getifaddrs getnameinfo getppid
     getpwnam_r getpwuid_r getrlimit getsockopt gettimeofday getuid glob gmtime_r inet_ntop inet_pton isblank kill lchown
-    localtime_r lstat memmem memmove memset mkfifo mkfifo nanosleep poll
+    localtime_r link_ntoa lstat memmem memmove memset mkfifo mkfifo nanosleep poll
     pthread_attr_getstacksize
     pthread_get_name_np pthread_get_stacksize_np pthread_getname_np putenv random
     readlink realloc realpath regcomp round select setegid setegid setenv

--- a/cmake/QoreMacros.cmake
+++ b/cmake/QoreMacros.cmake
@@ -188,7 +188,9 @@ MACRO (QORE_BINARY_MODULE_INTERN2 _module_name _version _install_suffix _mod_suf
     target_link_libraries(${_module_name} ${_libs})
 
     # ensure that modules use dynamic lookups; works with g++ & clang++
+    if(CMAKE_HOST_APPLE)
     set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-undefined -Wl,dynamic_lookup")
+    endif(CMAKE_HOST_APPLE)
 
     install( TARGETS ${_module_name} DESTINATION ${_mod_target_dir})
 

--- a/cmake/unix-config.h.cmake
+++ b/cmake/unix-config.h.cmake
@@ -10,10 +10,12 @@
 #cmakedefine HAVE_GRP_H
 #cmakedefine HAVE_ICONV_H
 #cmakedefine HAVE_INTTYPES_H
+#cmakedefine HAVE_LINUX_IF_PACKET_H
 #cmakedefine HAVE_MEMORY_H
 #cmakedefine HAVE_NETDB_H
 #cmakedefine HAVE_NETINET_IN_H
 #cmakedefine HAVE_NETINET_TCP_H
+#cmakedefine HAVE_NET_IF_DL_H
 #cmakedefine HAVE_POLL_H
 #cmakedefine HAVE_PWD_H
 #cmakedefine HAVE_STDBOOL_H
@@ -75,6 +77,7 @@
 #cmakedefine HAVE_ISBLANK
 #cmakedefine HAVE_KILL
 #cmakedefine HAVE_LCHOWN
+#cmakedefine HAVE_LINK_NTOA
 #cmakedefine HAVE_LOCALTIME_R
 #cmakedefine HAVE_LSTAT
 #cmakedefine HAVE_MEMMEM

--- a/configure.ac
+++ b/configure.ac
@@ -1529,7 +1529,7 @@ AC_SEARCH_LIBS(clock_gettime, rt)
 # Checks for header files.
 AC_HEADER_STDC
 AC_HEADER_SYS_WAIT
-AC_CHECK_HEADERS([fcntl.h inttypes.h netdb.h netinet/in.h stddef.h stdlib.h string.h strings.h sys/socket.h sys/time.h unistd.h execinfo.h cxxabi.h arpa/inet.h sys/socket.h sys/statvfs.h winsock2.h ws2tcpip.h glob.h sys/un.h termios.h netinet/tcp.h pwd.h sys/wait.h getopt.h stdint.h poll.h grp.h])
+AC_CHECK_HEADERS([fcntl.h inttypes.h netdb.h netinet/in.h stddef.h stdlib.h string.h strings.h sys/socket.h sys/time.h unistd.h execinfo.h cxxabi.h arpa/inet.h sys/socket.h sys/statvfs.h winsock2.h ws2tcpip.h glob.h sys/un.h termios.h netinet/tcp.h pwd.h sys/wait.h getopt.h stdint.h poll.h grp.h net/if_dl.h linux/if_packet.h])
 
 # check for umem.h
 AC_CHECK_HEADER([umem.h], have_umem_h=yes, have_umem_h=no)
@@ -1679,7 +1679,7 @@ AC_CHECK_FUNCS([bzero floor getaddrinfo gethostbyaddr gethostbyname gethostname 
     getgrgid_r getgrnam_r backtrace glob system inet_ntop inet_pton lstat fsync lchown chown setsid
     setuid mkfifo random kill getppid getgid getegid getuid geteuid setuid seteuid setgid setegid sleep
     usleep nanosleep readlink symlink access strcasestr strncasecmp setgroups getgroups poll realpath
-    memmem getifaddrs pthread_get_stacksize_np pthread_get_name_np pthread_getname_np])
+    memmem getifaddrs pthread_get_stacksize_np pthread_get_name_np pthread_getname_np link_ntoa])
 
 # some systems have internal gethostby*_r in libc but don't hide the
 # symbols, so we look if they are declared before checking in the libraries

--- a/lib/ql_lib.qpp
+++ b/lib/ql_lib.qpp
@@ -67,10 +67,10 @@
 #include <ifaddrs.h>
 #include <sys/socket.h>
 #include <sys/types.h>
-#ifdef AF_LINK
+#ifdef HAVE_NET_IF_DL_H
 #include <net/if_dl.h>
 #endif
-#ifdef AF_PACKET
+#ifdef HAVE_LINUX_IF_PACKET_H
 #include <linux/if_packet.h>
 #endif
 #endif
@@ -1199,7 +1199,7 @@ list<hash<NetIfInfo>> get_netif_list() [dom=EXTERNAL_INFO] {
                 break;
             }
 #endif
-#ifdef AF_LINK
+#if defined(HAVE_NET_IF_DL_H) && defined(HAVE_LINK_NTOA)
             case AF_LINK: {
                 QoreStringNode* addrstr = new QoreStringNode(link_ntoa((struct sockaddr_dl*)ifa->ifa_addr));
                 hh->setKeyValueIntern("address", addrstr);


### PR DESCRIPTION
refs #4798 Fix build on illumos.

Illumos defines both AF_LINK and AF_PACKET
but does not have link_ntoa.
Use the finding of net/if_dl.h and link_ntoa
as indicators instead of AF_LINK.
AF_PACKET is supported on illumos but it
does not have linux/if_packet.h and it is
not needed to read AF_PACKET from getifaddrs.
So use configure checks to see if it is to
be included.

The linker on illumos does not understand
"-undefined dynamic_lookup". It seems to be
macosx specific but tolerated by GNU ld.
So only use it when building on a mac.