### PR TITLE
fix: memory leaks with large integers in NaN-boxing implementation

### DIFF
--- a/include/qore/intern/QoreLValue.h
+++ b/include/qore/intern/QoreLValue.h
@@ -405,7 +405,28 @@ public:
     }
 
     DLLLOCAL QoreValue getReferencedValue() const {
-        return getValue().refSelf();
+        if (!assigned) {
+            return QoreValue();
+        }
+
+        // For QV_Node, ref the existing node before returning
+        if (type == QV_Node) {
+            if (v.n) {
+                v.n->ref();
+            }
+            return QoreValue(v.n);
+        }
+
+        // For scalar types, QoreValue constructor may allocate a new QoreBigIntNode/QoreBigFloatNode
+        // for large values. These are already created with ref count 1, so no additional ref needed.
+        switch (type) {
+            case QV_Bool: return QoreValue(v.b);
+            case QV_Int: return QoreValue(v.i);
+            case QV_Float: return QoreValue(v.f);
+            default: assert(false);
+                // no break
+        }
+        return QoreValue();
     }
 
     DLLLOCAL const ReferenceNode* getReference() const {
@@ -434,15 +455,28 @@ public:
             return QoreValue(v.n);
         }
 
-        needs_deref = false;
-
         switch (type) {
-            case QV_Bool: return QoreValue(v.b);
-            case QV_Int: return QoreValue(v.i);
-            case QV_Float: return QoreValue(v.f);
+            case QV_Bool:
+                needs_deref = false;
+                return QoreValue(v.b);
+            case QV_Int: {
+                // QoreValue(v.i) may allocate a QoreBigIntNode for large integers
+                QoreValue result(v.i);
+                // If a large integer was created (stored as pointer), set needs_deref = true
+                needs_deref = result.isPointer();
+                return result;
+            }
+            case QV_Float: {
+                // QoreValue(v.f) may allocate a QoreBigFloatNode for problematic doubles
+                QoreValue result(v.f);
+                // If a node was created, set needs_deref = true
+                needs_deref = result.isPointer();
+                return result;
+            }
             default: assert(false);
             // no break
         }
+        needs_deref = false;
         return QoreValue();
     }
 

--- a/lib/QoreUnaryMinusOperatorNode.cpp
+++ b/lib/QoreUnaryMinusOperatorNode.cpp
@@ -3,7 +3,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -57,18 +57,28 @@ QoreValue QoreUnaryMinusOperatorNode::evalImpl(bool& needs_deref, ExceptionSink*
         }
 
         case NT_FLOAT: {
-            return -(v->getAsFloat());
+            // QoreValue(double) may allocate a QoreBigFloatNode for problematic doubles
+            QoreValue result(-(v->getAsFloat()));
+            // If a node was created (stored as pointer), set needs_deref = true
+            needs_deref = result.isPointer();
+            return result;
         }
 
         case NT_DATE: {
+            needs_deref = true;
             return v->get<const DateTimeNode>()->unaryMinus();
         }
 
         case NT_INT: {
-            return -(v->getAsBigInt());
+            // QoreValue(int64) may allocate a QoreBigIntNode for large integers
+            QoreValue result(-(v->getAsBigInt()));
+            // If a node was created (stored as pointer), set needs_deref = true
+            needs_deref = result.isPointer();
+            return result;
         }
     }
 
+    needs_deref = false;
     return QoreValue(0ll);
 }
 


### PR DESCRIPTION
## Summary

Fixes memory leaks in the NaN-boxing implementation when handling large integers (outside the 48-bit inline range like `MAXINT` and `MININT`).

- Fix reference counting in `QoreLValue::getReferencedValue()` to not double-ref newly created `QoreBigIntNode` pointers
- Fix `QoreLValue::getReferencedValue(bool& needs_deref)` to set `needs_deref=true` when large integers are allocated
- Fix `QoreUnaryMinusOperatorNode::evalImpl()` to properly set `needs_deref` for large integer results

Fixes #5112
Fixes #5113
Fixes #5114
Fixes #5115

## Test plan

- [x] Verified with valgrind: `definitely lost: 0 bytes in 0 blocks`
- [x] Tested math constants (`MAXINT`, `MININT`) 
- [x] Tested large integer literals
- [x] Tested variable evaluation chains
- [x] Tested unary minus operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)