### PR TITLE
refs #5080 Add iterator element type inference for operators

### DIFF
--- a/include/qore/intern/FunctionCallNode.h
+++ b/include/qore/intern/FunctionCallNode.h
@@ -363,7 +363,7 @@ public:
 
     DLLLOCAL MethodCallNode(const MethodCallNode& old, QoreListNode* n_args)
             : AbstractMethodCallNode(old, n_args), c_str(old.c_str ? strdup(old.c_str) : nullptr),
-            pseudo(old.pseudo) {
+            pseudo(old.pseudo), sourceTypeInfo(old.sourceTypeInfo) {
     }
 
     DLLLOCAL virtual ~MethodCallNode() {
@@ -434,9 +434,22 @@ public:
         return pseudoTypeInfo;
     }
 
+    //! Sets the source type info (type of object the method is called on)
+    /** Used for iterator element type inference in map operators
+    */
+    DLLLOCAL void setSourceType(const QoreTypeInfo* ti) {
+        sourceTypeInfo = ti;
+    }
+
+    //! Returns the source type info (type of object the method is called on)
+    DLLLOCAL const QoreTypeInfo* getSourceType() const {
+        return sourceTypeInfo;
+    }
+
 protected:
     char* c_str;
     const QoreTypeInfo* pseudoTypeInfo = nullptr;
+    const QoreTypeInfo* sourceTypeInfo = nullptr;  //!< type of object the method is called on
     bool pseudo = false;
 
     using AbstractFunctionCallNode::evalImpl;

--- a/include/qore/intern/QoreDotEvalOperatorNode.h
+++ b/include/qore/intern/QoreDotEvalOperatorNode.h
@@ -66,6 +66,11 @@ public:
         return left;
     }
 
+    //! Returns the method call node
+    DLLLOCAL MethodCallNode* getMethodCall() const {
+        return m;
+    }
+
     DLLLOCAL void replaceExpression(QoreValue n_left) {
         left.discard(nullptr);
         left = n_left;

--- a/include/qore/intern/QoreTypeInfo.h
+++ b/include/qore/intern/QoreTypeInfo.h
@@ -605,20 +605,34 @@ public:
             : ti->return_vec[0].spec.getComplexList();
     }
 
-    //! Returns the element type for an iterator class based on source type
-    /** For HashPairIterator with source hash<string, int>: returns hash<HashPairInfo> with value: int
-        For HashKeyIterator with source hash<string, int>: returns string
-        For HashIterator with source hash<string, int>: returns int (value type)
-        For ListIterator with source list<T>: returns T
+    //! Returns the element type info for an iterator class based on source type
+    /** For HashPairIterator with source hash<string, int>: returns the type info for
+        hash<HashPairInfo> where HashPairInfo has key: string and value: int
+        For HashKeyIterator with source hash<string, int>: returns the type info for string
+        For HashIterator with source hash<string, int>: returns the type info for int (value type)
+        For ListIterator with source list<T>: returns the type info for T
 
         @param iteratorClass the iterator class (e.g., HashPairIterator)
         @param sourceTypeInfo the type of the source expression (e.g., hash<string, int>)
-        @return the element type, or nullptr if unknown
+        @return the element type info (QoreTypeInfo pointer), or nullptr if unknown
 
         @since Qore 2.1
     */
     DLLLOCAL static const QoreTypeInfo* getIteratorElementType(const QoreClass* iteratorClass,
         const QoreTypeInfo* sourceTypeInfo);
+
+    //! Returns the implicit argument type for a functional operator's iterator expression
+    /** This helper function extracts the implicit argument type from an iterator expression,
+        checking both list element types and iterator class element types.
+
+        @param iteratorExpr the iterator expression value (e.g., h.pairIterator())
+        @param iteratorTypeInfo the type info of the iterator expression
+        @return the implicit argument type for the iterator, or nullptr if unknown
+
+        @since Qore 2.1
+    */
+    DLLLOCAL static const QoreTypeInfo* getImplicitArgTypeForIterator(const QoreValue& iteratorExpr,
+        const QoreTypeInfo* iteratorTypeInfo);
 
     //! Returns or creates a HashPairInfo type with the given value type
     /** @param valueType the type for the "value" member

--- a/include/qore/intern/QoreTypeInfo.h
+++ b/include/qore/intern/QoreTypeInfo.h
@@ -605,6 +605,29 @@ public:
             : ti->return_vec[0].spec.getComplexList();
     }
 
+    //! Returns the element type for an iterator class based on source type
+    /** For HashPairIterator with source hash<string, int>: returns hash<HashPairInfo> with value: int
+        For HashKeyIterator with source hash<string, int>: returns string
+        For HashIterator with source hash<string, int>: returns int (value type)
+        For ListIterator with source list<T>: returns T
+
+        @param iteratorClass the iterator class (e.g., HashPairIterator)
+        @param sourceTypeInfo the type of the source expression (e.g., hash<string, int>)
+        @return the element type, or nullptr if unknown
+
+        @since Qore 2.1
+    */
+    DLLLOCAL static const QoreTypeInfo* getIteratorElementType(const QoreClass* iteratorClass,
+        const QoreTypeInfo* sourceTypeInfo);
+
+    //! Returns or creates a HashPairInfo type with the given value type
+    /** @param valueType the type for the "value" member
+        @return the HashPairInfo type with the specified value type
+
+        @since Qore 2.1
+    */
+    DLLLOCAL static const QoreTypeInfo* getHashPairType(const QoreTypeInfo* valueType);
+
     // static version of method, checking for null pointer
     DLLLOCAL static const QoreTypeInfo* getUniqueReturnComplexSoftList(const QoreTypeInfo* ti) {
         if (!ti || ti->return_vec.size() > 1 || !hasType(ti))

--- a/lib/QoreDotEvalOperatorNode.cpp
+++ b/lib/QoreDotEvalOperatorNode.cpp
@@ -97,6 +97,9 @@ int QoreDotEvalOperatorNode::parseInitImpl(QoreValue& val, QoreParseContext& par
     int err = parse_init_value(left, parse_context);
     const QoreTypeInfo* typeInfo = parse_context.typeInfo;
 
+    // Store the source type for iterator element type inference in map operators
+    m->setSourceType(typeInfo);
+
     QoreClass* qc = const_cast<QoreClass*>(QoreTypeInfo::getUniqueReturnClass(typeInfo));
 
     const QoreMethod* meth = nullptr;

--- a/lib/QoreFoldlOperatorNode.cpp
+++ b/lib/QoreFoldlOperatorNode.cpp
@@ -31,7 +31,6 @@
 #include <qore/Qore.h>
 
 #include "qore/intern/qore_program_private.h"
-#include "qore/intern/QoreDotEvalOperatorNode.h"
 
 #include <memory>
 
@@ -63,29 +62,8 @@ int QoreFoldlOperatorNode::parseInitImpl(QoreValue& val, QoreParseContext& parse
     {
         // set implicit argv arg type
         // FIXME: only works if the result of the fold operation results in the exact same type as the argument type
-        const QoreTypeInfo* implicitArgType = QoreTypeInfo::getUniqueReturnComplexList(iteratorTypeInfo);
-
-        // If not a list, check if it's an iterator class and get element type from source type
-        if (!implicitArgType) {
-            const QoreClass* qc = QoreTypeInfo::getUniqueReturnClass(iteratorTypeInfo);
-            if (qc) {
-                // Try to get the source type from the iterator expression if it's a method call
-                const QoreTypeInfo* sourceType = nullptr;
-                if (right.getType() == NT_OPERATOR) {
-                    const QoreDotEvalOperatorNode* dotOp =
-                        dynamic_cast<const QoreDotEvalOperatorNode*>(right.getInternalNode());
-                    if (dotOp) {
-                        MethodCallNode* mcn = dotOp->getMethodCall();
-                        if (mcn) {
-                            sourceType = mcn->getSourceType();
-                        }
-                    }
-                }
-                if (sourceType) {
-                    implicitArgType = QoreTypeInfo::getIteratorElementType(qc, sourceType);
-                }
-            }
-        }
+        const QoreTypeInfo* implicitArgType =
+            QoreTypeInfo::getImplicitArgTypeForIterator(right, iteratorTypeInfo);
 
         ParseImplicitArgTypeHelper pia(implicitArgType);
 

--- a/lib/QoreFoldlOperatorNode.cpp
+++ b/lib/QoreFoldlOperatorNode.cpp
@@ -31,6 +31,7 @@
 #include <qore/Qore.h>
 
 #include "qore/intern/qore_program_private.h"
+#include "qore/intern/QoreDotEvalOperatorNode.h"
 
 #include <memory>
 
@@ -62,7 +63,31 @@ int QoreFoldlOperatorNode::parseInitImpl(QoreValue& val, QoreParseContext& parse
     {
         // set implicit argv arg type
         // FIXME: only works if the result of the fold operation results in the exact same type as the argument type
-        ParseImplicitArgTypeHelper pia(QoreTypeInfo::getUniqueReturnComplexList(iteratorTypeInfo));
+        const QoreTypeInfo* implicitArgType = QoreTypeInfo::getUniqueReturnComplexList(iteratorTypeInfo);
+
+        // If not a list, check if it's an iterator class and get element type from source type
+        if (!implicitArgType) {
+            const QoreClass* qc = QoreTypeInfo::getUniqueReturnClass(iteratorTypeInfo);
+            if (qc) {
+                // Try to get the source type from the iterator expression if it's a method call
+                const QoreTypeInfo* sourceType = nullptr;
+                if (right.getType() == NT_OPERATOR) {
+                    const QoreDotEvalOperatorNode* dotOp =
+                        dynamic_cast<const QoreDotEvalOperatorNode*>(right.getInternalNode());
+                    if (dotOp) {
+                        MethodCallNode* mcn = dotOp->getMethodCall();
+                        if (mcn) {
+                            sourceType = mcn->getSourceType();
+                        }
+                    }
+                }
+                if (sourceType) {
+                    implicitArgType = QoreTypeInfo::getIteratorElementType(qc, sourceType);
+                }
+            }
+        }
+
+        ParseImplicitArgTypeHelper pia(implicitArgType);
 
         parse_context.typeInfo = nullptr;
         if (parse_init_value(left, parse_context) && !err) {

--- a/lib/QoreHashMapOperatorNode.cpp
+++ b/lib/QoreHashMapOperatorNode.cpp
@@ -32,6 +32,7 @@
 
 #include "qore/intern/qore_program_private.h"
 #include "qore/intern/QoreHashNodeIntern.h"
+#include "qore/intern/QoreDotEvalOperatorNode.h"
 
 QoreString QoreHashMapOperatorNode::map_str("map operator expression");
 
@@ -84,7 +85,32 @@ int QoreHashMapOperatorNode::parseInitImpl(QoreValue& val, QoreParseContext& par
     const QoreTypeInfo* expTypeInfo2;
     {
         // set implicit argv arg type
-        ParseImplicitArgTypeHelper pia(QoreTypeInfo::getUniqueReturnComplexList(iteratorTypeInfo));
+        // First try list element type (existing behavior)
+        const QoreTypeInfo* implicitArgType = QoreTypeInfo::getUniqueReturnComplexList(iteratorTypeInfo);
+
+        // If not a list, check if it's an iterator class and get element type from source type
+        if (!implicitArgType) {
+            const QoreClass* qc = QoreTypeInfo::getUniqueReturnClass(iteratorTypeInfo);
+            if (qc) {
+                // Try to get the source type from the iterator expression if it's a method call
+                const QoreTypeInfo* sourceType = nullptr;
+                if (e[2].getType() == NT_OPERATOR) {
+                    const QoreDotEvalOperatorNode* dotOp =
+                        dynamic_cast<const QoreDotEvalOperatorNode*>(e[2].getInternalNode());
+                    if (dotOp) {
+                        MethodCallNode* mcn = dotOp->getMethodCall();
+                        if (mcn) {
+                            sourceType = mcn->getSourceType();
+                        }
+                    }
+                }
+                if (sourceType) {
+                    implicitArgType = QoreTypeInfo::getIteratorElementType(qc, sourceType);
+                }
+            }
+        }
+
+        ParseImplicitArgTypeHelper pia(implicitArgType);
 
         // check key expression
         parse_context.typeInfo = nullptr;

--- a/lib/QoreHashMapOperatorNode.cpp
+++ b/lib/QoreHashMapOperatorNode.cpp
@@ -32,7 +32,6 @@
 
 #include "qore/intern/qore_program_private.h"
 #include "qore/intern/QoreHashNodeIntern.h"
-#include "qore/intern/QoreDotEvalOperatorNode.h"
 
 QoreString QoreHashMapOperatorNode::map_str("map operator expression");
 
@@ -85,30 +84,8 @@ int QoreHashMapOperatorNode::parseInitImpl(QoreValue& val, QoreParseContext& par
     const QoreTypeInfo* expTypeInfo2;
     {
         // set implicit argv arg type
-        // First try list element type (existing behavior)
-        const QoreTypeInfo* implicitArgType = QoreTypeInfo::getUniqueReturnComplexList(iteratorTypeInfo);
-
-        // If not a list, check if it's an iterator class and get element type from source type
-        if (!implicitArgType) {
-            const QoreClass* qc = QoreTypeInfo::getUniqueReturnClass(iteratorTypeInfo);
-            if (qc) {
-                // Try to get the source type from the iterator expression if it's a method call
-                const QoreTypeInfo* sourceType = nullptr;
-                if (e[2].getType() == NT_OPERATOR) {
-                    const QoreDotEvalOperatorNode* dotOp =
-                        dynamic_cast<const QoreDotEvalOperatorNode*>(e[2].getInternalNode());
-                    if (dotOp) {
-                        MethodCallNode* mcn = dotOp->getMethodCall();
-                        if (mcn) {
-                            sourceType = mcn->getSourceType();
-                        }
-                    }
-                }
-                if (sourceType) {
-                    implicitArgType = QoreTypeInfo::getIteratorElementType(qc, sourceType);
-                }
-            }
-        }
+        const QoreTypeInfo* implicitArgType =
+            QoreTypeInfo::getImplicitArgTypeForIterator(e[2], iteratorTypeInfo);
 
         ParseImplicitArgTypeHelper pia(implicitArgType);
 

--- a/lib/QoreHashMapSelectOperatorNode.cpp
+++ b/lib/QoreHashMapSelectOperatorNode.cpp
@@ -32,7 +32,6 @@
 
 #include "qore/intern/qore_program_private.h"
 #include "qore/intern/QoreHashNodeIntern.h"
-#include "qore/intern/QoreDotEvalOperatorNode.h"
 
 QoreString QoreHashMapSelectOperatorNode::map_str("map operator expression");
 
@@ -60,29 +59,8 @@ int QoreHashMapSelectOperatorNode::parseInitImpl(QoreValue& val, QoreParseContex
     const QoreTypeInfo* expTypeInfo2;
     {
         // set implicit argv arg type
-        const QoreTypeInfo* implicitArgType = QoreTypeInfo::getUniqueReturnComplexList(iteratorTypeInfo);
-
-        // If not a list, check if it's an iterator class and get element type from source type
-        if (!implicitArgType) {
-            const QoreClass* qc = QoreTypeInfo::getUniqueReturnClass(iteratorTypeInfo);
-            if (qc) {
-                // Try to get the source type from the iterator expression if it's a method call
-                const QoreTypeInfo* sourceType = nullptr;
-                if (e[2].getType() == NT_OPERATOR) {
-                    const QoreDotEvalOperatorNode* dotOp =
-                        dynamic_cast<const QoreDotEvalOperatorNode*>(e[2].getInternalNode());
-                    if (dotOp) {
-                        MethodCallNode* mcn = dotOp->getMethodCall();
-                        if (mcn) {
-                            sourceType = mcn->getSourceType();
-                        }
-                    }
-                }
-                if (sourceType) {
-                    implicitArgType = QoreTypeInfo::getIteratorElementType(qc, sourceType);
-                }
-            }
-        }
+        const QoreTypeInfo* implicitArgType =
+            QoreTypeInfo::getImplicitArgTypeForIterator(e[2], iteratorTypeInfo);
 
         ParseImplicitArgTypeHelper pia(implicitArgType);
 

--- a/lib/QoreHashMapSelectOperatorNode.cpp
+++ b/lib/QoreHashMapSelectOperatorNode.cpp
@@ -32,6 +32,7 @@
 
 #include "qore/intern/qore_program_private.h"
 #include "qore/intern/QoreHashNodeIntern.h"
+#include "qore/intern/QoreDotEvalOperatorNode.h"
 
 QoreString QoreHashMapSelectOperatorNode::map_str("map operator expression");
 
@@ -59,7 +60,31 @@ int QoreHashMapSelectOperatorNode::parseInitImpl(QoreValue& val, QoreParseContex
     const QoreTypeInfo* expTypeInfo2;
     {
         // set implicit argv arg type
-        ParseImplicitArgTypeHelper pia(QoreTypeInfo::getUniqueReturnComplexList(iteratorTypeInfo));
+        const QoreTypeInfo* implicitArgType = QoreTypeInfo::getUniqueReturnComplexList(iteratorTypeInfo);
+
+        // If not a list, check if it's an iterator class and get element type from source type
+        if (!implicitArgType) {
+            const QoreClass* qc = QoreTypeInfo::getUniqueReturnClass(iteratorTypeInfo);
+            if (qc) {
+                // Try to get the source type from the iterator expression if it's a method call
+                const QoreTypeInfo* sourceType = nullptr;
+                if (e[2].getType() == NT_OPERATOR) {
+                    const QoreDotEvalOperatorNode* dotOp =
+                        dynamic_cast<const QoreDotEvalOperatorNode*>(e[2].getInternalNode());
+                    if (dotOp) {
+                        MethodCallNode* mcn = dotOp->getMethodCall();
+                        if (mcn) {
+                            sourceType = mcn->getSourceType();
+                        }
+                    }
+                }
+                if (sourceType) {
+                    implicitArgType = QoreTypeInfo::getIteratorElementType(qc, sourceType);
+                }
+            }
+        }
+
+        ParseImplicitArgTypeHelper pia(implicitArgType);
 
         // check key expression
         parse_context.typeInfo = nullptr;

--- a/lib/QoreMapOperatorNode.cpp
+++ b/lib/QoreMapOperatorNode.cpp
@@ -34,6 +34,7 @@
 #include "qore/intern/FunctionalOperator.h"
 #include "qore/intern/FunctionalOperatorInterface.h"
 #include "qore/intern/qore_list_private.h"
+#include "qore/intern/QoreDotEvalOperatorNode.h"
 
 #include <memory>
 
@@ -90,7 +91,32 @@ int QoreMapOperatorNode::parseInitImpl(QoreValue& val, QoreParseContext& parse_c
     // check iterated expression
     {
         // set implicit argument type
-        ParseImplicitArgTypeHelper pia(QoreTypeInfo::getUniqueReturnComplexList(iteratorTypeInfo));
+        // First try list element type (existing behavior)
+        const QoreTypeInfo* implicitArgType = QoreTypeInfo::getUniqueReturnComplexList(iteratorTypeInfo);
+
+        // If not a list, check if it's an iterator class and get element type from source type
+        if (!implicitArgType) {
+            const QoreClass* qc = QoreTypeInfo::getUniqueReturnClass(iteratorTypeInfo);
+            if (qc) {
+                // Try to get the source type from the iterator expression if it's a method call
+                const QoreTypeInfo* sourceType = nullptr;
+                if (right.getType() == NT_OPERATOR) {
+                    const QoreDotEvalOperatorNode* dotOp =
+                        dynamic_cast<const QoreDotEvalOperatorNode*>(right.getInternalNode());
+                    if (dotOp) {
+                        MethodCallNode* mcn = dotOp->getMethodCall();
+                        if (mcn) {
+                            sourceType = mcn->getSourceType();
+                        }
+                    }
+                }
+                if (sourceType) {
+                    implicitArgType = QoreTypeInfo::getIteratorElementType(qc, sourceType);
+                }
+            }
+        }
+
+        ParseImplicitArgTypeHelper pia(implicitArgType);
         parse_context.typeInfo = nullptr;
         if (parse_init_value(left, parse_context) && !err) {
             err = -1;

--- a/lib/QoreMapOperatorNode.cpp
+++ b/lib/QoreMapOperatorNode.cpp
@@ -34,7 +34,6 @@
 #include "qore/intern/FunctionalOperator.h"
 #include "qore/intern/FunctionalOperatorInterface.h"
 #include "qore/intern/qore_list_private.h"
-#include "qore/intern/QoreDotEvalOperatorNode.h"
 
 #include <memory>
 
@@ -91,30 +90,8 @@ int QoreMapOperatorNode::parseInitImpl(QoreValue& val, QoreParseContext& parse_c
     // check iterated expression
     {
         // set implicit argument type
-        // First try list element type (existing behavior)
-        const QoreTypeInfo* implicitArgType = QoreTypeInfo::getUniqueReturnComplexList(iteratorTypeInfo);
-
-        // If not a list, check if it's an iterator class and get element type from source type
-        if (!implicitArgType) {
-            const QoreClass* qc = QoreTypeInfo::getUniqueReturnClass(iteratorTypeInfo);
-            if (qc) {
-                // Try to get the source type from the iterator expression if it's a method call
-                const QoreTypeInfo* sourceType = nullptr;
-                if (right.getType() == NT_OPERATOR) {
-                    const QoreDotEvalOperatorNode* dotOp =
-                        dynamic_cast<const QoreDotEvalOperatorNode*>(right.getInternalNode());
-                    if (dotOp) {
-                        MethodCallNode* mcn = dotOp->getMethodCall();
-                        if (mcn) {
-                            sourceType = mcn->getSourceType();
-                        }
-                    }
-                }
-                if (sourceType) {
-                    implicitArgType = QoreTypeInfo::getIteratorElementType(qc, sourceType);
-                }
-            }
-        }
+        const QoreTypeInfo* implicitArgType =
+            QoreTypeInfo::getImplicitArgTypeForIterator(right, iteratorTypeInfo);
 
         ParseImplicitArgTypeHelper pia(implicitArgType);
         parse_context.typeInfo = nullptr;

--- a/lib/QoreMapSelectOperatorNode.cpp
+++ b/lib/QoreMapSelectOperatorNode.cpp
@@ -32,6 +32,7 @@
 
 #include "qore/intern/qore_program_private.h"
 #include "qore/intern/qore_list_private.h"
+#include "qore/intern/QoreDotEvalOperatorNode.h"
 
 #include <memory>
 
@@ -61,7 +62,31 @@ int QoreMapSelectOperatorNode::parseInitImpl(QoreValue& val, QoreParseContext& p
 
     {
         // set implicit argument type
-        ParseImplicitArgTypeHelper pia(QoreTypeInfo::getUniqueReturnComplexList(iteratorTypeInfo));
+        const QoreTypeInfo* implicitArgType = QoreTypeInfo::getUniqueReturnComplexList(iteratorTypeInfo);
+
+        // If not a list, check if it's an iterator class and get element type from source type
+        if (!implicitArgType) {
+            const QoreClass* qc = QoreTypeInfo::getUniqueReturnClass(iteratorTypeInfo);
+            if (qc) {
+                // Try to get the source type from the iterator expression if it's a method call
+                const QoreTypeInfo* sourceType = nullptr;
+                if (e[1].getType() == NT_OPERATOR) {
+                    const QoreDotEvalOperatorNode* dotOp =
+                        dynamic_cast<const QoreDotEvalOperatorNode*>(e[1].getInternalNode());
+                    if (dotOp) {
+                        MethodCallNode* mcn = dotOp->getMethodCall();
+                        if (mcn) {
+                            sourceType = mcn->getSourceType();
+                        }
+                    }
+                }
+                if (sourceType) {
+                    implicitArgType = QoreTypeInfo::getIteratorElementType(qc, sourceType);
+                }
+            }
+        }
+
+        ParseImplicitArgTypeHelper pia(implicitArgType);
         // check iterated expression
         parse_context.typeInfo = nullptr;
         if (parse_init_value(e[0], parse_context) && !err) {

--- a/lib/QoreMapSelectOperatorNode.cpp
+++ b/lib/QoreMapSelectOperatorNode.cpp
@@ -32,7 +32,6 @@
 
 #include "qore/intern/qore_program_private.h"
 #include "qore/intern/qore_list_private.h"
-#include "qore/intern/QoreDotEvalOperatorNode.h"
 
 #include <memory>
 
@@ -62,29 +61,8 @@ int QoreMapSelectOperatorNode::parseInitImpl(QoreValue& val, QoreParseContext& p
 
     {
         // set implicit argument type
-        const QoreTypeInfo* implicitArgType = QoreTypeInfo::getUniqueReturnComplexList(iteratorTypeInfo);
-
-        // If not a list, check if it's an iterator class and get element type from source type
-        if (!implicitArgType) {
-            const QoreClass* qc = QoreTypeInfo::getUniqueReturnClass(iteratorTypeInfo);
-            if (qc) {
-                // Try to get the source type from the iterator expression if it's a method call
-                const QoreTypeInfo* sourceType = nullptr;
-                if (e[1].getType() == NT_OPERATOR) {
-                    const QoreDotEvalOperatorNode* dotOp =
-                        dynamic_cast<const QoreDotEvalOperatorNode*>(e[1].getInternalNode());
-                    if (dotOp) {
-                        MethodCallNode* mcn = dotOp->getMethodCall();
-                        if (mcn) {
-                            sourceType = mcn->getSourceType();
-                        }
-                    }
-                }
-                if (sourceType) {
-                    implicitArgType = QoreTypeInfo::getIteratorElementType(qc, sourceType);
-                }
-            }
-        }
+        const QoreTypeInfo* implicitArgType =
+            QoreTypeInfo::getImplicitArgTypeForIterator(e[1], iteratorTypeInfo);
 
         ParseImplicitArgTypeHelper pia(implicitArgType);
         // check iterated expression

--- a/lib/QoreParseHashNode.cpp
+++ b/lib/QoreParseHashNode.cpp
@@ -159,12 +159,16 @@ QoreValue QoreParseHashNode::evalImpl(bool& needs_deref, ExceptionSink* xsink) c
 
     for (size_t i = 0; i < keys.size(); ++i) {
         ValueEvalOptimizedRefHolder k(keys[i], xsink);
-        if (xsink && *xsink)
+        if (xsink && *xsink) {
+            needs_deref = false;
             return QoreValue();
+        }
 
         ValueEvalOptimizedRefHolder v(values[i], xsink);
-        if (xsink && *xsink)
+        if (xsink && *xsink) {
+            needs_deref = false;
             return QoreValue();
+        }
 
         const QoreTypeInfo* vt = v->getTypeInfo();
 
@@ -189,6 +193,7 @@ QoreValue QoreParseHashNode::evalImpl(bool& needs_deref, ExceptionSink* xsink) c
 
         h->setKeyValue(key->c_str(), val, xsink);
         if (xsink && *xsink) {
+            needs_deref = false;
             return QoreValue();
         }
     }

--- a/lib/QoreParseListNode.cpp
+++ b/lib/QoreParseListNode.cpp
@@ -134,6 +134,7 @@ QoreValue QoreParseListNode::evalImpl(bool& needs_deref, ExceptionSink* xsink) c
     for (size_t i = 0; i < values.size(); ++i) {
         ValueEvalOptimizedRefHolder v(values[i], xsink);
         if (xsink && *xsink) {
+            needs_deref = false;
             return QoreValue();
         }
 

--- a/lib/QoreSelectOperatorNode.cpp
+++ b/lib/QoreSelectOperatorNode.cpp
@@ -34,7 +34,6 @@
 #include "qore/intern/FunctionalOperator.h"
 #include "qore/intern/FunctionalOperatorInterface.h"
 #include "qore/intern/qore_list_private.h"
-#include "qore/intern/QoreDotEvalOperatorNode.h"
 
 #include <memory>
 
@@ -61,30 +60,9 @@ int QoreSelectOperatorNode::parseInitImpl(QoreValue& val, QoreParseContext& pars
     int err = parse_init_value(left, parse_context);
     const QoreTypeInfo* iteratorTypeInfo = parse_context.typeInfo;
 
-    // get list element type, if any
-    const QoreTypeInfo* elementTypeInfo = QoreTypeInfo::getUniqueReturnComplexList(iteratorTypeInfo);
-
-    // If not a list, check if it's an iterator class and get element type from source type
-    if (!elementTypeInfo) {
-        const QoreClass* qc = QoreTypeInfo::getUniqueReturnClass(iteratorTypeInfo);
-        if (qc) {
-            // Try to get the source type from the iterator expression if it's a method call
-            const QoreTypeInfo* sourceType = nullptr;
-            if (left.getType() == NT_OPERATOR) {
-                const QoreDotEvalOperatorNode* dotOp =
-                    dynamic_cast<const QoreDotEvalOperatorNode*>(left.getInternalNode());
-                if (dotOp) {
-                    MethodCallNode* mcn = dotOp->getMethodCall();
-                    if (mcn) {
-                        sourceType = mcn->getSourceType();
-                    }
-                }
-            }
-            if (sourceType) {
-                elementTypeInfo = QoreTypeInfo::getIteratorElementType(qc, sourceType);
-            }
-        }
-    }
+    // get element type for the iterator (works for both list<T> and iterator classes)
+    const QoreTypeInfo* elementTypeInfo =
+        QoreTypeInfo::getImplicitArgTypeForIterator(left, iteratorTypeInfo);
 
     parse_context.typeInfo = nullptr;
     {

--- a/lib/QoreSelectOperatorNode.cpp
+++ b/lib/QoreSelectOperatorNode.cpp
@@ -34,6 +34,7 @@
 #include "qore/intern/FunctionalOperator.h"
 #include "qore/intern/FunctionalOperatorInterface.h"
 #include "qore/intern/qore_list_private.h"
+#include "qore/intern/QoreDotEvalOperatorNode.h"
 
 #include <memory>
 
@@ -62,6 +63,28 @@ int QoreSelectOperatorNode::parseInitImpl(QoreValue& val, QoreParseContext& pars
 
     // get list element type, if any
     const QoreTypeInfo* elementTypeInfo = QoreTypeInfo::getUniqueReturnComplexList(iteratorTypeInfo);
+
+    // If not a list, check if it's an iterator class and get element type from source type
+    if (!elementTypeInfo) {
+        const QoreClass* qc = QoreTypeInfo::getUniqueReturnClass(iteratorTypeInfo);
+        if (qc) {
+            // Try to get the source type from the iterator expression if it's a method call
+            const QoreTypeInfo* sourceType = nullptr;
+            if (left.getType() == NT_OPERATOR) {
+                const QoreDotEvalOperatorNode* dotOp =
+                    dynamic_cast<const QoreDotEvalOperatorNode*>(left.getInternalNode());
+                if (dotOp) {
+                    MethodCallNode* mcn = dotOp->getMethodCall();
+                    if (mcn) {
+                        sourceType = mcn->getSourceType();
+                    }
+                }
+            }
+            if (sourceType) {
+                elementTypeInfo = QoreTypeInfo::getIteratorElementType(qc, sourceType);
+            }
+        }
+    }
 
     parse_context.typeInfo = nullptr;
     {
@@ -104,8 +127,9 @@ int QoreSelectOperatorNode::parseInitImpl(QoreValue& val, QoreParseContext& pars
         parse_context.typeInfo = nullptr;
     }
 
+    // If we have element type info, create a properly typed list
     if (parse_context.typeInfo == listTypeInfo && elementTypeInfo) {
-        parse_context.typeInfo = iteratorTypeInfo;
+        parse_context.typeInfo = qore_get_complex_list_type(elementTypeInfo);
     }
 
     return err;

--- a/lib/QoreTypeInfo.cpp
+++ b/lib/QoreTypeInfo.cpp
@@ -38,6 +38,8 @@
 #include "qore/intern/typed_hash_decl_private.h"
 #include "qore/intern/qore_list_private.h"
 #include "qore/intern/QoreHashNodeIntern.h"
+#include "qore/intern/QoreDotEvalOperatorNode.h"
+#include "qore/intern/FunctionCallNode.h"
 
 const QoreAnyTypeInfo staticAnyTypeInfo;
 const QoreAutoTypeInfo staticAutoTypeInfo;
@@ -2209,4 +2211,34 @@ const QoreTypeInfo* QoreTypeInfo::getIteratorElementType(const QoreClass* iterat
     }
 
     return nullptr;
+}
+
+const QoreTypeInfo* QoreTypeInfo::getImplicitArgTypeForIterator(const QoreValue& iteratorExpr,
+        const QoreTypeInfo* iteratorTypeInfo) {
+    // First try list element type (existing behavior for list<T> sources)
+    const QoreTypeInfo* implicitArgType = getUniqueReturnComplexList(iteratorTypeInfo);
+
+    // If not a list, check if it's an iterator class and get element type from source type
+    if (!implicitArgType) {
+        const QoreClass* qc = getUniqueReturnClass(iteratorTypeInfo);
+        if (qc) {
+            // Try to get the source type from the iterator expression if it's a method call
+            const QoreTypeInfo* sourceType = nullptr;
+            if (iteratorExpr.getType() == NT_OPERATOR) {
+                const QoreDotEvalOperatorNode* dotOp =
+                    dynamic_cast<const QoreDotEvalOperatorNode*>(iteratorExpr.getInternalNode());
+                if (dotOp) {
+                    MethodCallNode* mcn = dotOp->getMethodCall();
+                    if (mcn) {
+                        sourceType = mcn->getSourceType();
+                    }
+                }
+            }
+            if (sourceType) {
+                implicitArgType = getIteratorElementType(qc, sourceType);
+            }
+        }
+    }
+
+    return implicitArgType;
 }

--- a/lib/QoreTypeInfo.cpp
+++ b/lib/QoreTypeInfo.cpp
@@ -257,6 +257,10 @@ tmap_t ch_map,          // complex hash map
    csl_map,             // complex softlist map
    cslon_map;           // complex softlist or nothing map
 
+// Cache for parameterized HashPairInfo types based on value type
+typedef std::map<const QoreTypeInfo*, TypedHashDecl*> hp_decl_map_t;
+static hp_decl_map_t hp_decl_map;
+
 // rwlock for global type map
 static QoreRWLock extern_type_info_map_lock;
 
@@ -363,6 +367,9 @@ void delete_qore_types() {
         delete i.second;
     for (auto& i : cslon_map)
         delete i.second;
+    // Clean up hash pair info decl cache
+    for (auto& i : hp_decl_map)
+        typed_hash_decl_private::get(*i.second)->deref();
 }
 
 void add_to_type_map(qore_type_t t, const QoreTypeInfo* typeInfo) {
@@ -2117,4 +2124,89 @@ void map_get_plain_hash(QoreValue& n, ExceptionSink* xsink) {
 void map_get_plain_list(QoreValue& n, ExceptionSink* xsink) {
     ReferenceHolder<QoreListNode> l(n.get<QoreListNode>(), xsink);
     n.assign(copy_strip_complex_types(*l));
+}
+
+const QoreTypeInfo* QoreTypeInfo::getHashPairType(const QoreTypeInfo* valueType) {
+    // For auto/any value types, return autoHashTypeInfo as the element type
+    if (!valueType || valueType == autoTypeInfo || valueType == anyTypeInfo) {
+        return autoHashTypeInfo;
+    }
+
+    // Check cache under lock
+    {
+        AutoLocker al(ctl);
+        hp_decl_map_t::iterator i = hp_decl_map.lower_bound(valueType);
+        if (i != hp_decl_map.end() && i->first == valueType) {
+            return i->second->getTypeInfo();
+        }
+    }
+
+    // Create a new TypedHashDecl for this value type
+    // HashPairInfo has "key" (string) and "value" (valueType)
+    TypedHashDecl* hd = new TypedHashDecl("HashPairInfo", "Qore::HashPairInfo");
+    typed_hash_decl_private::get(*hd)->addMember("key", stringTypeInfo, QoreValue());
+    typed_hash_decl_private::get(*hd)->addMember("value", valueType, QoreValue());
+    typed_hash_decl_private::get(*hd)->setSystemPublic();
+
+    // Cache it under lock
+    {
+        AutoLocker al(ctl);
+        // Check again in case another thread added it
+        hp_decl_map_t::iterator i = hp_decl_map.lower_bound(valueType);
+        if (i != hp_decl_map.end() && i->first == valueType) {
+            // Another thread added it - clean up and use theirs
+            typed_hash_decl_private::get(*hd)->deref();
+            return i->second->getTypeInfo();
+        }
+        hp_decl_map.insert(i, hp_decl_map_t::value_type(valueType, hd));
+    }
+
+    return hd->getTypeInfo();
+}
+
+const QoreTypeInfo* QoreTypeInfo::getIteratorElementType(const QoreClass* iteratorClass,
+        const QoreTypeInfo* sourceTypeInfo) {
+    if (!iteratorClass || !sourceTypeInfo) {
+        return nullptr;
+    }
+
+    const char* className = iteratorClass->getName();
+
+    // Handle hash iterators
+    const QoreTypeInfo* hashValueType = getUniqueReturnComplexHash(sourceTypeInfo);
+    if (!hashValueType) {
+        // Also try hash-or-nothing types
+        hashValueType = getReturnComplexHashOrNothing(sourceTypeInfo);
+    }
+
+    if (hashValueType) {
+        // HashPairIterator / HashPairReverseIterator: return hash with key: string, value: T
+        if (!strcmp(className, "HashPairIterator") || !strcmp(className, "HashPairReverseIterator")) {
+            return getHashPairType(hashValueType);
+        }
+        // HashKeyIterator / HashKeyReverseIterator: return string
+        if (!strcmp(className, "HashKeyIterator") || !strcmp(className, "HashKeyReverseIterator")) {
+            return stringTypeInfo;
+        }
+        // HashIterator / HashReverseIterator: return value type
+        if (!strcmp(className, "HashIterator") || !strcmp(className, "HashReverseIterator")) {
+            return hashValueType;
+        }
+    }
+
+    // Handle list iterators
+    const QoreTypeInfo* listElementType = getUniqueReturnComplexList(sourceTypeInfo);
+    if (!listElementType) {
+        // Also try list-or-nothing types
+        listElementType = getReturnComplexListOrNothing(sourceTypeInfo);
+    }
+
+    if (listElementType) {
+        // ListIterator / ListReverseIterator: return element type
+        if (!strcmp(className, "ListIterator") || !strcmp(className, "ListReverseIterator")) {
+            return listElementType;
+        }
+    }
+
+    return nullptr;
 }


### PR DESCRIPTION
## Summary

- Add parse-time type inference for operators (`map`, `select`, `foldl`, `foldr`) when used with iterator methods
- Fix `needs_deref` handling in `evalImpl` methods for proper exception handling

## Changes

### Type Inference
- Track source expression type through method calls via `MethodCallNode::sourceTypeInfo`
- Resolve iterator element types based on iterator class and source type
- Cache parameterized `HashPairInfo` types for efficiency
- Support: `HashPairIterator`, `HashKeyIterator`, `HashIterator`, `ListIterator` (and reverse variants)

### Bug Fixes
- Fix `QoreSelectOperatorNode` return type to use `qore_get_complex_list_type(elementTypeInfo)` instead of `iteratorTypeInfo`
- Set `needs_deref = false` when returning early due to exceptions in `QoreParseHashNode::evalImpl` and `QoreParseListNode::evalImpl`

## Test plan

- [x] All operator tests pass (696 assertions)
- [x] Type inference tests pass
- [x] Valgrind shows no memory leaks (0 bytes definitely lost)

## Example

```qore
# Before: PARSE-TYPE-ERROR
# After: Works correctly
hash<string, int> h = map {$1.key: $1.value}, {"a": 1}.pairIterator();
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)