### PR TITLE
refs #4810 fixed a bug where%Qore could characters with the incorrect…

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -11,6 +11,9 @@
     - <a href="../../modules/RestClient/html/index.html">RestClient</a>
       - fixed a bug returning the token URL
         (<a href="https://github.com/qorelanguage/qore/issues/4809">issue 4809</a>)
+    - fixed a bug where %Qore could characters with the incorrect character encoding to strings while processing HTTP
+      headers in HTTP calls
+      (<a href="https://github.com/qorelanguage/qore/issues/4810">issue 4810</a>)
 
     @section qore_1_19_1 Qore 1.19.1
 

--- a/lib/QoreHttpClientObject.cpp
+++ b/lib/QoreHttpClientObject.cpp
@@ -727,7 +727,7 @@ struct qore_httpclient_priv {
             if (!str->empty()) {
                 str->concat(',');
             }
-            str->concat(*vh);
+            str->concat(*vh, xsink);
             //printd(5, "qore_httpclient_priv::addAppendHeader() %s: %s\n", key, str->c_str());
         }
     }


### PR DESCRIPTION
… character encoding to strings while processing HTTP headers in HTTP calls