### PR TITLE
refs #5010 ServiceNowRestDataProvider: add advanced expression support and bug fixes

### DIFF
--- a/examples/test/qlib/ServiceNowRestClient/ServiceNowRestClient.qtest
+++ b/examples/test/qlib/ServiceNowRestClient/ServiceNowRestClient.qtest
@@ -179,10 +179,115 @@ class ServiceNowTest inherits QUnit::Test {
 
             # update the record
             assertEq(1, incident.updateRecords({"short_description": "deleteme-now"}, {"sys_id": id}));
+
+            # Test nesting validation: AND containing OR should throw an error
+            # ServiceNow's query syntax doesn't support this pattern due to operator precedence
+            # "a^ORb^c" is interpreted as "a OR (b AND c)", not "(a OR b) AND c"
+            {
+                # Build an unsupported expression: AND(OR(a, b), c)
+                hash<DataProviderExpression> unsupported_expr = <DataProviderExpression>{
+                    "exp": DP_OP_AND,
+                    "args": (
+                        <DataProviderExpression>{
+                            "exp": DP_OP_OR,
+                            "args": (
+                                <DataProviderExpression>{
+                                    "exp": QUERY_OP_EQ,
+                                    "args": (
+                                        <DataProviderFieldReference>{"field": "state"},
+                                        "1",
+                                    ),
+                                },
+                                <DataProviderExpression>{
+                                    "exp": QUERY_OP_EQ,
+                                    "args": (
+                                        <DataProviderFieldReference>{"field": "state"},
+                                        "2",
+                                    ),
+                                },
+                            ),
+                        },
+                        <DataProviderExpression>{
+                            "exp": QUERY_OP_EQ,
+                            "args": (
+                                <DataProviderFieldReference>{"field": "priority"},
+                                "1",
+                            ),
+                        },
+                    ),
+                };
+                assertThrows("WHERE-ERROR", "ServiceNow does not support AND expressions containing OR",
+                    \incident.searchRecords(), (unsupported_expr,));
+            }
+
+            # Test that OR containing AND is supported (this should not throw)
+            # OR(AND(a, b), AND(c, d)) -> "a^b^ORc^d" = "(a AND b) OR (c AND d)"
+            {
+                hash<DataProviderExpression> supported_expr = <DataProviderExpression>{
+                    "exp": DP_OP_OR,
+                    "args": (
+                        <DataProviderExpression>{
+                            "exp": DP_OP_AND,
+                            "args": (
+                                <DataProviderExpression>{
+                                    "exp": QUERY_OP_EQ,
+                                    "args": (
+                                        <DataProviderFieldReference>{"field": "state"},
+                                        "1",
+                                    ),
+                                },
+                                <DataProviderExpression>{
+                                    "exp": QUERY_OP_EQ,
+                                    "args": (
+                                        <DataProviderFieldReference>{"field": "priority"},
+                                        "1",
+                                    ),
+                                },
+                            ),
+                        },
+                        <DataProviderExpression>{
+                            "exp": DP_OP_AND,
+                            "args": (
+                                <DataProviderExpression>{
+                                    "exp": QUERY_OP_EQ,
+                                    "args": (
+                                        <DataProviderFieldReference>{"field": "state"},
+                                        "2",
+                                    ),
+                                },
+                                <DataProviderExpression>{
+                                    "exp": QUERY_OP_EQ,
+                                    "args": (
+                                        <DataProviderFieldReference>{"field": "priority"},
+                                        "2",
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                };
+                # This should not throw - OR(AND(...), AND(...)) is supported
+                # The query will be: state=1^priority=1^ORstate=2^priority=2
+                # We don't care about results, just that no exception was thrown
+                map $1, incident.searchRecords(supported_expr, {"limit": 1});
+                assertTrue(True, "OR(AND(...), AND(...)) expression is supported");
+            }
         }
     }
 
     # Unit tests for ServiceNow query operators that don't require a connection
+    #
+    # NOTE: ServiceNow Nesting Limitation
+    # ServiceNow's encoded query syntax uses "^" for AND and "^OR" for OR, where AND has higher
+    # precedence than OR. This means:
+    # - "a^b^ORc^d" is interpreted as "(a AND b) OR (c AND d)" - works correctly
+    # - "a^ORb^c" is interpreted as "a OR (b AND c)" - NOT "(a OR b) AND c"
+    #
+    # Therefore:
+    # - OR(AND(...), AND(...)) expressions work correctly
+    # - AND(OR(...), ...) expressions are NOT supported and will throw an error
+    #
+    # See ServiceNowDataProviderTests for integration tests that verify this validation
     queryOperatorUnitTests() {
         # Test ServiceNowTableDataProvider::Expressions has all expected operators
         assertTrue(ServiceNowTableDataProvider::Expressions.hasKey(DP_OP_AND),

--- a/examples/test/qlib/ServiceNowRestClient/ServiceNowRestClient.qtest
+++ b/examples/test/qlib/ServiceNowRestClient/ServiceNowRestClient.qtest
@@ -57,6 +57,7 @@ class ServiceNowTest inherits QUnit::Test {
     constructor() : Test("ServiceNowTest", "1.0", \ARGV, MyOpts) {
         addTestCase("app/action catalog tests", \actionCatalogTests());
         addTestCase("ServiceNow DataProvider test", \ServiceNowDataProviderTests());
+        addTestCase("ServiceNow query operator unit tests", \queryOperatorUnitTests());
         addTestCase("ServiceNow REST", \ServiceNowRestTests());
         addTestCase("connection tests", \connectionTest());
 
@@ -178,6 +179,210 @@ class ServiceNowTest inherits QUnit::Test {
 
             # update the record
             assertEq(1, incident.updateRecords({"short_description": "deleteme-now"}, {"sys_id": id}));
+        }
+    }
+
+    # Unit tests for ServiceNow query operators that don't require a connection
+    queryOperatorUnitTests() {
+        # Test ServiceNowTableDataProvider::Expressions has all expected operators
+        assertTrue(ServiceNowTableDataProvider::Expressions.hasKey(DP_OP_AND),
+            "Expressions has AND");
+        assertTrue(ServiceNowTableDataProvider::Expressions.hasKey(DP_OP_OR),
+            "Expressions has OR");
+        assertTrue(ServiceNowTableDataProvider::Expressions.hasKey(QUERY_OP_EQ),
+            "Expressions has EQ");
+        assertTrue(ServiceNowTableDataProvider::Expressions.hasKey(QUERY_OP_NE),
+            "Expressions has NE");
+        assertTrue(ServiceNowTableDataProvider::Expressions.hasKey(QUERY_OP_LT),
+            "Expressions has LT");
+        assertTrue(ServiceNowTableDataProvider::Expressions.hasKey(QUERY_OP_LE),
+            "Expressions has LE");
+        assertTrue(ServiceNowTableDataProvider::Expressions.hasKey(QUERY_OP_GT),
+            "Expressions has GT");
+        assertTrue(ServiceNowTableDataProvider::Expressions.hasKey(QUERY_OP_GE),
+            "Expressions has GE");
+        assertTrue(ServiceNowTableDataProvider::Expressions.hasKey(QUERY_OP_IN),
+            "Expressions has IN");
+        assertTrue(ServiceNowTableDataProvider::Expressions.hasKey(QUERY_OP_NOTIN),
+            "Expressions has NOTIN");
+        assertTrue(ServiceNowTableDataProvider::Expressions.hasKey(QUERY_OP_LIKE),
+            "Expressions has LIKE");
+        assertTrue(ServiceNowTableDataProvider::Expressions.hasKey(QUERY_OP_NOTLIKE),
+            "Expressions has NOTLIKE");
+        assertTrue(ServiceNowTableDataProvider::Expressions.hasKey(QUERY_OP_STARTSWITH),
+            "Expressions has STARTSWITH");
+        assertTrue(ServiceNowTableDataProvider::Expressions.hasKey(QUERY_OP_ENDSWITH),
+            "Expressions has ENDSWITH");
+        assertTrue(ServiceNowTableDataProvider::Expressions.hasKey(QUERY_OP_ISEMPTY),
+            "Expressions has ISEMPTY");
+        assertTrue(ServiceNowTableDataProvider::Expressions.hasKey(QUERY_OP_ISNOTEMPTY),
+            "Expressions has ISNOTEMPTY");
+
+        # Test operator function structures
+        {
+            hash<QueryOperatorInfo> op = query_op_like("test");
+            assertEq(QUERY_OP_LIKE, op.op, "query_op_like creates correct operator");
+            assertEq("test", op.arg, "query_op_like preserves argument");
+        }
+
+        {
+            hash<QueryOperatorInfo> op = query_op_notlike("test");
+            assertEq(QUERY_OP_NOTLIKE, op.op, "query_op_notlike creates correct operator");
+        }
+
+        {
+            hash<QueryOperatorInfo> op = query_op_startswith("INC");
+            assertEq(QUERY_OP_STARTSWITH, op.op, "query_op_startswith creates correct operator");
+            assertEq("INC", op.arg, "query_op_startswith preserves argument");
+        }
+
+        {
+            hash<QueryOperatorInfo> op = query_op_endswith("001");
+            assertEq(QUERY_OP_ENDSWITH, op.op, "query_op_endswith creates correct operator");
+            assertEq("001", op.arg, "query_op_endswith preserves argument");
+        }
+
+        {
+            hash<QueryOperatorInfo> op = query_op_lt(10);
+            assertEq(QUERY_OP_LT, op.op, "query_op_lt creates correct operator");
+            assertEq(10, op.arg, "query_op_lt preserves argument");
+        }
+
+        {
+            hash<QueryOperatorInfo> op = query_op_le(10);
+            assertEq(QUERY_OP_LE, op.op, "query_op_le creates correct operator");
+        }
+
+        {
+            hash<QueryOperatorInfo> op = query_op_gt(5);
+            assertEq(QUERY_OP_GT, op.op, "query_op_gt creates correct operator");
+        }
+
+        {
+            hash<QueryOperatorInfo> op = query_op_ge(5);
+            assertEq(QUERY_OP_GE, op.op, "query_op_ge creates correct operator");
+        }
+
+        {
+            hash<QueryOperatorInfo> op = query_op_eq("value");
+            assertEq(QUERY_OP_EQ, op.op, "query_op_eq creates correct operator");
+        }
+
+        {
+            hash<QueryOperatorInfo> op = query_op_ne("value");
+            assertEq(QUERY_OP_NE, op.op, "query_op_ne creates correct operator");
+        }
+
+        {
+            hash<QueryOperatorInfo> op = query_op_in("a", "b", "c");
+            assertEq(QUERY_OP_IN, op.op, "query_op_in creates correct operator");
+            assertEq(("a", "b", "c"), op.arg, "query_op_in preserves arguments");
+        }
+
+        {
+            hash<QueryOperatorInfo> op = query_op_in(("x", "y", "z"));
+            assertEq(QUERY_OP_IN, op.op, "query_op_in with list creates correct operator");
+            assertEq(("x", "y", "z"), op.arg, "query_op_in with list preserves arguments");
+        }
+
+        {
+            hash<QueryOperatorInfo> op = query_op_notin("a", "b");
+            assertEq(QUERY_OP_NOTIN, op.op, "query_op_notin creates correct operator");
+            assertEq(("a", "b"), op.arg, "query_op_notin preserves arguments");
+        }
+
+        {
+            hash<QueryOperatorInfo> op = query_op_notin(("x", "y"));
+            assertEq(QUERY_OP_NOTIN, op.op, "query_op_notin with list creates correct operator");
+        }
+
+        {
+            hash<QueryOperatorInfo> op = query_op_isempty();
+            assertEq(QUERY_OP_ISEMPTY, op.op, "query_op_isempty creates correct operator");
+        }
+
+        {
+            hash<QueryOperatorInfo> op = query_op_isnotempty();
+            assertEq(QUERY_OP_ISNOTEMPTY, op.op, "query_op_isnotempty creates correct operator");
+        }
+
+        # Test expression impl functions by calling them directly
+        {
+            # Test EQ impl
+            code impl = ServiceNowTableDataProvider::Expressions{QUERY_OP_EQ}.impl;
+            assertEq("priority=1", impl("priority", "1"), "EQ impl generates correct query");
+        }
+
+        {
+            # Test NE impl
+            code impl = ServiceNowTableDataProvider::Expressions{QUERY_OP_NE}.impl;
+            assertEq("status!=closed", impl("status", "closed"), "NE impl generates correct query");
+        }
+
+        {
+            # Test LIKE impl
+            code impl = ServiceNowTableDataProvider::Expressions{QUERY_OP_LIKE}.impl;
+            assertEq("descriptionLIKEerror", impl("description", "error"), "LIKE impl generates correct query");
+        }
+
+        {
+            # Test STARTSWITH impl
+            code impl = ServiceNowTableDataProvider::Expressions{QUERY_OP_STARTSWITH}.impl;
+            assertEq("numberSTARTSWITHINC", impl("number", "INC"), "STARTSWITH impl generates correct query");
+        }
+
+        {
+            # Test ENDSWITH impl (this was buggy before - returned ISEMPTY)
+            code impl = ServiceNowTableDataProvider::Expressions{QUERY_OP_ENDSWITH}.impl;
+            assertEq("numberENDSWITH001", impl("number", "001"), "ENDSWITH impl generates correct query");
+        }
+
+        {
+            # Test ISEMPTY impl
+            code impl = ServiceNowTableDataProvider::Expressions{QUERY_OP_ISEMPTY}.impl;
+            assertEq("descriptionISEMPTY", impl("description", NOTHING), "ISEMPTY impl generates correct query");
+        }
+
+        {
+            # Test ISNOTEMPTY impl
+            code impl = ServiceNowTableDataProvider::Expressions{QUERY_OP_ISNOTEMPTY}.impl;
+            assertEq("descriptionISNOTEMPTY", impl("description", NOTHING), "ISNOTEMPTY impl generates correct query");
+        }
+
+        {
+            # Test IN impl
+            code impl = ServiceNowTableDataProvider::Expressions{QUERY_OP_IN}.impl;
+            assertEq("stateIN1,2,3", impl("state", ("1", "2", "3")), "IN impl generates correct query");
+        }
+
+        {
+            # Test IN impl with empty list (should return contradiction)
+            code impl = ServiceNowTableDataProvider::Expressions{QUERY_OP_IN}.impl;
+            assertEq("sys_id=NULL", impl("state", ()), "IN impl with empty list returns contradiction");
+        }
+
+        {
+            # Test NOTIN impl
+            code impl = ServiceNowTableDataProvider::Expressions{QUERY_OP_NOTIN}.impl;
+            assertEq("stateNOTIN4,5", impl("state", ("4", "5")), "NOTIN impl generates correct query");
+        }
+
+        {
+            # Test NOTIN impl with empty list (should return tautology)
+            code impl = ServiceNowTableDataProvider::Expressions{QUERY_OP_NOTIN}.impl;
+            assertEq("sys_id!=NULL", impl("state", ()), "NOTIN impl with empty list returns tautology");
+        }
+
+        {
+            # Test LT impl
+            code impl = ServiceNowTableDataProvider::Expressions{QUERY_OP_LT}.impl;
+            assertEq("priority<3", impl("priority", "3"), "LT impl generates correct query");
+        }
+
+        {
+            # Test GT impl
+            code impl = ServiceNowTableDataProvider::Expressions{QUERY_OP_GT}.impl;
+            assertEq("priority>1", impl("priority", "1"), "GT impl generates correct query");
         }
     }
 

--- a/qlib/ServiceNowRestDataProvider/ServiceNowRestDataProviderDefs.qc
+++ b/qlib/ServiceNowRestDataProvider/ServiceNowRestDataProviderDefs.qc
@@ -166,6 +166,34 @@ public hash<QueryOperatorInfo> sub query_op_notlike(string str) {
     return query_make_op(QUERY_OP_NOTLIKE, str);
 }
 
+#! returns an @ref QueryOperatorInfo hash for the \c "STARTSWITH" operator with the given argument for use in ServiceNow queries
+/** @par Example:
+    @code{.py}
+AbstractDataProviderRecordIterator i = provider.searchRecords({"name": query_op_startswith("INC")});
+    @endcode
+
+    @param str the argument for the operator
+
+    @return an @ref QueryOperatorInfo hash for use in ServiceNow queries
+*/
+public hash<QueryOperatorInfo> sub query_op_startswith(string str) {
+    return query_make_op(QUERY_OP_STARTSWITH, str);
+}
+
+#! returns an @ref QueryOperatorInfo hash for the \c "ENDSWITH" operator with the given argument for use in ServiceNow queries
+/** @par Example:
+    @code{.py}
+AbstractDataProviderRecordIterator i = provider.searchRecords({"name": query_op_endswith("001")});
+    @endcode
+
+    @param str the argument for the operator
+
+    @return an @ref QueryOperatorInfo hash for use in ServiceNow queries
+*/
+public hash<QueryOperatorInfo> sub query_op_endswith(string str) {
+    return query_make_op(QUERY_OP_ENDSWITH, str);
+}
+
 #! returns an @ref QueryOperatorInfo hash for the \c "<" operator with the given argument for use in ServiceNow queries when comparing column values to immediate values
 /** @par Example:
     @code{.py}
@@ -283,7 +311,7 @@ AbstractDataProviderRecordIterator i = provider.searchRecords({"value": query_op
     @note The argument list size may be constrained depending on the database server / driver used; passing a large
     number of arguments to this function may be a sign of an improper application or query design
 */
-public hash<QueryOperatorInfo> sub soql_op_in() {
+public hash<QueryOperatorInfo> sub query_op_in() {
     return query_make_op(QUERY_OP_IN, argv);
 }
 
@@ -300,7 +328,7 @@ AbstractDataProviderRecordIterator i = provider.searchRecords({"value": query_op
     @note The argument list size may be constrained depending on the database server / driver used; passing a large
     number of arguments to this function may be a sign of an improper application or query design
 */
-public hash<QueryOperatorInfo> sub soql_op_in(list<auto> args) {
+public hash<QueryOperatorInfo> sub query_op_in(list<auto> args) {
     return query_make_op(QUERY_OP_IN, args);
 }
 
@@ -315,7 +343,7 @@ AbstractDataProviderRecordIterator i = provider.searchRecords({"value": query_op
     @note The argument list size may be constrained depending on the database server / driver used; passing a large
     number of arguments to this function may be a sign of an improper application or query design
 */
-public hash<QueryOperatorInfo> sub soql_op_notin() {
+public hash<QueryOperatorInfo> sub query_op_notin() {
     return query_make_op(QUERY_OP_NOTIN, argv);
 }
 
@@ -332,7 +360,7 @@ AbstractDataProviderRecordIterator i = provider.searchRecords({"value": query_op
     @note The argument list size may be constrained depending on the database server / driver used; passing a large
     number of arguments to this function may be a sign of an improper application or query design
 */
-public hash<QueryOperatorInfo> sub soql_op_notin(list<auto> args) {
+public hash<QueryOperatorInfo> sub query_op_notin(list<auto> args) {
     return query_make_op(QUERY_OP_NOTIN, args);
 }
 

--- a/qlib/ServiceNowRestDataProvider/ServiceNowRestRecordIterator.qc
+++ b/qlib/ServiceNowRestDataProvider/ServiceNowRestRecordIterator.qc
@@ -228,30 +228,56 @@ public class ServiceNowRestRecordIterator inherits AbstractDataProviderRecordIte
     }
 
     private string doWhereExpression(hash<DataProviderExpression> where_cond, *hash<auto> search_options) {
-        list<string> clauses;
-        if (where_cond.exp == DP_OP_AND) {
-            map clauses += doWhereExpressionIntern($1), where_cond.args;
-        } else {
-            clauses += doWhereExpressionIntern(where_cond);
-        }
-        return foldl $1 + "^" + $2, clauses;
+        return processExpressionArg(where_cond);
     }
 
-    private string doWhereExpressionIntern(hash<DataProviderExpression> arg) {
-        *hash<auto> expinfo = ServiceNowTableDataProvider::Expressions{arg.exp};
+    #! Processes a DataProvider expression argument and returns the ServiceNow query string
+    /** @param exp the expression to process
+        @return the ServiceNow query string for the expression
+    */
+    string processExpressionArg(hash<DataProviderExpression> exp) {
+        *hash<auto> expinfo = ServiceNowTableDataProvider::Expressions{exp.exp};
         if (!expinfo) {
             throw "WHERE-ERROR", sprintf("expression references unknown operator %y; known operators: %y",
-                arg.exp, keys ServiceNowTableDataProvider::Expressions);
+                exp.exp, keys ServiceNowTableDataProvider::Expressions);
         }
-        if (!(arg.args[0] instanceof hash<DataProviderFieldReference>)) {
+
+        # Handle logical operators (AND, OR) - process recursively
+        if (exp.exp == DP_OP_AND) {
+            if (!exp.args) {
+                # Empty AND is always true - return a tautology
+                return "sys_id!=NULL";
+            }
+            list<string> clauses = map processExpressionArg($1), exp.args;
+            return foldl $1 + "^" + $2, clauses;
+        }
+        if (exp.exp == DP_OP_OR) {
+            if (!exp.args) {
+                # Empty OR is always false - return a contradiction
+                return "sys_id=NULL";
+            }
+            list<string> clauses = map processExpressionArg($1), exp.args;
+            return foldl $1 + "^OR" + $2, clauses;
+        }
+
+        # For comparison operators, first argument must be a field reference
+        if (exp.args.size() < 1 || !(exp.args[0] instanceof hash<DataProviderFieldReference>)) {
             throw "WHERE-ERROR", sprintf("the first argument to expression %y must be a field reference",
-                arg.exp);
+                exp.exp);
         }
-        string column = (shift arg.args).field;
+        string column = cast<hash<DataProviderFieldReference>>(exp.args[0]).field;
+
+        # Build args for the impl function
         list<auto> args = (column,);
-        if (arg.args) {
-            args += map getArgValue(column, $1), arg.args;
+        for (int j = 1; j < exp.args.size(); ++j) {
+            # If the argument is a list, flatten it for IN/NOTIN operators
+            if (exp.args[j].typeCode() == NT_LIST) {
+                args += map getArgValue(column, $1), exp.args[j];
+            } else {
+                push args, getArgValue(column, exp.args[j]);
+            }
         }
+
         return call_function_args(expinfo.impl, args);
     }
 

--- a/qlib/ServiceNowRestDataProvider/ServiceNowRestRecordIterator.qc
+++ b/qlib/ServiceNowRestDataProvider/ServiceNowRestRecordIterator.qc
@@ -234,6 +234,25 @@ public class ServiceNowRestRecordIterator inherits AbstractDataProviderRecordIte
     #! Processes a DataProvider expression argument and returns the ServiceNow query string
     /** @param exp the expression to process
         @return the ServiceNow query string for the expression
+
+        @note ServiceNow Nesting Limitation:
+        ServiceNow's encoded query syntax uses \c "^" for AND and \c "^OR" for OR, where AND has higher
+        precedence than OR.  This means:
+        - \c "a^b^ORc^d" is interpreted as \c "(a AND b) OR (c AND d)" - works correctly
+        - \c "a^ORb^c" is interpreted as \c "a OR (b AND c)" - NOT \c "(a OR b) AND c"
+
+        Therefore, \c OR(AND(...), AND(...)) expressions work correctly, but \c AND(OR(...), ...) expressions
+        cannot be correctly represented in ServiceNow's query syntax.  This method validates the expression
+        tree and throws an exception if an unsupported nesting pattern is detected.
+
+        Supported patterns:
+        - Simple comparisons: \c field=value
+        - AND at top level: \c AND(comp1, comp2, ...)
+        - OR at top level: \c OR(comp1, comp2, ...)
+        - OR containing AND children: \c OR(AND(a, b), AND(c, d)) -> \c "a^b^ORc^d"
+
+        Unsupported patterns:
+        - AND containing OR children: \c AND(OR(a, b), c) - would be misinterpreted
     */
     string processExpressionArg(hash<DataProviderExpression> exp) {
         *hash<auto> expinfo = ServiceNowTableDataProvider::Expressions{exp.exp};
@@ -248,6 +267,17 @@ public class ServiceNowRestRecordIterator inherits AbstractDataProviderRecordIte
                 # Empty AND is always true - return a tautology
                 return "sys_id!=NULL";
             }
+            # Validate: AND cannot contain OR children due to ServiceNow precedence rules
+            # ServiceNow interprets "a^ORb^c" as "a OR (b AND c)", not "(a OR b) AND c"
+            foreach hash<DataProviderExpression> child in (exp.args) {
+                if (child.exp == DP_OP_OR) {
+                    throw "WHERE-ERROR", "ServiceNow does not support AND expressions containing OR "
+                        "children; the query 'AND(OR(a, b), c)' cannot be correctly represented in "
+                        "ServiceNow's encoded query syntax due to operator precedence (AND binds tighter "
+                        "than OR). Consider restructuring your query or using OR(AND(...), AND(...)) "
+                        "instead, which is supported.";
+                }
+            }
             list<string> clauses = map processExpressionArg($1), exp.args;
             return foldl $1 + "^" + $2, clauses;
         }
@@ -256,6 +286,7 @@ public class ServiceNowRestRecordIterator inherits AbstractDataProviderRecordIte
                 # Empty OR is always false - return a contradiction
                 return "sys_id=NULL";
             }
+            # OR containing AND children is supported: "a^b^ORc^d" = "(a AND b) OR (c AND d)"
             list<string> clauses = map processExpressionArg($1), exp.args;
             return foldl $1 + "^OR" + $2, clauses;
         }

--- a/qlib/ServiceNowRestDataProvider/ServiceNowRestRecordIterator.qc
+++ b/qlib/ServiceNowRestDataProvider/ServiceNowRestRecordIterator.qc
@@ -244,7 +244,7 @@ public class ServiceNowRestRecordIterator inherits AbstractDataProviderRecordIte
 
         # Handle logical operators (AND, OR) - process recursively
         if (exp.exp == DP_OP_AND) {
-            if (!exp.args) {
+            if (!exists exp.args || !exp.args.size()) {
                 # Empty AND is always true - return a tautology
                 return "sys_id!=NULL";
             }
@@ -252,7 +252,7 @@ public class ServiceNowRestRecordIterator inherits AbstractDataProviderRecordIte
             return foldl $1 + "^" + $2, clauses;
         }
         if (exp.exp == DP_OP_OR) {
-            if (!exp.args) {
+            if (!exists exp.args || !exp.args.size()) {
                 # Empty OR is always false - return a contradiction
                 return "sys_id=NULL";
             }

--- a/qlib/ServiceNowRestDataProvider/ServiceNowTableDataProvider.qc
+++ b/qlib/ServiceNowRestDataProvider/ServiceNowTableDataProvider.qc
@@ -175,7 +175,7 @@ public class ServiceNowTableDataProvider inherits ServiceNowRestDataProviderBase
             QUERY_OP_IN: {
                 "exp": sym(AbstractDataProvider::GenericExpressions{DP_SEARCH_OP_IN}, QUERY_OP_IN),
                 "impl": string sub (string cn, auto arg) {
-                    if (!arg) {
+                    if (arg.typeCode() == NT_LIST && !arg.size()) {
                         # Empty IN list means no match possible
                         return "sys_id=NULL";
                     }
@@ -195,7 +195,7 @@ public class ServiceNowTableDataProvider inherits ServiceNowRestDataProviderBase
                     "return_type": AbstractDataProviderTypeMap."bool",
                 },
                 "impl": string sub (string cn, auto arg) {
-                    if (!arg) {
+                    if (arg.typeCode() == NT_LIST && !arg.size()) {
                         # Empty NOTIN list means all values match
                         return "sys_id!=NULL";
                     }

--- a/qlib/ServiceNowRestDataProvider/ServiceNowTableDataProvider.qc
+++ b/qlib/ServiceNowRestDataProvider/ServiceNowTableDataProvider.qc
@@ -128,9 +128,13 @@ public class ServiceNowTableDataProvider inherits ServiceNowRestDataProviderBase
         const Expressions = {
             DP_OP_AND: {
                 "exp": AbstractDataProvider::GenericExpressions{DP_OP_AND},
-                "impl": string sub (*string ignored, auto arg) {
-                    throw "WHERE-ERROR", "ServiceNow does not support nested boolean logic in queries";
-                },
+                # AND is handled specially in the iterator - this impl is for nested AND which is supported
+                "impl": "and",
+            },
+            DP_OP_OR: {
+                "exp": AbstractDataProvider::GenericExpressions{DP_OP_OR},
+                # OR is handled specially in the iterator using ^OR syntax
+                "impl": "or",
             },
             QUERY_OP_EQ: {
                 "exp": sym(AbstractDataProvider::GenericExpressions{DP_SEARCH_OP_EQ}, QUERY_OP_EQ),
@@ -171,6 +175,10 @@ public class ServiceNowTableDataProvider inherits ServiceNowRestDataProviderBase
             QUERY_OP_IN: {
                 "exp": sym(AbstractDataProvider::GenericExpressions{DP_SEARCH_OP_IN}, QUERY_OP_IN),
                 "impl": string sub (string cn, auto arg) {
+                    if (!arg) {
+                        # Empty IN list means no match possible
+                        return "sys_id=NULL";
+                    }
                     return sprintf("%sIN%s", cn, (foldl $1 + "," + $2, arg));
                 },
             },
@@ -183,10 +191,14 @@ public class ServiceNowTableDataProvider inherits ServiceNowRestDataProviderBase
                     "desc": "An expression with the ServiceNow 'notin' operator",
                     "symbol": "NOTIN",
                     "groups": "Comparison",
-                    "args": (DataProviderSignatureFieldType, DataProviderSignatureStringValueType),
+                    "args": (DataProviderSignatureFieldType, DataProviderSignatureListValueType),
                     "return_type": AbstractDataProviderTypeMap."bool",
                 },
                 "impl": string sub (string cn, auto arg) {
+                    if (!arg) {
+                        # Empty NOTIN list means all values match
+                        return "sys_id!=NULL";
+                    }
                     return sprintf("%sNOTIN%s", cn, (foldl $1 + "," + $2, arg));
                 },
             },
@@ -242,12 +254,28 @@ public class ServiceNowTableDataProvider inherits ServiceNowRestDataProviderBase
                 "exp": <DataProviderExpressionInfo>{
                     "type": DET_Operator,
                     "name": QUERY_OP_ENDSWITH,
-                    "display_name": "like",
+                    "display_name": "endswith",
                     "short_desc": "An expression with the ServiceNow 'endswith' operator",
                     "desc": "An expression with the ServiceNow 'endswith' operator",
                     "symbol": "ENDSWITH",
                     "groups": "Comparison",
                     "args": (DataProviderSignatureFieldType, DataProviderSignatureStringValueType),
+                    "return_type": AbstractDataProviderTypeMap."bool",
+                },
+                "impl": string sub (string cn, auto arg) {
+                    return sprintf("%sENDSWITH%s", cn, arg);
+                },
+            },
+            QUERY_OP_ISEMPTY: {
+                "exp": <DataProviderExpressionInfo>{
+                    "type": DET_Operator,
+                    "name": QUERY_OP_ISEMPTY,
+                    "display_name": "isempty",
+                    "short_desc": "An expression with the ServiceNow 'isempty' operator",
+                    "desc": "An expression with the ServiceNow 'isempty' operator",
+                    "symbol": "ISEMPTY",
+                    "groups": "Comparison",
+                    "args": (DataProviderSignatureFieldType,),
                     "return_type": AbstractDataProviderTypeMap."bool",
                 },
                 "impl": string sub (string cn, auto arg) {
@@ -258,7 +286,7 @@ public class ServiceNowTableDataProvider inherits ServiceNowRestDataProviderBase
                 "exp": <DataProviderExpressionInfo>{
                     "type": DET_Operator,
                     "name": QUERY_OP_ISNOTEMPTY,
-                    "display_name": "notlike",
+                    "display_name": "isnotempty",
                     "short_desc": "An expression with the ServiceNow 'isnotempty' operator",
                     "desc": "An expression with the ServiceNow 'isnotempty' operator",
                     "symbol": "ISNOTEMPTY",


### PR DESCRIPTION
## Summary

- Fixed ENDSWITH operator bug (was returning ISEMPTY instead of ENDSWITH)
- Added DP_OP_OR support using ServiceNow `^OR` syntax for OR expressions
- Added ISEMPTY expression (constant existed but wasn't in Expressions map)
- Added DP_OP_AND expression for nested AND support
- Fixed function naming: `soql_op_in`/`soql_op_notin` → `query_op_in`/`query_op_notin`
- Added `query_op_startswith()` and `query_op_endswith()` functions
- Added empty list validation for IN/NOTIN operators (stricter type checks per Copilot review)
- Implemented `processExpressionArg` for recursive AND/OR expression handling
- Added validation to reject unsupported nesting patterns (AND containing OR)
- Added comprehensive unit tests (65 assertions)

## ServiceNow Nesting Limitation

ServiceNow's encoded query syntax has operator precedence limitations:
- `^` (AND) has higher precedence than `^OR` (OR)
- `a^b^ORc^d` is interpreted as `(a AND b) OR (c AND d)` ✓
- `a^ORb^c` is interpreted as `a OR (b AND c)` - NOT `(a OR b) AND c` ✗

**Supported patterns:**
- `OR(AND(...), AND(...))` → `a^b^ORc^d`

**Unsupported patterns (throws WHERE-ERROR):**
- `AND(OR(...), ...)` - cannot be correctly represented

## Test plan

- [x] Run ServiceNowRestClient.qtest - 5 test cases, 65 assertions pass
- [x] Copilot review feedback addressed
- [ ] Integration tests for nesting validation (require ServiceNow connection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)