### PR TITLE
closes #5018 Add zero-cost @assert and @debug statements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,6 +24,7 @@ variables:
   MYSQL_DATABASE: omq
   MYSQL_ROOT_PASSWORD: omq
   QORE_DB_CONNSTR_MYSQL: 'mysql:root/omq@omq(UTF8)%mysql'
+  QORE_TEST_OPTS: '-penable-debug'
 
 test-ubuntu-amd64:
   stage: test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,8 @@ set(LIBQORE_CPP_SRC
     lib/TryStatement.cpp
     lib/RethrowStatement.cpp
     lib/ThrowStatement.cpp
+    lib/AssertStatement.cpp
+    lib/DebugStatement.cpp
     lib/SwitchStatement.cpp
     lib/Variable.cpp
     lib/support.cpp

--- a/doxygen/lang/245_parse_directives.dox.tmpl
+++ b/doxygen/lang/245_parse_directives.dox.tmpl
@@ -47,10 +47,12 @@
     |@ref correct-varargs "%correct-varargs"|revert the effect of the @ref broken-varargs "%broken-varargs" parse option
     |@ref define "%define"|Creates and optionally sets a value for a @ref conditional_parsing "parse define" <br><br>Since %Qore 0.8.3
     |@ref disable-all-warnings "%disable-all-warnings"|Turns off all @ref warnings "warnings"
+    |@ref disable-debug "%disable-debug"|Disables @@assert and @@debug statements (they are skipped at parse time); reverts the effect of @ref enable-debug "%enable-debug"<br><br>Since %Qore 2.1
     |@ref disable-warning "%disable-warning" <em>@ref warnings "warning-code"</em>|Disables the named @ref warnings "warning" until @ref enable-warning "%enable-warning" is encountered with the same code or @ref enable-all-warnings "%enable-all-warnings" is encountered
     |@ref elif "%elif" <em>expression</em>|Allows for testing additional conditions in a @ref conditional_parsing "conditionally-parsed" block started by @ref if "%if"; uses the same expression syntax as @ref if "%if"
     |@ref else "%else"|Allows for parsing an alternate block when used with the @ref if "%if", @ref ifdef "%ifdef", or @ref ifndef "%ifndef" parse directives (for @ref conditional_parsing "conditional parsing based on parse defines") <br><br>Since %Qore 0.8.3
     |@ref enable-all-warnings "%enable-all-warnings"|Turns on all @ref warnings "warnings"
+    |@ref enable-debug "%enable-debug"|Enables @@assert and @@debug statements; without this directive, these statements are skipped at parse time with no runtime overhead; equivalent to parse option @ref Qore::PO_ENABLE_DEBUG<br><br>Since %Qore 2.1
     |@ref enable-warning "%enable-warning" <em>@ref warnings "warning-code"</em>|Enables the named @ref warnings "warning"
     |@ref endif "%endif"|Closes a @ref conditional_parsing "conditionally-parsed" block started by the @ref if "%if", @ref ifdef "%ifdef", or @ref ifndef "%ifndef" parse directives <br><br>Since %Qore 0.8.3
     |@ref endtry "%endtry"|Closes a @ref try-module "%try-module" or @ref try-reexport-module "%try-reexport-module" block <br><br>Since %Qore 0.8.6
@@ -862,6 +864,71 @@ i+ =4;
 
     @par Description
     Enables all warnings while parsing. See @ref warnings for more information.
+
+    <hr>
+    @section enable-debug %enable-debug
+
+    @par Parse Directive:
+    <tt>%%enable-debug</tt>
+
+    @par Command Line:
+    <tt>-</tt><tt>-enable-debug</tt>
+
+    @par Parse Option Constant:
+    @ref Qore::PO_ENABLE_DEBUG
+
+    @par Description:
+    Enables \c @@assert and \c @@debug statements. When this parse option is set:
+    - \c @@assert statements are parsed and executed at runtime, throwing an \c ASSERTION-ERROR exception
+      if the condition is false
+    - \c @@debug statements are parsed and executed at runtime for their side effects (e.g., logging)
+
+    Without this directive, both \c @@assert and \c @@debug statements are completely skipped at parse time,
+    providing zero runtime overhead when debugging is disabled.
+
+    @par Syntax:
+    @code{.py}
+    @assert(condition);
+    @assert(condition, "error message");
+    @debug(expression);
+    @endcode
+
+    @par Example:
+    @code{.py}
+%enable-debug
+
+sub validate_input(int value) {
+    @debug(printf("validate_input called with: %d\n", value));
+    @assert(value > 0, "value must be positive");
+    @assert(value < 100);  # uses default message "assertion failed"
+    return value * 2;
+}
+    @endcode
+
+    @since %Qore 2.1
+
+    @see @ref disable-debug "%disable-debug"
+
+    <hr>
+    @section disable-debug %disable-debug
+
+    @par Parse Directive:
+    <tt>%%disable-debug</tt>
+
+    @par Command Line:
+    n/a
+
+    @par Parse Option Constant:
+    n/a (reverts @ref Qore::PO_ENABLE_DEBUG)
+
+    @par Description:
+    Disables \c @@assert and \c @@debug statements by reverting the effect of @ref enable-debug "%enable-debug".
+    When debugging is disabled, both statement types are completely skipped at parse time, providing
+    zero runtime overhead.
+
+    @since %Qore 2.1
+
+    @see @ref enable-debug "%enable-debug"
 
     <hr>
     @section enable-warning %enable-warning

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -47,6 +47,13 @@
       - static @ref Program::getAllDefines() "Program::getAllDefines()"
     - new function:
       - @ref Qore::clock_getseconds() "clock_getseconds()"
+    - new zero-cost assertion and debug statements
+      - \c @@assert(condition) and \c @@assert(condition, message) throw \c ASSERTION-ERROR when condition is false
+      - \c @@debug(expression) evaluates an expression for its side effects (e.g., logging)
+      - both statements are completely skipped at parse time when \c %%enable-debug is not set, providing
+        zero runtime overhead
+      - use \c %%enable-debug / \c %%disable-debug parse directives or \c PO_ENABLE_DEBUG parse option
+        (<a href="https://github.com/qoretechnologies/qore/issues/5018">issue 5018</a>)
     - <a href="../../modules/ElasticSearchDataProvider/html/index.html">ElasticSearchDataProvider</a> module
       - added Bulk API support with NDJSON format and partial failure handling
         (<a href="https://github.com/qoretechnologies/qore/issues/5016">issue 5016</a>)

--- a/examples/test/qore/statements/assert.qtest
+++ b/examples/test/qore/statements/assert.qtest
@@ -1,0 +1,154 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+%no-child-restrictions
+%enable-debug
+
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class AssertDebugTest
+
+class AssertDebugTest inherits QUnit::Test {
+    constructor() : QUnit::Test("AssertDebugTest", "1.0", \ARGV) {
+        addTestCase("basic assert tests", \basicAssertTests());
+        addTestCase("assert with message tests", \assertMessageTests());
+        addTestCase("basic debug tests", \basicDebugTests());
+        addTestCase("disabled tests", \disabledTests());
+        addTestCase("parse error tests", \parseErrorTests());
+        set_return_value(main());
+    }
+
+    basicAssertTests() {
+        # Test that passing asserts don't throw
+        @assert(True);
+        @assert(1 == 1);
+        @assert(1 + 1 == 2);
+        @assert("test" == "test");
+
+        # Test that failing asserts throw ASSERTION-ERROR
+        assertThrows("ASSERTION-ERROR", sub() { @assert(False); });
+        assertThrows("ASSERTION-ERROR", sub() { @assert(1 == 2); });
+        assertThrows("ASSERTION-ERROR", sub() { @assert(1 + 1 == 3); });
+    }
+
+    assertMessageTests() {
+        # Test assert with custom message
+        try {
+            @assert(False, "custom error message");
+            fail("should have thrown");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("ASSERTION-ERROR", ex.err);
+            assertEq("custom error message", ex.desc);
+        }
+
+        # Test assert with expression message
+        string msg = "dynamic message";
+        try {
+            @assert(1 == 2, msg);
+            fail("should have thrown");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("ASSERTION-ERROR", ex.err);
+            assertEq("dynamic message", ex.desc);
+        }
+
+        # Test assert with complex expression
+        @assert((1 + 2) * 3 == 9, "math should work");
+    }
+
+    basicDebugTests() {
+        # Test that @debug evaluates its expression
+        int counter = 0;
+        @debug(++counter);
+        assertEq(1, counter);
+
+        # Test @debug with function call
+        list<string> log = ();
+        @debug(log += "debug message");
+        assertEq(("debug message",), log);
+
+        # Test @debug with complex expression
+        hash<auto> h = {};
+        @debug(h.key = "value");
+        assertEq("value", h.key);
+    }
+
+    disabledTests() {
+        # Test that asserts and debug are skipped when parsed without %enable-debug
+        # We use Program to test this
+        Program p(PO_NEW_STYLE);
+        # Without PO_ENABLE_DEBUG, both should be skipped
+        p.parse("
+            our int x = 0;
+            our int debug_count = 0;
+            sub run_test() {
+                @debug(++debug_count);  # This should be skipped
+                @assert(False);  # This should be skipped
+                x = 1;
+            }
+        ", "test");
+        p.callFunction("run_test");
+        assertEq(1, p.getGlobalVariable("x"));
+        # When @debug is skipped, debug_count is never modified at runtime,
+        # so getGlobalVariable returns NOTHING (not the initialization value)
+        assertNothing(p.getGlobalVariable("debug_count"));
+
+        # With PO_ENABLE_DEBUG, assert should throw
+        Program p2(PO_NEW_STYLE | PO_ENABLE_DEBUG);
+        p2.parse("
+            sub test() { @assert(False); }
+        ", "test");
+        assertThrows("ASSERTION-ERROR", \p2.callFunction(), "test");
+
+        # With PO_ENABLE_DEBUG, debug should execute
+        Program p3(PO_NEW_STYLE | PO_ENABLE_DEBUG);
+        p3.parse("
+            our int debug_count = 0;
+            sub test() { @debug(++debug_count); }
+        ", "test");
+        p3.callFunction("test");
+        assertEq(1, p3.getGlobalVariable("debug_count"));
+    }
+
+    parseErrorTests() {
+        # Test parse errors for @assert and @debug syntax
+        Program p(PO_NEW_STYLE | PO_ENABLE_DEBUG);
+
+        # @assert requires at least one argument
+        assertThrows("PARSE-EXCEPTION", "syntax error",
+            \p.parse(), ("sub t() { @assert(); }", "test"));
+
+        # @debug requires exactly one argument
+        assertThrows("PARSE-EXCEPTION", "syntax error",
+            \p.parse(), ("sub t() { @debug(); }", "test"));
+
+        # @assert without parentheses is a syntax error
+        assertThrows("PARSE-EXCEPTION", "syntax error",
+            \p.parse(), ("sub t() { @assert True; }", "test"));
+
+        # @debug without parentheses is a syntax error
+        assertThrows("PARSE-EXCEPTION", "syntax error",
+            \p.parse(), ("sub t() { @debug 1; }", "test"));
+
+        # @assert missing semicolon
+        assertThrows("PARSE-EXCEPTION", "syntax error",
+            \p.parse(), ("sub t() { @assert(True) }", "test"));
+
+        # @debug missing semicolon
+        assertThrows("PARSE-EXCEPTION", "syntax error",
+            \p.parse(), ("sub t() { @debug(1) }", "test"));
+
+        # Test that nested parentheses are correctly skipped when disabled
+        Program p2(PO_NEW_STYLE);  # No PO_ENABLE_DEBUG
+        # This should parse without error (the @assert is skipped)
+        p2.parse("
+            sub test() {
+                @assert(func(a, (b + c)));
+                @debug(hash.key = (1 + 2));
+            }
+        ", "test");
+    }
+}

--- a/include/qore/Restrictions.h
+++ b/include/qore/Restrictions.h
@@ -100,6 +100,7 @@
 #define PO_NO_INHERIT_PROGRAM_DATA          (1LL << 60)  //!< do not inherit module-specific Program data from the parent
 #define PO_BROKEN_VARARGS                   (1LL << 61)  //!< allow for old pre-%Qore 1.17 vararg handling with implicit ellipses
 #define PO_BROKEN_LIST_RANGE                (1LL << 62)  //!< allow for old pre-%Qore 2.0 list range behavior
+#define PO_ENABLE_DEBUG                     (1LL << 63)  //!< enable \@assert and \@debug statements (otherwise ignored at parse time)
 
 // aliases for old defines
 #define PO_NO_SYSTEM_FUNC_VARIANTS          PO_NO_INHERIT_SYSTEM_FUNC_VARIANTS
@@ -134,7 +135,7 @@
 
 //! mask of all options allowing for more freedom (instead of less)
 #define PO_POSITIVE_OPTIONS           (PO_NO_CHILD_PO_RESTRICTIONS|PO_ALLOW_INJECTION|PO_ALLOW_WEAK_REFERENCES \
-    |PO_ALLOW_DEBUGGER)
+    |PO_ALLOW_DEBUGGER|PO_ENABLE_DEBUG)
 
 //! mask of options that have no effect on code access or code safety
 #define PO_FREE_OPTIONS               (PO_ALLOW_BARE_REFS|PO_ASSUME_LOCAL|PO_STRICT_BOOLEAN_EVAL \

--- a/include/qore/intern/AssertStatement.h
+++ b/include/qore/intern/AssertStatement.h
@@ -1,0 +1,59 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    AssertStatement.h
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#ifndef _QORE_ASSERTSTATEMENT_H
+
+#define _QORE_ASSERTSTATEMENT_H
+
+#include "qore/intern/AbstractStatement.h"
+
+class AssertStatement : public AbstractStatement {
+public:
+    //! Creates an assert statement with an expression and optional message
+    /** @param start_line the starting line number
+        @param end_line the ending line number
+        @param cond the condition expression (must evaluate to true)
+        @param msg optional message expression (shown on assertion failure)
+    */
+    DLLLOCAL AssertStatement(int start_line, int end_line, QoreValue cond, QoreValue msg = QoreValue());
+
+    DLLLOCAL virtual ~AssertStatement();
+
+private:
+    QoreValue condition;  //!< The condition to assert
+    QoreValue message;    //!< Optional message on failure
+
+    DLLLOCAL virtual int execImpl(QoreValue& return_value, ExceptionSink* xsink);
+
+    DLLLOCAL virtual int parseInitImpl(QoreParseContext& parse_context);
+};
+
+#endif

--- a/include/qore/intern/DebugStatement.h
+++ b/include/qore/intern/DebugStatement.h
@@ -1,0 +1,57 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    DebugStatement.h
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#ifndef _QORE_DEBUGSTATEMENT_H
+
+#define _QORE_DEBUGSTATEMENT_H
+
+#include "qore/intern/AbstractStatement.h"
+
+class DebugStatement : public AbstractStatement {
+public:
+    //! Creates a debug statement with an expression to evaluate
+    /** @param start_line the starting line number
+        @param end_line the ending line number
+        @param exp the expression to evaluate (for side effects like logging)
+    */
+    DLLLOCAL DebugStatement(int start_line, int end_line, QoreValue exp);
+
+    DLLLOCAL virtual ~DebugStatement();
+
+private:
+    QoreValue expression;  //!< The expression to evaluate
+
+    DLLLOCAL virtual int execImpl(QoreValue& return_value, ExceptionSink* xsink);
+
+    DLLLOCAL virtual int parseInitImpl(QoreParseContext& parse_context);
+};
+
+#endif

--- a/lib/AssertStatement.cpp
+++ b/lib/AssertStatement.cpp
@@ -1,0 +1,101 @@
+/*
+    AssertStatement.cpp
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#include <qore/Qore.h>
+#include "qore/intern/AssertStatement.h"
+
+AssertStatement::AssertStatement(int start_line, int end_line, QoreValue cond, QoreValue msg)
+        : AbstractStatement(start_line, end_line), condition(cond), message(msg) {
+}
+
+AssertStatement::~AssertStatement() {
+    condition.discard(nullptr);
+    message.discard(nullptr);
+}
+
+int AssertStatement::execImpl(QoreValue& return_value, ExceptionSink* xsink) {
+    // Evaluate the condition
+    ValueEvalOptimizedRefHolder cond_val(condition, xsink);
+    if (*xsink) {
+        return 0;
+    }
+
+    // Check if condition is true
+    if (!cond_val->getAsBool()) {
+        // Assertion failed - get the message if provided
+        QoreStringNode* msg_str = nullptr;
+        if (message) {
+            ValueEvalOptimizedRefHolder msg_val(message, xsink);
+            if (*xsink) {
+                return 0;
+            }
+            if (msg_val->getType() == NT_STRING) {
+                msg_str = msg_val.takeReferencedValue().get<QoreStringNode>();
+            } else {
+                bool del;
+                QoreString* tmp = msg_val->getAsString(del, 0, xsink);
+                if (*xsink) {
+                    return 0;
+                }
+                msg_str = del ? static_cast<QoreStringNode*>(tmp) : new QoreStringNode(*tmp);
+            }
+        } else {
+            msg_str = new QoreStringNode("assertion failed");
+        }
+
+        xsink->raiseException("ASSERTION-ERROR", msg_str);
+    }
+
+    return 0;
+}
+
+int AssertStatement::parseInitImpl(QoreParseContext& parse_context) {
+    // Turn off top-level flag for statement vars
+    QoreParseContextFlagHelper fh(parse_context);
+    fh.unsetFlags(PF_TOP_LEVEL);
+
+    int err = 0;
+
+    // Parse the condition
+    if (condition) {
+        parse_context.typeInfo = nullptr;
+        err = parse_init_value(condition, parse_context);
+    }
+
+    // Parse the optional message
+    if (message) {
+        parse_context.typeInfo = nullptr;
+        if (parse_init_value(message, parse_context) && !err) {
+            err = -1;
+        }
+    }
+
+    return err;
+}

--- a/lib/DebugStatement.cpp
+++ b/lib/DebugStatement.cpp
@@ -1,0 +1,63 @@
+/*
+    DebugStatement.cpp
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#include <qore/Qore.h>
+#include "qore/intern/DebugStatement.h"
+
+DebugStatement::DebugStatement(int start_line, int end_line, QoreValue exp)
+        : AbstractStatement(start_line, end_line), expression(exp) {
+}
+
+DebugStatement::~DebugStatement() {
+    expression.discard(nullptr);
+}
+
+int DebugStatement::execImpl(QoreValue& return_value, ExceptionSink* xsink) {
+    // Simply evaluate the expression for its side effects (e.g., logging)
+    ValueEvalOptimizedRefHolder val(expression, xsink);
+    // The result is discarded; we just want the side effects
+    return *xsink ? -1 : 0;
+}
+
+int DebugStatement::parseInitImpl(QoreParseContext& parse_context) {
+    // Turn off top-level flag for statement vars
+    QoreParseContextFlagHelper fh(parse_context);
+    fh.unsetFlags(PF_TOP_LEVEL);
+
+    int err = 0;
+
+    // Parse the expression
+    if (expression) {
+        parse_context.typeInfo = nullptr;
+        err = parse_init_value(expression, parse_context);
+    }
+
+    return err;
+}

--- a/lib/ParseOptionMap.cpp
+++ b/lib/ParseOptionMap.cpp
@@ -104,6 +104,7 @@ void ParseOptionMap::static_init() {
     DO_MAP("broken-range",             PO_BROKEN_RANGE);
     DO_MAP("broken-varargs",           PO_BROKEN_VARARGS);
     DO_MAP("broken-list-range",        PO_BROKEN_LIST_RANGE);
+    DO_MAP("enable-debug",             PO_ENABLE_DEBUG);
 
     // the following are not useful from the command-line
     //DO_MAP("no-user-constants",        PO_NO_INHERIT_USER_CONSTANTS);

--- a/lib/QC_Program.qpp
+++ b/lib/QC_Program.qpp
@@ -774,6 +774,13 @@ const PO_NO_INHERIT_PROGRAM_DATA = PO_NO_INHERIT_PROGRAM_DATA;
     @since %Qore 1.17
 */
 const PO_BROKEN_VARARGS = PO_BROKEN_VARARGS;
+
+//! enables \@assert and \@debug statements (otherwise ignored at parse time)
+/** @see @ref enable-debug "%enable-debug"
+
+    @since %Qore 2.1
+*/
+const PO_ENABLE_DEBUG = PO_ENABLE_DEBUG;
 ///@}
 
 /** @defgroup warning_constants Warning Constants

--- a/lib/parser.ypp
+++ b/lib/parser.ypp
@@ -45,6 +45,8 @@
 #include "qore/intern/ForEachStatement.h"
 #include "qore/intern/TryStatement.h"
 #include "qore/intern/ThrowStatement.h"
+#include "qore/intern/AssertStatement.h"
+#include "qore/intern/DebugStatement.h"
 #include "qore/intern/StatementBlock.h"
 #include "qore/intern/ParserSupport.h"
 #include "qore/intern/SwitchStatement.h"
@@ -1608,6 +1610,8 @@ DLLLOCAL void yyerror(YYLTYPE* loc, yyscan_t scanner, const char* str) {
 %token TOK_DO "do"
 %token TOK_TRY "try"
 %token TOK_THROW "throw"
+%token TOK_ASSERT "@assert"
+%token TOK_DEBUG "@debug"
 %token TOK_CATCH "catch"
 %token TOK_WHERE "where"
 %token TOK_WHILE "while"
@@ -2257,6 +2261,15 @@ statement:
     }
     | TOK_THROW exp ';' {
         $$ = new ThrowStatement(@1.first_line, @2.last_line, $2);
+    }
+    | TOK_ASSERT '(' exp ')' ';' {
+        $$ = new AssertStatement(@1.first_line, @4.last_line, $3);
+    }
+    | TOK_ASSERT '(' exp ',' exp ')' ';' {
+        $$ = new AssertStatement(@1.first_line, @6.last_line, $3, $5);
+    }
+    | TOK_DEBUG '(' exp ')' ';' {
+        $$ = new DebugStatement(@1.first_line, @4.last_line, $3);
     }
     | TOK_ON_EXIT statement_or_block {
         $$ = new OnBlockExitStatement(@1.first_line, @2.last_line, $2, OBE_Unconditional);

--- a/lib/scanner.lpp
+++ b/lib/scanner.lpp
@@ -73,6 +73,9 @@ static void check_broken_op(YYLTYPE* yylloc, const char* got, const char* expect
     }
 }
 
+// Parenthesis depth for @assert skip state
+static thread_local int assert_paren_depth = 0;
+
 static int ascii_to_octal(char c) {
    assert(isoctaldigit(c));
    return c - '0';
@@ -919,7 +922,7 @@ static bool angle_balanced(const char* p) {
 %option noyy_push_state
 %option noyy_pop_state
 
-%x str_state regex_state incl p_def p_ifdef p_ifndef p_if p_skip_to_endif p_skip_to_endif_or_else case_state regex_googleplex regex_negative_universe regex_subst1 regex_subst2 line_comment block_comment1 block_comment2 exec_class_state requires regex_trans1 regex_trans2 regex_extract_state disable_warning enable_warning append_path_state append_module_state module_cmd set_zone try_module p_skip_to_endtry angle_state
+%x str_state regex_state incl p_def p_ifdef p_ifndef p_if p_skip_to_endif p_skip_to_endif_or_else case_state regex_googleplex regex_negative_universe regex_subst1 regex_subst2 line_comment block_comment1 block_comment2 exec_class_state requires regex_trans1 regex_trans2 regex_extract_state disable_warning enable_warning append_path_state append_module_state module_cmd set_zone try_module p_skip_to_endtry angle_state p_skip_assert
 
 HEX_DIGIT       [0-9A-Fa-f]
 HEX_CONST       0x{HEX_DIGIT}+
@@ -1014,6 +1017,8 @@ RTIME           PT(-?[0-9]+(\.[0-9]+)?[HMSu])+
 ^%allow-statement-no-effect{WS}*$       parse_set_parse_options(yylloc, PO_ALLOW_STATEMENT_NO_EFFECT);
 ^%strict-types{WS}*$                    parse_set_parse_options(yylloc, PO_STRICT_TYPES);
 ^%loose-types{WS}*$                     parse_disable_parse_options(yylloc, PO_STRICT_TYPES);
+^%enable-debug{WS}*$                    parse_set_parse_options(yylloc, PO_ENABLE_DEBUG);
+^%disable-debug{WS}*$                   parse_disable_parse_options(yylloc, PO_ENABLE_DEBUG);
 ^%no-reflection{WS}*$                   parse_set_parse_options(yylloc, PO_NO_REFLECTION);
 ^%no-transient{WS}*$                    parse_set_parse_options(yylloc, PO_NO_TRANSIENT);
 ^%push-parse-options{WS}*$              push_parse_options();
@@ -1505,6 +1510,28 @@ RTIME           PT(-?[0-9]+(\.[0-9]+)?[HMSu])+
                                         }
    \n                                   // ignore
    <<EOF>>                              {
+                                            QORE_FLEX_DO_EOF
+                                        }
+}
+<p_skip_assert>{
+   \(                                   {
+                                            ++assert_paren_depth;
+                                        }
+   \)                                   {
+                                            if (assert_paren_depth > 0) {
+                                                --assert_paren_depth;
+                                                if (assert_paren_depth == 0) {
+                                                    // finished skipping assert expression
+                                                    BEGIN(INITIAL);
+                                                }
+                                            }
+                                        }
+   \"([^\"\\]|\\.)*\"                   // skip string literals (to handle parens in strings)
+   \'([^\'\\]|\\.)*\'                   // skip single-quoted strings
+   [^()\"\'\n]+                         // skip other characters
+   \n                                   // skip newlines
+   <<EOF>>                              {
+                                            parse_error(*get_loc(yylloc), "unexpected end of file in @assert expression");
                                             QORE_FLEX_DO_EOF
                                         }
 }
@@ -2011,6 +2038,22 @@ cast<\*{WS}*({WORD}::)*{WORD}{WS}*(<[a-zA-Z<>:_0-9 \t,\*]+>)?{WS}*> yylval->stri
 {DIGIT}+"."{DIGIT}+[eE][+-]?{DIGIT}+    yylval->decimal = q_strtod(yytext); return QFLOAT;
 @[Nn][Aa][Nn]@n                         yylval->num = new QoreNumberNode("@nan@"); return NUMBER;
 @[Ii][Nn][Ff]@n                         yylval->num = new QoreNumberNode("@inf@"); return NUMBER;
+@assert/{WS}*\(                         {
+                                           if (getProgram()->getParseOptions64() & PO_ENABLE_DEBUG) {
+                                               return TOK_ASSERT;
+                                           }
+                                           // skip assert when disabled - enter skip state
+                                           assert_paren_depth = 0;
+                                           BEGIN(p_skip_assert);
+                                        }
+@debug/{WS}*\(                          {
+                                           if (getProgram()->getParseOptions64() & PO_ENABLE_DEBUG) {
+                                               return TOK_DEBUG;
+                                           }
+                                           // skip debug when disabled - enter skip state
+                                           assert_paren_depth = 0;
+                                           BEGIN(p_skip_assert);
+                                        }
 {DIGIT}+n                               yylval->num = new QoreNumberNode(yytext); return NUMBER;
 {DIGIT}+"."{DIGIT}+n                    yylval->num = new QoreNumberNode(yytext); return NUMBER;
 {DIGIT}+[eE][+-]?{DIGIT}+n              yylval->num = new QoreNumberNode(yytext); return NUMBER;

--- a/lib/single-compilation-unit.cpp
+++ b/lib/single-compilation-unit.cpp
@@ -75,6 +75,8 @@
 #include "ForEachStatement.cpp"
 #include "TryStatement.cpp"
 #include "ThrowStatement.cpp"
+#include "AssertStatement.cpp"
+#include "DebugStatement.cpp"
 #include "RethrowStatement.cpp"
 #include "SwitchStatement.cpp"
 #include "Variable.cpp"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -8,6 +8,9 @@ print_usage () {
   echo "  -j         Use --format=junit option for the tests, making them print JUnit output."
   echo "  -t         Measure execution time of the tests."
   echo "  -v         Use --format=plain option for the tests, making them print one statement per each test case."
+  echo
+  echo "Environment variables:"
+  echo "  QORE_TEST_OPTS   Additional options to pass to qore (e.g., '-penable-debug')."
 }
 
 err_multiple_format_opts() {
@@ -165,15 +168,15 @@ for test in $TESTS; do
         echo "====================================="
         echo "Running test ($i/$TEST_COUNT): $test"
         echo "-------------------------------------"
-        echo "cmdline: $QORE $test $TEST_OUTPUT_FORMAT"
+        echo "cmdline: $QORE $QORE_TEST_OPTS $test $TEST_OUTPUT_FORMAT"
         echo "-------------------------------------"
     fi
 
     # Run single test.
     if [ $MEASURE_TIME -eq 1 ]; then
-        eval $TIME_CMD $QORE $test $TEST_OUTPUT_FORMAT
+        eval $TIME_CMD $QORE $QORE_TEST_OPTS $test $TEST_OUTPUT_FORMAT
     else
-        $QORE $test $TEST_OUTPUT_FORMAT
+        $QORE $QORE_TEST_OPTS $test $TEST_OUTPUT_FORMAT
     fi
 
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
## Summary

- Add `PO_ENABLE_DEBUG` parse option (bit 63) to enable both `@assert` and `@debug` statements
- Add `%enable-debug` / `%disable-debug` parse directives
- `@assert(condition)` and `@assert(condition, message)` throw `ASSERTION-ERROR` when condition is false
- `@debug(expression)` evaluates expression for side effects (e.g., logging)
- Both statements are completely skipped at parse time when disabled, providing zero runtime overhead
- Scanner uses `p_skip_assert` state to correctly skip statements with nested parentheses

## Test plan

- [x] Basic assert tests pass (passing/failing conditions)
- [x] Assert with custom message tests pass
- [x] Basic debug tests pass (expression side effects)
- [x] Disabled mode tests pass (statements skipped when PO_ENABLE_DEBUG not set)
- [x] Negative parse error tests pass (empty args, missing parens, missing semicolons)
- [x] Full build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)