### PR TITLE
refs #4910 Fix static memory leak in OpenSSL 3+ cipher/digest handling

### DIFF
--- a/include/qore/intern/EncryptionTransforms.h
+++ b/include/qore/intern/EncryptionTransforms.h
@@ -79,6 +79,8 @@ DLLLOCAL extern digest_map_t digest_map;
 #else
 const EVP_CIPHER* q_lookup_cipher(const char* cipher);
 DLLLOCAL QoreHashNode* q_get_cipher_hash(const EVP_CIPHER* c);
+// refs #4910: cleanup function to free cached cipher/digest references
+DLLLOCAL void crypto_cache_cleanup();
 #endif
 
 // init hash for giest encryption transformation constant

--- a/include/qore/intern/ql_crypto.h
+++ b/include/qore/intern/ql_crypto.h
@@ -297,4 +297,9 @@ public:
     DLLLOCAL int doHMAC(const char* err, const char* digest, const char* ptr, size_t len, ExceptionSink* xsink);
 };
 
+#ifdef OPENSSL_3_PLUS
+// refs #4910: cleanup function to free cached digest references
+DLLLOCAL void digest_cache_cleanup();
+#endif
+
 #endif // _QORE_QL_CRYPTO_H

--- a/lib/EncryptionTransforms.cpp
+++ b/lib/EncryptionTransforms.cpp
@@ -49,6 +49,13 @@
 #include <string>
 
 typedef std::map<std::string, std::string> strmap_t;
+
+// thread-safe cache for fetched ciphers to avoid memory leaks
+// refs #4910: EVP_CIPHER_fetch() returns references that must be freed
+typedef std::map<std::string, EVP_CIPHER*, ltstrcase> cipher_cache_t;
+static cipher_cache_t cipher_cache;
+static QoreThreadLock cipher_cache_lock;
+
 // map old cipher names -> new cipher names for backwards compatibility
 static strmap_t cipher_compat_aliases = {
     {"blowfish-cfb", "bf-cfb"},
@@ -453,7 +460,20 @@ const EVP_CIPHER* q_lookup_cipher(const char* cipher) {
     if (i != cipher_compat_aliases.end()) {
         cipher = i->second.c_str();
     }
-    return EVP_CIPHER_fetch(nullptr, cipher, nullptr);
+
+    // refs #4910: use cache to avoid memory leaks from EVP_CIPHER_fetch()
+    AutoLocker al(cipher_cache_lock);
+    cipher_cache_t::iterator ci = cipher_cache.find(cipher);
+    if (ci != cipher_cache.end()) {
+        return ci->second;
+    }
+
+    // fetch and cache
+    EVP_CIPHER* c = EVP_CIPHER_fetch(nullptr, cipher, nullptr);
+    if (c) {
+        cipher_cache[cipher] = c;
+    }
+    return c;
 }
 
 QoreHashNode* q_get_cipher_hash(const EVP_CIPHER* c) {
@@ -587,3 +607,17 @@ QoreHashNode* init_cipher_map_hash() {
     return rv.release();
 }
 
+#ifdef OPENSSL_3_PLUS
+void crypto_cache_cleanup() {
+    // refs #4910: free all cached cipher references
+    {
+        AutoLocker al(cipher_cache_lock);
+        for (auto& i : cipher_cache) {
+            EVP_CIPHER_free(i.second);
+        }
+        cipher_cache.clear();
+    }
+    // also clean up digest cache
+    digest_cache_cleanup();
+}
+#endif

--- a/lib/ql_crypto.qpp
+++ b/lib/ql_crypto.qpp
@@ -39,6 +39,17 @@
 #include <openssl/err.h>
 #include <openssl/rand.h>
 
+#ifdef OPENSSL_3_PLUS
+#include <map>
+#include <string>
+
+// thread-safe cache for fetched digests to avoid memory leaks
+// refs #4910: EVP_MD_fetch() returns references that must be freed
+typedef std::map<std::string, EVP_MD*, ltstrcase> digest_cache_t;
+static digest_cache_t digest_cache;
+static QoreThreadLock digest_cache_lock;
+#endif
+
 #define QCRYPTO_DECRYPT 0
 #define QCRYPTO_ENCRYPT 1
 
@@ -213,15 +224,38 @@ private:
     }
 };
 
-static const EVP_MD* q_lookup_digest(const char* cipher) {
+static const EVP_MD* q_lookup_digest(const char* digest) {
 #ifdef OPENSSL_3_PLUS
-    return EVP_MD_fetch(nullptr, cipher, nullptr);
+    // refs #4910: use cache to avoid memory leaks from EVP_MD_fetch()
+    AutoLocker al(digest_cache_lock);
+    digest_cache_t::iterator di = digest_cache.find(digest);
+    if (di != digest_cache.end()) {
+        return di->second;
+    }
+
+    // fetch and cache
+    EVP_MD* md = EVP_MD_fetch(nullptr, digest, nullptr);
+    if (md) {
+        digest_cache[digest] = md;
+    }
+    return md;
 #else
     // find digest
-    digest_map_t::const_iterator i = digest_map.find(cipher);
+    digest_map_t::const_iterator i = digest_map.find(digest);
     return i == digest_map.end() ? nullptr : i->second;
 #endif
 }
+
+#ifdef OPENSSL_3_PLUS
+void digest_cache_cleanup() {
+    // refs #4910: free all cached digest references
+    AutoLocker al(digest_cache_lock);
+    for (auto& i : digest_cache) {
+        EVP_MD_free(i.second);
+    }
+    digest_cache.clear();
+}
+#endif
 
 int HMACHelper::doHMAC(const char* err, const char* digest, const char* ptr, size_t len, ExceptionSink* xsink) {
 #ifdef OPENSSL_3_PLUS
@@ -230,6 +264,8 @@ int HMACHelper::doHMAC(const char* err, const char* digest, const char* ptr, siz
         xsink->raiseException(err, "error looking up MAC '%s'", digest);
         return -1;
     }
+    // refs #4910: EVP_MAC_fetch() returns a reference that must be freed
+    ON_BLOCK_EXIT(EVP_MAC_free, mac);
     EVP_MAC_CTX* ctx = EVP_MAC_CTX_new(mac);
     if (!ctx) {
         xsink->raiseException(err, "error creating MAC context for MAC '%s'", digest);

--- a/lib/qore-main.cpp
+++ b/lib/qore-main.cpp
@@ -35,6 +35,7 @@
 
 #include "qore/intern/QoreSignal.h"
 #include "qore/intern/ModuleInfo.h"
+#include "qore/intern/EncryptionTransforms.h"
 
 #include <cerrno>
 #include <csignal>
@@ -287,6 +288,11 @@ void qore_cleanup() {
         CONF_modules_unload(1);
 
         CRYPTO_cleanup_all_ex_data();
+
+#ifdef OPENSSL_3_PLUS
+        // refs #4910: free cached cipher and digest references
+        crypto_cache_cleanup();
+#endif
 
 #ifndef HAVE_OPENSSL_INIT_CRYPTO
         CRYPTO_set_id_callback(0);


### PR DESCRIPTION
## Summary

- Fix memory leak in `q_lookup_cipher()` and `q_lookup_digest()` for OpenSSL 3+
- Add thread-safe caching for fetched cipher and digest algorithm handles
- Add cleanup function called during `qore_cleanup()` to free cached references

## Problem

In OpenSSL 3+, `EVP_CIPHER_fetch()` and `EVP_MD_fetch()` return explicitly fetched algorithm handles with reference counts that must be freed with `EVP_CIPHER_free()` and `EVP_MD_free()`. The code was calling these functions but never freeing the returned references, causing static memory leaks.

## Solution

Implemented thread-safe caching using `QoreThreadLock`:

| File | Changes |
|------|---------|
| `lib/EncryptionTransforms.cpp` | Added `cipher_cache` map, modified `q_lookup_cipher()`, added `crypto_cache_cleanup()` |
| `lib/ql_crypto.qpp` | Added `digest_cache` map, modified `q_lookup_digest()`, added `digest_cache_cleanup()` |
| `lib/qore-main.cpp` | Call `crypto_cache_cleanup()` in `qore_cleanup()` |

## Test plan

- [x] Build succeeds
- [x] Crypto functions work correctly (digest, encrypt)
- [x] Valgrind shows 0 bytes definitely lost
- [x] Compression test passes with valgrind

## Valgrind results

```
==4074808== LEAK SUMMARY:
==4074808==    definitely lost: 0 bytes in 0 blocks
==4074808==    indirectly lost: 0 bytes in 0 blocks
==4074808== ERROR SUMMARY: 0 errors from 0 contexts
```

Closes #4910

🤖 Generated with [Claude Code](https://claude.com/claude-code)