### PR TITLE
refs #5033 fix client certificate capture in async I/O mode

### DIFF
--- a/examples/test/qore/classes/HTTPClient/HTTPClient.qtest
+++ b/examples/test/qore/classes/HTTPClient/HTTPClient.qtest
@@ -206,8 +206,7 @@ class RealTestHttpServer inherits HttpServer {
         return <HttpServerOptionInfo>{
             "logger": logger,
             "debug": True,
-            # Disable async mode due to client cert capture issue (see GitHub issue)
-            "async_mode": False,
+            "async_mode": True,
         };
     }
 }

--- a/qlib/HttpServer.qm
+++ b/qlib/HttpServer.qm
@@ -2719,6 +2719,15 @@ public class HttpListener inherits Qore::Socket, HttpServer::HttpListenerInterfa
         return opts.key;
     }
 
+    #! Returns whether to accept all client certificates (including self-signed) for async mode
+    /** @return True if all client certificates should be accepted
+
+        @since HttpServer 1.5
+    */
+    bool getSslAcceptAllCerts() {
+        return ssl_accept_all_certs;
+    }
+
     auto removeUserThreadContext(*string k) {
         if (!exists k) {
             remove_thread_data("uctx");
@@ -4121,6 +4130,7 @@ class HttpServerIoController {
                                         linfo.listener.getSslCertificateObject(),
                                         linfo.listener.getSslPrivateKeyObject(),
                                         linfo.listener.getSslVerifyFlags(),
+                                        linfo.listener.getSslAcceptAllCerts(),
                                     );
                                 @debug(log(LoggerLevel::DEBUG, "ioThread: accept op created for listener %s", key));
                             } catch (hash<ExceptionInfo> ex) {

--- a/qlib/HttpServerAsyncIo/HttpAcceptPollOperation.qc
+++ b/qlib/HttpServerAsyncIo/HttpAcceptPollOperation.qc
@@ -159,10 +159,8 @@ public class HttpAcceptPollOperation inherits AbstractPollOperation {
                             client_sock.setSslVerifyMode(ssl_verify_flags);
                             client_sock.captureRemoteCertificates();
                         }
-                        # Accept all client certificates if configured
-                        if (ssl_accept_all_certs) {
-                            client_sock.acceptAllCertificates();
-                        }
+                        # Configure client certificate acceptance behavior
+                        client_sock.acceptAllCertificates(ssl_accept_all_certs);
                         spop = client_sock.startPollUpgradeServerToSSL();
                         @assert(spop, "startPollUpgradeServerToSSL must return poll operation");
                         # Continue loop to poll the new operation

--- a/qlib/HttpServerAsyncIo/HttpAcceptPollOperation.qc
+++ b/qlib/HttpServerAsyncIo/HttpAcceptPollOperation.qc
@@ -61,6 +61,9 @@ public class HttpAcceptPollOperation inherits AbstractPollOperation {
         #! SSL verify flags for client certificate verification
         int ssl_verify_flags = SSL_VERIFY_NONE;
 
+        #! Accept all client certificates (including self-signed)
+        bool ssl_accept_all_certs = True;
+
         #! Current poll operation being executed
         SocketPollOperation spop;
 
@@ -77,9 +80,10 @@ public class HttpAcceptPollOperation inherits AbstractPollOperation {
         @param cert SSL certificate (SSLCertificate object or PEM data, required if ssl is True)
         @param key SSL private key (SSLPrivateKey object or PEM data, required if ssl is True)
         @param ssl_verify_flags SSL verification flags for client certificate verification (e.g. SSL_VERIFY_PEER)
+        @param ssl_accept_all_certs if True, accept all client certificates including self-signed ones
     */
     constructor(Socket listener, bool ssl = False, auto cert = NOTHING, auto key = NOTHING,
-            int ssl_verify_flags = SSL_VERIFY_NONE) {
+            int ssl_verify_flags = SSL_VERIFY_NONE, bool ssl_accept_all_certs = True) {
         @assert(listener, "listener socket cannot be null");
         @assert(!ssl || (cert && key), "SSL mode requires certificate and key");
         self.listener = listener;
@@ -87,6 +91,7 @@ public class HttpAcceptPollOperation inherits AbstractPollOperation {
         self.cert = cert;
         self.key = key;
         self.ssl_verify_flags = ssl_verify_flags;
+        self.ssl_accept_all_certs = ssl_accept_all_certs;
         # Start the accept poll operation
         spop = listener.startPollAccept();
         @assert(spop, "startPollAccept must return poll operation");
@@ -153,6 +158,10 @@ public class HttpAcceptPollOperation inherits AbstractPollOperation {
                         if (ssl_verify_flags != SSL_VERIFY_NONE) {
                             client_sock.setSslVerifyMode(ssl_verify_flags);
                             client_sock.captureRemoteCertificates();
+                        }
+                        # Accept all client certificates if configured
+                        if (ssl_accept_all_certs) {
+                            client_sock.acceptAllCertificates();
                         }
                         spop = client_sock.startPollUpgradeServerToSSL();
                         @assert(spop, "startPollUpgradeServerToSSL must return poll operation");


### PR DESCRIPTION
## Summary

Fixed client certificate capture in HttpServer async I/O mode by adding the missing `acceptAllCertificates()` call to the async SSL handshake flow.

- Added `ssl_accept_all_certs` parameter to `HttpAcceptPollOperation`
- Added `getSslAcceptAllCerts()` getter method to `HttpListener`
- Pass `ssl_accept_all_certs` when creating `HttpAcceptPollOperation`
- Re-enabled `async_mode` in HTTPClient.qtest (fix is now working)

## Root Cause

In sync mode, `acceptAllCertificates()` was called on the listener socket, and the accepted client sockets inherited this setting.

In async mode, SSL was not configured on the listener socket (to allow manual SSL handshake with client certificate verification). The `HttpAcceptPollOperation` was calling `setSslVerifyMode()` and `captureRemoteCertificates()` on the client socket before the SSL handshake, but it was missing the `acceptAllCertificates()` call.

Without `acceptAllCertificates()`, the SSL handshake would fail when the client presented a self-signed certificate, causing the connection to close before sending a response.

## Test plan

- [x] Run HTTPClient.qtest with async_mode enabled
- [x] Verify client certs test passes with 10 assertions
- [x] Verify all other tests still pass

Closes #5033

🤖 Generated with [Claude Code](https://claude.com/claude-code)