### PR TITLE
refs #5109 Qdx: implement proper tokenizer for Qore code parsing

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -134,6 +134,13 @@ code<int(string)> func = int sub(int x) { return x; };  # PARSE-TYPE-ERROR: para
       - @ref RestClient::RestConnection "RestConnection" inherits the \c http_version option from @ref ConnectionProvider::HttpConnection "HttpConnection"
     - @ref OpenApi3 "OpenApi3" module
       - new module supporting OpenAPI 3.* schemas for REST API integration
+    - @ref Qdx "Qdx" module
+      - added @ref Qdx::QoreTokenizer "QoreTokenizer" class for proper Qore lexical analysis
+        (<a href="https://github.com/qoretechnologies/qore/issues/5109">issue 5109</a>)
+        - correctly handles \c $# (loop iteration variable) vs \c # (comment start)
+        - supports strings, comments, regex, heredocs, substitution, and transliteration
+        - new @ref Qdx::count_braces() "count_braces()" and @ref Qdx::count_all_brackets() "count_all_brackets()"
+          helper functions for accurate bracket counting in Qore code
     - @ref RestSchemaDataProvider "RestSchemaDataProvider" module
       - new module providing a unified data provider API for both Swagger 2.0 and OpenAPI 3.0 / 3.1 REST schemas
     - @ref HttpServer "HttpServer" module

--- a/doxygen/qdx
+++ b/doxygen/qdx
@@ -477,39 +477,32 @@ class qdx {
                 }
             }
 
-            # remove quoted strings and line comments for the next comparison
+            # Check if line has brackets for multi-line detection
+            # Using tokenizer to correctly handle $# vs # comments
+            hash<auto> bc = count_all_brackets(line);
             string tline = line;
             tline =~ s/\\"/_/g;
             tline =~ s/"([^"]*)"/_/g;
-            tline =~ s/#.*//;
             # see if we have a function or method declaration that spans multiple lines
             bool fcall = (tline =~ /\w+\s?(\(|\))/) && tline !~ /;\s*$/ && tline !~ /^\s*_:\s*.*\),\s+$/
                 && tline !~ /^\s*\)/;
-            if (fcall || (!fcall && tline =~ /[{}]/ && tline =~ /[\(\)]/
+            if (fcall || (!fcall && (bc.open_braces || bc.close_braces) && (bc.open_parens || bc.close_parens)
                 && tline !~ /(namespace|class|struct|public|private|private:internal|private:hierarchy|const) /)) {
-                # copy of line to check it without parens in quotes
-                string line_copy = line;
-                line_copy =~ s/"(?:[^"\\]|\\.)*"/""/g;
-                line_copy =~ s/#.*//;
-                trim line_copy;
-                # count how many open parens
-                int ob = (line_copy =~ x/(\()/g).size();
-                # count how many close parens
-                int cb = (line_copy =~ x/(\))/g).size();
+                # use tokenizer-based counts for parens and braces
+                int ob = bc.open_parens;
+                int cb = bc.close_parens;
                 int tot = (ob - cb);
                 int otot = tot;
 
-                # count how many open curly brackets
-                int ocb = (line_copy =~ x/({)/g).size();
-                # count how many close curly brackets
-                int ccb = (line_copy =~ x/(})/g).size();
+                int ocb = bc.open_braces;
+                int ccb = bc.close_braces;
                 int ctot = (ocb - ccb);
                 int octot = ctot;
 
-                #printf("l: %y lc: %y fcall: %y tot: %y ctot: %y\n", line, line_copy, fcall, tot, ctot);
+                #printf("l: %y bc: %y fcall: %y tot: %y ctot: %y\n", line, bc, fcall, tot, ctot);
 
                 if (tot > 0
-                    || (!tot && !ctot && !ocb && !ccb && line_copy && line_copy !~ /;\s*(#.*)?$/)
+                    || (!tot && !ctot && !ocb && !ccb && line !~ /;\s*(#.*)?$/)
                     || (ctot > 0 && !fcall)) {
                     # trim trailing whitespace
                     line =~ s/\s*$//;
@@ -535,23 +528,22 @@ class qdx {
 
                         #printf("FOUND COMPLEX LINE: fcall: %y tot: %d ctot: %d: %y\n", fcall, tot, ctot, line);
 
-                        line_copy = new_line;
-                        line_copy =~ s/"(?:[^"\\]|\\.)*"/""/g;
-                        line_copy =~ s/#.*//;
+                        # use tokenizer-based counts for new_line
+                        hash<auto> new_bc = count_all_brackets(new_line);
 
                         # count how many open parens
-                        ob = (line_copy =~ x/(\()/g).size();
+                        ob = new_bc.open_parens;
                         # count how many close parens
-                        cb = (line_copy =~ x/(\))/g).size();
+                        cb = new_bc.close_parens;
                         tot += (ob - cb);
                         if (otot && !tot) {
                             break;
                         }
 
                         # count how many open curly brackets
-                        ocb = (line_copy =~ x/({)/g).size();
+                        ocb = new_bc.open_braces;
                         # count how many close curly brackets
-                        ccb = (line_copy =~ x/(})/g).size();
+                        ccb = new_bc.close_braces;
                         ctot += (ocb - ccb);
                         if ((octot && !ctot) || (fcall && ctot == 1)) {
                             break;
@@ -696,17 +688,9 @@ class qdx {
                     continue;
                 } else if (class_name) {
                     if (line =~ /({|})/) {
-                        # normalize line for brace counting: remove strings, comments, and hash access
-                        string brace_line = line;
-                        brace_line =~ s/"(?:[^"\\]|\\.)*"/""/g;  # remove string literals
-                        brace_line =~ s/'(?:[^'\\]|\\.)*'/''/g;  # remove single-quoted strings
-                        brace_line =~ s/#.*//;                    # remove line comments
-                        brace_line =~ s/\w+{[^{}]*}/_/g;          # remove hash access like foo{bar}
-                        # count how many open curly brackets
-                        int ob = (brace_line =~ x/({)/g).size();
-                        # count how many close curly brackets
-                        int cb = (brace_line =~ x/(})/g).size();
-                        cbc += (ob - cb);
+                        # use tokenizer-based brace counting to correctly handle $# vs # comments
+                        hash<auto> class_bc = count_braces(line);
+                        cbc += (class_bc.open - class_bc.close);
                         if (!cbc) {
                             line = regex_subst(line, "}", "};");
                             delete class_name;
@@ -752,17 +736,9 @@ class qdx {
                             continue;
                         }
                     } else {
-                        # normalize line for brace counting: remove strings, comments, and hash access
-                        string brace_line = line;
-                        brace_line =~ s/"(?:[^"\\]|\\.)*"/""/g;  # remove string literals
-                        brace_line =~ s/'(?:[^'\\]|\\.)*'/''/g;  # remove single-quoted strings
-                        brace_line =~ s/#.*//;                    # remove line comments
-                        brace_line =~ s/\w+{[^{}]*}/_/g;          # remove hash access like foo{bar}
-                        # count how many open curly brackets
-                        int ob = (brace_line =~ x/({)/g).size();
-                        # count how many close curly brackets
-                        int cb = (brace_line =~ x/(})/g).size();
-                        int tot = (ob - cb);
+                        # use tokenizer-based brace counting to correctly handle $# vs # comments
+                        hash<auto> pp_bc = count_braces(line);
+                        int tot = (pp_bc.open - pp_bc.close);
                         if (tot) {
                             ppc += tot;
                             if (!ppc) {

--- a/examples/test/qlib/Qdx/QoreTokenizer.qtest
+++ b/examples/test/qlib/Qdx/QoreTokenizer.qtest
@@ -1,0 +1,990 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+/*  QoreTokenizer.qtest Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+%exec-class QoreTokenizerTests
+
+%requires Qdx
+%requires QUnit
+
+public class QoreTokenizerTests inherits QUnit::Test {
+    constructor() : Test("QoreTokenizerTests", "1.0") {
+        addTestCase("Basic string tokenization", \testBasicStrings());
+        addTestCase("Single-quoted strings with escapes", \testSingleQuotedEscapes());
+        addTestCase("Double-quoted strings with escapes", \testDoubleQuotedEscapes());
+        addTestCase("Line comments", \testLineComments());
+        addTestCase("Block comments", \testBlockComments());
+        addTestCase("Braces and brackets", \testBracesAndBrackets());
+        addTestCase("Dollar hash special case", \testDollarHash());
+        addTestCase("Regex match operators", \testRegexMatchOperators());
+        addTestCase("Regex patterns", \testRegexPatterns());
+        addTestCase("Substitution patterns", \testSubstitutionPatterns());
+        addTestCase("Transliteration patterns", \testTransliterationPatterns());
+        addTestCase("Heredoc strings", \testHeredocStrings());
+        addTestCase("Whitespace and newlines", \testWhitespaceAndNewlines());
+        addTestCase("skipToCloseBrace basic", \testSkipToCloseBraceBasic());
+        addTestCase("skipToCloseBrace nested", \testSkipToCloseBraceNested());
+        addTestCase("skipToCloseBrace with strings", \testSkipToCloseBraceWithStrings());
+        addTestCase("skipToCloseBrace with comments", \testSkipToCloseBraceWithComments());
+        addTestCase("skipToCloseBrace with regex", \testSkipToCloseBraceWithRegex());
+        addTestCase("UTF-8 strings", \testUtf8Strings());
+        addTestCase("Line and column tracking", \testLineColumnTracking());
+        addTestCase("Original $# bug case", \testOriginalDollarHashBug());
+        addTestCase("Mixed code tokenization", \testMixedCode());
+        addTestCase("Edge cases", \testEdgeCases());
+        addTestCase("count_braces() helper function", \testCountBraces());
+        addTestCase("count_all_brackets() helper function", \testCountAllBrackets());
+        addTestCase("qdx integration - $# in loops", \testQdxDollarHashIntegration());
+        set_return_value(main());
+    }
+
+    testBasicStrings() {
+        # Simple single-quoted string
+        {
+            QoreTokenizer tok("'hello'");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_STRING_SINGLE, t.type, "single-quoted string type");
+            assertEq("'hello'", t.value, "single-quoted string value");
+            assertTrue(tok.atEnd(), "at end after single token");
+        }
+
+        # Simple double-quoted string
+        {
+            QoreTokenizer tok('"world"');
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_STRING_DOUBLE, t.type, "double-quoted string type");
+            assertEq('"world"', t.value, "double-quoted string value");
+            assertTrue(tok.atEnd(), "at end after single token");
+        }
+
+        # Empty strings
+        {
+            QoreTokenizer tok("''");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_STRING_SINGLE, t.type, "empty single-quoted string type");
+            assertEq("''", t.value, "empty single-quoted string value");
+        }
+        {
+            QoreTokenizer tok('""');
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_STRING_DOUBLE, t.type, "empty double-quoted string type");
+            assertEq('""', t.value, "empty double-quoted string value");
+        }
+    }
+
+    testSingleQuotedEscapes() {
+        # Escaped quote
+        {
+            QoreTokenizer tok("'it\\'s'");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_STRING_SINGLE, t.type, "escaped quote in single string");
+            assertEq("'it\\'s'", t.value, "escaped quote value preserved");
+        }
+
+        # Escaped backslash
+        {
+            QoreTokenizer tok("'path\\\\dir'");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_STRING_SINGLE, t.type);
+            assertEq("'path\\\\dir'", t.value);
+        }
+
+        # Other characters after backslash (not special in single quotes)
+        {
+            QoreTokenizer tok("'hello\\nworld'");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_STRING_SINGLE, t.type);
+            assertEq("'hello\\nworld'", t.value, "backslash-n preserved literally");
+        }
+    }
+
+    testDoubleQuotedEscapes() {
+        # Escaped quote - use explicit string building to avoid escape confusion
+        # Input: "say \"hello\""  (with backslash-quote sequences)
+        {
+            string input = "\"say \\\"hello\\\"\"";  # double-quoted string with escapes
+            QoreTokenizer tok(input);
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_STRING_DOUBLE, t.type, "escaped quote in double string");
+            assertEq(input, t.value, "escaped quote value preserved");
+        }
+
+        # Various escapes - \n in source becomes literal backslash-n in token
+        {
+            string input = "\"line1\\nline2\"";
+            QoreTokenizer tok(input);
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_STRING_DOUBLE, t.type);
+            assertEq(input, t.value, "escape sequences preserved");
+        }
+
+        # Escaped backslash
+        {
+            string input = "\"path\\\\file\"";
+            QoreTokenizer tok(input);
+            hash<TokenInfo> t = tok.next();
+            assertEq(input, t.value);
+        }
+    }
+
+    testLineComments() {
+        # Basic line comment
+        {
+            QoreTokenizer tok("# this is a comment");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_LINE_COMMENT, t.type, "line comment type");
+            assertEq("# this is a comment", t.value, "line comment value");
+        }
+
+        # Line comment with code before
+        {
+            QoreTokenizer tok("x = 1; # comment");
+            list<hash<TokenInfo>> tokens = ();
+            while (!tok.atEnd()) {
+                tokens += tok.next();
+            }
+            hash<TokenInfo> comment_tok;
+            foreach hash<TokenInfo> t in (tokens) {
+                if (t.type == TOK_LINE_COMMENT) {
+                    comment_tok = t;
+                    break;
+                }
+            }
+            assertEq("# comment", comment_tok.value, "line comment after code");
+        }
+
+        # Comment followed by newline
+        {
+            QoreTokenizer tok("# comment\ncode");
+            hash<TokenInfo> t1 = tok.next();
+            assertEq(TOK_LINE_COMMENT, t1.type);
+            assertEq("# comment", t1.value);
+            hash<TokenInfo> t2 = tok.next();
+            assertEq(TOK_NEWLINE, t2.type, "newline after comment");
+        }
+    }
+
+    testBlockComments() {
+        # Basic block comment
+        {
+            QoreTokenizer tok("/* comment */");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_BLOCK_COMMENT, t.type, "block comment type");
+            assertEq("/* comment */", t.value, "block comment value");
+        }
+
+        # Multi-line block comment
+        {
+            QoreTokenizer tok("/* line1\nline2 */");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_BLOCK_COMMENT, t.type);
+            assertEq("/* line1\nline2 */", t.value, "multi-line block comment");
+        }
+
+        # Nested asterisks (not real nesting)
+        {
+            QoreTokenizer tok("/* * * * */");
+            hash<TokenInfo> t = tok.next();
+            assertEq("/* * * * */", t.value);
+        }
+
+        # Block comment with braces inside
+        {
+            QoreTokenizer tok("/* { } */");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_BLOCK_COMMENT, t.type);
+            assertEq("/* { } */", t.value);
+        }
+    }
+
+    testBracesAndBrackets() {
+        # All brace types
+        {
+            QoreTokenizer tok("{}()[]");
+            assertEq(TOK_LBRACE, tok.next().type);
+            assertEq(TOK_RBRACE, tok.next().type);
+            assertEq(TOK_LPAREN, tok.next().type);
+            assertEq(TOK_RPAREN, tok.next().type);
+            assertEq(TOK_LBRACKET, tok.next().type);
+            assertEq(TOK_RBRACKET, tok.next().type);
+            assertTrue(tok.atEnd());
+        }
+
+        # Braces with content
+        {
+            QoreTokenizer tok("{x}");
+            hash<TokenInfo> t1 = tok.next();
+            assertEq(TOK_LBRACE, t1.type);
+            assertEq("{", t1.value);
+        }
+    }
+
+    testDollarHash() {
+        # $# alone
+        {
+            QoreTokenizer tok('$#');
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_DOLLAR_HASH, t.type, "$# type");
+            assertEq('$#', t.value, "$# value");
+        }
+
+        # $# in code context
+        {
+            QoreTokenizer tok('for (int i = 0; i < $#; ++i)');
+            list<hash<TokenInfo>> tokens = ();
+            while (!tok.atEnd()) {
+                tokens += tok.next();
+            }
+            bool found_dollar_hash = False;
+            foreach hash<TokenInfo> t in (tokens) {
+                if (t.type == TOK_DOLLAR_HASH) {
+                    found_dollar_hash = True;
+                    assertEq('$#', t.value);
+                    break;
+                }
+            }
+            assertTrue(found_dollar_hash, "$# found in code context");
+        }
+
+        # $ not followed by # (just regular $)
+        {
+            QoreTokenizer tok('$x');
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_OTHER, t.type, "$ alone is TOK_OTHER");
+            assertEq('$', t.value);
+        }
+    }
+
+    testRegexMatchOperators() {
+        # =~ operator
+        {
+            QoreTokenizer tok('=~');
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_REGEX_MATCH, t.type, "=~ type");
+        }
+
+        # !~ operator
+        {
+            QoreTokenizer tok('!~');
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_REGEX_NOT_MATCH, t.type, "!~ type");
+        }
+
+        # =~ followed by regex
+        {
+            QoreTokenizer tok('=~ /pattern/');
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_REGEX, t.type, "=~ followed by regex");
+            assertEq("/pattern/", t.value);
+        }
+    }
+
+    testRegexPatterns() {
+        # Basic regex
+        {
+            QoreTokenizer tok('=~ /hello/');
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_REGEX, t.type);
+            assertEq("/hello/", t.value);
+        }
+
+        # Regex with flags
+        {
+            QoreTokenizer tok('=~ /pattern/gi');
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_REGEX, t.type);
+            assertEq("/pattern/gi", t.value, "regex with flags");
+        }
+
+        # Regex with escape
+        {
+            string input = "=~ /path\\/file/";
+            QoreTokenizer tok(input);
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_REGEX, t.type);
+            assertEq("/path\\/file/", t.value, "regex with escaped slash");
+        }
+
+        # Regex with special chars
+        {
+            QoreTokenizer tok('=~ /[a-z]+/');
+            hash<TokenInfo> t = tok.next();
+            assertEq('/[a-z]+/', t.value);
+        }
+    }
+
+    testSubstitutionPatterns() {
+        # Basic substitution
+        {
+            QoreTokenizer tok('=~ s/old/new/');
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_SUBSTITUTION, t.type, "substitution type");
+            assertEq("s/old/new/", t.value, "substitution value");
+        }
+
+        # Substitution with flags
+        {
+            QoreTokenizer tok('=~ s/old/new/g');
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_SUBSTITUTION, t.type);
+            assertEq("s/old/new/g", t.value, "substitution with flags");
+        }
+
+        # Substitution with escaped delimiter
+        {
+            string input = "=~ s/a\\/b/c/";
+            QoreTokenizer tok(input);
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_SUBSTITUTION, t.type);
+            assertEq("s/a\\/b/c/", t.value, "substitution with escaped delimiter");
+        }
+    }
+
+    testTransliterationPatterns() {
+        # tr form
+        {
+            QoreTokenizer tok('=~ tr/abc/xyz/');
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_TRANSLITERATION, t.type, "tr type");
+            assertEq("tr/abc/xyz/", t.value, "tr value");
+        }
+
+        # y form
+        {
+            QoreTokenizer tok('=~ y/abc/xyz/');
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_TRANSLITERATION, t.type, "y type");
+            assertEq("y/abc/xyz/", t.value, "y value");
+        }
+    }
+
+    testHeredocStrings() {
+        # Basic heredoc
+        {
+            QoreTokenizer tok("<<END\nhello\nEND");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_HEREDOC, t.type, "heredoc type");
+            assertEq("<<END\nhello\nEND", t.value, "heredoc value");
+        }
+
+        # Heredoc with multiple lines
+        {
+            QoreTokenizer tok("<<MARKER\nline1\nline2\nline3\nMARKER");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_HEREDOC, t.type);
+            assertEq("<<MARKER\nline1\nline2\nline3\nMARKER", t.value);
+        }
+
+        # << not followed by identifier (shift operator)
+        {
+            QoreTokenizer tok("<<");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_OTHER, t.type, "<< alone is TOK_OTHER");
+            assertEq("<<", t.value);
+        }
+    }
+
+    testWhitespaceAndNewlines() {
+        # Whitespace token
+        {
+            QoreTokenizer tok("   \t  ");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_WHITESPACE, t.type, "whitespace type");
+            assertEq("   \t  ", t.value, "whitespace value preserved");
+        }
+
+        # Newline token
+        {
+            QoreTokenizer tok("\n");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_NEWLINE, t.type, "newline type");
+            assertEq("\n", t.value, "newline value");
+        }
+
+        # Mixed whitespace and newlines
+        {
+            QoreTokenizer tok("  \n  ");
+            hash<TokenInfo> t1 = tok.next();
+            assertEq(TOK_WHITESPACE, t1.type);
+            hash<TokenInfo> t2 = tok.next();
+            assertEq(TOK_NEWLINE, t2.type);
+            hash<TokenInfo> t3 = tok.next();
+            assertEq(TOK_WHITESPACE, t3.type);
+        }
+    }
+
+    testSkipToCloseBraceBasic() {
+        # Simple brace pair
+        {
+            QoreTokenizer tok("{ x = 1; }");
+            tok.next();  # consume {
+            int lines = tok.skipToCloseBrace();
+            assertEq(0, lines, "same line = 0 lines consumed");
+            assertTrue(tok.atEnd(), "at end after skip");
+        }
+
+        # Brace pair with newlines
+        {
+            QoreTokenizer tok("{\n  x = 1;\n}");
+            tok.next();  # consume {
+            int lines = tok.skipToCloseBrace();
+            assertEq(2, lines, "2 lines consumed");
+        }
+    }
+
+    testSkipToCloseBraceNested() {
+        # Nested braces
+        {
+            QoreTokenizer tok("{ if (x) { y; } }");
+            tok.next();  # consume first {
+            int lines = tok.skipToCloseBrace();
+            assertEq(0, lines);
+            assertTrue(tok.atEnd(), "skipped nested braces correctly");
+        }
+
+        # Deeply nested
+        {
+            QoreTokenizer tok("{ { { } } }");
+            tok.next();
+            int lines = tok.skipToCloseBrace();
+            assertEq(0, lines);
+            assertTrue(tok.atEnd());
+        }
+
+        # Multiple nested blocks
+        {
+            QoreTokenizer tok("{ if (a) { x; } else { y; } }");
+            tok.next();
+            tok.skipToCloseBrace();
+            assertTrue(tok.atEnd());
+        }
+    }
+
+    testSkipToCloseBraceWithStrings() {
+        # Brace inside single-quoted string
+        {
+            QoreTokenizer tok("{ '{' }");
+            tok.next();
+            tok.skipToCloseBrace();
+            assertTrue(tok.atEnd(), "brace in single-quoted string ignored");
+        }
+
+        # Brace inside double-quoted string
+        {
+            QoreTokenizer tok('{ "}" }');
+            tok.next();
+            tok.skipToCloseBrace();
+            assertTrue(tok.atEnd(), "brace in double-quoted string ignored");
+        }
+
+        # Multiple strings with braces
+        {
+            QoreTokenizer tok('{ x = "{"; y = "}"; }');
+            tok.next();
+            tok.skipToCloseBrace();
+            assertTrue(tok.atEnd());
+        }
+    }
+
+    testSkipToCloseBraceWithComments() {
+        # Brace inside line comment
+        {
+            QoreTokenizer tok("{ # }\nx; }");
+            tok.next();
+            tok.skipToCloseBrace();
+            assertTrue(tok.atEnd(), "brace in line comment ignored");
+        }
+
+        # Brace inside block comment
+        {
+            QoreTokenizer tok("{ /* } */ }");
+            tok.next();
+            tok.skipToCloseBrace();
+            assertTrue(tok.atEnd(), "brace in block comment ignored");
+        }
+
+        # The original $# bug: # should start comment, not be confused with $#
+        {
+            # This is the crux of the bug: "some_call({$#})" should work
+            # Inside the braces, there's $# followed by }
+            QoreTokenizer tok("{$#}");
+            tok.next();  # consume {
+            tok.skipToCloseBrace();
+            assertTrue(tok.atEnd(), "$# followed by } works correctly");
+        }
+    }
+
+    testSkipToCloseBraceWithRegex() {
+        # Brace inside regex
+        {
+            QoreTokenizer tok('{ x =~ /[{}]/; }');
+            tok.next();
+            tok.skipToCloseBrace();
+            assertTrue(tok.atEnd(), "brace in regex ignored");
+        }
+
+        # Brace in substitution
+        {
+            QoreTokenizer tok('{ x =~ s/{/(/; }');
+            tok.next();
+            tok.skipToCloseBrace();
+            assertTrue(tok.atEnd(), "brace in substitution ignored");
+        }
+    }
+
+    testUtf8Strings() {
+        # UTF-8 in single-quoted string
+        {
+            QoreTokenizer tok("'日本語'");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_STRING_SINGLE, t.type);
+            assertEq("'日本語'", t.value, "UTF-8 single-quoted string");
+        }
+
+        # UTF-8 in double-quoted string
+        {
+            QoreTokenizer tok('"中文"');
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_STRING_DOUBLE, t.type);
+            assertEq('"中文"', t.value, "UTF-8 double-quoted string");
+        }
+
+        # UTF-8 in comment
+        {
+            QoreTokenizer tok("# комментарий");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_LINE_COMMENT, t.type);
+            assertEq("# комментарий", t.value, "UTF-8 comment");
+        }
+
+        # Mixed UTF-8 and ASCII
+        {
+            QoreTokenizer tok("'hello 世界'");
+            hash<TokenInfo> t = tok.next();
+            assertEq("'hello 世界'", t.value);
+        }
+    }
+
+    testLineColumnTracking() {
+        # First token at line 1, column 1
+        {
+            QoreTokenizer tok("hello");
+            hash<TokenInfo> t = tok.next();
+            assertEq(1, t.line, "first token line");
+            assertEq(1, t.column, "first token column");
+        }
+
+        # Token after whitespace
+        {
+            QoreTokenizer tok("   x");
+            hash<TokenInfo> ws = tok.next();  # whitespace
+            assertEq(TOK_WHITESPACE, ws.type);
+            hash<TokenInfo> t = tok.next();  # 'x'
+            assertEq(1, t.line, "token after whitespace line");
+            assertEq(4, t.column, "token after whitespace column");
+        }
+
+        # Token on second line - consume until we get past the newline
+        {
+            QoreTokenizer tok("x\ny");
+            tok.next();  # 'x'
+            hash<TokenInfo> nl = tok.next();  # newline
+            assertEq(TOK_NEWLINE, nl.type);
+            hash<TokenInfo> t = tok.next();  # 'y'
+            assertEq(2, t.line, "second line");
+            assertEq(1, t.column, "start of second line");
+        }
+
+        # Multi-line string tracking
+        {
+            QoreTokenizer tok("\"line1\nline2\"\nx");
+            hash<TokenInfo> t1 = tok.next();  # string (consumes everything including the closing quote)
+            assertEq(TOK_STRING_DOUBLE, t1.type);
+            assertEq(1, t1.line, "multi-line string starts at line 1");
+            hash<TokenInfo> nl = tok.next();  # newline
+            assertEq(TOK_NEWLINE, nl.type);
+            hash<TokenInfo> t2 = tok.next();  # 'x'
+            assertEq(3, t2.line, "code after multi-line string on line 3");
+        }
+    }
+
+    testOriginalDollarHashBug() {
+        # The original bug: qdx parsing @code blocks incorrectly when $# is followed by }
+        # The issue was that # was being treated as start of comment, causing } to be missed
+        {
+            string code = '
+foreach string key in (keys hash) {
+    if (key == list[$#]) {
+        break;
+    }
+}';
+            QoreTokenizer tok(code);
+
+            # Skip to first {
+            while (!tok.atEnd()) {
+                hash<TokenInfo> t = tok.next();
+                if (t.type == TOK_LBRACE) {
+                    break;
+                }
+            }
+
+            # Now skip to close brace
+            tok.skipToCloseBrace();
+
+            # After skipToCloseBrace, we should be at the end (all braces matched)
+            # Let's see what's left
+            list<hash<TokenInfo>> remaining = ();
+            while (!tok.atEnd()) {
+                remaining += tok.next();
+            }
+
+            # Should only have whitespace/newlines left
+            foreach hash<TokenInfo> t in (remaining) {
+                assertTrue(t.type == TOK_WHITESPACE || t.type == TOK_NEWLINE || t.type == TOK_EOF,
+                    sprintf("remaining token should be whitespace/newline, got type %d: %y", t.type, t.value));
+            }
+        }
+
+        # Direct test: {$#} should match braces
+        {
+            QoreTokenizer tok("{$#}");
+            tok.next();  # consume {
+            tok.skipToCloseBrace();
+            assertTrue(tok.atEnd(), "{$#} braces matched correctly");
+        }
+
+        # Test: list[$#] should have matching brackets
+        {
+            QoreTokenizer tok("list[$#]");
+            list<hash<TokenInfo>> tokens = ();
+            while (!tok.atEnd()) {
+                tokens += tok.next();
+            }
+
+            # Should have: 'list', '[', '$#', ']'
+            int lbracket_count = 0;
+            int rbracket_count = 0;
+            int dollar_hash_count = 0;
+
+            foreach hash<TokenInfo> t in (tokens) {
+                if (t.type == TOK_LBRACKET) {
+                    ++lbracket_count;
+                } else if (t.type == TOK_RBRACKET) {
+                    ++rbracket_count;
+                } else if (t.type == TOK_DOLLAR_HASH) {
+                    ++dollar_hash_count;
+                }
+            }
+
+            assertEq(1, lbracket_count, "one left bracket");
+            assertEq(1, rbracket_count, "one right bracket");
+            assertEq(1, dollar_hash_count, "one $#");
+        }
+    }
+
+    testMixedCode() {
+        # Real-world code snippet - uses curly braces for both blocks and hash access
+        # Block braces: sub {...}, foreach {...}, if {...}
+        # Hash access braces: data{key}, result{key}, data{key}
+        # Total: 6 left braces, 6 right braces
+        {
+            string code = 'sub process(hash data) {
+    # Process each item
+    foreach string key in (keys data) {
+        if (data{key} =~ /pattern/) {
+            result{key} = data{key};
+        }
+    }
+}';
+            QoreTokenizer tok(code);
+
+            int lbrace = 0;
+            int rbrace = 0;
+            int comments = 0;
+            int regexes = 0;
+
+            while (!tok.atEnd()) {
+                hash<TokenInfo> t = tok.next();
+                switch (t.type) {
+                    case TOK_LBRACE:
+                        ++lbrace;
+                        break;
+                    case TOK_RBRACE:
+                        ++rbrace;
+                        break;
+                    case TOK_LINE_COMMENT:
+                        ++comments;
+                        break;
+                    case TOK_REGEX:
+                        ++regexes;
+                        break;
+                }
+            }
+
+            # 6 braces: 3 block + 3 hash access
+            assertEq(6, lbrace, "6 left braces (3 block + 3 hash access)");
+            assertEq(6, rbrace, "6 right braces (3 block + 3 hash access)");
+            assertEq(1, comments, "1 comment");
+            assertEq(1, regexes, "1 regex");
+        }
+    }
+
+    testEdgeCases() {
+        # Empty input
+        {
+            QoreTokenizer tok("");
+            assertTrue(tok.atEnd(), "empty input is at end");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_EOF, t.type, "empty input returns EOF");
+        }
+
+        # peek() without next()
+        {
+            QoreTokenizer tok("hello");
+            hash<TokenInfo> t1 = tok.peek();
+            hash<TokenInfo> t2 = tok.peek();
+            assertEq(t1.type, t2.type, "multiple peeks return same token");
+            assertEq(t1.value, t2.value);
+            hash<TokenInfo> t3 = tok.next();
+            assertEq(t1.value, t3.value, "next after peek returns peeked token");
+        }
+
+        # Unterminated single-quoted string
+        {
+            QoreTokenizer tok("'unterminated");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_STRING_SINGLE, t.type, "unterminated single string still tokenized");
+            assertEq("'unterminated", t.value);
+        }
+
+        # Unterminated double-quoted string
+        {
+            QoreTokenizer tok('"unterminated');
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_STRING_DOUBLE, t.type);
+            assertEq('"unterminated', t.value);
+        }
+
+        # Unterminated block comment
+        {
+            QoreTokenizer tok("/* unterminated");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_BLOCK_COMMENT, t.type);
+            assertEq("/* unterminated", t.value);
+        }
+
+        # Single / (not a regex or comment start)
+        {
+            QoreTokenizer tok("/");
+            hash<TokenInfo> t = tok.next();
+            assertEq(TOK_OTHER, t.type, "single / is OTHER");
+            assertEq("/", t.value);
+        }
+
+        # Division vs regex ambiguity (no context, so / is just OTHER)
+        {
+            QoreTokenizer tok("a / b");
+            list<hash<TokenInfo>> tokens = ();
+            while (!tok.atEnd()) {
+                tokens += tok.next();
+            }
+            # Should have tokens for 'a', ' ', '/', ' ', 'b'
+            bool found_slash = False;
+            foreach hash<TokenInfo> t in (tokens) {
+                if (t.value == "/") {
+                    assertEq(TOK_OTHER, t.type, "/ without =~ or !~ is OTHER");
+                    found_slash = True;
+                    break;
+                }
+            }
+            assertTrue(found_slash);
+        }
+
+        # getLine() and getColumn() methods
+        {
+            QoreTokenizer tok("x\ny");
+            assertEq(1, tok.getLine(), "initial line is 1");
+            assertEq(1, tok.getColumn(), "initial column is 1");
+            tok.next();  # 'x'
+            tok.next();  # newline - this advances us to line 2
+            assertEq(2, tok.getLine(), "after newline, line is 2");
+        }
+    }
+
+    testCountBraces() {
+        # Simple braces
+        {
+            hash<auto> bc = count_braces("{ }");
+            assertEq(1, bc.open, "one open brace");
+            assertEq(1, bc.close, "one close brace");
+        }
+
+        # Nested braces
+        {
+            hash<auto> bc = count_braces("{ { } }");
+            assertEq(2, bc.open, "two open braces");
+            assertEq(2, bc.close, "two close braces");
+        }
+
+        # Braces in strings are ignored
+        {
+            hash<auto> bc = count_braces("'{' + \"}\"");
+            assertEq(0, bc.open, "no open braces - all in strings");
+            assertEq(0, bc.close, "no close braces - all in strings");
+        }
+
+        # Braces in comments are ignored
+        {
+            hash<auto> bc = count_braces("x # { }");
+            assertEq(0, bc.open, "no open braces - all in comment");
+            assertEq(0, bc.close, "no close braces - all in comment");
+        }
+
+        # $# does not start a comment - THIS IS THE KEY BUG FIX
+        {
+            hash<auto> bc = count_braces("for (int i = 0; i < $#; ++i) { }");
+            assertEq(1, bc.open, "$# does not start comment - open brace counted");
+            assertEq(1, bc.close, "$# does not start comment - close brace counted");
+        }
+
+        # More complex $# case
+        {
+            hash<auto> bc = count_braces("if ($# > 0) { data{key} = $#; }");
+            assertEq(2, bc.open, "complex $# case - 2 open braces");
+            assertEq(2, bc.close, "complex $# case - 2 close braces");
+        }
+
+        # Braces in regex are ignored
+        {
+            hash<auto> bc = count_braces("if (x =~ /{/) { }");
+            assertEq(1, bc.open, "regex brace ignored - 1 open");
+            assertEq(1, bc.close, "regex brace ignored - 1 close");
+        }
+    }
+
+    testCountAllBrackets() {
+        # All bracket types
+        {
+            hash<auto> bc = count_all_brackets("{ ( [ ] ) }");
+            assertEq(1, bc.open_braces, "one open brace");
+            assertEq(1, bc.close_braces, "one close brace");
+            assertEq(1, bc.open_parens, "one open paren");
+            assertEq(1, bc.close_parens, "one close paren");
+            assertEq(1, bc.open_brackets, "one open bracket");
+            assertEq(1, bc.close_brackets, "one close bracket");
+        }
+
+        # Brackets in strings ignored
+        {
+            hash<auto> bc = count_all_brackets("'{ ( [' + \"] ) }\"");
+            assertEq(0, bc.open_braces, "no open braces in strings");
+            assertEq(0, bc.close_braces, "no close braces in strings");
+            assertEq(0, bc.open_parens, "no open parens in strings");
+            assertEq(0, bc.close_parens, "no close parens in strings");
+            assertEq(0, bc.open_brackets, "no open brackets in strings");
+            assertEq(0, bc.close_brackets, "no close brackets in strings");
+        }
+
+        # $# with all brackets
+        {
+            hash<auto> bc = count_all_brackets("for (int i = 0; i < $#; ++i) { list[i] = $#; }");
+            assertEq(1, bc.open_braces, "$# with brackets - 1 open brace");
+            assertEq(1, bc.close_braces, "$# with brackets - 1 close brace");
+            assertEq(1, bc.open_parens, "$# with brackets - 1 open paren");
+            assertEq(1, bc.close_parens, "$# with brackets - 1 close paren");
+            assertEq(1, bc.open_brackets, "$# with brackets - 1 open bracket");
+            assertEq(1, bc.close_brackets, "$# with brackets - 1 close bracket");
+        }
+
+        # Complex function declaration (qdx use case)
+        {
+            string code = "static string getDoxMod(string xs) {";
+            hash<auto> bc = count_all_brackets(code);
+            assertEq(1, bc.open_braces, "function decl - 1 open brace");
+            assertEq(0, bc.close_braces, "function decl - 0 close braces");
+            assertEq(1, bc.open_parens, "function decl - 1 open paren");
+            assertEq(1, bc.close_parens, "function decl - 1 close paren");
+        }
+    }
+
+    testQdxDollarHashIntegration() {
+        # This tests the exact bug that was reported - $# being treated as comment start
+        # causing brace counting to fail in qdx
+
+        # Simple loop with $#
+        {
+            string code = "for (int i = 0; i < $#; ++i) {\n    result += list[i];\n}";
+            hash<auto> bc = count_braces(code);
+            assertEq(1, bc.open, "loop with $# - 1 open brace");
+            assertEq(1, bc.close, "loop with $# - 1 close brace");
+        }
+
+        # Multiple $# on same line
+        {
+            string code = "if ($# > 0 && $# < 10) { }";
+            hash<auto> bc = count_braces(code);
+            assertEq(1, bc.open, "multiple $# - 1 open brace");
+            assertEq(1, bc.close, "multiple $# - 1 close brace");
+        }
+
+        # $# followed by actual comment
+        {
+            string code = "for (int i = 0; i < $#; ++i) { } # this is a comment with { }";
+            hash<auto> bc = count_braces(code);
+            assertEq(1, bc.open, "$# then comment - 1 open brace");
+            assertEq(1, bc.close, "$# then comment - 1 close brace");
+        }
+
+        # $# in hash access context
+        {
+            string code = "data{$#} = value;";
+            hash<auto> bc = count_braces(code);
+            assertEq(1, bc.open, "$# in hash access - 1 open brace");
+            assertEq(1, bc.close, "$# in hash access - 1 close brace");
+        }
+
+        # Nested blocks with $#
+        {
+            string code = "if (cond) {\n    for (int i = 0; i < $#; ++i) {\n        x = i;\n    }\n}";
+            hash<auto> bc = count_braces(code);
+            assertEq(2, bc.open, "nested blocks with $# - 2 open braces");
+            assertEq(2, bc.close, "nested blocks with $# - 2 close braces");
+        }
+
+        # Real-world example from Qore codebase
+        {
+            string code = "for (int i = 0, int e = $#; i < e; ++i) {\n"
+                "    if (val{argv[i]} > 0) {\n"
+                "        result += argv[i];\n"
+                "    }\n"
+                "}";
+            hash<auto> bc = count_braces(code);
+            assertEq(3, bc.open, "real-world $# example - 3 open braces");
+            assertEq(3, bc.close, "real-world $# example - 3 close braces");
+        }
+    }
+}

--- a/qlib/Qdx.qm
+++ b/qlib/Qdx.qm
@@ -72,6 +72,875 @@ module Qdx {
 
 #! the Qdx namespace contains all the objects in the Qdx module
 public namespace Qdx {
+    #! @defgroup token_types Token Type Constants
+    #! These constants define the different token types recognized by @ref QoreTokenizer
+    #!@{
+
+    #! Single-quoted string literal ('...')
+    public const TOK_STRING_SINGLE = 1;
+    #! Double-quoted string literal ("...")
+    public const TOK_STRING_DOUBLE = 2;
+    #! Heredoc string (<<END...END)
+    public const TOK_HEREDOC = 3;
+    #! Regex pattern (/pattern/flags)
+    public const TOK_REGEX = 4;
+    #! Regex substitution (s/pattern/replacement/flags)
+    public const TOK_SUBSTITUTION = 5;
+    #! Transliteration (tr/chars/replacements/ or y/.../)
+    public const TOK_TRANSLITERATION = 6;
+    #! Line comment (# to end of line)
+    public const TOK_LINE_COMMENT = 7;
+    #! Block comment (/* ... */)
+    public const TOK_BLOCK_COMMENT = 8;
+    #! Left brace ({)
+    public const TOK_LBRACE = 9;
+    #! Right brace (})
+    public const TOK_RBRACE = 10;
+    #! Left parenthesis (()
+    public const TOK_LPAREN = 11;
+    #! Right parenthesis ())
+    public const TOK_RPAREN = 12;
+    #! Left bracket ([)
+    public const TOK_LBRACKET = 13;
+    #! Right bracket (])
+    public const TOK_RBRACKET = 14;
+    #! Regex match operator (=~)
+    public const TOK_REGEX_MATCH = 15;
+    #! Regex not-match operator (!~)
+    public const TOK_REGEX_NOT_MATCH = 16;
+    #! Loop iteration index ($#)
+    public const TOK_DOLLAR_HASH = 17;
+    #! Identifier (variable/function names)
+    public const TOK_IDENTIFIER = 18;
+    #! Whitespace (spaces, tabs)
+    public const TOK_WHITESPACE = 19;
+    #! Newline character
+    public const TOK_NEWLINE = 20;
+    #! Any other single character
+    public const TOK_OTHER = 21;
+    #! End of input
+    public const TOK_EOF = 22;
+
+    #!@}
+
+    #! Token information structure returned by @ref QoreTokenizer
+    public hashdecl TokenInfo {
+        #! Token type (one of the TOK_* constants)
+        int type;
+        #! The actual text of the token
+        string value;
+        #! Line number where the token starts (1-based)
+        int line;
+        #! Column number where the token starts (1-based)
+        int column;
+    }
+
+    #! Tokenizer for Qore source code
+    /** This class provides lexical analysis of Qore source code, correctly handling:
+        - String literals (single and double quoted)
+        - Heredoc strings
+        - Regular expressions and substitutions
+        - Comments (line and block)
+        - All bracket types
+        - Special tokens like $# (loop iteration index)
+
+        @par Example:
+        @code{.py}
+QoreTokenizer tok("if (x == 1) { # comment\n    return x;\n}");
+while (!tok.atEnd()) {
+    hash<TokenInfo> t = tok.next();
+    printf("Token: type=%d value=%y line=%d\n", t.type, t.value, t.line);
+}
+        @endcode
+    */
+    public class QoreTokenizer {
+        private {
+            #! Input text
+            string input;
+            #! Current position (character index)
+            int pos = 0;
+            #! Current line number (1-based)
+            int line = 1;
+            #! Current column number (1-based)
+            int column = 1;
+            #! Input length in characters
+            int len;
+            #! Cached next token for peek()
+            *hash<TokenInfo> peeked;
+        }
+
+        #! Creates a tokenizer for the given input text
+        /** @param text the Qore source code to tokenize
+        */
+        constructor(string text) {
+            input = text;
+            len = text.length();
+        }
+
+        #! Returns True if at end of input
+        bool atEnd() {
+            return !peeked && pos >= len;
+        }
+
+        #! Returns the next token without consuming it
+        /** @return the next token, or a TOK_EOF token if at end of input
+        */
+        hash<TokenInfo> peek() {
+            if (!peeked) {
+                peeked = scanToken();
+            }
+            return peeked;
+        }
+
+        #! Returns the next token and advances the position
+        /** @return the next token, or a TOK_EOF token if at end of input
+        */
+        hash<TokenInfo> next() {
+            if (peeked) {
+                hash<TokenInfo> result = peeked;
+                delete peeked;
+                return result;
+            }
+            return scanToken();
+        }
+
+        #! Skips tokens until a matching close brace is found
+        /** Starts with brace count of 1 (assumes we just passed an open brace).
+            Correctly handles nested braces and skips braces inside strings,
+            comments, and regex patterns.
+
+            @return the number of lines consumed (0-based, so 0 means same line)
+        */
+        int skipToCloseBrace() {
+            int start_line = line;
+            int brace_count = 1;
+
+            while (!atEnd()) {
+                hash<TokenInfo> tok = next();
+                switch (tok.type) {
+                    case TOK_LBRACE:
+                        ++brace_count;
+                        break;
+                    case TOK_RBRACE:
+                        if (!--brace_count) {
+                            return line - start_line;
+                        }
+                        break;
+                    case TOK_EOF:
+                        return line - start_line;
+                }
+            }
+            return line - start_line;
+        }
+
+        #! Returns the current line number
+        int getLine() {
+            return line;
+        }
+
+        #! Returns the current column number
+        int getColumn() {
+            return column;
+        }
+
+        #! Returns the character at the current position, or NOTHING if at end
+        private:internal *string currentChar() {
+            if (pos >= len) {
+                return NOTHING;
+            }
+            return input[pos];
+        }
+
+        #! Returns the character at offset from current position, or NOTHING if out of bounds
+        private:internal *string peekChar(int offset = 1) {
+            int p = pos + offset;
+            if (p >= len || p < 0) {
+                return NOTHING;
+            }
+            return input[p];
+        }
+
+        #! Advances position by count characters, updating line/column
+        private:internal advance(int count = 1) {
+            for (int i = 0; i < count && pos < len; ++i) {
+                if (input[pos] == "\n") {
+                    ++line;
+                    column = 1;
+                } else {
+                    ++column;
+                }
+                ++pos;
+            }
+        }
+
+        #! Scans and returns the next token
+        private:internal hash<TokenInfo> scanToken() {
+            if (pos >= len) {
+                return <TokenInfo>{
+                    "type": TOK_EOF,
+                    "value": "",
+                    "line": line,
+                    "column": column,
+                };
+            }
+
+            int start_line = line;
+            int start_column = column;
+            *string c = currentChar();
+
+            # Newline
+            if (c == "\n") {
+                advance();
+                return <TokenInfo>{
+                    "type": TOK_NEWLINE,
+                    "value": "\n",
+                    "line": start_line,
+                    "column": start_column,
+                };
+            }
+
+            # Whitespace (not newline)
+            if (c == " " || c == "\t" || c == "\r") {
+                string ws = "";
+                while (pos < len) {
+                    c = currentChar();
+                    if (c != " " && c != "\t" && c != "\r") {
+                        break;
+                    }
+                    ws += c;
+                    advance();
+                }
+                return <TokenInfo>{
+                    "type": TOK_WHITESPACE,
+                    "value": ws,
+                    "line": start_line,
+                    "column": start_column,
+                };
+            }
+
+            # Single-quoted string
+            if (c == "'") {
+                return scanSingleQuotedString();
+            }
+
+            # Double-quoted string
+            if (c == '"') {
+                return scanDoubleQuotedString();
+            }
+
+            # Line comment or $#
+            if (c == "#") {
+                return scanLineComment();
+            }
+
+            # Block comment or division
+            if (c == "/") {
+                if (peekChar() == "*") {
+                    return scanBlockComment();
+                }
+                # Just a forward slash (division, etc.)
+                advance();
+                return <TokenInfo>{
+                    "type": TOK_OTHER,
+                    "value": "/",
+                    "line": start_line,
+                    "column": start_column,
+                };
+            }
+
+            # $# (loop iteration index) or other $ usage
+            if (c == "$") {
+                if (peekChar() == "#") {
+                    advance(2);
+                    return <TokenInfo>{
+                        "type": TOK_DOLLAR_HASH,
+                        "value": "$#",
+                        "line": start_line,
+                        "column": start_column,
+                    };
+                }
+                advance();
+                return <TokenInfo>{
+                    "type": TOK_OTHER,
+                    "value": "$",
+                    "line": start_line,
+                    "column": start_column,
+                };
+            }
+
+            # Regex match operators
+            if (c == "=" && peekChar() == "~") {
+                advance(2);
+                return scanAfterRegexOperator(TOK_REGEX_MATCH, "=~", start_line, start_column);
+            }
+
+            if (c == "!" && peekChar() == "~") {
+                advance(2);
+                return scanAfterRegexOperator(TOK_REGEX_NOT_MATCH, "!~", start_line, start_column);
+            }
+
+            # Braces and brackets
+            if (c == "{") {
+                advance();
+                return <TokenInfo>{
+                    "type": TOK_LBRACE,
+                    "value": "{",
+                    "line": start_line,
+                    "column": start_column,
+                };
+            }
+            if (c == "}") {
+                advance();
+                return <TokenInfo>{
+                    "type": TOK_RBRACE,
+                    "value": "}",
+                    "line": start_line,
+                    "column": start_column,
+                };
+            }
+            if (c == "(") {
+                advance();
+                return <TokenInfo>{
+                    "type": TOK_LPAREN,
+                    "value": "(",
+                    "line": start_line,
+                    "column": start_column,
+                };
+            }
+            if (c == ")") {
+                advance();
+                return <TokenInfo>{
+                    "type": TOK_RPAREN,
+                    "value": ")",
+                    "line": start_line,
+                    "column": start_column,
+                };
+            }
+            if (c == "[") {
+                advance();
+                return <TokenInfo>{
+                    "type": TOK_LBRACKET,
+                    "value": "[",
+                    "line": start_line,
+                    "column": start_column,
+                };
+            }
+            if (c == "]") {
+                advance();
+                return <TokenInfo>{
+                    "type": TOK_RBRACKET,
+                    "value": "]",
+                    "line": start_line,
+                    "column": start_column,
+                };
+            }
+
+            # Heredoc
+            if (c == "<" && peekChar() == "<") {
+                return scanHeredoc();
+            }
+
+            # Any other character
+            advance();
+            return <TokenInfo>{
+                "type": TOK_OTHER,
+                "value": c,
+                "line": start_line,
+                "column": start_column,
+            };
+        }
+
+        #! Scans a single-quoted string
+        private:internal hash<TokenInfo> scanSingleQuotedString() {
+            int start_line = line;
+            int start_column = column;
+            string value = "'";
+            advance();  # skip opening quote
+
+            while (pos < len) {
+                *string c = currentChar();
+                if (c == "'") {
+                    value += c;
+                    advance();
+                    break;
+                }
+                if (c == "\\") {
+                    value += c;
+                    advance();
+                    # In single-quoted strings, only \' and \\ are escapes
+                    if (pos < len) {
+                        value += currentChar();
+                        advance();
+                    }
+                } else {
+                    value += c;
+                    advance();
+                }
+            }
+
+            return <TokenInfo>{
+                "type": TOK_STRING_SINGLE,
+                "value": value,
+                "line": start_line,
+                "column": start_column,
+            };
+        }
+
+        #! Scans a double-quoted string
+        private:internal hash<TokenInfo> scanDoubleQuotedString() {
+            int start_line = line;
+            int start_column = column;
+            string value = '"';
+            advance();  # skip opening quote
+
+            while (pos < len) {
+                *string c = currentChar();
+                if (c == '"') {
+                    value += c;
+                    advance();
+                    break;
+                }
+                if (c == "\\") {
+                    value += c;
+                    advance();
+                    if (pos < len) {
+                        value += currentChar();
+                        advance();
+                    }
+                } else {
+                    value += c;
+                    advance();
+                }
+            }
+
+            return <TokenInfo>{
+                "type": TOK_STRING_DOUBLE,
+                "value": value,
+                "line": start_line,
+                "column": start_column,
+            };
+        }
+
+        #! Scans a line comment (# to end of line)
+        private:internal hash<TokenInfo> scanLineComment() {
+            int start_line = line;
+            int start_column = column;
+            string value = "#";
+            advance();  # skip #
+
+            while (pos < len) {
+                *string c = currentChar();
+                if (c == "\n") {
+                    break;
+                }
+                value += c;
+                advance();
+            }
+
+            return <TokenInfo>{
+                "type": TOK_LINE_COMMENT,
+                "value": value,
+                "line": start_line,
+                "column": start_column,
+            };
+        }
+
+        #! Scans a block comment (/* ... */)
+        private:internal hash<TokenInfo> scanBlockComment() {
+            int start_line = line;
+            int start_column = column;
+            string value = "/*";
+            advance(2);  # skip /*
+
+            while (pos < len) {
+                *string c = currentChar();
+                if (c == "*" && peekChar() == "/") {
+                    value += "*/";
+                    advance(2);
+                    break;
+                }
+                value += c;
+                advance();
+            }
+
+            return <TokenInfo>{
+                "type": TOK_BLOCK_COMMENT,
+                "value": value,
+                "line": start_line,
+                "column": start_column,
+            };
+        }
+
+        #! Scans after a regex operator (=~ or !~) to find the pattern
+        private:internal hash<TokenInfo> scanAfterRegexOperator(int op_type, string op_value, int start_line, int start_column) {
+            # Skip whitespace to find the regex
+            while (pos < len) {
+                *string c = currentChar();
+                if (c != " " && c != "\t") {
+                    break;
+                }
+                advance();
+            }
+
+            if (pos >= len) {
+                return <TokenInfo>{
+                    "type": op_type,
+                    "value": op_value,
+                    "line": start_line,
+                    "column": start_column,
+                };
+            }
+
+            *string c = currentChar();
+
+            # Check for s (substitution), tr or y (transliteration)
+            if (c == "s" && peekChar() =~ /[^a-zA-Z0-9_]/) {
+                return scanSubstitution(start_line, start_column);
+            }
+            if ((c == "t" && peekChar() == "r" && peekChar(2) =~ /[^a-zA-Z0-9_]/) ||
+                (c == "y" && peekChar() =~ /[^a-zA-Z0-9_]/)) {
+                return scanTransliteration(start_line, start_column);
+            }
+
+            # Regular regex pattern
+            if (c == "/") {
+                return scanRegex(start_line, start_column);
+            }
+
+            # Not followed by a regex - just return the operator
+            return <TokenInfo>{
+                "type": op_type,
+                "value": op_value,
+                "line": start_line,
+                "column": start_column,
+            };
+        }
+
+        #! Scans a regex pattern (/pattern/flags)
+        private:internal hash<TokenInfo> scanRegex(int start_line, int start_column) {
+            string value = "/";
+            advance();  # skip opening /
+
+            while (pos < len) {
+                *string c = currentChar();
+                if (c == "/") {
+                    value += c;
+                    advance();
+                    # Scan flags
+                    while (pos < len && currentChar() =~ /[gimsxn]/) {
+                        value += currentChar();
+                        advance();
+                    }
+                    break;
+                }
+                if (c == "\\") {
+                    value += c;
+                    advance();
+                    if (pos < len) {
+                        value += currentChar();
+                        advance();
+                    }
+                } else if (c == "\n") {
+                    # Regex can't span lines without escape
+                    break;
+                } else {
+                    value += c;
+                    advance();
+                }
+            }
+
+            return <TokenInfo>{
+                "type": TOK_REGEX,
+                "value": value,
+                "line": start_line,
+                "column": start_column,
+            };
+        }
+
+        #! Scans a substitution (s/pattern/replacement/flags)
+        private:internal hash<TokenInfo> scanSubstitution(int start_line, int start_column) {
+            string value = "s";
+            advance();  # skip 's'
+
+            *string delim = currentChar();
+            if (!delim) {
+                return <TokenInfo>{
+                    "type": TOK_OTHER,
+                    "value": value,
+                    "line": start_line,
+                    "column": start_column,
+                };
+            }
+
+            value += delim;
+            advance();
+
+            # Scan pattern
+            int pattern_count = 0;
+            while (pos < len) {
+                *string c = currentChar();
+                if (c == "\\") {
+                    value += c;
+                    advance();
+                    if (pos < len) {
+                        value += currentChar();
+                        advance();
+                    }
+                } else if (c == delim) {
+                    value += c;
+                    advance();
+                    ++pattern_count;
+                    if (pattern_count >= 2) {
+                        # Scan flags
+                        while (pos < len && currentChar() =~ /[gimsxn]/) {
+                            value += currentChar();
+                            advance();
+                        }
+                        break;
+                    }
+                } else {
+                    value += c;
+                    advance();
+                }
+            }
+
+            return <TokenInfo>{
+                "type": TOK_SUBSTITUTION,
+                "value": value,
+                "line": start_line,
+                "column": start_column,
+            };
+        }
+
+        #! Scans a transliteration (tr/chars/replacements/ or y/.../)
+        private:internal hash<TokenInfo> scanTransliteration(int start_line, int start_column) {
+            string value = "";
+            *string c = currentChar();
+
+            if (c == "t") {
+                value = "tr";
+                advance(2);
+            } else {
+                value = "y";
+                advance();
+            }
+
+            *string delim = currentChar();
+            if (!delim) {
+                return <TokenInfo>{
+                    "type": TOK_OTHER,
+                    "value": value,
+                    "line": start_line,
+                    "column": start_column,
+                };
+            }
+
+            value += delim;
+            advance();
+
+            # Scan two patterns
+            int pattern_count = 0;
+            while (pos < len) {
+                c = currentChar();
+                if (c == "\\") {
+                    value += c;
+                    advance();
+                    if (pos < len) {
+                        value += currentChar();
+                        advance();
+                    }
+                } else if (c == delim) {
+                    value += c;
+                    advance();
+                    ++pattern_count;
+                    if (pattern_count >= 2) {
+                        break;
+                    }
+                } else {
+                    value += c;
+                    advance();
+                }
+            }
+
+            return <TokenInfo>{
+                "type": TOK_TRANSLITERATION,
+                "value": value,
+                "line": start_line,
+                "column": start_column,
+            };
+        }
+
+        #! Scans a heredoc (<<MARKER...MARKER)
+        private:internal hash<TokenInfo> scanHeredoc() {
+            int start_line = line;
+            int start_column = column;
+            string value = "<<";
+            advance(2);  # skip <<
+
+            # Get the marker
+            string marker = "";
+            while (pos < len) {
+                *string c = currentChar();
+                if (c =~ /[a-zA-Z0-9_]/) {
+                    marker += c;
+                    value += c;
+                    advance();
+                } else {
+                    break;
+                }
+            }
+
+            if (marker == "") {
+                # Not a heredoc, just <<
+                return <TokenInfo>{
+                    "type": TOK_OTHER,
+                    "value": "<<",
+                    "line": start_line,
+                    "column": start_column,
+                };
+            }
+
+            # Find the end marker (must be at start of line)
+            bool at_line_start = False;
+            while (pos < len) {
+                *string c = currentChar();
+
+                if (c == "\n") {
+                    value += c;
+                    at_line_start = True;
+                    advance();
+                    continue;
+                }
+
+                if (at_line_start) {
+                    # Check if this line starts with the marker
+                    bool found = True;
+                    for (int i = 0; i < marker.length(); ++i) {
+                        if (pos + i >= len || input[pos + i] != marker[i]) {
+                            found = False;
+                            break;
+                        }
+                    }
+                    if (found) {
+                        # Check that marker is followed by non-identifier char or EOL
+                        int end_pos = pos + marker.length();
+                        if (end_pos >= len || input[end_pos] !~ /[a-zA-Z0-9_]/) {
+                            # Include the marker in the value (don't add 'c' first)
+                            value += marker;
+                            advance(marker.length());
+                            break;
+                        }
+                    }
+                }
+
+                # Only add character if not part of end marker
+                value += c;
+                at_line_start = False;
+                advance();
+            }
+
+            return <TokenInfo>{
+                "type": TOK_HEREDOC,
+                "value": value,
+                "line": start_line,
+                "column": start_column,
+            };
+        }
+    }
+
+    #! Counts open and close braces in a string using proper tokenization
+    /** This function correctly handles braces inside strings, comments, and regex patterns,
+        and correctly handles $# (loop iteration index) vs # (line comment start).
+
+        @param text the text to analyze
+        @return a hash with "open" and "close" keys containing the brace counts
+
+        @par Example:
+        @code{.py}
+hash<auto> counts = count_braces("if (x) { list[$#] }");
+printf("open: %d, close: %d\n", counts.open, counts.close);  # open: 1, close: 1
+        @endcode
+    */
+    public hash<auto> sub count_braces(string text) {
+        QoreTokenizer tok(text);
+        int open_braces = 0;
+        int close_braces = 0;
+
+        while (!tok.atEnd()) {
+            hash<TokenInfo> t = tok.next();
+            switch (t.type) {
+                case TOK_LBRACE:
+                    ++open_braces;
+                    break;
+                case TOK_RBRACE:
+                    ++close_braces;
+                    break;
+            }
+        }
+
+        return {
+            "open": open_braces,
+            "close": close_braces,
+        };
+    }
+
+    #! Counts all bracket types in a string using proper tokenization
+    /** This function correctly handles brackets inside strings, comments, and regex patterns,
+        and correctly handles $# (loop iteration index) vs # (line comment start).
+
+        @param text the text to analyze
+        @return a hash with counts for braces, parentheses, and brackets
+
+        @par Example:
+        @code{.py}
+hash<auto> counts = count_all_brackets("if (x[$#]) { y; }");
+printf("open_braces: %d, close_braces: %d\n", counts.open_braces, counts.close_braces);
+printf("open_parens: %d, close_parens: %d\n", counts.open_parens, counts.close_parens);
+        @endcode
+    */
+    public hash<auto> sub count_all_brackets(string text) {
+        QoreTokenizer tok(text);
+        int open_braces = 0;
+        int close_braces = 0;
+        int open_parens = 0;
+        int close_parens = 0;
+        int open_brackets = 0;
+        int close_brackets = 0;
+
+        while (!tok.atEnd()) {
+            hash<TokenInfo> t = tok.next();
+            switch (t.type) {
+                case TOK_LBRACE:
+                    ++open_braces;
+                    break;
+                case TOK_RBRACE:
+                    ++close_braces;
+                    break;
+                case TOK_LPAREN:
+                    ++open_parens;
+                    break;
+                case TOK_RPAREN:
+                    ++close_parens;
+                    break;
+                case TOK_LBRACKET:
+                    ++open_brackets;
+                    break;
+                case TOK_RBRACKET:
+                    ++close_brackets;
+                    break;
+            }
+        }
+
+        return {
+            "open_braces": open_braces,
+            "close_braces": close_braces,
+            "open_parens": open_parens,
+            "close_parens": close_parens,
+            "open_brackets": open_brackets,
+            "close_brackets": close_brackets,
+        };
+    }
+
     #! converts specially-formatted text in the input to HTML tables
     public class DocumentTableHelper {
         private:internal {


### PR DESCRIPTION
## Summary

Adds `QoreTokenizer` class to the Qdx module that correctly handles Qore lexical analysis, fixing the bug where `$#` was incorrectly treated as the start of a comment.

## Changes

- Added 22 token type constants (`TOK_STRING_SINGLE` through `TOK_EOF`)
- Added `TokenInfo` hashdecl for token metadata
- Added `QoreTokenizer` class with full lexical analysis supporting:
  - Single and double-quoted strings with escape sequences
  - Line comments (`#`) vs `$#` (loop iteration variable)
  - Block comments (`/* */`)
  - Heredoc strings
  - Regex patterns after `=~` and `!~` operators
  - Substitution (`s///`) and transliteration (`tr///`) operators
  - All bracket types: braces `{}`, parentheses `()`, square brackets `[]`
- Added `count_braces()` and `count_all_brackets()` helper functions
- Updated qdx to use tokenizer-based brace counting instead of regex
- Added release notes

## Bug Fix

This fixes the bug where `$#` was incorrectly treated as the start of a comment, causing brace counting to fail in loops like:
```qore
for (int i = 0; i < $#; ++i) { }
```

## Test plan

- [x] 26 test cases with 192 assertions pass
- [x] qdx successfully processes all modules containing `$#` (Util, QUnit, HttpServer, Mapper, TextWrap, DebugCmdLine)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)