### PR TITLE
fix: add streaming keys to HttpHandlerResponseInfo hashdecl

### DIFF
--- a/examples/test/qlib/HttpServerUtil/HttpServerUtil.qtest
+++ b/examples/test/qlib/HttpServerUtil/HttpServerUtil.qtest
@@ -16,6 +16,7 @@
 public class HttpServerUtilTest inherits QUnit::Test {
     constructor() : Test("HttpServerUtilTest", "1.0") {
         addTestCase("funcs", \funcTests());
+        addTestCase("hashdecl tests", \hashdeclTests());
 
         # Return for compatibility with test harness that checks the process's return value
         set_return_value(main());
@@ -74,5 +75,55 @@ public class HttpServerUtilTest inherits QUnit::Test {
         assertEq("\"passwd\" = 1", http_mask_data("\"passwd\" = 1"));
         assertEq("passenger = 1", http_mask_data("passenger = 1"));
         assertEq("\"passenger\" = 1", http_mask_data("\"passenger\" = 1"));
+    }
+
+    hashdeclTests() {
+        # Test HttpResponseInfo hashdecl with streaming keys
+        {
+            hash<HttpResponseInfo> resp = <HttpResponseInfo>{
+                "code": 200,
+                "streaming": True,
+                "stream_type": "sse",
+            };
+            assertEq(200, resp.code, "HttpResponseInfo code");
+            assertTrue(resp.streaming, "HttpResponseInfo streaming");
+            assertEq("sse", resp.stream_type, "HttpResponseInfo stream_type");
+        }
+
+        # Test HttpHandlerResponseInfo hashdecl with streaming keys
+        {
+            hash<HttpHandlerResponseInfo> resp = <HttpHandlerResponseInfo>{
+                "code": 200,
+                "streaming": True,
+                "stream_type": "websocket",
+            };
+            assertEq(200, resp.code, "HttpHandlerResponseInfo code");
+            assertTrue(resp.streaming, "HttpHandlerResponseInfo streaming");
+            assertEq("websocket", resp.stream_type, "HttpHandlerResponseInfo stream_type");
+        }
+
+        # Test cast from hash with streaming keys to HttpHandlerResponseInfo
+        {
+            hash<auto> src = {
+                "code": 200,
+                "body": "test",
+                "streaming": True,
+                "stream_type": "sse",
+            };
+            hash<HttpHandlerResponseInfo> resp = cast<hash<HttpHandlerResponseInfo>>(src);
+            assertEq(200, resp.code, "cast code");
+            assertEq("test", resp.body, "cast body");
+            assertTrue(resp.streaming, "cast streaming");
+            assertEq("sse", resp.stream_type, "cast stream_type");
+        }
+
+        # Test default values
+        {
+            hash<HttpHandlerResponseInfo> resp = <HttpHandlerResponseInfo>{
+                "code": 200,
+            };
+            assertFalse(resp.streaming, "default streaming should be False");
+            assertNothing(resp.stream_type, "default stream_type should be NOTHING");
+        }
     }
 }

--- a/qlib/HttpServerUtil.qm
+++ b/qlib/HttpServerUtil.qm
@@ -431,6 +431,18 @@ public hashdecl HttpHandlerResponseInfo {
 
     #! additional info to be added to the context (cx) variable's \a user_state key if the connection is not closed
     *hash<auto> user_state;
+
+    #! set to @ref True to indicate this is a streaming response (SSE or WebSocket)
+    /** When this is set, the connection will be handled as a dedicated socket.
+        @since Qore 2.3 (HttpServerUtil 2.1)
+    */
+    softbool streaming = False;
+
+    #! the type of streaming connection: "sse" or "websocket"
+    /** Only used when \c streaming is @ref True.
+        @since Qore 2.3 (HttpServerUtil 2.1)
+    */
+    *string stream_type;
 }
 
 # hashdecl for SSL info


### PR DESCRIPTION
## Summary
- Added missing `streaming` and `stream_type` keys to `HttpHandlerResponseInfo` hashdecl to match `HttpResponseInfo`

## Problem
The `HttpHandlerResponseInfo` hashdecl was missing the `streaming` and `stream_type` keys that are present in `HttpResponseInfo`. This caused a `HASHDECL-INIT-ERROR` when code returned streaming responses that were cast to `HttpHandlerResponseInfo`:

```
HASHDECL-INIT-ERROR: hashdecl 'HttpHandlerResponseInfo' hash initializer value contains unknown key 'streaming'
```

## Test plan
- [x] Added hashdecl tests to verify streaming keys work correctly
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)