### PR TITLE
fix: HTTP/2 client/server improvements and global mode support

### DIFF
--- a/examples/test/qlib/HttpServer/HttpServer.qtest
+++ b/examples/test/qlib/HttpServer/HttpServer.qtest
@@ -1104,6 +1104,19 @@ OKKqgBjNAlYDdPhOy8O8Agk=
                 version, h2client.isHttp2Active());
         }
 
+        # Test that response-uri is set correctly for HTTP/2 responses
+        # This is needed for tools like 'rest -l' that display the response status line
+        {
+            hash<auto> info;
+            h2client.send(NOTHING, "GET", "/http2-test", NOTHING, False, \info);
+            # Verify response-uri is set in the format "HTTP/2 <code> <message>"
+            assertTrue(info."response-uri".val(), "response-uri should be set for HTTP/2");
+            assertRegex("^HTTP/2 200", info."response-uri", "response-uri should start with HTTP/2 200");
+            if (m_options.verbose > 0) {
+                printf("HTTP/2 response-uri: %y\n", info."response-uri");
+            }
+        }
+
         # Test keep-alive with multiple requests (verifies HTTP/2 connection state preservation)
         # This is critical for browser compatibility - browsers reuse HTTP/2 connections
         for (int i = 1; i <= 5; i++) {

--- a/examples/test/qlib/HttpServer/HttpServer.qtest
+++ b/examples/test/qlib/HttpServer/HttpServer.qtest
@@ -65,6 +65,9 @@ class ReqHandler inherits AbstractHttpRequestHandler {
             int size = int(m[0]);
             string data = strmul("X", size);
             return makeResponse(200, data, {"Content-Type": "text/plain"});
+        } else if (rpath =~ /^echo-body/) {
+            # Echo back the request body for testing large POST bodies
+            return makeResponse(200, body, {"Content-Type": "application/octet-stream"});
         }
 
         if (hdr.method == "POST") {
@@ -1177,6 +1180,24 @@ OKKqgBjNAlYDdPhOy8O8Agk=
         hash<auto> postResp = h2client.send("http2-data", "POST", "/http2-post");
         assertEq(200, postResp.status_code);
         assertEq("POST, http2-data, http2-post, /http2-post", postResp.body);
+
+        # Test HTTP/2 POST with large request bodies
+        # This exercises HTTP/2 DATA frame handling for request bodies
+        # These sizes test different scenarios:
+        # - 50KB: moderate size, multiple DATA frames
+        # - 100KB: larger request body
+        # - 500KB: tests flow control with large uploads
+        list<int> post_sizes = (50000, 100000, 500000);
+        for (int j = 0; j < post_sizes.size(); j++) {
+            int post_size = post_sizes[j];
+            string large_body = strmul("X", post_size);
+            hash<auto> post_resp = h2client.send(large_body, "POST", "/echo-body");
+            assertEq(200, post_resp.status_code, sprintf("HTTP/2 POST %d bytes should succeed", post_size));
+            assertEq(post_size, post_resp.body.size(), sprintf("HTTP/2 POST %d bytes - response body size", post_size));
+            assertEq(large_body, post_resp.body, sprintf("HTTP/2 POST %d bytes - body content", post_size));
+            # Verify HTTP/2 connection is still active after large upload
+            assertTrue(h2client.isHttp2Active(), sprintf("HTTP/2 active after %d byte POST", post_size));
+        }
 
         # Test HTTP/2 disabled mode
         HTTPClient h1client({

--- a/examples/test/qlib/HttpServer/HttpServer.qtest
+++ b/examples/test/qlib/HttpServer/HttpServer.qtest
@@ -60,6 +60,11 @@ class ReqHandler inherits AbstractHttpRequestHandler {
             hash<MessageInfo> h = MultiPartMessage::parseBody(boundary, body, True);
             #printf("h: %N\n", h);
             return makeResponse(200, new BinaryInputStream(h.part[1].body), {"Content-Type": h.part[1].hdr."content-type"});
+        } else if (*list<*string> m = (rpath =~ x/largeresponse\/(\d+)/)) {
+            # Return a response of specified size for testing large HTTP/2 transfers
+            int size = int(m[0]);
+            string data = strmul("X", size);
+            return makeResponse(200, data, {"Content-Type": "text/plain"});
         }
 
         if (hdr.method == "POST") {
@@ -1099,9 +1104,61 @@ OKKqgBjNAlYDdPhOy8O8Agk=
                 version, h2client.isHttp2Active());
         }
 
-        # Test keep-alive with multiple requests
-        assertEq("GET, test1, /test1", h2client.get("/test1"));
-        assertEq("GET, test2, /test2", h2client.get("/test2"));
+        # Test keep-alive with multiple requests (verifies HTTP/2 connection state preservation)
+        # This is critical for browser compatibility - browsers reuse HTTP/2 connections
+        for (int i = 1; i <= 5; i++) {
+            string path = sprintf("/test%d", i);
+            string expected = sprintf("GET, test%d, %s", i, path);
+            assertEq(expected, h2client.get(path));
+        }
+
+        # Verify HTTP/2 is still active after multiple requests
+        assertTrue(h2client.isHttp2Active());
+
+        # Test larger payloads - this exercises the HTTP/2 DATA frame handling with substantial data
+        # These sizes are chosen to test different scenarios:
+        # - 50KB: moderate size
+        # - 100KB: larger response
+        # - 500KB: tests flow control and multiple DATA frames
+        list<int> sizes = (50000, 100000, 500000);
+        for (int i = 0; i < sizes.size(); i++) {
+            int size = sizes[i];
+            hash<auto> large_resp = h2client.send(NOTHING, "GET", "/largeresponse/" + size, NOTHING, True);
+            assertEq(200, large_resp.status_code);
+            assertEq(size, large_resp.body.size());
+            # Verify HTTP/2 connection is still active after large transfer
+            assertTrue(h2client.isHttp2Active());
+        }
+
+        # Test HTTP/2 compression - this was a bug where Accept-Encoding wasn't being parsed for HTTP/2
+        # The server should compress responses > 1KB when Accept-Encoding is provided
+        {
+            # Create a new HTTP/2 client that doesn't auto-decompress
+            HTTPClient h2compress({
+                "url": asyncSslUrl,
+                "timeout": 10s,
+                "ssl_verify_cert": False,
+                "http_version": "2",
+            });
+            h2compress.connect();
+            on_exit h2compress.disconnect();
+
+            # Request a 5KB response (well above the 1KB compression threshold)
+            # Send explicit Accept-Encoding header
+            hash<auto> hdr = {
+                "Accept-Encoding": "gzip, deflate, br",
+            };
+            hash<auto> info;
+            h2compress.send(NOTHING, "GET", "/largeresponse/5000", hdr, False, \info);
+            # Verify the response was compressed (Content-Encoding should be set)
+            # Note: HTTPClient auto-decompresses, so we check the original response headers
+            *string content_encoding = info."response-headers"."content-encoding"
+                ?? info."response-headers"."Content-Encoding";
+            if (m_options.verbose > 0) {
+                printf("HTTP/2 compression test: Content-Encoding = %y\n", content_encoding);
+            }
+            assertTrue(content_encoding.val(), "HTTP/2 response should be compressed");
+        }
 
         # Test POST request
         hash<auto> postResp = h2client.send("http2-data", "POST", "/http2-post");
@@ -1128,7 +1185,47 @@ OKKqgBjNAlYDdPhOy8O8Agk=
         # This should work with HTTP/1.1
         assertEq("GET, h1test, /h1test", h1client.get("/h1test"));
         assertFalse(h1client.isHttp2Active());
+
+        # Test set_global_http2_mode("disabled") - server should not offer HTTP/2
+        {
+            # Save original mode
+            string orig_mode = get_global_http2_mode();
+            on_exit set_global_http2_mode(orig_mode);
+
+            # Disable HTTP/2 globally
+            set_global_http2_mode("disabled");
+            assertEq("disabled", get_global_http2_mode());
+
+            # Create a new HTTPS listener that will be affected by the global mode
+            # The async server's listeners are cached, so we need a new one to test
+            hash<auto> linfo = mAsyncServer.addListener(<HttpListenerOptionInfo>{
+                "service": 0,
+                "cert": new SSLCertificate(CertPem),
+                "key": new SSLPrivateKey(KeyPem),
+            });
+            on_exit mAsyncServer.stopListenerID(linfo.id);
+
+            string disabledUrl = "https://localhost:" + linfo.port;
+
+            # Create an HTTP/2 client and try to connect - it should fall back to HTTP/1.1
+            # because the server won't offer HTTP/2 via ALPN
+            HTTPClient h2disabled({
+                "url": disabledUrl,
+                "timeout": 10s,
+                "ssl_verify_cert": False,
+                "http_version": "2",    # Client wants HTTP/2
+            });
+            h2disabled.connect();
+            on_exit h2disabled.disconnect();
+
+            # The client should fall back to HTTP/1.1 because server doesn't offer HTTP/2
+            assertFalse(h2disabled.isHttp2Active(), "HTTP/2 should not be active when globally disabled");
+
+            # Request should still work via HTTP/1.1
+            assertEq("GET, h2disabled, /h2disabled", h2disabled.get("/h2disabled"));
+        }
     }
+
 }
 
 #! Test handler that supports persistent connections

--- a/examples/test/qore/classes/HTTPClient/HTTPClient.qtest
+++ b/examples/test/qore/classes/HTTPClient/HTTPClient.qtest
@@ -651,8 +651,10 @@ I45SPdad6fpziP1EtT5rfrC0ZH7cMU8edg==
             RealTestHttpServer serv(cert.getPath(), cert.getPath());
             on_exit delete serv;
 
+            # Use HTTP/1.1 for poll operations - HTTP/2 poll is not supported
             HTTPClient hc({
                 "url": "https://localhost:" + serv.getPort(),
+                "http_version": "1.1",
             });
 
             SocketPollOperation spop = hc.startPollConnect();
@@ -758,8 +760,10 @@ I45SPdad6fpziP1EtT5rfrC0ZH7cMU8edg==
         RealTestHttpServer serv(cert.getPath(), cert.getPath());
         on_exit delete serv;
 
+        # Use HTTP/1.1 - chunked transfer-encoding is an HTTP/1.1 concept
         HTTPClient hc({
             "url": "https://localhost:" + serv.getPort(),
+            "http_version": "1.1",
         });
         hash<auto> hdr = {
             "Connection": "Keep-Alive",
@@ -777,8 +781,10 @@ I45SPdad6fpziP1EtT5rfrC0ZH7cMU8edg==
         RealTestHttpServer serv(cert.getPath(), cert.getPath());
         on_exit delete serv;
 
+        # Use HTTP/1.1 - streaming callbacks not supported with HTTP/2
         HTTPClient hc({
             "url": "https://localhost:" + serv.getPort(),
+            "http_version": "1.1",
         });
         hash<auto> hdr = {
             "X-Test-Disconnect": "true",

--- a/include/qore/intern/qore_socket_private.h
+++ b/include/qore/intern/qore_socket_private.h
@@ -611,6 +611,11 @@ struct qore_socket_private {
         return sock != QORE_INVALID_SOCKET;
     }
 
+    //! Returns true if ALPN protocols have been configured
+    DLLLOCAL bool hasAlpnProtocols() const {
+        return !alpn_protocols.empty();
+    }
+
     DLLLOCAL int close() {
         return close_internal();
     }

--- a/lib/QoreHttpClientObject.cpp
+++ b/lib/QoreHttpClientObject.cpp
@@ -581,6 +581,28 @@ struct qore_httpclient_priv {
             ? proxy_connection.ssl
             : connection.ssl;
 
+        // Set up ALPN protocols for HTTP/2 if not already set and http2_mode allows HTTP/2
+        if (connect_ssl && (http2_mode == HTTP2_MODE_AUTO || http2_mode == HTTP2_MODE_REQUIRED)) {
+            // Check global HTTP/2 mode - don't set ALPN if globally disabled
+            int global_mode = qore_global_http2_mode.load(std::memory_order_relaxed);
+            bool lib_disabled = qore_check_option(QLO_DISABLE_HTTP2);
+            if (global_mode != HTTP2_MODE_DISABLED && !lib_disabled) {
+                // Set ALPN protocols if not already configured
+                if (!msock->socket->priv->hasAlpnProtocols()) {
+                    ReferenceHolder<QoreListNode> protocols(new QoreListNode(autoTypeInfo), xsink);
+                    if (http2_mode == HTTP2_MODE_REQUIRED) {
+                        // HTTP/2 only
+                        protocols->push(new QoreStringNode("h2"), xsink);
+                    } else {
+                        // Auto mode: prefer h2, fall back to http/1.1
+                        protocols->push(new QoreStringNode("h2"), xsink);
+                        protocols->push(new QoreStringNode("http/1.1"), xsink);
+                    }
+                    msock->socket->setAlpnProtocols(*protocols, xsink);
+                }
+            }
+        }
+
         int rc;
         if (connect_ssl) {
             rc = msock->socket->connectSSL(xsink, socketpath.c_str(), connect_timeout_ms, msock->cert, msock->pk);

--- a/lib/QoreHttpClientObject.cpp
+++ b/lib/QoreHttpClientObject.cpp
@@ -2670,6 +2670,13 @@ int HttpClientConnectSendRecvPollOperation::connectDone(ExceptionSink* xsink) {
 int HttpClientConnectSendRecvPollOperation::startSend(ExceptionSink* xsink) {
     assert(client->http_priv->msock->m.trylock());
 
+    // Check if HTTP/2 is active - poll operations don't support HTTP/2
+    if (client->http_priv->http2_active) {
+        xsink->raiseException("HTTP2-POLL-ERROR", "poll operations are not supported with HTTP/2 connections; "
+            "use the synchronous send() method or disable HTTP/2 with http_version=1.1");
+        return -1;
+    }
+
     qore_socket_private* spriv = client->http_priv->msock->socket->priv;
 
     assert(!poll_state);
@@ -3693,6 +3700,13 @@ QoreHashNode* qore_httpclient_priv::sendMessageAndGetResponse(con_info& connecti
 
     // Use HTTP/2 if active
     if (http2_active && getH2Session()) {
+        // HTTP/2 doesn't support streaming callbacks - raise an error if they are used
+        if (send_callback || is || trailer_callback) {
+            xsink->raiseException("HTTP2-CALLBACK-ERROR", "streaming callbacks (send_callback, InputStream, "
+                "trailer_callback) are not supported with HTTP/2 connections; use the synchronous send() method "
+                "or disable HTTP/2 with http_version=1.1");
+            return nullptr;
+        }
         return sendHttp2MessageAndGetResponse(mname, meth, msgpath, nh, body, data, size,
             info, timeout_ms, code, xsink);
     }

--- a/lib/QoreHttpClientObject.cpp
+++ b/lib/QoreHttpClientObject.cpp
@@ -3888,6 +3888,10 @@ QoreHashNode* qore_httpclient_priv::sendHttp2MessageAndGetResponse(const char* m
 
     if (info) {
         info->setKeyValue("response-headers", response->refSelf(), xsink);
+        // Set response-uri for compatibility with HTTP/1.x clients (e.g., rest -l)
+        QoreStringNode* response_uri = new QoreStringNode();
+        response_uri->sprintf("HTTP/2 %d %s", code, status_msg);
+        info->setKeyValue("response-uri", response_uri, xsink);
     }
 
     return response.release();

--- a/lib/QoreHttpClientObject.cpp
+++ b/lib/QoreHttpClientObject.cpp
@@ -593,12 +593,24 @@ struct qore_httpclient_priv {
                     if (http2_mode == HTTP2_MODE_REQUIRED) {
                         // HTTP/2 only
                         protocols->push(new QoreStringNode("h2"), xsink);
+                        if (*xsink) {
+                            return -1;
+                        }
                     } else {
                         // Auto mode: prefer h2, fall back to http/1.1
                         protocols->push(new QoreStringNode("h2"), xsink);
+                        if (*xsink) {
+                            return -1;
+                        }
                         protocols->push(new QoreStringNode("http/1.1"), xsink);
+                        if (*xsink) {
+                            return -1;
+                        }
                     }
                     msock->socket->setAlpnProtocols(*protocols, xsink);
+                    if (*xsink) {
+                        return -1;
+                    }
                 }
             }
         }

--- a/qlib/HttpServer.qm
+++ b/qlib/HttpServer.qm
@@ -2130,6 +2130,7 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
 
             # compress body if eligible for compression
             if (rv.body && !rv.hdr."Content-Encoding" && rv.body.size() > CompressionThreshold) {
+                int orig_size = rv.body.size();
                 if (cx.encoding == "br") {
                     rv.hdr."Content-Encoding" = "br";
                     rv.body = brotli(rv.body);
@@ -2145,6 +2146,10 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
                 } else if (cx.encoding == "bzip2") {
                     rv.hdr."Content-Encoding" = "bzip2";
                     rv.body = bzip2(rv.body);
+                }
+                if (rv.hdr."Content-Encoding") {
+                    listener.log("cid %d: HTTP/2=%y compressed %s: %d -> %d bytes", cx.id,
+                        cx."header-info".http2, rv.hdr."Content-Encoding", orig_size, rv.body.size());
                 }
             }
 
@@ -2291,11 +2296,37 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
         }
 
         try {
-            if (!chunked) {
-                # send a normal monolithic response
+            # Check if this is an HTTP/2 connection
+            if (cx."header-info".http2) {
+                int stream_id = cx."header-info".stream_id;
+                # HTTP/2: read stream data into memory if needed
+                auto send_body = body;
+                if (chunked && body instanceof InputStream) {
+                    send_body = body.read(-1);
+                }
+                # Remove Transfer-Encoding header (HTTP/2 uses DATA frames, not chunked encoding)
+                hash<auto> hdr = rv.hdr ?? {};
+                remove hdr."Transfer-Encoding";
+                # Set Content-Length for HTTP/2 if body exists
+                auto final_body = send_body ?? rv.body;
+                if (final_body && !hdr."Content-Length") {
+                    hdr."Content-Length" = string(final_body.size());
+                }
+                # Send HTTP/2 response using poll operation
+                AbstractPollOperation op = s.startPollSendHttp2Response(stream_id, rv."code", hdr,
+                    final_body);
+                while (True) {
+                    *hash<SocketPollInfo> info = op.continuePoll();
+                    if (!info) {
+                        break;
+                    }
+                    Socket::poll((info,), 10s);
+                }
+            } else if (!chunked) {
+                # HTTP/1.x: send a normal monolithic response
                 s.sendHTTPResponse(rv."code", HttpServer::HttpCodes{rv."code"}, "1.1", rv.hdr ?? {}, rv.body);
             } else {
-                # send a chunked response stream
+                # HTTP/1.x: send a chunked response stream
                 s.sendHTTPResponse(rv."code", HttpServer::HttpCodes{rv."code"}, "1.1", rv.hdr ?? {}, body);
             }
         } catch (hash<ExceptionInfo> ex) {
@@ -2814,10 +2845,20 @@ public class HttpListener inherits Qore::Socket, HttpServer::HttpListenerInterfa
     #! Returns the HTTP version mode for this listener
     /** @return the HTTP version mode: "auto", "1.0", "1.1", or "2.0"
 
+        @note If get_global_http2_mode() returns "disabled", HTTP/2 is not offered even if the listener is
+        configured with "auto" or "2.0"
+
         @since HttpServer 1.6
     */
     string getHttpVersion() {
-        return opts.http_version ?? "auto";
+        string http_version = opts.http_version ?? "auto";
+        # Check global HTTP/2 mode - if disabled, don't offer HTTP/2
+        if (http_version == "auto" || http_version == "2.0" || http_version == "2") {
+            if (get_global_http2_mode() == "disabled") {
+                return "1.1";
+            }
+        }
+        return http_version;
     }
 
     auto removeUserThreadContext(*string k) {
@@ -3466,13 +3507,35 @@ public class HttpListener inherits Qore::Socket, HttpServer::HttpListenerInterfa
         @assert(response.code, "response.code must be set");
         @debug {
             auto body_size = response.body ? response.body.size() : 0;
-            log("DEBUG: sendResponseSync: code=%d body_size=%d chunked=%y", response.code,
-                body_size, response.chunked);
+            log("DEBUG: sendResponseSync: code=%d body_size=%d chunked=%y http2=%y", response.code,
+                body_size, response.chunked, response.cx."header-info".http2);
         }
         try {
-            # Send response (chunked data has already been read into memory in async_response)
-            s.sendHTTPResponse(response.code, HttpServer::HttpCodes{response.code}, "1.1",
-                response.hdr ?? {}, response.body);
+            # Check if this is an HTTP/2 connection
+            if (response.cx."header-info".http2) {
+                int stream_id = response.cx."header-info".stream_id;
+                # Remove Transfer-Encoding header (HTTP/2 uses DATA frames, not chunked encoding)
+                hash<auto> hdr = response.hdr ?? {};
+                remove hdr."Transfer-Encoding";
+                # Set Content-Length for HTTP/2 if body exists
+                if (response.body && !hdr."Content-Length") {
+                    hdr."Content-Length" = string(response.body.size());
+                }
+                # Send HTTP/2 response using poll operation
+                AbstractPollOperation op = s.startPollSendHttp2Response(stream_id, response.code, hdr,
+                    response.body);
+                while (True) {
+                    *hash<SocketPollInfo> info = op.continuePoll();
+                    if (!info) {
+                        break;
+                    }
+                    Socket::poll((info,), 10s);
+                }
+            } else {
+                # Send HTTP/1.x response (chunked data has already been read into memory in async_response)
+                s.sendHTTPResponse(response.code, HttpServer::HttpCodes{response.code}, "1.1",
+                    response.hdr ?? {}, response.body);
+            }
         } catch (hash<ExceptionInfo> ex) {
             log("ERROR: Failed to send response synchronously: %s: %s", ex.err, ex.desc);
             rethrow;
@@ -3524,10 +3587,7 @@ public class HttpListener inherits Qore::Socket, HttpServer::HttpListenerInterfa
                 }
 
                 date start = now_us();
-                while (!s.isDataAvailable(poll_interval)) {
-                    if (!s.isOpen()) {
-                        return;
-                    }
+                while (s.isOpen() && !s.isDataAvailable(poll_interval)) {
                     # Check for idle timeout only if persistence has been released
                     # (persistent connections have no idle timeout while active)
                     if (!phi.handler || !phi.handler.isPersistent()) {
@@ -4324,18 +4384,24 @@ class HttpServerIoController {
         }
 
         date now = now_us();
+        # Check if this is an HTTP/2 connection - preserve HTTP/2 state
+        bool is_http2 = cx."is_http2" || cx."header-info".http2;
         connections{key} = <HttpConnectionPollInfo>{
             "sock": sock,
             "spop": NOTHING,
-            "state": "idle",
+            "state": is_http2 ? "http2" : "idle",
             "timeout_date": now + server.getTtl(),
             "start": now,
             "listener_id": listener.getId(),
             "listener": listener,
             "cx": cx,
             "phi": phi,
+            "is_http2": is_http2,
         };
-        @assert(connections{key}.state == "idle", "new connection must be in idle state");
+        @assert(connections{key}.state == (is_http2 ? "http2" : "idle"), "new connection must be in correct state");
+
+        @debug(log(LoggerLevel::DEBUG, "returnConnection(): connection %y state=%y is_http2=%y", key,
+            connections{key}.state, is_http2));
 
         if (tid) {
             sendCmd(IO_RETURN_CONNECTION, key);
@@ -4369,7 +4435,6 @@ class HttpServerIoController {
         @assert(response.code >= 100 && response.code < 600, "response code must be valid HTTP status");
         AutoLock al(m);
         string key = sock.uniqueHash();
-        @debug(log(LoggerLevel::DEBUG, "queueResponse(): queuing response %d for %y", response.code, key));
 
         # Remove any existing connection entry (connection might be in "dispatched" state)
         remove connections{key};
@@ -4507,6 +4572,9 @@ class HttpServerIoController {
                                 if (!poll_timeout || conn_timeout < poll_timeout) {
                                     poll_timeout = conn_timeout;
                                 }
+                            } else if (!cinfo.sock.isOpen()) {
+                                # Socket was closed - mark for removal
+                                to_remove{key} = True;
                             }
                         } catch (hash<ExceptionInfo> ex) {
                             log(LoggerLevel::ERROR, "Error with connection %y: %s: %s", key, ex.err, ex.desc);
@@ -4530,10 +4598,17 @@ class HttpServerIoController {
                 # Cap poll timeout at 100ms for responsiveness
                 timeout_ms = min(timeout_ms, 100);
 
-                # Poll all sockets
-                @debug(log(LoggerLevel::DEBUG, "ioThread: polling %d items, timeout=%d", poll_list.size(), timeout_ms));
-                Socket::poll(poll_list, timeout_ms);
-                @debug(log(LoggerLevel::DEBUG, "ioThread: poll returned"));
+                # Filter out any closed sockets from poll_list before calling poll
+                # This handles the race condition where a socket closes between building
+                # the poll_list and calling Socket::poll()
+                poll_list = map $1, poll_list, !($1.socket instanceof Socket) || cast<Socket>($1.socket).isOpen();
+
+                # Poll all sockets (skip if empty after filtering)
+                if (poll_list) {
+                    @debug(log(LoggerLevel::DEBUG, "ioThread: polling %d items, timeout=%d", poll_list.size(), timeout_ms));
+                    Socket::poll(poll_list, timeout_ms);
+                    @debug(log(LoggerLevel::DEBUG, "ioThread: poll returned"));
+                }
 
                 # Process any commands
                 if (processCommands()) {
@@ -4541,7 +4616,13 @@ class HttpServerIoController {
                 }
 
             } catch (hash<ExceptionInfo> ex) {
-                log(LoggerLevel::ERROR, "Error in I/O thread: %s", get_exception_string(ex));
+                # Handle SOCKET-NOT-OPEN gracefully - this can happen in rare race conditions
+                # where a socket closes between our isOpen() check and the poll() call
+                if (ex.err == "SOCKET-NOT-OPEN") {
+                    @debug(log(LoggerLevel::DEBUG, "Socket closed during poll preparation: %s", ex.desc));
+                } else {
+                    log(LoggerLevel::ERROR, "Error in I/O thread: %s", get_exception_string(ex));
+                }
             }
         }
 
@@ -4557,6 +4638,11 @@ class HttpServerIoController {
         SSL handshake is handled by HttpAcceptPollOperation for new connections
     */
     private *hash<SocketPollInfo> getConnectionPollInfo(string key, hash<HttpConnectionPollInfo> cinfo) {
+        # First check if socket is still open (client may have closed connection)
+        if (!cinfo.sock.isOpen()) {
+            return NOTHING;
+        }
+
         # Initialize poll operation if needed
         if (!cinfo.spop) {
             switch (cinfo.state) {
@@ -4586,11 +4672,22 @@ class HttpServerIoController {
                     # Check if this is an HTTP/2 response
                     if (cinfo.response.cx."header-info".http2) {
                         int stream_id = cinfo.response.cx."header-info".stream_id;
-                        @debug(log(LoggerLevel::DEBUG, "sending HTTP/2 response for stream %d", stream_id));
+                        int body_size = cinfo.response.body ? cinfo.response.body.size() : 0;
+                        log(LoggerLevel::DEBUG, "HTTP/2 response: stream=%d, code=%d, body_size=%d",
+                            stream_id, cinfo.response.code, body_size);
+                        # Remove Transfer-Encoding header - HTTP/2 uses DATA frames, not chunked encoding
+                        hash<auto> hdr = cinfo.response.hdr ?? {};
+                        remove hdr."Transfer-Encoding";
+                        # Set Content-Length for HTTP/2 if body exists (helps clients know expected size)
+                        if (cinfo.response.body && !hdr."Content-Length") {
+                            hdr."Content-Length" = string(cinfo.response.body.size());
+                        }
+                        log(LoggerLevel::DEBUG, "HTTP/2 response: starting send, Content-Length=%y",
+                            hdr."Content-Length");
                         cinfo.spop = connections{key}.spop = cinfo.sock.startPollSendHttp2Response(
                             stream_id,
                             cinfo.response.code,
-                            cinfo.response.hdr,
+                            hdr,
                             cinfo.response.body,
                         );
                         # Mark this as an HTTP/2 connection for proper keep-alive handling
@@ -4633,7 +4730,8 @@ class HttpServerIoController {
             }
 
             # Check if data is available and we should continue immediately
-            if (!cinfo.sock.isDataAvailable(0ms)) {
+            # First check if socket is still open (client may have closed connection)
+            if (!cinfo.sock.isOpen() || !cinfo.sock.isDataAvailable(0ms)) {
                 break;
             }
         }
@@ -4776,16 +4874,28 @@ class HttpServerIoController {
                     hdr.path = request.path;
                     hdr.":authority" = request.authority;
                     hdr.":scheme" = request.scheme;
+                    # Map :authority to host for HTTP/1.x compatibility (many handlers expect host header)
+                    hdr.host = request.authority;
+                    # Set HTTP version for logging and version checks
+                    hdr.http_version = "HTTP/2";
 
                     # Store request info
                     connections{key}.hdr = hdr;
                     # RFC 8441: HTTP/2 WebSocket uses CONNECT with :protocol=websocket
                     bool is_ws_connect = (hdr.method == "CONNECT" && hdr.":protocol" == "websocket");
+                    # Parse accept-encoding header for compression support
+                    *list<string> accept_encoding;
+                    if (hdr."accept-encoding") {
+                        # Parse comma-separated list, strip quality values (e.g., "gzip, br;q=1.0")
+                        accept_encoding = map trim($1.split(";")[0]),
+                            hdr."accept-encoding".split(",");
+                    }
                     connections{key}.header_info = {
                         "http2": True,
                         "stream_id": request.stream_id,
                         "is_websocket_connect": is_ws_connect,
                         "body": request.body,  # HTTP/2 body is already read by poll operation
+                        "accept-encoding": accept_encoding,
                     };
 
                     # Dispatch to ThreadPool for handling
@@ -4881,8 +4991,9 @@ class HttpServerIoController {
 
     #! Handles completion of sending a response
     private handleSendComplete(string key, hash<HttpConnectionPollInfo> cinfo) {
-        log(LoggerLevel::DEBUG, "Response sent for %y (close: %y, is_http2: %y)", key, cinfo.response.close,
-            cinfo.is_http2);
+        int body_size = cinfo.response.body ? cinfo.response.body.size() : 0;
+        log(LoggerLevel::DEBUG, "Response sent for %y (close: %y, is_http2: %y, body_size: %d, Content-Length: %y)",
+            key, cinfo.response.close, cinfo.is_http2, body_size, cinfo.response.hdr."Content-Length");
 
         if (cinfo.response.close || !cinfo.sock.isOpen()) {
             # Close the connection

--- a/qlib/HttpServerAsyncIo/HttpAsyncSocketIoController.qc
+++ b/qlib/HttpServerAsyncIo/HttpAsyncSocketIoController.qc
@@ -701,6 +701,14 @@ public class HttpAsyncSocketIoController {
         bool is_websocket_connect = request.method == "CONNECT" &&
             request.headers.":protocol" == "websocket";
 
+        # Parse accept-encoding header for compression support
+        *list<string> accept_encoding;
+        if (request.headers."accept-encoding") {
+            # Parse comma-separated list, strip quality values (e.g., "gzip, br;q=1.0")
+            accept_encoding = map trim($1.split(";")[0]),
+                request.headers."accept-encoding".split(",");
+        }
+
         # Convert HTTP/2 request to HttpConnectionInfo format
         hash<HttpConnectionInfo> conn_info = <HttpConnectionInfo>{
             "sock": cinfo.sock,
@@ -720,6 +728,7 @@ public class HttpAsyncSocketIoController {
                 "is_websocket_connect": is_websocket_connect,
                 "push_resource": h2op.getPushResourceCallback(),
                 "h2op": h2op,  # Pass for startSendPushedResponse()
+                "accept-encoding": accept_encoding,
             },
             "listener": cinfo.listener,
             "cx": cinfo.cx,

--- a/qlib/HttpServerAsyncIo/HttpAsyncSocketIoController.qc
+++ b/qlib/HttpServerAsyncIo/HttpAsyncSocketIoController.qc
@@ -276,6 +276,11 @@ public class HttpAsyncSocketIoController {
                     foreach string key in (keys connections) {
                         if (!active_polls{key}) {
                             hash<HttpActiveConnectionInfo> cinfo = connections{key};
+                            # Check if socket is still open
+                            if (!cinfo.sock.isOpen()) {
+                                remove connections{key};
+                                continue;
+                            }
                             switch (cinfo.state) {
                                 case "idle": {
                                     HttpIdlePollOperation op(cinfo.sock, cinfo.ttl);
@@ -385,8 +390,13 @@ public class HttpAsyncSocketIoController {
                 # Remove completed operations
                 map remove active_polls{$1}, keys to_remove;
 
-                # Perform the poll
-                Socket::poll(poll_list, poll_timeout);
+                # Filter out any closed sockets from poll_list before calling poll
+                poll_list = map $1, poll_list, !($1.socket instanceof Socket) || cast<Socket>($1.socket).isOpen();
+
+                # Perform the poll (skip if empty after filtering)
+                if (poll_list) {
+                    Socket::poll(poll_list, poll_timeout);
+                }
 
                 # Process commands
                 if (processCommands()) {
@@ -394,7 +404,12 @@ public class HttpAsyncSocketIoController {
                 }
 
             } catch (hash<ExceptionInfo> ex) {
-                log(LoggerLevel::ERROR, "I/O thread error: %s: %s", ex.err, ex.desc);
+                # Handle SOCKET-NOT-OPEN gracefully
+                if (ex.err == "SOCKET-NOT-OPEN") {
+                    @debug(log(LoggerLevel::DEBUG, "Socket closed during poll: %s", ex.desc));
+                } else {
+                    log(LoggerLevel::ERROR, "I/O thread error: %s: %s", ex.err, ex.desc);
+                }
             }
         }
     }
@@ -694,6 +709,10 @@ public class HttpAsyncSocketIoController {
                 "path": request.path,
                 ":authority": request.authority,
                 ":scheme": request.scheme,
+                # Map :authority to host for HTTP/1.x compatibility (many handlers expect host header)
+                "host": request.authority,
+                # Set HTTP version for logging and version checks
+                "http_version": "HTTP/2",
             },
             "header_info": {
                 "http2": True,

--- a/qlib/HttpServerUtil.qm
+++ b/qlib/HttpServerUtil.qm
@@ -1408,7 +1408,28 @@ public class AbstractStreamRequest {
             return rv;
         }
 
-        # send chunked response
+        # For HTTP/2 connections, buffer the response data
+        # HTTP/2 doesn't support raw chunked transfer encoding - data must go in DATA frames
+        if (cx."header-info".http2) {
+            # Buffer all the data from the callback (can be string or binary)
+            binary data;
+            auto chunk;
+            while (chunk = send()) {
+                if (chunk.typeCode() == NT_STRING) {
+                    data += binary(chunk);
+                } else if (chunk.typeCode() == NT_BINARY) {
+                    data += chunk;
+                }
+            }
+            # Remove Transfer-Encoding header (HTTP/2 uses DATA frames, not chunked encoding)
+            remove rv.hdr."Transfer-Encoding";
+            # Don't set Content-Length here - the body may be compressed later in HttpServer::sendReply()
+            # which would change the size. Content-Length will be set correctly by doResponse/startPollSendHttp2Response
+            rv.body = data;
+            return rv;
+        }
+
+        # HTTP/1.x: send chunked response
         s.sendHTTPResponseWithCallback(\send(), rv."code", HttpServer::HttpCodes{rv."code"}, "1.1", rv.hdr,
             timeout_ms);
         rv.reply_sent = True;


### PR DESCRIPTION
## Summary

- **HTTPClient**: Auto-configure ALPN protocols for HTTP/2 when `http2_mode` is AUTO/REQUIRED, fixing HTTP/2 not working by default
- **HttpServer**: Fix accept-encoding header parsing for HTTP/2 requests, enabling compression
- **HttpServer**: Respect `get_global_http2_mode()` setting to disable HTTP/2 globally
- **HttpServer**: Use DATA frames instead of chunked transfer encoding for HTTP/2 responses
- **HttpServer**: Buffer streaming responses for HTTP/2 to set proper Content-Length

## Test plan

- [x] All 26 HttpServer test cases pass (173 assertions)
- [x] Valgrind shows no memory leaks
- [x] HTTP/2 compression test added
- [x] `set_global_http2_mode("disabled")` test added
- [x] Verified HTTP/2 works by default with HTTPClient connecting to Google

🤖 Generated with [Claude Code](https://claude.com/claude-code)