### PR TITLE
refs #5089 Implement typed callable syntax code<ReturnType(ParamTypes...)>

### DIFF
--- a/doxygen/lang/155_data_type_declarations.dox.tmpl
+++ b/doxygen/lang/155_data_type_declarations.dox.tmpl
@@ -43,6 +43,7 @@
     |@ref softlist_complex_type "softlist<...>"|all types|@ref list|Accepts all data types; @ref nothing is returned as an empty list; a list is returned with its elements processed by the subtype declaration, and any other type is returned as the first element of a new list, also processed by the subtype declaration
     |@ref data_type "data"|@ref string or @ref binary|same as received|Restricts input to @ref string and @ref binary and returns the same type
     |@ref code_type "code"|@ref closure, @ref call_reference|same as received|Restricts values to @ref closure "closures" and @ref call_reference "call references"
+    |@ref code_complex_type "code<...>"|@ref closure, @ref call_reference with compatible signature|same as received|Restricts values to @ref closure "closures" and @ref call_reference "call references" with signature matching the type arguments
     |@ref reference_type "reference"|@ref lvalue_references|the type the reference points to|Restricts values to references to lvalues
     |@ref reference_complex_type "reference<...>"|@ref lvalue_references|the type given as an argument|Restricts values to references to lvalues compatible with the given type
     |@ref int_or_nothing_type "*int"|@ref integer, @ref null, or @ref nothing|@ref integer or @ref nothing|Restricts values to %Qore's @ref integer or @ref nothing types; if @ref null is passed then @ref nothing is returned
@@ -63,6 +64,7 @@
     |@ref null_or_nothing_type "*null"|@ref null or @ref nothing|@ref null or @ref nothing|Restricts input to @ref null or @ref nothing and returns the same type
     |@ref data_or_nothing_type "*data"|@ref string, @ref binary, @ref null, or @ref nothing|@ref string, @ref binary, or @ref nothing|Restricts input to @ref string, @ref binary, or @ref nothing and returns the same type; if @ref null is passed then @ref nothing is returned
     |@ref code_or_nothing_type "*code"|@ref closure, @ref call_reference, @ref null, or @ref nothing|@ref closure, @ref call_reference, or @ref nothing|Restricts values to @ref closure "closures", @ref call_reference "call references" and @ref nothing; if @ref null is passed then @ref nothing is returned
+    |@ref code_complex_or_nothing_type "*code<...>"|@ref closure, @ref call_reference with compatible signature, @ref null, or @ref nothing|@ref closure, @ref call_reference, or @ref nothing|Restricts values to @ref closure "closures" and @ref call_reference "call references" with signature matching the type arguments, or @ref nothing
     |@ref timeout_or_nothing_type "*timeout"|@ref integer, @ref date, @ref null, or @ref nothing|@ref integer or @ref nothing|Accepts @ref integer, @ref date and converts dates to an integer value representing milliseconds and returns the integer; incoming integers are assumed to represent milliseconds. If no value or @ref null is passed, then @ref nothing is returned
     |@ref reference_or_nothing_type "*reference"|@ref lvalue_references, @ref null, or @ref nothing|the type the reference points to and @ref nothing|Restricts values to references to lvalues and @ref nothing; if @ref null is passed then @ref nothing is returned
     |@ref reference_complex_or_nothing_type "*reference<...>"|@ref lvalue_references, @ref null, or @ref nothing|the type given as an argument and @ref nothing|Restricts values to references to lvalues compatible with the given type and @ref nothing; if @ref null is passed then @ref nothing is returned
@@ -718,6 +720,83 @@ sub foo(code c) {
 
     @note that also \c "closure" and \c "callref" are accepted as synonyms for \c "code" (they are not more specific than \c "code" but rather provide identical type restrictions)
 
+    @subsection code_complex_type Typed Callable
+
+    <b>Typed Callable Type Restriction</b>
+    |!Name|!Accepts %Qore Type(s)|!Returns %Qore Type(s)|!Description
+    |\c code&lt;<em>ReturnType</em>(<em>ParamTypes...</em>)&gt;|@ref closure, @ref call_reference with compatible signature|same as received|Restricts values to @ref closure and @ref call_reference with a specific signature
+
+    The typed callable syntax allows specifying the expected return type and parameter types for closures and call references. The signature follows the format \c code<ReturnType(ParamType1, ParamType2, ...)>.
+
+    Type compatibility follows standard variance rules:
+    - <b>Return types</b> are covariant: the assigned closure can return a more specific type than declared
+    - <b>Parameter types</b> are contravariant: the assigned closure can accept more general types than declared
+
+    @par Examples
+    @code{.py}
+# Basic typed callable with return and parameter types
+code<int(string)> lengthFunc = int sub (string s) { return s.length(); };
+int len = lengthFunc("hello");  # returns 5
+
+# Multiple parameters
+code<string(int, string)> formatter = string sub (int x, string s) {
+    return sprintf("%d: %s", x, s);
+};
+
+# Covariant return: auto accepts any specific return type
+code<auto(string)> flexReturn = int sub (string s) { return s.length(); };
+
+# Contravariant parameters: closure accepts auto where string is expected
+code<int(string)> acceptsGeneral = int sub (auto x) { return 42; };
+
+# Complex parameter and return types
+code<list<int>(hash<string, int>)> transformer = list<int> sub (hash<string, int> h) {
+    return h.values();
+};
+
+# Function parameter with typed callable
+sub process(code<int(string)> processor, string input) {
+    int result = processor(input);
+    printf("Result: %d\n", result);
+}
+process(lengthFunc, "test");
+
+# Class member with typed callable
+class Calculator {
+    private code<int(int, int)> operation = int sub (int a, int b) { return a + b; };
+
+    int calculate(int x, int y) {
+        return operation(x, y);
+    }
+
+    setOperation(code<int(int, int)> op) {
+        operation = op;
+    }
+}
+
+# Higher-order functions: function returning typed callable
+code<int(int)> sub getMultiplier(int factor) {
+    return int sub (int x) { return x * factor; };
+}
+code<int(int)> tripler = getMultiplier(3);
+int result = tripler(5);  # returns 15
+    @endcode
+
+    @note Closures with default parameters can be assigned to typed callables expecting fewer parameters, as long as the required parameters match.
+
+    @par Incompatible Assignments
+    The following will cause parse-time type errors:
+    @code{.py}
+# Error: return type mismatch (string vs int)
+code<int(string)> func = string sub (string s) { return s; };
+
+# Error: parameter type mismatch (int vs string)
+code<int(string)> func = int sub (int x) { return x; };
+
+# Error: fewer parameters than expected
+code<int(int, string)> func = int sub (int x) { return x; };
+    @endcode
+
     <hr>
     @section reference_type reference
 
@@ -982,6 +1061,39 @@ sub foo(*data d) {
 sub foo(*code c) {
 }
     @endcode
+
+    @subsection code_complex_or_nothing_type *code<...>
+
+    <b>Typed Callable Or-Nothing Type Restriction</b>
+    |!Name|!Accepts %Qore Type(s)|!Returns %Qore Type(s)|!Description
+    |\c *code&lt;<em>ReturnType</em>(<em>ParamTypes...</em>)&gt;|@ref closure, @ref call_reference with compatible signature, @ref null, or @ref nothing|same as received, or @ref nothing|Restricts values to @ref closure and @ref call_reference with a specific signature, and @ref nothing
+
+    Combines the typed callable signature checking with the ability to hold @ref nothing.
+
+    @par Example
+    @code{.py}
+# Declare or-nothing typed callable
+*code<int(string)> maybeFunc;
+# Initially NOTHING
+assert(maybeFunc == NOTHING);
+
+# Assign compatible closure
+maybeFunc = int sub (string s) { return s.length(); };
+int len = maybeFunc("hello");  # returns 5
+
+# Reset to NOTHING
+maybeFunc = NOTHING;
+
+# Use in function with optional callback
+sub processWithOptionalCallback(string data, *code<nothing(string)> callback) {
+    # process data...
+    if (callback) {
+        callback(data);
+    }
+}
+    @endcode
+
+    @note Typed or-nothing callables still enforce signature compatibility - incompatible closures will cause parse-time type errors.
 
     <hr>
     @section timeout_or_nothing_type *timeout

--- a/doxygen/lang/155_data_type_declarations.dox.tmpl
+++ b/doxygen/lang/155_data_type_declarations.dox.tmpl
@@ -1269,4 +1269,203 @@ global_config = {"setting": "value"};
     - @ref hash_type "hash<auto>"
     - @ref list_type "list<auto>"
     - @ref softlist_type "softlist<auto>"
+
+    <hr>
+    @section typedef_keyword typedef
+
+    The \c typedef keyword creates type aliases, allowing you to define custom names for existing types.
+    This improves code readability and maintainability by giving meaningful names to complex type declarations.
+
+    @par Syntax
+    @code{.py}
+typedef TypeName = type_declaration;
+public typedef TypeName = type_declaration;  # exported from module
+    @endcode
+
+    @par Basic Examples
+    @code{.py}
+# Simple type aliases
+typedef MyInt = int;
+typedef MyString = string;
+
+# Using the type alias
+MyInt x = 42;
+MyString s = "hello";
+
+# Complex type aliases
+typedef IntList = list<int>;
+typedef StringHash = hash<string, string>;
+
+IntList numbers = (1, 2, 3);
+StringHash mapping = {"key": "value"};
+    @endcode
+
+    @par With Or-Nothing Modifier
+    The or-nothing modifier (\c *) can be applied to typedef types:
+    @code{.py}
+typedef MyInt = int;
+
+*MyInt x;       # x can be int or NOTHING
+*MyInt y = 10;  # y is 10
+    @endcode
+
+    @par In Namespaces
+    Typedefs can be declared within namespaces and follow standard scoping rules:
+    @code{.py}
+namespace MyNs {
+    typedef UserId = int;
+
+    UserId sub getCurrentUser() {
+        return 42;
+    }
+}
+
+# Use with namespace qualifier
+MyNs::UserId id = MyNs::getCurrentUser();
+    @endcode
+
+    @par Public Typedefs
+    Use the \c public modifier to export typedefs from modules:
+    @code{.py}
+public typedef PublicType = hash<string, int>;
+    @endcode
+
+    @par Typedef Chains
+    Typedefs can reference other typedefs:
+    @code{.py}
+typedef MyInt = int;
+typedef AliasInt = MyInt;
+typedef AnotherAlias = AliasInt;  # Still resolves to int
+    @endcode
+
+    @par Disabling typedef
+    The \c typedef keyword can be disabled with:
+    - Parse directive: \c %%no-typedef
+    - Parse option: @ref PO_NO_TYPEDEF
+
+    When disabled, \c typedef is treated as an identifier rather than a keyword.
+
+    <hr>
+    @section union_type union<...>
+
+    The \c union<...> syntax creates an explicit union type that can hold values of any of the specified
+    member types. This is useful when a variable, parameter, or return value needs to accept multiple
+    specific types.
+
+    @par Syntax
+    @code{.py}
+union<type1, type2, ...>   # union of specified types
+*union<type1, type2, ...>  # or-nothing union (also accepts NOTHING)
+    @endcode
+
+    @par Basic Examples
+    @code{.py}
+# Variable that can hold int or string
+union<int, string> value = 42;
+value = "hello";  # OK - string is in the union
+
+# Function returning different types
+union<int, string> sub getValue(bool useInt) {
+    if (useInt) {
+        return 42;
+    }
+    return "hello";
+}
+    @endcode
+
+    @par Or-Nothing Unions
+    The or-nothing modifier allows the union to also accept NOTHING:
+    @code{.py}
+*union<int, string> x;       # x is NOTHING
+*union<int, string> y = 10;  # y is 10
+*union<int, string> z = "hello";  # z is "hello"
+    @endcode
+
+    @par In Function Signatures
+    @code{.py}
+string sub describe(union<int, string> val) {
+    if (val.typeCode() == NT_INT) {
+        return "integer: " + string(val);
+    }
+    return "string: " + val;
+}
+    @endcode
+
+    @par In Class Members
+    @code{.py}
+class Container {
+    private {
+        union<int, string> value;
+    }
+
+    constructor(union<int, string> v) {
+        value = v;
+    }
+
+    union<int, string> getValue() {
+        return value;
+    }
+}
+    @endcode
+
+    @par With Complex Types
+    Unions can contain complex types and be nested in other complex types:
+    @code{.py}
+# Union of complex types
+union<list<int>, hash<string, int>> data;
+
+# Union as element type
+list<union<int, string>> items = (1, "two", 3, "four");
+
+# Hash with union values
+hash<string, union<int, bool>> flags = {
+    "count": 5,
+    "enabled": True
+};
+    @endcode
+
+    @par With typedef
+    Unions work well with typedef for readable type declarations:
+    @code{.py}
+typedef IntOrString = union<int, string>;
+
+IntOrString sub getValue(bool useInt) {
+    return useInt ? 42 : "hello";
+}
+
+IntOrString x = 10;
+IntOrString y = "world";
+    @endcode
+
+    @par Type Checking and Narrowing
+    After a type check, the compiler narrows the type within that branch:
+    @code{.py}
+sub process(union<int, string> val) {
+    if (val.typeCode() == NT_INT) {
+        # val is treated as int here
+        return val * 2;
+    } else {
+        # val is treated as string here
+        return val + "!";
+    }
+}
+    @endcode
+
+    @par Constraints
+    Union types have the following constraints:
+    - Maximum of 100 member types
+    - At most one soft type (e.g., \c softint, \c softstring)
+    - Cannot have both soft and non-soft versions of the same base type
+      (e.g., \c union<int, \c softint> is invalid)
+
+    @code{.py}
+# Valid unions
+union<int, string>
+union<int, string, bool, float>
+union<int, softstring>  # OK - different base types
+
+# Invalid unions
+union<softint, softstring>  # Error: multiple soft types
+union<int, softint>         # Error: soft and non-soft of same base
+    @endcode
 */

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -126,6 +126,15 @@
       - integrates with typedef: \c typedef \c IntOrString \c = \c union<int, \c string>;
       - supports parse-time type narrowing after type checks
       - constraints: maximum 100 member types, at most one soft type, no soft+non-soft of same base type
+    - new @ref code_complex_type "code<ReturnType(ParamTypes...)>" typed callable syntax
+      (<a href="https://github.com/qoretechnologies/qore/issues/5089">issue 5089</a>)
+      - syntax: \c code<int(string)> for a callable returning int and taking a string parameter
+      - enables parse-time type checking for closures and call references
+      - covariant return types: assigned closure can return a more specific type
+      - contravariant parameter types: assigned closure can accept more general types
+      - supports or-nothing variant: \c *code<int(string)>
+      - works with complex types: \c code<list<int>(hash<string, \c int>)>
+      - incompatible signature assignments cause parse-time \c PARSE-TYPE-ERROR
     - <a href="../../modules/ElasticSearchDataProvider/html/index.html">ElasticSearchDataProvider</a> module
       - added Bulk API support with NDJSON format and partial failure handling
         (<a href="https://github.com/qoretechnologies/qore/issues/5016">issue 5016</a>)

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -113,6 +113,19 @@
       - \c auto!, \c hash<auto!>, \c list<auto!> prevent parse-time type inference errors
       - allows variables to accept values of different types without \c PARSE-TYPE-ERROR
       - runtime type enforcement still applies to individual values
+    - new @ref typedef_keyword "typedef" keyword for type aliases
+      - syntax: \c typedef \c MyType \c = \c int; or \c typedef \c IntList \c = \c list<int>;
+      - supports all type declarations including complex types, hashdecls, and classes
+      - can be declared \c public for module exports
+      - works in namespaces with standard scoping rules
+      - can be disabled with \c %%no-typedef parse directive or @ref PO_NO_TYPEDEF
+    - new @ref union_type "union<...>" explicit union type syntax
+      - syntax: \c union<int, \c string> for a type accepting either int or string
+      - supports or-nothing modifier: \c *union<int, \c string> accepts NOTHING as well
+      - works with complex types: \c list<union<int, \c string>>, \c hash<string, \c union<int, \c bool>>
+      - integrates with typedef: \c typedef \c IntOrString \c = \c union<int, \c string>;
+      - supports parse-time type narrowing after type checks
+      - constraints: maximum 100 member types, at most one soft type, no soft+non-soft of same base type
     - <a href="../../modules/ElasticSearchDataProvider/html/index.html">ElasticSearchDataProvider</a> module
       - added Bulk API support with NDJSON format and partial failure handling
         (<a href="https://github.com/qoretechnologies/qore/issues/5016">issue 5016</a>)

--- a/examples/test/qore/parser/typed_code_comprehensive.qtest
+++ b/examples/test/qore/parser/typed_code_comprehensive.qtest
@@ -1,0 +1,281 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class TypedCodeComprehensiveTest
+
+class TypedCodeComprehensiveTest inherits QUnit::Test {
+    constructor() : QUnit::Test("TypedCodeComprehensiveTest", "1.0") {
+        addTestCase("Function parameter with typed code", \functionParamTest());
+        addTestCase("Return typed code from function", \returnTypedCodeTest());
+        addTestCase("Class member with typed code", \classMemberTest());
+        addTestCase("Call reference assignment", \callRefTest());
+        addTestCase("Nested complex types in signature", \nestedComplexTypesTest());
+        addTestCase("Multiple typed code operations", \multipleOperationsTest());
+        addTestCase("Higher-order functions", \higherOrderTest());
+        addTestCase("Default parameter in closure", \defaultParamTest());
+        addTestCase("Closure capturing variables", \closureCapturingTest());
+        addTestCase("Type inference edge cases", \typeInferenceEdgeCasesTest());
+        set_return_value(main());
+    }
+
+    functionParamTest() {
+        # Function that takes typed code as parameter
+        int result = applyToString(int sub (string s) { return s.length(); }, "hello");
+        assertEq(5, result);
+
+        # Function with typed code param - passing compatible closure
+        result = applyToString(int sub (auto s) { return 99; }, "test");
+        assertEq(99, result);
+    }
+
+    private int applyToString(code<int(string)> func, string s) {
+        return func(s);
+    }
+
+    returnTypedCodeTest() {
+        # Function that returns typed code
+        code<int(int)> doubler = getDoubler();
+        assertEq(10, doubler(5));
+
+        # Return different typed closures based on condition
+        code<int(int)> op1 = getIntOperation(True);
+        code<int(int)> op2 = getIntOperation(False);
+        assertEq(10, op1(5));
+        assertEq(25, op2(5));
+    }
+
+    private code<int(int)> getDoubler() {
+        return int sub (int x) { return x * 2; };
+    }
+
+    private code<int(int)> getIntOperation(bool double_it) {
+        if (double_it) {
+            return int sub (int x) { return x * 2; };
+        }
+        return int sub (int x) { return x * x; };
+    }
+
+    classMemberTest() {
+        TypedCodeHolder holder();
+
+        # Use member typed code
+        assertEq(5, holder.transform("hello"));
+
+        # Update member typed code
+        holder.setTransformer(int sub (string s) { return s.length() * 2; });
+        assertEq(10, holder.transform("hello"));
+
+        # Verify or-nothing member
+        assertFalse(holder.hasOptionalTransformer());
+        holder.setOptionalTransformer(int sub (string s) { return 42; });
+        assertTrue(holder.hasOptionalTransformer());
+        assertEq(42, holder.transformOptional("x"));
+    }
+
+    callRefTest() {
+        # Assign call reference to typed code
+        code<int(string)> func = \stringLength();
+        assertEq(5, func("hello"));
+
+        # Call reference with compatible signature
+        code<auto(int)> func2 = \intToString();
+        assertEq("42", func2(42));
+
+        # Method reference
+        TypedCodeHolder holder();
+        code<int(string)> memberFunc = \holder.transform();
+        assertEq(5, memberFunc("hello"));
+    }
+
+    private int stringLength(string s) {
+        return s.length();
+    }
+
+    private string intToString(int x) {
+        return sprintf("%d", x);
+    }
+
+    nestedComplexTypesTest() {
+        # Typed code with list<int> parameter
+        code<int(list<int>)> sumList = int sub (list<int> l) {
+            int sum = 0;
+            foreach int i in (l) {
+                sum += i;
+            }
+            return sum;
+        };
+        assertEq(15, sumList((1, 2, 3, 4, 5)));
+
+        # Typed code with hash<string, int> return
+        code<hash<string, int>()> getHash = hash<string, int> sub () {
+            return {"a": 1, "b": 2};
+        };
+        assertEq({"a": 1, "b": 2}, getHash());
+
+        # Complex nested types
+        code<list<hash<string, int>>(int)> createList = list<hash<string, int>> sub (int n) {
+            list<hash<string, int>> result = ();
+            for (int i = 0; i < n; ++i) {
+                result += {"index": i};
+            }
+            return result;
+        };
+        assertEq(({"index": 0}, {"index": 1}), createList(2));
+    }
+
+    multipleOperationsTest() {
+        # Chain of typed code assignments
+        code<int(int)> step1 = int sub (int x) { return x + 1; };
+        code<int(int)> step2 = int sub (int x) { return x * 2; };
+        code<int(int)> step3 = int sub (int x) { return x - 3; };
+
+        int result = step3(step2(step1(5)));
+        assertEq(9, result);  # ((5+1)*2)-3 = 9
+
+        # Array of typed code
+        list<code<int(int)>> operations = (step1, step2, step3);
+        result = 5;
+        foreach code<int(int)> op in (operations) {
+            result = op(result);
+        }
+        assertEq(9, result);
+    }
+
+    higherOrderTest() {
+        # Map function using typed code
+        list<int> numbers = (1, 2, 3, 4, 5);
+        list<int> doubled = mapInts(numbers, int sub (int x) { return x * 2; });
+        assertEq((2, 4, 6, 8, 10), doubled);
+
+        # Filter function using typed code
+        list<int> evens = filterInts(numbers, bool sub (int x) { return x % 2 == 0; });
+        assertEq((2, 4), evens);
+
+        # Compose functions
+        code<int(int)> composed = compose(
+            int sub (int x) { return x + 1; },
+            int sub (int x) { return x * 2; }
+        );
+        assertEq(12, composed(5));  # (5+1)*2 = 12
+    }
+
+    private list<int> mapInts(list<int> l, code<int(int)> mapper) {
+        list<int> result = ();
+        foreach int x in (l) {
+            result += mapper(x);
+        }
+        return result;
+    }
+
+    private list<int> filterInts(list<int> l, code<bool(int)> predicate) {
+        list<int> result = ();
+        foreach int x in (l) {
+            if (predicate(x)) {
+                result += x;
+            }
+        }
+        return result;
+    }
+
+    private code<int(int)> compose(code<int(int)> f, code<int(int)> g) {
+        return int sub (int x) { return g(f(x)); };
+    }
+
+    defaultParamTest() {
+        # Closure with default parameter assigned to typed code expecting fewer params
+        code<int(int)> func = int sub (int x, int y = 10) { return x + y; };
+        assertEq(15, func(5));
+
+        # Multiple default params
+        code<string(string)> greeting = string sub (string name, string prefix = "Hello", string suffix = "!") {
+            return sprintf("%s, %s%s", prefix, name, suffix);
+        };
+        assertEq("Hello, World!", greeting("World"));
+    }
+
+    closureCapturingTest() {
+        # Closure capturing local variable
+        int multiplier = 3;
+        code<int(int)> tripler = int sub (int x) { return x * multiplier; };
+        assertEq(15, tripler(5));
+
+        # Closure capturing and modifying (counter)
+        int counter = 0;
+        code<int()> increment = int sub () { return ++counter; };
+        assertEq(1, increment());
+        assertEq(2, increment());
+        assertEq(3, increment());
+        assertEq(3, counter);
+
+        # Factory function creating closures
+        code<int(int)> adder5 = createAdder(5);
+        code<int(int)> adder10 = createAdder(10);
+        assertEq(15, adder5(10));
+        assertEq(15, adder10(5));
+    }
+
+    private code<int(int)> createAdder(int n) {
+        return int sub (int x) { return x + n; };
+    }
+
+    typeInferenceEdgeCasesTest() {
+        # Assign nothing to or-nothing typed code
+        *code<int(string)> maybeFunc = NOTHING;
+        assertEq(NOTHING, maybeFunc);
+
+        # Re-assign to valid closure
+        maybeFunc = int sub (string s) { return s.length(); };
+        assertEq(5, maybeFunc("hello"));
+
+        # Incompatible signature - parse error test
+        bool caught = False;
+        try {
+            Program p(PO_NEW_STYLE | PO_REQUIRE_TYPES);
+            p.parse("sub test() { code<int(int, int)> func = int sub (int x) { return x; }; }", "test");
+        } catch (hash<ExceptionInfo> ex) {
+            caught = ex.err == "PARSE-TYPE-ERROR";
+        }
+        assertTrue(caught, "Should catch source with fewer params");
+
+        # Test that regular code type still works
+        code genericFunc = int sub () { return 42; };
+        assertEq(42, genericFunc());
+    }
+}
+
+class TypedCodeHolder {
+    private {
+        code<int(string)> transformer = int sub (string s) { return s.length(); };
+        *code<int(string)> optionalTransformer;
+    }
+
+    int transform(string s) {
+        return transformer(s);
+    }
+
+    setTransformer(code<int(string)> t) {
+        transformer = t;
+    }
+
+    bool hasOptionalTransformer() {
+        return exists optionalTransformer;
+    }
+
+    setOptionalTransformer(code<int(string)> t) {
+        optionalTransformer = t;
+    }
+
+    int transformOptional(string s) {
+        if (!optionalTransformer) {
+            throw "NO-TRANSFORMER", "No optional transformer set";
+        }
+        return optionalTransformer(s);
+    }
+}

--- a/examples/test/qore/parser/typed_code_phase1.qtest
+++ b/examples/test/qore/parser/typed_code_phase1.qtest
@@ -1,0 +1,111 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class TypedCodePhase1Test
+
+class TypedCodePhase1Test inherits QUnit::Test {
+    constructor() : QUnit::Test("TypedCodePhase1Test", "1.0") {
+        addTestCase("Basic type infrastructure test", \basicTypeTest());
+        addTestCase("Code type basic assignment test", \codeTypeBasicTest());
+        addTestCase("Closure signature test", \closureSignatureTest());
+        addTestCase("Call reference signature test", \callRefSignatureTest());
+        addTestCase("Or-nothing code test", \orNothingCodeTest());
+        set_return_value(main());
+    }
+
+    basicTypeTest() {
+        # Test that basic code type still works
+        code c = auto sub () { return 1; };
+        assertEq(1, c());
+
+        code c2 = auto sub (int x) { return x * 2; };
+        assertEq(10, c2(5));
+
+        code c3 = int sub (int x, int y) { return x + y; };
+        assertEq(7, c3(3, 4));
+    }
+
+    codeTypeBasicTest() {
+        # Test basic code type assignments with closures
+        code adder = int sub (int a, int b) { return a + b; };
+        assertEq(5, adder(2, 3));
+
+        # Test with string return type
+        code formatter = string sub (string s) { return "Hello, " + s; };
+        assertEq("Hello, World", formatter("World"));
+
+        # Test with no return type (nothing)
+        list<int> results = ();
+        code appender = sub (int x) { push results, x; };
+        appender(1);
+        appender(2);
+        assertEq((1, 2), results);
+    }
+
+    closureSignatureTest() {
+        # Test closures with various signatures
+        # No params, int return
+        code getOne = int sub () { return 1; };
+        assertEq(1, getOne());
+
+        # One param
+        code double_val = int sub (int x) { return x * 2; };
+        assertEq(6, double_val(3));
+
+        # Multiple params
+        code multiply = int sub (int a, int b, int c) { return a * b * c; };
+        assertEq(24, multiply(2, 3, 4));
+
+        # String params and return
+        code concat = string sub (string a, string b) { return a + b; };
+        assertEq("foobar", concat("foo", "bar"));
+
+        # Mixed types
+        code mixed = string sub (int n, string s) { return s + sprintf("%d", n); };
+        assertEq("test42", mixed(42, "test"));
+    }
+
+    callRefSignatureTest() {
+        # Test call references
+        code intFunc = \getInt();
+        assertEq(42, intFunc());
+
+        code strFunc = \getString();
+        assertEq("hello", strFunc());
+
+        code sumFunc = \sumInts();
+        assertEq(15, sumFunc(5, 10));
+    }
+
+    orNothingCodeTest() {
+        # Test *code (or-nothing code type)
+        *code maybeCode;
+        assertEq(NOTHING, maybeCode);
+
+        maybeCode = int sub () { return 99; };
+        assertEq(99, maybeCode());
+
+        maybeCode = NOTHING;
+        assertEq(NOTHING, maybeCode);
+    }
+
+    # Helper functions for call reference tests
+    static int getInt() {
+        return 42;
+    }
+
+    static string getString() {
+        return "hello";
+    }
+
+    static int sumInts(int a, int b) {
+        return a + b;
+    }
+}

--- a/examples/test/qore/parser/typed_code_phase2.qtest
+++ b/examples/test/qore/parser/typed_code_phase2.qtest
@@ -1,0 +1,127 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class TypedCodePhase2Test
+
+class TypedCodePhase2Test inherits QUnit::Test {
+    constructor() : QUnit::Test("TypedCodePhase2Test", "1.0") {
+        addTestCase("Simple typed code parsing", \simpleTypedCodeTest());
+        addTestCase("Complex return type parsing", \complexReturnTypeTest());
+        addTestCase("Complex parameter type parsing", \complexParamTypeTest());
+        addTestCase("Nested complex types", \nestedComplexTypesTest());
+        addTestCase("Or-nothing typed code", \orNothingTypedCodeTest());
+        addTestCase("Multiple parameters", \multipleParamsTest());
+        addTestCase("Nothing return type", \nothingReturnTypeTest());
+        addTestCase("Auto return type", \autoReturnTypeTest());
+        set_return_value(main());
+    }
+
+    simpleTypedCodeTest() {
+        # Test basic typed code declarations
+        code<int()> noParamFunc;
+        assertEq(NOTHING, noParamFunc);
+
+        code<string(int)> oneParamFunc;
+        assertEq(NOTHING, oneParamFunc);
+
+        code<bool(int, string)> twoParamFunc;
+        assertEq(NOTHING, twoParamFunc);
+
+        code<float(int, string, bool)> threeParamFunc;
+        assertEq(NOTHING, threeParamFunc);
+    }
+
+    complexReturnTypeTest() {
+        # Test typed code with complex return types
+        code<list<int>()> listReturn;
+        assertEq(NOTHING, listReturn);
+
+        code<hash<string, int>()> hashReturn;
+        assertEq(NOTHING, hashReturn);
+
+        code<hash<string, list<int>>()> nestedHashReturn;
+        assertEq(NOTHING, nestedHashReturn);
+    }
+
+    complexParamTypeTest() {
+        # Test typed code with complex parameter types
+        code<int(list<string>)> listParam;
+        assertEq(NOTHING, listParam);
+
+        code<string(hash<string, int>)> hashParam;
+        assertEq(NOTHING, hashParam);
+
+        code<bool(hash<string, list<int>>)> nestedHashParam;
+        assertEq(NOTHING, nestedHashParam);
+    }
+
+    nestedComplexTypesTest() {
+        # Test deeply nested complex types
+        code<hash<string, list<hash<string, int>>>()> deepReturn;
+        assertEq(NOTHING, deepReturn);
+
+        code<int(hash<string, list<hash<string, int>>>)> deepParam;
+        assertEq(NOTHING, deepParam);
+
+        # Complex return and params
+        code<list<hash<string, int>>(hash<string, list<int>>)> bothComplex;
+        assertEq(NOTHING, bothComplex);
+    }
+
+    orNothingTypedCodeTest() {
+        # Test or-nothing typed code
+        *code<int(string)> maybeFunc;
+        assertEq(NOTHING, maybeFunc);
+
+        # Assign a closure
+        maybeFunc = int sub (string s) { return s.length(); };
+        assertEq(5, maybeFunc("hello"));
+
+        # Assign NOTHING
+        maybeFunc = NOTHING;
+        assertEq(NOTHING, maybeFunc);
+    }
+
+    multipleParamsTest() {
+        # Test multiple complex parameters
+        code<int(list<string>, hash<string, int>)> twoComplexParams;
+        assertEq(NOTHING, twoComplexParams);
+
+        code<string(int, list<int>, hash<string, bool>, string)> mixedParams;
+        assertEq(NOTHING, mixedParams);
+
+        code<list<int>(hash<string, int>, list<string>, hash<string, list<int>>)> allComplexParams;
+        assertEq(NOTHING, allComplexParams);
+    }
+
+    nothingReturnTypeTest() {
+        # Test nothing return type
+        code<nothing()> voidLikeNoParam;
+        assertEq(NOTHING, voidLikeNoParam);
+
+        code<nothing(int)> voidLikeOneParam;
+        assertEq(NOTHING, voidLikeOneParam);
+
+        code<nothing(string, bool)> voidLikeTwoParams;
+        assertEq(NOTHING, voidLikeTwoParams);
+    }
+
+    autoReturnTypeTest() {
+        # Test auto return type
+        code<auto()> autoReturnNoParam;
+        assertEq(NOTHING, autoReturnNoParam);
+
+        code<auto(string)> autoReturnOneParam;
+        assertEq(NOTHING, autoReturnOneParam);
+
+        code<auto(int, string, bool)> autoReturnMultiParams;
+        assertEq(NOTHING, autoReturnMultiParams);
+    }
+}

--- a/examples/test/qore/parser/typed_code_phase3.qtest
+++ b/examples/test/qore/parser/typed_code_phase3.qtest
@@ -1,0 +1,174 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class TypedCodePhase3Test
+
+class TypedCodePhase3Test inherits QUnit::Test {
+    constructor() : QUnit::Test("TypedCodePhase3Test", "1.0") {
+        addTestCase("Compatible assignment test", \compatibleAssignmentTest());
+        addTestCase("Covariant return type test", \covariantReturnTest());
+        addTestCase("Contravariant parameter test", \contravariantParamTest());
+        addTestCase("Incompatible return type test", \incompatibleReturnTest());
+        addTestCase("Incompatible parameter type test", \incompatibleParamTest());
+        addTestCase("Parameter count mismatch test", \paramCountMismatchTest());
+        addTestCase("Complex type compatibility test", \complexTypeCompatibilityTest());
+        addTestCase("Or-nothing code assignment test", \orNothingCodeTest());
+        set_return_value(main());
+    }
+
+    compatibleAssignmentTest() {
+        # Exact match
+        code<int(string)> func1 = int sub (string s) { return s.length(); };
+        assertEq(5, func1("hello"));
+
+        # Multiple params exact match
+        code<string(int, string)> func2 = string sub (int x, string s) { return sprintf("%d: %s", x, s); };
+        assertEq("42: test", func2(42, "test"));
+
+        # No params
+        code<int()> func3 = int sub () { return 99; };
+        assertEq(99, func3());
+    }
+
+    covariantReturnTest() {
+        # auto return accepts any specific return type (covariant)
+        code<auto(string)> func1 = int sub (string s) { return s.length(); };
+        assertEq(5, func1("hello"));
+
+        code<auto(int)> func2 = string sub (int x) { return sprintf("num: %d", x); };
+        assertEq("num: 42", func2(42));
+
+        # Assign closure with more specific return type
+        code<auto()> func3 = list<int> sub () { return (1, 2, 3); };
+        assertEq((1, 2, 3), func3());
+    }
+
+    contravariantParamTest() {
+        # Closure takes auto, target expects string (contravariant)
+        code<int(string)> func1 = int sub (auto x) { return 42; };
+        assertEq(42, func1("test"));
+
+        # Closure takes auto for multiple params
+        code<string(int, string)> func2 = string sub (auto x, auto y) { return "ok"; };
+        assertEq("ok", func2(1, "test"));
+
+        # Closure takes softint where int is expected
+        code<int(int)> func3 = int sub (softint x) { return x * 2; };
+        assertEq(10, func3(5));
+    }
+
+    incompatibleReturnTest() {
+        # Test that incompatible return types are caught at parse time
+        bool caught = False;
+        string err_msg;
+        try {
+            Program p(PO_NEW_STYLE | PO_REQUIRE_TYPES);
+            p.parse("sub test() { code<int(string)> func = string sub (string s) { return s; }; }", "test");
+            err_msg = "no exception";
+        } catch (hash<ExceptionInfo> ex) {
+            caught = ex.err == "PARSE-TYPE-ERROR";
+            err_msg = sprintf("%s: %s", ex.err, ex.desc);
+        }
+        assertTrue(caught, sprintf("Should catch incompatible return type at parse time (got: %s)", err_msg));
+
+        # Also test bool vs int (different specific types)
+        caught = False;
+        try {
+            Program p(PO_NEW_STYLE | PO_REQUIRE_TYPES);
+            p.parse("sub test() { code<int(string)> func = bool sub (string s) { return True; }; }", "test");
+        } catch (hash<ExceptionInfo> ex) {
+            caught = ex.err == "PARSE-TYPE-ERROR";
+        }
+        assertTrue(caught, "Should catch bool vs int return type mismatch");
+    }
+
+    incompatibleParamTest() {
+        # Test that incompatible parameter types are caught at parse time
+        bool caught = False;
+        try {
+            Program p(PO_NEW_STYLE | PO_REQUIRE_TYPES);
+            p.parse("sub test() { code<int(string)> func = int sub (int x) { return x; }; }", "test");
+        } catch (hash<ExceptionInfo> ex) {
+            caught = ex.err == "PARSE-TYPE-ERROR";
+        }
+        assertTrue(caught, "Should catch incompatible param type at parse time");
+
+        # Different specific types
+        caught = False;
+        try {
+            Program p(PO_NEW_STYLE | PO_REQUIRE_TYPES);
+            p.parse("sub test() { code<int(int, string)> func = int sub (string x, int y) { return 1; }; }", "test");
+        } catch (hash<ExceptionInfo> ex) {
+            caught = ex.err == "PARSE-TYPE-ERROR";
+        }
+        assertTrue(caught, "Should catch swapped param types");
+    }
+
+    paramCountMismatchTest() {
+        # Source has fewer params than target expects (should fail)
+        bool caught = False;
+        try {
+            Program p(PO_NEW_STYLE | PO_REQUIRE_TYPES);
+            p.parse("sub test() { code<int(int, string)> func = int sub (int x) { return x; }; }", "test");
+        } catch (hash<ExceptionInfo> ex) {
+            caught = ex.err == "PARSE-TYPE-ERROR";
+        }
+        assertTrue(caught, "Should catch source with fewer params");
+
+        # Source has more params than target expects (OK if source params have defaults or we allow more)
+        # Actually, this depends on the design - let's test what happens
+        code<int(int)> func = int sub (int x, int y = 0) { return x + y; };
+        assertEq(5, func(5));
+    }
+
+    complexTypeCompatibilityTest() {
+        # Complex return types
+        code<list<int>()> func1 = list<int> sub () { return (1, 2, 3); };
+        assertEq((1, 2, 3), func1());
+
+        # Complex param types
+        code<int(list<string>)> func2 = int sub (list<string> l) { return l.size(); };
+        assertEq(3, func2(("a", "b", "c")));
+
+        # Both complex
+        code<hash<string, int>(list<string>)> func3 = hash<string, int> sub (list<string> l) {
+            hash<string, int> rv;
+            for (int i = 0; i < l.size(); ++i) {
+                rv{l[i]} = i;
+            }
+            return rv;
+        };
+        assertEq({"a": 0, "b": 1}, func3(("a", "b")));
+    }
+
+    orNothingCodeTest() {
+        # Or-nothing code accepts NOTHING
+        *code<int(string)> maybeFunc;
+        assertEq(NOTHING, maybeFunc);
+
+        # Or-nothing code accepts compatible closure
+        maybeFunc = int sub (string s) { return s.length(); };
+        assertEq(5, maybeFunc("hello"));
+
+        # Reset to NOTHING
+        maybeFunc = NOTHING;
+        assertEq(NOTHING, maybeFunc);
+
+        # Or-nothing typed code should also check signature compatibility
+        bool caught = False;
+        try {
+            Program p(PO_NEW_STYLE | PO_REQUIRE_TYPES);
+            p.parse("sub test() { *code<int(string)> func = string sub (string s) { return s; }; }", "test");
+        } catch (hash<ExceptionInfo> ex) {
+            caught = ex.err == "PARSE-TYPE-ERROR";
+        }
+        assertTrue(caught, "Or-nothing typed code should also check signature compatibility");
+    }
+}

--- a/examples/test/qore/parser/typedef.qtest
+++ b/examples/test/qore/parser/typedef.qtest
@@ -1,0 +1,228 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+%no-child-restrictions
+
+%requires ../../../../qlib/Util.qm
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class TypedefTest
+
+class TypedefTest inherits QUnit::Test {
+    constructor() : QUnit::Test("Typedef test", "1.0") {
+        addTestCase("Basic typedef", \testBasicTypedef());
+        addTestCase("Typedef with or-nothing", \testTypedefOrNothing());
+        addTestCase("Typedef with complex types", \testTypedefComplexTypes());
+        addTestCase("Typedef in namespace", \testTypedefInNamespace());
+        addTestCase("Public typedef", \testPublicTypedef());
+        addTestCase("Typedef usage in function", \testTypedefInFunction());
+        addTestCase("Typedef usage in class", \testTypedefInClass());
+        addTestCase("Typedef to typedef", \testTypedefToTypedef());
+        addTestCase("Typedef with %no-typedef", \testNoTypedefOption());
+        addTestCase("Typedef duplicate error", \testTypedefDuplicateError());
+        addTestCase("Typedef class conflict error", \testTypedefClassConflict());
+        set_return_value(main());
+    }
+
+    testBasicTypedef() {
+        # Test basic typedef for simple types
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            typedef MyInt = int;
+            typedef MyString = string;
+            typedef MyBool = bool;
+
+            int sub test() {
+                MyInt x = 5;
+                MyString s = 'hello';
+                MyBool b = True;
+                return x + s.length() + (b ? 1 : 0);
+            }
+        ", "test");
+        p.run();
+        assertEq(11, p.callFunction("test"));
+    }
+
+    testTypedefOrNothing() {
+        # Test typedef with or-nothing modifier
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            typedef MyInt = int;
+
+            auto sub test() {
+                *MyInt x;
+                *MyInt y = 10;
+                return (x, y);
+            }
+        ", "test");
+        p.run();
+        list<auto> result = p.callFunction("test");
+        assertEq(NOTHING, result[0]);
+        assertEq(10, result[1]);
+    }
+
+    testTypedefComplexTypes() {
+        # Test typedef with complex types (hash, list)
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            typedef IntList = list<int>;
+            typedef StringHash = hash<string, string>;
+
+            auto sub test() {
+                IntList myList = (1, 2, 3);
+                StringHash myHash = {'a': 'b', 'c': 'd'};
+
+                int sum = 0;
+                foreach int i in (myList) {
+                    sum += i;
+                }
+                return (sum, myHash{'a'});
+            }
+        ", "test");
+        p.run();
+        list<auto> result = p.callFunction("test");
+        assertEq(6, result[0]);
+        assertEq("b", result[1]);
+    }
+
+    testTypedefInNamespace() {
+        # Test typedef inside a namespace
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            namespace MyNs {
+                typedef MyInt = int;
+
+                int sub getValue() {
+                    MyInt x = 42;
+                    return x;
+                }
+            }
+
+            int sub test() {
+                return MyNs::getValue();
+            }
+        ", "test");
+        p.run();
+        assertEq(42, p.callFunction("test"));
+    }
+
+    testPublicTypedef() {
+        # Test public typedef visibility
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            public typedef PublicInt = int;
+
+            PublicInt sub getValue() {
+                return 100;
+            }
+        ", "test");
+        p.run();
+        assertEq(100, p.callFunction("getValue"));
+    }
+
+    testTypedefInFunction() {
+        # Test typedef usage in function parameters and return types
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            typedef MyInt = int;
+            typedef MyString = string;
+
+            MyInt sub doubleIt(MyInt x) {
+                return x * 2;
+            }
+
+            MyString sub greet(MyString name) {
+                return 'Hello, ' + name;
+            }
+
+            auto sub test() {
+                return (doubleIt(10), greet('World'));
+            }
+        ", "test");
+        p.run();
+        list<auto> result = p.callFunction("test");
+        assertEq(20, result[0]);
+        assertEq("Hello, World", result[1]);
+    }
+
+    testTypedefInClass() {
+        # Test typedef usage in class members and methods
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            typedef MyInt = int;
+
+            class Counter {
+                private {
+                    MyInt count = 0;
+                }
+
+                MyInt getCount() {
+                    return count;
+                }
+
+                increment(MyInt amount) {
+                    count += amount;
+                }
+            }
+
+            int sub test() {
+                Counter c();
+                c.increment(5);
+                c.increment(3);
+                return c.getCount();
+            }
+        ", "test");
+        p.run();
+        assertEq(8, p.callFunction("test"));
+    }
+
+    testTypedefToTypedef() {
+        # Test typedef referring to another typedef
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            typedef MyInt = int;
+            typedef AliasInt = MyInt;
+            typedef AnotherAlias = AliasInt;
+
+            AnotherAlias sub getValue() {
+                AnotherAlias x = 42;
+                return x;
+            }
+        ", "test");
+        p.run();
+        assertEq(42, p.callFunction("getValue"));
+    }
+
+    testNoTypedefOption() {
+        # Test that %no-typedef disables the typedef keyword
+        Program p(PO_NEW_STYLE);
+
+        # With %no-typedef, 'typedef' should be treated as an identifier
+        assertThrows("PARSE-EXCEPTION", \p.parse(), ("
+            %no-typedef
+            typedef MyInt = int;  # Should fail - typedef is not a keyword
+        ", "test"));
+    }
+
+    testTypedefDuplicateError() {
+        # Test that duplicate typedef names in same namespace cause error
+        Program p(PO_NEW_STYLE);
+        assertThrows("PARSE-EXCEPTION", \p.parse(), ("
+            typedef MyInt = int;
+            typedef MyInt = string;  # Should fail - duplicate typedef
+        ", "test"));
+    }
+
+    testTypedefClassConflict() {
+        # Test that typedef with same name as class causes error
+        Program p(PO_NEW_STYLE);
+        assertThrows("PARSE-EXCEPTION", \p.parse(), ("
+            class Foo {}
+            typedef Foo = int;  # Should fail - conflicts with class
+        ", "test"));
+    }
+}

--- a/examples/test/qore/parser/union.qtest
+++ b/examples/test/qore/parser/union.qtest
@@ -1,0 +1,451 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+/*
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%new-style
+%enable-all-warnings
+%require-types
+%strict-args
+%no-child-restrictions
+
+%requires ../../../../qlib/Util.qm
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class UnionTypeTest
+
+class UnionTypeTest inherits QUnit::Test {
+    constructor() : QUnit::Test("Union type test", "1.0") {
+        addTestCase("Basic union type", \testBasicUnion());
+        addTestCase("Union with multiple types", \testMultipleTypes());
+        addTestCase("Union or-nothing", \testUnionOrNothing());
+        addTestCase("Union type assignment", \testUnionAssignment());
+        addTestCase("Union in function signature", \testUnionInFunction());
+        addTestCase("Union in class", \testUnionInClass());
+        addTestCase("Union with complex types", \testUnionComplexTypes());
+        addTestCase("Union with typedef", \testUnionWithTypedef());
+        addTestCase("Union type checking", \testUnionTypeChecking());
+        addTestCase("Union error - empty", \testUnionEmptyError());
+        addTestCase("Union error - too many members", \testUnionTooManyMembers());
+        addTestCase("Union error - multiple soft types", \testMultipleSoftTypesError());
+        addTestCase("Union error - soft and non-soft conflict", \testSoftNonSoftConflict());
+        addTestCase("Union variant resolution", \testUnionVariantResolution());
+        addTestCase("Union type compatibility", \testUnionTypeCompatibility());
+        addTestCase("Union nested in complex type", \testUnionNestedInComplexType());
+        addTestCase("Union parse narrowing", \testUnionParseNarrowing());
+        set_return_value(main());
+    }
+
+    testBasicUnion() {
+        # Test basic union type declaration
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            union<int, string> sub getValue(bool useInt) {
+                if (useInt) {
+                    return 42;
+                }
+                return 'hello';
+            }
+
+            auto sub test() {
+                return (getValue(True), getValue(False));
+            }
+        ", "test");
+        p.run();
+        list<auto> result = p.callFunction("test");
+        assertEq(42, result[0]);
+        assertEq("hello", result[1]);
+    }
+
+    testMultipleTypes() {
+        # Test union with multiple types
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            union<int, string, bool, float> sub test(int choice) {
+                switch (choice) {
+                    case 0: return 42;
+                    case 1: return 'hello';
+                    case 2: return True;
+                    case 3: return 3.14;
+                }
+                return 0;
+            }
+        ", "test");
+        p.run();
+        assertEq(42, p.callFunction("test", 0));
+        assertEq("hello", p.callFunction("test", 1));
+        assertEq(True, p.callFunction("test", 2));
+        assertEq(3.14, p.callFunction("test", 3));
+    }
+
+    testUnionOrNothing() {
+        # Test union with or-nothing modifier
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            auto sub test() {
+                *union<int, string> x;
+                *union<int, string> y = 10;
+                *union<int, string> z = 'hello';
+                return (x, y, z);
+            }
+        ", "test");
+        p.run();
+        list<auto> result = p.callFunction("test");
+        assertEq(NOTHING, result[0]);
+        assertEq(10, result[1]);
+        assertEq("hello", result[2]);
+    }
+
+    testUnionAssignment() {
+        # Test union type assignment and reassignment
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            auto sub test() {
+                union<int, string> x = 42;
+                auto first = x;
+                x = 'now a string';
+                auto second = x;
+                x = 100;
+                auto third = x;
+                return (first, second, third);
+            }
+        ", "test");
+        p.run();
+        list<auto> result = p.callFunction("test");
+        assertEq(42, result[0]);
+        assertEq("now a string", result[1]);
+        assertEq(100, result[2]);
+    }
+
+    testUnionInFunction() {
+        # Test union in function parameters and return types
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            string sub describe(union<int, string> val) {
+                if (val.typeCode() == NT_INT) {
+                    return 'integer: ' + string(val);
+                }
+                return 'string: ' + val;
+            }
+
+            auto sub test() {
+                return (describe(42), describe('hello'));
+            }
+        ", "test");
+        p.run();
+        list<auto> result = p.callFunction("test");
+        assertEq("integer: 42", result[0]);
+        assertEq("string: hello", result[1]);
+    }
+
+    testUnionInClass() {
+        # Test union in class members and methods
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            class Container {
+                private {
+                    union<int, string> value;
+                }
+
+                constructor(union<int, string> v) {
+                    value = v;
+                }
+
+                union<int, string> getValue() {
+                    return value;
+                }
+
+                setValue(union<int, string> v) {
+                    value = v;
+                }
+            }
+
+            auto sub test() {
+                Container c(42);
+                auto v1 = c.getValue();
+                c.setValue('hello');
+                auto v2 = c.getValue();
+                return (v1, v2);
+            }
+        ", "test");
+        p.run();
+        list<auto> result = p.callFunction("test");
+        assertEq(42, result[0]);
+        assertEq("hello", result[1]);
+    }
+
+    testUnionComplexTypes() {
+        # Test union with complex types
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            auto sub test() {
+                union<list<int>, hash<string, int>> val1 = (1, 2, 3);
+                union<list<int>, hash<string, int>> val2 = {'a': 1, 'b': 2};
+
+                int sum1 = 0;
+                if (val1.typeCode() == NT_LIST) {
+                    foreach int i in (val1) {
+                        sum1 += i;
+                    }
+                }
+
+                int sum2 = 0;
+                if (val2.typeCode() == NT_HASH) {
+                    foreach auto v in (val2.values()) {
+                        sum2 += v;
+                    }
+                }
+
+                return (sum1, sum2);
+            }
+        ", "test");
+        p.run();
+        list<auto> result = p.callFunction("test");
+        assertEq(6, result[0]);
+        assertEq(3, result[1]);
+    }
+
+    testUnionWithTypedef() {
+        # Test union type with typedef
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            typedef IntOrString = union<int, string>;
+
+            IntOrString sub getValue(bool useInt) {
+                if (useInt) {
+                    return 42;
+                }
+                return 'hello';
+            }
+
+            auto sub test() {
+                IntOrString x = 10;
+                IntOrString y = 'world';
+                return (x, y, getValue(True), getValue(False));
+            }
+        ", "test");
+        p.run();
+        list<auto> result = p.callFunction("test");
+        assertEq(10, result[0]);
+        assertEq("world", result[1]);
+        assertEq(42, result[2]);
+        assertEq("hello", result[3]);
+    }
+
+    testUnionTypeChecking() {
+        # Test that invalid assignments to union types fail at parse time
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            sub test() {
+                union<int, string> x = 42;  # OK
+                x = 'hello';  # OK
+                # Attempting to assign incompatible type should fail
+            }
+        ", "test");
+        p.run();
+        p.callFunction("test");
+
+        # Test parse-time type error (Qore catches this at parse time)
+        Program p2(PO_NEW_STYLE);
+        assertThrows("PARSE-TYPE-ERROR", \p2.parse(), ("
+            sub test() {
+                union<int, string> x = 3.14;  # Should fail - float not in union
+            }
+        ", "test"));
+    }
+
+    testUnionEmptyError() {
+        # Test that empty union type causes parse error
+        Program p(PO_NEW_STYLE);
+        assertThrows("PARSE-EXCEPTION", \p.parse(), ("
+            union<> sub test() {
+                return 1;
+            }
+        ", "test"));
+    }
+
+    testUnionTooManyMembers() {
+        # Test that union with too many members causes parse error (max 100)
+        Program p(PO_NEW_STYLE);
+
+        # Build a union type string with 101 types
+        string types = "";
+        for (int i = 0; i < 101; i++) {
+            if (i > 0) {
+                types += ", ";
+            }
+            types += "int";  # Same type repeated - just testing limit
+        }
+
+        assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("
+            union<" + types + "> sub test() {
+                return 1;
+            }
+        ", "test"));
+    }
+
+    testMultipleSoftTypesError() {
+        # Test that multiple soft types in union causes parse error
+        Program p(PO_NEW_STYLE);
+        assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("
+            union<softint, softstring> sub test() {
+                return 1;
+            }
+        ", "test"));
+    }
+
+    testSoftNonSoftConflict() {
+        # Test that soft type with corresponding non-soft type causes parse error
+        Program p(PO_NEW_STYLE);
+        assertThrows("PARSE-TYPE-ERROR", \p.parse(), ("
+            union<int, softint> sub test() {
+                return 1;
+            }
+        ", "test"));
+    }
+
+    testUnionVariantResolution() {
+        # Test that function variant resolution works correctly with unions
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            string sub describe(int x) {
+                return 'int: ' + string(x);
+            }
+
+            string sub describe(string x) {
+                return 'string: ' + x;
+            }
+
+            string sub describe(bool x) {
+                return 'bool: ' + string(x);
+            }
+
+            # Pass union values to overloaded function
+            auto sub test() {
+                union<int, string, bool> v1 = 42;
+                union<int, string, bool> v2 = 'hello';
+                union<int, string, bool> v3 = True;
+
+                return (describe(v1), describe(v2), describe(v3));
+            }
+        ", "test");
+        p.run();
+        list<auto> result = p.callFunction("test");
+        assertEq("int: 42", result[0]);
+        assertEq("string: hello", result[1]);
+        assertEq("bool: 1", result[2]);  # Note: bool to string converts to "1" or "0" in Qore
+    }
+
+    testUnionTypeCompatibility() {
+        # Test union type compatibility - narrower union should be assignable to wider
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            auto sub test() {
+                # A single type should be assignable to a union containing that type
+                int x = 42;
+                union<int, string> y = x;
+
+                # A union should be usable where auto is expected
+                auto z = y;
+
+                return (y, z);
+            }
+        ", "test");
+        p.run();
+        list<auto> result = p.callFunction("test");
+        assertEq(42, result[0]);
+        assertEq(42, result[1]);
+    }
+
+    testUnionNestedInComplexType() {
+        # Test union nested in complex types like list and hash
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            auto sub test() {
+                # List containing union values
+                list<union<int, string>> items = (1, 'two', 3, 'four');
+
+                int intSum = 0;
+                string strConcat = '';
+                foreach auto item in (items) {
+                    if (item.typeCode() == NT_INT) {
+                        intSum += item;
+                    } else {
+                        strConcat += item;
+                    }
+                }
+
+                # Hash with union values
+                hash<string, union<int, bool>> flags = {
+                    'count': 5,
+                    'enabled': True,
+                    'level': 3,
+                    'active': False
+                };
+
+                return (intSum, strConcat, flags{'count'}, flags{'enabled'});
+            }
+        ", "test");
+        p.run();
+        list<auto> result = p.callFunction("test");
+        assertEq(4, result[0]);
+        assertEq("twofour", result[1]);
+        assertEq(5, result[2]);
+        assertEq(True, result[3]);
+    }
+
+    testUnionParseNarrowing() {
+        # Test that parse narrowing works with union types
+        Program p(PO_NEW_STYLE);
+        p.parse("
+            int sub processInt(int x) {
+                return x * 2;
+            }
+
+            string sub processString(string x) {
+                return x + '!';
+            }
+
+            auto sub test(union<int, string> val) {
+                # After type check, the type should be narrowed
+                if (val.typeCode() == NT_INT) {
+                    # Here val should be treated as int
+                    return processInt(val);
+                } else {
+                    # Here val should be treated as string
+                    return processString(val);
+                }
+            }
+
+            auto sub main_test() {
+                return (test(21), test('hello'));
+            }
+        ", "test");
+        p.run();
+        list<auto> result = p.callFunction("main_test");
+        assertEq(42, result[0]);
+        assertEq("hello!", result[1]);
+    }
+}

--- a/include/qore/Restrictions.h
+++ b/include/qore/Restrictions.h
@@ -4,7 +4,7 @@
 
     QORE programming language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -44,7 +44,8 @@
 #define PO_NO_TOP_LEVEL_STATEMENTS          (1 <<  4)    //!< cannot define new top-level statements (outside of sub or class defs)
 #define PO_ALLOW_REPARSE                    (1 <<  5)    //!< allow multiple parse/commit cycles (for REPL support); requires no other threads active in Program
 #define PO_BROKEN_NARROWED_TYPES            (1 <<  6)    //!< disables parse-time type narrowing (narrowed type information is not used)
-// bits 7, 8 are available for future use
+#define PO_NO_TYPEDEF                       (1 <<  7)    //!< disables the typedef keyword (for backwards compatibility)
+// bit 8 is available for future use
 #define PO_NO_INHERIT_SYSTEM_CLASSES        (1 <<  9)    //!< do not inherit system classes into this program space
 #define PO_NO_INHERIT_USER_CLASSES          (1 << 10)    //!< do not inherit public user classes into this program space
 #define PO_NO_CHILD_PO_RESTRICTIONS         (1 << 11)    //!< turn off parse option inheritance restrictions

--- a/include/qore/intern/QoreNamespaceIntern.h
+++ b/include/qore/intern/QoreNamespaceIntern.h
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2025 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -51,6 +51,37 @@ class QoreModuleContext;
 
 typedef std::list<const qore_ns_private*> nslist_t;
 
+//! Entry for a type alias (typedef)
+struct TypedefEntry {
+    const QoreProgramLocation* loc;
+    QoreParseTypeInfo* parseTypeInfo = nullptr;  //!< parse-time type info (before resolution)
+    const QoreTypeInfo* typeInfo = nullptr;      //!< resolved type info (after resolution)
+    bool pub = false;                            //!< is this typedef public?
+
+    //! Constructor for parse-time type info only
+    DLLLOCAL TypedefEntry(const QoreProgramLocation* loc, QoreParseTypeInfo* pti, bool p = false)
+            : loc(loc), parseTypeInfo(pti), pub(p) {
+    }
+
+    //! Constructor for both resolved type info and parse-time type info
+    DLLLOCAL TypedefEntry(const QoreProgramLocation* loc, const QoreTypeInfo* ti, QoreParseTypeInfo* pti,
+            bool p = false)
+            : loc(loc), parseTypeInfo(pti), typeInfo(ti), pub(p) {
+    }
+
+    DLLLOCAL TypedefEntry(const TypedefEntry& old)
+            : loc(old.loc), parseTypeInfo(old.parseTypeInfo ? new QoreParseTypeInfo(*old.parseTypeInfo) : nullptr),
+              typeInfo(old.typeInfo), pub(old.pub) {
+    }
+
+    DLLLOCAL ~TypedefEntry() {
+        delete parseTypeInfo;
+    }
+};
+
+//! Map of type aliases
+typedef std::map<std::string, TypedefEntry*> typedef_map_t;
+
 class qore_ns_private {
 public:
     const QoreProgramLocation* loc;
@@ -63,6 +94,7 @@ public:
     QoreClassList classList;       // class map
     HashDeclList hashDeclList;     // hashdecl map
     ConstantList constant;         // constant map
+    typedef_map_t typedefMap;      // typedef map
     QoreNamespaceList nsl;         // namespace map
     FunctionList func_list;        // function map
     GlobalVariableList var_list;   // global variable map
@@ -76,6 +108,7 @@ public:
     std::vector<std::string> pending_class_names;    // Classes added in pending parse
     std::vector<std::string> pending_const_names;    // Constants added in pending parse
     std::vector<std::string> pending_hashdecl_names; // Hashdecls added in pending parse
+    std::vector<std::string> pending_typedef_names;  // Typedefs added in pending parse
     std::vector<std::string> pending_ns_names;       // Child namespaces added in pending parse
 
     // 0 = root namespace, ...
@@ -317,6 +350,17 @@ public:
 
     DLLLOCAL void parseAddConstant(const QoreProgramLocation* loc, const NamedScope& name, QoreValue value,
             bool pub);
+
+    //! Adds a typedef to the namespace; returns the TypedefEntry* on success, nullptr on error
+    DLLLOCAL TypedefEntry* parseAddTypedef(const QoreProgramLocation* loc, const char* name,
+            const QoreTypeInfo* typeInfo, QoreParseTypeInfo* parseTypeInfo, bool pub);
+
+    //! Adds a typedef to the namespace (scoped version for use inside unattached namespaces)
+    DLLLOCAL void parseAddTypedef(const QoreProgramLocation* loc, const NamedScope& name,
+            const QoreTypeInfo* typeInfo, QoreParseTypeInfo* parseTypeInfo, bool pub);
+
+    //! Finds a typedef in this namespace
+    DLLLOCAL const TypedefEntry* findLocalTypedef(const char* name) const;
 
     DLLLOCAL int parseAddMethodToClass(const QoreProgramLocation* loc, const NamedScope& name,
             MethodVariantBase* qcmethod, bool static_flag);
@@ -1072,6 +1116,8 @@ typedef RootMap<TypedHashDecl> thdmap_t;
 
 typedef RootMap<Var> varmap_t;
 
+typedef RootMap<TypedefEntry> tdmap_t;
+
 struct deferred_new_check_t {
     const qore_class_private* qc;
     const QoreProgramLocation* loc;
@@ -1371,6 +1417,27 @@ protected:
         return nullptr;
     }
 
+    DLLLOCAL TypedefEntry* parseFindTypedefIntern(const char* tdname) {
+        {
+            // try to check in current namespace first
+            qore_ns_private* nscx = parse_get_ns();
+            if (nscx) {
+                const TypedefEntry* td = nscx->findLocalTypedef(tdname);
+                if (td)
+                    return const_cast<TypedefEntry*>(td);
+            }
+        }
+
+        tdmap_t::iterator i = tdmap.find(tdname);
+
+        if (i != tdmap.end()) {
+            return i->second.obj;
+        }
+
+        //printd(5, "qore_root_ns_private::parseFindTypedefIntern() this: %p '%s' not found\n", this, tdname);
+        return nullptr;
+    }
+
     DLLLOCAL QoreClass* parseFindScopedClassIntern(const QoreProgramLocation* loc, const NamedScope& name,
             bool raise_error);
     DLLLOCAL QoreClass* parseFindScopedClassIntern(const NamedScope& name, unsigned& matched);
@@ -1474,6 +1541,9 @@ protected:
     DLLLOCAL void parseAddClassIntern(const QoreProgramLocation* loc, const NamedScope& name, QoreClass* oc);
 
     DLLLOCAL void parseAddHashDeclIntern(const QoreProgramLocation* loc, const NamedScope& name, TypedHashDecl* hd);
+
+    DLLLOCAL void parseAddTypedefIntern(const QoreProgramLocation* loc, const NamedScope& name,
+            const QoreTypeInfo* typeInfo, QoreParseTypeInfo* parseTypeInfo, bool pub);
 
     DLLLOCAL qore_ns_private* parseResolveNamespaceIntern(const QoreProgramLocation* loc, const NamedScope& nscope,
             qore_ns_private* sns);
@@ -1612,6 +1682,11 @@ protected:
             thdmap.update(hdli.getName(), ns, hdli.get());
     }
 
+    DLLLOCAL static void rebuildTypedefIndexes(tdmap_t& tdmap, typedef_map_t& tdm, qore_ns_private* ns) {
+        for (typedef_map_t::iterator i = tdm.begin(), e = tdm.end(); i != e; ++i)
+            tdmap.update(i->first, ns, i->second);
+    }
+
     DLLLOCAL static void rebuildFunctionIndexes(fmap_t& fmap, fl_map_t& flmap, qore_ns_private* ns) {
         for (fl_map_t::iterator i = flmap.begin(), e = flmap.end(); i != e; ++i) {
             assert(i->second->getNamespace() == ns);
@@ -1637,6 +1712,9 @@ protected:
 
         // process hashdecl indexes
         rebuildHashDeclIndexes(thdmap, ns->hashDeclList, ns);
+
+        // process typedef indexes
+        rebuildTypedefIndexes(tdmap, ns->typedefMap, ns);
 
         // reindex namespace
         nsmap.update(ns);
@@ -1668,6 +1746,9 @@ protected:
         // process hashdecl indexes
         rebuildHashDeclIndexes(thdmap, ns->hashDeclList, ns);
 
+        // process typedef indexes
+        rebuildTypedefIndexes(tdmap, ns->typedefMap, ns);
+
         // reindex namespace
         nsmap.update(ns);
     }
@@ -1690,6 +1771,8 @@ public:
     clmap_t clmap;       // root class map
 
     thdmap_t thdmap;     // root hashdecl map
+
+    tdmap_t tdmap;       // root typedef map
 
     varmap_t varmap;     // root variable map
 
@@ -1842,6 +1925,7 @@ public:
         varmap.clear();
         clmap.clear();
         thdmap.clear();
+        tdmap.clear();
         nsmap.clear();
 
         // Only rebuild indexes for atomic rollback - with full reset, the program is unusable anyway
@@ -2093,6 +2177,10 @@ public:
         return getRootNS()->rpriv->parseFindScopedClassWithMethodInternError(loc, name, error);
     }
 
+    DLLLOCAL static TypedefEntry* parseFindTypedef(const char* name) {
+        return getRootNS()->rpriv->parseFindTypedefIntern(name);
+    }
+
     DLLLOCAL static void parseAddConstant(const QoreProgramLocation* loc, QoreNamespace& ns, const NamedScope& name,
             QoreValue value, bool pub) {
         getRootNS()->rpriv->parseAddConstantIntern(loc, ns, name, value, pub);
@@ -2110,6 +2198,11 @@ public:
 
     DLLLOCAL static void parseAddHashDecl(const QoreProgramLocation* loc, const NamedScope& name, TypedHashDecl* hd) {
         getRootNS()->rpriv->parseAddHashDeclIntern(loc, name, hd);
+    }
+
+    DLLLOCAL static void parseAddTypedef(const QoreProgramLocation* loc, const NamedScope& name,
+            const QoreTypeInfo* typeInfo, QoreParseTypeInfo* parseTypeInfo, bool pub) {
+        getRootNS()->rpriv->parseAddTypedefIntern(loc, name, typeInfo, parseTypeInfo, pub);
     }
 
     DLLLOCAL static void parseAddNamespace(QoreNamespace* nns) {

--- a/include/qore/intern/QoreTypeInfo.h
+++ b/include/qore/intern/QoreTypeInfo.h
@@ -605,6 +605,24 @@ public:
             : ti->return_vec[0].spec.getComplexList();
     }
 
+    //! Returns the complex code type info if this is a typed callable type
+    /** @param ti the type to check
+        @return the QoreComplexCodeTypeInfo pointer if this is a typed callable, nullptr otherwise
+    */
+    DLLLOCAL static const class QoreComplexCodeTypeInfo* getComplexCodeType(const QoreTypeInfo* ti);
+
+    //! Checks if two typed callable types have compatible signatures
+    /** This is used for additional type checking when assigning closures/call references
+        to typed code variables. Standard variance rules apply:
+        - Return types: covariant (source can be more specific)
+        - Parameter types: contravariant (source can be more general)
+
+        @param target the target type (typed code variable)
+        @param source the source type (closure/call reference)
+        @return true if compatible, false otherwise
+    */
+    DLLLOCAL static bool checkComplexCodeCompatibility(const QoreTypeInfo* target, const QoreTypeInfo* source);
+
     //! Returns the element type info for an iterator class based on source type
     /** For HashPairIterator with source hash<string, int>: returns the type info for
         hash<HashPairInfo> where HashPairInfo has key: string and value: int
@@ -4002,5 +4020,107 @@ DLLLOCAL const QoreTypeInfo* qore_get_union_type(const type_vec_t& member_types,
 
 //! Creates or retrieves a cached or-nothing union type for the given member types
 DLLLOCAL const QoreTypeInfo* qore_get_union_or_nothing_type(const type_vec_t& member_types);
+
+//! Type info for typed callable types: code<ReturnType(ParamTypes...)>
+/** This class represents a callable type with specified return type and parameter types.
+    It supports:
+    - Return type specification
+    - Parameter type specification (zero or more)
+    - Varargs support via "..." syntax
+    - Standard variance: covariant returns, contravariant parameters
+*/
+class QoreComplexCodeTypeInfo : public QoreTypeInfo {
+public:
+    //! Constructor for typed callable types
+    /** @param ret_type the return type (nullptr for nothing/void)
+        @param param_types vector of parameter types
+        @param varargs if true, accepts variable arguments
+        @param or_nothing if true, the code type also accepts NOTHING
+    */
+    DLLLOCAL QoreComplexCodeTypeInfo(const QoreTypeInfo* ret_type, type_vec_t&& param_types,
+            bool varargs = false, bool or_nothing = false);
+
+    //! Returns the return type of this callable
+    DLLLOCAL const QoreTypeInfo* getReturnType() const {
+        return returnType;
+    }
+
+    //! Returns the parameter types of this callable
+    DLLLOCAL const type_vec_t& getParamTypes() const {
+        return paramTypes;
+    }
+
+    //! Returns true if this callable accepts variable arguments
+    DLLLOCAL bool hasVarArgs() const {
+        return varargs;
+    }
+
+    //! Returns true if this is an or-nothing callable type
+    DLLLOCAL bool isOrNothing() const {
+        return orNothing;
+    }
+
+    //! Checks if the given signature is compatible with this callable type
+    /** Uses standard variance rules:
+        - Return type: covariant (assigned callable can return more specific type)
+        - Parameter types: contravariant (assigned callable can accept more general type)
+        @param sig the function signature to check
+        @return true if the signature is compatible, false otherwise
+    */
+    DLLLOCAL bool isSignatureCompatible(const class AbstractFunctionSignature* sig) const;
+
+protected:
+    const QoreTypeInfo* returnType;  //!< return type (nullptr = nothing)
+    type_vec_t paramTypes;           //!< parameter types
+    bool varargs;                    //!< true if accepts variable arguments
+    bool orNothing;                  //!< true if accepts NOTHING
+    QoreString pname;                //!< path name for type
+
+    DLLLOCAL virtual void getThisTypeImpl(QoreString& str) const {
+        str.concat(&tname);
+    }
+
+    DLLLOCAL virtual bool canConvertToScalarImpl() const {
+        return false;
+    }
+
+    DLLLOCAL virtual bool hasDefaultValueImpl() const {
+        return orNothing;
+    }
+
+    DLLLOCAL virtual QoreValue getDefaultQoreValueImpl() const {
+        return QoreValue();  // NOTHING
+    }
+
+    DLLLOCAL virtual bool needsScanImpl() const {
+        return true;  // closures need scanning
+    }
+
+    DLLLOCAL const char* getPathImpl() const {
+        return pname.empty() ? tname.c_str() : pname.c_str();
+    }
+};
+
+//! Creates or retrieves a cached typed callable type
+/** @param return_type the return type (nullptr for nothing)
+    @param param_types vector of parameter types
+    @param varargs if true, accepts variable arguments
+    @param or_nothing if true, also accepts NOTHING
+    @return the typed callable type info
+*/
+DLLLOCAL const QoreTypeInfo* qore_get_complex_code_type(const QoreTypeInfo* return_type,
+    const type_vec_t& param_types, bool varargs = false, bool or_nothing = false);
+
+//! Creates or retrieves a cached or-nothing typed callable type
+DLLLOCAL const QoreTypeInfo* qore_get_complex_code_or_nothing_type(const QoreTypeInfo* return_type,
+    const type_vec_t& param_types, bool varargs = false);
+
+//! Creates a typed callable type from a function signature
+/** @param sig the function signature to create the type from
+    @param or_nothing if true, also accepts NOTHING
+    @return the typed callable type info
+*/
+DLLLOCAL const QoreTypeInfo* qore_get_complex_code_type_from_signature(const class AbstractFunctionSignature* sig,
+    bool or_nothing = false);
 
 #endif // _QORE_QORETYPEINFO_H

--- a/include/qore/intern/QoreTypeInfo.h
+++ b/include/qore/intern/QoreTypeInfo.h
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2025 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -3944,5 +3944,63 @@ protected:
         return false;
     }
 };
+
+//! Maximum number of types allowed in a union type
+constexpr size_t QORE_MAX_UNION_MEMBERS = 100;
+
+//! Type info for explicitly declared union types (union<T1, T2, ...>)
+class QoreUnionTypeInfo : public QoreTypeInfo {
+public:
+    //! Constructor for explicit union types
+    DLLLOCAL QoreUnionTypeInfo(const q_accept_vec_t&& a_vec, const q_return_vec_t&& r_vec,
+            const QoreString& name, bool or_nothing = false)
+            : QoreTypeInfo(std::move(a_vec), std::move(r_vec), name), orNothing(or_nothing) {
+    }
+
+    //! Returns true if this is an or-nothing union type
+    DLLLOCAL bool isOrNothing() const {
+        return orNothing;
+    }
+
+protected:
+    bool orNothing;  //!< true if this union type accepts NOTHING
+
+    DLLLOCAL virtual void getThisTypeImpl(QoreString& str) const {
+        str.concat(&tname);
+    }
+
+    // returns true if there is no type or if the type can be converted to a scalar value, false if otherwise
+    DLLLOCAL virtual bool canConvertToScalarImpl() const {
+        // union types generally cannot be converted to scalars unless all members can
+        return false;
+    }
+
+    DLLLOCAL virtual bool hasDefaultValueImpl() const {
+        return orNothing;  // *union<...> has a default value of NOTHING
+    }
+
+    DLLLOCAL virtual QoreValue getDefaultQoreValueImpl() const {
+        // Only *union<...> has a default value (NOTHING); regular union<...> has no default
+        return QoreValue();
+    }
+
+    // returns true if this type could contain an object or a closure
+    DLLLOCAL virtual bool needsScanImpl() const {
+        return true;  // conservatively assume union could contain scannable types
+    }
+};
+
+//! Vector of type infos for union member types
+typedef std::vector<const QoreTypeInfo*> type_vec_t;
+
+//! Creates or retrieves a cached union type for the given member types
+/** @param member_types vector of member types
+    @param or_nothing if true, the union type also accepts NOTHING
+    @return the union type info, or nullptr on error
+*/
+DLLLOCAL const QoreTypeInfo* qore_get_union_type(const type_vec_t& member_types, bool or_nothing = false);
+
+//! Creates or retrieves a cached or-nothing union type for the given member types
+DLLLOCAL const QoreTypeInfo* qore_get_union_or_nothing_type(const type_vec_t& member_types);
 
 #endif // _QORE_QORETYPEINFO_H

--- a/lib/ParseOptionMap.cpp
+++ b/lib/ParseOptionMap.cpp
@@ -3,7 +3,7 @@
 
     Qore Programming language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -95,6 +95,7 @@ void ParseOptionMap::static_init() {
     DO_MAP("allow-statement-no-effect",PO_ALLOW_STATEMENT_NO_EFFECT);
     DO_MAP("no-reflection",            PO_NO_REFLECTION);
     DO_MAP("no-transient",             PO_NO_TRANSIENT);
+    DO_MAP("no-typedef",               PO_NO_TYPEDEF);
     DO_MAP("broken-sprintf",           PO_BROKEN_SPRINTF);
     DO_MAP("broken-cast",              PO_BROKEN_CAST);
     DO_MAP("allow-returns",            PO_ALLOW_RETURNS);

--- a/lib/QoreAssignmentOperatorNode.cpp
+++ b/lib/QoreAssignmentOperatorNode.cpp
@@ -109,6 +109,11 @@ int QoreAssignmentOperatorNode::parseInitIntern(QoreParseContext& parse_context,
         //printd(5, "QoreAssignmentOperatorNode::parseInitImpl() '%s' <- '%s' res: %d may_not_match: %d "
         //    "may_need_filter: %d ident: %d\n", QoreTypeInfo::getName(ti),
         //    QoreTypeInfo::getName(parse_context.typeInfo), res, may_not_match, may_need_filter, ident);
+
+        // Additional check for typed callable signature compatibility
+        if (res && !QoreTypeInfo::checkComplexCodeCompatibility(ti, parse_context.typeInfo)) {
+            res = QTI_NOT_EQUAL;
+        }
     } else {
         res = QTI_AMBIGUOUS;
     }

--- a/lib/QoreClosureParseNode.cpp
+++ b/lib/QoreClosureParseNode.cpp
@@ -87,11 +87,20 @@ int QoreClosureParseNode::parseInitImpl(QoreValue& val, QoreParseContext& parse_
         parse_qc = parse_get_class_priv();
         parse_ns = parse_get_ns();
         //printd(5, "QoreClosureParseNode::parseInitImpl() this: %p set deferred\n", this);
+        // Use generic closure type for deferred initialization
+        parse_context.typeInfo = runTimeClosureTypeInfo;
     } else {
         err = uf->parseInit(nullptr);
         uf->parseCommit();
+
+        // After parseCommit, the signature is available - create a typed callable type
+        AbstractFunctionSignature* sig = uf->getUniqueSignature();
+        if (sig) {
+            parse_context.typeInfo = qore_get_complex_code_type_from_signature(sig);
+        } else {
+            parse_context.typeInfo = runTimeClosureTypeInfo;
+        }
     }
-    parse_context.typeInfo = runTimeClosureTypeInfo;
     return err;
 }
 

--- a/lib/QoreNamespace.cpp
+++ b/lib/QoreNamespace.cpp
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2025 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -331,6 +331,10 @@ qore_ns_private::qore_ns_private(const QoreProgramLocation* loc) : loc(loc), con
 }
 
 qore_ns_private::~qore_ns_private() {
+    // Clean up typedef entries
+    for (auto& i : typedefMap) {
+        delete i.second;
+    }
 }
 
 QoreProgram* qore_ns_private::getProgram() const {
@@ -2539,6 +2543,7 @@ void qore_ns_private::parseCommit() {
     pending_class_names.clear();
     pending_const_names.clear();
     pending_hashdecl_names.clear();
+    pending_typedef_names.clear();
     pending_ns_names.clear();
 }
 
@@ -2589,6 +2594,16 @@ void qore_ns_private::parseRollback(ExceptionSink* xsink, bool atomic_rollback) 
             hashDeclList.parseRemove(name.c_str());
         }
         pending_hashdecl_names.clear();
+
+        // remove only typedefs added in this pending transaction
+        for (const auto& name : pending_typedef_names) {
+            typedef_map_t::iterator i = typedefMap.find(name);
+            if (i != typedefMap.end()) {
+                delete i->second;
+                typedefMap.erase(i);
+            }
+        }
+        pending_typedef_names.clear();
 
         // remove only namespaces added in this pending transaction
         for (const auto& name : pending_ns_names) {
@@ -2738,6 +2753,83 @@ void qore_ns_private::parseAddConstant(const QoreProgramLocation* loc, const Nam
       return;
 
    sns->priv->parseAddConstant(loc, nscope[nscope.size() - 1], vh.release(), cpub);
+}
+
+// only called while parsing before addition to namespace tree, no locking needed
+// returns TypedefEntry* on success, nullptr on error
+TypedefEntry* qore_ns_private::parseAddTypedef(const QoreProgramLocation* loc, const char* tdname,
+        const QoreTypeInfo* typeInfo, QoreParseTypeInfo* parseTypeInfo, bool pub) {
+    std::unique_ptr<QoreParseTypeInfo> pti_holder(parseTypeInfo);
+
+    // Check for duplicate typedef name
+    if (typedefMap.find(tdname) != typedefMap.end()) {
+        std::string nspath;
+        getPath(nspath, true);
+        parse_error(*loc, "typedef '%s' has already been defined in '%s'", tdname, nspath.c_str());
+        return nullptr;
+    }
+
+    // Check for conflict with class name
+    if (classList.find(tdname)) {
+        parse_error(*loc, "typedef '%s' conflicts with existing class in namespace '%s::'", tdname, name.c_str());
+        return nullptr;
+    }
+
+    // Check for conflict with hashdecl name
+    if (hashDeclList.find(tdname)) {
+        parse_error(*loc, "typedef '%s' conflicts with existing hashdecl in namespace '%s::'", tdname, name.c_str());
+        return nullptr;
+    }
+
+    // Check public visibility warning
+    if (!imported && pub && !this->pub && parse_check_parse_option(PO_IN_MODULE))
+        qore_program_private::makeParseWarning(getProgram(), *loc, QP_WARN_INVALID_OPERATION, "INVALID-OPERATION",
+        "typedef '%s::%s' is declared public but the enclosing namespace '%s::' is not public", name.c_str(), tdname,
+        name.c_str());
+
+    // Add the typedef
+    TypedefEntry* entry = new TypedefEntry(loc, typeInfo, pti_holder.release(), pub);
+    typedefMap[tdname] = entry;
+    pending_typedef_names.push_back(tdname);
+    return entry;
+}
+
+// only called while parsing inside unattached namespaces
+// global tdmap is updated when namespace is attached via parseRebuildIndexes
+void qore_ns_private::parseAddTypedef(const QoreProgramLocation* loc, const NamedScope& nscope,
+        const QoreTypeInfo* typeInfo, QoreParseTypeInfo* parseTypeInfo, bool pub) {
+    std::unique_ptr<QoreParseTypeInfo> pti_holder(parseTypeInfo);
+
+    QoreNamespace* sns = resolveNameScope(loc, nscope);
+    if (!sns)
+        return;
+
+    sns->priv->parseAddTypedef(loc, nscope[nscope.size() - 1], typeInfo, pti_holder.release(), pub);
+}
+
+// only called with RootNS
+void qore_root_ns_private::parseAddTypedefIntern(const QoreProgramLocation* loc, const NamedScope& nscope,
+        const QoreTypeInfo* typeInfo, QoreParseTypeInfo* parseTypeInfo, bool pub) {
+    std::unique_ptr<QoreParseTypeInfo> pti_holder(parseTypeInfo);
+
+    qore_ns_private* sns = parseResolveNamespace(loc, nscope);
+    if (!sns) {
+        return;
+    }
+
+    const char* tdname = nscope.getIdentifier();
+    TypedefEntry* entry = sns->parseAddTypedef(loc, tdname, typeInfo, pti_holder.release(), pub);
+    if (entry) {
+        // add to global typedef map
+        tdmap.update(tdname, sns, entry);
+    }
+}
+
+const TypedefEntry* qore_ns_private::findLocalTypedef(const char* tdname) const {
+    typedef_map_t::const_iterator i = typedefMap.find(tdname);
+    if (i != typedefMap.end())
+        return i->second;
+    return nullptr;
 }
 
 // public, only called either in single-threaded initialization or

--- a/lib/QoreTypeInfo.cpp
+++ b/lib/QoreTypeInfo.cpp
@@ -3,7 +3,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2025 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -40,6 +40,9 @@
 #include "qore/intern/QoreHashNodeIntern.h"
 #include "qore/intern/QoreDotEvalOperatorNode.h"
 #include "qore/intern/FunctionCallNode.h"
+
+#include <algorithm>
+#include <set>
 
 const QoreAnyTypeInfo staticAnyTypeInfo;
 const QoreAutoTypeInfo staticAutoTypeInfo;
@@ -268,6 +271,11 @@ tmap_t ch_map,          // complex hash map
    cron_map,            // complex reference or nothing map
    csl_map,             // complex softlist map
    cslon_map;           // complex softlist or nothing map
+
+// Cache for union types - keyed by sorted vector of member types
+typedef std::map<type_vec_t, QoreUnionTypeInfo*> union_map_t;
+static union_map_t union_map,       // union types
+                   union_on_map;    // union or-nothing types
 
 // Cache for parameterized HashPairInfo types based on value type
 typedef std::map<const QoreTypeInfo*, TypedHashDecl*> hp_decl_map_t;
@@ -657,6 +665,105 @@ const QoreTypeInfo* qore_get_complex_reference_or_nothing_type(const QoreTypeInf
     QoreComplexReferenceOrNothingTypeInfo* ti = new QoreComplexReferenceOrNothingTypeInfo(vti);
     cron_map.insert(i, tmap_t::value_type(vti, ti));
     return ti;
+}
+
+// Helper function to create a normalized key for union type caching
+// Sorts member types by pointer value to ensure consistent cache lookups
+static type_vec_t normalize_union_key(const type_vec_t& member_types) {
+    type_vec_t key(member_types);
+    std::sort(key.begin(), key.end());
+    // Remove duplicates
+    key.erase(std::unique(key.begin(), key.end()), key.end());
+    return key;
+}
+
+// Helper function to build the union type name
+static QoreString build_union_name(const type_vec_t& member_types, bool or_nothing) {
+    QoreString name;
+    if (or_nothing) {
+        name.concat('*');
+    }
+    name.concat("union<");
+    for (size_t i = 0; i < member_types.size(); ++i) {
+        if (i > 0) {
+            name.concat(", ");
+        }
+        name.concat(QoreTypeInfo::getName(member_types[i]));
+    }
+    name.concat('>');
+    return name;
+}
+
+const QoreTypeInfo* qore_get_union_type(const type_vec_t& member_types, bool or_nothing) {
+    // Handle edge cases
+    if (member_types.empty()) {
+        return autoTypeInfo;  // empty union accepts anything
+    }
+    if (member_types.size() == 1) {
+        const QoreTypeInfo* ti = member_types[0];
+        if (or_nothing) {
+            const QoreTypeInfo* orn = get_or_nothing_type(ti);
+            return orn ? orn : ti;
+        }
+        return ti;
+    }
+
+    // Normalize the key for consistent cache lookup
+    type_vec_t key = normalize_union_key(member_types);
+
+    // Check if any member already accepts NOTHING, if so, or_nothing is already covered
+    bool has_nothing = false;
+    for (const QoreTypeInfo* ti : key) {
+        if (QoreTypeInfo::parseAcceptsReturns(ti, NT_NOTHING)) {
+            has_nothing = true;
+            break;
+        }
+    }
+
+    // Use appropriate cache
+    union_map_t& cache = (or_nothing && !has_nothing) ? union_on_map : union_map;
+
+    AutoLocker al(ctl);
+
+    union_map_t::iterator i = cache.find(key);
+    if (i != cache.end()) {
+        return i->second;
+    }
+
+    // Build accept and return vectors from all member types
+    q_accept_vec_t accept_vec;
+    q_return_vec_t return_vec;
+
+    for (const QoreTypeInfo* ti : key) {
+        // Add accept types from this member
+        for (const auto& a : ti->accept_vec) {
+            accept_vec.push_back(a);
+        }
+        // Add return types from this member
+        for (const auto& r : ti->return_vec) {
+            return_vec.push_back(r);
+        }
+    }
+
+    // If or_nothing and no member accepts NOTHING, add it
+    if (or_nothing && !has_nothing) {
+        accept_vec.push_back({NT_NOTHING, nullptr});
+        accept_vec.push_back({NT_NULL, [] (QoreValue& n, ExceptionSink* xsink) { n.assignNothing(); }});
+        return_vec.push_back({NT_NOTHING});
+    }
+
+    // Build the name
+    QoreString name = build_union_name(member_types, or_nothing && !has_nothing);
+
+    // Create the union type
+    QoreUnionTypeInfo* ti = new QoreUnionTypeInfo(std::move(accept_vec), std::move(return_vec), name,
+        or_nothing || has_nothing);
+    cache[key] = ti;
+    return ti;
+}
+
+const QoreTypeInfo* qore_get_union_or_nothing_type(const type_vec_t& member_types) {
+    return qore_get_union_type(member_types, true);
 }
 
 static const QoreTypeInfo* getExternalTypeInfoForType(qore_type_t t) {
@@ -1866,6 +1973,29 @@ const QoreTypeInfo* QoreParseTypeInfo::resolveRuntimeSubtype() const {
         // resolve class
         return resolveRuntimeClass(*subtypes[0]->cscope, or_nothing);
     }
+    if (!strcmp(cscope->ostr, "union")) {
+        if (subtypes.empty() || subtypes.size() > QORE_MAX_UNION_MEMBERS) {
+            return nullptr;
+        }
+
+        // Resolve all member types
+        type_vec_t member_types;
+        member_types.reserve(subtypes.size());
+
+        for (const auto& st : subtypes) {
+            if (!strcmp(st->cscope->ostr, "auto")) {
+                return autoTypeInfo;  // union<auto> = auto
+            }
+
+            const QoreTypeInfo* member = st->resolveRuntime();
+            if (!member) {
+                return nullptr;
+            }
+            member_types.push_back(member);
+        }
+
+        return qore_get_union_type(member_types, or_nothing);
+    }
     return nullptr;
 }
 
@@ -1998,6 +2128,78 @@ const QoreTypeInfo* QoreParseTypeInfo::resolveSubtype(const QoreProgramLocation*
         // resolve class
         return resolveClass(loc, *subtypes[0]->cscope, or_nothing, err);
     }
+    if (!strcmp(cscope->ostr, "union")) {
+        // Validate union constraints
+        if (subtypes.empty()) {
+            parseException(*loc, "PARSE-TYPE-ERROR", "cannot resolve '%s'; union type requires at least one member " \
+                "type", getName());
+            err = -1;
+            return autoTypeInfo;  // return auto on error
+        }
+        if (subtypes.size() > QORE_MAX_UNION_MEMBERS) {
+            parseException(*loc, "PARSE-TYPE-ERROR", "cannot resolve '%s'; union type has %d member types but " \
+                "maximum allowed is %d", getName(), (int)subtypes.size(), (int)QORE_MAX_UNION_MEMBERS);
+            err = -1;
+            return autoTypeInfo;  // return auto on error
+        }
+
+        // Resolve all member types
+        type_vec_t member_types;
+        member_types.reserve(subtypes.size());
+
+        // Track soft types for validation
+        const QoreTypeInfo* soft_type = nullptr;
+        std::set<qore_type_t> base_types;
+
+        for (const auto& st : subtypes) {
+            if (!strcmp(st->cscope->ostr, "auto")) {
+                // union<auto> is equivalent to auto
+                return autoTypeInfo;
+            }
+
+            const QoreTypeInfo* member = QoreParseTypeInfo::resolveAny(st, loc, err);
+            if (err) {
+                return autoTypeInfo;  // return auto on error
+            }
+
+            // Check for soft type constraints
+            qore_type_t base_type = QoreTypeInfo::getBaseType(member);
+            bool is_soft = QoreTypeInfo::getName(member)[0] == 's' &&
+                           (strncmp(QoreTypeInfo::getName(member), "soft", 4) == 0);
+
+            if (is_soft) {
+                if (soft_type && soft_type != member) {
+                    parseException(*loc, "PARSE-TYPE-ERROR", "cannot resolve '%s'; union type can have at most one " \
+                        "soft type but found '%s' and '%s'", getName(), QoreTypeInfo::getName(soft_type),
+                        QoreTypeInfo::getName(member));
+                    err = -1;
+                    return autoTypeInfo;  // return auto on error
+                }
+                soft_type = member;
+
+                // Check for soft+non-soft of same base type
+                if (base_types.find(base_type) != base_types.end()) {
+                    parseException(*loc, "PARSE-TYPE-ERROR", "cannot resolve '%s'; union type cannot have both soft " \
+                        "and non-soft versions of the same base type", getName());
+                    err = -1;
+                    return autoTypeInfo;  // return auto on error
+                }
+            } else {
+                // Check if we already have a soft version of this base type
+                if (soft_type && QoreTypeInfo::getBaseType(soft_type) == base_type) {
+                    parseException(*loc, "PARSE-TYPE-ERROR", "cannot resolve '%s'; union type cannot have both soft " \
+                        "and non-soft versions of the same base type", getName());
+                    err = -1;
+                    return autoTypeInfo;  // return auto on error
+                }
+                base_types.insert(base_type);
+            }
+
+            member_types.push_back(member);
+        }
+
+        return qore_get_union_type(member_types, or_nothing);
+    }
 
     parseException(*loc, "PARSE-TYPE-ERROR", "cannot resolve '%s'; type '%s' does not take subtype declarations",
         getName(), cscope->getIdentifier());
@@ -2031,6 +2233,41 @@ const QoreTypeInfo* QoreParseTypeInfo::resolveAndDelete(const QoreProgramLocatio
 
 const QoreTypeInfo* QoreParseTypeInfo::resolveClass(const QoreProgramLocation* loc, const NamedScope& cscope,
         bool or_nothing, int& err) {
+    // check for typedef first (only for simple names without scope qualification)
+    if (cscope.size() == 1) {
+        TypedefEntry* td = qore_root_ns_private::parseFindTypedef(cscope.ostr);
+        if (td) {
+            // resolve the typedef's underlying type
+            const QoreTypeInfo* rv;
+            if (td->typeInfo) {
+                // already resolved
+                rv = td->typeInfo;
+            } else if (td->parseTypeInfo) {
+                // resolve the parse type info
+                rv = td->parseTypeInfo->resolve(loc, err);
+                // cache the resolved type for future lookups
+                td->typeInfo = rv;
+            } else {
+                // should not happen - typedef without type info
+                parse_error(*loc, "internal error: typedef '%s' has no type information", cscope.ostr);
+                err = -1;
+                return autoTypeInfo;
+            }
+
+            // apply or_nothing if needed and the underlying type doesn't already accept NOTHING
+            if (or_nothing && !QoreTypeInfo::parseAcceptsReturns(rv, NT_NOTHING)) {
+                // need to get the or-nothing variant of this type
+                const QoreTypeInfo* orn = qore_get_or_nothing_type(rv);
+                if (orn) {
+                    return orn;
+                }
+                // if we can't get or-nothing variant, just return the base type
+                // the caller should handle the or_nothing semantics
+            }
+            return rv;
+        }
+    }
+
     // resolve class
     const QoreClass* qc = qore_root_ns_private::parseFindScopedClass(loc, cscope);
 

--- a/lib/QoreTypeInfo.cpp
+++ b/lib/QoreTypeInfo.cpp
@@ -40,6 +40,7 @@
 #include "qore/intern/QoreHashNodeIntern.h"
 #include "qore/intern/QoreDotEvalOperatorNode.h"
 #include "qore/intern/FunctionCallNode.h"
+#include "qore/intern/Function.h"
 
 #include <algorithm>
 #include <set>
@@ -277,6 +278,28 @@ typedef std::map<type_vec_t, QoreUnionTypeInfo*> union_map_t;
 static union_map_t union_map,       // union types
                    union_on_map;    // union or-nothing types
 
+// Cache key for typed callable types: (returnType, paramTypes, varargs, or_nothing)
+struct ComplexCodeCacheKey {
+    const QoreTypeInfo* returnType;
+    type_vec_t paramTypes;
+    bool varargs;
+    bool orNothing;
+
+    bool operator<(const ComplexCodeCacheKey& other) const {
+        if (returnType != other.returnType) return returnType < other.returnType;
+        if (paramTypes.size() != other.paramTypes.size()) return paramTypes.size() < other.paramTypes.size();
+        for (size_t i = 0; i < paramTypes.size(); ++i) {
+            if (paramTypes[i] != other.paramTypes[i]) return paramTypes[i] < other.paramTypes[i];
+        }
+        if (varargs != other.varargs) return varargs < other.varargs;
+        return orNothing < other.orNothing;
+    }
+};
+
+// Cache for typed callable types
+typedef std::map<ComplexCodeCacheKey, QoreComplexCodeTypeInfo*> complex_code_map_t;
+static complex_code_map_t complex_code_map;
+
 // Cache for parameterized HashPairInfo types based on value type
 typedef std::map<const QoreTypeInfo*, TypedHashDecl*> hp_decl_map_t;
 static hp_decl_map_t hp_decl_map;
@@ -390,6 +413,14 @@ void delete_qore_types() {
     for (auto& i : csl_map)
         delete i.second;
     for (auto& i : cslon_map)
+        delete i.second;
+    // Clean up union type cache
+    for (auto& i : union_map)
+        delete i.second;
+    for (auto& i : union_on_map)
+        delete i.second;
+    // Clean up typed callable type cache
+    for (auto& i : complex_code_map)
         delete i.second;
     // Clean up hash pair info decl cache
     for (auto& i : hp_decl_map)
@@ -764,6 +795,411 @@ const QoreTypeInfo* qore_get_union_type(const type_vec_t& member_types, bool or_
 
 const QoreTypeInfo* qore_get_union_or_nothing_type(const type_vec_t& member_types) {
     return qore_get_union_type(member_types, true);
+}
+
+// Forward declaration
+static QoreParseTypeInfo* parse_type_string_to_pti(const char* type_str);
+
+// Helper function to parse a type string into a QoreParseTypeInfo with proper subtypes
+static QoreParseTypeInfo* parse_type_string_to_pti(const char* type_str) {
+    // Trim whitespace
+    while (*type_str && isspace(*type_str)) ++type_str;
+    if (!*type_str) return nullptr;
+
+    std::string str(type_str);
+    while (!str.empty() && isspace(str.back())) str.pop_back();
+    if (str.empty()) return nullptr;
+
+    // Check for or-nothing prefix
+    bool or_nothing = false;
+    if (str[0] == '*') {
+        or_nothing = true;
+        str.erase(0, 1);
+    }
+
+    // Check if this is a complex type (has angle brackets)
+    size_t angle_pos = str.find('<');
+    if (angle_pos == std::string::npos) {
+        // Simple type
+        return new QoreParseTypeInfo(strdup(str.c_str()), or_nothing);
+    }
+
+    // Complex type - find matching '>'
+    int depth = 1;
+    size_t close_pos = angle_pos + 1;
+    while (close_pos < str.size() && depth > 0) {
+        if (str[close_pos] == '<') ++depth;
+        else if (str[close_pos] == '>') --depth;
+        ++close_pos;
+    }
+    if (depth != 0) {
+        // Unbalanced brackets - return as-is
+        return new QoreParseTypeInfo(strdup(str.c_str()), or_nothing);
+    }
+    --close_pos;  // Point to the closing '>'
+
+    // Extract base type and subtype content
+    std::string base_type = str.substr(0, angle_pos);
+    std::string subtype_content = str.substr(angle_pos + 1, close_pos - angle_pos - 1);
+
+    // Parse subtypes (split on commas, respecting nested brackets)
+    parse_type_vec_t subtypes;
+    std::string current;
+    int angle_depth = 0;
+    for (size_t i = 0; i <= subtype_content.size(); ++i) {
+        char c = i < subtype_content.size() ? subtype_content[i] : '\0';
+        if (c == '<') {
+            ++angle_depth;
+            current += c;
+        } else if (c == '>') {
+            --angle_depth;
+            current += c;
+        } else if ((c == ',' || c == '\0') && angle_depth == 0) {
+            // Trim whitespace
+            while (!current.empty() && isspace(current.back())) current.pop_back();
+            while (!current.empty() && isspace(current.front())) current.erase(0, 1);
+            if (!current.empty()) {
+                // Recursively parse this subtype
+                QoreParseTypeInfo* sub_pti = parse_type_string_to_pti(current.c_str());
+                if (sub_pti) {
+                    subtypes.push_back(sub_pti);
+                }
+            }
+            current.clear();
+        } else {
+            current += c;
+        }
+    }
+
+    return new QoreParseTypeInfo(strdup(base_type.c_str()), or_nothing, std::move(subtypes));
+}
+
+// Helper function to parse a type string and resolve it (for use in code<> signature parsing)
+// This handles complex types like "hash<string, int>" and "list<string>"
+static const QoreTypeInfo* parse_and_resolve_type_string(const char* type_str, const QoreProgramLocation* loc, int& err) {
+    // Trim whitespace
+    while (*type_str && isspace(*type_str)) ++type_str;
+    if (!*type_str) return nullptr;
+
+    std::string str(type_str);
+    while (!str.empty() && isspace(str.back())) str.pop_back();
+    if (str.empty()) return nullptr;
+
+    // Check for or-nothing prefix
+    bool or_nothing = false;
+    const char* check_str = str.c_str();
+    if (str[0] == '*') {
+        or_nothing = true;
+        check_str++;
+    }
+
+    // Check for "nothing" type
+    if (!strcmp(check_str, "nothing")) {
+        return nothingTypeInfo;
+    }
+
+    // Check for "auto" type
+    if (!strcmp(check_str, "auto")) {
+        return autoTypeInfo;
+    }
+
+    // Check if this is a simple type (no angle brackets)
+    if (!strchr(str.c_str(), '<')) {
+        // Simple type - try to resolve as builtin first
+        const QoreTypeInfo* rv = or_nothing
+            ? getBuiltinUserOrNothingTypeInfo(check_str)
+            : getBuiltinUserTypeInfo(check_str);
+        if (rv) return rv;
+    }
+
+    // Parse the type string into a QoreParseTypeInfo with proper structure
+    QoreParseTypeInfo* pti = parse_type_string_to_pti(type_str);
+    if (!pti) return nullptr;
+
+    return QoreParseTypeInfo::resolveAndDelete(pti, loc, err);
+}
+
+// Helper function to build the typed callable type name
+static QoreString build_complex_code_name(const QoreTypeInfo* returnType, const type_vec_t& paramTypes,
+        bool varargs, bool or_nothing) {
+    QoreString name;
+    if (or_nothing) {
+        name.concat('*');
+    }
+    name.concat("code<");
+    // Return type
+    if (returnType) {
+        name.concat(QoreTypeInfo::getName(returnType));
+    } else {
+        name.concat("nothing");
+    }
+    name.concat('(');
+    // Parameter types
+    for (size_t i = 0; i < paramTypes.size(); ++i) {
+        if (i > 0) {
+            name.concat(", ");
+        }
+        name.concat(QoreTypeInfo::getName(paramTypes[i]));
+    }
+    if (varargs) {
+        if (!paramTypes.empty()) {
+            name.concat(", ");
+        }
+        name.concat("...");
+    }
+    name.concat(")>");
+    return name;
+}
+
+// Helper function to build the path name for typed callable
+static QoreString build_complex_code_path(const QoreTypeInfo* returnType, const type_vec_t& paramTypes,
+        bool varargs, bool or_nothing) {
+    QoreString name;
+    if (or_nothing) {
+        name.concat('*');
+    }
+    name.concat("code<");
+    // Return type
+    if (returnType) {
+        name.concat(QoreTypeInfo::getPath(returnType));
+    } else {
+        name.concat("nothing");
+    }
+    name.concat('(');
+    // Parameter types
+    for (size_t i = 0; i < paramTypes.size(); ++i) {
+        if (i > 0) {
+            name.concat(", ");
+        }
+        name.concat(QoreTypeInfo::getPath(paramTypes[i]));
+    }
+    if (varargs) {
+        if (!paramTypes.empty()) {
+            name.concat(", ");
+        }
+        name.concat("...");
+    }
+    name.concat(")>");
+    return name;
+}
+
+// Helper to build accept_vec for typed callable
+static q_accept_vec_t build_complex_code_accept_vec(bool or_nothing) {
+    q_accept_vec_t avec;
+    avec.push_back({NT_RUNTIME_CLOSURE, nullptr});
+    avec.push_back({NT_FUNCREF, nullptr});
+    if (or_nothing) {
+        avec.push_back({NT_NOTHING, nullptr});
+        avec.push_back({NT_NULL, [] (QoreValue& n, ExceptionSink* xsink) { n.assignNothing(); }});
+    }
+    return avec;
+}
+
+// Helper to build return_vec for typed callable
+static q_return_vec_t build_complex_code_return_vec(bool or_nothing) {
+    q_return_vec_t rvec;
+    rvec.push_back({NT_RUNTIME_CLOSURE});
+    rvec.push_back({NT_FUNCREF});
+    if (or_nothing) {
+        rvec.push_back({NT_NOTHING});
+    }
+    return rvec;
+}
+
+QoreComplexCodeTypeInfo::QoreComplexCodeTypeInfo(const QoreTypeInfo* ret_type, type_vec_t&& param_types,
+        bool varargs_arg, bool or_nothing_arg)
+        : QoreTypeInfo(build_complex_code_accept_vec(or_nothing_arg),
+            build_complex_code_return_vec(or_nothing_arg),
+            build_complex_code_name(ret_type, param_types, varargs_arg, or_nothing_arg)),
+          returnType(ret_type), paramTypes(std::move(param_types)),
+          varargs(varargs_arg), orNothing(or_nothing_arg) {
+    // Set path name
+    pname = build_complex_code_path(ret_type, paramTypes, varargs, orNothing);
+}
+
+bool QoreComplexCodeTypeInfo::isSignatureCompatible(const AbstractFunctionSignature* sig) const {
+    if (!sig) {
+        return false;
+    }
+
+    // Check return type compatibility (covariant)
+    // The callable's return type must be assignable to our return type
+    const QoreTypeInfo* sigReturnType = sig->getReturnTypeInfo();
+    if (returnType) {
+        // We expect a specific return type - check if the callable's return type is compatible
+        // Covariant: the callable can return a more specific type
+        if (!QoreTypeInfo::parseAccepts(returnType, sigReturnType)) {
+            return false;
+        }
+    }
+    // If returnType is nullptr (nothing), any return type is accepted
+
+    // If we accept varargs, any parameter count is OK
+    if (varargs) {
+        return true;
+    }
+
+    // Check parameter count
+    unsigned sigNumParams = sig->numParams();
+    size_t ourParamCount = paramTypes.size();
+
+    // Compute minimum required params for the signature (params without defaults)
+    unsigned sigMinParams = 0;
+    for (unsigned i = 0; i < sigNumParams; ++i) {
+        if (!sig->hasDefaultArg(i)) {
+            sigMinParams = i + 1;
+        }
+    }
+
+    // The callable must be able to accept our parameter count
+    // - We need at least sigMinParams
+    // - We can have at most sigNumParams unless the callable has varargs
+    if (ourParamCount < sigMinParams) {
+        return false;
+    }
+    if (ourParamCount > sigNumParams && !sig->hasVarargs()) {
+        return false;
+    }
+
+    // Check each parameter type (contravariant)
+    // Our param types must be assignable to the callable's param types
+    for (size_t i = 0; i < ourParamCount && i < sigNumParams; ++i) {
+        const QoreTypeInfo* sigParamType = sig->getParamTypeInfo(i);
+        const QoreTypeInfo* ourParamType = paramTypes[i];
+
+        if (ourParamType) {
+            // We specify a param type - check contravariance
+            // The callable's param type must accept our param type
+            if (!QoreTypeInfo::parseAccepts(sigParamType, ourParamType)) {
+                return false;
+            }
+        }
+        // If ourParamType is nullptr, any param type is accepted
+    }
+
+    return true;
+}
+
+const QoreTypeInfo* qore_get_complex_code_type(const QoreTypeInfo* return_type,
+        const type_vec_t& param_types, bool varargs, bool or_nothing) {
+    // Create cache key
+    ComplexCodeCacheKey key{return_type, param_types, varargs, or_nothing};
+
+    AutoLocker al(ctl);
+
+    complex_code_map_t::iterator i = complex_code_map.find(key);
+    if (i != complex_code_map.end()) {
+        return i->second;
+    }
+
+    // Create copy of param_types for the constructor
+    type_vec_t params_copy(param_types);
+
+    // Create the typed callable type
+    QoreComplexCodeTypeInfo* ti = new QoreComplexCodeTypeInfo(return_type, std::move(params_copy),
+        varargs, or_nothing);
+    complex_code_map[key] = ti;
+    return ti;
+}
+
+const QoreTypeInfo* qore_get_complex_code_or_nothing_type(const QoreTypeInfo* return_type,
+        const type_vec_t& param_types, bool varargs) {
+    return qore_get_complex_code_type(return_type, param_types, varargs, true);
+}
+
+const QoreTypeInfo* qore_get_complex_code_type_from_signature(const AbstractFunctionSignature* sig,
+        bool or_nothing) {
+    if (!sig) {
+        return or_nothing ? codeOrNothingTypeInfo : codeTypeInfo;
+    }
+
+    // Extract return type
+    const QoreTypeInfo* return_type = sig->getReturnTypeInfo();
+
+    // Extract parameter types
+    type_vec_t param_types;
+    unsigned num_params = sig->numParams();
+    for (unsigned i = 0; i < num_params; ++i) {
+        param_types.push_back(sig->getParamTypeInfo(i));
+    }
+
+    // Check for varargs
+    bool varargs = sig->hasVarargs();
+
+    return qore_get_complex_code_type(return_type, param_types, varargs, or_nothing);
+}
+
+const QoreComplexCodeTypeInfo* QoreTypeInfo::getComplexCodeType(const QoreTypeInfo* ti) {
+    if (!ti || !hasType(ti)) {
+        return nullptr;
+    }
+    // Check if the type is a QoreComplexCodeTypeInfo by attempting a dynamic_cast
+    return dynamic_cast<const QoreComplexCodeTypeInfo*>(ti);
+}
+
+bool QoreTypeInfo::checkComplexCodeCompatibility(const QoreTypeInfo* target, const QoreTypeInfo* source) {
+    // Get complex code types
+    const QoreComplexCodeTypeInfo* target_code = getComplexCodeType(target);
+    const QoreComplexCodeTypeInfo* source_code = getComplexCodeType(source);
+
+    // If target is not a typed callable, no additional checking needed
+    if (!target_code) {
+        return true;
+    }
+
+    // If source is not a typed callable but target is, it's compatible
+    // (the basic parseAccepts already checked that source is a code type)
+    if (!source_code) {
+        // Source is generic code type - compatible at parse time, runtime check needed
+        return true;
+    }
+
+    // Both are typed callables - compare signatures
+    // Check return type compatibility (covariant)
+    // Source's return type must be assignable to target's return type
+    const QoreTypeInfo* target_ret = target_code->getReturnType();
+    const QoreTypeInfo* source_ret = source_code->getReturnType();
+
+    if (target_ret) {
+        // Target expects a specific return type
+        if (!parseAccepts(target_ret, source_ret)) {
+            return false;
+        }
+    }
+
+    // If target accepts varargs, skip param count checking
+    if (target_code->hasVarArgs()) {
+        return true;
+    }
+
+    // Check parameter count
+    const type_vec_t& target_params = target_code->getParamTypes();
+    const type_vec_t& source_params = source_code->getParamTypes();
+
+    // Source must accept at least as many params as target specifies
+    // (contravariance means source can have fewer required params)
+    if (source_params.size() < target_params.size() && !source_code->hasVarArgs()) {
+        // Source doesn't have varargs and has fewer params than target
+        return false;
+    }
+
+    // Check each parameter type (contravariant)
+    // Source's param types must accept target's param types
+    size_t check_count = std::min(target_params.size(), source_params.size());
+    for (size_t i = 0; i < check_count; ++i) {
+        const QoreTypeInfo* target_param = target_params[i];
+        const QoreTypeInfo* source_param = source_params[i];
+
+        if (target_param) {
+            // Target specifies a param type - check contravariance
+            // Source's param type must accept target's param type
+            if (!parseAccepts(source_param, target_param)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
 }
 
 static const QoreTypeInfo* getExternalTypeInfoForType(qore_type_t t) {
@@ -2199,6 +2635,120 @@ const QoreTypeInfo* QoreParseTypeInfo::resolveSubtype(const QoreProgramLocation*
         }
 
         return qore_get_union_type(member_types, or_nothing);
+    }
+    if (!strcmp(cscope->ostr, "code")) {
+        // Parse typed callable: code<ReturnType(ParamType1, ParamType2, ...)>
+        // Expected format: subtypes[0] contains "ReturnType(ParamType1, ParamType2, ...)"
+        if (subtypes.size() != 1) {
+            parseException(*loc, "PARSE-TYPE-ERROR", "cannot resolve '%s'; 'code' type takes a single callable " \
+                "signature specification in the form 'ReturnType(ParamTypes...)'", getName());
+            err = -1;
+            return or_nothing ? codeOrNothingTypeInfo : codeTypeInfo;
+        }
+
+        // Use getName() to get the full type string including angle brackets and parentheses
+        const char* sig_str = subtypes[0]->getName();
+
+        // Find the opening parenthesis to split return type from params
+        const char* paren_open = strchr(sig_str, '(');
+        if (!paren_open) {
+            parseException(*loc, "PARSE-TYPE-ERROR", "cannot resolve '%s'; invalid callable signature '%s'; " \
+                "expected format 'ReturnType(ParamTypes...)' with parentheses", getName(), sig_str);
+            err = -1;
+            return or_nothing ? codeOrNothingTypeInfo : codeTypeInfo;
+        }
+
+        // Find closing parenthesis
+        const char* paren_close = strrchr(sig_str, ')');
+        if (!paren_close || paren_close < paren_open) {
+            parseException(*loc, "PARSE-TYPE-ERROR", "cannot resolve '%s'; invalid callable signature '%s'; " \
+                "missing closing parenthesis", getName(), sig_str);
+            err = -1;
+            return or_nothing ? codeOrNothingTypeInfo : codeTypeInfo;
+        }
+
+        // Extract return type string
+        std::string return_type_str(sig_str, paren_open - sig_str);
+        // Trim whitespace
+        while (!return_type_str.empty() && isspace(return_type_str.back())) {
+            return_type_str.pop_back();
+        }
+        while (!return_type_str.empty() && isspace(return_type_str.front())) {
+            return_type_str.erase(0, 1);
+        }
+
+        // Resolve return type
+        const QoreTypeInfo* returnType = nullptr;
+        if (!return_type_str.empty() && return_type_str != "nothing") {
+            // Use the helper to properly parse and resolve complex types
+            returnType = parse_and_resolve_type_string(return_type_str.c_str(), loc, err);
+            if (err) {
+                return or_nothing ? codeOrNothingTypeInfo : codeTypeInfo;
+            }
+        }
+        // If empty or "nothing", returnType stays nullptr (means nothing return)
+
+        // Extract parameter types string
+        std::string params_str(paren_open + 1, paren_close - paren_open - 1);
+
+        // Check for varargs
+        bool has_varargs = false;
+        size_t dotdotdot_pos = params_str.rfind("...");
+        if (dotdotdot_pos != std::string::npos) {
+            has_varargs = true;
+            // Remove "..." from params_str
+            params_str = params_str.substr(0, dotdotdot_pos);
+            // Trim trailing comma and whitespace
+            while (!params_str.empty() && (isspace(params_str.back()) || params_str.back() == ',')) {
+                params_str.pop_back();
+            }
+        }
+
+        // Parse parameter types
+        type_vec_t param_types;
+        if (!params_str.empty()) {
+            // Split on commas, handling nested angle brackets
+            std::string current_param;
+            int angle_depth = 0;
+            int paren_depth = 0;
+            for (size_t i = 0; i <= params_str.size(); ++i) {
+                char c = i < params_str.size() ? params_str[i] : '\0';
+                if (c == '<') {
+                    ++angle_depth;
+                    current_param += c;
+                } else if (c == '>') {
+                    --angle_depth;
+                    current_param += c;
+                } else if (c == '(') {
+                    ++paren_depth;
+                    current_param += c;
+                } else if (c == ')') {
+                    --paren_depth;
+                    current_param += c;
+                } else if ((c == ',' || c == '\0') && angle_depth == 0 && paren_depth == 0) {
+                    // Trim whitespace from current_param
+                    while (!current_param.empty() && isspace(current_param.back())) {
+                        current_param.pop_back();
+                    }
+                    while (!current_param.empty() && isspace(current_param.front())) {
+                        current_param.erase(0, 1);
+                    }
+                    if (!current_param.empty()) {
+                        // Use the helper to properly parse and resolve complex types
+                        const QoreTypeInfo* param_type = parse_and_resolve_type_string(current_param.c_str(), loc, err);
+                        if (err) {
+                            return or_nothing ? codeOrNothingTypeInfo : codeTypeInfo;
+                        }
+                        param_types.push_back(param_type);
+                    }
+                    current_param.clear();
+                } else {
+                    current_param += c;
+                }
+            }
+        }
+
+        return qore_get_complex_code_type(returnType, param_types, has_varargs, or_nothing);
     }
 
     parseException(*loc, "PARSE-TYPE-ERROR", "cannot resolve '%s'; type '%s' does not take subtype declarations",

--- a/lib/parser.ypp
+++ b/lib/parser.ypp
@@ -1107,6 +1107,7 @@ public:
         QoreString buf;
         bool or_nothing = false;
         bool comma = false;
+        int paren_depth = 0;  // Track parenthesis depth for callable types like code<int(string, bool)>
 
         const char* p = str;
         while (true) {
@@ -1120,7 +1121,26 @@ public:
                 break;
             }
             switch (*p) {
+                case '(':
+                    ++paren_depth;
+                    buf.concat(*p);
+                    if (comma)
+                        comma = false;
+                    break;
+                case ')':
+                    --paren_depth;
+                    buf.concat(*p);
+                    if (comma)
+                        comma = false;
+                    break;
                 case '<': {
+                    // Inside parentheses, just accumulate the character
+                    if (paren_depth > 0) {
+                        buf.concat(*p);
+                        if (comma)
+                            comma = false;
+                        break;
+                    }
                     if (buf.empty()) {
                         if (raise_error)
                             parse_error(*loc, "invalid subtype specification in '%s'", str);
@@ -1128,20 +1148,31 @@ public:
                     }
                     // Find matching '>' using bracket counting instead of strrchr
                     // This correctly handles nested types like hash<list<int>, list<string>>
-                    int depth = 1;
+                    // Also handle parentheses inside angle brackets for callable types
+                    int angle_depth = 1;
+                    int inner_paren_depth = 0;
                     const char* e = p + 1;
-                    while (*e && depth > 0) {
-                        if (*e == '<') ++depth;
-                        else if (*e == '>') --depth;
-                        if (depth > 0) ++e;
+                    while (*e && angle_depth > 0) {
+                        if (*e == '(') ++inner_paren_depth;
+                        else if (*e == ')') --inner_paren_depth;
+                        else if (*e == '<' && inner_paren_depth == 0) ++angle_depth;
+                        else if (*e == '>' && inner_paren_depth == 0) --angle_depth;
+                        if (angle_depth > 0) ++e;
                     }
-                    if (depth != 0 || *e != '>') {
+                    if (angle_depth != 0 || *e != '>') {
                         if (raise_error)
                             parse_error(*loc, "unbalanced angle brackets in subtype specification in '%s'", str);
                         return;
                     }
                     buf.concat(p, e - p + 1);
                     //printd(5, "ST: '%s' (str: '%s') p: %p '%s'\n", buf.c_str(), str, p, p);
+                    // Check if next character is '(' - if so, continue accumulating for callable type syntax
+                    // e.g., hash<string, int>(list<string>) should be a single subtype
+                    if (*(e + 1) == '(') {
+                        // Don't push yet - continue accumulating
+                        p = e;
+                        break;
+                    }
                     subtypes.push_back(getParseType(loc, buf.giveBuffer(), or_nothing));
                     buf.reset();
                     or_nothing = false;
@@ -1149,7 +1180,25 @@ public:
                     p = e;
                     break;
                 }
+                case '>':
+                    // Inside parentheses, just accumulate the character
+                    if (paren_depth > 0) {
+                        buf.concat(*p);
+                        if (comma)
+                            comma = false;
+                        break;
+                    }
+                    // Otherwise this is unexpected - accumulate for error reporting
+                    buf.concat(*p);
+                    if (comma)
+                        comma = false;
+                    break;
                 case ',':
+                    // Inside parentheses, don't split on comma - just accumulate
+                    if (paren_depth > 0) {
+                        buf.concat(*p);
+                        break;
+                    }
                     buf.trim();
                     if (!buf.empty()) {
                         // Push the accumulated simple type
@@ -1194,6 +1243,23 @@ public:
         //printd(0, "gPT() '%s'\n", id);
         char* p0 = strchr(id, '<');
         if (p0) {
+            // Check if this is a callable signature with form: ReturnType(Params...)
+            // where ReturnType may be a complex type like hash<string, int>
+            // In this case, we should NOT parse it as a complex type - keep the raw string
+            char* paren = strchr(id, '(');
+            if (paren) {
+                // Find where angle brackets end
+                int angle_depth = 0;
+                for (char* p = id; p < paren; ++p) {
+                    if (*p == '<') ++angle_depth;
+                    else if (*p == '>') --angle_depth;
+                }
+                // If parentheses come after angle brackets are balanced (or there are none),
+                // this is a callable signature - don't parse as complex type
+                if (angle_depth == 0) {
+                    return new QoreParseTypeInfo(id, or_nothing);
+                }
+            }
             char* p1 = strrchr(id, '>');
             if (p1 > (p0 + 1)) {
                 // terminate main type string

--- a/lib/parser.ypp
+++ b/lib/parser.ypp
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -151,6 +151,41 @@ public:
     }
     DLLLOCAL bool isPublic() const {
         return pub;
+    }
+};
+
+class TypedefNode {
+public:
+    const QoreProgramLocation* loc;
+    NamedScope name;
+    const QoreTypeInfo* typeInfo;       //!< resolved type info (for built-in types)
+    QoreParseTypeInfo* parseTypeInfo;   //!< parse-time type info (for complex types)
+    bool pub;
+
+    DLLLOCAL TypedefNode(const QoreProgramLocation* loc, char* n, const QoreTypeInfo* ti,
+            QoreParseTypeInfo* pti, bool p = false)
+            : loc(loc), name(n), typeInfo(ti), parseTypeInfo(pti), pub(p) {
+    }
+    DLLLOCAL TypedefNode(const QoreProgramLocation* loc, NamedScope* n, const QoreTypeInfo* ti,
+            QoreParseTypeInfo* pti, bool p = false)
+            : loc(loc), name(n), typeInfo(ti), parseTypeInfo(pti), pub(p) {
+    }
+    DLLLOCAL ~TypedefNode() {
+        delete parseTypeInfo;
+    }
+    DLLLOCAL const char* getName() const {
+        return name.getIdentifier();
+    }
+    DLLLOCAL bool isPublic() const {
+        return pub;
+    }
+    DLLLOCAL const QoreTypeInfo* getTypeInfo() const {
+        return typeInfo;
+    }
+    DLLLOCAL QoreParseTypeInfo* takeParseTypeInfo() {
+        QoreParseTypeInfo* rv = parseTypeInfo;
+        parseTypeInfo = nullptr;
+        return rv;
     }
 };
 
@@ -657,6 +692,7 @@ static AbstractQoreNode* parse_map(const QoreProgramLocation* loc, QoreValue exp
 #define NSN_NS       4
 #define NSN_FUNC     5
 #define NSN_SFUNC    6
+#define NSN_TYPEDEF  9
 #define NSN_VAR      7
 #define NSN_METH     8
 
@@ -666,6 +702,7 @@ struct NSNode {
         ObjClassDef* ocd;
         HashDeclDef* hashdecl;
         ConstNode* cn;
+        TypedefNode* td;
         QoreNamespace* ns;
         ParseUserFunction* func;
         ParseScopedUserFunction* sfunc;
@@ -676,6 +713,7 @@ struct NSNode {
     DLLLOCAL NSNode(ObjClassDef* o) { type = NSN_OCD; n.ocd = o; }
     DLLLOCAL NSNode(HashDeclDef* h) { type = NSN_HASHDECL; n.hashdecl = h; }
     DLLLOCAL NSNode(ConstNode* c) { type = NSN_CONST; n.cn = c; }
+    DLLLOCAL NSNode(TypedefNode* t) { type = NSN_TYPEDEF; n.td = t; }
     DLLLOCAL NSNode(QoreNamespace* s) { type = NSN_NS; n.ns = s; }
     DLLLOCAL NSNode(ParseUserFunction* f) : type(NSN_FUNC) {
         n.func = f;
@@ -702,6 +740,9 @@ struct NSNode {
                 break;
             case NSN_CONST:
                 delete n.cn;
+                break;
+            case NSN_TYPEDEF:
+                delete n.td;
                 break;
             case NSN_NS:
                 delete n.ns;
@@ -739,6 +780,10 @@ struct NSNode {
             case NSN_CONST:
                 ns.parseAddConstant(n.cn->loc, n.cn->name, n.cn->value, n.cn->pub);
                 delete n.cn;
+                break;
+            case NSN_TYPEDEF:
+                ns.parseAddTypedef(n.td->loc, n.td->name, n.td->getTypeInfo(), n.td->takeParseTypeInfo(), n.td->pub);
+                delete n.td;
                 break;
             case NSN_NS:
                 ns.parseAddNamespace(n.ns);
@@ -1573,6 +1618,7 @@ static void check_operator_bin_xor(const QoreProgramLocation* loc, QoreValue n, 
     QoreClass* qoreclass;
     typed_hash_decl_private* hashdeclpriv;
     class ConstNode* constnode;
+    class TypedefNode* typedefnode;
     QoreNamespace *ns;
     struct NSNodeList* nsnlist;
     struct NSNode* nsn;
@@ -1665,6 +1711,7 @@ DLLLOCAL void yyerror(YYLTYPE* loc, yyscan_t scanner, const char* str) {
 %token TOK_ABSTRACT "abstract"
 %token TOK_HASHDECL "hashdecl"
 %token TOK_TRANSIENT "transient"
+%token TOK_TYPEDEF "typedef"
 %token TOK_NULL "NULL"
 %token TOK_NOTHING "NOTHING"
 %token TOK_TRUE "True"
@@ -1834,6 +1881,8 @@ DLLLOCAL void yyerror(YYLTYPE* loc, yyscan_t scanner, const char* str) {
 %type <nsn>            namespace_decl
 %type <constnode>      scoped_const_decl
 %type <constnode>      unscoped_const_decl
+%type <typedefnode>    typedef_decl
+%type <typedefnode>    scoped_typedef_decl
 %type <i4>             method_modifiers
 %type <i4>             method_modifier
 %type <i4>             nsc_modifiers
@@ -1886,6 +1935,17 @@ top_level_command:
     }
     | hashdecl_def {
         qore_root_ns_private::parseAddHashDecl($1->loc, *($1->name), $1->takeHashDecl());
+        delete $1;
+    }
+    | typedef_decl {
+        NamedScope ns($1->getName());
+        qore_root_ns_private::parseAddTypedef($1->loc, ns, $1->getTypeInfo(), $1->takeParseTypeInfo(), $1->isPublic());
+        delete $1;
+    }
+    | scoped_typedef_decl {
+        // see if strong encapsulation is enabled
+        check_strong_encapsulation($1->loc, "typedef", $1->name.ostr);
+        qore_root_ns_private::parseAddTypedef($1->loc, $1->name, $1->getTypeInfo(), $1->takeParseTypeInfo(), $1->isPublic());
         delete $1;
     }
     | scoped_const_decl {
@@ -2133,6 +2193,14 @@ namespace_decl:
     | unscoped_const_decl {
         $$ = new NSNode($1);
     }
+    | scoped_typedef_decl {
+        // see if strong encapsulation is enabled
+        check_strong_encapsulation($1->loc, "typedef", $1->name.ostr);
+        $$ = new NSNode($1);
+    }
+    | typedef_decl {
+        $$ = new NSNode($1);
+    }
     | class_def {
         $$ = new NSNode($1);
     }
@@ -2173,6 +2241,40 @@ scoped_const_decl:
     }
     | TOK_PUBLIC TOK_CONST SCOPED_REF '=' exp ';' {
         $$ = new ConstNode(qore_program_private::get(*getProgram())->getLocation(@1.first_line, @5.last_line), $3, $5, true);
+    }
+    ;
+
+typedef_decl:
+    TOK_TYPEDEF IDENTIFIER '=' uncqtypedef ';' {
+        const QoreProgramLocation* loc = qore_program_private::get(*getProgram())->getLocation(@1.first_line, @4.last_line);
+        const QoreTypeInfo* ti = $4->getTypeInfo();
+        QoreParseTypeInfo* pti = $4->getParseTypeInfo();
+        delete $4;
+        $$ = new TypedefNode(loc, $2, ti, pti);
+    }
+    | TOK_PUBLIC TOK_TYPEDEF IDENTIFIER '=' uncqtypedef ';' {
+        const QoreProgramLocation* loc = qore_program_private::get(*getProgram())->getLocation(@1.first_line, @5.last_line);
+        const QoreTypeInfo* ti = $5->getTypeInfo();
+        QoreParseTypeInfo* pti = $5->getParseTypeInfo();
+        delete $5;
+        $$ = new TypedefNode(loc, $3, ti, pti, true);
+    }
+    ;
+
+scoped_typedef_decl:
+    TOK_TYPEDEF SCOPED_REF '=' uncqtypedef ';' {
+        const QoreProgramLocation* loc = qore_program_private::get(*getProgram())->getLocation(@1.first_line, @4.last_line);
+        const QoreTypeInfo* ti = $4->getTypeInfo();
+        QoreParseTypeInfo* pti = $4->getParseTypeInfo();
+        delete $4;
+        $$ = new TypedefNode(loc, $2, ti, pti);
+    }
+    | TOK_PUBLIC TOK_TYPEDEF SCOPED_REF '=' uncqtypedef ';' {
+        const QoreProgramLocation* loc = qore_program_private::get(*getProgram())->getLocation(@1.first_line, @5.last_line);
+        const QoreTypeInfo* ti = $5->getTypeInfo();
+        QoreParseTypeInfo* pti = $5->getParseTypeInfo();
+        delete $5;
+        $$ = new TypedefNode(loc, $3, ti, pti, true);
     }
     ;
 

--- a/lib/qore-main.cpp
+++ b/lib/qore-main.cpp
@@ -324,6 +324,18 @@ DLLEXPORT int JNI_OnLoad(void* vm, void* reserved) {
     ExceptionSink xsink;
     QoreProgramHelper qpgm(0, xsink);
     if (MM.runTimeLoadModule("jni", *qpgm, &xsink)) {
+        // output error information to help diagnose module loading failures
+        if (xsink.isException()) {
+            QoreStringNode* err = xsink.getExceptionErr();
+            QoreStringNode* desc = xsink.getExceptionDesc();
+            fprintf(stderr, "JNI_OnLoad: failed to load jni module: %s: %s\n",
+                err ? err->c_str() : "unknown error",
+                desc ? desc->c_str() : "no description");
+            fflush(stderr);
+        } else {
+            fprintf(stderr, "JNI_OnLoad: failed to load jni module (no exception info)\n");
+            fflush(stderr);
+        }
         return 0;
     }
 

--- a/lib/qore-main.cpp
+++ b/lib/qore-main.cpp
@@ -3,7 +3,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),

--- a/lib/scanner.lpp
+++ b/lib/scanner.lpp
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -1023,6 +1023,7 @@ RTIME           PT(-?[0-9]+(\.[0-9]+)?[HMSu])+
 ^%disable-debug{WS}*$                   parse_disable_parse_options(yylloc, PO_ENABLE_DEBUG);
 ^%no-reflection{WS}*$                   parse_set_parse_options(yylloc, PO_NO_REFLECTION);
 ^%no-transient{WS}*$                    parse_set_parse_options(yylloc, PO_NO_TRANSIENT);
+^%no-typedef{WS}*$                      parse_set_parse_options(yylloc, PO_NO_TYPEDEF);
 ^%push-parse-options{WS}*$              push_parse_options();
 ^%append-include-path{WS}*$             { parse_error(*get_loc(yylloc), "missing argument to %%append-include-path"); }
 ^%append-include-path{WS}+              BEGIN(append_path_state);
@@ -1932,6 +1933,12 @@ transient                               {
                                                 yylval->string = strdup("transient"); return IDENTIFIER;
                                             }
                                             return TOK_TRANSIENT;
+                                        }
+typedef                                 {
+                                            if (getProgram()->getParseOptions64() & PO_NO_TYPEDEF) {
+                                                yylval->string = strdup("typedef"); return IDENTIFIER;
+                                            }
+                                            return TOK_TYPEDEF;
                                         }
 map                                     { push_ignore_numeric_argv_ref(); return TOK_MAP; }
 foldr                                   { push_ignore_numeric_argv_ref(); return TOK_FOLDR; }

--- a/lib/scanner.lpp
+++ b/lib/scanner.lpp
@@ -2136,7 +2136,7 @@ hash\<{WORD}\>\{                        {
                                             yylval->string[strlen(yylval->string) - 2] = '\0';
                                             return HASHDECL_IDENTIFIER_OPENCURLY;
                                         }
-{WORD}<[a-zA-Z\*<:_0-9 \t,!]+>          {
+{WORD}<[a-zA-Z\*<:_0-9 \t,!().]+>       {
                                            if (angle_balanced(yytext)) {
                                                yylval->string = strdup(yytext);
                                                return ANGLE_IDENTIFIER;

--- a/qlib/PgsqlSqlUtilBase.qm
+++ b/qlib/PgsqlSqlUtilBase.qm
@@ -1131,11 +1131,11 @@ public class PgsqlDatabase inherits SqlUtil::AbstractDatabase {
     }
 
     *PgsqlType getType(string name) {
-        *hash qh = ds.select("select attname, pg_catalog.format_type(a.atttypid, a.atttypmod) typedef from pg_class c, pg_catalog.pg_attribute a where relkind = 'c' and attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped and relname = %v order by attnum", name);
+        *hash qh = ds.select("select attname, pg_catalog.format_type(a.atttypid, a.atttypmod) type_def from pg_class c, pg_catalog.pg_attribute a where relkind = 'c' and attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped and relname = %v order by attnum", name);
         if (!qh.attname)
             return;
 
-        string src = foldl $1 + ", " + $2, (map sprintf("%s %s", $1.attname, $1.typedef), qh.contextIterator());
+        string src = foldl $1 + ", " + $2, (map sprintf("%s %s", $1.attname, $1.type_def), qh.contextIterator());
 
         # replace common type names with verbose type names as stored in PostgreSQL
         foreach hash<auto> h in (PgsqlTable::PgsqlNameMap.pairIterator()) {

--- a/qlib/SqlUtil/AbstractTable.qc
+++ b/qlib/SqlUtil/AbstractTable.qc
@@ -3423,7 +3423,7 @@ map upsert($1), row_list;
         closure; the closure returned by this method is faster than the one returned by
         @ref SqlUtil::AbstractTable::getUpsertClosure() since there is no validation
     */
-    code getUpsertClosure(hash<auto> row, int upsert_strategy = UpsertAuto, *hash<auto> opt) {
+    code<int(hash<auto>)> getUpsertClosure(hash<auto> row, int upsert_strategy = UpsertAuto, *hash<auto> opt) {
         # check upsert options
         validateOptionsIntern("OPTION-ERROR", getUpsertOptions(), \opt);
 
@@ -3498,8 +3498,8 @@ upsert(row_hash);
         - getUpsertClosure()
         - getUpsertClosureWithValidation()
     */
-    code getBulkUpsertClosure(hash<auto> example_row, int upsert_strategy = AbstractTable::UpsertAuto, *hash<auto> opt) {
-        code upsert = getUpsertClosure(example_row, upsert_strategy, opt);
+    code<int(hash<auto>)> getBulkUpsertClosure(hash<auto> example_row, int upsert_strategy = AbstractTable::UpsertAuto, *hash<auto> opt) {
+        code<int(hash<auto>)> upsert = getUpsertClosure(example_row, upsert_strategy, opt);
         return int sub (hash<auto> h) {
             map upsert($1), h.contextIterator();
             return UR_Verified;
@@ -3528,8 +3528,8 @@ map upsert($1), row_list;
 
         @note the row values passed to the closure for upserting are checked if they match the example row passed to the getUpsertClosure() method; passing non-conforming data to the closure will cause the closure to throw an \c UPSERT-ERROR exception; see @ref SqlUtil::AbstractTable::getUpsertClosure() for a similar method that returns a non-validating closure; the closure returned by this method is a little slower than the one returned by @ref SqlUtil::AbstractTable::getUpsertClosure() since each row is validated
     */
-    code getUpsertClosureWithValidation(hash<auto> example_row, int upsert_strategy = UpsertAuto, *hash<auto> opt) {
-        code upsert = getUpsertClosure(example_row, upsert_strategy, opt);
+    code<int(hash<auto>)> getUpsertClosureWithValidation(hash<auto> example_row, int upsert_strategy = UpsertAuto, *hash<auto> opt) {
+        code<int(hash<auto>)> upsert = getUpsertClosure(example_row, upsert_strategy, opt);
 
         return int sub (hash<auto> row) {
             if (!row.compareKeys(example_row)) {
@@ -5688,7 +5688,7 @@ hash<SqlResultInfo> info = table.updateWithInfo({"id": id}, {"name": name});
         return getAllUpsertColumns(row).firstValue();
     }
 
-    private code getUpsertInsertFirst(Columns cols, hash<auto> example_row, *hash<auto> opt) {
+    private code<int(hash<auto>)> getUpsertInsertFirst(Columns cols, hash<auto> example_row, *hash<auto> opt) {
         string insert_sql = getUpsertInsertSql(example_row);
         list updc = ();
         string update_sql = getUpsertUpdateSql(example_row, cols, \updc, opt);
@@ -5702,7 +5702,7 @@ hash<SqlResultInfo> info = table.updateWithInfo({"id": id}, {"name": name});
         };
     }
 
-    private code getUpsertUpdateFirst(Columns cols, hash<auto> example_row, *hash<auto> opt) {
+    private code<int(hash<auto>)> getUpsertUpdateFirst(Columns cols, hash<auto> example_row, *hash<auto> opt) {
         list updc = ();
         string update_sql = getUpsertUpdateSql(example_row, cols, \updc, opt);
         string insert_sql = getUpsertInsertSql(example_row);
@@ -5716,7 +5716,7 @@ hash<SqlResultInfo> info = table.updateWithInfo({"id": id}, {"name": name});
         };
     }
 
-    private code getUpsertSelectFirst(Columns cols, hash<auto> example_row, *hash<auto> opt) {
+    private code<int(hash<auto>)> getUpsertSelectFirst(Columns cols, hash<auto> example_row, *hash<auto> opt) {
         #printf("getUpsertSelectFirst() %s: %y\n", name, cols.keys());
         list<string> updc();
         string select_sql = getUpsertSelectSql(example_row, cols, \updc);
@@ -5741,7 +5741,7 @@ hash<SqlResultInfo> info = table.updateWithInfo({"id": id}, {"name": name});
         };
     }
 
-    private code getUpsertInsertOnly(Columns cols, hash<auto> example_row, *hash<auto> opt) {
+    private code<int(hash<auto>)> getUpsertInsertOnly(Columns cols, hash<auto> example_row, *hash<auto> opt) {
         string insert_sql = getUpsertInsertSql(example_row);
 
         return int sub (hash<auto> row) {
@@ -5749,7 +5749,7 @@ hash<SqlResultInfo> info = table.updateWithInfo({"id": id}, {"name": name});
         };
     }
 
-    private code getUpsertUpdateOnly(Columns cols, hash<auto> example_row, *hash<auto> opt) {
+    private code<int(hash<auto>)> getUpsertUpdateOnly(Columns cols, hash<auto> example_row, *hash<auto> opt) {
         list updc = ();
         string update_sql = getUpsertUpdateSql(example_row, cols, \updc, opt);
 

--- a/qlib/TableMapper.qm
+++ b/qlib/TableMapper.qm
@@ -358,7 +358,7 @@ public namespace TableMapper {
             *int hbuf_size;
 
             #! per-row @ref closure or @ref call_reference for batch inserts/upserts
-            *code rowcode;
+            *code<nothing(hash<auto>)> rowcode;
 
             #! upsert flag
             bool upsert = False;
@@ -367,7 +367,7 @@ public namespace TableMapper {
             *int upsert_strategy;
 
             #! closure used for upserting
-            *code upsert_code;
+            *code<int(hash<auto>)> upsert_code;
         }
 
         #! builds the object based on a hash providing field mappings, data constraints, and optionally custom mapping logic
@@ -709,7 +709,7 @@ table_mapper.setRowCode(rowcode);
 
             @note the per-row @ref closure "closure" or @ref call_reference "call reference" can also be set by using the \c "rowcode" option in the constructor()
         */
-        setRowCode(*code rowc) {
+        setRowCode(*code<nothing(hash<auto>)> rowc) {
             rowcode = rowc;
         }
 


### PR DESCRIPTION
## Summary

Implements typed callable syntax `code<ReturnType(ParamTypes...)>` for parse-time type checking of closures and call references.

- **Syntax**: `code<int(string)>` for a callable returning int and taking a string parameter
- **Covariant returns**: Assigned closure can return a more specific type
- **Contravariant parameters**: Assigned closure can accept more general types  
- **Or-nothing variant**: `*code<int(string)>`
- **Complex types**: `code<list<int>(hash<string, int>)>`
- Incompatible signature assignments cause parse-time `PARSE-TYPE-ERROR`

Closes #5089

## Changes

### Core Implementation
- `QoreComplexCodeTypeInfo` class for typed callable types
- Type caching with `ComplexCodeCacheKey` for efficient type reuse
- Factory function `qore_get_complex_code_type()`
- Scanner updated to allow parentheses in angle bracket tokens
- Parser updated for code type parsing
- Signature compatibility checking with variance rules

### Module Updates
- `SqlUtil::AbstractTable`: Typed upsert closures (`code<int(hash<auto>)>`)
- `TableMapper`: Typed row callbacks (`*code<nothing(hash<auto>)>`)
- `PgsqlSqlUtilBase`: Fixed `typedef` column alias conflict with new keyword

### Documentation
- Added typed callable section to data type declarations
- Added release notes entry

## Test plan

- [x] Phase 1 tests: Type infrastructure (5 cases, 17 assertions)
- [x] Phase 2 tests: Parsing (8 cases, 25 assertions)
- [x] Phase 3 tests: Type compatibility (8 cases, 22 assertions)
- [x] Comprehensive tests (10 cases, 34 assertions)
- [x] TableMapper tests (5 cases, 304 assertions)
- [x] All tests pass under valgrind with no memory errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)