### PR TITLE
refs #5006 refactored REST schema modules for polymorphism

### DIFF
--- a/qlib/OpenApi3.qm
+++ b/qlib/OpenApi3.qm
@@ -2123,7 +2123,7 @@ public class OpenApi3Schema inherits ObjectBase, AbstractRestSchemaValidator {
 
     #! Returns a field definition from an abstract schema object
     /** This method provides polymorphic access to getFieldFromSchema()
-        @since OpenApi3 1.2
+        @since OpenApi3 2.3
     */
     AbstractDataField getFieldFromSchema(string name, *string desc, RestSchemaValidator::AbstractSchemaObject schema,
             bool required = True, *HTTPClient rest) {

--- a/qlib/OpenApi3.qm
+++ b/qlib/OpenApi3.qm
@@ -53,7 +53,7 @@
 %allow-weak-references
 
 module OpenApi3 {
-    version = "1.0";
+    version = "2.3";
     desc = "OpenApi3 module providing functionality for OpenApi 3 schema definitions";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -157,8 +157,24 @@ RestHandler handler(NOTHING, openapi3);
 
     @section openapi3_relnotes OpenApi3 Module Release Notes
 
-    @subsection openapi3_1_0 OpenApi3 v1.0
+    @subsection openapi3_2_3 OpenApi3 v2.3
     - initial release of the %OpenApi3 module
+    - classes inherit from abstract base classes in @ref RestSchemaValidator for polymorphic usage:
+      - @ref OpenApi3::SchemaBase "SchemaBase": inherits
+        @ref RestSchemaValidator::AbstractSchemaBase "AbstractSchemaBase"
+      - @ref OpenApi3::SchemaObject "SchemaObject": inherits
+        @ref RestSchemaValidator::AbstractSchemaObject "AbstractSchemaObject"
+      - @ref OpenApi3::ParameterBase "ParameterBase": inherits
+        @ref RestSchemaValidator::AbstractParameterObject "AbstractParameterObject"
+      - @ref OpenApi3::ResponseObject "ResponseObject": inherits
+        @ref RestSchemaValidator::AbstractResponseObject "AbstractResponseObject"
+      - @ref OpenApi3::ResponsesObject "ResponsesObject": inherits
+        @ref RestSchemaValidator::AbstractResponsesObject "AbstractResponsesObject"
+      - @ref OpenApi3::PathItemObject "PathItemObject": inherits
+        @ref RestSchemaValidator::AbstractPathItemObject "AbstractPathItemObject"
+      - @ref OpenApi3::OperationObject "OperationObject": inherits
+        @ref RestSchemaValidator::AbstractOperationObject "AbstractOperationObject"
+      (<a href="https://github.com/qorelanguage/qore/issues/5006">issue 5006</a>)
 */
 
 #! main namespace for all public %OpenApi3 declarations
@@ -307,26 +323,11 @@ class ObjectBase inherits Qore::Serializable {
 }
 
 #! Base used by @ref HeaderObject and @ref SchemaObject
-class SchemaBase inherits Qore::Serializable {
+/** Inherits common validation constraint members from
+    @ref RestSchemaValidator::AbstractSchemaBase "AbstractSchemaBase".
+*/
+class SchemaBase inherits RestSchemaValidator::AbstractSchemaBase {
     public {
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.2.
-        *softfloat maximum;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.3.
-        *softfloat minimum;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.2.
-        /** In OpenAPI 3.0, this is a boolean modifier for maximum.
-            In OpenAPI 3.1, exclusiveMaximum is a numeric value directly.
-        */
-        *bool exclusiveMax;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.3.
-        /** In OpenAPI 3.0, this is a boolean modifier for minimum.
-            In OpenAPI 3.1, exclusiveMinimum is a numeric value directly.
-        */
-        *bool exclusiveMin;
-
         #! OpenAPI 3.1 numeric exclusiveMaximum value
         /** In OpenAPI 3.1, exclusiveMaximum is a direct numeric value (not a boolean modifier)
         */
@@ -336,33 +337,6 @@ class SchemaBase inherits Qore::Serializable {
         /** In OpenAPI 3.1, exclusiveMinimum is a direct numeric value (not a boolean modifier)
         */
         *softfloat exclusiveMinValue;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.1.
-        *int maxLength;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.2.
-        *int minLength;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.3.
-        *string pattern;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.2.
-        *int maxItems;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.3.
-        *int minItems;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.4.
-        *bool uniqueItems;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.1.
-        /** @note OpenApi3 enums can be of any type, but we only support enums of simple types that can be converted
-            to a string for fast lookups in a hash
-        */
-        hash<string, bool> enum;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.1.
-        *float multipleOf;
     }
 
     #! Constructor.
@@ -1108,7 +1082,7 @@ public class ParameterGroup {
 
     #! Adds a parameter to the group
     addParameter(string key, ParameterObject p) {
-        if (p.in_loc == "query" && p.schema && p.schema.type == "object") {
+        if (p.inLoc == "query" && p.schema && p.schema.type == "object") {
             if (exists query_obj) {
                 throw "OPENAPI3-SCHEMA-ERROR", sprintf("Query parameter %y has already been defined with type "
                     "\"object\"; cannot define subsequent parameter %y with the same type", query_obj, key);
@@ -2147,6 +2121,15 @@ public class OpenApi3Schema inherits ObjectBase, AbstractRestSchemaValidator {
         return schema.getField(name, desc, required, rest);
     }
 
+    #! Returns a field definition from an abstract schema object
+    /** This method provides polymorphic access to getFieldFromSchema()
+        @since OpenApi3 1.2
+    */
+    AbstractDataField getFieldFromSchema(string name, *string desc, RestSchemaValidator::AbstractSchemaObject schema,
+            bool required = True, *HTTPClient rest) {
+        return cast<SchemaObject>(schema).getField(name, desc, required, rest);
+    }
+
     #! Adds field definitions to a hash type from OpenAPI 3.0 parameters
     addFieldsFromParameters(HashDataType rv, hash<string, ParameterBase> parameters,
             reference<bool> required) {
@@ -2168,25 +2151,25 @@ public class OpenApi3Schema inherits ObjectBase, AbstractRestSchemaValidator {
         # required flag map for type: loc -> bool
         hash<string, bool> req_map;
         foreach hash<auto> i in (parameters.pairIterator()) {
-            switch (i.value.in_loc) {
+            switch (i.value.inLoc) {
                 # body and formData parameters are handled directly under the operation
                 case "query": {
-                    params{i.value.in_loc}{i.value.name} =
+                    params{i.value.inLoc}{i.value.name} =
                         i.value.schema.getField(i.value.name, i.value.desc, i.value.required);
                     # if at least one query argument is required, then we set "required" to True for the hash
-                    if (i.value.required && !req_map{i.value.in_loc}) {
-                        req_map{i.value.in_loc} = True;
+                    if (i.value.required && !req_map{i.value.inLoc}) {
+                        req_map{i.value.inLoc} = True;
                     }
                     break;
                 }
 
                 case "header": {
-                    params{i.value.in_loc}{i.value.name} =
+                    params{i.value.inLoc}{i.value.name} =
                         i.value.schema.getField(i.value.name, i.value.desc, i.value.required);
                     # if at least one query argument is required, then we set "required" to True for the hash
                     if (i.value.required) {
-                        if (!req_map{i.value.in_loc}) {
-                            req_map{i.value.in_loc} = True;
+                        if (!req_map{i.value.inLoc}) {
+                            req_map{i.value.inLoc} = True;
                         }
                         if (!required) {
                             required = True;
@@ -2836,7 +2819,7 @@ public class PathsObject inherits ObjectBase {
     exposed to the documentation viewer but they will not know which operations
     and parameters are available.
  */
-public class PathItemObject inherits ObjectBase, ParameterGroup {
+public class PathItemObject inherits ObjectBase, ParameterGroup, RestSchemaValidator::AbstractPathItemObject {
     public {
         #! Allows for an external definition of this path item.
         /**
@@ -2917,7 +2900,7 @@ public class PathItemObject inherits ObjectBase, ParameterGroup {
                 ParameterObject p = ParameterObject::newParameter(
                     sprintf("%d/%d", $# + 1, params.lsize()), param, openapi3
                 );
-                if (p.in_loc == "body") {
+                if (p.inLoc == "body") {
                     if (body)
                         throw "INVALID-FIELD-VALUE", sprintf("path %y: more than one \"body\" parameter provided",
                             path);
@@ -2951,28 +2934,30 @@ public class PathItemObject inherits ObjectBase, ParameterGroup {
     softlist getMethods() {
         return keys operations;
     }
+
+    #! Returns the body parameter, if any
+    *RestSchemaValidator::AbstractParameterObject getBody() {
+        return body;
+    }
+
+    #! Returns the parameters hash
+    hash<string, RestSchemaValidator::AbstractParameterObject> getParameters() {
+        return cast<hash<string, RestSchemaValidator::AbstractParameterObject>>(parameters);
+    }
 }
 
 #! Describes a single API operation on a path.
-public class OperationObject inherits ObjectBase, ParameterGroup {
+/** Inherits common operation members from
+    @ref RestSchemaValidator::AbstractOperationObject "AbstractOperationObject":
+    - path, method, summary, desc, consumes, produces
+*/
+public class OperationObject inherits ObjectBase, ParameterGroup, RestSchemaValidator::AbstractOperationObject {
     public {
-        #! the URI path for the operation
-        string path;
-
-        #! the HTTP method for the operation
-        string method;
-
         #! A list of tags (strings or @ref TagObject "TagObjects") for API documentation control.
         /**
             Tags can be used for logical grouping of operations by resources or any other qualifier.
          */
         list tags;
-
-        #! A short summary of what the operation does.
-        *string summary;
-
-        #! A verbose explanation of the operation behavior. GFM syntax can be used for rich text representation.
-        *string desc;
 
         #! Declares this operation to be deprecated.
         /**
@@ -2992,22 +2977,6 @@ public class OperationObject inherits ObjectBase, ParameterGroup {
             programming naming conventions.
          */
         *string operationId;
-
-        #! A list of MIME types (strings) the operation can consume.
-        /**
-            This overrides the @ref OpenApi3Schema::consumes "consumes" definition
-            at the %OpenApi3 Object. An empty value MAY be used to clear the global definition.
-            Key values MUST be Mime Types.
-         */
-        hash<string, bool> consumes;
-
-        #! A hash of MIME types (strings) the operation can produce.
-        /**
-            This overrides the @ref OpenApi3Schema::produces "produces" definition
-            at the %OpenApi3 Object. An empty value MAY be used to clear the global definition.
-            Key values MUST be Mime Types.
-         */
-        hash<string, bool> produces;
 
         #! formData parameter; if defined for this operation, body parameter will be excluded
         hash<string, ParameterObject> formData;
@@ -3109,9 +3078,9 @@ public class OperationObject inherits ObjectBase, ParameterGroup {
                 }
                 ParameterObject param = ParameterObject::newParameter(sprintf("%d/%d", $# + 1,
                     listObj.lsize()), p, openapi3);
-                if (param.in_loc == "body") {
+                if (param.inLoc == "body") {
                     body = param;
-                } else if (param.in_loc == "formData") {
+                } else if (param.inLoc == "formData") {
                     formData{param.name} = param;
                 } else {
                     addParameter(param);
@@ -3187,8 +3156,17 @@ public class OperationObject inherits ObjectBase, ParameterGroup {
     }
 
     #! Processes a generated request
-    *data getRequestBody(PathItemObject pio, auto body, reference<hash<auto>> headers) {
-        *ParameterObject body_po = self.body ?? pio.body;
+    /** @param pio the path item object
+        @param body the request body
+        @param headers reference to headers
+        @param freeform if \c True, allow freeform validation (optional)
+
+        @return the serialized request body data
+    */
+    *data getRequestBody(RestSchemaValidator::AbstractPathItemObject pio, auto body, reference<hash<auto>> headers,
+            *bool freeform) {
+        PathItemObject real_pio = cast<PathItemObject>(pio);
+        *ParameterObject body_po = self.body ?? real_pio.body;
         if (body_po) {
             body_po.check(True, True, path, method, "body", \body);
         } else if (formData) {
@@ -3239,32 +3217,37 @@ public class OperationObject inherits ObjectBase, ParameterGroup {
         @param body a reference to the deserialized HTTP message body data
         @param headers a reference to a hash of HTTP headers
         @param mime_types a reference to a hash of valid mime types for the operation
+        @param freeform if \c True, allow freeform validation (optional, Swagger-specific)
 
         @throws SCHEMA-VALIDATION-ERROR invalid parameter name or location, missing parameter and parameter has no
         default value
     */
-    validateRequest(bool serialize, PathItemObject pio, reference<hash<UriQueryInfo>> h, reference<auto> body,
-            reference<hash> headers, *reference<hash<string, bool>> mime_types) {
+    validateRequest(bool serialize, RestSchemaValidator::AbstractPathItemObject pio, reference<hash<UriQueryInfo>> h,
+            reference<auto> body, reference<hash> headers, *reference<hash<string, bool>> mime_types,
+            *bool freeform) {
+        PathItemObject real_pio = cast<PathItemObject>(pio);
+
         # check query parameters
-        *string query_obj = self.query_obj ?? pio.query_obj;
+        *string query_obj = self.query_obj ?? real_pio.query_obj;
         if (exists query_obj) {
-            h.params{query_obj} = map {$1: remove h.params{$1}}, keys h.params, !parameters{$1} && !pio.parameters{$1};
+            h.params{query_obj} = map {$1: remove h.params{$1}}, keys h.params,
+                !parameters{$1} && !real_pio.parameters{$1};
         }
 
         foreach string key in (keys h.params) {
             # find URI parameter object
-            *ParameterObject po = parameters{key} ?? pio.parameters{key};
+            *ParameterObject po = parameters{key} ?? real_pio.parameters{key};
             if (!po) {
-                if (exists (*string op = (query_obj ?? pio.query_obj))) {
+                if (exists (*string op = (query_obj ?? real_pio.query_obj))) {
                     h.params{op}{key} = remove h.params{key};
                 } else {
                     error("SCHEMA-VALIDATION-ERROR", "No query parameter named %y defined for this path and method; "
-                        "known query parameters: %y", key, keys (parameters + pio.parameters));
+                        "known query parameters: %y", key, keys (parameters + real_pio.parameters));
                 }
             }
-            if (po.in_loc != "query") {
+            if (po.inLoc != "query") {
                 error("SCHEMA-VALIDATION-ERROR", "invalid parameter %y given in the URI query; expected location %y",
-                    key, po.in_loc);
+                    key, po.inLoc);
             }
 
             po.check(serialize, True, path, method, key, \h.params{key});
@@ -3278,9 +3261,9 @@ public class OperationObject inherits ObjectBase, ParameterGroup {
         # check header parameters
         foreach string key in (keys headers) {
             # find URI parameter object
-            *ParameterObject po = parameters{key} ?? pio.parameters{key};
+            *ParameterObject po = parameters{key} ?? real_pio.parameters{key};
             # extra headers are OK
-            if (!po || po.in_loc != "header") {
+            if (!po || po.inLoc != "header") {
                 continue;
             }
 
@@ -3289,7 +3272,7 @@ public class OperationObject inherits ObjectBase, ParameterGroup {
 
         # check body parameters
         {
-            *ParameterObject body_po = self.body ?? pio.body;
+            *ParameterObject body_po = self.body ?? real_pio.body;
             if (body_po) {
                 body_po.check(serialize, True, path, method, "body", \body);
             } else if (formData) {
@@ -3303,10 +3286,10 @@ public class OperationObject inherits ObjectBase, ParameterGroup {
 
         # check path parameters
         foreach string param in (path =~ x/{([^}]+)}/g) {
-            *ParameterObject po = parameters{param} ?? pio.parameters{param};
+            *ParameterObject po = parameters{param} ?? real_pio.parameters{param};
             if (!po) {
                 error("SCHEMA-VALIDATION-ERROR", "No path parameter named %y defined for this path and method; "
-                    "known parameters: %y", param, keys (parameters + pio.parameters));
+                    "known parameters: %y", param, keys (parameters + real_pio.parameters));
             }
 
             string pattern = replace(path, "{" + param + "}", "(.*)");
@@ -3334,7 +3317,7 @@ public class OperationObject inherits ObjectBase, ParameterGroup {
 
         # check for missing required parameters
         checkMissingParams(h, headers, body, parameters);
-        checkMissingParams(h, headers, body, pio.parameters, parameters);
+        checkMissingParams(h, headers, body, real_pio.parameters, parameters);
 
         if (consumes) {
             mime_types = consumes;
@@ -3519,9 +3502,9 @@ public class OperationObject inherits ObjectBase, ParameterGroup {
             hash<string, ParameterObject> parameters, *hash<string, ParameterObject> child_params) {
         foreach hash<auto> ph in (parameters.pairIterator()) {
             # don't check if child params already checked or if it's the single message body param
-            if (child_params{ph.key} || ph.value.in_loc == "body" || ph.value.in_loc == "formData")
+            if (child_params{ph.key} || ph.value.inLoc == "body" || ph.value.inLoc == "formData")
                 continue;
-            switch (ph.value.in_loc) {
+            switch (ph.value.inLoc) {
                 case "query":
                     query{ph.key} = ph.value.getExampleValue();
                     break;
@@ -3537,10 +3520,10 @@ public class OperationObject inherits ObjectBase, ParameterGroup {
             hash<string, ParameterObject> parameters, *hash<string, ParameterObject> child_params) {
         foreach hash<auto> ph in (parameters.pairIterator()) {
             # don't check if child params already checked or if it's the single message body param
-            if (child_params{ph.key} || ph.value.in_loc == "body")
+            if (child_params{ph.key} || ph.value.inLoc == "body")
                 continue;
             if (exists (auto val = ph.value.getDefaultValue())) {
-                switch (ph.value.in_loc) {
+                switch (ph.value.inLoc) {
                     case "query":
                         if (!exists h.params{ph.key})
                             h.params{ph.key} = val;
@@ -3564,10 +3547,10 @@ public class OperationObject inherits ObjectBase, ParameterGroup {
             hash<string, ParameterObject> parameters, *hash<string, ParameterObject> child_params) {
         foreach hash<auto> ph in (parameters.pairIterator()) {
             # don't check if child params already checked
-            if (child_params{ph.key} || ph.value.in_loc == "body")
+            if (child_params{ph.key} || ph.value.inLoc == "body")
                 continue;
             if (ph.value.required) {
-                switch (ph.value.in_loc) {
+                switch (ph.value.inLoc) {
                     case "query":
                         if (!exists h.params{ph.key})
                             error("SCHEMA-VALIDATION-ERROR", "request is missing required query parameter %y",
@@ -3619,6 +3602,21 @@ public class OperationObject inherits ObjectBase, ParameterGroup {
     *string getXSummary() {
         return vendorExtensions."x-summary";
     }
+
+    #! Returns the responses object
+    RestSchemaValidator::AbstractResponsesObject getResponses() {
+        return responses;
+    }
+
+    #! Returns the body parameter, if any
+    *RestSchemaValidator::AbstractParameterObject getBody() {
+        return body;
+    }
+
+    #! Returns the parameters hash
+    hash<string, RestSchemaValidator::AbstractParameterObject> getParameters() {
+        return cast<hash<string, RestSchemaValidator::AbstractParameterObject>>(parameters);
+    }
 }
 
 #! Allows referencing an external resource for extended documentation.
@@ -3646,31 +3644,11 @@ public class ExternalDocumentationObject inherits ObjectBase {
 }
 
 #! Base class for ParameterObject and HeaderObject
-public class ParameterBase inherits ObjectBase {
+/** Inherits common parameter members from
+    @ref RestSchemaValidator::AbstractParameterObject "AbstractParameterObject".
+*/
+public class ParameterBase inherits ObjectBase, RestSchemaValidator::AbstractParameterObject {
     public {
-        #! Required. The name of the parameter. Parameter names are case sensitive
-        /**
-            - If @ref ParameterObject::in_loc "in_loc" is \c "path", the \c name
-                field MUST correspond to the associated path segment from the
-                \c "path" field in the @ref OpenApi3::PathsObject.
-            - For all other cases, the name corresponds to the parameter name
-                used based on the @ref ParameterObject::in_loc "in_loc" property.
-        */
-        string name;
-
-        #! Required. The location of the parameter
-        /**
-            Possible values are \c "query", \c "header", \c "path", \c "formData" or \c "body".
-        */
-        string in_loc;
-
-        #! A brief description of the parameter
-        /** This could contain examples of use
-
-            CommonMark syntax MAY be used for rich text representation
-        */
-        *string desc;
-
         #! Describes how the parameter value will be serialized depending on the type of the parameter value
         /** Default values (based on value of in):
             - for query - form
@@ -3693,14 +3671,6 @@ public class ParameterBase inherits ObjectBase {
             an in value of query. The default value is false.
         */
         bool allowReserved;
-
-        #! Determines whether this parameter is mandatory
-        /**
-            If the parameter is @ref ParameterObject::in_loc "in" "path",
-            this property is \b required and its value MUST be \c true.
-            Otherwise, the property MAY be included and its default value is \c false.
-        */
-        bool required = False;
 
         #! Specifies that a parameter is deprecated and SHOULD be transitioned out of usage
         /**
@@ -3768,11 +3738,11 @@ public class ParameterBase inherits ObjectBase {
 
     #! Parse the parameter data
     private parseData(hash<auto> oh, OpenApi3Schema openapi3) {
-        string obj_type = sprintf("%s parameter", in_loc);
+        string obj_type = sprintf("%s parameter", inLoc);
         on_error rethrow $1.err, sprintf("%s (%s %y)", $1.desc, obj_type, name);
 
         optional_field(obj_type, oh, "description", (NT_STRING: True, NT_NOTHING: True), \desc);
-        if (in_loc == "path") {
+        if (inLoc == "path") {
             required_field(obj_type, oh, "required", NT_BOOLEAN, \required);
             if (!required) {
                 throw "INVALID-PARAMETER", sprintf("Path parameter %y has 'required: false'", name);
@@ -3792,11 +3762,11 @@ public class ParameterBase inherits ObjectBase {
             if (!StyleMap{style}) {
                 throw "INVALID-STYLE", sprintf("Style %y is invalid; known styles: %y", style, keys StyleMap);
             }
-            if (!LocStyleMap{in_loc}{style}) {
+            if (!LocStyleMap{inLoc}{style}) {
                 throw "INVALID-STYLE", sprintf("Style %y is invalid for location %y; valid styles for this "
-                    "location: %y", style, in_loc, keys LocStyleMap{in_loc});
+                    "location: %y", style, inLoc, keys LocStyleMap{inLoc});
             }
-        } else if (exists (*string s = DefaultStyles{in_loc})) {
+        } else if (exists (*string s = DefaultStyles{inLoc})) {
             style = s;
         }
 
@@ -3804,7 +3774,7 @@ public class ParameterBase inherits ObjectBase {
             explode = True;
         }
 
-        if (in_loc == "query") {
+        if (inLoc == "query") {
             optional_field(obj_type, oh, "allowReserved", NT_BOOLEAN, \allowReserved);
         }
 
@@ -3828,7 +3798,7 @@ public class ParameterBase inherits ObjectBase {
 #! Describes a single operation parameter
 /**
     A unique parameter is defined by a combination of a @ref ParameterObject::name "name"
-    and @ref ParameterObject::in_loc "location".
+    and @ref ParameterObject::inLoc "location".
 
     There are five possible parameter types:
     - Path: Used together with Path Templating, where the parameter value is
@@ -3893,12 +3863,12 @@ public class ParameterObject inherits ParameterBase {
     */
     public constructor(hash<auto> oh, OpenApi3Schema openapi3) : ParameterBase(oh) {
         required_field("parameter", oh, "name", NT_STRING, \name);
-        required_field("parameter", oh, "in", NT_STRING, \in_loc);
-        if (!ParameterLocations{in_loc}) {
+        required_field("parameter", oh, "in", NT_STRING, \inLoc);
+        if (!ParameterLocations{inLoc}) {
             throw "INVALID-FIELD-VALUE", sprintf("parameter %y: invalid location (\"in\") value: %y", name, oh."in");
         }
-        if (in_loc == "query") {
-            optional_field(in_loc + " parameter", oh, "allowEmptyValue", NT_BOOLEAN, \allowEmptyValue);
+        if (inLoc == "query") {
+            optional_field(inLoc + " parameter", oh, "allowEmptyValue", NT_BOOLEAN, \allowEmptyValue);
         }
         parseData(oh, openapi3);
     }
@@ -3913,7 +3883,7 @@ public class ParameterObject inherits ParameterBase {
         on_error rethrow $1.err, sprintf("%s (while checking %s parameter)", $1.desc, self.name);
 
         # issue #2388 ensure that query parameters are converted to their target type first
-        if (in_loc == "query") {
+        if (inLoc == "query") {
             switch (schema.type) {
                 case "integer": {
                     if (value.typeCode() == NT_STRING) {
@@ -3982,7 +3952,7 @@ public class ParameterObject inherits ParameterBase {
                     }
                     break;
             }
-        } else if (in_loc == "path" && !value && path) {
+        } else if (inLoc == "path" && !value && path) {
             # if we have a path and a missing value then ignore the missing value
             return;
         }
@@ -4016,10 +3986,17 @@ public class ParameterObject inherits ParameterBase {
         }
         return new ParameterObject(oh, openapi3);
     }
+
+    #! Returns the schema for this parameter
+    *RestSchemaValidator::AbstractSchemaObject getSchema() {
+        return schema;
+    }
 }
 
 #! contains the possible responses for an operation
-public class ResponsesObject inherits ObjectBase {
+/** Inherits from @ref RestSchemaValidator::AbstractResponsesObject "AbstractResponsesObject".
+*/
+public class ResponsesObject inherits ObjectBase, RestSchemaValidator::AbstractResponsesObject {
     public {
         # The documentation of responses other than the ones declared for specific HTTP response codes.
         /**
@@ -4063,14 +4040,24 @@ public class ResponsesObject inherits ObjectBase {
         if (responses.empty() && !defaultObj)
             throw "EMPTY-RESPONSES", sprintf("%s %s: no valid responses provided for operation", method, path);
     }
+
+    #! Returns the default response, if any
+    *RestSchemaValidator::AbstractResponseObject getDefaultResponse() {
+        return defaultResp;
+    }
+
+    #! Returns the hash of responses by HTTP status code
+    *hash<string, RestSchemaValidator::AbstractResponseObject> getResponses() {
+        return cast<*hash<string, RestSchemaValidator::AbstractResponseObject>>(responses);
+    }
 }
 
 #! Describes a single response from an API Operation.
-public class ResponseObject inherits ObjectBase {
+/** Inherits common response members from
+    @ref RestSchemaValidator::AbstractResponseObject "AbstractResponseObject".
+*/
+public class ResponseObject inherits ObjectBase, RestSchemaValidator::AbstractResponseObject {
     public {
-        #! Required. A short description of the response. GFM syntax can be used for rich text representation.
-        string desc;
-
         #! A definition of the response structure.
         /**
             It can be a primitive, an array or an object. If this field does not exist,
@@ -4079,22 +4066,6 @@ public class ResponseObject inherits ObjectBase {
             be \c "file". This SHOULD be accompanied by a relevant \c produces mime-type.
          */
         *SchemaObject schema;
-
-        #! A hash of headers that are (can be) sent with the response.
-        /**
-            A hash of @ref HeaderObject objects. Keys are header names.
-         */
-        hash<auto> headers;
-
-        #! A hash of example response messages.
-        /**
-            A hash of example responses in the form of <tt>Example Object</tt>.
-            See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#exampleObject
-            Keys MUST be one of the Operation @ref OperationObject::produces "produces"
-            values (either implicit or inherited). The value SHOULD be an example
-            of what such a response would look like.
-         */
-        hash examples;
 
         #! Content types supported by this response (OpenAPI 3.0).
         /**
@@ -4157,6 +4128,11 @@ public class ResponseObject inherits ObjectBase {
             return openapi3.resolveResponse(key, oh."$ref", oh);
         return new ResponseObject(key, oh, openapi3);
     }
+
+    #! Returns the response schema, if any
+    *RestSchemaValidator::AbstractSchemaObject getSchema() {
+        return schema;
+    }
 }
 
 #! describes a single HTTP header
@@ -4172,11 +4148,26 @@ public class HeaderObject inherits ParameterBase {
      */
     public constructor(string name, hash<auto> oh, OpenApi3Schema openapi3) : ParameterBase(oh) {
         self.name = name;
-        in_loc = "header";
+        inLoc = "header";
         if (oh.hasKey("in")) {
             throw "HEADER-ERROR", sprintf("Header %y must not specify the 'in' keyword (%y)", name, oh."in");
         }
         parseData(oh, openapi3);
+    }
+
+    #! Validates the header value
+    check(bool serialize, bool request, string path, string method, string name, reference<auto> value) {
+        if (!exists value && !required) {
+            return;
+        }
+        if (schema) {
+            schema.check(serialize, request, path, method, name, \value);
+        }
+    }
+
+    #! Returns the schema for this header
+    *RestSchemaValidator::AbstractSchemaObject getSchema() {
+        return schema;
     }
 }
 
@@ -4395,43 +4386,13 @@ public class OpenApi3HashDataType inherits HashDataType {
 }
 
 #! defines an object in a schema
-public class SchemaObject inherits ObjectBase, SchemaBase {
+/** Inherits common schema members from
+    @ref RestSchemaValidator::AbstractSchemaObject "AbstractSchemaObject".
+*/
+public class SchemaObject inherits ObjectBase, SchemaBase, RestSchemaValidator::AbstractSchemaObject {
     public {
-        #! the name of this object for documentation and example purposes
-        string name;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.2.
-        /**
-            MUST be either a string or an array (list). If it's an array,
-            it's elements MUST be strings and MUST be unique.
-         */
-        string type;
-
-        #! The extending format for the previously mentioned \c type. See Data Type Formats for further details.
-        *string format;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.1.
-        *string title;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.1.
-        *string desc;
-
         #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.1.
         *SchemaObject items;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.2.
-        auto defaultVal;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.1.
-        *int maxProperties;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.2.
-        *int minProperties;
-
-        #! extension that allows types to be nullable
-        /** the OpenAPI specification 2.0 otherwise does not allow for nullable types
-        */
-        bool nullable = False;
 
         #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.4.
         /**
@@ -4449,43 +4410,6 @@ public class SchemaObject inherits ObjectBase, SchemaBase {
             a valid JSON Schema (@ref SchemaObject).
          */
         auto additionalProperties;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.3.
-        /**
-            Set of strings. Must have at least one element.
-         */
-        hash<string, bool> required;
-
-        #! Adds support for polymorphism.
-        /**
-            The discriminator is the schema property name that is used to
-            differentiate between other schemas that inherit this schema.
-            The property name used MUST be defined at this schema and it MUST
-            be in the @ref SchemaObject::required "required" property list.
-            When used, the value MUST be the name of this schema or any schema
-            that inherits it.
-
-            While composition offers model extensibility, it does not imply
-            a hierarchy between the models. To support polymorphism, OpenApi3
-            adds the support of the \c discriminator field. When used,
-            the \c discriminator will be the name of the property used to decide
-            which schema definition is used to validate the structure of the model.
-            As such, the \c discriminator field MUST be a required field.
-            The value of the chosen property has to be the friendly name given to
-            the model under the \c definitions property. As such, inline schema
-            definitions, which do not have a given id, \e cannot be used in polymorphism.
-         */
-        *string discriminator;
-
-        #! Relevant only for Schema \c "properties" definitions. Declares the property as "read only".
-        /**
-            Declares the property as "read only". This means that it MAY be sent
-            as part of a response but MUST NOT be sent as part of the request.
-            Properties marked as \c readOnly being \c true SHOULD NOT be in the
-            @ref SchemaObject::required "required" list of the defined schema.
-            Default value is \c false.
-         */
-        bool readOnly = False;
 
         #! Relevant only for Schema \c "properties" definitions. Declares the property as "write only".
         /**
@@ -5365,6 +5289,16 @@ public class SchemaObject inherits ObjectBase, SchemaBase {
     *string getClassName() {
         return vendorExtensions."x-class-name";
     }
+
+    #! Returns the items schema for arrays
+    *RestSchemaValidator::AbstractSchemaObject getItems() {
+        return items;
+    }
+
+    #! Returns a hash of property schemas for objects
+    *hash<string, RestSchemaValidator::AbstractSchemaObject> getProperties() {
+        return cast<*hash<string, RestSchemaValidator::AbstractSchemaObject>>(properties);
+    }
 }
 
 #! A metadata object that allows for more fine-tuned XML model definitions.
@@ -5541,7 +5475,7 @@ public class SecuritySchemeObject inherits ObjectBase {
         #! The location of the API key
         /** Valid values are \c "query", \c "header", or \c "cookie".
             Required when type is \c "apiKey" */
-        *string in_loc;
+        *string inLoc;
 
         #! The name of the HTTP Authorization scheme
         /** Required when type is \c "http".
@@ -5577,10 +5511,10 @@ public class SecuritySchemeObject inherits ObjectBase {
         switch (type) {
             case "apiKey": {
                 required_field(obj_type, oh, "name", NT_STRING, \name);
-                required_field(obj_type, oh, "in", NT_STRING, \in_loc);
-                if (in_loc != "query" && in_loc != "header" && in_loc != "cookie") {
+                required_field(obj_type, oh, "in", NT_STRING, \inLoc);
+                if (inLoc != "query" && inLoc != "header" && inLoc != "cookie") {
                     throw "INVALID-APIKEY-LOCATION", sprintf("Security Scheme Object: invalid 'in' (location) "
-                        "value passed: %y; valid values are 'query', 'header', 'cookie'", in_loc);
+                        "value passed: %y; valid values are 'query', 'header', 'cookie'", inLoc);
                 }
                 break;
             }

--- a/qlib/RestSchemaDataProvider/RestSchemaDataProvider.qm
+++ b/qlib/RestSchemaDataProvider/RestSchemaDataProvider.qm
@@ -42,7 +42,7 @@
 %requires(reexport) OpenApi3
 
 module RestSchemaDataProvider {
-    version = "1.0";
+    version = "2.3";
     desc = "user module providing a data provider API for REST schemas (Swagger 2.0 and OpenAPI 3.0)";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -81,8 +81,11 @@ module RestSchemaDataProvider {
 
     @section restschemamdataprovider_relnotes Release Notes
 
-    @subsection restschemamdataprovider_v1_0 RestSchemaDataProvider v1.0
+    @subsection restschemamdataprovider_v2_3 RestSchemaDataProvider v2.3
     - initial release of the module supporting both Swagger 2.0 and OpenAPI 3.0 schemas
+    - uses abstract base classes from RestSchemaValidator module for polymorphic access to
+      operation and path item objects
+      (<a href="https://github.com/qorelanguage/qore/issues/5006">issue 5006</a>)
 */
 
 #! contains all public definitions in the RestSchemaDataProvider module

--- a/qlib/RestSchemaDataProvider/RestSchemaRequestDataProvider.qc
+++ b/qlib/RestSchemaDataProvider/RestSchemaRequestDataProvider.qc
@@ -50,17 +50,11 @@ public class RestSchemaRequestDataProvider inherits RestSchemaDataProviderBase {
     }
 
     private {
-        #! The path item object for the operation (Swagger)
-        *Swagger::PathItemObject swagger_pio;
+        #! The path item object for the operation
+        RestSchemaValidator::AbstractPathItemObject pio;
 
-        #! The path item object for the operation (OpenAPI 3.0)
-        *OpenApi3::PathItemObject openapi3_pio;
-
-        #! The operation object (Swagger)
-        *Swagger::OperationObject swagger_op;
-
-        #! The operation object (OpenAPI 3.0)
-        *OpenApi3::OperationObject openapi3_op;
+        #! The operation object
+        RestSchemaValidator::AbstractOperationObject op;
 
         #! Disable checking the request type
         bool disable_request_type_check;
@@ -72,15 +66,16 @@ public class RestSchemaRequestDataProvider inherits RestSchemaDataProviderBase {
             : RestSchemaDataProviderBase(rest) {
         self.schema = schema;
         self.uri_path = uri_path;
-        self.swagger_pio := pio;
-        self.swagger_op := op;
+        self.pio := pio;
+        self.op := op;
 
         if (cb_value_needs_resolution) {
             resolve_uri = cb_value_needs_resolution(uri_path);
         }
 
         # check for any successful response data structure
-        foreach hash<auto> i in (op.responses.responses.pairIterator()) {
+        RestSchemaValidator::AbstractResponsesObject responses = op.getResponses();
+        foreach hash<auto> i in (responses.getResponses().pairIterator()) {
             if (i.key =~ /^2/ && i.value) {
                 success_response = i.key;
                 break;
@@ -94,15 +89,16 @@ public class RestSchemaRequestDataProvider inherits RestSchemaDataProviderBase {
             : RestSchemaDataProviderBase(rest) {
         self.schema = schema;
         self.uri_path = uri_path;
-        self.openapi3_pio := pio;
-        self.openapi3_op := op;
+        self.pio := pio;
+        self.op := op;
 
         if (cb_value_needs_resolution) {
             resolve_uri = cb_value_needs_resolution(uri_path);
         }
 
         # check for any successful response data structure
-        foreach hash<auto> i in (op.responses.responses.pairIterator()) {
+        RestSchemaValidator::AbstractResponsesObject responses = op.getResponses();
+        foreach hash<auto> i in (responses.getResponses().pairIterator()) {
             if (i.key =~ /^2/ && i.value) {
                 success_response = i.key;
                 break;
@@ -115,37 +111,26 @@ public class RestSchemaRequestDataProvider inherits RestSchemaDataProviderBase {
         return getMethod().upr();
     }
 
-    #! Returns the HTTP method (in lower case)
+    #! Returns the HTTP method (in UPPER case)
     string getMethod() {
-        return swagger_op ? swagger_op.method : openapi3_op.method;
+        return op.method;
     }
 
     #! Returns the consumes hash for the operation
     *hash<string, bool> getConsumes() {
-        return swagger_op ? swagger_op.consumes : openapi3_op.consumes;
+        return op.consumes;
     }
 
     #! Sets a mime type in the consumes hash for the operation
     setConsumes(string mime_type) {
-        if (swagger_op) {
-            swagger_op.consumes{mime_type} = True;
-        } else {
-            openapi3_op.consumes{mime_type} = True;
-        }
+        op.consumes{mime_type} = True;
     }
 
     #! Returns the data provider description
     *string getDesc() {
         string method = getMethod();
-        string summary;
-        string desc;
-        if (swagger_op) {
-            summary = swagger_op.summary ?? "";
-            desc = swagger_op.desc ?? "";
-        } else {
-            summary = openapi3_op.summary ?? "";
-            desc = openapi3_op.desc ?? "";
-        }
+        string summary = op.summary ?? "";
+        string desc = op.desc ?? "";
         string type = isSwagger() ? "Swagger/OpenAPI 2.0" : "OpenAPI 3.0";
         return sprintf("%s data provider for URL `%s`, URI path `%s`, and HTTP method `%s`.\n\n"
             "## Summary\n\n%s\n\n## Description\n\n%s",
@@ -193,34 +178,11 @@ public class RestSchemaRequestDataProvider inherits RestSchemaDataProviderBase {
     }
 
     private *hash<string, AbstractDataField> getRecordTypeIntern() {
-        if (swagger_op) {
-            return getSwaggerRecordType();
-        }
-        return getOpenApi3RecordType();
-    }
-
-    private *hash<string, AbstractDataField> getSwaggerRecordType() {
-        *Swagger::ResponseObject response = getSwaggerSuccessResponse();
-        if (response.schema) {
-            SwaggerSchema swagger = cast<SwaggerSchema>(schema);
-            AbstractDataField response_field = swagger.getFieldFromSchema("body", "REST response body argument",
-                response.schema);
-            AbstractDataProviderType type = response_field.getType();
-            *hash<string, AbstractDataField> rv = type.getFields();
-            # if we have a list of hashes, then return the list element type
-            if (type.getBaseTypeCode() == NT_LIST) {
-                rv = type.getElementType().getFields();
-            }
-            return rv;
-        }
-    }
-
-    private *hash<string, AbstractDataField> getOpenApi3RecordType() {
-        *OpenApi3::ResponseObject response = getOpenApi3SuccessResponse();
-        if (response.schema) {
-            OpenApi3Schema openapi3 = cast<OpenApi3Schema>(schema);
-            AbstractDataField response_field = openapi3.getFieldFromSchema("body", "REST response body argument",
-                response.schema);
+        *RestSchemaValidator::AbstractResponseObject response = getSuccessResponse();
+        *RestSchemaValidator::AbstractSchemaObject response_schema = response.getSchema();
+        if (response_schema) {
+            AbstractDataField response_field = schema.getFieldFromSchema("body", "REST response body argument",
+                response_schema);
             AbstractDataProviderType type = response_field.getType();
             *hash<string, AbstractDataField> rv = type.getFields();
             # if we have a list of hashes, then return the list element type
@@ -237,7 +199,7 @@ public class RestSchemaRequestDataProvider inherits RestSchemaDataProviderBase {
             return request_type;
         }
 
-        if (swagger_op) {
+        if (isSwagger()) {
             return request_type = getSwaggerRequestType();
         }
         return request_type = getOpenApi3RequestType();
@@ -245,13 +207,15 @@ public class RestSchemaRequestDataProvider inherits RestSchemaDataProviderBase {
 
     private AbstractDataProviderType getSwaggerRequestType() {
         SwaggerSchema swagger = cast<SwaggerSchema>(schema);
+        Swagger::PathItemObject swagger_pio = cast<Swagger::PathItemObject>(pio);
+        Swagger::OperationObject swagger_op = cast<Swagger::OperationObject>(op);
         HashDataType rv(getName() + ": request");
         bool required = False;
-        *hash<string, Swagger::AbstractParameterObject> params = swagger_pio.parameters + swagger_op.parameters;
+        *hash<string, Swagger::AbstractSwaggerParameterObject> params = swagger_pio.parameters + swagger_op.parameters;
         if (params) {
             swagger.addFieldsFromParameters(rv, params, \required);
         }
-        *Swagger::AbstractParameterObject body = swagger_op.body ?? swagger_pio.body;
+        *Swagger::AbstractSwaggerParameterObject body = swagger_op.body ?? swagger_pio.body;
         if (body) {
             AbstractDataField body_field = swagger.getFieldFromSchema("body", "REST request body argument",
                 cast<Swagger::BodyParameter>(body).schema, body.required ?? False, rest);
@@ -276,6 +240,8 @@ public class RestSchemaRequestDataProvider inherits RestSchemaDataProviderBase {
 
     private AbstractDataProviderType getOpenApi3RequestType() {
         OpenApi3Schema openapi3 = cast<OpenApi3Schema>(schema);
+        OpenApi3::PathItemObject openapi3_pio = cast<OpenApi3::PathItemObject>(pio);
+        OpenApi3::OperationObject openapi3_op = cast<OpenApi3::OperationObject>(op);
         HashDataType rv(getName() + ": request");
         bool required = False;
         *hash<string, OpenApi3::ParameterBase> params = openapi3_pio.parameters + openapi3_op.parameters;
@@ -301,107 +267,65 @@ public class RestSchemaRequestDataProvider inherits RestSchemaDataProviderBase {
             return response_type;
         }
 
-        if (swagger_op) {
-            *Swagger::ResponseObject response = getSwaggerSuccessResponse();
-            if (response) {
-                return response_type = getSwaggerResponseType(response, "success");
-            }
-        } else {
-            *OpenApi3::ResponseObject response = getOpenApi3SuccessResponse();
-            if (response) {
-                return response_type = getOpenApi3ResponseType(response, "success");
-            }
+        *RestSchemaValidator::AbstractResponseObject response = getSuccessResponse();
+        if (response) {
+            return response_type = getResponseTypeFromResponse(response, "success");
         }
     }
 
     #! Returns a hash of error responses, if any
     private *hash<string, AbstractDataProviderType> getErrorResponseTypesImpl() {
-        if (swagger_op) {
-            *hash<string, AbstractDataProviderType> rv = map {$1.key: getSwaggerResponseType($1.value,
-                ($1.key =~ /^2/ ? "success" : "error") + sprintf(" (%s)", $1.key))},
-                swagger_op.responses.responses.pairIterator(), $1.key != success_response;
-            if (swagger_op.responses.defaultResp) {
-                rv."default" = getSwaggerResponseType(swagger_op.responses.defaultResp, "default");
-            }
-            return rv;
-        }
-
-        *hash<string, AbstractDataProviderType> rv = map {$1.key: getOpenApi3ResponseType($1.value,
+        RestSchemaValidator::AbstractResponsesObject responses = op.getResponses();
+        *hash<string, RestSchemaValidator::AbstractResponseObject> resp_hash = responses.getResponses();
+        *hash<string, AbstractDataProviderType> rv = map {$1.key: getResponseTypeFromResponse($1.value,
             ($1.key =~ /^2/ ? "success" : "error") + sprintf(" (%s)", $1.key))},
-            openapi3_op.responses.responses.pairIterator(), $1.key != success_response;
-        if (openapi3_op.responses.defaultResp) {
-            rv."default" = getOpenApi3ResponseType(openapi3_op.responses.defaultResp, "default");
+            resp_hash.pairIterator(), $1.key != success_response;
+        *RestSchemaValidator::AbstractResponseObject default_resp = responses.getDefaultResponse();
+        if (default_resp) {
+            rv."default" = getResponseTypeFromResponse(default_resp, "default");
         }
         return rv;
     }
 
     #! Returns the type for the given error code
     private AbstractDataProviderType getErrorResponseTypeImpl(string error_code) {
-        if (swagger_op) {
-            *Swagger::ResponseObject resp = swagger_op.responses.responses{error_code};
-            if (!resp && error_code == "default" && swagger_op.responses.defaultResp) {
-                resp = swagger_op.responses.defaultResp;
-            }
-            if (!resp) {
-                throw "UNKNOWN-ERROR-RESPONSE", sprintf("error code %y is unknown; known error codes: %y", error_code,
-                    keys swagger_op.responses.responses + (swagger_op.responses.defaultResp ? ("default",) : ()));
-            }
-            return getSwaggerResponseType(resp, error_code);
-        }
-
-        *OpenApi3::ResponseObject resp = openapi3_op.responses.responses{error_code};
-        if (!resp && error_code == "default" && openapi3_op.responses.defaultResp) {
-            resp = openapi3_op.responses.defaultResp;
+        RestSchemaValidator::AbstractResponsesObject responses = op.getResponses();
+        *hash<string, RestSchemaValidator::AbstractResponseObject> resp_hash = responses.getResponses();
+        *RestSchemaValidator::AbstractResponseObject resp = resp_hash{error_code};
+        if (!resp && error_code == "default") {
+            resp = responses.getDefaultResponse();
         }
         if (!resp) {
             throw "UNKNOWN-ERROR-RESPONSE", sprintf("error code %y is unknown; known error codes: %y", error_code,
-                keys openapi3_op.responses.responses + (openapi3_op.responses.defaultResp ? ("default",) : ()));
+                keys resp_hash + (responses.getDefaultResponse() ? ("default",) : ()));
         }
-        return getOpenApi3ResponseType(resp, error_code);
+        return getResponseTypeFromResponse(resp, error_code);
     }
 
-    #! Returns a data provider type object for a Swagger response
-    private AbstractDataProviderType getSwaggerResponseType(Swagger::ResponseObject response, string label) {
-        SwaggerSchema swagger = cast<SwaggerSchema>(schema);
+    #! Returns a data provider type object for a response using abstract types
+    private AbstractDataProviderType getResponseTypeFromResponse(RestSchemaValidator::AbstractResponseObject response,
+            string label) {
         label += " response";
         HashDataType rv();
-        if (response.schema) {
-            rv.addField(swagger.getFieldFromSchema("body", "REST " + label + " body argument", response.schema));
+        *RestSchemaValidator::AbstractSchemaObject response_schema = response.getSchema();
+        if (response_schema) {
+            rv.addField(schema.getFieldFromSchema("body", "REST " + label + " body argument", response_schema));
         }
         if (response.headers) {
-            rv.addField(swagger.getFieldForHeaders("headers", response.headers));
+            rv.addField(schema.getFieldForHeaders("headers", response.headers));
             response_headers = keys response.headers;
         }
         return rv;
     }
 
-    #! Returns a data provider type object for an OpenAPI 3.0 response
-    private AbstractDataProviderType getOpenApi3ResponseType(OpenApi3::ResponseObject response, string label) {
-        OpenApi3Schema openapi3 = cast<OpenApi3Schema>(schema);
-        label += " response";
-        HashDataType rv();
-        if (response.schema) {
-            rv.addField(openapi3.getFieldFromSchema("body", "REST " + label + " body argument", response.schema));
+    #! Returns the success response using abstract types
+    private *RestSchemaValidator::AbstractResponseObject getSuccessResponse() {
+        RestSchemaValidator::AbstractResponsesObject responses = op.getResponses();
+        if (success_response) {
+            *hash<string, RestSchemaValidator::AbstractResponseObject> resp_hash = responses.getResponses();
+            return resp_hash{success_response};
         }
-        if (response.headers) {
-            rv.addField(openapi3.getFieldForHeaders("headers", response.headers));
-            response_headers = keys response.headers;
-        }
-        return rv;
-    }
-
-    #! Returns the Swagger success response
-    private *Swagger::ResponseObject getSwaggerSuccessResponse() {
-        return success_response
-            ? swagger_op.responses.responses{success_response}
-            : swagger_op.responses.defaultResp;
-    }
-
-    #! Returns the OpenAPI 3.0 success response
-    private *OpenApi3::ResponseObject getOpenApi3SuccessResponse() {
-        return success_response
-            ? openapi3_op.responses.responses{success_response}
-            : openapi3_op.responses.defaultResp;
+        return responses.getDefaultResponse();
     }
 
     #! Makes a request and returned the response
@@ -478,26 +402,14 @@ public class RestSchemaRequestDataProvider inherits RestSchemaDataProviderBase {
         hash<UriQueryInfo> uri_info = parse_uri_query(uri_path);
         auto req_body = req.body ?? req.formData;
 
-        if (swagger_op) {
-            Swagger::PathItemObject pio = cast<SwaggerSchema>(schema).paths.match(uri_path);
-            swagger_op.validateRequest(True, pio, \uri_info, \req_body, \hdr, \mime_types, disable_request_type_check);
-        } else {
-            OpenApi3::PathItemObject pio = cast<OpenApi3Schema>(schema).paths.match(uri_path);
-            openapi3_op.validateRequest(True, pio, \uri_info, \req_body, \hdr, \mime_types, disable_request_type_check);
-        }
+        # validate the request using abstract types
+        op.validateRequest(True, pio, \uri_info, \req_body, \hdr, \mime_types, disable_request_type_check);
 
         # make the call
         hash<auto> info;
         try {
-            *data body;
-            *hash<string, bool> produces;
-            if (swagger_op) {
-                body = swagger_op.getRequestBody(swagger_pio, req_body, \hdr, disable_request_type_check);
-                produces = swagger_op.produces;
-            } else {
-                body = openapi3_op.getRequestBody(openapi3_pio, req_body, \hdr, disable_request_type_check);
-                produces = openapi3_op.produces;
-            }
+            *data body = op.getRequestBody(pio, req_body, \hdr, disable_request_type_check);
+            *hash<string, bool> produces = op.produces;
 
             # ensure we specify JSON for the response if possible
             if (!hdr.Accept && produces{MimeTypeJson}) {
@@ -540,24 +452,12 @@ public class RestSchemaRequestDataProvider inherits RestSchemaDataProviderBase {
             case NT_LIST:
                 return foldl $1 + "," + $2, (map getUriValue($1), v);
             case NT_DATE: {
-                if (swagger_op) {
-                    SwaggerSchema swagger = cast<SwaggerSchema>(schema);
-                    if (swagger.getUtcDates()) {
-                        TimeZone utc(0);
-                        v = utc.date(v);
-                    }
-                    if (exists (*string fmt = swagger.getQueryDateFormat())) {
-                        return v.format(fmt);
-                    }
-                } else {
-                    OpenApi3Schema openapi3 = cast<OpenApi3Schema>(schema);
-                    if (openapi3.getUtcDates()) {
-                        TimeZone utc(0);
-                        v = utc.date(v);
-                    }
-                    if (exists (*string fmt = openapi3.getQueryDateFormat())) {
-                        return v.format(fmt);
-                    }
+                if (schema.getUtcDates()) {
+                    TimeZone utc(0);
+                    v = utc.date(v);
+                }
+                if (exists (*string fmt = schema.getQueryDateFormat())) {
+                    return v.format(fmt);
                 }
                 return v.format("IF");
             }

--- a/qlib/RestSchemaDataProvider/RestSchemaRequestDataProvider.qc
+++ b/qlib/RestSchemaDataProvider/RestSchemaRequestDataProvider.qc
@@ -179,6 +179,9 @@ public class RestSchemaRequestDataProvider inherits RestSchemaDataProviderBase {
 
     private *hash<string, AbstractDataField> getRecordTypeIntern() {
         *RestSchemaValidator::AbstractResponseObject response = getSuccessResponse();
+        if (!response) {
+            return;
+        }
         *RestSchemaValidator::AbstractSchemaObject response_schema = response.getSchema();
         if (response_schema) {
             AbstractDataField response_field = schema.getFieldFromSchema("body", "REST response body argument",

--- a/qlib/RestSchemaValidator.qm
+++ b/qlib/RestSchemaValidator.qm
@@ -55,7 +55,7 @@
 %endtry
 
 module RestSchemaValidator {
-    version = "2.2.1";
+    version = "2.4";
     desc = "RestSchemaValidator module providing an abstract REST schema validation API";
     author = "David Nichols <david.nichols@qoretechnologies.com>";
     url = "http://qore.org";
@@ -75,6 +75,23 @@ module RestSchemaValidator {
     - @ref RestSchemaValidator::NullRestSchemaValidator "NullRestSchemaValidator"
 
     @section restschemavalidator_relnotes RestSchemaValidator Module Release Notes
+
+    @subsection restschemavalidator_2_4 RestSchemaValidator v2.4
+    - added abstract methods to enable polymorphic access for data providers:
+      - @ref RestSchemaValidator::AbstractSchemaObject::getField() "AbstractSchemaObject::getField()"
+      - @ref RestSchemaValidator::AbstractRestSchemaValidator::getFieldFromSchema() "AbstractRestSchemaValidator::getFieldFromSchema()"
+      - @ref RestSchemaValidator::AbstractRestSchemaValidator::getFieldForHeaders() "AbstractRestSchemaValidator::getFieldForHeaders()"
+      (<a href="https://github.com/qorelanguage/qore/issues/5006">issue 5006</a>)
+
+    @subsection restschemavalidator_2_3 RestSchemaValidator v2.3
+    - added abstract base classes for REST schema objects to enable polymorphic usage:
+      - @ref RestSchemaValidator::AbstractSchemaBase "AbstractSchemaBase": base class for schema validation constraints
+      - @ref RestSchemaValidator::AbstractSchemaObject "AbstractSchemaObject": base class for JSON schema objects
+      - @ref RestSchemaValidator::AbstractParameterObject "AbstractParameterObject": base class for parameter objects
+      - @ref RestSchemaValidator::AbstractResponseObject "AbstractResponseObject": base class for response objects
+      - @ref RestSchemaValidator::AbstractResponsesObject "AbstractResponsesObject": base class for responses container
+      - @ref RestSchemaValidator::AbstractPathItemObject "AbstractPathItemObject": base class for path item objects
+      - @ref RestSchemaValidator::AbstractOperationObject "AbstractOperationObject": base class for operation objects
 
     @subsection restschemavalidator_2_2_1 RestSchemaValidator v2.2.1
     - assume UTF-8 encoding for JSON and YAML payloads, as otherwise deserialization errors occur
@@ -206,6 +223,340 @@ public namespace RestSchemaValidator {
 
         #! a string giving the example code generation
         string example;
+    }
+
+    #! Abstract base class for schema validation constraints (JSON Schema)
+    /** This class provides common validation constraint members shared by both
+        Swagger 2.0 and OpenAPI 3.0 schema definitions.
+    */
+    public class AbstractSchemaBase inherits Qore::Serializable {
+        public {
+            #! Maximum value constraint
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.2
+            */
+            *softfloat maximum;
+
+            #! Minimum value constraint
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.3
+            */
+            *softfloat minimum;
+
+            #! Exclusive maximum flag
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.2
+            */
+            *bool exclusiveMax;
+
+            #! Exclusive minimum flag
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.3
+            */
+            *bool exclusiveMin;
+
+            #! Maximum string length
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.1
+            */
+            *int maxLength;
+
+            #! Minimum string length
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.2
+            */
+            *int minLength;
+
+            #! Regex pattern constraint
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.3
+            */
+            *string pattern;
+
+            #! Maximum array items
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.2
+            */
+            *int maxItems;
+
+            #! Minimum array items
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.3
+            */
+            *int minItems;
+
+            #! Unique items constraint
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.4
+            */
+            *bool uniqueItems;
+
+            #! Enum values as a hash for fast lookup
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.1
+
+                @note enums can be of any type, but we only support enums of simple types that can be
+                converted to a string for fast lookups in a hash
+            */
+            hash<string, bool> enum;
+
+            #! Multiple-of constraint
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.1
+            */
+            *float multipleOf;
+        }
+    }
+
+    #! Abstract base class for schema objects (JSON Schema)
+    /** This class provides the common interface for schema objects shared by both
+        Swagger 2.0 and OpenAPI 3.0 specifications.
+    */
+    public class AbstractSchemaObject inherits AbstractSchemaBase {
+        public {
+            #! The name of this object for documentation and example purposes
+            string name;
+
+            #! The data type (string, integer, boolean, object, array, etc.)
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.2
+
+                MUST be either a string or an array (list). If it's an array,
+                its elements MUST be strings and MUST be unique.
+            */
+            string type;
+
+            #! The extending format for the type (date-time, int64, etc.)
+            /** See Data Type Formats for further details.
+            */
+            *string format;
+
+            #! Title for documentation
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.1
+            */
+            *string title;
+
+            #! Description
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.1
+            */
+            *string desc;
+
+            #! Default value
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.2
+            */
+            auto defaultVal;
+
+            #! Maximum number of properties (for objects)
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.1
+            */
+            *int maxProperties;
+
+            #! Minimum number of properties (for objects)
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.2
+            */
+            *int minProperties;
+
+            #! Whether the value can be null
+            /** Extension that allows types to be nullable; the OpenAPI specification 2.0
+                otherwise does not allow for nullable types.
+            */
+            bool nullable = False;
+
+            #! Required properties (for objects)
+            /** @see https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.3
+
+                Set of strings. Must have at least one element.
+            */
+            hash<string, bool> required;
+
+            #! Discriminator for polymorphism
+            /** The discriminator is the schema property name that is used to
+                differentiate between other schemas that inherit this schema.
+            */
+            *string discriminator;
+
+            #! Read-only flag
+            /** Declares the property as "read only". This means that it MAY be sent
+                as part of a response but MUST NOT be sent as part of the request.
+            */
+            bool readOnly = False;
+        }
+
+        #! Returns the items schema for arrays
+        abstract *AbstractSchemaObject getItems();
+
+        #! Returns a hash of property schemas for objects
+        abstract *hash<string, AbstractSchemaObject> getProperties();
+
+        #! Returns a data field definition from this schema
+        /** @param name the name of the field
+            @param desc optional description for the field
+            @param required if the field is required
+            @param rest optional REST client for URL resolution
+            @param default_value optional default value
+
+            @return the data field definition
+        */
+        abstract AbstractDataField getField(string name, *string desc, bool required = True, *HTTPClient rest,
+            auto default_value);
+    }
+
+    #! Abstract base class for parameter objects
+    /** This class provides the common interface for parameter objects shared by both
+        Swagger 2.0 and OpenAPI 3.0 specifications.
+    */
+    public class AbstractParameterObject inherits Qore::Serializable {
+        public {
+            #! The name of the parameter (case sensitive)
+            /** - If @ref inLoc is \c "path", the \c name field MUST correspond to the
+                  associated path segment from the path field in the Paths Object.
+                - For all other cases, the name corresponds to the parameter name
+                  used based on the @ref inLoc property.
+            */
+            string name;
+
+            #! The location of the parameter
+            /** Possible values are \c "query", \c "header", \c "path", \c "formData" or \c "body".
+            */
+            string inLoc;
+
+            #! Description of the parameter
+            /** This could contain examples of use. GFM/CommonMark syntax can be used for
+                rich text representation.
+            */
+            *string desc;
+
+            #! Whether the parameter is required
+            /** If the parameter is in "path", this property is required and its value
+                MUST be \c True. Otherwise, the property MAY be included and its default
+                value is \c False.
+            */
+            bool required = False;
+        }
+
+        #! Validates the parameter value
+        /** @param serialize if serializing the value
+            @param request if processing a request (vs response)
+            @param path the URI path
+            @param method the HTTP method
+            @param name the parameter name
+            @param value reference to the value to validate/transform
+        */
+        abstract check(bool serialize, bool request, string path, string method,
+            string name, reference value);
+
+        #! Returns the schema for this parameter, if any
+        abstract *AbstractSchemaObject getSchema();
+    }
+
+    #! Abstract base class for response objects
+    /** This class provides the common interface for response objects shared by both
+        Swagger 2.0 and OpenAPI 3.0 specifications.
+    */
+    public class AbstractResponseObject inherits Qore::Serializable {
+        public {
+            #! A short description of the response
+            /** GFM/CommonMark syntax can be used for rich text representation.
+            */
+            string desc;
+
+            #! A hash of headers that can be sent with the response
+            /** Keys are header names.
+            */
+            hash<auto> headers;
+
+            #! A hash of example response messages
+            hash examples;
+        }
+
+        #! Returns the response schema, if any
+        abstract *AbstractSchemaObject getSchema();
+    }
+
+    #! Abstract base class for responses container
+    /** This class provides the common interface for the responses object shared by both
+        Swagger 2.0 and OpenAPI 3.0 specifications.
+    */
+    public class AbstractResponsesObject inherits Qore::Serializable {
+        #! Returns the default response, if any
+        abstract *AbstractResponseObject getDefaultResponse();
+
+        #! Returns the hash of responses by HTTP status code
+        abstract *hash<string, AbstractResponseObject> getResponses();
+    }
+
+    #! Abstract base class for path item objects
+    /** This class provides the common interface for path item objects shared by both
+        Swagger 2.0 and OpenAPI 3.0 specifications.
+    */
+    public class AbstractPathItemObject inherits Qore::Serializable {
+        #! Returns the operation for the given HTTP method
+        /** @param method the HTTP method name (case insensitive)
+            @param path the path for error reporting
+
+            @return the operation object for the given method
+
+            @throws INVALID-METHOD the given path does not have any operation defined for the given method
+        */
+        abstract AbstractOperationObject getOperation(string method, string path);
+
+        #! Returns a list of HTTP methods supported by this path
+        abstract softlist getMethods();
+
+        #! Returns the body parameter defined at the path level, if any
+        abstract *AbstractParameterObject getBody();
+
+        #! Returns a hash of parameters defined at the path level
+        abstract *hash<string, AbstractParameterObject> getParameters();
+    }
+
+    #! Abstract base class for operation objects
+    /** This class provides the common interface for operation objects shared by both
+        Swagger 2.0 and OpenAPI 3.0 specifications.
+    */
+    public class AbstractOperationObject inherits Qore::Serializable {
+        public {
+            #! The URI path for the operation
+            string path;
+
+            #! The HTTP method (uppercase)
+            string method;
+
+            #! A short summary of what the operation does
+            *string summary;
+
+            #! A verbose explanation of the operation behavior
+            /** GFM/CommonMark syntax can be used for rich text representation.
+            */
+            *string desc;
+
+            #! MIME types the operation can consume
+            hash<string, bool> consumes;
+
+            #! MIME types the operation can produce
+            hash<string, bool> produces;
+        }
+
+        #! Returns the responses object for this operation
+        abstract AbstractResponsesObject getResponses();
+
+        #! Returns the body parameter, if any
+        abstract *AbstractParameterObject getBody();
+
+        #! Returns a hash of parameters for this operation
+        abstract *hash<string, AbstractParameterObject> getParameters();
+
+        #! Validates the request against the schema
+        /** @param serialize if \c True, serialize the body
+            @param pio the path item object
+            @param h reference to URI query info
+            @param body reference to the request body
+            @param headers reference to headers
+            @param mime_types reference to accepted MIME types
+            @param freeform if \c True, allow freeform validation (optional, Swagger-specific)
+        */
+        abstract validateRequest(bool serialize, AbstractPathItemObject pio,
+            reference<hash<UriQueryInfo>> h, reference<auto> body,
+            reference<hash> headers, *reference<hash<string, bool>> mime_types,
+            *bool freeform);
+
+        #! Returns the serialized request body
+        /** @param pio the path item object
+            @param body the request body
+            @param headers reference to headers
+            @param freeform if \c True, allow freeform validation (optional)
+
+            @return the serialized request body data
+        */
+        abstract *data getRequestBody(AbstractPathItemObject pio, auto body,
+            reference<hash<auto>> headers, *bool freeform);
     }
 
     #! abstract REST schema validation classes
@@ -583,6 +934,30 @@ public namespace RestSchemaValidator {
             @since RestSchemaValidator 2.1.3
         */
         private abstract *TimeZone getTimeZoneLocaleImpl();
+
+        #! Returns a field definition from a schema object
+        /** @param name the name of the field
+            @param desc optional description for the field
+            @param schema the schema object
+            @param required if the field is required
+            @param rest optional REST client for URL resolution
+
+            @return the data field definition
+
+            @since RestSchemaValidator 2.4
+        */
+        abstract AbstractDataField getFieldFromSchema(string name, *string desc, AbstractSchemaObject schema,
+            bool required = True, *HTTPClient rest);
+
+        #! Returns a field for header fields
+        /** @param name the name of the field
+            @param headers a hash of header definitions
+
+            @return a data field for the headers
+
+            @since RestSchemaValidator 2.4
+        */
+        abstract AbstractDataField getFieldForHeaders(string name, hash<auto> headers);
     }
 
     #! null REST validator; no schema is used but default serialization and deserialization is performed
@@ -1101,6 +1476,38 @@ public namespace RestSchemaValidator {
         */
         private *TimeZone getTimeZoneLocaleImpl() {
             return get_thread_tz();
+        }
+
+        #! Returns a field definition from a schema object
+        /** @param name the name of the field
+            @param desc optional description for the field
+            @param schema the schema object
+            @param required if the field is required
+            @param rest optional REST client for URL resolution
+
+            @return the data field definition
+
+            @since RestSchemaValidator 2.4
+
+            @throws UNSUPPORTED-OPERATION the NullRestSchemaValidator does not support schema operations
+        */
+        AbstractDataField getFieldFromSchema(string name, *string desc, AbstractSchemaObject schema,
+                bool required = True, *HTTPClient rest) {
+            throw "UNSUPPORTED-OPERATION", "the NullRestSchemaValidator class does not support schema operations";
+        }
+
+        #! Returns a field for header fields
+        /** @param name the name of the field
+            @param headers a hash of header definitions
+
+            @return a data field for the headers
+
+            @since RestSchemaValidator 2.4
+
+            @throws UNSUPPORTED-OPERATION the NullRestSchemaValidator does not support schema operations
+        */
+        AbstractDataField getFieldForHeaders(string name, hash<auto> headers) {
+            throw "UNSUPPORTED-OPERATION", "the NullRestSchemaValidator class does not support schema operations";
         }
     }
 }

--- a/qlib/Swagger.qm
+++ b/qlib/Swagger.qm
@@ -53,7 +53,7 @@
 %allow-weak-references
 
 module Swagger {
-    version = "2.2.3";
+    version = "2.4";
     desc = "Swagger module providing functionality for Swagger 2.0 schema definitions";
     author = "Ondrej Musil <ondrej.musil@qoretechnologies.com>, David Nichols <david.nichols@qoretechnologies.com>";
     url = "http://qore.org";
@@ -152,6 +152,31 @@ RestHandler handler(NOTHING, swagger);
     @endcode
 
     @section swagger_relnotes Swagger Module Release Notes
+
+    @subsection swagger_2_4 Swagger v2.4
+    - renamed @ref Swagger::AbstractSwaggerParameterObject "AbstractSwaggerParameterObject" from
+      \c AbstractParameterObject to avoid confusion with
+      @ref RestSchemaValidator::AbstractParameterObject "RestSchemaValidator::AbstractParameterObject"
+    - added overloaded @ref Swagger::SwaggerSchema::getFieldFromSchema() "getFieldFromSchema()" method
+      that accepts @ref RestSchemaValidator::AbstractSchemaObject "AbstractSchemaObject" for polymorphic access
+      (<a href="https://github.com/qorelanguage/qore/issues/5006">issue 5006</a>)
+
+    @subsection swagger_2_3 Swagger v2.3
+    - updated classes to inherit from abstract base classes in @ref RestSchemaValidator for polymorphic usage:
+      - @ref Swagger::SchemaBase "SchemaBase" now inherits from
+        @ref RestSchemaValidator::AbstractSchemaBase "AbstractSchemaBase"
+      - @ref Swagger::SchemaObject "SchemaObject" now inherits from
+        @ref RestSchemaValidator::AbstractSchemaObject "AbstractSchemaObject"
+      - @ref Swagger::AbstractSwaggerParameterObject "AbstractSwaggerParameterObject" now inherits from
+        @ref RestSchemaValidator::AbstractParameterObject "RestSchemaValidator::AbstractParameterObject"
+      - @ref Swagger::ResponseObject "ResponseObject" now inherits from
+        @ref RestSchemaValidator::AbstractResponseObject "AbstractResponseObject"
+      - @ref Swagger::ResponsesObject "ResponsesObject" now inherits from
+        @ref RestSchemaValidator::AbstractResponsesObject "AbstractResponsesObject"
+      - @ref Swagger::PathItemObject "PathItemObject" now inherits from
+        @ref RestSchemaValidator::AbstractPathItemObject "AbstractPathItemObject"
+      - @ref Swagger::OperationObject "OperationObject" now inherits from
+        @ref RestSchemaValidator::AbstractOperationObject "AbstractOperationObject"
 
     @subsection swagger_2_2_3 Swagger v2.2.3
     - improved parsing Swagger schemas with type errors
@@ -449,48 +474,10 @@ class ObjectBase inherits Qore::Serializable {
 }
 
 #! Base used by @ref OtherParameter, @ref HeaderObject and @ref SchemaObject.
-class SchemaBase inherits Qore::Serializable {
-    public {
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.2.
-        *softfloat maximum;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.3.
-        *softfloat minimum;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.2.
-        *bool exclusiveMax;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.3.
-        *bool exclusiveMin;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.1.
-        *int maxLength;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.2.
-        *int minLength;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.3.
-        *string pattern;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.2.
-        *int maxItems;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.3.
-        *int minItems;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.4.
-        *bool uniqueItems;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.1.
-        /** @note Swagger enums can be of any type, but we only support enums of simple types that can be converted
-            to a string for fast lookups in a hash
-        */
-        hash<string, bool> enum;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.1.
-        *float multipleOf;
-    }
-
+/** Inherits common validation constraint members from
+    @ref RestSchemaValidator::AbstractSchemaBase "AbstractSchemaBase".
+*/
+class SchemaBase inherits RestSchemaValidator::AbstractSchemaBase {
     #! Constructor.
     /** @param objType the type of object
         @param oh deserialized hash from the source schema description
@@ -1131,9 +1118,9 @@ public class ParameterGroup inherits ObjectBase {
     public {
         #! A hash of parameters for this object
         /**
-            Hash values are @ref AbstractParameterObject "AbstractParameterObjects"
+            Hash values are @ref AbstractSwaggerParameterObject "AbstractSwaggerParameterObjects"
         */
-        hash<string, AbstractParameterObject> parameters();
+        hash<string, AbstractSwaggerParameterObject> parameters();
 
         #! Any query param with type "object"? (OpenAPI 3 compatible)
         string query_obj;
@@ -1144,12 +1131,12 @@ public class ParameterGroup inherits ObjectBase {
     }
 
     #! Adds a parameter to the group
-    addParameter(AbstractParameterObject p) {
+    addParameter(AbstractSwaggerParameterObject p) {
         addParameter(p.name, p);
     }
 
     #! Adds a parameter to the group
-    addParameter(string key, AbstractParameterObject p) {
+    addParameter(string key, AbstractSwaggerParameterObject p) {
         if (p.inLoc == "query" && cast<OtherParameter>(p).type == "object") {
             if (exists query_obj) {
                 throw "SWAGGER-SCHEMA-ERROR", sprintf("Query parameter %y has already been defined with type "
@@ -1416,7 +1403,7 @@ public class SwaggerSchema inherits ParameterGroup, AbstractRestSchemaValidator 
             foreach hash<auto> item in (obj.pairIterator()) {
                 if (item.value.typeCode() != NT_HASH)
                     throw "INVALID-FIELD-TYPE", "Swagger Object: invalid parameter datatype: " + item.value.type();
-                addParameter(item.key, AbstractParameterObject::newParameter(item.key, item.value, self));
+                addParameter(item.key, AbstractSwaggerParameterObject::newParameter(item.key, item.value, self));
                 if (opt_flags & LM_AUTO_FORM_DATA && parameters{item.key}.inLoc.formData
                     && !consumes{MimeTypeFormUrlEncoded}) {
                     consumes{MimeTypeFormUrlEncoded} = True;
@@ -1580,15 +1567,15 @@ public class SwaggerSchema inherits ParameterGroup, AbstractRestSchemaValidator 
     #! resolves a reference to a parameter
     /** @throw INVALID-REFERENCE invalid reference
     */
-    AbstractParameterObject resolveParameter(string name, string refstr, hash<auto> oh) {
+    AbstractSwaggerParameterObject resolveParameter(string name, string refstr, hash<auto> oh) {
         # resolve external reference
         if (refstr !~ /^#\//)
-            return AbstractParameterObject::newParameter(name, getExternalReference(refstr), self);
+            return AbstractSwaggerParameterObject::newParameter(name, getExternalReference(refstr), self);
         if (refstr !~ /^#\/parameters\//)
             throw "INVALID-REFERENCE", sprintf("cannot resolve ParameterObject %y reference %y; expecting "
                 "\"#/parameters/...\"", name, refstr);
         string rstr = (refstr =~ x/^#\/parameters\/(.*)$/)[0];
-        *AbstractParameterObject ref = parameters{rstr};
+        *AbstractSwaggerParameterObject ref = parameters{rstr};
         if (!ref)
             throw "INVALID-REFERENCE", sprintf("cannot resolve ParameterObject %y reference %y; known parameter "
                 "references: %y", name, refstr, keys parameters);
@@ -1719,8 +1706,17 @@ public class SwaggerSchema inherits ParameterGroup, AbstractRestSchemaValidator 
         return schema.getField(name, desc, required, rest);
     }
 
+    #! Returns a field definition from an abstract schema object
+    /** This method provides polymorphic access to getFieldFromSchema()
+        @since Swagger 2.4
+    */
+    AbstractDataField getFieldFromSchema(string name, *string desc, RestSchemaValidator::AbstractSchemaObject schema,
+            bool required = True, *HTTPClient rest) {
+        return cast<SchemaObject>(schema).getField(name, desc, required, rest);
+    }
+
     #! Adds field definitions to a hash type from Swagger parameters
-    addFieldsFromParameters(HashDataType rv, hash<string, AbstractParameterObject> parameters,
+    addFieldsFromParameters(HashDataType rv, hash<string, AbstractSwaggerParameterObject> parameters,
             reference<bool> required) {
         addFieldsFromParametersIntern(rv, parameters, \required);
     }
@@ -1759,7 +1755,7 @@ public class SwaggerSchema inherits ParameterGroup, AbstractRestSchemaValidator 
     }
 
     #! Adds field definitions from Swagger parameters
-    private addFieldsFromParametersIntern(HashDataType rv, hash<string, AbstractParameterObject> parameters,
+    private addFieldsFromParametersIntern(HashDataType rv, hash<string, AbstractSwaggerParameterObject> parameters,
             reference<bool> required) {
         # temporary hash for fields: loc -> name -> field
         hash<string, hash<string, AbstractDataField>> params;
@@ -2832,7 +2828,9 @@ public class PathsObject inherits ObjectBase {
     exposed to the documentation viewer but they will not know which operations
     and parameters are available.
  */
-public class PathItemObject inherits ParameterGroup {
+/** Inherits from @ref RestSchemaValidator::AbstractPathItemObject "AbstractPathItemObject".
+*/
+public class PathItemObject inherits ParameterGroup, RestSchemaValidator::AbstractPathItemObject {
     public {
         #! Allows for an external definition of this path item.
         /**
@@ -2843,7 +2841,7 @@ public class PathItemObject inherits ParameterGroup {
         *string ref;
 
         #! The body parameter, if defined
-        AbstractParameterObject body;
+        AbstractSwaggerParameterObject body;
     }
 
     private {
@@ -2891,7 +2889,7 @@ public class PathItemObject inherits ParameterGroup {
                     throw "INVALID-FIELD-TYPE",
                         sprintf("Path Item Object: 'parameters' list value has invalid type %y",
                             param.type());
-                AbstractParameterObject p = AbstractParameterObject::newParameter(
+                AbstractSwaggerParameterObject p = AbstractSwaggerParameterObject::newParameter(
                     sprintf("%d/%d", $# + 1, params.lsize()), param, swagger
                 );
                 if (p.inLoc == "body") {
@@ -2941,28 +2939,29 @@ public class PathItemObject inherits ParameterGroup {
     softlist getMethods() {
         return keys operations;
     }
+
+    #! Returns the body parameter defined at the path level, if any
+    *RestSchemaValidator::AbstractParameterObject getBody() {
+        return body;
+    }
+
+    #! Returns a hash of parameters defined at the path level
+    *hash<string, RestSchemaValidator::AbstractParameterObject> getParameters() {
+        return cast<*hash<string, RestSchemaValidator::AbstractParameterObject>>(parameters);
+    }
 }
 
 #! Describes a single API operation on a path.
-public class OperationObject inherits ParameterGroup {
+/** Inherits common operation members from
+    @ref RestSchemaValidator::AbstractOperationObject "AbstractOperationObject".
+*/
+public class OperationObject inherits ParameterGroup, RestSchemaValidator::AbstractOperationObject {
     public {
-        #! the URI path for the operation
-        string path;
-
-        #! the HTTP method for the operation
-        string method;
-
         #! A list of tags (strings or @ref TagObject "TagObjects") for API documentation control.
         /**
             Tags can be used for logical grouping of operations by resources or any other qualifier.
          */
         list tags;
-
-        #! A short summary of what the operation does.
-        *string summary;
-
-        #! A verbose explanation of the operation behavior. GFM syntax can be used for rich text representation.
-        *string desc;
 
         #! Declares this operation to be deprecated.
         /**
@@ -2983,27 +2982,11 @@ public class OperationObject inherits ParameterGroup {
          */
         *string operationId;
 
-        #! A list of MIME types (strings) the operation can consume.
-        /**
-            This overrides the @ref SwaggerSchema::consumes "consumes" definition
-            at the %Swagger Object. An empty value MAY be used to clear the global definition.
-            Key values MUST be Mime Types.
-         */
-        hash<string, bool> consumes;
-
-        #! A hash of MIME types (strings) the operation can produce.
-        /**
-            This overrides the @ref SwaggerSchema::produces "produces" definition
-            at the %Swagger Object. An empty value MAY be used to clear the global definition.
-            Key values MUST be Mime Types.
-         */
-        hash<string, bool> produces;
-
         #! formData parameter; if defined for this operation, body parameter will be excluded
-        hash<string, AbstractParameterObject> formData;
+        hash<string, AbstractSwaggerParameterObject> formData;
 
         #! The body parameter, if defined
-        AbstractParameterObject body;
+        AbstractSwaggerParameterObject body;
 
         #! Required. The list of possible responses as they are returned from executing this operation.
         ResponsesObject responses;
@@ -3144,7 +3127,7 @@ public class OperationObject inherits ParameterGroup {
                     error("INVALID-FIELD-TYPE", "invalid 'parameters' list value datatype %y; expecing \"hash\"",
                         p.fullType());
                 }
-                AbstractParameterObject param = AbstractParameterObject::newParameter(sprintf("%d/%d", $# + 1,
+                AbstractSwaggerParameterObject param = AbstractSwaggerParameterObject::newParameter(sprintf("%d/%d", $# + 1,
                     listObj.lsize()), p, swagger);
                 if (param.inLoc == "body") {
                     body = param;
@@ -3211,8 +3194,10 @@ public class OperationObject inherits ParameterGroup {
     }
 
     #! Processes a generated request
-    *data getRequestBody(PathItemObject pio, auto body, reference<hash<auto>> headers, *bool freeform) {
-        *AbstractParameterObject body_po = self.body ?? pio.body;
+    *data getRequestBody(RestSchemaValidator::AbstractPathItemObject abstract_pio, auto body,
+            reference<hash<auto>> headers, *bool freeform) {
+        PathItemObject pio = cast<PathItemObject>(abstract_pio);
+        *AbstractSwaggerParameterObject body_po = self.body ?? pio.body;
         if (body_po) {
             if (!freeform) {
                 body_po.check(True, True, path, method, "body", \body);
@@ -3271,8 +3256,10 @@ public class OperationObject inherits ParameterGroup {
         @throws SCHEMA-VALIDATION-ERROR invalid parameter name or location, missing parameter and parameter has no
         default value
     */
-    validateRequest(bool serialize, PathItemObject pio, reference<hash<UriQueryInfo>> h, reference<auto> body,
+    validateRequest(bool serialize, RestSchemaValidator::AbstractPathItemObject abstract_pio,
+            reference<hash<UriQueryInfo>> h, reference<auto> body,
             reference<hash> headers, *reference<hash<string, bool>> mime_types, *bool freeform) {
+        PathItemObject pio = cast<PathItemObject>(abstract_pio);
         # check query parameters
         *string query_obj = self.query_obj ?? pio.query_obj;
         if (exists query_obj) {
@@ -3281,7 +3268,7 @@ public class OperationObject inherits ParameterGroup {
 
         foreach string key in (keys h.params) {
             # find URI parameter object
-            *AbstractParameterObject po = parameters{key} ?? pio.parameters{key};
+            *AbstractSwaggerParameterObject po = parameters{key} ?? pio.parameters{key};
             if (!po) {
                 if (exists (*string op = (query_obj ?? pio.query_obj))) {
                     h.params{op}{key} = remove h.params{key};
@@ -3306,7 +3293,7 @@ public class OperationObject inherits ParameterGroup {
         # check header parameters
         foreach string key in (keys headers) {
             # find URI parameter object
-            *AbstractParameterObject po = parameters{key} ?? pio.parameters{key};
+            *AbstractSwaggerParameterObject po = parameters{key} ?? pio.parameters{key};
             # extra headers are OK
             if (!po || po.inLoc != "header") {
                 continue;
@@ -3317,7 +3304,7 @@ public class OperationObject inherits ParameterGroup {
 
         # check body parameters
         {
-            *AbstractParameterObject body_po = self.body ?? pio.body;
+            *AbstractSwaggerParameterObject body_po = self.body ?? pio.body;
             if (body_po) {
                 if (!freeform) {
                     body_po.check(serialize, True, path, method, "body", \body);
@@ -3544,7 +3531,7 @@ public class OperationObject inherits ParameterGroup {
     }
 
     private getQoreExampleParams(reference<hash<auto>> query, reference<hash<auto>> headers,
-            hash<string, AbstractParameterObject> parameters, *hash<string, AbstractParameterObject> child_params) {
+            hash<string, AbstractSwaggerParameterObject> parameters, *hash<string, AbstractSwaggerParameterObject> child_params) {
         foreach hash<auto> ph in (parameters.pairIterator()) {
             # don't check if child params already checked or if it's the single message body param
             if (child_params{ph.key} || ph.value.inLoc == "body" || ph.value.inLoc == "formData")
@@ -3562,7 +3549,7 @@ public class OperationObject inherits ParameterGroup {
 
     #! add default parameters
     private doDefaultParams(reference<hash<UriQueryInfo>> h, reference<hash> headers, reference<auto> body,
-            hash<string, AbstractParameterObject> parameters, *hash<string, AbstractParameterObject> child_params) {
+            hash<string, AbstractSwaggerParameterObject> parameters, *hash<string, AbstractSwaggerParameterObject> child_params) {
         foreach hash<auto> ph in (parameters.pairIterator()) {
             # don't check if child params already checked or if it's the single message body param
             if (child_params{ph.key} || ph.value.inLoc == "body")
@@ -3589,7 +3576,7 @@ public class OperationObject inherits ParameterGroup {
 
     #! checks for missing params
     private checkMissingParams(hash<UriQueryInfo> h, *hash<auto> headers, auto body,
-            hash<string, AbstractParameterObject> parameters, *hash<string, AbstractParameterObject> child_params) {
+            hash<string, AbstractSwaggerParameterObject> parameters, *hash<string, AbstractSwaggerParameterObject> child_params) {
         foreach hash<auto> ph in (parameters.pairIterator()) {
             # don't check if child params already checked
             if (child_params{ph.key} || ph.value.inLoc == "body")
@@ -3629,6 +3616,21 @@ public class OperationObject inherits ParameterGroup {
     private error(string err, string fmt, ...) {
         throw err, sprintf("%s %s Operation Object: %s", method.upr(), path, vsprintf(fmt, argv));
     }
+
+    #! Returns the responses object for this operation
+    RestSchemaValidator::AbstractResponsesObject getResponses() {
+        return responses;
+    }
+
+    #! Returns the body parameter, if any
+    *RestSchemaValidator::AbstractParameterObject getBody() {
+        return body;
+    }
+
+    #! Returns a hash of parameters for this operation
+    *hash<string, RestSchemaValidator::AbstractParameterObject> getParameters() {
+        return cast<*hash<string, RestSchemaValidator::AbstractParameterObject>>(parameters);
+    }
 }
 
 #! Allows referencing an external resource for extended documentation.
@@ -3657,8 +3659,8 @@ public class ExternalDocumentationObject inherits ObjectBase {
 
 #! Describes a single operation parameter.
 /**
-    A unique parameter is defined by a combination of a @ref AbstractParameterObject::name "name"
-    and @ref AbstractParameterObject::inLoc "location".
+    A unique parameter is defined by a combination of a @ref AbstractSwaggerParameterObject::name "name"
+    and @ref AbstractSwaggerParameterObject::inLoc "location".
 
     There are five possible parameter types:
     - Path: Used together with Path Templating, where the parameter value is
@@ -3692,36 +3694,10 @@ public class ExternalDocumentationObject inherits ObjectBase {
                 of the parameter is \c submit-name. This type of form parameters
                 is more commonly used for file transfers.
  */
-public class AbstractParameterObject inherits ObjectBase {
-    public {
-        #! Required. The name of the parameter. Parameter names are case sensitive.
-        /**
-            - If @ref AbstractParameterObject::inLoc "inLoc" is \c "path", the \c name
-                field MUST correspond to the associated path segment from the
-                \c "path" field in the @ref Swagger::PathsObject.
-            - For all other cases, the name corresponds to the parameter name
-                used based on the @ref AbstractParameterObject::inLoc "inLoc" property.
-        */
-        string name;
-
-        #! Required. The location of the parameter.
-        /**
-            Possible values are \c "query", \c "header", \c "path", \c "formData" or \c "body".
-        */
-        string inLoc;
-
-        #! A brief description of the parameter. This could contain examples of use. GFM syntax can be used for rich text representation.
-        *string desc;
-
-        #! Determines whether this parameter is mandatory.
-        /**
-            If the parameter is @ref AbstractParameterObject::inLoc "in" "path",
-            this property is \b required and its value MUST be \c true.
-            Otherwise, the property MAY be included and its default value is \c false.
-        */
-        bool required = False;
-    }
-
+/** Inherits common parameter members from
+    @ref RestSchemaValidator::AbstractParameterObject "AbstractParameterObject".
+*/
+public class AbstractSwaggerParameterObject inherits ObjectBase, RestSchemaValidator::AbstractParameterObject {
     private {
         const OtherParameterMap = (
             "query": True,
@@ -3754,12 +3730,15 @@ public class AbstractParameterObject inherits ObjectBase {
     #! verifies the parameter in an actual REST API call
     abstract check(bool serialize, bool request, string path, string method, string name, reference value);
 
+    #! Returns the schema for this parameter, if any
+    abstract *RestSchemaValidator::AbstractSchemaObject getSchema();
+
     #! returns the default value of the parameter (default: @ref nothing)
     auto getDefaultValue() {
     }
 
-    #! gets a concrete instance of an AbstractParameterObject
-    static AbstractParameterObject newParameter(string name, hash<auto> oh, SwaggerSchema swagger) {
+    #! gets a concrete instance of an AbstractSwaggerParameterObject
+    static AbstractSwaggerParameterObject newParameter(string name, hash<auto> oh, SwaggerSchema swagger) {
         on_error rethrow $1.err, sprintf("%s (while processing parameter %y in %y)", $1.desc, name, oh."in");
         if (oh.hasKey("$ref"))
             return swagger.resolveParameter(name, oh."$ref", oh);
@@ -3778,8 +3757,8 @@ public class AbstractParameterObject inherits ObjectBase {
     }
 }
 
-#! @ref AbstractParameterObject specialization for \c "body" parameters.
-public class BodyParameter inherits AbstractParameterObject {
+#! @ref AbstractSwaggerParameterObject specialization for \c "body" parameters.
+public class BodyParameter inherits AbstractSwaggerParameterObject {
     public {
         #! Required. The schema defining the type used for the body parameter.
         SchemaObject schema;
@@ -3793,7 +3772,8 @@ public class BodyParameter inherits AbstractParameterObject {
         @throws INVALID-FIELD-TYPE field has invalid type
         @throws REQUIRED-FIELD-MISSING required field is missing
      */
-    public constructor(hash<auto> oh, SwaggerSchema swagger) : AbstractParameterObject(oh, swagger.getParseFlags()) {
+    public constructor(hash<auto> oh, SwaggerSchema swagger)
+            : AbstractSwaggerParameterObject(oh, swagger.getParseFlags()) {
         hash schemaObj;
         required_field("Body Parameter", oh, "schema", NT_HASH, \schemaObj);
         schema = SchemaObject::newSchemaObject("body", schemaObj, swagger, True);
@@ -3822,10 +3802,15 @@ public class BodyParameter inherits AbstractParameterObject {
     auto getExampleValue(*hash<string, bool> emap, *string fname) {
         return schema.getExampleValue(emap, fname);
     }
+
+    #! Returns the schema for this parameter
+    *RestSchemaValidator::AbstractSchemaObject getSchema() {
+        return schema;
+    }
 }
 
-#! @ref AbstractParameterObject specialization for parameters other than \c "body"
-public class TypedParameter inherits AbstractParameterObject, SchemaBase {
+#! @ref AbstractSwaggerParameterObject specialization for parameters other than \c "body"
+public class TypedParameter inherits AbstractSwaggerParameterObject, SchemaBase {
     public {
         #! Required. The type of the parameter.
         /**
@@ -3836,7 +3821,7 @@ public class TypedParameter inherits AbstractParameterObject, SchemaBase {
             \c "boolean", \c "array" or \c "file". If \c type is \c "file",
             the @ref OperationObject::consumes "consumes" MUST be either
             \c "multipart/form-data", \c " application/x-www-form-urlencoded" or
-            both and the parameter MUST be @ref AbstractParameterObject::inLoc "in" \c "formData".
+            both and the parameter MUST be @ref AbstractSwaggerParameterObject::inLoc "in" \c "formData".
         */
         string type;
 
@@ -3863,7 +3848,7 @@ public class TypedParameter inherits AbstractParameterObject, SchemaBase {
             - \c "pipes": pipe separated values; ex: foo|bar
             - \c "multi": corresponds to multiple parameter instances instead of
                 multiple values for a single instance <tt>foo=bar&foo=baz</tt>.
-                This is valid only for parameters @ref AbstractParameterObject::inLoc "in"
+                This is valid only for parameters @ref AbstractSwaggerParameterObject::inLoc "in"
                 \c "query" or \c "formData".
 
             Default value is \c "csv".
@@ -3883,7 +3868,7 @@ public class TypedParameter inherits AbstractParameterObject, SchemaBase {
 
     #! Creates the object
     public constructor(string name, hash<auto> oh, SwaggerSchema swagger)
-            : AbstractParameterObject(oh, swagger.getParseFlags()), SchemaBase("Parameter", oh) {
+            : AbstractSwaggerParameterObject(oh, swagger.getParseFlags()), SchemaBase("Parameter", oh) {
         string objType = "Parameter";
         optional_field(objType, oh, "type", NT_STRING, \type);
         setType(swagger);
@@ -4053,9 +4038,16 @@ public class TypedParameter inherits AbstractParameterObject, SchemaBase {
 
     #! Sets the parameter type
     abstract private setType(SwaggerSchema swagger);
+
+    #! Returns the schema for this parameter
+    /** TypedParameter doesn't have a schema object; returns NOTHING
+    */
+    *RestSchemaValidator::AbstractSchemaObject getSchema() {
+        return NOTHING;
+    }
 }
 
-#! @ref AbstractParameterObject specialization for formData parameters
+#! @ref AbstractSwaggerParameterObject specialization for formData parameters
 public class FormDataParameter inherits TypedParameter {
     public {
         #! valid parameter types
@@ -4079,7 +4071,7 @@ public class FormDataParameter inherits TypedParameter {
     }
 }
 
-#! @ref AbstractParameterObject specialization for parameters other than \c "body" and \c "formData"
+#! @ref AbstractSwaggerParameterObject specialization for parameters other than \c "body" and \c "formData"
 public class OtherParameter inherits TypedParameter {
     public {
         #! valid parameter types
@@ -4112,7 +4104,9 @@ public class OtherParameter inherits TypedParameter {
 }
 
 #! contains the possible responses for an operation
-public class ResponsesObject inherits ObjectBase {
+/** Inherits from @ref RestSchemaValidator::AbstractResponsesObject "AbstractResponsesObject".
+*/
+public class ResponsesObject inherits ObjectBase, RestSchemaValidator::AbstractResponsesObject {
     public {
         # The documentation of responses other than the ones declared for specific HTTP response codes.
         /**
@@ -4156,14 +4150,24 @@ public class ResponsesObject inherits ObjectBase {
         if (responses.empty() && !defaultObj)
             throw "EMPTY-RESPONSES", sprintf("%s %s: no valid responses provided for operation", method, path);
     }
+
+    #! Returns the default response, if any
+    *RestSchemaValidator::AbstractResponseObject getDefaultResponse() {
+        return defaultResp;
+    }
+
+    #! Returns the hash of responses by HTTP status code
+    *hash<string, RestSchemaValidator::AbstractResponseObject> getResponses() {
+        return cast<*hash<string, RestSchemaValidator::AbstractResponseObject>>(responses);
+    }
 }
 
 #! Describes a single response from an API Operation.
-public class ResponseObject inherits ObjectBase {
+/** Inherits common response members from
+    @ref RestSchemaValidator::AbstractResponseObject "AbstractResponseObject".
+*/
+public class ResponseObject inherits ObjectBase, RestSchemaValidator::AbstractResponseObject {
     public {
-        #! Required. A short description of the response. GFM syntax can be used for rich text representation.
-        string desc;
-
         #! A definition of the response structure.
         /**
             It can be a primitive, an array or an object. If this field does not exist,
@@ -4172,22 +4176,6 @@ public class ResponseObject inherits ObjectBase {
             be \c "file". This SHOULD be accompanied by a relevant \c produces mime-type.
          */
         *SchemaObject schema;
-
-        #! A hash of headers that are (can be) sent with the response.
-        /**
-            A hash of @ref HeaderObject objects. Keys are header names.
-         */
-        hash<auto> headers;
-
-        #! A hash of example response messages.
-        /**
-            A hash of example responses in the form of <tt>Example Object</tt>.
-            See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#exampleObject
-            Keys MUST be one of the Operation @ref OperationObject::produces "produces"
-            values (either implicit or inherited). The value SHOULD be an example
-            of what such a response would look like.
-         */
-        hash examples;
     }
 
     #! private constructor; use newResponse() instead
@@ -4229,6 +4217,11 @@ public class ResponseObject inherits ObjectBase {
         if (oh.hasKey("$ref"))
             return swagger.resolveResponse(key, oh."$ref", oh);
         return new ResponseObject(key, oh, swagger);
+    }
+
+    #! Returns the response schema, if any
+    *RestSchemaValidator::AbstractSchemaObject getSchema() {
+        return schema;
     }
 }
 
@@ -4367,43 +4360,13 @@ public class TagObject inherits ObjectBase {
 }
 
 #! defines an object in a schema
-public class SchemaObject inherits ObjectBase, SchemaBase {
+/** Inherits common schema members from
+    @ref RestSchemaValidator::AbstractSchemaObject "AbstractSchemaObject".
+*/
+public class SchemaObject inherits ObjectBase, SchemaBase, RestSchemaValidator::AbstractSchemaObject {
     public {
-        #! the name of this object for documentation and example purposes
-        string name;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.2.
-        /**
-            MUST be either a string or an array (list). If it's an array,
-            it's elements MUST be strings and MUST be unique.
-         */
-        string type;
-
-        #! The extending format for the previously mentioned \c type. See Data Type Formats for further details.
-        *string format;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.1.
-        *string title;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.1.
-        *string desc;
-
         #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.1.
         *SchemaObject items;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.2.
-        auto defaultVal;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.1.
-        *int maxProperties;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.2.
-        *int minProperties;
-
-        #! extension that allows types to be nullable
-        /** the OpenAPI specification 2.0 otherwise does not allow for nullable types
-        */
-        bool nullable = False;
 
         #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.4.
         /**
@@ -4421,43 +4384,6 @@ public class SchemaObject inherits ObjectBase, SchemaBase {
             a valid JSON Schema (@ref SchemaObject).
          */
         auto additionalProperties;
-
-        #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.3.
-        /**
-            Set of strings. Must have at least one element.
-         */
-        hash<string, bool> required;
-
-        #! Adds support for polymorphism.
-        /**
-            The discriminator is the schema property name that is used to
-            differentiate between other schemas that inherit this schema.
-            The property name used MUST be defined at this schema and it MUST
-            be in the @ref SchemaObject::required "required" property list.
-            When used, the value MUST be the name of this schema or any schema
-            that inherits it.
-
-            While composition offers model extensibility, it does not imply
-            a hierarchy between the models. To support polymorphism, Swagger
-            adds the support of the \c discriminator field. When used,
-            the \c discriminator will be the name of the property used to decide
-            which schema definition is used to validate the structure of the model.
-            As such, the \c discriminator field MUST be a required field.
-            The value of the chosen property has to be the friendly name given to
-            the model under the \c definitions property. As such, inline schema
-            definitions, which do not have a given id, \e cannot be used in polymorphism.
-         */
-        *string discriminator;
-
-        #! Relevant only for Schema \c "properties" definitions. Declares the property as "read only".
-        /**
-            Declares the property as "read only". This means that it MAY be sent
-            as part of a response but MUST NOT be sent as part of the request.
-            Properties marked as \c readOnly being \c true SHOULD NOT be in the
-            @ref SchemaObject::required "required" list of the defined schema.
-            Default value is \c false.
-         */
-        bool readOnly = False;
 
         #! See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.3.
         /**
@@ -5100,6 +5026,16 @@ public class SchemaObject inherits ObjectBase, SchemaBase {
         throw "INVALID-FIELD-TYPE", sprintf("invalid field type %y for key %y; expecting \"hash\"", error.type(),
             name);
     }
+
+    #! Returns the items schema for arrays
+    *RestSchemaValidator::AbstractSchemaObject getItems() {
+        return items;
+    }
+
+    #! Returns a hash of property schemas for objects
+    *hash<string, RestSchemaValidator::AbstractSchemaObject> getProperties() {
+        return cast<*hash<string, RestSchemaValidator::AbstractSchemaObject>>(properties);
+    }
 }
 
 #! items schema object for non-body parameters
@@ -5114,7 +5050,7 @@ public class ParameterItemsSchemaObject inherits SchemaObject {
             - \c "pipes": pipe separated values; ex: foo|bar
             - \c "multi": corresponds to multiple parameter instances instead of
                 multiple values for a single instance <tt>foo=bar&foo=baz</tt>.
-                This is valid only for parameters @ref AbstractParameterObject::inLoc "in"
+                This is valid only for parameters @ref AbstractSwaggerParameterObject::inLoc "in"
                 \c "query" or \c "formData".
 
             Default value is \c "csv".


### PR DESCRIPTION
- RestSchemaValidator v2.4: added abstract methods for polymorphic data provider access (getField, getFieldFromSchema, getFieldForHeaders)
- Swagger v2.4: renamed AbstractParameterObject to AbstractSwaggerParameterObject to avoid confusion; added polymorphic getFieldFromSchema overload
- OpenApi3 v2.3: initial release with abstract base class inheritance
- RestSchemaDataProvider v2.3: initial release; consolidated duplicate methods using abstract types for improved maintainability

🤖 Generated with [Claude Code](https://claude.com/claude-code)