### PR TITLE
refs #5018 add sprintf-style formatting support to @assert

### DIFF
--- a/doxygen/lang/245_parse_directives.dox.tmpl
+++ b/doxygen/lang/245_parse_directives.dox.tmpl
@@ -890,16 +890,21 @@ i+ =4;
     @code{.py}
     @assert(condition);
     @assert(condition, "error message");
+    @assert(condition, "format string", arg1, arg2, ...);  # sprintf-style formatting
     @debug(expression);
     @endcode
+
+    The \c @@assert statement supports sprintf-style formatting when multiple arguments are provided after
+    the condition. The format string and arguments are processed with \c sprintf() to create the error message.
 
     @par Example:
     @code{.py}
 %enable-debug
 
-sub validate_input(int value) {
+sub validate_input(int value, int max_value) {
     @debug(printf("validate_input called with: %d\n", value));
-    @assert(value > 0, "value must be positive");
+    @assert(value > 0, "value must be positive, got: %d", value);
+    @assert(value < max_value, "value %d exceeds maximum %d", value, max_value);
     @assert(value < 100);  # uses default message "assertion failed"
     return value * 2;
 }

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -49,6 +49,7 @@
       - @ref Qore::clock_getseconds() "clock_getseconds()"
     - new zero-cost assertion and debug statements
       - \c @@assert(condition) and \c @@assert(condition, message) throw \c ASSERTION-ERROR when condition is false
+      - \c @@assert supports sprintf-style formatting: \c @@assert(condition, "format", arg1, arg2, ...)
       - \c @@debug(expression) evaluates an expression for its side effects (e.g., logging)
       - both statements are completely skipped at parse time when \c %%enable-debug is not set, providing
         zero runtime overhead

--- a/examples/test/qore/statements/assert.qtest
+++ b/examples/test/qore/statements/assert.qtest
@@ -19,6 +19,7 @@ class AssertDebugTest inherits QUnit::Test {
         addTestCase("basic debug tests", \basicDebugTests());
         addTestCase("disabled tests", \disabledTests());
         addTestCase("parse error tests", \parseErrorTests());
+        addTestCase("sprintf corner case tests", \sprintfCornerCaseTests());
         set_return_value(main());
     }
 
@@ -57,6 +58,27 @@ class AssertDebugTest inherits QUnit::Test {
 
         # Test assert with complex expression
         @assert((1 + 2) * 3 == 9, "math should work");
+
+        # Test assert with sprintf-style format and single arg
+        int x = 5;
+        try {
+            @assert(x > 10, "x must be > 10, got: %d", x);
+            fail("should have thrown");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("ASSERTION-ERROR", ex.err);
+            assertEq("x must be > 10, got: 5", ex.desc);
+        }
+
+        # Test assert with sprintf-style format and multiple args
+        int expected = 10;
+        int actual = 5;
+        try {
+            @assert(expected == actual, "expected %d but got %d", expected, actual);
+            fail("should have thrown");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("ASSERTION-ERROR", ex.err);
+            assertEq("expected 10 but got 5", ex.desc);
+        }
     }
 
     basicDebugTests() {
@@ -150,5 +172,83 @@ class AssertDebugTest inherits QUnit::Test {
                 @debug(hash.key = (1 + 2));
             }
         ", "test");
+    }
+
+    sprintfCornerCaseTests() {
+        # Test sprintf with more args than format placeholders (extra args ignored)
+        try {
+            @assert(False, "only one: %d", 1, 2, 3);
+            fail("should have thrown");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("ASSERTION-ERROR", ex.err);
+            assertEq("only one: 1", ex.desc);
+        }
+
+        # Test sprintf with fewer args than placeholders (missing args become empty)
+        try {
+            @assert(False, "need two: %d %d", 42);
+            fail("should have thrown");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("ASSERTION-ERROR", ex.err);
+            # sprintf handles missing args gracefully
+            assertTrue(ex.desc.find("42") >= 0);
+        }
+
+        # Test with non-string as format (converted to string)
+        try {
+            @assert(False, 123);
+            fail("should have thrown");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("ASSERTION-ERROR", ex.err);
+            assertEq("123", ex.desc);
+        }
+
+        # Test format string with no placeholders but args provided
+        try {
+            @assert(False, "no placeholders", 1, 2, 3);
+            fail("should have thrown");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("ASSERTION-ERROR", ex.err);
+            assertEq("no placeholders", ex.desc);
+        }
+
+        # Test with various format specifiers
+        try {
+            @assert(False, "int:%d str:%s float:%f", 42, "hello", 3.14);
+            fail("should have thrown");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("ASSERTION-ERROR", ex.err);
+            assertTrue(ex.desc.find("int:42") >= 0);
+            assertTrue(ex.desc.find("str:hello") >= 0);
+            assertTrue(ex.desc.find("float:3.14") >= 0);
+        }
+
+        # Test empty format string with args
+        try {
+            @assert(False, "", 1, 2);
+            fail("should have thrown");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("ASSERTION-ERROR", ex.err);
+            assertEq("", ex.desc);
+        }
+
+        # Test condition that uses parentheses to group a complex expression
+        int a = 1;
+        int b = 2;
+        @assert((a + b) == 3, "math works");
+
+        # Test that comma in condition still works with simple message
+        # (comma operator returns last value, so (False, True) == True)
+        @assert((False, True), "comma operator condition");
+
+        # Test variadic with complex expressions as args
+        hash<auto> h = {"value": 42};
+        try {
+            @assert(False, "hash value: %d, calc: %d", h.value, 1 + 2 + 3);
+            fail("should have thrown");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("ASSERTION-ERROR", ex.err);
+            assertEq("hash value: 42, calc: 6", ex.desc);
+        }
     }
 }

--- a/include/qore/intern/AssertStatement.h
+++ b/include/qore/intern/AssertStatement.h
@@ -37,19 +37,18 @@
 
 class AssertStatement : public AbstractStatement {
 public:
-    //! Creates an assert statement with an expression and optional message
+    //! Creates an assert statement with an expression
     /** @param start_line the starting line number
         @param end_line the ending line number
-        @param cond the condition expression (must evaluate to true)
-        @param msg optional message expression (shown on assertion failure)
+        @param exp the expression - can be a single condition or a list (condition, msg, args...)
     */
-    DLLLOCAL AssertStatement(int start_line, int end_line, QoreValue cond, QoreValue msg = QoreValue());
+    DLLLOCAL AssertStatement(int start_line, int end_line, QoreValue exp);
 
     DLLLOCAL virtual ~AssertStatement();
 
 private:
     QoreValue condition;  //!< The condition to assert
-    QoreValue message;    //!< Optional message on failure
+    QoreValue message;    //!< Optional message/format args on failure (can be list for sprintf)
 
     DLLLOCAL virtual int execImpl(QoreValue& return_value, ExceptionSink* xsink);
 

--- a/lib/AssertStatement.cpp
+++ b/lib/AssertStatement.cpp
@@ -30,9 +30,38 @@
 
 #include <qore/Qore.h>
 #include "qore/intern/AssertStatement.h"
+#include "qore/intern/QoreParseListNode.h"
 
-AssertStatement::AssertStatement(int start_line, int end_line, QoreValue cond, QoreValue msg)
-        : AbstractStatement(start_line, end_line), condition(cond), message(msg) {
+AssertStatement::AssertStatement(int start_line, int end_line, QoreValue exp)
+        : AbstractStatement(start_line, end_line) {
+    // If exp is a parse list, split it into condition and message args
+    if (exp.getType() == NT_PARSE_LIST) {
+        QoreParseListNode* l = exp.get<QoreParseListNode>();
+        if (l->size() >= 1) {
+            // First element is the condition
+            condition = l->get(0);
+            l->swap(0, QoreValue());  // prevent double-free
+
+            if (l->size() == 2) {
+                // Second element is the message (single value)
+                message = l->get(1);
+                // Take ownership to prevent double-free when l is deref'd
+                l->swap(1, QoreValue());
+            } else if (l->size() > 2) {
+                // Elements 1+ are format string and args - keep as list
+                QoreParseListNode* msg_args = l->copyBlank();
+                for (size_t i = 1; i < l->size(); ++i) {
+                    msg_args->add(l->get(i), l->getLocation(i));
+                    l->swap(i, QoreValue());
+                }
+                message = msg_args;
+            }
+        }
+        l->deref();
+    } else {
+        // Single expression is just the condition
+        condition = exp;
+    }
 }
 
 AssertStatement::~AssertStatement() {
@@ -56,7 +85,14 @@ int AssertStatement::execImpl(QoreValue& return_value, ExceptionSink* xsink) {
             if (*xsink) {
                 return 0;
             }
-            if (msg_val->getType() == NT_STRING) {
+            if (msg_val->getType() == NT_LIST) {
+                // Variadic case: use sprintf with the list (format, args...)
+                const QoreListNode* args = msg_val->get<const QoreListNode>();
+                msg_str = q_sprintf(args, -1, 0, xsink);
+                if (*xsink) {
+                    return 0;
+                }
+            } else if (msg_val->getType() == NT_STRING) {
                 msg_str = msg_val.takeReferencedValue().get<QoreStringNode>();
             } else {
                 bool del;
@@ -64,7 +100,14 @@ int AssertStatement::execImpl(QoreValue& return_value, ExceptionSink* xsink) {
                 if (*xsink) {
                     return 0;
                 }
-                msg_str = del ? static_cast<QoreStringNode*>(tmp) : new QoreStringNode(*tmp);
+                if (tmp) {
+                    msg_str = new QoreStringNode(*tmp);
+                    if (del) {
+                        delete tmp;
+                    }
+                } else {
+                    msg_str = new QoreStringNode("assertion failed");
+                }
             }
         } else {
             msg_str = new QoreStringNode("assertion failed");

--- a/lib/AssertStatement.cpp
+++ b/lib/AssertStatement.cpp
@@ -88,7 +88,7 @@ int AssertStatement::execImpl(QoreValue& return_value, ExceptionSink* xsink) {
             if (msg_val->getType() == NT_LIST) {
                 // Variadic case: use sprintf with the list (format, args...)
                 const QoreListNode* args = msg_val->get<const QoreListNode>();
-                msg_str = q_sprintf(args, -1, 0, xsink);
+                msg_str = q_sprintf(args, 0, 0, xsink);
                 if (*xsink) {
                     return 0;
                 }

--- a/lib/parser.ypp
+++ b/lib/parser.ypp
@@ -2263,10 +2263,9 @@ statement:
         $$ = new ThrowStatement(@1.first_line, @2.last_line, $2);
     }
     | TOK_ASSERT '(' exp ')' ';' {
+        // exp could be: single condition, or list (condition, msg, args...)
+        // AssertStatement handles both cases
         $$ = new AssertStatement(@1.first_line, @4.last_line, $3);
-    }
-    | TOK_ASSERT '(' exp ',' exp ')' ';' {
-        $$ = new AssertStatement(@1.first_line, @6.last_line, $3, $5);
     }
     | TOK_DEBUG '(' exp ')' ';' {
         $$ = new DebugStatement(@1.first_line, @4.last_line, $3);


### PR DESCRIPTION
## Summary

- Simplify grammar to single rule that handles all cases
- Constructor parses list to extract condition, message, and args
- Support variadic args: `@assert(cond, "fmt %d %s", arg1, arg2, ...)`
- Fix `getAsString` handling for non-string immediate values
- Add comprehensive corner case tests

## Test plan

- [x] Basic sprintf-style formatting: `@assert(False, "got %d", x)`
- [x] Multiple format args: `@assert(False, "expected %d but got %d", exp, act)`
- [x] Extra args ignored
- [x] Fewer args than placeholders handled gracefully
- [x] Non-string format converted to string: `@assert(False, 123)` → "123"
- [x] Complex expressions as args
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)