### PR TITLE
refs #5000: implement interruptible I/O for sandbox support

### DIFF
--- a/doxygen/lang/222_sandboxing.dox.tmpl
+++ b/doxygen/lang/222_sandboxing.dox.tmpl
@@ -388,6 +388,10 @@ sm.clearInterrupt();
     - **Auto-lock constructors**: AutoLock, AutoReadLock, AutoWriteLock (polled every 500ms)
     - **Queue operations**: Queue::get(), Queue::pop() (polled every 500ms)
     - **Thread synchronization**: Counter::waitForZero(), Condition::wait(), Gate::enter() (polled every 500ms)
+    - **File I/O**: File read, write, and lock operations (polled at I/O poll interval)
+    - **Stream I/O**: PipeInputStream::read(), PipeOutputStream::write() (polled at I/O poll interval)
+    - **Standard I/O**: StdoutOutputStream::write(), StderrOutputStream::write() (polled at I/O poll interval)
+    - **Database operations**: Datasource transaction lock acquisition (polled at I/O poll interval)
 
     When interrupted, a \c PROGRAM-INTERRUPTED exception is raised.
 
@@ -402,6 +406,7 @@ sm.clearInterrupt();
     |----------------|------------------|---------|
     | sleep(), usleep() | 100ms | Fast response for timed waits |
     | Threading primitives | 500ms | Lower overhead for lock contention |
+    | I/O operations | 500ms | Consistent with threading primitives |
 
     @note The polling mechanism only incurs overhead when a @ref Qore::SandboxManager "SandboxManager"
     is attached to the Program. Normal programs without a SandboxManager have zero polling overhead.

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -172,6 +172,13 @@ code<int(string)> func = int sub(int x) { return x; };  # PARSE-TYPE-ERROR: para
       - SSRF prevention with @ref Qore::SandboxManager::blockPrivateNetworks() "blockPrivateNetworks()" preset
       - @ref sandbox_resources "resource limits" for memory, CPU time, wall time, threads, and recursion
       - @ref sandbox_interrupt "safe interrupt mechanism" for stopping runaway code in loops and blocking operations
+      - I/O interruptibility: all file, stream, database, and standard I/O operations respect interrupt requests
+        (<a href="https://github.com/qoretechnologies/qore/issues/5000">issue 5000</a>)
+        - uses 500ms polling interval (same as threading primitives) to check for interrupts
+        - @ref Qore::File "File" read, write, and lock operations use polling with interrupt checks
+        - @ref Qore::PipeInputStream "PipeInputStream" and @ref Qore::PipeOutputStream "PipeOutputStream" operations use polling
+        - @ref Qore::StdoutOutputStream "StdoutOutputStream" and @ref Qore::StderrOutputStream "StderrOutputStream" use polling
+        - @ref Qore::Datasource "Datasource" transaction lock acquisition is interruptible
       - security presets: @ref Qore::SandboxManager::createLockdown() "createLockdown()" and
         @ref Qore::SandboxManager::createWebSafe() "createWebSafe()"
       - see @ref sandboxing "Sandboxing and Security" for full documentation

--- a/doxygen/lang/interruptible-io-module-guide.md
+++ b/doxygen/lang/interruptible-io-module-guide.md
@@ -1,0 +1,363 @@
+# Interruptible I/O for Qore Binary Modules
+
+## Overview
+
+Qore 2.0 introduces a sandboxing mechanism that allows I/O operations to be interrupted on demand. This is essential for:
+
+- Sandbox environments where user code must be stoppable
+- Web applications with request timeouts
+- IDE integrations requiring responsive cancellation
+- Any scenario where blocking operations must be interruptible
+
+This document describes the API and implementation considerations for making binary modules support interruptible I/O.
+
+## Public API
+
+The following API is available in `<qore/QoreSandboxManager.h>`:
+
+### Core Functions
+
+```cpp
+#include <qore/QoreSandboxManager.h>
+
+// Get the sandbox manager for the current program context (may be nullptr)
+DLLEXPORT QoreSandboxManager* runtime_get_sandbox_manager();
+
+// Check if an interrupt has been requested and optionally raise an exception
+// Returns true if interrupted (and exception was raised if xsink provided)
+DLLEXPORT bool qore_check_io_interrupt(ExceptionSink* xsink = nullptr);
+```
+
+### QoreSandboxManager Methods
+
+```cpp
+class QoreSandboxManager {
+public:
+    // Check if an interrupt has been requested
+    bool isInterruptRequested() const;
+
+    // Request an interrupt (called by controlling code)
+    void requestInterrupt();
+
+    // Clear the interrupt flag
+    void clearInterrupt();
+};
+```
+
+### Constants
+
+```cpp
+// Recommended polling interval for long I/O operations (500ms)
+#define QORE_IO_POLL_INTERVAL_MS 500
+```
+
+## Implementation Patterns
+
+### Pattern 1: Pre-Operation Check
+
+Always check for interrupt before starting a potentially blocking operation:
+
+```cpp
+int myBlockingOperation(ExceptionSink* xsink) {
+    // Check before starting
+    if (qore_check_io_interrupt(xsink)) {
+        return -1;  // Exception already raised
+    }
+
+    // Proceed with operation...
+}
+```
+
+### Pattern 2: Polling During Long Operations
+
+For operations that may block for extended periods, use polling with timeouts:
+
+```cpp
+ssize_t myLongRead(void* buf, size_t len, int timeout_ms, ExceptionSink* xsink) {
+    QoreSandboxManager* sm = runtime_get_sandbox_manager();
+
+    // Fast path: no sandbox manager attached
+    if (!sm) {
+        return do_blocking_read(buf, len, timeout_ms);
+    }
+
+    // Check before starting
+    if (sm->isInterruptRequested()) {
+        xsink->raiseException("PROGRAM-INTERRUPTED", "I/O operation interrupted");
+        return -1;
+    }
+
+    // Poll with short timeouts
+    int remaining = timeout_ms;
+    while (remaining > 0 || timeout_ms < 0) {  // timeout_ms < 0 means infinite
+        // Check for interrupt
+        if (sm->isInterruptRequested()) {
+            xsink->raiseException("PROGRAM-INTERRUPTED", "I/O operation interrupted");
+            return -1;
+        }
+
+        // Use chunk timeout (don't exceed remaining time)
+        int chunk = QORE_IO_POLL_INTERVAL_MS;
+        if (timeout_ms >= 0 && remaining < chunk) {
+            chunk = remaining;
+        }
+
+        ssize_t rv = do_nonblocking_read_with_timeout(buf, len, chunk);
+
+        if (rv > 0) {
+            return rv;  // Success
+        }
+        if (rv < 0 && errno != ETIMEDOUT && errno != EAGAIN) {
+            return rv;  // Real error
+        }
+
+        if (timeout_ms >= 0) {
+            remaining -= chunk;
+        }
+    }
+
+    errno = ETIMEDOUT;
+    return -1;
+}
+```
+
+### Pattern 3: Library Cancellation API
+
+If the underlying library provides a cancellation mechanism, use it:
+
+```cpp
+class MyDatabaseConnection {
+    db_handle_t* handle;
+
+public:
+    int executeQuery(const char* sql, ExceptionSink* xsink) {
+        QoreSandboxManager* sm = runtime_get_sandbox_manager();
+
+        // Check before starting
+        if (qore_check_io_interrupt(xsink)) {
+            return -1;
+        }
+
+        // Start async query if sandbox is active
+        if (sm) {
+            // Start query asynchronously
+            db_query_async(handle, sql);
+
+            // Poll for completion with interrupt checking
+            while (!db_query_complete(handle)) {
+                if (sm->isInterruptRequested()) {
+                    // Cancel the query using library API
+                    db_cancel_query(handle);
+                    xsink->raiseException("PROGRAM-INTERRUPTED", "query interrupted");
+                    return -1;
+                }
+                usleep(QORE_IO_POLL_INTERVAL_MS * 1000);
+            }
+
+            return db_get_result(handle);
+        }
+
+        // No sandbox - use synchronous call
+        return db_query_sync(handle, sql);
+    }
+};
+```
+
+### Pattern 4: Custom Stream/Socket Wrapper
+
+For libraries that support custom I/O callbacks (like MongoDB), wrap the stream:
+
+```cpp
+// Custom stream that checks for interrupts during I/O
+typedef struct {
+    library_stream_t vtable;    // Must be first
+    library_stream_t* base;     // Wrapped stream
+} interruptible_stream_t;
+
+static ssize_t interruptible_read(library_stream_t* stream, void* buf,
+                                   size_t len, int timeout_ms) {
+    interruptible_stream_t* s = (interruptible_stream_t*)stream;
+
+    QoreSandboxManager* sm = runtime_get_sandbox_manager();
+    if (!sm) {
+        return library_stream_read(s->base, buf, len, timeout_ms);
+    }
+
+    if (sm->isInterruptRequested()) {
+        errno = EINTR;
+        return -1;
+    }
+
+    // Polling read with interrupt checking
+    int remaining = timeout_ms;
+    while (remaining > 0 || timeout_ms < 0) {
+        if (sm->isInterruptRequested()) {
+            errno = EINTR;
+            return -1;
+        }
+
+        int chunk = (remaining > QORE_IO_POLL_INTERVAL_MS || timeout_ms < 0)
+                    ? QORE_IO_POLL_INTERVAL_MS : remaining;
+
+        ssize_t rv = library_stream_read(s->base, buf, len, chunk);
+        if (rv >= 0 || (errno != ETIMEDOUT && errno != EAGAIN)) {
+            return rv;
+        }
+
+        if (timeout_ms >= 0) {
+            remaining -= chunk;
+        }
+    }
+
+    errno = ETIMEDOUT;
+    return -1;
+}
+```
+
+## Database Driver Considerations
+
+### Common DB Library Cancellation APIs
+
+| Database | Cancellation API | Notes |
+|----------|------------------|-------|
+| Oracle OCI | `OCIBreak(svchp, errhp)` | Cancels current operation on service context |
+| MySQL | `mysql_kill(conn, thread_id)` | Kills query from another connection |
+| PostgreSQL | `PQcancel(cancel, errbuf, len)` | Requires PGcancel object from `PQgetCancel()` |
+| SQLite | `sqlite3_interrupt(db)` | Safe to call from any thread |
+| ODBC | `SQLCancel(stmt)` | Cancels statement execution |
+| FreeTDS | `dbcancel(dbproc)` | Cancels current command batch |
+
+### Implementation Strategy by Library Type
+
+**Type A: Async API Available**
+- Use async query execution
+- Poll for completion with interrupt checking
+- Cancel if interrupted
+- Examples: Some Oracle OCI modes, modern PostgreSQL
+
+**Type B: Cancellation from Another Thread**
+- Execute query in current thread
+- Have a monitoring thread check for interrupts
+- Call cancel API from monitoring thread if interrupted
+- Examples: MySQL, PostgreSQL PQcancel
+
+**Type C: Custom I/O Callbacks**
+- Wrap socket/stream operations
+- Check interrupt during I/O
+- Examples: MongoDB (libmongoc)
+
+**Type D: Timeout-Based**
+- Set short statement/connection timeouts
+- Retry with interrupt checking between attempts
+- Less responsive but works with any library
+
+## Exception Handling
+
+When an interrupt is detected, raise a consistent exception:
+
+```cpp
+if (sm->isInterruptRequested()) {
+    xsink->raiseException("PROGRAM-INTERRUPTED",
+        "operation interrupted by sandbox manager");
+    return -1;
+}
+```
+
+The `qore_check_io_interrupt()` helper does this automatically:
+
+```cpp
+if (qore_check_io_interrupt(xsink)) {
+    return -1;  // Exception already raised with "PROGRAM-INTERRUPTED"
+}
+```
+
+## Performance Considerations
+
+1. **Zero Overhead When Disabled**: Always check `runtime_get_sandbox_manager()` first. If it returns `nullptr`, use the fast synchronous path.
+
+2. **Polling Interval**: Use `QORE_IO_POLL_INTERVAL_MS` (500ms) for consistency. This balances responsiveness with overhead.
+
+3. **Avoid Excessive Checking**: Don't check on every byte read. For streaming operations, check every N bytes or N iterations:
+
+```cpp
+// For character-by-character reads
+int chars_read = 0;
+while ((c = read_char()) != EOF) {
+    if (++chars_read % 100 == 0) {  // Check every 100 chars
+        if (qore_check_io_interrupt(xsink)) {
+            return -1;
+        }
+    }
+    // process character...
+}
+```
+
+4. **Connection vs Operation**: Consider whether to check at connection time, operation time, or both. Generally:
+   - Check at connection time (catches pre-requested interrupts)
+   - Check during long operations (catches runtime interrupts)
+
+## Testing
+
+### Test 1: Pre-Requested Interrupt
+
+```qore
+# Set interrupt BEFORE operation starts
+Program pgm(PO_NEW_STYLE);
+pgm.parse(code_that_does_io, "test");
+
+SandboxManager sm();
+pgm.setSandboxManager(sm);
+
+# Request interrupt before calling
+sm.requestInterrupt();
+
+# Operation should fail immediately
+pgm.callFunction("do_io_operation");
+
+# Verify exception was raised
+```
+
+### Test 2: Runtime Interrupt
+
+```qore
+# Interrupt DURING a blocking operation
+Counter cnt(1);
+
+background sub() {
+    cnt.dec();  # Signal ready
+    do_long_blocking_operation();
+}();
+
+cnt.waitForZero();  # Wait for operation to start
+sleep(100ms);       # Let it block
+sm.requestInterrupt();
+
+# Operation should be interrupted within ~500ms
+```
+
+### Test 3: No Sandbox (Fast Path)
+
+```qore
+# Verify operations work normally without sandbox
+# (no SandboxManager attached)
+do_io_operation();  # Should work normally
+```
+
+## Checklist for Module Updates
+
+- [ ] Include `<qore/QoreSandboxManager.h>`
+- [ ] Check `runtime_get_sandbox_manager()` at operation start
+- [ ] Implement polling for long operations using `QORE_IO_POLL_INTERVAL_MS`
+- [ ] Use library cancellation API if available
+- [ ] Raise `PROGRAM-INTERRUPTED` exception on interrupt
+- [ ] Ensure zero overhead when no sandbox manager is attached
+- [ ] Add tests for pre-requested and runtime interrupts
+- [ ] Document any limitations (e.g., "interrupt may not be immediate")
+
+## Reference Implementation
+
+See `modules/mongodb/src/QoreMongoStream.cpp` for a complete example of wrapping a library's I/O layer with interrupt support.
+
+## Version History
+
+- **Qore 2.0**: Initial implementation of interruptible I/O infrastructure

--- a/examples/test/qlib/Http2/Http2.qtest
+++ b/examples/test/qlib/Http2/Http2.qtest
@@ -133,6 +133,15 @@ class EchoWebSocketHandler inherits WebSocketHandler::WebSocketHandler {
 }
 
 public class Http2Test inherits QUnit::Test {
+    public {
+        # Command-line options
+        const MyOpts = Opts + {
+            "external": "e,external",
+        };
+
+        const OptionColumn = 22;
+    }
+
     private {
         HttpServer mServer;
         int port;
@@ -141,7 +150,7 @@ public class Http2Test inherits QUnit::Test {
         bool skip_complex_tests = is_file("/etc/alpine-release");
     }
 
-    constructor() : Test("Http2Test", "1.0") {
+    constructor() : Test("Http2Test", "1.0", \ARGV, MyOpts) {
         addTestCase("HTTP/2 settings test", \testHttp2Settings());
         addTestCase("HTTP/2 enable/disable test", \testHttp2EnableDisable());
         addTestCase("HTTP/2 version string test", \testHttp2VersionString());
@@ -170,6 +179,11 @@ public class Http2Test inherits QUnit::Test {
         if (mServer) {
             delete mServer;
         }
+    }
+
+    private usageIntern() {
+        TestReporter::usageIntern(OptionColumn);
+        printOption("-e,--external", "run tests that connect to external servers", OptionColumn);
     }
 
     testAlpnNegotiation() {
@@ -916,6 +930,12 @@ public class Http2Test inherits QUnit::Test {
     }
 
     testHttp2ConnectionPersistence() {
+        # Skip external server tests unless explicitly enabled with -e,--external
+        if (!m_options.external) {
+            testSkip("external server tests disabled; use -e,--external to enable");
+            return;
+        }
+
         # Skip on Alpine - external network tests can hang
         if (skip_complex_tests) {
             testSkip("Skipping external server test on Alpine");

--- a/examples/test/qore/io/io_interrupt.qtest
+++ b/examples/test/qore/io/io_interrupt.qtest
@@ -1,0 +1,578 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+%disable-warning unreferenced-variable
+
+%requires ../../../../qlib/Util.qm
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class IOInterruptTest
+
+public class IOInterruptTest inherits QUnit::Test {
+    constructor() : Test("IOInterruptTest", "1.0") {
+        # Basic interrupt mechanism tests
+        addTestCase("SandboxManager interrupt mechanism", \testSandboxManagerInterrupt());
+        addTestCase("SandboxManager configuration", \testSandboxManagerConfiguration());
+
+        # File I/O tests - normal operations
+        addTestCase("File read without interrupt", \testFileReadNoInterrupt());
+        addTestCase("File write without interrupt", \testFileWriteNoInterrupt());
+        addTestCase("File lock without interrupt", \testFileLockNoInterrupt());
+
+        # Stream I/O tests - normal operations
+        addTestCase("Pipe stream without interrupt", \testPipeStreamNoInterrupt());
+        addTestCase("Pipe stream with timeout", \testPipeStreamTimeout());
+
+        # Interrupt tests using embedded Program
+        addTestCase("Interrupt pipe read in Program", \testInterruptPipeReadInProgram());
+        addTestCase("Interrupt pipe write in Program", \testInterruptPipeWriteInProgram());
+
+        # Thread primitive interrupt tests
+        addTestCase("Queue shift interrupt", \testQueueShiftInterrupt());
+        addTestCase("Queue push interrupt (full queue)", \testQueuePushInterrupt());
+        addTestCase("Queue normal operations", \testQueueNormalOperations());
+        addTestCase("Counter waitForZero interrupt", \testCounterWaitInterrupt());
+
+        # Corner cases
+        addTestCase("Multiple interrupt requests", \testMultipleInterrupts());
+
+        # Negative tests
+        addTestCase("Operations without SandboxManager", \testNoSandboxManager());
+        addTestCase("Invalid file operations", \testInvalidFileOperations());
+
+        set_return_value(main());
+    }
+
+    #------------------------------------------------------------------
+    # Basic interrupt mechanism tests
+    #------------------------------------------------------------------
+
+    testSandboxManagerInterrupt() {
+        SandboxManager sm();
+
+        # Test initial state
+        assertFalse(sm.isInterruptRequested(), "interrupt should not be requested initially");
+
+        # Test requesting interrupt
+        sm.requestInterrupt();
+        assertTrue(sm.isInterruptRequested(), "interrupt should be requested after requestInterrupt()");
+
+        # Test clearing interrupt
+        sm.clearInterrupt();
+        assertFalse(sm.isInterruptRequested(), "interrupt should not be requested after clearInterrupt()");
+
+        # Test multiple request/clear cycles
+        for (int i = 0; i < 5; i++) {
+            sm.requestInterrupt();
+            assertTrue(sm.isInterruptRequested(), sprintf("interrupt cycle %d: should be requested", i));
+            sm.clearInterrupt();
+            assertFalse(sm.isInterruptRequested(), sprintf("interrupt cycle %d: should be cleared", i));
+        }
+    }
+
+    testSandboxManagerConfiguration() {
+        SandboxManager sm();
+
+        # Verify configuration contains expected keys
+        hash<auto> config = sm.getConfiguration();
+        assertTrue(exists config.interrupt_requested, "configuration should have interrupt_requested");
+        assertTrue(exists config.memory_limit, "configuration should have memory_limit");
+        assertTrue(exists config.cpu_time_limit, "configuration should have cpu_time_limit");
+        assertTrue(exists config.wall_time_limit, "configuration should have wall_time_limit");
+        assertTrue(exists config.max_threads, "configuration should have max_threads");
+        assertTrue(exists config.max_recursion, "configuration should have max_recursion");
+
+        # Verify interrupt_requested reflects actual state
+        assertFalse(config.interrupt_requested, "interrupt_requested should be false initially");
+
+        sm.requestInterrupt();
+        config = sm.getConfiguration();
+        assertTrue(config.interrupt_requested, "interrupt_requested should be true after request");
+
+        sm.clearInterrupt();
+        config = sm.getConfiguration();
+        assertFalse(config.interrupt_requested, "interrupt_requested should be false after clear");
+    }
+
+    #------------------------------------------------------------------
+    # File I/O tests - normal operations
+    #------------------------------------------------------------------
+
+    testFileReadNoInterrupt() {
+        string tmpfile = tmp_location() + "/test_read_interrupt.txt";
+        string test_data = "test data for interrupt testing\n" + strmul("x", 1000);
+        {
+            File f();
+            f.open2(tmpfile, O_CREAT | O_WRONLY | O_TRUNC);
+            f.write(test_data);
+        }
+        on_exit unlink(tmpfile);
+
+        # Test that file read works normally
+        {
+            File f();
+            f.open2(tmpfile);
+            string data = f.read(-1);
+            assertEq(test_data.size(), data.size(), "file read should return all data");
+            assertEq(test_data, data, "file read data should match");
+        }
+
+        assertTrue(True, "file read test completed");
+    }
+
+    testFileWriteNoInterrupt() {
+        string tmpfile = tmp_location() + "/test_write_interrupt.txt";
+        on_exit {
+            if (is_file(tmpfile))
+                unlink(tmpfile);
+        }
+
+        string test_data = strmul("test data ", 100);
+
+        # Test that file write works normally
+        {
+            File f();
+            f.open2(tmpfile, O_CREAT | O_WRONLY | O_TRUNC);
+            int written = f.write(test_data);
+            assertEq(test_data.size(), written, "file write should write all data");
+        }
+
+        # Verify data was written correctly
+        {
+            File f();
+            f.open2(tmpfile);
+            string data = f.read(-1);
+            assertEq(test_data, data, "written data should match");
+        }
+
+        assertTrue(True, "file write test completed");
+    }
+
+    testFileLockNoInterrupt() {
+        string tmpfile = tmp_location() + "/test_lock_interrupt.txt";
+        {
+            File f();
+            f.open2(tmpfile, O_CREAT | O_WRONLY | O_TRUNC);
+            f.write("test");
+        }
+        on_exit unlink(tmpfile);
+
+        # Test that file locking works normally
+        {
+            File f();
+            f.open2(tmpfile, O_RDWR);
+            f.lock(F_WRLCK);
+            assertTrue(True, "write lock acquired");
+        }
+
+        # Test that we can lock again after previous file closed
+        {
+            File f();
+            f.open2(tmpfile, O_RDWR);
+            f.lock(F_WRLCK);
+            assertTrue(True, "second write lock acquired after first released");
+        }
+
+        assertTrue(True, "file lock test completed");
+    }
+
+    #------------------------------------------------------------------
+    # Stream I/O tests - normal operations
+    #------------------------------------------------------------------
+
+    testPipeStreamNoInterrupt() {
+        StreamPipe pipe(True, 5000, 1024);
+        PipeOutputStream pos = pipe.getOutputStream();
+        PipeInputStream pis = pipe.getInputStream();
+
+        binary test_data = <01020304050607080910>;
+
+        # Write data in background
+        Counter c(1);
+        background sub() {
+            c.dec();
+            pos.write(test_data);
+            pos.close();
+        }();
+
+        c.waitForZero();
+        usleep(50ms);
+
+        *binary data = pis.read(100);
+        assertEq(test_data.size(), data.size(), "pipe read should return all data");
+        assertEq(test_data, data, "pipe data should match");
+        pis.finishClose();
+
+        assertTrue(True, "pipe stream test completed");
+    }
+
+    testPipeStreamTimeout() {
+        # Test that pipe read times out correctly (raises TIMEOUT-ERROR)
+        # Use non-syncClose to avoid close timeout issues
+        StreamPipe pipe(False, 100, 1024);  # 100ms timeout, no syncClose
+        PipeInputStream pis = pipe.getInputStream();
+        PipeOutputStream pos = pipe.getOutputStream();
+
+        # Don't write anything - read should timeout
+        bool got_timeout = False;
+        date start = now_us();
+        try {
+            *binary data = pis.read(100);
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.err == "TIMEOUT-ERROR") {
+                got_timeout = True;
+            }
+        }
+        date elapsed = now_us() - start;
+
+        # Read should timeout
+        assertTrue(got_timeout, "read should raise TIMEOUT-ERROR");
+        # Elapsed time should be around 100ms (allow some slack)
+        assertTrue(elapsed >= 50ms, "elapsed time should be at least 50ms");
+
+        # Cleanup - no syncClose so close is immediate
+        pos.close();
+    }
+
+    #------------------------------------------------------------------
+    # Interrupt tests using embedded Program
+    #------------------------------------------------------------------
+
+    testInterruptPipeReadInProgram() {
+        # Test interrupt with pipe - using pre-requested interrupt
+        SandboxManager sm();
+        sm.requestInterrupt();
+
+        Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+        p.setSandboxManager(sm);
+
+        p.parse("
+%require-types
+%new-style
+%strict-args
+
+*binary sub read_pipe() {
+    StreamPipe pipe(True, 30000, 1024);
+    PipeInputStream pis = pipe.getInputStream();
+    # This should be interrupted before blocking
+    return pis.read(100);
+}
+", "interrupt_pipe_test");
+
+        bool got_interrupt = False;
+        try {
+            p.callFunction("read_pipe");
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.err == "PROGRAM-INTERRUPTED") {
+                got_interrupt = True;
+            }
+        }
+
+        assertTrue(got_interrupt, "pipe read should be interrupted when interrupt is pre-requested");
+        sm.clearInterrupt();
+    }
+
+    testInterruptPipeWriteInProgram() {
+        # Test interrupt with pipe write - using pre-requested interrupt
+        SandboxManager sm();
+        sm.requestInterrupt();
+
+        Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+        p.setSandboxManager(sm);
+
+        p.parse("
+%require-types
+%new-style
+%strict-args
+
+sub write_pipe() {
+    StreamPipe pipe(True, 30000, 16);  # Small buffer
+    PipeOutputStream pos = pipe.getOutputStream();
+    # Try to write lots of data - should be interrupted
+    binary large_data = binary();
+    for (int i = 0; i < 100; i++) {
+        large_data += <0102030405060708>;
+    }
+    pos.write(large_data);
+}
+", "interrupt_pipe_write_test");
+
+        bool got_interrupt = False;
+        try {
+            p.callFunction("write_pipe");
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.err == "PROGRAM-INTERRUPTED") {
+                got_interrupt = True;
+            }
+        }
+
+        assertTrue(got_interrupt, "pipe write should be interrupted when interrupt is pre-requested");
+        sm.clearInterrupt();
+    }
+
+    #------------------------------------------------------------------
+    # Thread primitive interrupt tests
+    #------------------------------------------------------------------
+
+    testQueueShiftInterrupt() {
+        # Test interrupt of Queue::shift() on empty queue
+        SandboxManager sm();
+        sm.requestInterrupt();
+
+        Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+        p.setSandboxManager(sm);
+
+        p.parse("
+%require-types
+%new-style
+%strict-args
+
+auto sub shift_queue() {
+    Queue q();
+    # This should be interrupted - queue is empty, would block forever
+    return q.get(30000);  # 30 second timeout
+}
+", "queue_shift_test");
+
+        bool got_interrupt = False;
+        try {
+            p.callFunction("shift_queue");
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.err == "PROGRAM-INTERRUPTED") {
+                got_interrupt = True;
+            }
+        }
+
+        assertTrue(got_interrupt, "Queue::get() should be interrupted when interrupt is pre-requested");
+        sm.clearInterrupt();
+    }
+
+    testQueuePushInterrupt() {
+        # Test interrupt of Queue::push() on full queue
+        SandboxManager sm();
+        sm.requestInterrupt();
+
+        Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+        p.setSandboxManager(sm);
+
+        p.parse("
+%require-types
+%new-style
+%strict-args
+
+sub push_queue() {
+    Queue q(1);  # Max size 1
+    q.push(1);   # Fill the queue
+    # This should be interrupted - queue is full, would block
+    q.push(2, 30000);  # 30 second timeout
+}
+", "queue_push_test");
+
+        bool got_interrupt = False;
+        try {
+            p.callFunction("push_queue");
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.err == "PROGRAM-INTERRUPTED") {
+                got_interrupt = True;
+            }
+        }
+
+        assertTrue(got_interrupt, "Queue::push() on full queue should be interrupted");
+        sm.clearInterrupt();
+    }
+
+    testQueueNormalOperations() {
+        # Test that Queue operations work normally without interrupt
+        Queue q(10);
+
+        # Push and shift
+        q.push("test1");
+        q.push("test2");
+        q.push(123);
+
+        assertEq(3, q.size(), "queue should have 3 elements");
+
+        auto v1 = q.get();
+        assertEq("test1", v1, "first element should be test1");
+
+        auto v2 = q.get();
+        assertEq("test2", v2, "second element should be test2");
+
+        auto v3 = q.get();
+        assertEq(123, v3, "third element should be 123");
+
+        assertEq(0, q.size(), "queue should be empty");
+
+        # Test with timeout - should return NOTHING immediately on empty queue with 0 timeout
+        bool got_timeout = False;
+        try {
+            auto v = q.get(0);
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.err == "QUEUE-TIMEOUT") {
+                got_timeout = True;
+            }
+        }
+        assertTrue(got_timeout, "get with 0 timeout on empty queue should timeout");
+
+        assertTrue(True, "queue normal operations test completed");
+    }
+
+    testCounterWaitInterrupt() {
+        # Test interrupt of Counter::waitForZero()
+        SandboxManager sm();
+        sm.requestInterrupt();
+
+        Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+        p.setSandboxManager(sm);
+
+        p.parse("
+%require-types
+%new-style
+%strict-args
+
+int sub wait_counter() {
+    Counter c(1);  # Counter at 1, will never reach 0
+    # This should be interrupted - counter won't reach 0
+    return c.waitForZero(30000);  # 30 second timeout
+}
+", "counter_wait_test");
+
+        bool got_interrupt = False;
+        try {
+            p.callFunction("wait_counter");
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.err == "PROGRAM-INTERRUPTED") {
+                got_interrupt = True;
+            }
+        }
+
+        assertTrue(got_interrupt, "Counter::waitForZero() should be interrupted");
+        sm.clearInterrupt();
+    }
+
+    #------------------------------------------------------------------
+    # Corner cases
+    #------------------------------------------------------------------
+
+    testMultipleInterrupts() {
+        SandboxManager sm();
+
+        # Test rapid interrupt/clear cycles
+        for (int i = 0; i < 100; i++) {
+            sm.requestInterrupt();
+            assertTrue(sm.isInterruptRequested(), sprintf("rapid cycle %d: interrupt requested", i));
+            sm.clearInterrupt();
+            assertFalse(sm.isInterruptRequested(), sprintf("rapid cycle %d: interrupt cleared", i));
+        }
+
+        # Test multiple requests without clear (should be idempotent)
+        sm.requestInterrupt();
+        sm.requestInterrupt();
+        sm.requestInterrupt();
+        assertTrue(sm.isInterruptRequested(), "multiple requests should keep interrupt set");
+
+        # Single clear should clear it
+        sm.clearInterrupt();
+        assertFalse(sm.isInterruptRequested(), "single clear should clear interrupt");
+
+        # Test multiple clears (should be idempotent)
+        sm.clearInterrupt();
+        sm.clearInterrupt();
+        sm.clearInterrupt();
+        assertFalse(sm.isInterruptRequested(), "multiple clears should keep interrupt cleared");
+    }
+
+    #------------------------------------------------------------------
+    # Negative tests
+    #------------------------------------------------------------------
+
+    testNoSandboxManager() {
+        # Test that operations work without SandboxManager
+        string tmpfile = tmp_location() + "/test_no_sm.txt";
+        {
+            File f();
+            f.open2(tmpfile, O_CREAT | O_WRONLY | O_TRUNC);
+            f.write("test data for no sandbox manager test");
+        }
+        on_exit unlink(tmpfile);
+
+        # Operation should work normally without sandbox manager
+        {
+            File f();
+            f.open2(tmpfile);
+            string result = f.read(-1);
+            assertTrue(result.size() > 0, "read without SandboxManager should work");
+        }
+
+        # Pipe operations should also work
+        StreamPipe pipe(True, 1000, 1024);
+        PipeInputStream pis = pipe.getInputStream();
+        PipeOutputStream pos = pipe.getOutputStream();
+
+        Counter c(1);
+        background sub() {
+            c.dec();
+            pos.write(<01020304>);
+            pos.close();
+        }();
+
+        c.waitForZero();
+        usleep(50ms);
+
+        *binary data = pis.read(100);
+        assertTrue(data.size() > 0, "pipe read without SandboxManager should work");
+        pis.finishClose();
+    }
+
+    testInvalidFileOperations() {
+        # Test error handling for invalid file operations
+        string nonexistent = tmp_location() + "/nonexistent_file_12345.txt";
+
+        # Try to read non-existent file
+        bool got_error = False;
+        try {
+            File f();
+            f.open2(nonexistent);
+        } catch (hash<ExceptionInfo> ex) {
+            got_error = True;
+        }
+        assertTrue(got_error, "opening non-existent file should raise error");
+
+        # Try to lock file that isn't open
+        got_error = False;
+        try {
+            File f();
+            f.lock(F_WRLCK);
+        } catch (hash<ExceptionInfo> ex) {
+            got_error = True;
+            assertEq("FILE-LOCK-ERROR", ex.err, "locking unopened file should raise FILE-LOCK-ERROR");
+        }
+        assertTrue(got_error, "locking unopened file should raise error");
+
+        # Test pipe with no syncClose (simpler cleanup)
+        {
+            StreamPipe pipe(False, 100, 1024);  # No syncClose, short timeout
+            PipeInputStream pis = pipe.getInputStream();
+            PipeOutputStream pos = pipe.getOutputStream();
+
+            # Close output without writing
+            pos.close();
+
+            # Read should return empty/nothing or timeout
+            bool read_ok = False;
+            try {
+                *binary data = pis.read(100);
+                read_ok = True;  # Empty read is fine
+            } catch (hash<ExceptionInfo> ex) {
+                if (ex.err == "TIMEOUT-ERROR") {
+                    read_ok = True;  # Timeout is also acceptable
+                }
+            }
+            assertTrue(read_ok, "read from closed pipe should return empty or timeout");
+        }
+    }
+}

--- a/examples/test/qore/io/io_interrupt.qtest
+++ b/examples/test/qore/io/io_interrupt.qtest
@@ -407,16 +407,17 @@ sub push_queue() {
 
         assertEq(0, q.size(), "queue should be empty");
 
-        # Test with timeout - should return NOTHING immediately on empty queue with 0 timeout
+        # Test with negative timeout - should timeout immediately on empty queue
+        # (Queue semantics: negative = immediate timeout, 0 = infinite wait)
         bool got_timeout = False;
         try {
-            auto v = q.get(0);
+            auto v = q.get(-1);
         } catch (hash<ExceptionInfo> ex) {
             if (ex.err == "QUEUE-TIMEOUT") {
                 got_timeout = True;
             }
         }
-        assertTrue(got_timeout, "get with 0 timeout on empty queue should timeout");
+        assertTrue(got_timeout, "get with negative timeout on empty queue should timeout immediately");
 
         assertTrue(True, "queue normal operations test completed");
     }

--- a/include/qore/QoreCondition.h
+++ b/include/qore/QoreCondition.h
@@ -38,6 +38,20 @@
 
 #include <qore/QoreThreadLock.h>
 
+// Forward declaration
+class ExceptionSink;
+
+//! @defgroup condition_wait_results Condition Wait Result Codes
+//! Result codes for QoreCondition::waitWithInterrupt() methods
+//@{
+//! Wait completed successfully (condition was signaled)
+#define QORE_COND_RESULT_SUCCESS 0
+//! Wait timed out
+#define QORE_COND_RESULT_TIMEOUT 1
+//! Wait was interrupted by sandbox manager
+#define QORE_COND_RESULT_INTERRUPTED 2
+//@}
+
 //! a thread condition class implementing a wrapper for pthread_cond_t
 /** all threads that block on a given QoreCondition object should use the same mutex or QoreThreadLock object for blocking
     @see QoreThreadLock
@@ -150,6 +164,93 @@ public:
     */
     DLLLOCAL int wait2(QoreThreadLock& l, int64 timeout_ms) {
         return wait2(&l, timeout_ms);
+    }
+
+    //! blocks a thread on a mutex until the condition is signaled, with interrupt support
+    /** This method supports sandbox interrupt checking. When a SandboxManager is attached
+        to the current program and an interrupt is requested, this method will return
+        with QORE_COND_RESULT_INTERRUPTED.
+
+        @param m the mutex to wait on
+        @param xsink exception sink for interrupt errors (optional - if nullptr, no exception raised)
+
+        @return QORE_COND_RESULT_SUCCESS (0) if signaled, QORE_COND_RESULT_INTERRUPTED if interrupted
+
+        @since Qore 2.1
+    */
+    DLLEXPORT int waitWithInterrupt(pthread_mutex_t* m, ExceptionSink* xsink = nullptr);
+
+    //! blocks a thread on a mutex for a certain number of milliseconds until the condition is signaled, with interrupt support
+    /** This method supports sandbox interrupt checking. When a SandboxManager is attached
+        to the current program and an interrupt is requested, this method will return
+        with QORE_COND_RESULT_INTERRUPTED.
+
+        @param m the mutex to wait on
+        @param timeout_ms the timeout value in milliseconds; if < 0 will wait indefinitely
+        @param xsink exception sink for interrupt errors (optional - if nullptr, no exception raised)
+
+        @return QORE_COND_RESULT_SUCCESS (0) if signaled, QORE_COND_RESULT_TIMEOUT if timed out, QORE_COND_RESULT_INTERRUPTED if interrupted
+
+        @since Qore 2.1
+    */
+    DLLEXPORT int waitWithInterrupt(pthread_mutex_t* m, int64 timeout_ms, ExceptionSink* xsink = nullptr);
+
+    //! blocks a thread on a lock until the condition is signaled, with interrupt support
+    /** This method supports sandbox interrupt checking.
+
+        @param l the QoreThreadLock to wait on
+        @param xsink exception sink for interrupt errors (optional)
+
+        @return QORE_COND_RESULT_SUCCESS (0) if signaled, QORE_COND_RESULT_INTERRUPTED if interrupted
+
+        @since Qore 2.1
+    */
+    DLLLOCAL int waitWithInterrupt(QoreThreadLock* l, ExceptionSink* xsink = nullptr) {
+        return waitWithInterrupt(&l->ptm_lock, xsink);
+    }
+
+    //! blocks a thread on a lock for a certain number of milliseconds until the condition is signaled, with interrupt support
+    /** This method supports sandbox interrupt checking.
+
+        @param l the QoreThreadLock to wait on
+        @param timeout_ms the timeout value in milliseconds; if < 0 will wait indefinitely
+        @param xsink exception sink for interrupt errors (optional)
+
+        @return QORE_COND_RESULT_SUCCESS (0) if signaled, QORE_COND_RESULT_TIMEOUT if timed out, QORE_COND_RESULT_INTERRUPTED if interrupted
+
+        @since Qore 2.1
+    */
+    DLLLOCAL int waitWithInterrupt(QoreThreadLock* l, int64 timeout_ms, ExceptionSink* xsink = nullptr) {
+        return waitWithInterrupt(&l->ptm_lock, timeout_ms, xsink);
+    }
+
+    //! blocks a thread on a lock until the condition is signaled, with interrupt support
+    /** This method supports sandbox interrupt checking.
+
+        @param l the QoreThreadLock to wait on
+        @param xsink exception sink for interrupt errors (optional)
+
+        @return QORE_COND_RESULT_SUCCESS (0) if signaled, QORE_COND_RESULT_INTERRUPTED if interrupted
+
+        @since Qore 2.1
+    */
+    DLLLOCAL int waitWithInterrupt(QoreThreadLock& l, ExceptionSink* xsink = nullptr) {
+        return waitWithInterrupt(&l, xsink);
+    }
+
+    //! blocks a thread on a lock for a certain number of milliseconds until the condition is signaled, with interrupt support
+    /** This method supports sandbox interrupt checking.
+
+        @param l the QoreThreadLock to wait on
+        @param timeout_ms the timeout value in milliseconds; if < 0 will wait indefinitely
+        @param xsink exception sink for interrupt errors (optional)
+
+        @return QORE_COND_RESULT_SUCCESS (0) if signaled, QORE_COND_RESULT_TIMEOUT if timed out, QORE_COND_RESULT_INTERRUPTED if interrupted
+
+        @since Qore 2.1
+    */
+    DLLLOCAL int waitWithInterrupt(QoreThreadLock& l, int64 timeout_ms, ExceptionSink* xsink = nullptr) {
+        return waitWithInterrupt(&l, timeout_ms, xsink);
     }
 
 private:

--- a/include/qore/QoreSandboxManager.h
+++ b/include/qore/QoreSandboxManager.h
@@ -523,6 +523,17 @@ public:
     */
     DLLEXPORT bool isInterruptRequested() const;
 
+    //! Checks if interrupt has been requested and raises exception if so
+    /** This is a convenience method for I/O operations that need to check
+        for interrupts and raise an exception if interrupted.
+
+        @param xsink Exception sink for error reporting
+        @param operation Description of the operation being interrupted (e.g., "reading file")
+
+        @return true if interrupted (exception raised), false otherwise
+    */
+    DLLEXPORT bool checkIOInterrupt(ExceptionSink* xsink, const char* operation = "I/O operation") const;
+
     //! Returns the full configuration as a hash
     /** @return A hash containing all sandbox configuration including
         filesystem, network, and resource limit settings
@@ -621,5 +632,26 @@ private:
     security restrictions.
 */
 DLLEXPORT QoreSandboxManager* runtime_get_sandbox_manager();
+
+//! Checks if the current program has been interrupted and raises exception if so
+/** This is a convenience function for I/O operations that need to check
+    for interrupts. It checks if a SandboxManager exists for the current
+    program and if an interrupt has been requested.
+
+    @param xsink Exception sink for error reporting
+    @param operation Description of the operation being interrupted
+
+    @return true if interrupted (exception raised), false otherwise
+
+    @note If no SandboxManager is attached, this returns false (no interrupt).
+*/
+DLLEXPORT bool qore_check_io_interrupt(ExceptionSink* xsink, const char* operation = "I/O operation");
+
+//! Polling interval for blocking I/O operations in milliseconds
+/** This constant defines how frequently blocking I/O operations check for
+    interrupt requests. It matches the polling interval used for threading
+    primitives (500ms).
+*/
+#define QORE_IO_POLL_INTERVAL_MS 500
 
 #endif // _QORE_QORE_SANDBOX_MANAGER_H

--- a/include/qore/intern/ManagedDatasource.h
+++ b/include/qore/intern/ManagedDatasource.h
@@ -68,8 +68,8 @@ protected:
     // returns true if we have the transaction lock, false if not
     DLLLOCAL bool endDBAction(char cmd = DAH_NOCHANGE, bool new_transaction = false);
     DLLLOCAL int closeUnlocked(ExceptionSink* xsink);
-    // returns 0 for OK, -1 for error
-    DLLLOCAL int grabLockIntern();
+    // returns 0 for OK, -1 for timeout, -2 for interrupt
+    DLLLOCAL int grabLockIntern(ExceptionSink* xsink = nullptr);
     DLLLOCAL void grabLockUnconditionalIntern();
     // returns 0 for OK, -1 for error
     DLLLOCAL int grabLock(ExceptionSink* xsink);

--- a/include/qore/intern/StderrOutputStream.h
+++ b/include/qore/intern/StderrOutputStream.h
@@ -33,6 +33,11 @@
 #define _QORE_STDERROUTPUTSTREAM_H
 
 #include "qore/OutputStream.h"
+#include <qore/QoreSandboxManager.h>
+
+#include <unistd.h>
+#include <poll.h>
+#include <cerrno>
 
 /**
  * @brief Private data for the Qore::StderrOutputStream class.
@@ -57,16 +62,47 @@ public:
 
    DLLLOCAL void write(const void *ptr, int64 count, ExceptionSink *xsink) override {
       assert(count >= 0);
-      if (count < 0)
+      if (count <= 0)
          return;
+
+      // Check for sandbox interrupt support
+      QoreSandboxManager* sm = runtime_get_sandbox_manager();
+
       const char* current = reinterpret_cast<const char*>(ptr);
-      int64 blockCount = count / WRITE_BLOCK_SIZE;
-      for (int64 i = 0; i < blockCount; i++) {
-         fwrite(current, WRITE_BLOCK_SIZE, 1, stderr);
-         current = (current + WRITE_BLOCK_SIZE);
-         count -= WRITE_BLOCK_SIZE;
+      int64 remaining = count;
+
+      while (remaining > 0) {
+         // Check for interrupt
+         if (sm && sm->checkIOInterrupt(xsink, "stderr write")) {
+            return;
+         }
+
+         // Write in blocks
+         size_t to_write = remaining > WRITE_BLOCK_SIZE ? WRITE_BLOCK_SIZE : remaining;
+         ssize_t written = ::write(STDERR_FILENO, current, to_write);
+
+         if (written < 0) {
+            if (errno == EINTR) {
+               continue;
+            }
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+               // Would block - poll for write readiness
+               if (sm) {
+                  const int poll_ms = QORE_IO_POLL_INTERVAL_MS;
+                  struct pollfd pfd;
+                  pfd.fd = STDERR_FILENO;
+                  pfd.events = POLLOUT;
+                  poll(&pfd, 1, poll_ms);
+               }
+               continue;
+            }
+            xsink->raiseErrnoException("STDERR-WRITE-ERROR", errno, "error writing to stderr");
+            return;
+         }
+
+         current += written;
+         remaining -= written;
       }
-      fwrite(ptr, count, 1, stderr);
    }
 private:
    static const int WRITE_BLOCK_SIZE = 1024;

--- a/include/qore/intern/StderrOutputStream.h
+++ b/include/qore/intern/StderrOutputStream.h
@@ -87,12 +87,35 @@ public:
             }
             if (errno == EAGAIN || errno == EWOULDBLOCK) {
                // Would block - poll for write readiness
-               if (sm) {
-                  const int poll_ms = QORE_IO_POLL_INTERVAL_MS;
-                  struct pollfd pfd;
-                  pfd.fd = STDERR_FILENO;
-                  pfd.events = POLLOUT;
-                  poll(&pfd, 1, poll_ms);
+               const int poll_ms = QORE_IO_POLL_INTERVAL_MS;
+               struct pollfd pfd;
+               pfd.fd = STDERR_FILENO;
+               pfd.events = POLLOUT;
+
+               while (true) {
+                  int pret = ::poll(&pfd, 1, poll_ms);
+                  if (pret > 0) {
+                     // Ready for writing
+                     break;
+                  }
+                  if (pret == 0) {
+                     // Timeout - check for interrupt and retry
+                     if (sm && sm->checkIOInterrupt(xsink, "stderr write")) {
+                        return;
+                     }
+                     break;
+                  }
+                  // pret < 0: error
+                  if (errno == EINTR) {
+                     // Interrupted by signal - check for sandbox interrupt then retry poll
+                     if (sm && sm->checkIOInterrupt(xsink, "stderr write")) {
+                        return;
+                     }
+                     continue;
+                  }
+                  xsink->raiseErrnoException("STDERR-WRITE-ERROR", errno,
+                     "error polling stderr for write readiness");
+                  return;
                }
                continue;
             }

--- a/include/qore/intern/StdoutOutputStream.h
+++ b/include/qore/intern/StdoutOutputStream.h
@@ -33,6 +33,11 @@
 #define _QORE_STDOUTOUTPUTSTREAM_H
 
 #include "qore/OutputStream.h"
+#include <qore/QoreSandboxManager.h>
+
+#include <unistd.h>
+#include <poll.h>
+#include <cerrno>
 
 /**
  * @brief Private data for the Qore::StdoutOutputStream class.
@@ -57,16 +62,47 @@ public:
 
    DLLLOCAL void write(const void *ptr, int64 count, ExceptionSink *xsink) override {
       assert(count >= 0);
-      if (count < 0)
+      if (count <= 0)
          return;
+
+      // Check for sandbox interrupt support
+      QoreSandboxManager* sm = runtime_get_sandbox_manager();
+
       const char* current = reinterpret_cast<const char*>(ptr);
-      int64 blockCount = count / WRITE_BLOCK_SIZE;
-      for (int64 i = 0; i < blockCount; i++) {
-         fwrite(current, WRITE_BLOCK_SIZE, 1, stdout);
-         current = (current + WRITE_BLOCK_SIZE);
-         count -= WRITE_BLOCK_SIZE;
+      int64 remaining = count;
+
+      while (remaining > 0) {
+         // Check for interrupt
+         if (sm && sm->checkIOInterrupt(xsink, "stdout write")) {
+            return;
+         }
+
+         // Write in blocks
+         size_t to_write = remaining > WRITE_BLOCK_SIZE ? WRITE_BLOCK_SIZE : remaining;
+         ssize_t written = ::write(STDOUT_FILENO, current, to_write);
+
+         if (written < 0) {
+            if (errno == EINTR) {
+               continue;
+            }
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+               // Would block - poll for write readiness
+               if (sm) {
+                  const int poll_ms = QORE_IO_POLL_INTERVAL_MS;
+                  struct pollfd pfd;
+                  pfd.fd = STDOUT_FILENO;
+                  pfd.events = POLLOUT;
+                  poll(&pfd, 1, poll_ms);
+               }
+               continue;
+            }
+            xsink->raiseErrnoException("STDOUT-WRITE-ERROR", errno, "error writing to stdout");
+            return;
+         }
+
+         current += written;
+         remaining -= written;
       }
-      fwrite(ptr, count, 1, stdout);
    }
 private:
    static const int WRITE_BLOCK_SIZE = 1024;

--- a/include/qore/intern/StdoutOutputStream.h
+++ b/include/qore/intern/StdoutOutputStream.h
@@ -87,12 +87,35 @@ public:
             }
             if (errno == EAGAIN || errno == EWOULDBLOCK) {
                // Would block - poll for write readiness
-               if (sm) {
-                  const int poll_ms = QORE_IO_POLL_INTERVAL_MS;
-                  struct pollfd pfd;
-                  pfd.fd = STDOUT_FILENO;
-                  pfd.events = POLLOUT;
-                  poll(&pfd, 1, poll_ms);
+               const int poll_ms = QORE_IO_POLL_INTERVAL_MS;
+               struct pollfd pfd;
+               pfd.fd = STDOUT_FILENO;
+               pfd.events = POLLOUT;
+
+               while (true) {
+                  int pret = ::poll(&pfd, 1, poll_ms);
+                  if (pret > 0) {
+                     // Ready for writing
+                     break;
+                  }
+                  if (pret == 0) {
+                     // Timeout - check for interrupt and retry
+                     if (sm && sm->checkIOInterrupt(xsink, "stdout write")) {
+                        return;
+                     }
+                     break;
+                  }
+                  // pret < 0: error
+                  if (errno == EINTR) {
+                     // Interrupted by signal - check for sandbox interrupt then retry poll
+                     if (sm && sm->checkIOInterrupt(xsink, "stdout write")) {
+                        return;
+                     }
+                     continue;
+                  }
+                  xsink->raiseErrnoException("STDOUT-WRITE-ERROR", errno,
+                     "error polling stdout for write readiness");
+                  return;
                }
                continue;
             }

--- a/include/qore/intern/qore_qf_private.h
+++ b/include/qore/intern/qore_qf_private.h
@@ -39,6 +39,7 @@
 
 #include "qore/intern/StringReaderHelper.h"
 #include "qore/AbstractPollState.h"
+#include <qore/QoreSandboxManager.h>
 
 #include <cerrno>
 #include <cstdio>
@@ -372,22 +373,45 @@ struct qore_qf_private {
         // must be called with the lock held
         assert(m.trylock());
 
-        ssize_t rc;
-        while (true) {
-            rc = ::write(fd, buf, len);
-            // try again if we are interrupted by a signal
-            if (rc >= 0 || errno != EINTR)
+        // Check for sandbox interrupt support
+        QoreSandboxManager* sm = runtime_get_sandbox_manager();
+
+        const char* ptr = static_cast<const char*>(buf);
+        size_t remaining = len;
+        size_t total_written = 0;
+
+        while (remaining > 0) {
+            // Check for interrupt
+            if (sm && xsink && sm->checkIOInterrupt(xsink, "file write")) {
+                return -1;
+            }
+
+            ssize_t rc;
+            while (true) {
+                rc = ::write(fd, ptr, remaining);
+                // try again if we are interrupted by a signal
+                if (rc >= 0 || errno != EINTR)
+                    break;
+            }
+
+            if (rc > 0) {
+                ptr += rc;
+                remaining -= rc;
+                total_written += rc;
+                do_write_event_unlocked(rc, total_written, len);
+            } else if (rc < 0) {
+                if (xsink) {
+                    xsink->raiseErrnoException("FILE-WRITE-ERROR", errno, "failed writing " QSD " byte%s to File", len,
+                        len == 1 ? "" : "s");
+                }
+                return rc;
+            } else {
+                // rc == 0, nothing written but no error
                 break;
+            }
         }
 
-        if (rc > 0) {
-            do_write_event_unlocked(rc, rc, len);
-        } else if (xsink && rc < 0) {
-            xsink->raiseErrnoException("FILE-WRITE-ERROR", errno, "failed writing " QSD " byte%s to File", len,
-                len == 1 ? "" : "s");
-        }
-
-        return rc;
+        return total_written;
     }
 
     // private function, unlocked
@@ -441,12 +465,43 @@ struct qore_qf_private {
         char* buf = (char* )malloc(sizeof(char) * bs);
         char* bbuf = 0;
 
+        // Check for sandbox interrupt support
+        QoreSandboxManager* sm = runtime_get_sandbox_manager();
+        const int poll_interval = QORE_IO_POLL_INTERVAL_MS;
+
         while (true) {
-            // wait for data
-            if (timeout_ms >= 0 && !isDataAvailableIntern(timeout_ms, mname, xsink)) {
-                if (!*xsink)
-                    xsink->raiseException("FILE-READ-TIMEOUT", "timeout limit exceeded (%d ms) reading file block in "
-                        "ReadOnlyFile::%s()", timeout_ms, mname);
+            // Check for interrupt
+            if (sm && sm->checkIOInterrupt(xsink, "file read")) {
+                br = 0;
+                break;
+            }
+
+            // wait for data with polling for interruptibility
+            int effective_timeout = timeout_ms;
+            if (sm && (timeout_ms < 0 || timeout_ms > poll_interval)) {
+                effective_timeout = poll_interval;
+            }
+
+            if (effective_timeout >= 0 && !isDataAvailableIntern(effective_timeout, mname, xsink)) {
+                if (*xsink) {
+                    br = 0;
+                    break;
+                }
+                // If we used a smaller timeout for polling, continue if not timed out yet
+                if (sm && timeout_ms != effective_timeout) {
+                    if (timeout_ms > 0) {
+                        timeout_ms -= effective_timeout;
+                        if (timeout_ms <= 0) {
+                            xsink->raiseException("FILE-READ-TIMEOUT", "timeout limit exceeded reading file block in "
+                                "ReadOnlyFile::%s()", mname);
+                            br = 0;
+                            break;
+                        }
+                    }
+                    continue;  // Continue polling
+                }
+                xsink->raiseException("FILE-READ-TIMEOUT", "timeout limit exceeded (%d ms) reading file block in "
+                    "ReadOnlyFile::%s()", timeout_ms, mname);
                 br = 0;
                 break;
             }
@@ -505,7 +560,7 @@ struct qore_qf_private {
         return rc == -1 ? 0 : str.release();
     }
 
-    DLLLOCAL int readLine(QoreString& str, bool incl_eol = true) {
+    DLLLOCAL int readLine(QoreString& str, bool incl_eol = true, ExceptionSink* xsink = nullptr) {
         str.clear();
 
         AutoLocker al(m);
@@ -516,9 +571,22 @@ struct qore_qf_private {
 
         bool tty = (bool)isatty(fd);
 
+        // Check for sandbox interrupt support
+        QoreSandboxManager* sm = runtime_get_sandbox_manager();
+
         int ch, rc = -1;
+        int char_count = 0;
+        const int check_interval = 100;  // Check interrupt every 100 characters
 
         while ((ch = readChar()) >= 0) {
+            // Check for interrupt periodically
+            if (sm && xsink && ++char_count >= check_interval) {
+                char_count = 0;
+                if (sm->checkIOInterrupt(xsink, "file readLine")) {
+                    return -1;
+                }
+            }
+
             str.concat((char)ch);
             if (rc == -1)
                 rc = 0;
@@ -552,7 +620,7 @@ struct qore_qf_private {
         return rc;
     }
 
-    DLLLOCAL int readUntil(char byte, QoreString& str, bool incl_byte = true) {
+    DLLLOCAL int readUntil(char byte, QoreString& str, bool incl_byte = true, ExceptionSink* xsink = nullptr) {
         str.clear();
 
         AutoLocker al(m);
@@ -561,9 +629,22 @@ struct qore_qf_private {
         if (!is_open)
             return -2;
 
+        // Check for sandbox interrupt support
+        QoreSandboxManager* sm = runtime_get_sandbox_manager();
+
         int ch, rc = -1;
+        int char_count = 0;
+        const int check_interval = 100;  // Check interrupt every 100 characters
 
         while ((ch = readChar()) >= 0) {
+            // Check for interrupt periodically
+            if (sm && xsink && ++char_count >= check_interval) {
+                char_count = 0;
+                if (sm->checkIOInterrupt(xsink, "file readUntil")) {
+                    return -1;
+                }
+            }
+
             char c = ch;
             str.concat(c);
             if (rc == -1)
@@ -745,9 +826,9 @@ struct qore_qf_private {
     }
 
     // not the most efficient search algorithm, restarts the search the byte after it fails for multi-byte patterns
-    DLLLOCAL int readUntil(const char* bytes, QoreString& str, bool incl_bytes) {
+    DLLLOCAL int readUntil(const char* bytes, QoreString& str, bool incl_bytes, ExceptionSink* xsink = nullptr) {
         if (!bytes[1])
-            return readUntil(bytes[0], str, incl_bytes);
+            return readUntil(bytes[0], str, incl_bytes, xsink);
 
         str.clear();
 
@@ -757,12 +838,25 @@ struct qore_qf_private {
         if (!is_open)
             return -2;
 
+        // Check for sandbox interrupt support
+        QoreSandboxManager* sm = runtime_get_sandbox_manager();
+
         // offset in bytes
         unsigned pos = 0;
 
         int ch, rc = -1;
+        int char_count = 0;
+        const int check_interval = 100;  // Check interrupt every 100 characters
 
         while ((ch = readChar()) >= 0) {
+            // Check for interrupt periodically
+            if (sm && xsink && ++char_count >= check_interval) {
+                char_count = 0;
+                if (sm->checkIOInterrupt(xsink, "file readUntil")) {
+                    return -1;
+                }
+            }
+
             char c = ch;
             str.concat(c);
             if (rc == -1)

--- a/lib/ManagedDatasource.cpp
+++ b/lib/ManagedDatasource.cpp
@@ -29,6 +29,7 @@
 */
 
 #include <qore/Qore.h>
+#include <qore/QoreSandboxManager.h>
 #include "qore/intern/ManagedDatasource.h"
 #include "qore/intern/qore_ds_private.h"
 
@@ -99,25 +100,61 @@ void ManagedDatasource::deref() {
 #endif
 }
 
-int ManagedDatasource::grabLockIntern() {
+int ManagedDatasource::grabLockIntern(ExceptionSink* xsink) {
     int ctid = q_gettid();
 
     if (tid == ctid)
         return 0;
 
+    // Check for sandbox interrupt support
+    QoreSandboxManager* sm = runtime_get_sandbox_manager();
+    const int poll_interval = QORE_IO_POLL_INTERVAL_MS;
+    int64 remaining_timeout = tl_timeout_ms;
+
     while (tid != -1) {
+        // Check for interrupt
+        if (sm && xsink && sm->checkIOInterrupt(xsink, "datasource lock acquisition")) {
+            return -2;  // -2 indicates interrupt
+        }
+
         ++waiting;
-        if (tl_timeout_ms) {
-            int rc = cond.wait(&ds_lock, tl_timeout_ms);
+        if (tl_timeout_ms || sm) {
+            // Use smaller timeout for interrupt checking when sandbox manager exists
+            int effective_timeout;
+            if (sm) {
+                if (tl_timeout_ms == 0) {
+                    effective_timeout = poll_interval;
+                } else {
+                    effective_timeout = remaining_timeout > poll_interval ? poll_interval : remaining_timeout;
+                }
+            } else {
+                effective_timeout = tl_timeout_ms;
+            }
+
+            int rc = cond.wait(&ds_lock, effective_timeout);
             --waiting;
             if (!rc)
                 continue;
-            printd(5, "ManagedDatasource::grabLockIntern() this=%p timed out after %dms waiting for tid %d to release lock\n", this, tl_timeout_ms, tid);
-            return -1;
+
+            // Timeout occurred
+            if (sm && tl_timeout_ms > 0) {
+                remaining_timeout -= effective_timeout;
+                if (remaining_timeout <= 0) {
+                    printd(5, "ManagedDatasource::grabLockIntern() this=%p timed out after %dms waiting for tid %d to release lock\n", this, tl_timeout_ms, tid);
+                    return -1;
+                }
+            } else if (sm) {
+                // Infinite timeout with sandbox manager - continue polling
+                continue;
+            } else {
+                printd(5, "ManagedDatasource::grabLockIntern() this=%p timed out after %dms waiting for tid %d to release lock\n", this, tl_timeout_ms, tid);
+                return -1;
+            }
         }
-        else
+        else {
             cond.wait(&ds_lock);
-        --waiting;
+            --waiting;
+        }
     }
 
     tid = ctid;
@@ -126,14 +163,19 @@ int ManagedDatasource::grabLockIntern() {
 }
 
 int ManagedDatasource::grabLock(ExceptionSink *xsink) {
-    if (grabLockIntern() < 0) {
+    int rc = grabLockIntern(xsink);
+    if (rc < 0) {
         endDBActionIntern();
-        const char *un = getUsername();
-        const char *db = getDBName();
-        xsink->raiseException("TRANSACTION-LOCK-TIMEOUT", "%s:%s@%s: TID %d timed out on datasource '%s@%s' after waiting %d millisecond%s on transaction lock held by TID %d",
-                                getDriverName(), getUsernameStr().c_str(), getDBNameStr().c_str(),
-                                q_gettid(), un ? un : "<n/a>", db ? db : "<n/a>", tl_timeout_ms,
-                                tl_timeout_ms == 1 ? "" : "s", tid);
+        if (rc == -1) {
+            // Timeout
+            const char *un = getUsername();
+            const char *db = getDBName();
+            xsink->raiseException("TRANSACTION-LOCK-TIMEOUT", "%s:%s@%s: TID %d timed out on datasource '%s@%s' after waiting %d millisecond%s on transaction lock held by TID %d",
+                                    getDriverName(), getUsernameStr().c_str(), getDBNameStr().c_str(),
+                                    q_gettid(), un ? un : "<n/a>", db ? db : "<n/a>", tl_timeout_ms,
+                                    tl_timeout_ms == 1 ? "" : "s", tid);
+        }
+        // rc == -2 means interrupt, exception already raised by checkIOInterrupt
         return -1;
     }
     return 0;

--- a/lib/ManagedDatasource.cpp
+++ b/lib/ManagedDatasource.cpp
@@ -118,16 +118,15 @@ int ManagedDatasource::grabLockIntern(ExceptionSink* xsink) {
         }
 
         ++waiting;
-        if (tl_timeout_ms || sm) {
-            // Use smaller timeout for interrupt checking when sandbox manager exists
+        if (tl_timeout_ms > 0 || (tl_timeout_ms < 0 && sm)) {
+            // Positive timeout or infinite timeout with sandbox manager: use polling
             int effective_timeout;
             if (sm) {
-                if (tl_timeout_ms == 0) {
-                    effective_timeout = poll_interval;
-                } else {
-                    effective_timeout = remaining_timeout > poll_interval ? poll_interval : remaining_timeout;
-                }
+                // With sandbox manager, poll at intervals for interrupt checking
+                effective_timeout = (tl_timeout_ms < 0 || remaining_timeout > poll_interval)
+                    ? poll_interval : remaining_timeout;
             } else {
+                // No sandbox manager: use full timeout
                 effective_timeout = tl_timeout_ms;
             }
 
@@ -143,15 +142,20 @@ int ManagedDatasource::grabLockIntern(ExceptionSink* xsink) {
                     printd(5, "ManagedDatasource::grabLockIntern() this=%p timed out after %dms waiting for tid %d to release lock\n", this, tl_timeout_ms, tid);
                     return -1;
                 }
-            } else if (sm) {
+            } else if (sm && tl_timeout_ms < 0) {
                 // Infinite timeout with sandbox manager - continue polling
                 continue;
             } else {
                 printd(5, "ManagedDatasource::grabLockIntern() this=%p timed out after %dms waiting for tid %d to release lock\n", this, tl_timeout_ms, tid);
                 return -1;
             }
-        }
-        else {
+        } else if (tl_timeout_ms == 0) {
+            // Zero timeout means try once without waiting - fail immediately if lock not available
+            printd(5, "ManagedDatasource::grabLockIntern() this=%p lock not available (tl_timeout_ms=0), tid %d holds lock\n", this, tid);
+            --waiting;
+            return -1;
+        } else {
+            // Infinite timeout without sandbox manager
             cond.wait(&ds_lock);
             --waiting;
         }

--- a/lib/QoreCondition.cpp
+++ b/lib/QoreCondition.cpp
@@ -176,6 +176,13 @@ int QoreCondition::waitWithInterrupt(pthread_mutex_t* m, int64 timeout_ms, Excep
             return QORE_COND_RESULT_SUCCESS;
         }
 
+        // Check if it was actually a timeout (ETIMEDOUT) vs other errors
+        if (rc != ETIMEDOUT) {
+            // Non-timeout error (e.g., EINVAL) - this shouldn't happen normally
+            // but if it does, treat it as an error and return timeout to avoid infinite loop
+            return QORE_COND_RESULT_TIMEOUT;
+        }
+
         // Timeout occurred - check for interrupt
         if (sm->isInterruptRequested()) {
             if (xsink) {

--- a/lib/QoreCondition.cpp
+++ b/lib/QoreCondition.cpp
@@ -30,6 +30,7 @@
 
 #include <qore/Qore.h>
 #include <qore/QoreCondition.h>
+#include <qore/QoreSandboxManager.h>
 
 #include <cerrno>
 #include <cstring>
@@ -129,4 +130,67 @@ int QoreCondition::wait2(pthread_mutex_t* m, int64 timeout_ms) {
     return rc;
 #endif // DEBUG
 #endif // DARWIN
+}
+
+int QoreCondition::waitWithInterrupt(pthread_mutex_t* m, ExceptionSink* xsink) {
+    return waitWithInterrupt(m, -1, xsink);
+}
+
+int QoreCondition::waitWithInterrupt(pthread_mutex_t* m, int64 timeout_ms, ExceptionSink* xsink) {
+    // Check for sandbox interrupt support
+    QoreSandboxManager* sm = runtime_get_sandbox_manager();
+
+    // If no sandbox manager, use regular wait
+    if (!sm) {
+        int rc = (timeout_ms < 0) ? wait(m) : wait2(m, timeout_ms);
+        return rc ? QORE_COND_RESULT_TIMEOUT : QORE_COND_RESULT_SUCCESS;
+    }
+
+    // Check for interrupt before waiting
+    if (sm->isInterruptRequested()) {
+        if (xsink) {
+            xsink->raiseException("PROGRAM-INTERRUPTED", "condition wait interrupted");
+        }
+        return QORE_COND_RESULT_INTERRUPTED;
+    }
+
+    const int poll_interval = QORE_IO_POLL_INTERVAL_MS;
+    int64 remaining_timeout = timeout_ms;
+
+    while (true) {
+        // Calculate effective timeout for this poll cycle
+        int effective_timeout;
+        if (timeout_ms < 0) {
+            // Infinite timeout - poll at intervals
+            effective_timeout = poll_interval;
+        } else {
+            // Finite timeout - use smaller of remaining or poll interval
+            effective_timeout = remaining_timeout > poll_interval ? poll_interval : remaining_timeout;
+        }
+
+        // Wait for the effective timeout
+        int rc = wait2(m, effective_timeout);
+
+        if (rc == 0) {
+            // Condition was signaled
+            return QORE_COND_RESULT_SUCCESS;
+        }
+
+        // Timeout occurred - check for interrupt
+        if (sm->isInterruptRequested()) {
+            if (xsink) {
+                xsink->raiseException("PROGRAM-INTERRUPTED", "condition wait interrupted");
+            }
+            return QORE_COND_RESULT_INTERRUPTED;
+        }
+
+        // Check if we've exceeded the total timeout
+        if (timeout_ms >= 0) {
+            remaining_timeout -= effective_timeout;
+            if (remaining_timeout <= 0) {
+                return QORE_COND_RESULT_TIMEOUT;
+            }
+        }
+        // For infinite timeout, continue polling
+    }
 }

--- a/lib/QoreCounter.cpp
+++ b/lib/QoreCounter.cpp
@@ -30,6 +30,9 @@
 
 #include <qore/Qore.h>
 #include <qore/QoreCounter.h>
+#include <qore/QoreCondition.h>
+
+#include <cerrno>
 
 struct qore_counter_private {
     enum cond_status_e { Cond_Deleted = -1 };
@@ -92,9 +95,20 @@ struct qore_counter_private {
         ++waiting;
         while (cnt && cnt != Cond_Deleted) {
             if (!timeout_ms) {
-                cond.wait(&l);
+                // Use interruptible wait for sandbox support
+                rc = cond.waitWithInterrupt(&l, xsink);
+                if (rc == QORE_COND_RESULT_INTERRUPTED) {
+                    --waiting;
+                    return -1;  // Exception already raised
+                }
             } else {
-                if ((rc = cond.wait(&l, timeout_ms))) {
+                // Use interruptible wait with timeout for sandbox support
+                rc = cond.waitWithInterrupt(&l, timeout_ms, xsink);
+                if (rc == QORE_COND_RESULT_INTERRUPTED) {
+                    --waiting;
+                    return -1;  // Exception already raised
+                }
+                if (rc == QORE_COND_RESULT_TIMEOUT) {
                     break;
                 }
             }
@@ -105,7 +119,7 @@ struct qore_counter_private {
                 "another thread while waiting %p", this);
             return -1;
         }
-        return rc;
+        return rc == QORE_COND_RESULT_TIMEOUT ? ETIMEDOUT : 0;
     }
 
     DLLLOCAL void waitForZero() {

--- a/lib/QoreFile.cpp
+++ b/lib/QoreFile.cpp
@@ -307,6 +307,48 @@ int QoreFile::lockBlocking(struct flock& fl, ExceptionSink* xsink) {
         return -1;
     }
 
+    // Check for sandbox interrupt support
+    QoreSandboxManager* sm = runtime_get_sandbox_manager();
+    if (sm) {
+        // Use polling with interrupt checks
+        const int poll_ms = QORE_IO_POLL_INTERVAL_MS;
+
+        while (true) {
+            // Check for interrupt
+            if (sm->checkIOInterrupt(xsink, "file lock")) {
+                return -1;
+            }
+
+            // Try non-blocking lock
+            int rc = fcntl(priv->fd, F_SETLK, &fl);
+            if (rc == 0) {
+                return 0;  // Lock acquired
+            }
+
+            // If lock is held by another process, wait and retry
+            if (rc == -1 && (errno == EACCES || errno == EAGAIN)) {
+                // Sleep for poll interval before retrying
+                struct timespec ts;
+                ts.tv_sec = poll_ms / 1000;
+                ts.tv_nsec = (poll_ms % 1000) * 1000000;
+                nanosleep(&ts, nullptr);
+                continue;
+            }
+
+            // Handle EINTR
+            if (rc == -1 && errno == EINTR) {
+                continue;
+            }
+
+            // Other errors
+            if (rc == -1) {
+                xsink->raiseErrnoException("FILE-LOCK-ERROR", errno, "the call to fcntl(F_SETLK) failed");
+                return -1;
+            }
+        }
+    }
+
+    // No sandbox manager - use blocking call
     int rc;
     while (true) {
         rc = fcntl(priv->fd, F_SETLKW, &fl);

--- a/lib/QoreQueue.cpp
+++ b/lib/QoreQueue.cpp
@@ -87,7 +87,9 @@ int qore_queue_private::waitReadIntern(ExceptionSink *xsink, int timeout_ms) {
         if (timeout_ms >= 0) {
             ++read_waiting;
             // Use interruptible wait for sandbox support
-            rc = read_cond.waitWithInterrupt(l, timeout_ms, xsink);
+            // Queue semantics: 0 = infinite wait, but waitWithInterrupt uses -1 for infinite
+            int64 cond_timeout = (timeout_ms == 0) ? -1 : timeout_ms;
+            rc = read_cond.waitWithInterrupt(l, cond_timeout, xsink);
             --read_waiting;
             // Check for interrupt
             if (rc == QORE_COND_RESULT_INTERRUPTED) {
@@ -134,7 +136,9 @@ int qore_queue_private::waitWriteIntern(ExceptionSink *xsink, int timeout_ms) {
         if (timeout_ms >= 0) {
             ++write_waiting;
             // Use interruptible wait for sandbox support
-            rc = write_cond.waitWithInterrupt(l, timeout_ms, xsink);
+            // Queue semantics: 0 = infinite wait, but waitWithInterrupt uses -1 for infinite
+            int64 cond_timeout = (timeout_ms == 0) ? -1 : timeout_ms;
+            rc = write_cond.waitWithInterrupt(l, cond_timeout, xsink);
             --write_waiting;
             // Check for interrupt
             if (rc == QORE_COND_RESULT_INTERRUPTED) {

--- a/lib/QoreQueue.cpp
+++ b/lib/QoreQueue.cpp
@@ -86,20 +86,24 @@ int qore_queue_private::waitReadIntern(ExceptionSink *xsink, int timeout_ms) {
         // issue #4077: do not call QoreCondition::wait() with a negative timeout value
         if (timeout_ms >= 0) {
             ++read_waiting;
-            rc = timeout_ms ? read_cond.wait(l, timeout_ms) : read_cond.wait(l);
+            // Use interruptible wait for sandbox support
+            rc = read_cond.waitWithInterrupt(l, timeout_ms, xsink);
             --read_waiting;
+            // Check for interrupt
+            if (rc == QORE_COND_RESULT_INTERRUPTED) {
+                return QW_ERROR;  // Exception already raised
+            }
         } else {
-            rc = ETIMEDOUT;
+            rc = QORE_COND_RESULT_TIMEOUT;
         }
 
-        if (rc) {
+        if (rc == QORE_COND_RESULT_TIMEOUT) {
 #ifdef DEBUG
             // if an error has occurred, then it must be due to a timeout
             if (!timeout_ms)
                 printd(0, "qore_queue_private::waitReadIntern(timeout_ms=0) this: %p pthread_cond_wait() returned rc: %d\n", this, rc);
 #endif
             assert(timeout_ms);
-            assert(rc == ETIMEDOUT);
             return QW_TIMEOUT;
         }
 
@@ -129,20 +133,24 @@ int qore_queue_private::waitWriteIntern(ExceptionSink *xsink, int timeout_ms) {
         // issue #4077: do not call QoreCondition::wait() with a negative timeout value
         if (timeout_ms >= 0) {
             ++write_waiting;
-            rc = timeout_ms ? write_cond.wait(l, timeout_ms) : write_cond.wait(l);
+            // Use interruptible wait for sandbox support
+            rc = write_cond.waitWithInterrupt(l, timeout_ms, xsink);
             --write_waiting;
+            // Check for interrupt
+            if (rc == QORE_COND_RESULT_INTERRUPTED) {
+                return QW_ERROR;  // Exception already raised
+            }
         } else {
-            rc = ETIMEDOUT;
+            rc = QORE_COND_RESULT_TIMEOUT;
         }
 
-        if (rc) {
+        if (rc == QORE_COND_RESULT_TIMEOUT) {
 #ifdef DEBUG
             // if an error has occurred, then it must be due to a timeout
             if (!timeout_ms)
                 printd(0, "qore_queue_private::waitWriteIntern(timeout_ms=0) this: %p pthread_cond_wait() returned rc: %d\n", this, rc);
 #endif
             assert(timeout_ms);
-            assert(rc == ETIMEDOUT);
             return QW_TIMEOUT;
         }
 

--- a/lib/QoreSandboxManager.cpp
+++ b/lib/QoreSandboxManager.cpp
@@ -819,6 +819,15 @@ bool QoreSandboxManager::isInterruptRequested() const {
     return interrupt_requested.load(std::memory_order_acquire);
 }
 
+bool QoreSandboxManager::checkIOInterrupt(ExceptionSink* xsink, const char* operation) const {
+    if (interrupt_requested.load(std::memory_order_acquire)) {
+        xsink->raiseException("PROGRAM-INTERRUPTED",
+            "program execution was interrupted during %s", operation);
+        return true;
+    }
+    return false;
+}
+
 QoreHashNode* QoreSandboxManager::getConfiguration() const {
     ReferenceHolder<QoreHashNode> config(new QoreHashNode(autoTypeInfo), nullptr);
 
@@ -908,4 +917,12 @@ QoreSandboxManager* QoreSandboxManager::createWebSafe() {
 QoreSandboxManager* runtime_get_sandbox_manager() {
     QoreProgram* pgm = getProgram();
     return pgm ? pgm->getSandboxManager() : nullptr;
+}
+
+bool qore_check_io_interrupt(ExceptionSink* xsink, const char* operation) {
+    QoreSandboxManager* sm = runtime_get_sandbox_manager();
+    if (sm) {
+        return sm->checkIOInterrupt(xsink, operation);
+    }
+    return false;
 }

--- a/lib/StreamPipe.cpp
+++ b/lib/StreamPipe.cpp
@@ -29,6 +29,7 @@
     information.
 */
 #include <qore/Qore.h>
+#include <qore/QoreSandboxManager.h>
 #include "qore/intern/StreamPipe.h"
 
 StreamPipe::StreamPipe(bool syncClose, int64 timeout, int64 bufferSize, ExceptionSink *xsink)
@@ -73,8 +74,18 @@ int64 PipeInputStream::read(void *ptr, int64 limit, ExceptionSink *xsink) {
     printd(1, "PipeInputStream::read()\n");
     AutoLocker lock(pipe->mutex);
 
+    // Check for sandbox interrupt support
+    QoreSandboxManager* sm = runtime_get_sandbox_manager();
+    const int poll_interval = QORE_IO_POLL_INTERVAL_MS;
+
     printd(1, "read - lock acquired, limit: " QLLD "\n", limit);
+    int64 remaining_timeout = pipe->timeout;
     while (true) {
+        // Check for interrupt
+        if (sm && sm->checkIOInterrupt(xsink, "pipe read")) {
+            return 0;
+        }
+
         if (pipe->exception) {
             pipe->rethrow(xsink);
             return 0;
@@ -95,12 +106,37 @@ int64 PipeInputStream::read(void *ptr, int64 limit, ExceptionSink *xsink) {
         }
 
         printd(1, "read - buffer empty, before wait\n");
-        int rc = pipe->timeout < 0 ? pipe->readCondVar.wait(pipe->mutex) : pipe->readCondVar.wait2(pipe->mutex,
-            pipe->timeout);
+        // Use smaller timeout for interrupt checking when sandbox manager exists
+        int effective_timeout;
+        if (sm) {
+            if (pipe->timeout < 0) {
+                effective_timeout = poll_interval;
+            } else {
+                effective_timeout = remaining_timeout > poll_interval ? poll_interval : remaining_timeout;
+            }
+        } else {
+            effective_timeout = pipe->timeout;
+        }
+
+        int rc = effective_timeout < 0 ? pipe->readCondVar.wait(pipe->mutex)
+                                        : pipe->readCondVar.wait2(pipe->mutex, effective_timeout);
         printd(1, "read - buffer empty, after wait, rc: %d\n", rc);
+
         if (rc != 0) {
-            xsink->raiseException("TIMEOUT-ERROR", "operation timed out");
-            return 0;
+            // Timeout occurred
+            if (sm && pipe->timeout >= 0) {
+                remaining_timeout -= effective_timeout;
+                if (remaining_timeout <= 0) {
+                    xsink->raiseException("TIMEOUT-ERROR", "operation timed out");
+                    return 0;
+                }
+            } else if (sm) {
+                // Infinite timeout with sandbox manager - continue polling
+                continue;
+            } else {
+                xsink->raiseException("TIMEOUT-ERROR", "operation timed out");
+                return 0;
+            }
         }
     }
 
@@ -127,8 +163,18 @@ int64 PipeInputStream::peek(ExceptionSink *xsink) {
     printd(1, "PipeInputStream::peek()\n");
     AutoLocker lock(pipe->mutex);
 
+    // Check for sandbox interrupt support
+    QoreSandboxManager* sm = runtime_get_sandbox_manager();
+    const int poll_interval = QORE_IO_POLL_INTERVAL_MS;
+
     printd(1, "peek - lock acquired\n");
+    int64 remaining_timeout = pipe->timeout;
     while (true) {
+        // Check for interrupt
+        if (sm && sm->checkIOInterrupt(xsink, "pipe peek")) {
+            return -2;
+        }
+
         if (pipe->exception) {
             pipe->rethrow(xsink);
             return -2;
@@ -148,12 +194,36 @@ int64 PipeInputStream::peek(ExceptionSink *xsink) {
         }
 
         printd(1, "peek - buffer empty, before wait\n");
-        int rc = pipe->timeout < 0 ? pipe->readCondVar.wait(pipe->mutex) : pipe->readCondVar.wait2(pipe->mutex,
-            pipe->timeout);
+        // Use smaller timeout for interrupt checking when sandbox manager exists
+        int effective_timeout;
+        if (sm) {
+            if (pipe->timeout < 0) {
+                effective_timeout = poll_interval;
+            } else {
+                effective_timeout = remaining_timeout > poll_interval ? poll_interval : remaining_timeout;
+            }
+        } else {
+            effective_timeout = pipe->timeout;
+        }
+
+        int rc = effective_timeout < 0 ? pipe->readCondVar.wait(pipe->mutex)
+                                        : pipe->readCondVar.wait2(pipe->mutex, effective_timeout);
         printd(1, "peek - buffer empty, after wait, rc: %d\n", rc);
         if (rc != 0) {
-            xsink->raiseException("TIMEOUT-ERROR", "operation timed out");
-            return -2;
+            // Timeout occurred
+            if (sm && pipe->timeout >= 0) {
+                remaining_timeout -= effective_timeout;
+                if (remaining_timeout <= 0) {
+                    xsink->raiseException("TIMEOUT-ERROR", "operation timed out");
+                    return -2;
+                }
+            } else if (sm) {
+                // Infinite timeout with sandbox manager - continue polling
+                continue;
+            } else {
+                xsink->raiseException("TIMEOUT-ERROR", "operation timed out");
+                return -2;
+            }
         }
     }
 
@@ -172,6 +242,11 @@ PipeOutputStream::~PipeOutputStream() {
 void PipeOutputStream::close(ExceptionSink* xsink) {
     printd(1, "PipeOutputStream::close()\n");
     AutoLocker lock(pipe->mutex);
+
+    // Check for sandbox interrupt support
+    QoreSandboxManager* sm = runtime_get_sandbox_manager();
+    const int poll_interval = QORE_IO_POLL_INTERVAL_MS;
+
     if (pipe->outputClosed) {
         xsink->raiseException("OUTPUT-STREAM-CLOSED-ERROR", "this PipeOutputStream object has been already closed");
         return;
@@ -180,15 +255,47 @@ void PipeOutputStream::close(ExceptionSink* xsink) {
     pipe->readCondVar.broadcast();
     pipe->writeCondVar.broadcast();
 
+    int64 remaining_timeout = pipe->timeout;
     while (!pipe->closeFinished) {
+        // Check for interrupt
+        if (sm && sm->checkIOInterrupt(xsink, "pipe close")) {
+            return;
+        }
+
         if (pipe->exception) {
             pipe->rethrow(xsink);
             return;
         }
-        int rc = pipe->timeout < 0 ? pipe->writeCondVar.wait(pipe->mutex) : pipe->writeCondVar.wait2(pipe->mutex, pipe->timeout);
+
+        // Use smaller timeout for interrupt checking when sandbox manager exists
+        int effective_timeout;
+        if (sm) {
+            if (pipe->timeout < 0) {
+                effective_timeout = poll_interval;
+            } else {
+                effective_timeout = remaining_timeout > poll_interval ? poll_interval : remaining_timeout;
+            }
+        } else {
+            effective_timeout = pipe->timeout;
+        }
+
+        int rc = effective_timeout < 0 ? pipe->writeCondVar.wait(pipe->mutex)
+                                        : pipe->writeCondVar.wait2(pipe->mutex, effective_timeout);
         if (rc != 0) {
-            xsink->raiseException("TIMEOUT-ERROR", "operation timed out");
-            return;
+            // Timeout occurred
+            if (sm && pipe->timeout >= 0) {
+                remaining_timeout -= effective_timeout;
+                if (remaining_timeout <= 0) {
+                    xsink->raiseException("TIMEOUT-ERROR", "operation timed out");
+                    return;
+                }
+            } else if (sm) {
+                // Infinite timeout with sandbox manager - continue polling
+                continue;
+            } else {
+                xsink->raiseException("TIMEOUT-ERROR", "operation timed out");
+                return;
+            }
         }
     }
 }
@@ -198,9 +305,19 @@ void PipeOutputStream::write(const void *ptr, int64 toWrite, ExceptionSink *xsin
     printd(1, "PipeOutputStream::write()\n");
     AutoLocker lock(pipe->mutex);
 
+    // Check for sandbox interrupt support
+    QoreSandboxManager* sm = runtime_get_sandbox_manager();
+    const int poll_interval = QORE_IO_POLL_INTERVAL_MS;
+
     printd(1, "write - lock acquired, toWrite: " QLLD "\n", toWrite);
     const uint8_t *src = static_cast<const uint8_t *>(ptr);
+    int64 remaining_timeout = pipe->timeout;
     while (toWrite > 0) {
+        // Check for interrupt
+        if (sm && sm->checkIOInterrupt(xsink, "pipe write")) {
+            return;
+        }
+
         if (pipe->exception) {
             pipe->rethrow(xsink);
             return;
@@ -230,12 +347,36 @@ void PipeOutputStream::write(const void *ptr, int64 toWrite, ExceptionSink *xsin
             pipe->readCondVar.broadcast();
         } else {
             printd(1, "write - buffer full, before wait\n");
-            int rc = pipe->timeout < 0 ? pipe->writeCondVar.wait(pipe->mutex) : pipe->writeCondVar.wait2(pipe->mutex,
-                pipe->timeout);
+            // Use smaller timeout for interrupt checking when sandbox manager exists
+            int effective_timeout;
+            if (sm) {
+                if (pipe->timeout < 0) {
+                    effective_timeout = poll_interval;
+                } else {
+                    effective_timeout = remaining_timeout > poll_interval ? poll_interval : remaining_timeout;
+                }
+            } else {
+                effective_timeout = pipe->timeout;
+            }
+
+            int rc = effective_timeout < 0 ? pipe->writeCondVar.wait(pipe->mutex)
+                                            : pipe->writeCondVar.wait2(pipe->mutex, effective_timeout);
             printd(1, "write - buffer full, after wait, rc: %d\n", rc);
             if (rc != 0) {
-                xsink->raiseException("TIMEOUT-ERROR", "operation timed out");
-                return;
+                // Timeout occurred
+                if (sm && pipe->timeout >= 0) {
+                    remaining_timeout -= effective_timeout;
+                    if (remaining_timeout <= 0) {
+                        xsink->raiseException("TIMEOUT-ERROR", "operation timed out");
+                        return;
+                    }
+                } else if (sm) {
+                    // Infinite timeout with sandbox manager - continue polling
+                    continue;
+                } else {
+                    xsink->raiseException("TIMEOUT-ERROR", "operation timed out");
+                    return;
+                }
             }
         }
     }

--- a/modules/mongodb/CMakeLists.txt
+++ b/modules/mongodb/CMakeLists.txt
@@ -89,6 +89,7 @@ set(MONGODB_CPP_SRC
     src/MongoCollection.cpp
     src/MongoCursor.cpp
     src/ObjectId.cpp
+    src/QoreMongoStream.cpp
 )
 
 set(QORE_DOX_MONGODB_TMPL_SRC

--- a/modules/mongodb/src/QC_MongoClient.h
+++ b/modules/mongodb/src/QC_MongoClient.h
@@ -32,6 +32,8 @@
 
 #include <mongoc/mongoc.h>
 
+#include "QoreMongoStream.h"
+
 DLLEXPORT extern qore_classid_t CID_MONGOCLIENT;
 DLLLOCAL extern QoreClass* QC_MONGOCLIENT;
 
@@ -56,6 +58,8 @@ public:
             xsink->raiseException("MONGODB-CLIENT-ERROR", "failed to create MongoDB client");
             return;
         }
+        // Set up interruptible streams for sandbox support
+        qore_mongo_setup_interruptible_streams(client);
         // Set application name
         mongoc_client_set_appname(client, "qore-mongodb");
     }

--- a/modules/mongodb/src/QoreMongoStream.cpp
+++ b/modules/mongodb/src/QoreMongoStream.cpp
@@ -30,6 +30,7 @@
 #include <cerrno>
 #include <cstring>
 #include <netdb.h>
+#include <netinet/in.h>
 #include <sys/socket.h>
 
 //! Interruptible stream structure
@@ -269,6 +270,14 @@ mongoc_stream_t* qore_mongo_stream_initiator(
     void* user_data,
     bson_error_t* error) {
 
+    // Check for interrupt before starting connection
+    QoreSandboxManager* sm = runtime_get_sandbox_manager();
+    if (sm && sm->isInterruptRequested()) {
+        bson_set_error(error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT,
+            "MongoDB connection interrupted");
+        return nullptr;
+    }
+
     // Resolve the hostname
     struct addrinfo hints;
     struct addrinfo* result = nullptr;
@@ -293,6 +302,30 @@ mongoc_stream_t* qore_mongo_stream_initiator(
     struct addrinfo* rp;
 
     for (rp = result; rp != nullptr; rp = rp->ai_next) {
+        // Check for interrupt before each connection attempt
+        if (sm && sm->isInterruptRequested()) {
+            freeaddrinfo(result);
+            bson_set_error(error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT,
+                "MongoDB connection interrupted");
+            return nullptr;
+        }
+
+        // Check network access if sandbox manager is present
+        if (sm) {
+            ExceptionSink xsink;
+            if (!sm->checkNetworkAccess(rp->ai_addr, rp->ai_addrlen, IPPROTO_TCP, &xsink)) {
+                // Network access denied by sandbox
+                if (xsink) {
+                    freeaddrinfo(result);
+                    bson_set_error(error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT,
+                        "MongoDB connection denied by sandbox: network access restricted");
+                    return nullptr;
+                }
+                // Try next address
+                continue;
+            }
+        }
+
         sock = mongoc_socket_new(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
         if (!sock) {
             continue;
@@ -329,12 +362,28 @@ mongoc_stream_t* qore_mongo_stream_initiator(
 
     // Check if SSL/TLS is required
     if (mongoc_uri_get_tls(uri)) {
+        // Check for interrupt before TLS setup
+        if (sm && sm->isInterruptRequested()) {
+            mongoc_stream_destroy(base);
+            bson_set_error(error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT,
+                "MongoDB TLS setup interrupted");
+            return nullptr;
+        }
+
         // Use default SSL options (nullptr means use system defaults)
         mongoc_stream_t* tls_stream = mongoc_stream_tls_new_with_hostname(base, host->host, nullptr, 1);
         if (!tls_stream) {
             mongoc_stream_destroy(base);
             bson_set_error(error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET,
                 "Failed to create TLS stream for '%s:%u'", host->host, host->port);
+            return nullptr;
+        }
+
+        // Check for interrupt before TLS handshake
+        if (sm && sm->isInterruptRequested()) {
+            mongoc_stream_destroy(tls_stream);
+            bson_set_error(error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT,
+                "MongoDB TLS handshake interrupted");
             return nullptr;
         }
 

--- a/modules/mongodb/src/QoreMongoStream.cpp
+++ b/modules/mongodb/src/QoreMongoStream.cpp
@@ -1,0 +1,356 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QoreMongoStream.cpp
+
+    Qore mongodb module - Interruptible stream wrapper implementation
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "QoreMongoStream.h"
+
+#include <cerrno>
+#include <cstring>
+#include <netdb.h>
+#include <sys/socket.h>
+
+//! Interruptible stream structure
+/** This structure wraps the default MongoDB socket stream and adds
+    interrupt checking capability.
+*/
+typedef struct {
+    mongoc_stream_t vtable;     //!< Must be first - stream vtable
+    mongoc_stream_t* base;      //!< Wrapped base stream
+} qore_interruptible_stream_t;
+
+// Forward declarations for stream methods
+static void qore_stream_destroy(mongoc_stream_t* stream);
+static int qore_stream_close(mongoc_stream_t* stream);
+static int qore_stream_flush(mongoc_stream_t* stream);
+static ssize_t qore_stream_writev(mongoc_stream_t* stream, mongoc_iovec_t* iov, size_t iovcnt, int32_t timeout_msec);
+static ssize_t qore_stream_readv(mongoc_stream_t* stream, mongoc_iovec_t* iov, size_t iovcnt, size_t min_bytes, int32_t timeout_msec);
+static int qore_stream_setsockopt(mongoc_stream_t* stream, int level, int optname, void* optval, mongoc_socklen_t optlen);
+static mongoc_stream_t* qore_stream_get_base_stream(mongoc_stream_t* stream);
+static bool qore_stream_check_closed(mongoc_stream_t* stream);
+static ssize_t qore_stream_poll(mongoc_stream_poll_t* streams, size_t nstreams, int32_t timeout);
+static bool qore_stream_timed_out(mongoc_stream_t* stream);
+static bool qore_stream_should_retry(mongoc_stream_t* stream);
+
+//! Check if an interrupt has been requested
+/** @return true if interrupted, false otherwise
+*/
+static bool check_interrupt() {
+    QoreSandboxManager* sm = runtime_get_sandbox_manager();
+    if (sm && sm->isInterruptRequested()) {
+        errno = EINTR;
+        return true;
+    }
+    return false;
+}
+
+//! Destroy the interruptible stream
+static void qore_stream_destroy(mongoc_stream_t* stream) {
+    qore_interruptible_stream_t* s = (qore_interruptible_stream_t*)stream;
+    if (s->base) {
+        mongoc_stream_destroy(s->base);
+    }
+    bson_free(s);
+}
+
+//! Close the interruptible stream
+static int qore_stream_close(mongoc_stream_t* stream) {
+    qore_interruptible_stream_t* s = (qore_interruptible_stream_t*)stream;
+    return s->base ? mongoc_stream_close(s->base) : 0;
+}
+
+//! Flush the interruptible stream
+static int qore_stream_flush(mongoc_stream_t* stream) {
+    qore_interruptible_stream_t* s = (qore_interruptible_stream_t*)stream;
+    return s->base ? mongoc_stream_flush(s->base) : 0;
+}
+
+//! Write to the interruptible stream with interrupt checking
+static ssize_t qore_stream_writev(mongoc_stream_t* stream, mongoc_iovec_t* iov, size_t iovcnt, int32_t timeout_msec) {
+    qore_interruptible_stream_t* s = (qore_interruptible_stream_t*)stream;
+
+    // Check for interrupt before writing
+    if (check_interrupt()) {
+        return -1;
+    }
+
+    if (!s->base) {
+        errno = EBADF;
+        return -1;
+    }
+
+    // For short timeouts or no sandbox manager, use direct call
+    QoreSandboxManager* sm = runtime_get_sandbox_manager();
+    if (!sm || timeout_msec <= QORE_IO_POLL_INTERVAL_MS) {
+        return mongoc_stream_writev(s->base, iov, iovcnt, timeout_msec);
+    }
+
+    // Use polling with interrupt checking for long timeouts
+    int32_t remaining = timeout_msec;
+    while (remaining > 0) {
+        if (check_interrupt()) {
+            return -1;
+        }
+
+        int32_t chunk_timeout = remaining > QORE_IO_POLL_INTERVAL_MS ? QORE_IO_POLL_INTERVAL_MS : remaining;
+        ssize_t rv = mongoc_stream_writev(s->base, iov, iovcnt, chunk_timeout);
+
+        if (rv >= 0) {
+            return rv;
+        }
+
+        // Check if it was a timeout
+        if (errno != ETIMEDOUT && errno != EAGAIN && errno != EWOULDBLOCK) {
+            return rv;
+        }
+
+        remaining -= chunk_timeout;
+    }
+
+    errno = ETIMEDOUT;
+    return -1;
+}
+
+//! Read from the interruptible stream with interrupt checking
+static ssize_t qore_stream_readv(mongoc_stream_t* stream, mongoc_iovec_t* iov, size_t iovcnt, size_t min_bytes, int32_t timeout_msec) {
+    qore_interruptible_stream_t* s = (qore_interruptible_stream_t*)stream;
+
+    // Check for interrupt before reading
+    if (check_interrupt()) {
+        return -1;
+    }
+
+    if (!s->base) {
+        errno = EBADF;
+        return -1;
+    }
+
+    // For short timeouts or no sandbox manager, use direct call
+    QoreSandboxManager* sm = runtime_get_sandbox_manager();
+    if (!sm || timeout_msec <= QORE_IO_POLL_INTERVAL_MS) {
+        return mongoc_stream_readv(s->base, iov, iovcnt, min_bytes, timeout_msec);
+    }
+
+    // Use polling with interrupt checking for long timeouts
+    int32_t remaining = timeout_msec;
+    while (remaining > 0) {
+        if (check_interrupt()) {
+            return -1;
+        }
+
+        int32_t chunk_timeout = remaining > QORE_IO_POLL_INTERVAL_MS ? QORE_IO_POLL_INTERVAL_MS : remaining;
+        ssize_t rv = mongoc_stream_readv(s->base, iov, iovcnt, min_bytes, chunk_timeout);
+
+        if (rv >= 0) {
+            return rv;
+        }
+
+        // Check if it was a timeout
+        if (errno != ETIMEDOUT && errno != EAGAIN && errno != EWOULDBLOCK) {
+            return rv;
+        }
+
+        remaining -= chunk_timeout;
+    }
+
+    errno = ETIMEDOUT;
+    return -1;
+}
+
+//! Set socket option on the interruptible stream
+static int qore_stream_setsockopt(mongoc_stream_t* stream, int level, int optname, void* optval, mongoc_socklen_t optlen) {
+    qore_interruptible_stream_t* s = (qore_interruptible_stream_t*)stream;
+    return s->base ? mongoc_stream_setsockopt(s->base, level, optname, optval, optlen) : -1;
+}
+
+//! Get the base stream
+static mongoc_stream_t* qore_stream_get_base_stream(mongoc_stream_t* stream) {
+    qore_interruptible_stream_t* s = (qore_interruptible_stream_t*)stream;
+    return s->base;
+}
+
+//! Check if stream is closed
+static bool qore_stream_check_closed(mongoc_stream_t* stream) {
+    qore_interruptible_stream_t* s = (qore_interruptible_stream_t*)stream;
+    return s->base ? mongoc_stream_check_closed(s->base) : true;
+}
+
+//! Poll multiple streams with interrupt checking
+static ssize_t qore_stream_poll(mongoc_stream_poll_t* streams, size_t nstreams, int32_t timeout) {
+    // Check for interrupt before polling
+    if (check_interrupt()) {
+        return -1;
+    }
+
+    // For short timeouts or no sandbox manager, use direct call
+    QoreSandboxManager* sm = runtime_get_sandbox_manager();
+    if (!sm || timeout <= QORE_IO_POLL_INTERVAL_MS) {
+        return mongoc_stream_poll(streams, nstreams, timeout);
+    }
+
+    // Use polling with interrupt checking
+    int32_t remaining = timeout;
+    while (remaining > 0) {
+        if (check_interrupt()) {
+            return -1;
+        }
+
+        int32_t chunk_timeout = remaining > QORE_IO_POLL_INTERVAL_MS ? QORE_IO_POLL_INTERVAL_MS : remaining;
+        ssize_t rv = mongoc_stream_poll(streams, nstreams, chunk_timeout);
+
+        if (rv != 0) {
+            return rv;
+        }
+
+        remaining -= chunk_timeout;
+    }
+
+    return 0;  // Timeout
+}
+
+//! Check if stream timed out
+static bool qore_stream_timed_out(mongoc_stream_t* stream) {
+    qore_interruptible_stream_t* s = (qore_interruptible_stream_t*)stream;
+    return s->base ? mongoc_stream_timed_out(s->base) : false;
+}
+
+//! Check if stream should retry
+static bool qore_stream_should_retry(mongoc_stream_t* stream) {
+    qore_interruptible_stream_t* s = (qore_interruptible_stream_t*)stream;
+    return s->base ? mongoc_stream_should_retry(s->base) : false;
+}
+
+//! Create a new interruptible stream wrapping a base stream
+static mongoc_stream_t* qore_stream_new(mongoc_stream_t* base) {
+    qore_interruptible_stream_t* stream = (qore_interruptible_stream_t*)bson_malloc0(sizeof(qore_interruptible_stream_t));
+
+    stream->vtable.type = 100;  // Custom type
+    stream->vtable.destroy = qore_stream_destroy;
+    stream->vtable.close = qore_stream_close;
+    stream->vtable.flush = qore_stream_flush;
+    stream->vtable.writev = qore_stream_writev;
+    stream->vtable.readv = qore_stream_readv;
+    stream->vtable.setsockopt = qore_stream_setsockopt;
+    stream->vtable.get_base_stream = qore_stream_get_base_stream;
+    stream->vtable.check_closed = qore_stream_check_closed;
+    stream->vtable.poll = qore_stream_poll;
+    stream->vtable.timed_out = qore_stream_timed_out;
+    stream->vtable.should_retry = qore_stream_should_retry;
+    stream->base = base;
+
+    return (mongoc_stream_t*)stream;
+}
+
+mongoc_stream_t* qore_mongo_stream_initiator(
+    const mongoc_uri_t* uri,
+    const mongoc_host_list_t* host,
+    void* user_data,
+    bson_error_t* error) {
+
+    // Resolve the hostname
+    struct addrinfo hints;
+    struct addrinfo* result = nullptr;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = host->family;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+
+    char port_str[8];
+    snprintf(port_str, sizeof(port_str), "%u", host->port);
+
+    int rv = getaddrinfo(host->host, port_str, &hints, &result);
+    if (rv != 0) {
+        bson_set_error(error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_NAME_RESOLUTION,
+            "Failed to resolve '%s': %s", host->host, gai_strerror(rv));
+        return nullptr;
+    }
+
+    // Try each address until we successfully connect
+    mongoc_socket_t* sock = nullptr;
+    struct addrinfo* rp;
+
+    for (rp = result; rp != nullptr; rp = rp->ai_next) {
+        sock = mongoc_socket_new(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (!sock) {
+            continue;
+        }
+
+        // Get connect timeout from URI (default 10 seconds)
+        int32_t connecttimeoutms = mongoc_uri_get_option_as_int32(uri, MONGOC_URI_CONNECTTIMEOUTMS, 10000);
+        int64_t expire_at = bson_get_monotonic_time() + (connecttimeoutms * 1000);
+
+        if (mongoc_socket_connect(sock, rp->ai_addr, (mongoc_socklen_t)rp->ai_addrlen, expire_at) == 0) {
+            break;  // Success
+        }
+
+        mongoc_socket_destroy(sock);
+        sock = nullptr;
+    }
+
+    freeaddrinfo(result);
+
+    if (!sock) {
+        bson_set_error(error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT,
+            "Failed to connect to '%s:%u'", host->host, host->port);
+        return nullptr;
+    }
+
+    // Create socket stream
+    mongoc_stream_t* base = mongoc_stream_socket_new(sock);
+    if (!base) {
+        mongoc_socket_destroy(sock);
+        bson_set_error(error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET,
+            "Failed to create stream for '%s:%u'", host->host, host->port);
+        return nullptr;
+    }
+
+    // Check if SSL/TLS is required
+    if (mongoc_uri_get_tls(uri)) {
+        // Use default SSL options (nullptr means use system defaults)
+        mongoc_stream_t* tls_stream = mongoc_stream_tls_new_with_hostname(base, host->host, nullptr, 1);
+        if (!tls_stream) {
+            mongoc_stream_destroy(base);
+            bson_set_error(error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET,
+                "Failed to create TLS stream for '%s:%u'", host->host, host->port);
+            return nullptr;
+        }
+
+        // Perform TLS handshake
+        if (!mongoc_stream_tls_handshake_block(tls_stream, host->host, 10000, error)) {
+            mongoc_stream_destroy(tls_stream);
+            return nullptr;
+        }
+
+        base = tls_stream;
+    }
+
+    // Wrap it with our interruptible stream
+    return qore_stream_new(base);
+}
+
+void qore_mongo_setup_interruptible_streams(mongoc_client_t* client) {
+    mongoc_client_set_stream_initiator(client, qore_mongo_stream_initiator, nullptr);
+}

--- a/modules/mongodb/src/QoreMongoStream.h
+++ b/modules/mongodb/src/QoreMongoStream.h
@@ -1,0 +1,71 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QoreMongoStream.h
+
+    Qore mongodb module - Interruptible stream wrapper
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _QORE_MODULE_MONGODB_QOREMONGOSTREAM_H
+#define _QORE_MODULE_MONGODB_QOREMONGOSTREAM_H
+
+#include <qore/Qore.h>
+#include <qore/QoreSandboxManager.h>
+
+#include <mongoc/mongoc.h>
+
+//! Interruptible stream wrapper for MongoDB operations
+/** This stream wrapper wraps the default MongoDB socket stream and adds
+    interrupt checking at regular intervals during blocking I/O operations.
+
+    When a SandboxManager is attached to the current program and an interrupt
+    is requested, I/O operations will return with an error, allowing the
+    operation to be cancelled.
+*/
+
+//! Stream initiator function for interruptible MongoDB streams
+/** This function creates a new interruptible stream that wraps the default
+    socket stream. It should be set on the MongoDB client using
+    mongoc_client_set_stream_initiator().
+
+    @param uri The MongoDB URI
+    @param host The host to connect to
+    @param user_data User data (unused)
+    @param error Error structure for reporting errors
+
+    @return A new interruptible stream or nullptr on error
+*/
+DLLLOCAL mongoc_stream_t* qore_mongo_stream_initiator(
+    const mongoc_uri_t* uri,
+    const mongoc_host_list_t* host,
+    void* user_data,
+    bson_error_t* error);
+
+//! Set up interruptible streams for a MongoDB client
+/** This function configures the given MongoDB client to use interruptible
+    streams for all I/O operations.
+
+    @param client The MongoDB client to configure
+*/
+DLLLOCAL void qore_mongo_setup_interruptible_streams(mongoc_client_t* client);
+
+#endif // _QORE_MODULE_MONGODB_QOREMONGOSTREAM_H

--- a/modules/mongodb/test/mongodb.qtest
+++ b/modules/mongodb/test/mongodb.qtest
@@ -61,6 +61,7 @@ public class MongoDbTest inherits QUnit::Test {
         addTestCase("Data type tests", \dataTypeTests());
         addTestCase("Large data tests", \largeDataTests());
         addTestCase("Memory stress tests", \memoryStressTests());
+        addTestCase("Interrupt test", \interruptTests());
         set_return_value(main());
     }
 
@@ -1130,5 +1131,145 @@ public class MongoDbTest inherits QUnit::Test {
 
         # Clean up
         coll.drop();
+    }
+
+    interruptTests() {
+        if (!ensureClient()) return;
+
+        # Test 1: Pre-requested interrupt - set interrupt before attempting operation
+        # This is more deterministic than trying to interrupt during an operation
+        {
+            string pre_interrupt_code = '
+%require-types
+%new-style
+%strict-args
+
+%requires mongodb
+
+our *hash<ExceptionInfo> ex_info;
+
+sub test_pre_interrupt() {
+    try {
+        # This should fail because interrupt was already requested before we started
+        MongoClient client(ENV.MONGODB_URL ?? "mongodb://localhost:27017");
+        # The connection attempt or first operation should detect the interrupt
+        client.ping();
+    } catch (hash<ExceptionInfo> ex) {
+        ex_info = ex;
+    }
+}
+';
+
+            Program pgm(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+            pgm.parse(pre_interrupt_code, "pre_interrupt_test");
+
+            SandboxManager sm();
+            pgm.setSandboxManager(sm);
+
+            # Request interrupt BEFORE the operation
+            sm.requestInterrupt();
+
+            # Now try to perform the operation - it should be interrupted immediately
+            pgm.callFunction("test_pre_interrupt");
+
+            *hash<ExceptionInfo> ex_info = pgm.getGlobalVariable("ex_info");
+            # The operation should have been interrupted
+            assertTrue(ex_info.val(), "Pre-interrupt: operation was interrupted");
+            if (ex_info) {
+                # Should be some kind of interrupt-related error
+                assertTrue(ex_info.err.val(), "Pre-interrupt: exception has error code: " + ex_info.err);
+            }
+        }
+
+        # Test 2: Test that we can interrupt a MongoDB operation using the sandbox mechanism
+        # This test verifies that the interruptible stream wrapper is working
+
+        # Create embedded program with sandbox for interrupt testing
+        string code = '
+%require-types
+%new-style
+%strict-args
+
+%requires mongodb
+
+our Counter cnt(1);
+our *hash<auto> result;
+our *hash<ExceptionInfo> ex_info;
+
+sub test_interrupt() {
+    try {
+        # Use a server command with a sleep - "$where" with a JavaScript function
+        # that includes a sleep can be used to create a blocking operation
+        MongoClient client(ENV.MONGODB_URL ?? "mongodb://localhost:27017");
+        MongoDatabase db = client.getDatabase("qore_interrupt_test");
+        MongoCollection coll = db.createCollection("interrupt_test_coll");
+
+        # Insert some data
+        for (int i = 0; i < 100; i++) {
+            coll.insertOne({"x": i, "data": "test data " + string(i)});
+        }
+
+        # Try to perform a blocking operation - serverStatus with slow sections
+        # or run a command that takes some time
+        cnt.dec();  # Signal that we are about to block
+
+        # This command should be interruptible
+        result = db.runCommand({"serverStatus": 1, "repl": 0, "metrics": 0});
+    } catch (hash<ExceptionInfo> ex) {
+        ex_info = ex;
+    }
+}
+';
+
+        Program pgm(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+        pgm.parse(code, "interrupt_test");
+
+        # Get the counter from the embedded program
+        Counter cnt = pgm.getGlobalVariable("cnt");
+
+        # Set up the sandbox manager
+        SandboxManager sm();
+        pgm.setSandboxManager(sm);
+
+        # Run the blocking operation in a background thread
+        background pgm.callFunction("test_interrupt");
+
+        # Wait for the operation to start
+        cnt.waitForZero();
+
+        # Give it a moment to actually start the blocking I/O
+        sleep(100ms);
+
+        # Request interrupt
+        sm.requestInterrupt();
+
+        # Wait a bit for the interrupt to take effect
+        sleep(500ms);
+
+        # Check if the operation completed or was interrupted
+        # Note: The interrupt may or may not have been triggered depending on timing
+        # We mainly want to verify no crash occurs and the mechanism is in place
+
+        *hash<ExceptionInfo> ex_info = pgm.getGlobalVariable("ex_info");
+        *hash<auto> result = pgm.getGlobalVariable("result");
+
+        # Either the operation completed (result is set) or was interrupted (exception)
+        # Both are valid outcomes depending on timing
+        assertTrue(result.val() || ex_info.val(),
+            "MongoDB operation either completed or was interrupted");
+
+        if (ex_info) {
+            # If there was an exception, it should be a program interrupted or I/O error
+            assertTrue(ex_info.err =~ /INTERRUPT|PROGRAM|MONGODB/i,
+                "Exception is interrupt-related: " + ex_info.err);
+        }
+
+        # Clean up - use the class member client for cleanup
+        try {
+            MongoDatabase db = self.client.getDatabase("qore_interrupt_test");
+            db.getCollection("interrupt_test_coll").drop();
+        } catch () {
+            # Ignore cleanup errors
+        }
     }
 }


### PR DESCRIPTION
## Summary

Implements comprehensive support for interrupting I/O operations when a SandboxManager is attached and an interrupt is requested. This enables sandbox environments to stop blocking operations on demand.

### Core Infrastructure
- `QoreCondition`: new `waitWithInterrupt()` methods with 500ms polling
- `QoreSandboxManager`: new `qore_check_io_interrupt()` API and `QORE_IO_POLL_INTERVAL_MS` constant

### I/O Operations Made Interruptible
- **File**: read/write/readLine/readUntil operations
- **StdoutOutputStream/StderrOutputStream**: rewritten with interrupt support
- **StreamPipe**: pipe read/write operations
- **ManagedDatasource**: transaction lock waiting

### Threading Primitives Made Interruptible
- **Queue**: shift/push operations (when queue is full/empty)
- **Counter**: waitForZero operation

### MongoDB Module
- Custom `mongoc_stream_t` wrapper for interrupt-aware I/O
- Polls at `QORE_IO_POLL_INTERVAL_MS` (500ms) during blocking operations

### Documentation
- Added module guide for implementing interruptible I/O in external modules
- Updated sandboxing and release notes documentation

## Test plan

- [ ] Run `examples/test/qore/io/io_interrupt.qtest` - tests all interruptible operations
- [ ] Run MongoDB tests (requires MongoDB server): `modules/mongodb/test/mongodb.qtest`
- [ ] Verify no regressions in existing I/O tests
- [ ] CI passes

## Closes

Closes #5000

🤖 Generated with [Claude Code](https://claude.com/claude-code)