### PR TITLE
refs #5024 add %Y printf format specifier for multi-line YAML output

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -47,6 +47,8 @@
       - static @ref Program::getAllDefines() "Program::getAllDefines()"
     - new function:
       - @ref Qore::clock_getseconds() "clock_getseconds()"
+    - new @ref string_formatting "printf format specifier":
+      - \c %%Y: formats any value as multi-line pseudo-YAML with proper indentation for nested structures
     - new zero-cost assertion and debug statements
       - \c @@assert(condition) and \c @@assert(condition, message) throw \c ASSERTION-ERROR when condition is false
       - \c @@assert supports sprintf-style formatting: \c @@assert(condition, "format", arg1, arg2, ...)

--- a/examples/test/qore/functions/sprintf.qtest
+++ b/examples/test/qore/functions/sprintf.qtest
@@ -18,6 +18,7 @@ public class SprintfTest inherits QUnit::Test {
         addTestCase("separators", \separators());
         addTestCase("broken sprintf test", \brokenSprintf());
         addTestCase("Test 1", \test(), NOTHING);
+        addTestCase("yaml long format", \yamlLongFormat());
 
         # Return for compatibility with test harness that checks return value.
         set_return_value(main());
@@ -84,5 +85,61 @@ auto sub test1(string fmt) { softlist<auto> args = fmt; if (argv) args += argv; 
         assertEq("%", vsprintf("%%% s", ()));
         assertEq("arg", vsprintf("%s", "arg"));
         assertEq("arg", vsprintf("%s", ("arg",)));
+    }
+
+    yamlLongFormat() {
+        # Basic hash
+        assertEq("name: \"John\"\nage: 30", sprintf("%Y", ("name": "John", "age": 30)));
+
+        # Basic list
+        assertEq("- 1\n- 2\n- 3", sprintf("%Y", (1, 2, 3)));
+
+        # Nested hash
+        assertEq("outer:\n  inner: 1", sprintf("%Y", ("outer": ("inner": 1))));
+
+        # Deeply nested hash
+        assertEq("a:\n  b:\n    c: 1", sprintf("%Y", ("a": ("b": ("c": 1)))));
+
+        # Hash with list value
+        assertEq("items:\n  - 1\n  - 2\n  - 3", sprintf("%Y", ("items": (1, 2, 3))));
+
+        # List with hash items
+        assertEq("- 1\n- 2\n-\n  key: \"value\"", sprintf("%Y", (1, 2, ("key": "value"))));
+
+        # Nested list
+        assertEq("-\n  - 1\n  - 2\n-\n  - 3\n  - 4", sprintf("%Y", ((1, 2), (3, 4))));
+
+        # Empty containers
+        assertEq("empty_hash:\n  {}\nempty_list:\n  []", sprintf("%Y", ("empty_hash": {}, "empty_list": ())));
+
+        # NOTHING/null
+        assertEq("value: null", sprintf("%Y", ("value": NOTHING)));
+
+        # Binary data
+        assertEq("data: !!binary SGVsbG8=", sprintf("%Y", ("data": <48656c6c6f>)));
+
+        # Compare %y (short) vs %Y (long)
+        hash<auto> data = ("a": 1, "b": (1, 2));
+        assertEq("{a: 1, b: [1, 2]}", sprintf("%y", data));
+        assertEq("a: 1\nb:\n  - 1\n  - 2", sprintf("%Y", data));
+
+        # Top-level simple values use YAML short format
+        assertEq("42", sprintf("%Y", 42));
+        assertEq("\"hello\"", sprintf("%Y", "hello"));
+        assertEq("null", sprintf("%Y", NOTHING));
+
+        # Complex nested structure
+        hash<auto> complex = (
+            "users": (
+                ("name": "Alice", "age": 30),
+                ("name": "Bob", "age": 25),
+            ),
+            "config": (
+                "debug": True,
+                "timeout": 30,
+            ),
+        );
+        string expected = "users:\n  -\n    name: \"Alice\"\n    age: 30\n  -\n    name: \"Bob\"\n    age: 25\nconfig:\n  debug: True\n  timeout: 30";
+        assertEq(expected, sprintf("%Y", complex));
     }
 }

--- a/include/qore/AbstractQoreNode.h
+++ b/include/qore/AbstractQoreNode.h
@@ -41,6 +41,7 @@
 
 #include <cassert>
 
+#define FMT_YAML_LONG  -3
 #define FMT_YAML_SHORT -2
 #define FMT_NONE       -1
 #define FMT_NORMAL      0

--- a/lib/QoreHashNode.cpp
+++ b/lib/QoreHashNode.cpp
@@ -692,6 +692,39 @@ int QoreHashNode::getAsString(QoreString& str, int foff, ExceptionSink* xsink) c
         return 0;
     }
 
+    if (foff <= FMT_YAML_LONG) {
+        // Multi-line YAML format; indent encoded as FMT_YAML_LONG - foff
+        int indent = FMT_YAML_LONG - foff;
+        if (!size()) {
+            if (indent > 0)
+                str.addch(' ', indent);
+            str.concat("{}");
+            return 0;
+        }
+        ConstHashIterator hi(this);
+        while (hi.next()) {
+            if (indent > 0)
+                str.addch(' ', indent);
+            str.sprintf("%s:", hi.getKey());
+            QoreValue v = hi.get();
+            qore_type_t vtype = v.getType();
+            if (vtype == NT_HASH || vtype == NT_LIST) {
+                // Complex value: newline then indented content
+                str.concat('\n');
+                if (v.getAsString(str, foff - 2, xsink))
+                    return -1;
+            } else {
+                // Simple value: space then value in YAML short format
+                str.concat(' ');
+                if (v.getAsString(str, FMT_YAML_SHORT, xsink))
+                    return -1;
+            }
+            if (!hi.last())
+                str.concat('\n');
+        }
+        return 0;
+    }
+
     if (!size()) {
         str.concat(&EmptyHashString);
         return 0;
@@ -730,7 +763,7 @@ int QoreHashNode::getAsString(QoreString& str, int foff, ExceptionSink* xsink) c
 QoreString* QoreHashNode::getAsString(bool &del, int foff, ExceptionSink* xsink) const {
     del = false;
     size_t elements = size();
-    if (!elements && foff != FMT_YAML_SHORT)
+    if (!elements && foff != FMT_YAML_SHORT && foff > FMT_YAML_LONG)
         return &EmptyHashString;
 
     TempString rv(new QoreString);

--- a/lib/QoreLib.cpp
+++ b/lib/QoreLib.cpp
@@ -781,6 +781,11 @@ static int process_opt(QoreString *cstr, char* param, QoreValue qv, int type, bo
             tbuf.concat(*t, xsink);
             break;
         }
+        case 'Y': {
+            QoreNodeAsStringHelper t(qv, FMT_YAML_LONG, xsink);
+            tbuf.concat(*t, xsink);
+            break;
+        }
         default:
             // if the format argument is not understood, then make sure and just consume the '%' char
             tbuf.concat('%');

--- a/lib/QoreListNode.cpp
+++ b/lib/QoreListNode.cpp
@@ -995,6 +995,39 @@ int QoreListNode::getAsString(QoreString &str, int foff, ExceptionSink* xsink) c
         return 0;
     }
 
+    if (foff <= FMT_YAML_LONG) {
+        // Multi-line YAML format; indent encoded as FMT_YAML_LONG - foff
+        int indent = FMT_YAML_LONG - foff;
+        if (!size()) {
+            if (indent > 0)
+                str.addch(' ', indent);
+            str.concat("[]");
+            return 0;
+        }
+        ConstListIterator li(this);
+        while (li.next()) {
+            if (indent > 0)
+                str.addch(' ', indent);
+            str.concat('-');
+            QoreValue v = li.getValue();
+            qore_type_t vtype = v.getType();
+            if (vtype == NT_HASH || vtype == NT_LIST) {
+                // Complex value: newline then indented content
+                str.concat('\n');
+                if (v.getAsString(str, foff - 2, xsink))
+                    return -1;
+            } else {
+                // Simple value: space then value in YAML short format
+                str.concat(' ');
+                if (v.getAsString(str, FMT_YAML_SHORT, xsink))
+                    return -1;
+            }
+            if (!li.last())
+                str.concat('\n');
+        }
+        return 0;
+    }
+
     if (!size()) {
         str.concat(&EmptyListString);
         return 0;
@@ -1038,7 +1071,7 @@ int QoreListNode::getAsString(QoreString &str, int foff, ExceptionSink* xsink) c
 // use the QoreNodeAsStringHelper class (defined in QoreStringNode.h) instead of using this function directly
 QoreString *QoreListNode::getAsString(bool &del, int foff, ExceptionSink* xsink) const {
     del = false;
-    if (!priv->length && foff != FMT_YAML_SHORT) {
+    if (!priv->length && foff != FMT_YAML_SHORT && foff > FMT_YAML_LONG) {
         return &EmptyListString;
     }
 

--- a/lib/QoreNothingNode.cpp
+++ b/lib/QoreNothingNode.cpp
@@ -50,14 +50,14 @@ QoreValue QoreNothingNode::evalImpl(bool& needs_deref, ExceptionSink* xsink) con
 // use the QoreNodeAsStringHelper class (defined in QoreStringNode.h) instead of using these functions directly
 // returns -1 for exception raised, 0 = OK
 int QoreNothingNode::getAsString(QoreString &str, int foff, ExceptionSink *xsink) const {
-    str.concat(foff == FMT_YAML_SHORT ? &YamlNullString : &NothingTypeString);
+    str.concat((foff == FMT_YAML_SHORT || foff <= FMT_YAML_LONG) ? &YamlNullString : &NothingTypeString);
     return 0;
 }
 
 // if del is true, then the returned QoreString * should be deleted, if false, then it must not be
 QoreString *QoreNothingNode::getAsString(bool &del, int foff, ExceptionSink *xsink) const {
     del = false;
-    return foff == FMT_YAML_SHORT ? &YamlNullString : &NothingTypeString;
+    return (foff == FMT_YAML_SHORT || foff <= FMT_YAML_LONG) ? &YamlNullString : &NothingTypeString;
 }
 
 // performs a lexical compare, return -1, 0, or 1 if the "this" value is less than, equal, or greater than

--- a/lib/QoreValue.cpp
+++ b/lib/QoreValue.cpp
@@ -438,7 +438,8 @@ void QoreValue::discard(ExceptionSink* xsink) {
 
 int QoreValue::getAsString(QoreString& str, int format_offset, ExceptionSink *xsink) const {
     if (isNothing()) {
-        str.concat(format_offset == FMT_YAML_SHORT ? &YamlNullString : &NothingTypeString);
+        str.concat((format_offset == FMT_YAML_SHORT || format_offset <= FMT_YAML_LONG)
+            ? &YamlNullString : &NothingTypeString);
         return 0;
     }
     switch (type) {
@@ -461,7 +462,8 @@ int QoreValue::getAsString(QoreString& str, int format_offset, ExceptionSink *xs
 QoreString* QoreValue::getAsString(bool& del, int format_offset, ExceptionSink* xsink) const {
     if (isNothing()) {
         del = false;
-        return format_offset == FMT_YAML_SHORT ? &YamlNullString : &NothingTypeString;
+        return (format_offset == FMT_YAML_SHORT || format_offset <= FMT_YAML_LONG)
+            ? &YamlNullString : &NothingTypeString;
     }
     switch (type) {
         case QV_Int: del = true; return new QoreStringMaker(QLLD, v.i);

--- a/lib/ql_string.qpp
+++ b/lib/ql_string.qpp
@@ -548,6 +548,7 @@ const RE_Unicode = PCRE2_UCP;
     |\c x|Integer, output in base 16 (hexadecimal) format with lower-case a-f
     |\c X|Integer, output in base 16 (hexadecimal) format with upper-case A-F
     |\c y|Any %Qore value, formatted as a pseudo-YAML string, without any line breaks; this format option is similar to \c "%n", but uses a YAML-like format.  Note that the output is not guaranteed to be parsed by the yaml module's parseYAML() function; it is for display purposes only; to get real YAML functionality, use the yaml module.
+    |\c Y|Any %Qore value, formatted as a multi-line pseudo-YAML string with proper indentation for nested structures; similar to \c "%y" but with line breaks and indentation for readability. Note that the output is not guaranteed to be parsed by the yaml module's parseYAML() function; it is for display purposes only; to get real YAML functionality, use the yaml module.
 
     @anchor string_escape_chars
     <b>String Escape Characters</b>


### PR DESCRIPTION
## Summary

- Add new `%Y` printf format specifier for multi-line YAML-like output with proper indentation
- Complements existing `%y` (single-line) format specifier

## Changes

- Add `FMT_YAML_LONG` constant (-3) for multi-line YAML formatting
- Indent level encoded as: `indent = FMT_YAML_LONG - foff`
- Complex values (hash/list) get newline + increased indent
- Simple values use `FMT_YAML_SHORT` for consistent quoting
- Empty containers output as `{}` and `[]`
- NOTHING outputs as `null`

## Example

```qore
hash<auto> data = ("name": "John", "items": (1, 2, 3));

printf("%y\n", data);
# Output: {name: "John", items: [1, 2, 3]}

printf("%Y\n", data);  
# Output:
# name: "John"
# items:
#   - 1
#   - 2
#   - 3
```

## Test plan

- [x] Basic hash formatting
- [x] Nested hash formatting (2-3 levels deep)
- [x] Basic list formatting
- [x] List with hash items
- [x] Nested lists
- [x] Empty containers (`{}`, `[]`)
- [x] NOTHING/null values (top-level and nested)
- [x] Binary data (`!!binary` format)
- [x] Complex nested structures
- [x] All existing sprintf tests still pass

Closes #5024

🤖 Generated with [Claude Code](https://claude.com/claude-code)