### PR TITLE
refs #5076 Implement parse-time type narrowing for hash<auto> and list<auto>

### DIFF
--- a/examples/test/qlib/FileLocationHandler/FileLocationHandler.qtest
+++ b/examples/test/qlib/FileLocationHandler/FileLocationHandler.qtest
@@ -156,11 +156,11 @@ public class FileLocationHandlerTest inherits QUnit::Test {
         list<string> l = FileLocationHandler::getHandlerNames();
         assertGt(0, l.size());
 
-        hash<auto> h = FileLocationHandler::getHandlers();
-        assertGt(0, h.size());
+        hash<auto> handlers = FileLocationHandler::getHandlers();
+        assertGt(0, handlers.size());
 
-        h = FileLocationHandler::getHandlerInfo("http");
-        assertEq("http", h.scheme);
+        hash<auto> info = FileLocationHandler::getHandlerInfo("http");
+        assertEq("http", info.scheme);
     }
 
     private dataTests() {

--- a/examples/test/qlib/OpenApi3/OpenApi3.qtest
+++ b/examples/test/qlib/OpenApi3/OpenApi3.qtest
@@ -1032,7 +1032,8 @@ public class OpenApi3Test inherits QUnit::Test {
             {
                 OpenApi3Schema so("", soh);
                 string uri_path = "/test?float=1.1&dt=1726733382";
-                hash<auto> hdr = {"Test-Header": "Test"};
+                # Use += to avoid type narrowing; parseRequest takes reference<hash<auto>>
+                hash<auto> hdr += {"Test-Header": "Test"};
                 hash<RestRequestServerInfo> req = so.parseRequest("GET", uri_path, NOTHING, \hdr);
                 assertEq(Type::Float, req.query."float".type());
                 assertEq(2024-09-19T10:09:42, req.query.dt);
@@ -1316,7 +1317,8 @@ public class OpenApi3Test inherits QUnit::Test {
         hash oh = OpenApi3Loader::parseSchemaContent(filePath, ReadOnlyFile::readTextFile(filePath));
         OperationObject op = new OperationObject("/create", "post", oh.paths."/create".post, openapi3);
         string body = "body";
-        hash<auto> headers = {"header": "header"};
+        # Use += to avoid type narrowing; validateRequest takes reference<hash>
+        hash<auto> headers += {"header": "header"};
 
         assertThrows("SCHEMA-VALIDATION-ERROR",
             'Parameter \"formData.upfile\".*expected type is \"string\"',
@@ -3249,7 +3251,8 @@ public class OpenApi3Test inherits QUnit::Test {
             #printf("h: %y\n", h);
 
             {
-                hash<auto> hdr = ("content-type": h.content);
+                # Use += to avoid type narrowing; parseRequest takes reference<hash<auto>>
+                hash<auto> hdr += ("content-type": h.content);
                 hash<RestRequestServerInfo> sh = so.parseRequest("post", h.uri_path, h.body, \hdr);
                 on_error printf("sh: %N\n", sh);
                 assertEq("/api/unix-time", sh.path);

--- a/examples/test/qlib/ServiceNowRestClient/ServiceNowRestClient.qtest
+++ b/examples/test/qlib/ServiceNowRestClient/ServiceNowRestClient.qtest
@@ -541,12 +541,12 @@ class ServiceNowTest inherits QUnit::Test {
 
             monitor.add(snrc);
 
-            info = monitor.waitForResult();
-            assertEq(info.name, "test");
-            on_error if (info.ex) {
-                printf("%s\n", get_exception_string(info.ex));
+            hash<auto> poll_info = monitor.waitForResult();
+            assertEq(poll_info.name, "test");
+            on_error if (poll_info.ex) {
+                printf("%s\n", get_exception_string(poll_info.ex));
             }
-            assertEq("OK", info.result);
+            assertEq("OK", poll_info.result);
         }
 
         if (snopts.oauth2_client_id && snopts.oauth2_client_secret && snopts.username && snopts.password
@@ -573,12 +573,12 @@ class ServiceNowTest inherits QUnit::Test {
 
             monitor.add(snrc);
 
-            info = monitor.waitForResult();
-            assertEq(info.name, "test");
-            on_error if (info.ex) {
-                printf("%s\n", get_exception_string(info.ex));
+            hash<auto> poll_info = monitor.waitForResult();
+            assertEq(poll_info.name, "test");
+            on_error if (poll_info.ex) {
+                printf("%s\n", get_exception_string(poll_info.ex));
             }
-            assertEq("OK", info.result);
+            assertEq("OK", poll_info.result);
         }
     }
 

--- a/examples/test/qlib/Swagger/Swagger.qtest
+++ b/examples/test/qlib/Swagger/Swagger.qtest
@@ -903,7 +903,8 @@ public class SwaggerTest inherits QUnit::Test {
             {
                 SwaggerSchema so("", soh);
                 string uri_path = "/test?float=1.1&dt=1726733382";
-                hash<auto> hdr = {"Test-Header": "Test"};
+                # Use += to avoid type narrowing; parseRequest takes reference<hash<auto>>
+                hash<auto> hdr += {"Test-Header": "Test"};
                 hash<RestRequestServerInfo> req = so.parseRequest("GET", uri_path, NOTHING, \hdr);
                 assertEq(Type::Float, req.query."float".type());
                 assertEq(2024-09-19T08:09:42Z, req.query.dt);
@@ -1191,7 +1192,8 @@ public class SwaggerTest inherits QUnit::Test {
         hash oh = SwaggerLoader::parseSchemaContent(filePath, ReadOnlyFile::readTextFile(filePath));
         OperationObject op = new OperationObject("/create", "post", oh.paths."/create".post, swagger);
         string body = "body";
-        hash<auto> headers = {"header": "header"};
+        # Use += to avoid type narrowing; validateRequest takes reference<hash>
+        hash<auto> headers += {"header": "header"};
 
         assertThrows("SCHEMA-VALIDATION-ERROR",
             'Parameter \"formData.upfile\".*expected type is \"file\"',
@@ -2663,7 +2665,8 @@ public class SwaggerTest inherits QUnit::Test {
             #printf("h: %y\n", h);
 
             {
-                hash<auto> hdr = ("content-type": h.content);
+                # Use += to avoid type narrowing; parseRequest takes reference<hash<auto>>
+                hash<auto> hdr += ("content-type": h.content);
                 hash<RestRequestServerInfo> sh = so.parseRequest("post", h.uri_path, h.body, \hdr);
                 on_error printf("sh: %N\n", sh);
                 assertEq("/api/unix-time", sh.path);

--- a/examples/test/qore/vars/overload.qtest
+++ b/examples/test/qore/vars/overload.qtest
@@ -282,9 +282,12 @@ public class OverloadTest inherits QUnit::Test {
     }
 
     issue3441() {
+        # With type narrowing, hash<auto> h = <StatInfo>{} narrows to hash<StatInfo>
+        # and the type mismatch is caught at parse time, not runtime
         Program p(PO_NEW_STYLE);
-        p.parse("sub t(hash<string, bool> h) {} sub t(int x) {} hash<auto> h = <StatInfo>{}; t(h);", "");
-        assertThrows("RUNTIME-OVERLOAD-ERROR", "t\\(hash<.*StatInfo>\\)", \p.run());
+        assertThrows("PARSE-TYPE-ERROR", sub() {
+            p.parse("sub t(hash<string, bool> h) {} sub t(int x) {} hash<auto> h = <StatInfo>{}; t(h);", "");
+        });
     }
 
     testValues() {

--- a/examples/test/qore/vars/type_narrowing.qtest
+++ b/examples/test/qore/vars/type_narrowing.qtest
@@ -1,0 +1,749 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class TypeNarrowingTest
+
+public class TypeNarrowingTest inherits QUnit::Test {
+    constructor() : QUnit::Test("TypeNarrowingTest", "1.0") {
+        addTestCase("hash<auto> basic narrowing", \hashAutoBasicTest());
+        addTestCase("list<auto> basic narrowing", \listAutoBasicTest());
+        addTestCase("hash<auto> compatible assignment", \hashAutoCompatibleTest());
+        addTestCase("list<auto> compatible assignment", \listAutoCompatibleTest());
+        addTestCase("pure auto not narrowed", \pureAutoNotNarrowedTest());
+        addTestCase("hash<auto> multiple assignments", \hashAutoMultipleAssignmentsTest());
+        addTestCase("list<auto> multiple assignments", \listAutoMultipleAssignmentsTest());
+        addTestCase("nested hash<auto>", \nestedHashAutoTest());
+        addTestCase("hash<auto> with different value types", \hashAutoDifferentValuesTest());
+        addTestCase("list<auto> append operations", \listAutoAppendTest());
+        addTestCase("softlist<auto> narrowing", \softlistAutoTest());
+        addTestCase("hash<auto> slice operations", \hashAutoSliceTest());
+        addTestCase("empty hash<auto> initialization", \emptyHashAutoTest());
+        addTestCase("empty list<auto> initialization", \emptyListAutoTest());
+        addTestCase("hash<auto> with complex values", \hashAutoComplexValuesTest());
+        addTestCase("type narrowing parse error detection", \parseErrorDetectionTest());
+        addTestCase("broken-narrowed-types option", \brokenNarrowedTypesTest());
+        addTestCase("hash<auto> with nothing values", \hashAutoNothingTest());
+        addTestCase("list<auto> with nothing values", \listAutoNothingTest());
+        addTestCase("*hash<auto> or-nothing type", \hashAutoOrNothingTest());
+        addTestCase("*list<auto> or-nothing type", \listAutoOrNothingTest());
+        addTestCase("hash<auto> key deletion", \hashAutoKeyDeletionTest());
+        addTestCase("list<auto> element operations", \listAutoElementOpsTest());
+        addTestCase("global hash<auto> variable", \globalHashAutoTest());
+        addTestCase("branch type reset", \branchTypeResetTest());
+        addTestCase("branch type merge same", \branchTypeMergeSameTest());
+        addTestCase("branch type merge compatible", \branchTypeMergeCompatibleTest());
+        addTestCase("branch type merge incompatible", \branchTypeMergeIncompatibleTest());
+        addTestCase("branch no else", \branchNoElseTest());
+        addTestCase("switch type merge same", \switchTypeMergeSameTest());
+        addTestCase("switch type merge incompatible", \switchTypeMergeIncompatibleTest());
+        addTestCase("switch no default", \switchNoDefaultTest());
+        addTestCase("switch with default", \switchWithDefaultTest());
+        addTestCase("closure variable narrowing", \closureVarNarrowingTest());
+
+        set_return_value(main());
+    }
+
+    # Basic hash<auto> narrowing - value type should be tracked
+    hashAutoBasicTest() {
+        hash<auto> h = {"a": "b", "c": "d"};
+        assertEq("string", h.a.type());
+        assertEq("b", h.a);
+
+        # Compatible assignment should work
+        h.e = "f";
+        assertEq("f", h.e);
+    }
+
+    # Basic list<auto> narrowing - element type should be tracked
+    listAutoBasicTest() {
+        list<auto> l = (1, 2, 3);
+        assertEq("integer", l[0].type());
+        assertEq(1, l[0]);
+
+        # Compatible assignment should work
+        l[0] = 100;
+        assertEq(100, l[0]);
+    }
+
+    # Hash with compatible string assignments
+    hashAutoCompatibleTest() {
+        hash<auto> h = {"key1": "value1"};
+        h.key2 = "value2";
+        h{"key3"} = "value3";
+
+        assertEq("value1", h.key1);
+        assertEq("value2", h.key2);
+        assertEq("value3", h.key3);
+        assertEq(3, h.size());
+    }
+
+    # List with compatible int assignments
+    listAutoCompatibleTest() {
+        list<auto> l = (10, 20, 30);
+        l[0] = 100;
+        l[1] = 200;
+        l += 40;
+
+        assertEq(100, l[0]);
+        assertEq(200, l[1]);
+        assertEq(30, l[2]);
+        assertEq(40, l[3]);
+    }
+
+    # Pure auto should NOT be narrowed - can hold any type
+    pureAutoNotNarrowedTest() {
+        auto v;
+        v = {"a": "b"};
+        assertEq("hash", v.type());
+
+        v = (1, 2, 3);
+        assertEq("list", v.type());
+
+        v = "string";
+        assertEq("string", v.type());
+
+        v = 42;
+        assertEq("integer", v.type());
+    }
+
+    # Multiple assignments to hash<auto> should work if compatible
+    hashAutoMultipleAssignmentsTest() {
+        hash<auto> h = {"a": "first"};
+        h.a = "second";
+        h.a = "third";
+        h.b = "new";
+
+        assertEq("third", h.a);
+        assertEq("new", h.b);
+    }
+
+    # Multiple assignments to list<auto> should work if compatible
+    listAutoMultipleAssignmentsTest() {
+        list<auto> l = (1,);
+        l[0] = 2;
+        l[0] = 3;
+        l += 4;
+        l += 5;
+
+        assertEq(3, l[0]);
+        assertEq(4, l[1]);
+        assertEq(5, l[2]);
+    }
+
+    # Nested hash structures
+    nestedHashAutoTest() {
+        hash<auto> outer = {
+            "inner": {
+                "key": "value"
+            }
+        };
+
+        assertEq("hash", outer.inner.type());
+        assertEq("value", outer.inner.key);
+
+        # Assign to nested key
+        outer.inner.key2 = "value2";
+        assertEq("value2", outer.inner.key2);
+    }
+
+    # Hash with different initial value types
+    hashAutoDifferentValuesTest() {
+        # Hash with int values
+        hash<auto> h1 = {"a": 1, "b": 2};
+        assertEq(1, h1.a);
+        h1.c = 3;
+        assertEq(3, h1.c);
+
+        # Hash with float values
+        hash<auto> h2 = {"x": 1.5, "y": 2.5};
+        assertEq(1.5, h2.x);
+        h2.z = 3.5;
+        assertEq(3.5, h2.z);
+
+        # Hash with bool values
+        hash<auto> h3 = {"t": True, "f": False};
+        assertEq(True, h3.t);
+        h3.u = True;
+        assertEq(True, h3.u);
+    }
+
+    # List append operations
+    listAutoAppendTest() {
+        list<auto> l = (1, 2);
+        l += 3;
+        l += (4, 5);
+        push l, 6;
+
+        assertEq((1, 2, 3, 4, 5, 6), l);
+    }
+
+    # softlist<auto> is NOT narrowed at parse time because it accepts scalar values
+    # that get automatically converted to lists, making type narrowing incorrect.
+    # However, runtime type checking still applies.
+    softlistAutoTest() {
+        softlist<auto> sl = (1, 2, 3);
+        assertEq(1, sl[0]);
+
+        # Compatible assignment works
+        sl[0] = 100;
+        assertEq(100, sl[0]);
+
+        # Note: runtime type checking still enforces element types
+        # even though parse-time narrowing is disabled for softlist<auto>
+    }
+
+    # Hash slice operations
+    hashAutoSliceTest() {
+        hash<auto> h = {"a": 1, "b": 2, "c": 3};
+        hash slice = h{("a", "b")};
+
+        assertEq(1, slice.a);
+        assertEq(2, slice.b);
+        assertFalse(slice.hasKey("c"));
+    }
+
+    # Empty hash initialization
+    emptyHashAutoTest() {
+        hash<auto> h = {};
+        assertEq(0, h.size());
+
+        # Can assign any type to empty hash
+        h.a = "string";
+        assertEq("string", h.a);
+    }
+
+    # Empty list initialization
+    emptyListAutoTest() {
+        list<auto> l = ();
+        assertEq(0, l.size());
+
+        # Can assign any type to empty list
+        l += 1;
+        assertEq(1, l[0]);
+    }
+
+    # Hash with complex value types
+    hashAutoComplexValuesTest() {
+        # Hash of lists
+        hash<auto> h1 = {"a": (1, 2, 3), "b": (4, 5, 6)};
+        assertEq((1, 2, 3), h1.a);
+        h1.c = (7, 8, 9);
+        assertEq((7, 8, 9), h1.c);
+
+        # Hash of hashes
+        hash<auto> h2 = {"a": {"x": 1}, "b": {"y": 2}};
+        assertEq(1, h2.a.x);
+        h2.c = {"z": 3};
+        assertEq(3, h2.c.z);
+    }
+
+    # Test that parse errors are detected for type mismatches
+    parseErrorDetectionTest() {
+        # This test verifies that parse errors are raised for incompatible assignments
+        # We use Program to test parse-time behavior
+
+        # Should fail: assigning int to hash<string, string>
+        string code1 = "%new-style
+sub test() {
+    hash<auto> h = {\"a\": \"b\"};
+    h.c = 1;
+}
+";
+        assertThrows("PARSE-TYPE-ERROR", sub() { Program p(); p.parse(code1, "test1"); });
+
+        # Should fail: assigning string to list<int>
+        string code2 = "%new-style
+sub test() {
+    list<auto> l = (1, 2, 3);
+    l[0] = \"x\";
+}
+";
+        assertThrows("PARSE-TYPE-ERROR", sub() { Program p(); p.parse(code2, "test2"); });
+
+        # Should succeed: compatible assignment
+        string code3 = "%new-style
+sub test() {
+    hash<auto> h = {\"a\": \"b\"};
+    h.c = \"d\";
+}
+";
+        {
+            Program p();
+            p.parse(code3, "test3");
+            # No exception means success
+        }
+
+        # Should succeed: compatible list assignment
+        string code4 = "%new-style
+sub test() {
+    list<auto> l = (1, 2, 3);
+    l[0] = 100;
+}
+";
+        {
+            Program p();
+            p.parse(code4, "test4");
+            # No exception means success
+        }
+    }
+
+    # Test %broken-narrowed-types option
+    brokenNarrowedTypesTest() {
+        # With %broken-narrowed-types, parse errors should not be raised
+        string code = "%new-style
+%broken-narrowed-types
+sub test() {
+    hash<auto> h = {\"a\": \"b\"};
+    h.c = 1;
+}
+";
+
+        # Should parse without error (runtime error would occur if executed)
+        {
+            Program p();
+            p.parse(code, "test_broken");
+            # No exception means the parse succeeded
+        }
+
+        # Verify the directive is recognized
+        string code2 = "%new-style
+%broken-narrowed-types
+%correct-narrowed-types
+sub test() {
+    hash<auto> h = {\"a\": \"b\"};
+    h.c = 1;
+}
+";
+        # With %correct-narrowed-types after %broken-narrowed-types, error should be raised
+        assertThrows("PARSE-TYPE-ERROR", sub() { Program p(); p.parse(code2, "test_correct"); });
+    }
+
+    hashAutoNothingTest() {
+        # Hash with only string values should narrow to hash<string, string>
+        hash<auto> h = {"a": "x", "b": "y"};
+        assertEq("x", h.a);
+        assertEq("y", h.b);
+
+        # NOTHING is accepted by any type in Qore (converts to default value at runtime)
+        # So this should parse successfully
+        string code = "%new-style
+sub test() {
+    hash<auto> h = {\"a\": \"b\"};
+    h.c = NOTHING;
+}
+";
+        # Should parse without error - NOTHING is compatible with any type
+        {
+            Program p();
+            p.parse(code, "test_nothing");
+        }
+    }
+
+    listAutoNothingTest() {
+        # List with ints should narrow to list<int>
+        list<auto> l = (1, 2, 3);
+        assertEq(1, l[0]);
+        assertEq(2, l[1]);
+        assertEq(3, l[2]);
+
+        # NOTHING is accepted by any type in Qore
+        string code = "%new-style
+sub test() {
+    list<auto> l = (1, 2, 3);
+    l[0] = NOTHING;
+}
+";
+        # Should parse without error - NOTHING is compatible with any type
+        {
+            Program p();
+            p.parse(code, "test_list_nothing");
+        }
+    }
+
+    hashAutoOrNothingTest() {
+        # Test or-nothing hash variable
+        *hash<auto> h;
+        assertEq(NOTHING, h);
+
+        # After assignment, can still read values
+        h = {"a": "b"};
+        assertEq("b", h.a);
+
+        # Note: assigning NOTHING to *hash<auto> after narrowing requires
+        # preserving the or-nothing aspect during narrowing (future enhancement)
+    }
+
+    listAutoOrNothingTest() {
+        # Test or-nothing list variable
+        *list<auto> l;
+        assertEq(NOTHING, l);
+
+        # After assignment, can still read values
+        l = (1, 2, 3);
+        assertEq(1, l[0]);
+
+        # Note: assigning NOTHING to *list<auto> after narrowing requires
+        # preserving the or-nothing aspect during narrowing (future enhancement)
+    }
+
+    hashAutoKeyDeletionTest() {
+        hash<auto> h = {"a": "x", "b": "y", "c": "z"};
+        assertEq(3, h.size());
+
+        remove h.b;
+        assertEq(2, h.size());
+        assertFalse(h.hasKey("b"));
+
+        # Can still add keys after deletion
+        h.d = "w";
+        assertEq(3, h.size());
+        assertEq("w", h.d);
+    }
+
+    listAutoElementOpsTest() {
+        list<auto> l = (1, 2, 3);
+
+        # pop element
+        int popped = pop l;
+        assertEq(3, popped);
+        assertEq(2, l.size());
+
+        # shift element
+        int shifted = shift l;
+        assertEq(1, shifted);
+        assertEq(1, l.size());
+
+        # push element
+        push l, 10;
+        assertEq(2, l.size());
+        assertEq(10, l[1]);
+
+        # unshift element
+        unshift l, 0;
+        assertEq(3, l.size());
+        assertEq(0, l[0]);
+    }
+
+    globalHashAutoTest() {
+        # Test that global variable narrowing works via the VT_GLOBAL code path
+        # Note: Static class members use a different code path and are not currently narrowed
+        # This test verifies the behavior with function-scope variables which ARE narrowed
+
+        # Test that narrowing works properly in a function context
+        # Should fail: assigning string to hash<string, int>
+        string code1 = "%new-style
+sub test() {
+    hash<auto> gh = {\"x\": 1, \"y\": 2};
+    gh.z = \"invalid\";
+}
+";
+        assertThrows("PARSE-TYPE-ERROR", sub() {
+            Program p(PO_NEW_STYLE);
+            p.parse(code1, "global_test1");
+        });
+
+        # Should succeed: compatible int assignment
+        string code2 = "%new-style
+sub test() {
+    hash<auto> gh = {\"x\": 1, \"y\": 2};
+    gh.z = 3;
+}
+";
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse(code2, "global_test2");
+            # No exception means success
+        }
+    }
+
+    # Test branch type tracking - variable narrowed in if branch resets after
+    branchTypeResetTest() {
+        # Test that narrowing inside a branch doesn't affect code after
+        string code = "%new-style
+string sub test() {
+    hash<auto> h;
+    if (True) {
+        h = {\"a\": \"b\"};
+        # Inside branch, h is narrowed to hash<string, string>
+    }
+    # After branch, h should be back to hash<auto>
+    h.x = 1;  # Should work - hash<auto> accepts any value
+    return \"ok\";
+}
+";
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse(code, "branch_reset_test");
+            # No parse error means the narrowing was reset after the branch
+        }
+    }
+
+    # Test branch type merging - same type in both branches
+    branchTypeMergeSameTest() {
+        # When both branches narrow to same type, that type should persist
+        string code = "%new-style
+sub test() {
+    hash<auto> h;
+    if (True) {
+        h = {\"a\": \"x\"};
+    } else {
+        h = {\"b\": \"y\"};
+    }
+    # Both branches narrowed to hash<string, string>
+    # After merge, should still be hash<string, string>
+    h.c = 1;  # Should fail - int not compatible with string
+}
+";
+        assertThrows("PARSE-TYPE-ERROR", sub() {
+            Program p(PO_NEW_STYLE);
+            p.parse(code, "branch_merge_same_test");
+        });
+    }
+
+    # Test compatible branch merge
+    branchTypeMergeCompatibleTest() {
+        # When both branches narrow to compatible types, the common type should persist
+        string code = "%new-style
+string sub test() {
+    hash<auto> h;
+    if (True) {
+        h = {\"a\": \"x\"};
+    } else {
+        h = {\"b\": \"y\"};
+    }
+    # Both branches narrowed to hash<string, string>
+    h.c = \"z\";  # Should work - string compatible
+    return h.c;
+}
+";
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse(code, "branch_merge_compatible_test");
+            # No parse error means merge worked correctly
+        }
+    }
+
+    # Test incompatible branch type merge - should reset to original type
+    branchTypeMergeIncompatibleTest() {
+        # When branches narrow to incompatible types, should reset to original
+        string code = "%new-style
+string sub test() {
+    hash<auto> h;
+    if (True) {
+        h = {\"a\": \"x\"};  # narrows to hash<string, string>
+    } else {
+        h = {\"b\": 1};  # narrows to hash<string, int>
+    }
+    # Branches have incompatible types, should reset to hash<auto>
+    h.c = True;  # Should work - hash<auto> accepts any value
+    return \"ok\";
+}
+";
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse(code, "branch_merge_incompatible_test");
+            # No parse error means narrowing was reset
+        }
+    }
+
+    # Test no else branch - original narrowing persists
+    branchNoElseTest() {
+        # With no else branch, the original narrowed type persists
+        # because the "else" path (implicit) doesn't change the type
+        string code = "%new-style
+string sub test() {
+    hash<auto> h = {\"x\": 1};  # initially narrowed to hash<string, int>
+    if (True) {
+        h.y = 2;  # compatible assignment inside if branch
+    }
+    # No else branch - original narrowing persists
+    h.z = 3;  # Should work - still hash<string, int>
+    return \"ok\";
+}
+";
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse(code, "branch_no_else_test");
+        }
+
+        # Test that original narrowing blocks incompatible assignments after if
+        string code2 = "%new-style
+sub test() {
+    hash<auto> h = {\"x\": 1};  # initially narrowed to hash<string, int>
+    if (True) {
+        h.y = 2;
+    }
+    h.z = \"wrong\";  # Should fail - type is still hash<string, int>
+}
+";
+        assertThrows("PARSE-TYPE-ERROR", sub() {
+            Program p(PO_NEW_STYLE);
+            p.parse(code2, "branch_no_else_test2");
+        });
+    }
+
+    # Test switch - all cases narrow to same type
+    switchTypeMergeSameTest() {
+        # When all cases narrow to same type, that type should persist after switch
+        string code = "%new-style
+sub test() {
+    hash<auto> h;
+    int x = 1;
+    switch (x) {
+        case 1:
+            h = {\"a\": \"x\"};
+            break;
+        case 2:
+            h = {\"b\": \"y\"};
+            break;
+        default:
+            h = {\"c\": \"z\"};
+            break;
+    }
+    # All cases narrowed to hash<string, string>
+    h.d = 1;  # Should fail - int not compatible with string
+}
+";
+        assertThrows("PARSE-TYPE-ERROR", sub() {
+            Program p(PO_NEW_STYLE);
+            p.parse(code, "switch_merge_same_test");
+        });
+    }
+
+    # Test switch - cases narrow to incompatible types
+    switchTypeMergeIncompatibleTest() {
+        # When cases narrow to incompatible types, should reset to original
+        string code = "%new-style
+string sub test() {
+    hash<auto> h;
+    int x = 1;
+    switch (x) {
+        case 1:
+            h = {\"a\": \"x\"};  # narrows to hash<string, string>
+            break;
+        case 2:
+            h = {\"b\": 1};  # narrows to hash<string, int>
+            break;
+        default:
+            h = {\"c\": True};  # narrows to hash<string, bool>
+            break;
+    }
+    # Cases have incompatible types, should reset to hash<auto>
+    h.d = 42;  # Should work - hash<auto> accepts any value
+    return \"ok\";
+}
+";
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse(code, "switch_merge_incompatible_test");
+            # No parse error means narrowing was reset
+        }
+    }
+
+    # Test switch without default - original narrowing preserved
+    switchNoDefaultTest() {
+        # With no default case, the implicit "no match" path preserves original type
+        string code = "%new-style
+string sub test() {
+    hash<auto> h;
+    int x = 1;
+    switch (x) {
+        case 1:
+            h = {\"a\": \"x\"};
+            break;
+        case 2:
+            h = {\"b\": \"y\"};
+            break;
+    }
+    # No default - implicit path preserves hash<auto>
+    # Even though cases narrowed to hash<string, string>, overall is hash<auto>
+    h.d = 42;  # Should work - hash<auto> accepts any value
+    return \"ok\";
+}
+";
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse(code, "switch_no_default_test");
+            # No parse error means type was reset due to implicit branch
+        }
+    }
+
+    # Test switch with default - only explicit branches matter
+    switchWithDefaultTest() {
+        # With default case, all paths are covered by explicit branches
+        string code = "%new-style
+string sub test() {
+    hash<auto> h;
+    int x = 1;
+    switch (x) {
+        case 1:
+            h = {\"a\": \"x\"};
+            break;
+        case 2:
+            h = {\"b\": \"y\"};
+            break;
+        default:
+            h = {\"c\": \"z\"};
+            break;
+    }
+    # With default, all paths narrow to hash<string, string>
+    h.d = \"w\";  # Should work - string compatible
+    return \"ok\";
+}
+";
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse(code, "switch_with_default_test");
+            # No parse error means merge worked correctly
+        }
+    }
+
+    # Test closure variable narrowing
+    closureVarNarrowingTest() {
+        # Closure variables should be narrowed correctly
+        string code1 = "%new-style
+auto sub test() {
+    code c;
+    {
+        hash<auto> h = {\"a\": \"b\"};
+        c = auto sub() {
+            h.c = \"d\";  # should work - string compatible
+            return h;
+        };
+    }
+    return c();
+}
+";
+        {
+            Program p(PO_NEW_STYLE);
+            p.parse(code1, "closure_narrowing_ok");
+            # No parse error means narrowing works in closures
+        }
+
+        # Type error in closure should be caught at parse time
+        string code2 = "%new-style
+auto sub test() {
+    code c;
+    {
+        hash<auto> h = {\"a\": \"b\"};
+        c = auto sub() {
+            h.c = 1;  # should fail - int not compatible with string
+            return h;
+        };
+    }
+    return c();
+}
+";
+        assertThrows("PARSE-TYPE-ERROR", sub() {
+            Program p(PO_NEW_STYLE);
+            p.parse(code2, "closure_narrowing_error");
+        });
+    }
+}

--- a/include/qore/Restrictions.h
+++ b/include/qore/Restrictions.h
@@ -43,7 +43,8 @@
 #define PO_NO_THREAD_CLASSES                (1 <<  3)    //!< no access to thread classes
 #define PO_NO_TOP_LEVEL_STATEMENTS          (1 <<  4)    //!< cannot define new top-level statements (outside of sub or class defs)
 #define PO_ALLOW_REPARSE                    (1 <<  5)    //!< allow multiple parse/commit cycles (for REPL support); requires no other threads active in Program
-// bits 6, 7, 8 are available for future use
+#define PO_BROKEN_NARROWED_TYPES            (1 <<  6)    //!< allows parse-time type narrowing violations to be warnings instead of errors
+// bits 7, 8 are available for future use
 #define PO_NO_INHERIT_SYSTEM_CLASSES        (1 <<  9)    //!< do not inherit system classes into this program space
 #define PO_NO_INHERIT_USER_CLASSES          (1 << 10)    //!< do not inherit public user classes into this program space
 #define PO_NO_CHILD_PO_RESTRICTIONS         (1 << 11)    //!< turn off parse option inheritance restrictions
@@ -145,7 +146,7 @@
 #define PO_FREE_OPTIONS               (PO_ALLOW_BARE_REFS|PO_ASSUME_LOCAL|PO_STRICT_BOOLEAN_EVAL \
     |PO_BROKEN_LIST_PARSING|PO_BROKEN_LOGIC_PRECEDENCE|PO_BROKEN_INT_ASSIGNMENTS|PO_BROKEN_OPERATORS \
     |PO_BROKEN_LOOP_STATEMENT|PO_BROKEN_REFERENCES|PO_BROKEN_SPRINTF|PO_BROKEN_RANGE|PO_BROKEN_VARARGS \
-    |PO_BROKEN_LIST_RANGE)
+    |PO_BROKEN_LIST_RANGE|PO_BROKEN_NARROWED_TYPES)
 
 //! mask of options related to style but not capabilities
 #define PO_STYLE_OPTIONS              (PO_NO_TOP_LEVEL_STATEMENTS|PO_REQUIRE_PROTOTYPES|PO_REQUIRE_TYPES \

--- a/include/qore/Restrictions.h
+++ b/include/qore/Restrictions.h
@@ -43,7 +43,7 @@
 #define PO_NO_THREAD_CLASSES                (1 <<  3)    //!< no access to thread classes
 #define PO_NO_TOP_LEVEL_STATEMENTS          (1 <<  4)    //!< cannot define new top-level statements (outside of sub or class defs)
 #define PO_ALLOW_REPARSE                    (1 <<  5)    //!< allow multiple parse/commit cycles (for REPL support); requires no other threads active in Program
-#define PO_BROKEN_NARROWED_TYPES            (1 <<  6)    //!< allows parse-time type narrowing violations to be warnings instead of errors
+#define PO_BROKEN_NARROWED_TYPES            (1 <<  6)    //!< disables parse-time type narrowing (narrowed type information is not used)
 // bits 7, 8 are available for future use
 #define PO_NO_INHERIT_SYSTEM_CLASSES        (1 <<  9)    //!< do not inherit system classes into this program space
 #define PO_NO_INHERIT_USER_CLASSES          (1 << 10)    //!< do not inherit public user classes into this program space

--- a/include/qore/intern/AbstractStatement.h
+++ b/include/qore/intern/AbstractStatement.h
@@ -48,6 +48,7 @@
 #define PF_BREAK_OK              (1 << 6)
 #define PF_CONTINUE_OK           (1 << 7)
 #define PF_NO_TOP_LEVEL_LVARS    (1 << 8)
+#define PF_NARROWED_TYPE         (1 << 9) //!< current expression involves a narrowed auto type
 
 // all definitions in this file are private to the library and subject to change
 // forward references

--- a/include/qore/intern/LocalVar.h
+++ b/include/qore/intern/LocalVar.h
@@ -503,9 +503,16 @@ public:
         }
         // If this is an auto type with a narrowed type, return the narrowed type
         // unless PO_BROKEN_NARROWED_TYPES is set
+        // NOTE: For or-nothing types (types that can return NOTHING), we don't return
+        // the narrowed type because narrowing loses the or-nothing semantics which are
+        // important for type checking
         if (is_auto_type && narrowedTypeInfo) {
             QoreProgram* pgm = getProgram();
             if (!pgm || !(pgm->getParseOptions64() & PO_BROKEN_NARROWED_TYPES)) {
+                // Don't return narrowed type if declared type is or-nothing
+                if (QoreTypeInfo::parseReturns(typeInfo, NT_NOTHING) != QTI_NOT_EQUAL) {
+                    return typeInfo;
+                }
                 return narrowedTypeInfo;
             }
         }

--- a/include/qore/intern/LocalVar.h
+++ b/include/qore/intern/LocalVar.h
@@ -349,12 +349,13 @@ public:
 class LocalVar {
 public:
     DLLLOCAL LocalVar(const char* n_name, const QoreTypeInfo* ti)
-            : name(n_name), typeInfo(ti), refTypeInfo(QoreTypeInfo::getReferenceTarget(ti)) {
+            : name(n_name), is_auto_type(isAutoTypeInfo(ti)), typeInfo(ti),
+              refTypeInfo(QoreTypeInfo::getReferenceTarget(ti)) {
     }
 
     DLLLOCAL LocalVar(const LocalVar& old) : name(old.name), closure_use(old.closure_use),
-            parse_assigned(old.parse_assigned), is_self(old.is_self), typeInfo(old.typeInfo),
-            refTypeInfo(old.refTypeInfo) {
+            parse_assigned(old.parse_assigned), is_self(old.is_self), is_auto_type(old.is_auto_type),
+            typeInfo(old.typeInfo), refTypeInfo(old.refTypeInfo), narrowedTypeInfo(old.narrowedTypeInfo) {
     }
 
     DLLLOCAL ~LocalVar() {
@@ -496,7 +497,19 @@ public:
     }
 
     DLLLOCAL const QoreTypeInfo* parseGetTypeInfo() const {
-        return parse_assigned && refTypeInfo ? refTypeInfo : typeInfo;
+        // If this is a reference type with a target type, return that
+        if (parse_assigned && refTypeInfo) {
+            return refTypeInfo;
+        }
+        // If this is an auto type with a narrowed type, return the narrowed type
+        // unless PO_BROKEN_NARROWED_TYPES is set
+        if (is_auto_type && narrowedTypeInfo) {
+            QoreProgram* pgm = getProgram();
+            if (!pgm || !(pgm->getParseOptions64() & PO_BROKEN_NARROWED_TYPES)) {
+                return narrowedTypeInfo;
+            }
+        }
+        return typeInfo;
     }
 
     DLLLOCAL const QoreTypeInfo* parseGetTypeInfoForInitialAssignment() const {
@@ -521,17 +534,50 @@ public:
         is_self = true;
     }
 
+    //! Returns true if the variable has an auto type that can be narrowed
+    DLLLOCAL bool isAutoType() const {
+        return is_auto_type;
+    }
+
+    //! Sets the narrowed type for the variable (called during assignment parsing)
+    /** Only sets if this is an auto-typed variable and the new type is more specific
+        @param ti the type from the right-hand side of the assignment
+    */
+    DLLLOCAL void parseSetNarrowedType(const QoreTypeInfo* ti);
+
+    //! Merges the given type with the current narrowed type (for branch handling)
+    /** Uses matchCommonType to find the union type between the current narrowed type
+        and the new type
+        @param ti the type to merge with the current narrowed type
+    */
+    DLLLOCAL void parseMergeNarrowedType(const QoreTypeInfo* ti);
+
+    //! Returns the narrowed type if set, otherwise nullptr
+    DLLLOCAL const QoreTypeInfo* parseGetNarrowedType() const {
+        return narrowedTypeInfo;
+    }
+
+    //! Resets the narrowed type (e.g., when entering a new scope)
+    DLLLOCAL void parseResetNarrowedType() {
+        narrowedTypeInfo = nullptr;
+    }
+
 private:
     std::string name;
     bool closure_use = false,
         parse_assigned = false,
-        is_self = false;
+        is_self = false,
+        is_auto_type = false;       // true if declared type is an auto type (hash<auto>, list<auto>, etc.)
     const QoreTypeInfo* typeInfo = nullptr;
     const QoreTypeInfo* refTypeInfo = nullptr;
+    const QoreTypeInfo* narrowedTypeInfo = nullptr;  // narrowed type from assignment (parse-time only)
 
     DLLLOCAL LocalVarValue* get_var() const {
         return thread_find_lvar(name.c_str());
     }
+
+    //! Helper to detect if a type is an auto type that can be narrowed
+    DLLLOCAL static bool isAutoTypeInfo(const QoreTypeInfo* ti);
 };
 
 typedef LocalVar* lvar_ptr_t;

--- a/include/qore/intern/QoreLibIntern.h
+++ b/include/qore/intern/QoreLibIntern.h
@@ -218,6 +218,13 @@ public:
         parse_context.pflag |= flags;
     }
 
+    //! Copies specified flags from the current parse_context.pflag to the saved pflag
+    /** This ensures that specified flags set during parsing are preserved when the helper destructs.
+    */
+    DLLLOCAL void preserveFlags(int flags) {
+        pflag |= (parse_context.pflag & flags);
+    }
+
 private:
     QoreParseContext& parse_context;
     int pflag;

--- a/include/qore/intern/StatementBlock.h
+++ b/include/qore/intern/StatementBlock.h
@@ -311,4 +311,44 @@ public:
     }
 };
 
+//! Helper class to save and restore narrowed types for branch tracking
+/** This class is used during if/else and switch statement parsing to track
+    narrowed types across branches. It saves the current narrowed types before
+    parsing a branch and can restore them after, allowing each branch to
+    have independent type narrowing while ensuring the correct merged type
+    is used after the branching statement.
+*/
+class NarrowedTypeHelper {
+private:
+    typedef std::vector<std::pair<LocalVar*, const QoreTypeInfo*>> type_map_t;
+    type_map_t saved_types;
+    std::vector<type_map_t> branch_types;
+
+public:
+    //! Save the current narrowed types of all local auto variables
+    DLLLOCAL void saveState();
+
+    //! Restore the narrowed types to the saved state
+    DLLLOCAL void restoreState();
+
+    //! Record current branch types and restore to saved state
+    /** Call this after parsing each branch to record its final types
+        and restore to the pre-branch state for the next branch
+    */
+    DLLLOCAL void recordBranchAndRestore();
+
+    //! Merge all recorded branch types and apply the common type
+    /** Call this after all branches have been parsed to compute and
+        apply the common type across all branches
+    */
+    DLLLOCAL void mergeAndApply();
+
+    //! Record the saved state as an implicit branch (for if without else)
+    /** When there is no else branch, the implicit else path preserves the
+        original types. This method records the saved types as a branch so
+        that mergeAndApply() considers both paths.
+    */
+    DLLLOCAL void recordSavedAsImplicitBranch();
+};
+
 #endif // _QORE_STATEMENT_BLOCK_H

--- a/include/qore/intern/Variable.h
+++ b/include/qore/intern/Variable.h
@@ -109,6 +109,8 @@ private:
     QoreParseTypeInfo* parseTypeInfo = nullptr;
     const QoreTypeInfo* typeInfo = nullptr;
     const QoreTypeInfo* refTypeInfo = nullptr;
+    const QoreTypeInfo* narrowedTypeInfo = nullptr;  // narrowed type from assignment
+    bool is_auto_type = false;          // true if declared type is an auto type
     bool pub;                           // is this global var public (valid and set for modules only)
     mutable bool finalized;             // has this var already been cleared during Program destruction?
     bool is_thread_local;               // is this a thread_local var?
@@ -261,12 +263,17 @@ public:
             val.set(typeInfo);
         }
 
+        // Set is_auto_type flag based on the resolved typeInfo
+        is_auto_type = isAutoTypeInfo(typeInfo);
+
         if ((getProgram()->getParseOptions64() & PO_STRICT_TYPES) && !val.hasValue()) {
             discard(val.assignInitial(QoreTypeInfo::getDefaultQoreValue(typeInfo)), nullptr);
         }
 
         return err;
     }
+
+    DLLLOCAL static bool isAutoTypeInfo(const QoreTypeInfo* ti);
 
     DLLLOCAL QoreParseTypeInfo* copyParseTypeInfo() const {
         return parseTypeInfo ? parseTypeInfo->copy() : nullptr;
@@ -296,6 +303,21 @@ public:
 
     DLLLOCAL const QoreProgramLocation* getParseLocation() const {
         return loc;
+    }
+
+    DLLLOCAL bool isAutoType() const {
+        return is_auto_type;
+    }
+
+    DLLLOCAL void parseSetNarrowedType(const QoreTypeInfo* ti);
+    DLLLOCAL void parseMergeNarrowedType(const QoreTypeInfo* ti);
+
+    DLLLOCAL const QoreTypeInfo* parseGetNarrowedType() const {
+        return narrowedTypeInfo;
+    }
+
+    DLLLOCAL void parseResetNarrowedType() {
+        narrowedTypeInfo = nullptr;
     }
 };
 

--- a/lib/IfStatement.cpp
+++ b/lib/IfStatement.cpp
@@ -82,16 +82,32 @@ int IfStatement::parseInitImpl(QoreParseContext& parse_context) {
         err = parse_init_value(cond, parse_context);
         // FIXME: generate a warning here if the type cannot be converted to a bool (i.e. always false)
     }
+
+    // Track narrowed types across branches
+    NarrowedTypeHelper nth;
+    nth.saveState();
+
     if (if_code) {
         if (if_code->parseInitImpl(parse_context) && !err) {
             err = -1;
         }
+        // Record narrowed types after if branch and restore for else branch
+        nth.recordBranchAndRestore();
     }
     if (else_code) {
         if (else_code->parseInitImpl(parse_context) && !err) {
             err = -1;
         }
+        // Record narrowed types after else branch
+        nth.recordBranchAndRestore();
+    } else {
+        // No else branch - the implicit else path preserves the original type
+        // Record the saved state as an implicit branch
+        nth.recordSavedAsImplicitBranch();
     }
+
+    // Merge types from all branches
+    nth.mergeAndApply();
 
     return err;
 }

--- a/lib/IfStatement.cpp
+++ b/lib/IfStatement.cpp
@@ -93,6 +93,9 @@ int IfStatement::parseInitImpl(QoreParseContext& parse_context) {
         }
         // Record narrowed types after if branch and restore for else branch
         nth.recordBranchAndRestore();
+    } else {
+        // Empty if block (e.g., "if (cond) ;") - record saved state as this branch
+        nth.recordSavedAsImplicitBranch();
     }
     if (else_code) {
         if (else_code->parseInitImpl(parse_context) && !err) {

--- a/lib/ParseOptionMap.cpp
+++ b/lib/ParseOptionMap.cpp
@@ -82,6 +82,7 @@ void ParseOptionMap::static_init() {
     DO_MAP("broken-int-assignments",   PO_BROKEN_INT_ASSIGNMENTS);
     DO_MAP("broken-operators",         PO_BROKEN_OPERATORS);
     DO_MAP("broken-loop-statement",    PO_BROKEN_LOOP_STATEMENT);
+    DO_MAP("broken-narrowed-types",    PO_BROKEN_NARROWED_TYPES);
     DO_MAP("strong-encapsulation",     PO_STRONG_ENCAPSULATION);
     DO_MAP("no-uncontrolled-apis",     PO_NO_UNCONTROLLED_APIS);
     DO_MAP("no-debugging",             PO_NO_DEBUGGING);

--- a/lib/QoreAssignmentOperatorNode.cpp
+++ b/lib/QoreAssignmentOperatorNode.cpp
@@ -31,6 +31,8 @@
 #include <qore/Qore.h>
 
 #include "qore/intern/qore_program_private.h"
+#include "qore/intern/LocalVar.h"
+#include "qore/intern/Variable.h"
 
 QoreString QoreAssignmentOperatorNode::op_str("assignment (=) operator expression");
 QoreString QoreWeakAssignmentOperatorNode::op_str("weak assignment (:=) operator expression");
@@ -45,6 +47,8 @@ int QoreAssignmentOperatorNode::parseInitIntern(QoreParseContext& parse_context,
         QoreParseContextFlagHelper fh0(parse_context);
         fh0.setFlags(PF_FOR_ASSIGNMENT);
         err = parse_init_value(left, parse_context);
+        // Preserve the PF_NARROWED_TYPE flag if set during left side parsing
+        fh0.preserveFlags(PF_NARROWED_TYPE);
     }
     // return type info is the same as the lvalue's typeinfo
     ti = parse_context.typeInfo;
@@ -109,7 +113,43 @@ int QoreAssignmentOperatorNode::parseInitIntern(QoreParseContext& parse_context,
         res = QTI_AMBIGUOUS;
     }
 
-    if (parse_context.pgm->getParseExceptionSink() && !res) {
+    // Check for type mismatch - either with parse exception sink enabled, or for narrowed types
+    bool type_mismatch = !res;
+
+    // Check if the lvalue involves a narrowed auto-type (via PF_NARROWED_TYPE flag)
+    bool has_narrowed_type = (parse_context.pflag & PF_NARROWED_TYPE) != 0;
+
+    // Check if this is a direct assignment to an auto-type variable
+    // Direct assignment to auto-type variables should NOT raise narrowed type errors
+    // because the assignment updates the narrowed type (not a member assignment)
+    bool is_direct_auto_assignment = false;
+    if (left.getType() == NT_VARREF) {
+        VarRefNode* vrn = left.get<VarRefNode>();
+        qore_var_t vtype = vrn->getType();
+        if (vtype == VT_LOCAL || vtype == VT_CLOSURE || vtype == VT_LOCAL_TS) {
+            LocalVar* lvar = vrn->ref.id;
+            if (lvar && lvar->isAutoType()) {
+                is_direct_auto_assignment = true;
+            }
+        } else if (vtype == VT_GLOBAL || vtype == VT_THREAD_LOCAL) {
+            Var* gvar = vrn->ref.var;
+            if (gvar && gvar->isAutoType()) {
+                is_direct_auto_assignment = true;
+            }
+        }
+    }
+
+    // Raise parse exception for type mismatch
+    // - Always raise for narrowed types (unless PO_BROKEN_NARROWED_TYPES is set)
+    // - But NOT for direct assignment to auto-type variables (reassignment updates the type)
+    // - Otherwise only raise if parse exception sink is enabled
+    bool raise_exception = type_mismatch && (
+        parse_context.pgm->getParseExceptionSink() ||
+        (has_narrowed_type && !is_direct_auto_assignment &&
+         !(parse_context.pgm->getParseOptions64() & PO_BROKEN_NARROWED_TYPES))
+    );
+
+    if (raise_exception) {
         QoreStringNode* edesc = new QoreStringNodeMaker("lvalue for %sassignment operator '%s' expects ",
             weak_assignment ? "weak " : "", weak_assignment ? ":=" : "=");
         QoreTypeInfo::getThisType(ti, *edesc);
@@ -118,6 +158,37 @@ int QoreAssignmentOperatorNode::parseInitIntern(QoreParseContext& parse_context,
         qore_program_private::makeParseException(parse_context.pgm, *loc, "PARSE-TYPE-ERROR", edesc);
         if (!err) {
             err = -1;
+        }
+    }
+
+    // Update narrowed type for auto-typed variables
+    if (!err && left.getType() == NT_VARREF) {
+        VarRefNode* vrn = left.get<VarRefNode>();
+        qore_var_t vtype = vrn->getType();
+        if (vtype == VT_LOCAL || vtype == VT_CLOSURE || vtype == VT_LOCAL_TS) {
+            LocalVar* lvar = vrn->ref.id;
+            if (lvar && lvar->isAutoType() && QoreTypeInfo::hasType(parse_context.typeInfo)) {
+                // For initial assignment (declaration with initializer), set the narrowed type directly
+                bool initial_assignment = vrn->parseIsDecl();
+                if (initial_assignment) {
+                    lvar->parseSetNarrowedType(parse_context.typeInfo);
+                } else {
+                    // For subsequent assignments, merge types
+                    lvar->parseMergeNarrowedType(parse_context.typeInfo);
+                }
+            }
+        } else if (vtype == VT_GLOBAL || vtype == VT_THREAD_LOCAL) {
+            Var* gvar = vrn->ref.var;
+            if (gvar && gvar->isAutoType() && QoreTypeInfo::hasType(parse_context.typeInfo)) {
+                // For initial assignment (declaration with initializer), set the narrowed type directly
+                bool initial_assignment = vrn->parseIsDecl();
+                if (initial_assignment) {
+                    gvar->parseSetNarrowedType(parse_context.typeInfo);
+                } else {
+                    // For subsequent assignments, merge types
+                    gvar->parseMergeNarrowedType(parse_context.typeInfo);
+                }
+            }
         }
     }
 

--- a/lib/QoreAssignmentOperatorNode.cpp
+++ b/lib/QoreAssignmentOperatorNode.cpp
@@ -140,19 +140,58 @@ int QoreAssignmentOperatorNode::parseInitIntern(QoreParseContext& parse_context,
     }
 
     // Raise parse exception for type mismatch
+    // - For direct auto-type assignments, check against declared type (not narrowed)
     // - Always raise for narrowed types (unless PO_BROKEN_NARROWED_TYPES is set)
     // - But NOT for direct assignment to auto-type variables (reassignment updates the type)
     // - Otherwise only raise if parse exception sink is enabled
-    bool raise_exception = type_mismatch && (
-        parse_context.pgm->getParseExceptionSink() ||
-        (has_narrowed_type && !is_direct_auto_assignment &&
-         !(parse_context.pgm->getParseOptions64() & PO_BROKEN_NARROWED_TYPES))
-    );
+    bool raise_exception = false;
+    const QoreTypeInfo* error_ti = ti;  // Type info to use in error message
+
+    if (type_mismatch) {
+        if (is_direct_auto_assignment) {
+            // For direct auto-type assignments, re-check against the declared type
+            // The narrowed type will be updated by this assignment, so we only need
+            // to verify compatibility with the declared type
+            const QoreTypeInfo* declared_ti = nullptr;
+            VarRefNode* vrn = left.get<VarRefNode>();
+            qore_var_t vtype = vrn->getType();
+            if (vtype == VT_LOCAL || vtype == VT_CLOSURE || vtype == VT_LOCAL_TS) {
+                LocalVar* lvar = vrn->ref.id;
+                if (lvar) {
+                    declared_ti = lvar->getTypeInfo();
+                }
+            } else if (vtype == VT_GLOBAL || vtype == VT_THREAD_LOCAL) {
+                Var* gvar = vrn->ref.var;
+                if (gvar) {
+                    declared_ti = gvar->getTypeInfo();
+                }
+            }
+
+            if (declared_ti) {
+                // Re-check compatibility against declared type
+                bool may_not_match = false;
+                bool may_need_filter = false;
+                qore_type_result_e max_result = QTI_NOT_EQUAL;
+                qore_type_result_e declared_res = QoreTypeInfo::parseAccepts(declared_ti,
+                    parse_context.typeInfo, may_not_match, may_need_filter, max_result);
+                // Only raise error if incompatible with declared type and parse exception sink is enabled
+                if (!declared_res && parse_context.pgm->getParseExceptionSink()) {
+                    raise_exception = true;
+                    error_ti = declared_ti;
+                }
+            }
+        } else {
+            // Not a direct auto assignment - use normal logic
+            raise_exception = parse_context.pgm->getParseExceptionSink() ||
+                (has_narrowed_type &&
+                 !(parse_context.pgm->getParseOptions64() & PO_BROKEN_NARROWED_TYPES));
+        }
+    }
 
     if (raise_exception) {
         QoreStringNode* edesc = new QoreStringNodeMaker("lvalue for %sassignment operator '%s' expects ",
             weak_assignment ? "weak " : "", weak_assignment ? ":=" : "=");
-        QoreTypeInfo::getThisType(ti, *edesc);
+        QoreTypeInfo::getThisType(error_ti, *edesc);
         edesc->concat(", but right-hand side is ");
         QoreTypeInfo::getThisType(parse_context.typeInfo, *edesc);
         qore_program_private::makeParseException(parse_context.pgm, *loc, "PARSE-TYPE-ERROR", edesc);

--- a/lib/QoreAssignmentOperatorNode.cpp
+++ b/lib/QoreAssignmentOperatorNode.cpp
@@ -201,32 +201,22 @@ int QoreAssignmentOperatorNode::parseInitIntern(QoreParseContext& parse_context,
     }
 
     // Update narrowed type for auto-typed variables
+    // Direct assignment replaces the narrowed type completely (use parseSetNarrowedType)
+    // Branch merging is handled by NarrowedTypeHelper which uses parseMergeNarrowedType
     if (!err && left.getType() == NT_VARREF) {
         VarRefNode* vrn = left.get<VarRefNode>();
         qore_var_t vtype = vrn->getType();
         if (vtype == VT_LOCAL || vtype == VT_CLOSURE || vtype == VT_LOCAL_TS) {
             LocalVar* lvar = vrn->ref.id;
             if (lvar && lvar->isAutoType() && QoreTypeInfo::hasType(parse_context.typeInfo)) {
-                // For initial assignment (declaration with initializer), set the narrowed type directly
-                bool initial_assignment = vrn->parseIsDecl();
-                if (initial_assignment) {
-                    lvar->parseSetNarrowedType(parse_context.typeInfo);
-                } else {
-                    // For subsequent assignments, merge types
-                    lvar->parseMergeNarrowedType(parse_context.typeInfo);
-                }
+                // Direct assignment replaces the narrowed type
+                lvar->parseSetNarrowedType(parse_context.typeInfo);
             }
         } else if (vtype == VT_GLOBAL || vtype == VT_THREAD_LOCAL) {
             Var* gvar = vrn->ref.var;
             if (gvar && gvar->isAutoType() && QoreTypeInfo::hasType(parse_context.typeInfo)) {
-                // For initial assignment (declaration with initializer), set the narrowed type directly
-                bool initial_assignment = vrn->parseIsDecl();
-                if (initial_assignment) {
-                    gvar->parseSetNarrowedType(parse_context.typeInfo);
-                } else {
-                    // For subsequent assignments, merge types
-                    gvar->parseMergeNarrowedType(parse_context.typeInfo);
-                }
+                // Direct assignment replaces the narrowed type
+                gvar->parseSetNarrowedType(parse_context.typeInfo);
             }
         }
     }

--- a/lib/QoreHashObjectDereferenceOperatorNode.cpp
+++ b/lib/QoreHashObjectDereferenceOperatorNode.cpp
@@ -45,6 +45,9 @@ int QoreHashObjectDereferenceOperatorNode::parseInitImpl(QoreValue& val, QorePar
     int err = parse_init_value(left, parse_context);
     const QoreTypeInfo* lti = parse_context.typeInfo;
 
+    // Preserve the PF_NARROWED_TYPE flag if set during left side parsing
+    fh.preserveFlags(PF_NARROWED_TYPE);
+
     bool for_assignment = parse_context.pflag & PF_FOR_ASSIGNMENT;
     if (!err && for_assignment && check_lvalue(left)) {
         parse_error(*loc, "expression used for assignment requires an lvalue, got '%s' instead", left.getTypeName());

--- a/lib/StatementBlock.cpp
+++ b/lib/StatementBlock.cpp
@@ -711,3 +711,107 @@ QoreParseContextLvarHelper::~QoreParseContextLvarHelper() {
     }
     parse_context.lvids = lvids;
 }
+
+// NarrowedTypeHelper implementation
+
+void NarrowedTypeHelper::saveState() {
+    saved_types.clear();
+    VNode* vnode = getVStack();
+    while (vnode) {
+        if (vnode->lvar && vnode->lvar->isAutoType()) {
+            saved_types.push_back({vnode->lvar, vnode->lvar->parseGetNarrowedType()});
+        }
+        vnode = vnode->nextSearch();
+    }
+}
+
+void NarrowedTypeHelper::restoreState() {
+    for (const auto& entry : saved_types) {
+        // Reset or set the narrowed type
+        if (entry.second) {
+            entry.first->parseSetNarrowedType(entry.second);
+        } else {
+            entry.first->parseResetNarrowedType();
+        }
+    }
+}
+
+void NarrowedTypeHelper::recordBranchAndRestore() {
+    // Record current narrowed types for this branch
+    type_map_t branch;
+    VNode* vnode = getVStack();
+    while (vnode) {
+        if (vnode->lvar && vnode->lvar->isAutoType()) {
+            branch.push_back({vnode->lvar, vnode->lvar->parseGetNarrowedType()});
+        }
+        vnode = vnode->nextSearch();
+    }
+    branch_types.push_back(std::move(branch));
+
+    // Restore to pre-branch state
+    restoreState();
+}
+
+void NarrowedTypeHelper::recordSavedAsImplicitBranch() {
+    // Record the saved types as an implicit branch
+    // This represents the code path where the if condition was false
+    branch_types.push_back(saved_types);
+}
+
+void NarrowedTypeHelper::mergeAndApply() {
+    if (branch_types.empty()) {
+        return;
+    }
+
+    // For each saved variable, find the common type across all branches
+    for (const auto& saved_entry : saved_types) {
+        LocalVar* lvar = saved_entry.first;
+        const QoreTypeInfo* common_type = nullptr;
+        bool found_in_all = true;
+        bool first = true;
+
+        for (const auto& branch : branch_types) {
+            bool found = false;
+            for (const auto& branch_entry : branch) {
+                if (branch_entry.first == lvar) {
+                    found = true;
+                    if (first) {
+                        common_type = branch_entry.second;
+                        first = false;
+                    } else if (branch_entry.second != common_type) {
+                        // Merge types using matchCommonType
+                        if (common_type && branch_entry.second) {
+                            const QoreTypeInfo* merged = common_type;
+                            if (!QoreTypeInfo::matchCommonType(merged, branch_entry.second)) {
+                                // Types incompatible, reset to original (un-narrowed)
+                                common_type = nullptr;
+                            } else {
+                                common_type = merged;
+                            }
+                        } else {
+                            // One branch has null (reset), use null
+                            common_type = nullptr;
+                        }
+                    }
+                    break;
+                }
+            }
+            if (!found) {
+                found_in_all = false;
+                break;
+            }
+        }
+
+        // Apply the merged type
+        if (found_in_all && common_type) {
+            lvar->parseSetNarrowedType(common_type);
+        } else if (found_in_all) {
+            // All branches found but no common type - keep original
+            if (saved_entry.second) {
+                lvar->parseSetNarrowedType(saved_entry.second);
+            } else {
+                lvar->parseResetNarrowedType();
+            }
+        }
+    }
+}

--- a/lib/SwitchStatement.cpp
+++ b/lib/SwitchStatement.cpp
@@ -133,6 +133,10 @@ int SwitchStatement::parseInitImpl(QoreParseContext& parse_context) {
     parse_context.typeInfo = nullptr;
     int err = parse_init_value(sexp, parse_context);
 
+    // Track narrowed types across switch branches
+    NarrowedTypeHelper nth;
+    nth.saveState();
+
     CaseNode* w = head;
     ExceptionSink xsink;
     while (w) {
@@ -199,9 +203,19 @@ int SwitchStatement::parseInitImpl(QoreParseContext& parse_context) {
             if (w->code->parseInitImpl(parse_context) && !err) {
                 err = -1;
             }
+            // Record narrowed types after this case block and restore for next case
+            nth.recordBranchAndRestore();
         }
         w = w->next;
     }
+
+    // If there's no default case, the implicit "no match" path preserves original types
+    if (!deflt) {
+        nth.recordSavedAsImplicitBranch();
+    }
+
+    // Merge types from all branches
+    nth.mergeAndApply();
 
     return err;
 }

--- a/lib/VarRefNode.cpp
+++ b/lib/VarRefNode.cpp
@@ -36,6 +36,7 @@
 #include "qore/intern/typed_hash_decl_private.h"
 #include "qore/intern/QoreHashNodeIntern.h"
 #include "qore/intern/qore_list_private.h"
+#include "qore/intern/LocalVar.h"
 
 bool VarRefNode::parseEqualTo(const VarRefNode& other) const {
     if (type != other.type) {
@@ -209,6 +210,18 @@ int VarRefNode::parseInitImpl(QoreValue& val, QoreParseContext& parse_context) {
             parse_context.typeInfo = parseGetTypeInfo();
         }
     }
+
+    // Set PF_NARROWED_TYPE flag if this variable has a narrowed type
+    if (type == VT_LOCAL || type == VT_CLOSURE || type == VT_LOCAL_TS) {
+        if (ref.id && ref.id->isAutoType() && ref.id->parseGetNarrowedType()) {
+            parse_context.pflag |= PF_NARROWED_TYPE;
+        }
+    } else if (type == VT_GLOBAL || type == VT_THREAD_LOCAL) {
+        if (ref.var && ref.var->isAutoType() && ref.var->parseGetNarrowedType()) {
+            parse_context.pflag |= PF_NARROWED_TYPE;
+        }
+    }
+
     return err;
 }
 
@@ -322,6 +335,17 @@ int VarRefDeclNode::parseInitImpl(QoreValue& val, QoreParseContext& parse_contex
             parse_context.typeInfo = parseGetTypeInfoForInitialAssignment();
         } else {
             parse_context.typeInfo = parseGetTypeInfo();
+        }
+    }
+
+    // Set PF_NARROWED_TYPE flag if this variable has a narrowed type
+    if (type == VT_LOCAL || type == VT_CLOSURE || type == VT_LOCAL_TS) {
+        if (ref.id && ref.id->isAutoType() && ref.id->parseGetNarrowedType()) {
+            parse_context.pflag |= PF_NARROWED_TYPE;
+        }
+    } else if (type == VT_GLOBAL || type == VT_THREAD_LOCAL) {
+        if (ref.var && ref.var->isAutoType() && ref.var->parseGetNarrowedType()) {
+            parse_context.pflag |= PF_NARROWED_TYPE;
         }
     }
 

--- a/lib/Variable.cpp
+++ b/lib/Variable.cpp
@@ -136,9 +136,16 @@ const QoreTypeInfo* Var::parseGetTypeInfo() {
 
     // Return narrowed type if available for auto-typed variables
     // unless PO_BROKEN_NARROWED_TYPES is set
+    // NOTE: For or-nothing types (types that can return NOTHING), we don't return
+    // the narrowed type because narrowing loses the or-nothing semantics which are
+    // important for type checking
     if (is_auto_type && narrowedTypeInfo) {
         QoreProgram* pgm = getProgram();
         if (!pgm || !(pgm->getParseOptions64() & PO_BROKEN_NARROWED_TYPES)) {
+            // Don't return narrowed type if declared type is or-nothing
+            if (QoreTypeInfo::parseReturns(typeInfo, NT_NOTHING) != QTI_NOT_EQUAL) {
+                return refTypeInfo ? refTypeInfo : typeInfo;
+            }
             return narrowedTypeInfo;
         }
     }

--- a/lib/Variable.cpp
+++ b/lib/Variable.cpp
@@ -133,6 +133,15 @@ const QoreTypeInfo* Var::parseGetTypeInfo() {
         return val.v.getPtr()->getTypeInfo();
 
     parseInit();
+
+    // Return narrowed type if available for auto-typed variables
+    // unless PO_BROKEN_NARROWED_TYPES is set
+    if (is_auto_type && narrowedTypeInfo) {
+        QoreProgram* pgm = getProgram();
+        if (!pgm || !(pgm->getParseOptions64() & PO_BROKEN_NARROWED_TYPES)) {
+            return narrowedTypeInfo;
+        }
+    }
     return refTypeInfo ? refTypeInfo : typeInfo;
 }
 
@@ -2217,4 +2226,109 @@ AbstractQoreNode* ClosureVarValue::getReference(const QoreProgramLocation* loc, 
 
     //printd(5, "ClosureVarValue::getReference() this: %p '%s' closure lvalue_id: %p\n", this, name, lvalue_id);
     return new VarRefImmediateNode(loc, strdup(name), this, typeInfo);
+}
+
+// LocalVar type narrowing methods
+
+bool LocalVar::isAutoTypeInfo(const QoreTypeInfo* ti) {
+    // Check for direct auto types (but NOT pure auto - it's meant to hold any type)
+    // Note: softlist<auto> is excluded because it accepts scalar values that get
+    // automatically converted to lists, making straightforward type narrowing incorrect
+    if (ti == autoHashTypeInfo || ti == autoHashOrNothingTypeInfo
+        || ti == autoListTypeInfo || ti == autoListOrNothingTypeInfo) {
+        return true;
+    }
+    // Check for complex types with auto element type (hash only, not list)
+    // List types are excluded because softlist accepts scalars
+    const QoreTypeInfo* elementType = QoreTypeInfo::getComplexHashValueType(ti);
+    if (elementType == autoTypeInfo) {
+        return true;
+    }
+    return false;
+}
+
+void LocalVar::parseSetNarrowedType(const QoreTypeInfo* ti) {
+    if (!is_auto_type) {
+        return;  // Only narrow auto types
+    }
+    // Don't narrow if the new type is also auto or unspecified
+    if (!QoreTypeInfo::hasType(ti) || ti == autoTypeInfo) {
+        return;
+    }
+    narrowedTypeInfo = ti;
+}
+
+void LocalVar::parseMergeNarrowedType(const QoreTypeInfo* ti) {
+    if (!is_auto_type) {
+        return;  // Only narrow auto types
+    }
+    // Don't merge if the new type is unspecified
+    if (!QoreTypeInfo::hasType(ti)) {
+        return;
+    }
+    if (!narrowedTypeInfo) {
+        narrowedTypeInfo = ti;
+        return;
+    }
+    // Use matchCommonType to find union type
+    // Note: matchCommonType modifies the first argument in place
+    const QoreTypeInfo* common = narrowedTypeInfo;
+    if (!QoreTypeInfo::matchCommonType(common, ti)) {
+        // Types are incompatible, fall back to auto
+        narrowedTypeInfo = nullptr;
+    } else {
+        narrowedTypeInfo = common;
+    }
+}
+
+// Var (global variable) narrowed type methods
+
+bool Var::isAutoTypeInfo(const QoreTypeInfo* ti) {
+    // Check for direct auto types (but NOT pure auto - it's meant to hold any type)
+    // Note: softlist<auto> is excluded because it accepts scalar values that get
+    // automatically converted to lists, making straightforward type narrowing incorrect
+    if (ti == autoHashTypeInfo || ti == autoHashOrNothingTypeInfo
+        || ti == autoListTypeInfo || ti == autoListOrNothingTypeInfo) {
+        return true;
+    }
+    // Check for complex types with auto element type (hash only, not list)
+    // List types are excluded because softlist accepts scalars
+    const QoreTypeInfo* elementType = QoreTypeInfo::getComplexHashValueType(ti);
+    if (elementType == autoTypeInfo) {
+        return true;
+    }
+    return false;
+}
+
+void Var::parseSetNarrowedType(const QoreTypeInfo* ti) {
+    if (!is_auto_type) {
+        return;  // Only narrow auto types
+    }
+    // Don't narrow if the new type is also auto or unspecified
+    if (!QoreTypeInfo::hasType(ti) || ti == autoTypeInfo) {
+        return;
+    }
+    narrowedTypeInfo = ti;
+}
+
+void Var::parseMergeNarrowedType(const QoreTypeInfo* ti) {
+    if (!is_auto_type) {
+        return;  // Only narrow auto types
+    }
+    // Don't merge if the new type is unspecified
+    if (!QoreTypeInfo::hasType(ti)) {
+        return;
+    }
+    if (!narrowedTypeInfo) {
+        narrowedTypeInfo = ti;
+        return;
+    }
+    // Use matchCommonType to find union type
+    const QoreTypeInfo* common = narrowedTypeInfo;
+    if (!QoreTypeInfo::matchCommonType(common, ti)) {
+        // Types are incompatible, fall back to auto
+        narrowedTypeInfo = nullptr;
+    } else {
+        narrowedTypeInfo = common;
+    }
 }

--- a/lib/scanner.lpp
+++ b/lib/scanner.lpp
@@ -995,11 +995,13 @@ RTIME           PT(-?[0-9]+(\.[0-9]+)?[HMSu])+
 ^%broken-loop-statement{WS}*$           parse_set_parse_options(yylloc, PO_BROKEN_LOOP_STATEMENT);
 ^%broken-int-assignments{WS}*$          parse_set_parse_options(yylloc, PO_BROKEN_INT_ASSIGNMENTS);
 ^%broken-operators{WS}*$                parse_set_parse_options(yylloc, PO_BROKEN_OPERATORS);
+^%broken-narrowed-types{WS}*$           parse_set_parse_options(yylloc, PO_BROKEN_NARROWED_TYPES);
 ^%correct-list-parsing{WS}*$            parse_disable_parse_options(yylloc, PO_BROKEN_LIST_PARSING);
 ^%correct-logic-precedence{WS}*$        parse_disable_parse_options(yylloc, PO_BROKEN_LOGIC_PRECEDENCE);
 ^%correct-loop-statement{WS}*$          parse_disable_parse_options(yylloc, PO_BROKEN_LOOP_STATEMENT);
 ^%correct-int-assignments{WS}*$         parse_disable_parse_options(yylloc, PO_BROKEN_INT_ASSIGNMENTS);
 ^%correct-operators{WS}*$               parse_disable_parse_options(yylloc, PO_BROKEN_OPERATORS);
+^%correct-narrowed-types{WS}*$          parse_disable_parse_options(yylloc, PO_BROKEN_NARROWED_TYPES);
 ^%loose-args{WS}*$                      parse_disable_parse_options(yylloc, PO_STRICT_ARGS);
 ^%broken-range{WS}*$                    parse_set_parse_options(yylloc, PO_BROKEN_RANGE);
 ^%correct-range{WS}*$                   parse_disable_parse_options(yylloc, PO_BROKEN_RANGE);

--- a/qlib/ElasticSearchDataProvider/ElasticSearchBulkOperation.qc
+++ b/qlib/ElasticSearchDataProvider/ElasticSearchBulkOperation.qc
@@ -151,9 +151,9 @@ public class ElasticSearchBulkOperation inherits DataProvider::AbstractDataProvi
     }
 
     #! Handles errors from a bulk response
-    /** @param response the bulk API response body
+    /** @param response the bulk API response body (caller guarantees non-NOTHING via response.errors check)
     */
-    private handleBulkErrors(hash<auto> response) {
+    private handleBulkErrors(*hash<auto> response) {
         list<hash<auto>> failures = ();
         int i = 0;
         foreach hash<auto> item in (response.items) {

--- a/qlib/ElasticSearchDataProvider/ElasticSearchBulkOperation.qc
+++ b/qlib/ElasticSearchDataProvider/ElasticSearchBulkOperation.qc
@@ -153,7 +153,7 @@ public class ElasticSearchBulkOperation inherits DataProvider::AbstractDataProvi
     #! Handles errors from a bulk response
     /** @param response the bulk API response body
     */
-    private handleBulkErrors(*hash<auto> response) {
+    private handleBulkErrors(hash<auto> response) {
         list<hash<auto>> failures = ();
         int i = 0;
         foreach hash<auto> item in (response.items) {

--- a/qlib/ElasticSearchDataProvider/ElasticSearchBulkOperation.qc
+++ b/qlib/ElasticSearchDataProvider/ElasticSearchBulkOperation.qc
@@ -151,7 +151,7 @@ public class ElasticSearchBulkOperation inherits DataProvider::AbstractDataProvi
     }
 
     #! Handles errors from a bulk response
-    /** @param response the bulk API response body (caller guarantees non-NOTHING via response.errors check)
+    /** @param response the bulk API response body
     */
     private handleBulkErrors(*hash<auto> response) {
         list<hash<auto>> failures = ();

--- a/qlib/OpenApi3.qm
+++ b/qlib/OpenApi3.qm
@@ -221,12 +221,12 @@ const JsonSerialization = {
 %endif
 
 #! supported mime types for de/serializing data
-public const MimeDataTypes = (
+public const MimeDataTypes =
 %ifndef NoJson
-    # JSON-compatible MIME types from centralized list
-    map {$1: JsonSerialization}, keys MimeTypesJson,
+    # JSON-compatible MIME types from centralized list - use foldl to merge into single hash
+    (foldl $1 + $2, (map {$1: JsonSerialization}, keys MimeTypesJson)) +
 %endif
-) + {
+{
 %ifndef NoYaml
     # issue #3699: more YAML MIME types must be supported
     MimeTypeYaml: YamlSerialization,

--- a/qlib/RestSchemaValidator.qm
+++ b/qlib/RestSchemaValidator.qm
@@ -973,12 +973,12 @@ public namespace RestSchemaValidator {
     public class NullRestSchemaValidator inherits AbstractRestSchemaValidator {
         public {
             #! Data serialization support mapping codes to MIME types and de/serialization functions
-            const DataSerializationSupport = (
+            const DataSerializationSupport =
 %ifndef NoJson
-                # JSON-compatible MIME types from centralized list
-                map {$1: \make_json()}, keys MimeTypesJson,
+                # JSON-compatible MIME types from centralized list - use foldl to merge into single hash
+                (foldl $1 + $2, (map {$1: \make_json()}, keys MimeTypesJson)) +
 %endif
-            ) + {
+            {
 %ifndef NoYaml
                 MimeTypeYamlRpc: \make_yaml(),
                 MimeTypeYaml: \make_yaml(),
@@ -1063,12 +1063,12 @@ public namespace RestSchemaValidator {
                     "code": "url",
                     "in": \mime_parse_form_urlencoded_string(),
                 ),
-            } + (
+            } +
 %ifndef NoJson
-                # JSON-compatible MIME types from centralized list
-                map {$1: {"code": "json", "in": \parse_json()}}, keys MimeTypesJson,
+                # JSON-compatible MIME types from centralized list - use foldl to merge into single hash
+                (foldl $1 + $2, (map {$1: {"code": "json", "in": \parse_json()}}, keys MimeTypesJson)) +
 %endif
-            ) + {
+            {
 %ifndef NoYaml
                 MimeTypeYamlRpc: DeserializeYaml,
                 MimeTypeYaml: DeserializeYaml,

--- a/qlib/Swagger.qm
+++ b/qlib/Swagger.qm
@@ -370,11 +370,11 @@ public const ParameterCollectionFormats = CollectionFormats + (
 );
 
 #! A hash of valid integer type formats
-public const ValidIntFormatsHash = map {$1: True}, ValidIntFormats;
+public const ValidIntFormatsHash = foldl $1 + $2, (map {$1: True}, ValidIntFormats);
 #! A hash of valid number type formats
-public const ValidNumberFormatsHash = map {$1: True}, ValidNumberFormats;
+public const ValidNumberFormatsHash = foldl $1 + $2, (map {$1: True}, ValidNumberFormats);
 #! A hash of valid string type formats
-public const ValidStringFormatsHash = map {$1: True}, ValidStringFormats;
+public const ValidStringFormatsHash = foldl $1 + $2, (map {$1: True}, ValidStringFormats);
 
 %ifndef NoYaml
 #! Yaml serialization
@@ -396,12 +396,12 @@ const JsonSerialization = {
 %endif
 
 #! supported mime types for de/serializing data
-public const MimeDataTypes = (
+public const MimeDataTypes =
 %ifndef NoJson
-    # JSON-compatible MIME types from centralized list
-    map {$1: JsonSerialization}, keys MimeTypesJson,
+    # JSON-compatible MIME types from centralized list - use foldl to merge into single hash
+    (foldl $1 + $2, (map {$1: JsonSerialization}, keys MimeTypesJson)) +
 %endif
-) + {
+{
 %ifndef NoYaml
     # issue #3699: more YAML MIME types must be supported
     MimeTypeYaml: YamlSerialization,
@@ -435,7 +435,7 @@ public const MimeContentTypes = keys MimeDataTypes;
 
 #! Valid transfer protocol schemes.
 public const ValidSchemes = ("http", "https", "ws", "wss");
-public const ValidSchemesHash = map {$1: True}, ValidSchemes;
+public const ValidSchemesHash = foldl $1 + $2, (map {$1: True}, ValidSchemes);
 
 #! Base class for the %Swagger specification objects, wrapping the vendor extensions.
 class ObjectBase inherits Qore::Serializable {

--- a/qlib/Swagger.qm
+++ b/qlib/Swagger.qm
@@ -370,11 +370,11 @@ public const ParameterCollectionFormats = CollectionFormats + (
 );
 
 #! A hash of valid integer type formats
-public const ValidIntFormatsHash = foldl $1 + $2, (map {$1: True}, ValidIntFormats);
+public const ValidIntFormatsHash = map {$1: True}, ValidIntFormats;
 #! A hash of valid number type formats
-public const ValidNumberFormatsHash = foldl $1 + $2, (map {$1: True}, ValidNumberFormats);
+public const ValidNumberFormatsHash = map {$1: True}, ValidNumberFormats;
 #! A hash of valid string type formats
-public const ValidStringFormatsHash = foldl $1 + $2, (map {$1: True}, ValidStringFormats);
+public const ValidStringFormatsHash = map {$1: True}, ValidStringFormats;
 
 %ifndef NoYaml
 #! Yaml serialization
@@ -435,7 +435,7 @@ public const MimeContentTypes = keys MimeDataTypes;
 
 #! Valid transfer protocol schemes.
 public const ValidSchemes = ("http", "https", "ws", "wss");
-public const ValidSchemesHash = foldl $1 + $2, (map {$1: True}, ValidSchemes);
+public const ValidSchemesHash = map {$1: True}, ValidSchemes;
 
 #! Base class for the %Swagger specification objects, wrapping the vendor extensions.
 class ObjectBase inherits Qore::Serializable {


### PR DESCRIPTION
## Summary

Implement parse-time type narrowing for `hash<auto>` and `list<auto>` types. When a variable is declared with an auto-typed container and initialized with a specific type, subsequent incompatible member assignments produce parse-time errors instead of runtime errors.

Closes #5076

## Changes

### Core Implementation
- **LocalVar/Var classes**: Added `narrowedTypeInfo` member, `is_auto_type` flag, and accessor methods (`parseSetNarrowedType`, `parseMergeNarrowedType`, `parseGetNarrowedType`)
- **StatementBlock**: Added `NarrowedTypeHelper` class for tracking and merging types across branches
- **QoreAssignmentOperatorNode**: Update narrowed type during assignment, distinguish between direct variable assignment (updates type) and member assignment (checks against narrowed type)
- **IfStatement/SwitchStatement**: Track narrowed types across branches and merge using common type
- **VarRefNode**: Set `PF_NARROWED_TYPE` parse flag when variable has narrowed type

### New Parse Option
- `PO_BROKEN_NARROWED_TYPES` / `%broken-narrowed-types`: Opt-out mechanism for backwards compatibility (converts errors to the previous behavior)

### Test File Fixes
- `OpenApi3.qtest`, `Swagger.qtest`: Use `+=` operator to avoid type narrowing when passing `hash<auto>` by reference
- `ElasticSearchBulkOperation.qc`: Changed parameter type to `*hash<auto>` to accept nothing

## Example

```qore
hash<auto> h = {"a": "b"};  # Narrowed to hash<string, string>
h.c = 1;  # PARSE-TYPE-ERROR: expects string, got int

# Direct reassignment updates the narrowed type
h = {"x": 1};  # Now narrowed to hash<string, int>
h.y = 2;  # OK
```

## Test plan

- [x] New test file `type_narrowing.qtest` with 34 test cases covering basic narrowing, branch merging, and backwards compatibility
- [x] All existing module tests pass (OpenApi3, Swagger, ServiceNow, Salesforce, HttpServer, RestHandler, DataProvider, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #5076