### PR TITLE
refs #5121 Add DPQL (Data Provider Query Language)

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -132,6 +132,20 @@ code<int(string)> func = int sub(int x) { return x; };  # PARSE-TYPE-ERROR: para
       - added the @ref ConnectionProvider::RestartableIoHelper "RestartableIoHelper" class
       - new \c http_version option in @ref ConnectionProvider::HttpConnection "HttpConnection" for HTTP version control ("auto", "1.0", "1.1", "2.0")
       - @ref RestClient::RestConnection "RestConnection" inherits the \c http_version option from @ref ConnectionProvider::HttpConnection "HttpConnection"
+    - @ref DataProvider "DataProvider" module
+      - added DPQL (Data Provider Query Language) for human/AI-readable query expressions
+        - new @ref DataProvider::DpqlTokenizer "DpqlTokenizer" class for lexical analysis
+        - new @ref DataProvider::DpqlParser "DpqlParser" class for parsing DPQL strings to \c DataProviderExpression hashes
+        - new @ref DataProvider::DpqlSerializer "DpqlSerializer" class for converting expressions back to DPQL strings
+        - new @ref DataProvider::DpqlCompletionProvider "DpqlCompletionProvider" class for IDE/editor autocomplete
+        - static API methods: @ref DataProvider::DataProvider::parseDpqlExpression() "parseDpqlExpression()",
+          @ref DataProvider::DataProvider::parseDpqlExpressionWithInfo() "parseDpqlExpressionWithInfo()",
+          @ref DataProvider::DataProvider::serializeDpqlExpression() "serializeDpqlExpression()",
+          @ref DataProvider::DataProvider::getDpqlTokens() "getDpqlTokens()",
+          @ref DataProvider::DataProvider::getDpqlCompletions() "getDpqlCompletions()",
+          @ref DataProvider::DataProvider::validateDpqlExpression() "validateDpqlExpression()"
+        - DPQL syntax: \c @name \c == \c "John" \c && \c @age \c > \c 18
+        - supports field refs (\c @field), comparison ops, logical ops, ranges, \c in, and regex
     - @ref OpenApi3 "OpenApi3" module
       - new module supporting OpenAPI 3.* schemas for REST API integration
     - @ref Qdx "Qdx" module

--- a/examples/test/qlib/DataProvider/Dpql.qtest
+++ b/examples/test/qlib/DataProvider/Dpql.qtest
@@ -1,0 +1,641 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+%allow-injection
+
+%requires ../../../../qlib/Util.qm
+%requires ../../../../qlib/QUnit.qm
+%requires ../../../../qlib/Logger.qm
+%requires ../../../../qlib/Mime.qm
+%requires ../../../../qlib/DataProvider
+
+%requires reflection
+
+%exec-class DpqlTest
+
+public class DpqlTest inherits QUnit::Test {
+    constructor() : Test("DPQL Test", "1.0") {
+        addTestCase("tokenizer tests", \tokenizerTests());
+        addTestCase("parser basic tests", \parserBasicTests());
+        addTestCase("parser operator tests", \parserOperatorTests());
+        addTestCase("parser complex tests", \parserComplexTests());
+        addTestCase("parser function tests", \parserFunctionTests());
+        addTestCase("parser error tests", \parserErrorTests());
+        addTestCase("serializer tests", \serializerTests());
+        addTestCase("round-trip tests", \roundTripTests());
+        addTestCase("completion tests", \completionTests());
+        addTestCase("static API tests", \staticApiTests());
+        addTestCase("validation tests", \validationTests());
+
+        # Return for compatibility with test harnesses that check the return value.
+        set_return_value(main());
+    }
+
+    private hash<string, AbstractDataField> getTestFields() {
+        return {
+            "name": new QoreDataField("name", "User name", new QoreStringDataType()),
+            "age": new QoreDataField("age", "User age", new QoreIntDataType()),
+            "email": new QoreDataField("email", "Email address", new QoreStringDataType()),
+            "status": new QoreDataField("status", "Account status", new QoreStringDataType()),
+            "score": new QoreDataField("score", "User score", new QoreFloatDataType()),
+            "active": new QoreDataField("active", "Is active", new QoreBoolDataType()),
+        };
+    }
+
+    tokenizerTests() {
+        # Test basic tokens
+        {
+            DpqlTokenizer tok('@name == "John"');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(5, tokens.size());
+            assertEq(DPQL_TOK_FIELD, tokens[0].type);
+            assertEq("@name", tokens[0].value);
+            assertEq(DPQL_TOK_WHITESPACE, tokens[1].type);
+            assertEq(DPQL_TOK_OP_EQ, tokens[2].type);
+            assertEq(DPQL_TOK_WHITESPACE, tokens[3].type);
+            assertEq(DPQL_TOK_STRING, tokens[4].type);
+            assertEq('"John"', tokens[4].value);
+        }
+
+        # Test all comparison operators
+        {
+            DpqlTokenizer tok("== != < <= > >=");
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_OP_EQ, tokens[0].type);
+            assertEq(DPQL_TOK_OP_NE, tokens[2].type);
+            assertEq(DPQL_TOK_OP_LT, tokens[4].type);
+            assertEq(DPQL_TOK_OP_LE, tokens[6].type);
+            assertEq(DPQL_TOK_OP_GT, tokens[8].type);
+            assertEq(DPQL_TOK_OP_GE, tokens[10].type);
+        }
+
+        # Test logical operators
+        {
+            DpqlTokenizer tok("&& || !");
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_OP_AND, tokens[0].type);
+            assertEq(DPQL_TOK_OP_OR, tokens[2].type);
+            assertEq(DPQL_TOK_OP_NOT, tokens[4].type);
+        }
+
+        # Test regex operator
+        {
+            DpqlTokenizer tok('=~ /pattern/i');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_OP_REGEX, tokens[0].type);
+            assertEq(DPQL_TOK_WHITESPACE, tokens[1].type);
+            assertEq(DPQL_TOK_REGEX, tokens[2].type);
+            assertEq("/pattern/i", tokens[2].value);
+        }
+
+        # Test numbers
+        {
+            DpqlTokenizer tok("123 -456 78.90 -12.34");
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_NUMBER, tokens[0].type);
+            assertEq("123", tokens[0].value);
+            assertEq(DPQL_TOK_NUMBER, tokens[2].type);
+            assertEq("-456", tokens[2].value);
+            assertEq(DPQL_TOK_NUMBER, tokens[4].type);
+            assertEq("78.90", tokens[4].value);
+            assertEq(DPQL_TOK_NUMBER, tokens[6].type);
+            assertEq("-12.34", tokens[6].value);
+        }
+
+        # Test quoted field reference
+        {
+            DpqlTokenizer tok('@"field with spaces"');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_FIELD, tokens[0].type);
+            assertEq('@"field with spaces"', tokens[0].value);
+        }
+
+        # Test keywords and boolean/null
+        {
+            DpqlTokenizer tok("true false null between and in");
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_BOOLEAN, tokens[0].type);
+            assertEq("true", tokens[0].value);
+            assertEq(DPQL_TOK_BOOLEAN, tokens[2].type);
+            assertEq("false", tokens[2].value);
+            assertEq(DPQL_TOK_NULL, tokens[4].type);
+            assertEq("null", tokens[4].value);
+            assertEq(DPQL_TOK_IDENTIFIER, tokens[6].type);
+            assertEq("between", tokens[6].value);
+            assertEq(DPQL_TOK_IDENTIFIER, tokens[8].type);
+            assertEq("and", tokens[8].value);
+            assertEq(DPQL_TOK_IDENTIFIER, tokens[10].type);
+            assertEq("in", tokens[10].value);
+        }
+
+        # Test position tracking
+        {
+            DpqlTokenizer tok("@name\n@age");
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(1, tokens[0].line);
+            assertEq(1, tokens[0].column);
+            assertEq(2, tokens[2].line);
+            assertEq(1, tokens[2].column);
+        }
+
+        # Test string escape sequences
+        {
+            DpqlTokenizer tok('"hello\\nworld"');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_STRING, tokens[0].type);
+            assertEq('"hello\\nworld"', tokens[0].value);
+        }
+
+        # Test parentheses and comma
+        {
+            DpqlTokenizer tok("(a, b)");
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_LPAREN, tokens[0].type);
+            assertEq(DPQL_TOK_IDENTIFIER, tokens[1].type);
+            assertEq(DPQL_TOK_COMMA, tokens[2].type);
+            assertEq(DPQL_TOK_IDENTIFIER, tokens[4].type);
+            assertEq(DPQL_TOK_RPAREN, tokens[5].type);
+        }
+    }
+
+    parserBasicTests() {
+        # Test simple equality
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('@name == "John"');
+            assertEq(DP_SEARCH_OP_EQ, exp.exp);
+            assertEq(2, exp.args.size());
+            assertEq("name", exp.args[0].field);
+            assertEq("John", exp.args[1]);
+        }
+
+        # Test with quoted field name
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('@"field name" == "value"');
+            assertEq(DP_SEARCH_OP_EQ, exp.exp);
+            assertEq("field name", exp.args[0].field);
+        }
+
+        # Test numeric comparison
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('@age > 18');
+            assertEq(DP_SEARCH_OP_GT, exp.exp);
+            assertEq("age", exp.args[0].field);
+            assertEq(18, exp.args[1]);
+        }
+
+        # Test float comparison
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('@score >= 75.5');
+            assertEq(DP_SEARCH_OP_GE, exp.exp);
+            assertEq("score", exp.args[0].field);
+            assertEq(75.5, exp.args[1]);
+        }
+
+        # Test negative number
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('@temp < -10');
+            assertEq(DP_SEARCH_OP_LT, exp.exp);
+            assertEq(-10, exp.args[1]);
+        }
+
+        # Test boolean literal
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('@active == true');
+            assertEq(DP_SEARCH_OP_EQ, exp.exp);
+            assertEq(True, exp.args[1]);
+        }
+
+        # Test null literal
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('@value != null');
+            assertEq(DP_SEARCH_OP_NE, exp.exp);
+            assertEq(NOTHING, exp.args[1]);
+        }
+    }
+
+    parserOperatorTests() {
+        # Test AND operator
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@name == "John" && @age > 18');
+            assertEq(DP_OP_AND, exp.exp);
+            assertEq(2, exp.args.size());
+            assertEq(DP_SEARCH_OP_EQ, exp.args[0].exp);
+            assertEq(DP_SEARCH_OP_GT, exp.args[1].exp);
+        }
+
+        # Test OR operator
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@status == "active" || @status == "pending"');
+            assertEq(DP_OP_OR, exp.exp);
+            assertEq(2, exp.args.size());
+        }
+
+        # Test NOT operator
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '!(@deleted == true)');
+            assertEq(DP_SEARCH_OP_NOT, exp.exp);
+            assertEq(1, exp.args.size());
+            assertEq(DP_SEARCH_OP_EQ, exp.args[0].exp);
+        }
+
+        # Test BETWEEN operator
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@age between 18 and 65');
+            assertEq(DP_SEARCH_OP_BETWEEN, exp.exp);
+            assertEq(3, exp.args.size());
+            assertEq("age", exp.args[0].field);
+            assertEq(18, exp.args[1]);
+            assertEq(65, exp.args[2]);
+        }
+
+        # Test IN operator
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@role in ("admin", "editor", "moderator")');
+            assertEq(DP_SEARCH_OP_IN, exp.exp);
+            assertEq(4, exp.args.size());
+            assertEq("role", exp.args[0].field);
+            assertEq("admin", exp.args[1]);
+            assertEq("editor", exp.args[2]);
+            assertEq("moderator", exp.args[3]);
+        }
+
+        # Test regex operator (simple pattern without escapes)
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@email =~ /example.com$/i');
+            assertEq(DP_SEARCH_OP_REGEX, exp.exp);
+            assertEq("email", exp.args[0].field);
+            assertEq("example.com$", exp.args[1]);
+            # Check for case-insensitive flag
+            assertEq(RE_Caseless, exp.args[2]);
+        }
+    }
+
+    parserComplexTests() {
+        # Test operator precedence (AND binds tighter than OR)
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@a == 1 || @b == 2 && @c == 3');
+            assertEq(DP_OP_OR, exp.exp);
+            assertEq(2, exp.args.size());
+            # First arg is simple comparison
+            assertEq(DP_SEARCH_OP_EQ, exp.args[0].exp);
+            # Second arg is AND expression
+            assertEq(DP_OP_AND, exp.args[1].exp);
+        }
+
+        # Test grouping with parentheses
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '(@a == 1 || @b == 2) && @c == 3');
+            assertEq(DP_OP_AND, exp.exp);
+            assertEq(2, exp.args.size());
+            # First arg is OR expression
+            assertEq(DP_OP_OR, exp.args[0].exp);
+            # Second arg is simple comparison
+            assertEq(DP_SEARCH_OP_EQ, exp.args[1].exp);
+        }
+
+        # Test multiple AND expressions
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@a == 1 && @b == 2 && @c == 3');
+            assertEq(DP_OP_AND, exp.exp);
+            assertEq(3, exp.args.size());
+        }
+
+        # Test nested grouping
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '(@a == 1 && (@b == 2 || @c == 3)) || @d == 4');
+            assertEq(DP_OP_OR, exp.exp);
+            assertEq(2, exp.args.size());
+        }
+
+        # Test dotted field names
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@address.city == "NYC"');
+            assertEq(DP_SEARCH_OP_EQ, exp.exp);
+            assertEq("address.city", exp.args[0].field);
+        }
+    }
+
+    parserFunctionTests() {
+        # Test function call in expression
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                'calculate(@score, 100) > 50');
+            assertEq(DP_SEARCH_OP_GT, exp.exp);
+            assertEq("calculate", exp.args[0].exp);
+            assertEq(2, exp.args[0].args.size());
+            assertEq("score", exp.args[0].args[0].field);
+            assertEq(100, exp.args[0].args[1]);
+            assertEq(50, exp.args[1]);
+        }
+
+        # Test function with no arguments
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                'now() > @created');
+            assertEq(DP_SEARCH_OP_GT, exp.exp);
+            assertEq("now", exp.args[0].exp);
+            assertEq(0, exp.args[0].args.size());
+        }
+
+        # Test nested function calls
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                'upper(trim(@name)) == "JOHN"');
+            assertEq(DP_SEARCH_OP_EQ, exp.exp);
+            assertEq("upper", exp.args[0].exp);
+            assertEq("trim", exp.args[0].args[0].exp);
+            assertEq("name", exp.args[0].args[0].args[0].field);
+        }
+    }
+
+    parserErrorTests() {
+        # Test unterminated string
+        {
+            hash<DpqlParseResult> result = DataProvider::parseDpqlExpressionWithInfo('@name == "John');
+            assertFalse(result.success);
+            assertTrue(result.diagnostics.size() > 0);
+            assertEq("DPQL-E002", result.diagnostics[0].code);
+        }
+
+        # Test invalid operator
+        {
+            hash<DpqlParseResult> result = DataProvider::parseDpqlExpressionWithInfo('@name = "John"');
+            assertFalse(result.success);
+            assertTrue(result.diagnostics.size() > 0);
+        }
+
+        # Test missing closing parenthesis
+        {
+            hash<DpqlParseResult> result = DataProvider::parseDpqlExpressionWithInfo('(@name == "John"');
+            assertFalse(result.success);
+        }
+
+        # Test incomplete field reference
+        {
+            hash<DpqlParseResult> result = DataProvider::parseDpqlExpressionWithInfo('@ == "value"');
+            assertFalse(result.success);
+        }
+
+        # Test missing value after operator
+        {
+            hash<DpqlParseResult> result = DataProvider::parseDpqlExpressionWithInfo('@name ==');
+            assertFalse(result.success);
+        }
+
+        # Test parse throws exception
+        {
+            bool caught = False;
+            try {
+                DataProvider::parseDpqlExpression('@name == "John');
+            } catch (hash<ExceptionInfo> ex) {
+                caught = True;
+                assertEq("DPQL-PARSE-ERROR", ex.err);
+            }
+            assertTrue(caught);
+        }
+    }
+
+    serializerTests() {
+        # Test simple equality
+        {
+            hash<DataProviderExpression> exp = <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_EQ,
+                "args": (<DataProviderFieldReference>{"field": "name"}, "John"),
+            };
+            string dpql = DataProvider::serializeDpqlExpression(exp);
+            assertEq('@name == "John"', dpql);
+        }
+
+        # Test AND expression
+        {
+            hash<DataProviderExpression> exp = <DataProviderExpression>{
+                "exp": DP_OP_AND,
+                "args": (
+                    <DataProviderExpression>{
+                        "exp": DP_SEARCH_OP_EQ,
+                        "args": (<DataProviderFieldReference>{"field": "name"}, "John"),
+                    },
+                    <DataProviderExpression>{
+                        "exp": DP_SEARCH_OP_GT,
+                        "args": (<DataProviderFieldReference>{"field": "age"}, 18),
+                    },
+                ),
+            };
+            string dpql = DataProvider::serializeDpqlExpression(exp);
+            assertEq('@name == "John" && @age > 18', dpql);
+        }
+
+        # Test NOT expression
+        {
+            hash<DataProviderExpression> exp = <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_NOT,
+                "args": (
+                    <DataProviderExpression>{
+                        "exp": DP_SEARCH_OP_EQ,
+                        "args": (<DataProviderFieldReference>{"field": "deleted"}, True),
+                    },
+                ),
+            };
+            string dpql = DataProvider::serializeDpqlExpression(exp);
+            assertEq('!(@deleted == true)', dpql);
+        }
+
+        # Test BETWEEN expression
+        {
+            hash<DataProviderExpression> exp = <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_BETWEEN,
+                "args": (
+                    <DataProviderFieldReference>{"field": "age"},
+                    18,
+                    65,
+                ),
+            };
+            string dpql = DataProvider::serializeDpqlExpression(exp);
+            assertEq("@age between 18 and 65", dpql);
+        }
+
+        # Test IN expression
+        {
+            hash<DataProviderExpression> exp = <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_IN,
+                "args": (
+                    <DataProviderFieldReference>{"field": "role"},
+                    "admin",
+                    "editor",
+                ),
+            };
+            string dpql = DataProvider::serializeDpqlExpression(exp);
+            assertEq('@role in ("admin", "editor")', dpql);
+        }
+
+        # Test quoted field name
+        {
+            hash<DataProviderExpression> exp = <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_EQ,
+                "args": (<DataProviderFieldReference>{"field": "field name"}, "value"),
+            };
+            string dpql = DataProvider::serializeDpqlExpression(exp);
+            assertEq('@"field name" == "value"', dpql);
+        }
+
+        # Test null value
+        {
+            hash<DataProviderExpression> exp = <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_NE,
+                "args": (<DataProviderFieldReference>{"field": "value"}, NOTHING),
+            };
+            string dpql = DataProvider::serializeDpqlExpression(exp);
+            assertEq("@value != null", dpql);
+        }
+    }
+
+    roundTripTests() {
+        # Test various expressions for round-trip consistency
+        list<string> expressions = (
+            '@name == "John"',
+            '@age > 18',
+            '@name == "John" && @age > 18',
+            '@status == "active" || @status == "pending"',
+            '@age between 18 and 65',
+            '@role in ("admin", "editor")',
+            '!(@deleted == true)',
+            '(@a == 1 || @b == 2) && @c == 3',
+            '@active == true',
+            '@value != null',
+            '@score >= 75.5',
+            '@temp < -10',
+        );
+
+        foreach string expr in (expressions) {
+            hash<DataProviderExpression> parsed = DataProvider::parseDpqlExpression(expr);
+            string serialized = DataProvider::serializeDpqlExpression(parsed);
+            hash<DataProviderExpression> reparsed = DataProvider::parseDpqlExpression(serialized);
+            # Compare the expressions
+            assertEq(parsed.exp, reparsed.exp, sprintf("Round-trip failed for: %s", expr));
+            assertEq(parsed.args.size(), reparsed.args.size(), sprintf("Round-trip args size for: %s", expr));
+        }
+    }
+
+    completionTests() {
+        hash<string, AbstractDataField> fields = getTestFields();
+
+        # Test field completions after @
+        {
+            list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('@', 1, fields);
+            assertTrue(items.size() > 0);
+            # Should have field completions
+            assertTrue((select items, $1.kind == "field").size() > 0);
+        }
+
+        # Test field prefix filtering
+        {
+            list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('@na', 3, fields);
+            # Should only include "name"
+            list<hash<DpqlCompletionItem>> field_items = select items, $1.kind == "field";
+            assertEq(1, field_items.size());
+            assertEq("name", field_items[0].label);
+        }
+
+        # Test operator completions after field
+        {
+            list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('@name ', 6, fields);
+            # Should have operator completions
+            assertTrue((select items, $1.kind == "operator").size() > 0);
+        }
+
+        # Test value completions after operator
+        {
+            list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('@name == ', 9, fields);
+            # Should suggest fields and keywords
+            assertTrue(items.size() > 0);
+        }
+
+        # Test keyword completions
+        {
+            list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('@name == tr', 11, fields);
+            list<hash<DpqlCompletionItem>> keyword_items = select items, $1.kind == "keyword" && $1.label == "true";
+            assertTrue(keyword_items.size() > 0);
+        }
+    }
+
+    staticApiTests() {
+        # Test getDpqlTokens
+        {
+            list<hash<DpqlTokenInfo>> tokens = DataProvider::getDpqlTokens('@name == "John"');
+            assertTrue(tokens.size() > 0);
+            assertEq(DPQL_TOK_FIELD, tokens[0].type);
+        }
+
+        # Test parseDpqlExpression
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('@name == "John"');
+            assertEq(DP_SEARCH_OP_EQ, exp.exp);
+        }
+
+        # Test parseDpqlExpressionWithInfo
+        {
+            hash<DpqlParseResult> result = DataProvider::parseDpqlExpressionWithInfo('@name == "John"');
+            assertTrue(result.success);
+            assertEq(DP_SEARCH_OP_EQ, result.expression.exp);
+            assertTrue(result.tokens.size() > 0);
+        }
+
+        # Test serializeDpqlExpression
+        {
+            hash<DataProviderExpression> exp = <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_EQ,
+                "args": (<DataProviderFieldReference>{"field": "name"}, "John"),
+            };
+            string dpql = DataProvider::serializeDpqlExpression(exp);
+            assertEq('@name == "John"', dpql);
+        }
+    }
+
+    validationTests() {
+        hash<string, AbstractDataField> fields = getTestFields();
+
+        # Test valid expression
+        {
+            list<hash<DpqlDiagnostic>> errors = DataProvider::validateDpqlExpression(
+                '@name == "John"', fields);
+            assertEq(0, errors.size());
+        }
+
+        # Test unknown field
+        {
+            list<hash<DpqlDiagnostic>> errors = DataProvider::validateDpqlExpression(
+                '@unknown_field == "value"', fields);
+            assertTrue(errors.size() > 0);
+            assertEq("DPQL-E010", errors[0].code);
+        }
+
+        # Test multiple unknown fields
+        {
+            list<hash<DpqlDiagnostic>> errors = DataProvider::validateDpqlExpression(
+                '@unknown1 == "a" && @unknown2 == "b"', fields);
+            assertTrue(errors.size() >= 2);
+        }
+
+        # Test valid nested expression
+        {
+            list<hash<DpqlDiagnostic>> errors = DataProvider::validateDpqlExpression(
+                '(@name == "John" && @age > 18) || @status == "admin"', fields);
+            assertEq(0, errors.size());
+        }
+    }
+}

--- a/examples/test/qlib/DataProvider/Dpql.qtest
+++ b/examples/test/qlib/DataProvider/Dpql.qtest
@@ -30,6 +30,7 @@ public class DpqlTest inherits QUnit::Test {
         addTestCase("completion tests", \completionTests());
         addTestCase("static API tests", \staticApiTests());
         addTestCase("validation tests", \validationTests());
+        addTestCase("stress tests", \stressTests());
 
         # Return for compatibility with test harnesses that check the return value.
         set_return_value(main());
@@ -277,6 +278,39 @@ public class DpqlTest inherits QUnit::Test {
             assertEq("example.com$", exp.args[1]);
             # Check for case-insensitive flag
             assertEq(RE_Caseless, exp.args[2]);
+        }
+
+        # Test regex with combined flags
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@text =~ /^start.*end$/ims');
+            assertEq(DP_SEARCH_OP_REGEX, exp.exp);
+            assertEq("text", exp.args[0].field);
+            assertEq("^start.*end$", exp.args[1]);
+            # Check all flags are present
+            assertTrue(exp.args.size() >= 4);
+            list<int> flags = exp.args[2..];
+            assertTrue(inlist(RE_Caseless, flags));
+            assertTrue(inlist(RE_MultiLine, flags));
+            assertTrue(inlist(RE_DotAll, flags));
+        }
+
+        # Test scientific notation
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@value == 1.5e10');
+            assertEq(DP_SEARCH_OP_EQ, exp.exp);
+            assertEq("value", exp.args[0].field);
+            assertEq(1.5e10, exp.args[1]);
+        }
+
+        # Test negative scientific notation
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@value > -2.5E-3');
+            assertEq(DP_SEARCH_OP_GT, exp.exp);
+            assertEq("value", exp.args[0].field);
+            assertEq(-2.5e-3, exp.args[1]);
         }
     }
 
@@ -636,6 +670,50 @@ public class DpqlTest inherits QUnit::Test {
             list<hash<DpqlDiagnostic>> errors = DataProvider::validateDpqlExpression(
                 '(@name == "John" && @age > 18) || @status == "admin"', fields);
             assertEq(0, errors.size());
+        }
+    }
+
+    stressTests() {
+        # Test deeply nested expressions
+        {
+            # Build expression: (((((@a == 1) && @b == 2) && @c == 3) ...
+            string dpql = "@a == 1";
+            for (int i = 0; i < 20; ++i) {
+                dpql = "(" + dpql + " && @x" + string(i) + " == " + string(i) + ")";
+            }
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(dpql);
+            assertEq(DP_OP_AND, exp.exp);
+
+            # Round-trip
+            string serialized = DataProvider::serializeDpqlExpression(exp);
+            hash<DataProviderExpression> exp2 = DataProvider::parseDpqlExpression(serialized);
+            assertEq(exp.exp, exp2.exp);
+        }
+
+        # Test long OR chain
+        {
+            list<string> conditions = ();
+            for (int i = 0; i < 50; ++i) {
+                conditions += "@field" + string(i) + " == " + string(i);
+            }
+            string dpql = conditions.join(" || ");
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(dpql);
+            assertEq(DP_OP_OR, exp.exp);
+            assertEq(50, exp.args.size());
+        }
+
+        # Test complex mixed expression
+        {
+            string dpql = '(@a == 1 || @b == 2) && (@c == 3 || @d == 4) && ' +
+                '(@e in (1, 2, 3) || @f between 10 and 20) && !(@g == "deleted")';
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(dpql);
+            assertEq(DP_OP_AND, exp.exp);
+
+            # Round-trip
+            string serialized = DataProvider::serializeDpqlExpression(exp);
+            hash<DataProviderExpression> exp2 = DataProvider::parseDpqlExpression(serialized);
+            assertEq(exp.exp, exp2.exp);
+            assertEq(exp.args.size(), exp2.args.size());
         }
     }
 }

--- a/qlib/DataProvider/DataProvider.qc
+++ b/qlib/DataProvider/DataProvider.qc
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! @file DataProvider.qc module for data access and introspection
 
-/** DataProvider.qc Copyright 2019 - 2024 Qore Technologies, s.r.o.
+/** DataProvider.qc Copyright 2019 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -100,7 +100,7 @@ public class DataProvider {
             "kafka": "KafkaDataProvider",
 
             # provided by the json module
-            "McpClientDataProvider": "McpClientDataProvider",
+            "mcpclient": "McpClientDataProvider",
 
             "mewsrest": "MewsRestDataProvider",
             "memcached": "MemcachedDataProvider",
@@ -131,10 +131,19 @@ public class DataProvider {
 
             "swagger": "SwaggerDataProvider",
 
+            # provided by the tar module
+            "tar": "TarDataProvider",
+
+            # provided by the xml module
+            "webdavclient": "WebDavClientDataProvider",
+
             # provided by the ts-toolkit repo
             "ts-actions": "TypeScriptActionInterface",
 
             "wsclient": "WebSocketClient",
+
+            # provided by the zip module
+            "zip": "ZipDataProvider",
         };
 
         #! Map of known type path prefixes to modules
@@ -611,6 +620,156 @@ DbDataProvider db = DataProvider::getFactoryObjectFromStringUseEnv("db{datasourc
             }
         }
         return str;
+    }
+
+    #! Parses a DPQL expression string into a DataProviderExpression
+    /** @param text the DPQL expression to parse
+        @param expressions optional map of expression names to their info for validation
+
+        @return the parsed DataProviderExpression
+
+        @throw DPQL-PARSE-ERROR if the expression contains syntax errors
+
+        @par Example:
+        @code{.py}
+hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('@name == "John" && @age > 18');
+        @endcode
+
+        @since DataProvider 3.4
+    */
+    static hash<DataProviderExpression> parseDpqlExpression(string text,
+            *hash<string, hash<DataProviderExpressionInfo>> expressions) {
+        DpqlParser parser(expressions ?? DataProviderGenericExpressions);
+        return parser.parse(text);
+    }
+
+    #! Parses a DPQL expression with full diagnostic information
+    /** @param text the DPQL expression to parse
+        @param expressions optional map of expression names to their info for validation
+
+        @return a DpqlParseResult containing the expression, diagnostics, and tokens
+
+        @par Example:
+        @code{.py}
+hash<DpqlParseResult> result = DataProvider::parseDpqlExpressionWithInfo('@name ==');
+if (!result.success) {
+    foreach hash<DpqlDiagnostic> diag in (result.diagnostics) {
+        printf("Error at %d:%d: %s\n", diag.line, diag.column, diag.message);
+    }
+}
+        @endcode
+
+        @since DataProvider 3.4
+    */
+    static hash<DpqlParseResult> parseDpqlExpressionWithInfo(string text,
+            *hash<string, hash<DataProviderExpressionInfo>> expressions) {
+        DpqlParser parser(expressions ?? DataProviderGenericExpressions);
+        return parser.parseWithInfo(text);
+    }
+
+    #! Serializes a DataProviderExpression to a DPQL string
+    /** @param exp the expression to serialize
+        @param expressions optional map of expression names to their info
+
+        @return the DPQL string representation of the expression
+
+        @par Example:
+        @code{.py}
+hash<DataProviderExpression> exp = <DataProviderExpression>{
+    "exp": "==",
+    "args": (<DataProviderFieldReference>{"field": "name"}, "John"),
+};
+string dpql = DataProvider::serializeDpqlExpression(exp);
+# Result: @name == "John"
+        @endcode
+
+        @since DataProvider 3.4
+    */
+    static string serializeDpqlExpression(hash<DataProviderExpression> exp,
+            *hash<string, hash<DataProviderExpressionInfo>> expressions) {
+        DpqlSerializer serializer(expressions ?? DataProviderGenericExpressions);
+        return serializer.serialize(exp);
+    }
+
+    #! Gets all tokens from a DPQL expression for syntax highlighting
+    /** @param text the DPQL expression to tokenize
+
+        @return a list of tokens with type and position information
+
+        @par Example:
+        @code{.py}
+list<hash<DpqlTokenInfo>> tokens = DataProvider::getDpqlTokens('@name == "value"');
+foreach hash<DpqlTokenInfo> tok in (tokens) {
+    printf("Token: %s at %d:%d\n", DpqlTokenTypeNames{tok.type}, tok.line, tok.column);
+}
+        @endcode
+
+        @since DataProvider 3.4
+    */
+    static list<hash<DpqlTokenInfo>> getDpqlTokens(string text) {
+        DpqlTokenizer tokenizer(text);
+        return tokenizer.getAllTokens();
+    }
+
+    #! Gets DPQL completions at the given cursor position
+    /** @param text the DPQL expression text
+        @param position cursor position (0-based character offset)
+        @param fields available fields for completion
+        @param expressions optional map of expression names to their info
+
+        @return a list of completion items sorted by priority
+
+        @par Example:
+        @code{.py}
+hash<string, AbstractDataField> fields = {
+    "name": new QoreDataField("name", "Name", new QoreStringDataType()),
+    "age": new QoreDataField("age", "Age", new QoreIntDataType()),
+};
+list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('@na', 3, fields);
+# Returns completions for fields starting with "na"
+        @endcode
+
+        @since DataProvider 3.4
+    */
+    static list<hash<DpqlCompletionItem>> getDpqlCompletions(string text, int position,
+            hash<string, AbstractDataField> fields,
+            *hash<string, hash<DataProviderExpressionInfo>> expressions) {
+        DpqlCompletionProvider provider(expressions ?? DataProviderGenericExpressions);
+        return provider.getCompletions(text, position, fields);
+    }
+
+    #! Validates a DPQL expression against available fields
+    /** @param text the DPQL expression to validate
+        @param fields available fields
+        @param expressions optional map of expression names to their info
+
+        @return a list of diagnostic messages for any validation errors
+
+        @par Example:
+        @code{.py}
+list<hash<DpqlDiagnostic>> errors = DataProvider::validateDpqlExpression(
+    '@unknown_field == "value"',
+    my_fields
+);
+if (errors) {
+    foreach hash<DpqlDiagnostic> err in (errors) {
+        printf("Error: %s\n", err.message);
+    }
+}
+        @endcode
+
+        @since DataProvider 3.4
+    */
+    static list<hash<DpqlDiagnostic>> validateDpqlExpression(string text,
+            hash<string, AbstractDataField> fields,
+            *hash<string, hash<DataProviderExpressionInfo>> expressions) {
+        DpqlParser parser(expressions ?? DataProviderGenericExpressions);
+        hash<DpqlParseResult> result = parser.parseWithInfo(text);
+        list<hash<DpqlDiagnostic>> diags = result.diagnostics;
+        if (result.success && result.expression) {
+            diags += parser.validate(result.expression, fields);
+        }
+        return diags;
     }
 
     #! Loads data providers from the environment

--- a/qlib/DataProvider/DataProvider.qm
+++ b/qlib/DataProvider/DataProvider.qm
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! @file DataProvider.qm module for data access and introspection
 
-/*  DataProvider.qm Copyright 2019 - 2025 Qore Technologies, s.r.o.
+/*  DataProvider.qm Copyright 2019 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -45,7 +45,7 @@
 %endtry
 
 module DataProvider {
-    version = "3.3.0";
+    version = "3.4.0";
     desc = "user module for data integration patterns and data and API introspection";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -164,7 +164,185 @@ $env:QORE_DATA_PROVIDERS="MyDataProvider;OtherDataProvider"
     iterated, and each record will be passed separately to the processor with a significant performance penalty when
     processing large volumes of data.
 
+    @section dataprovider_dpql DPQL - Data Provider Query Language
+
+    DPQL (Data Provider Query Language) is a human-readable query language for constructing DataProviderExpression
+    structures. It provides a simple, intuitive syntax for writing search expressions that can be used with data
+    provider search, update, and delete operations.
+
+    @subsection dpql_syntax DPQL Syntax
+
+    DPQL supports the following syntax elements:
+
+    @par Field References
+    Fields are referenced using the \c @ prefix:
+    - \c @name - simple field name
+    - \c @"field with spaces" - quoted field names for special characters
+    - \c @user.email - dotted paths for nested fields
+
+    @par Comparison Operators
+    - \c == - equals
+    - \c != - not equals
+    - \c < - less than
+    - \c <= - less than or equal
+    - \c > - greater than
+    - \c >= - greater than or equal
+    - \c between - range comparison (\c @age \c between \c 18 \c and \c 65)
+    - \c in - set membership (\c @status \c in \c ("active", \c "pending"))
+    - \c =~ - regex match (\c @email \c =~ \c /example.com$/i)
+
+    @par Logical Operators
+    - \c && - logical AND
+    - \c || - logical OR
+    - \c ! - logical NOT
+
+    @par Literals
+    - Strings: \c "hello" or \c 'world'
+    - Numbers: \c 123, \c 45.67, \c -10
+    - Booleans: \c true, \c false
+    - Null: \c null
+
+    @par Function Calls
+    Custom functions can be used: \c calculate(@score, \c 100) \c > \c 50
+
+    @subsection dpql_examples DPQL Examples
+
+    @par Simple Comparison
+    @code{.py}
+# Parse a simple equality expression
+hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('@name == "John"');
+# Result: {"exp": "==", "args": [{"field": "name"}, "John"]}
+    @endcode
+
+    @par Complex Query
+    @code{.py}
+# Parse a complex query with multiple conditions
+hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+    '@age > 18 && @status == "active" || @role == "admin"');
+    @endcode
+
+    @par Range Query
+    @code{.py}
+# Find records where age is between 18 and 65
+hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('@age between 18 and 65');
+    @endcode
+
+    @par Set Membership
+    @code{.py}
+# Find records with specific status values
+hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+    '@status in ("pending", "active", "review")');
+    @endcode
+
+    @par Regex Matching
+    @code{.py}
+# Find email addresses from a specific domain (case-insensitive)
+hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('@email =~ /example.com$/i');
+    @endcode
+
+    @par Negation
+    @code{.py}
+# Find non-deleted records
+hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('!(@deleted == true)');
+    @endcode
+
+    @par Using with Data Providers
+    @code{.py}
+# Search a data provider using DPQL
+hash<DataProviderExpression> where = DataProvider::parseDpqlExpression(
+    '@created > "2024-01-01" && @type == "order"');
+AbstractDataProviderRecordIterator i = provider.searchRecords({"where": where});
+    @endcode
+
+    @subsection dpql_round_trip Round-Trip Conversion
+
+    DPQL expressions can be serialized back to strings:
+    @code{.py}
+# Parse and serialize an expression
+hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('@name == "John" && @age > 18');
+string dpql = DataProvider::serializeDpqlExpression(exp);
+# Result: '@name == "John" && @age > 18'
+    @endcode
+
+    @subsection dpql_diagnostics Error Handling and Diagnostics
+
+    The parser provides detailed diagnostics for syntax errors:
+    @code{.py}
+# Parse with diagnostics
+hash<DpqlParseResult> result = DataProvider::parseDpqlExpressionWithInfo('@name ==');
+if (!result.success) {
+    foreach hash<DpqlDiagnostic> diag in (result.diagnostics) {
+        printf("Error at line %d, column %d: %s (code: %s)\n",
+            diag.line, diag.column, diag.message, diag.code);
+    }
+}
+    @endcode
+
+    @subsection dpql_syntax_highlighting Syntax Highlighting
+
+    For IDE integration, DPQL provides token information with position tracking:
+    @code{.py}
+# Get tokens for syntax highlighting
+list<hash<DpqlTokenInfo>> tokens = DataProvider::getDpqlTokens('@name == "John"');
+foreach hash<DpqlTokenInfo> tok in (tokens) {
+    printf("Token: type=%d value='%s' at line %d, col %d\n",
+        tok.type, tok.value, tok.line, tok.column);
+}
+    @endcode
+
+    Token types include:
+    - \c DPQL_TOK_FIELD (1) - field references
+    - \c DPQL_TOK_STRING (2) - string literals
+    - \c DPQL_TOK_NUMBER (3) - numeric literals
+    - \c DPQL_TOK_BOOLEAN (4) - boolean values
+    - \c DPQL_TOK_IDENTIFIER (6) - identifiers/keywords
+    - \c DPQL_TOK_OP_EQ (10) through \c DPQL_TOK_OP_REGEX (19) - operators
+    - \c DPQL_TOK_REGEX (20) - regex patterns
+
+    @subsection dpql_completions Auto-Completion
+
+    For IDE integration, DPQL provides context-aware completions:
+    @code{.py}
+# Get completions at cursor position
+hash<string, AbstractDataField> fields = {
+    "name": new QoreDataField("name", "Name", StringType),
+    "age": new QoreDataField("age", "Age", IntType),
+    "email": new QoreDataField("email", "Email", StringType),
+};
+list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('@na', 3, fields);
+# Returns completions matching "na", e.g., [{"label": "name", "kind": "field", ...}]
+    @endcode
+
+    @subsection dpql_validation Expression Validation
+
+    Expressions can be validated against available fields:
+    @code{.py}
+# Validate expression against fields
+hash<string, AbstractDataField> fields = {
+    "name": new QoreDataField("name", "Name", StringType),
+};
+list<hash<DpqlDiagnostic>> errors = DataProvider::validateDpqlExpression(
+    '@unknown_field == "test"', fields);
+if (errors) {
+    printf("Validation error: %s\n", errors[0].message);
+    # Output: "Validation error: Unknown field 'unknown_field'"
+}
+    @endcode
+
     @section dataprovider_relnotes Release Notes
+
+    @subsection dataprovider_v3_4 DataProvider v3.4
+    - added DPQL (Data Provider Query Language) support for human-readable query expressions
+      - @ref DataProvider::DpqlTokenizer "DpqlTokenizer": Tokenizes DPQL expressions with position tracking
+      - @ref DataProvider::DpqlParser "DpqlParser": Parses DPQL strings into DataProviderExpression structures
+      - @ref DataProvider::DpqlSerializer "DpqlSerializer": Serializes DataProviderExpression back to DPQL strings
+      - @ref DataProvider::DpqlCompletionProvider "DpqlCompletionProvider": Context-aware completions for IDE support
+      - @ref DataProvider::DataProvider::parseDpqlExpression() "DataProvider::parseDpqlExpression()": Parse DPQL to expression
+      - @ref DataProvider::DataProvider::parseDpqlExpressionWithInfo() "DataProvider::parseDpqlExpressionWithInfo()": Parse with diagnostics
+      - @ref DataProvider::DataProvider::serializeDpqlExpression() "DataProvider::serializeDpqlExpression()": Serialize expression to DPQL
+      - @ref DataProvider::DataProvider::getDpqlTokens() "DataProvider::getDpqlTokens()": Get tokens for syntax highlighting
+      - @ref DataProvider::DataProvider::getDpqlCompletions() "DataProvider::getDpqlCompletions()": Get completions at cursor position
+      - @ref DataProvider::DataProvider::validateDpqlExpression() "DataProvider::validateDpqlExpression()": Validate against fields
 
     @subsection dataprovider_v3_3 DataProvider v3.3
     - added methods to return data provider types in the context of option dataprovider_message_support

--- a/qlib/DataProvider/DpqlCompletionProvider.qc
+++ b/qlib/DataProvider/DpqlCompletionProvider.qc
@@ -1,0 +1,432 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! @file DpqlCompletionProvider.qc DPQL completion provider implementation
+
+/*  DpqlCompletionProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the DataProvider module
+public namespace DataProvider {
+
+#! DPQL Completion item structure
+/** Contains information about a single completion suggestion.
+*/
+public hashdecl DpqlCompletionItem {
+    #! Display text shown in the completion menu
+    string label;
+    #! Item kind: "field", "operator", "function", "keyword", "value"
+    string kind;
+    #! Text to insert when this completion is selected
+    string insert_text;
+    #! Optional documentation or help text
+    *string documentation;
+    #! Sort priority (lower = higher priority)
+    int sort_priority = 100;
+}
+
+#! DPQL Completion context structure
+/** Contains context information for generating completions.
+*/
+public hashdecl DpqlCompletionContext {
+    #! The input text
+    string text;
+    #! Cursor position (0-based character offset)
+    int position;
+    #! Available fields
+    hash<string, AbstractDataField> fields;
+    #! Available expressions
+    *hash<string, hash<DataProviderExpressionInfo>> expressions;
+}
+
+#! Completion context types
+const DPQL_CTX_START = "start";              # Start of expression
+const DPQL_CTX_AFTER_FIELD = "after_field";  # After a field reference
+const DPQL_CTX_AFTER_OP = "after_op";        # After an operator
+const DPQL_CTX_AFTER_VALUE = "after_value";  # After a value
+const DPQL_CTX_IN_FIELD = "in_field";        # Inside a field reference (after @)
+const DPQL_CTX_IN_STRING = "in_string";      # Inside a string
+const DPQL_CTX_IN_PAREN = "in_paren";        # Inside parentheses
+
+#! Completion provider for DPQL expressions
+/** This class provides context-aware code completion for DPQL query expressions.
+    It analyzes the cursor position and surrounding text to suggest relevant
+    completions.
+
+    @par Example:
+    @code{.py}
+hash<string, AbstractDataField> fields = {
+    "name": new QoreDataField("name", "Name", new QoreStringDataType()),
+    "age": new QoreDataField("age", "Age", new QoreIntDataType()),
+};
+
+DpqlCompletionProvider provider();
+list<hash<DpqlCompletionItem>> items = provider.getCompletions('@na', 3, fields);
+# Returns: [{"label": "name", "kind": "field", "insert_text": "name", ...}]
+    @endcode
+*/
+public class DpqlCompletionProvider {
+    private {
+        #! Available expressions
+        *hash<string, hash<DataProviderExpressionInfo>> expressions;
+
+        #! Comparison operators with descriptions
+        const ComparisonOperators = (
+            {"label": "==", "kind": "operator", "insert_text": "== ",
+                "documentation": "Equals comparison", "sort_priority": 10},
+            {"label": "!=", "kind": "operator", "insert_text": "!= ",
+                "documentation": "Not equals comparison", "sort_priority": 11},
+            {"label": "<", "kind": "operator", "insert_text": "< ",
+                "documentation": "Less than comparison", "sort_priority": 12},
+            {"label": "<=", "kind": "operator", "insert_text": "<= ",
+                "documentation": "Less than or equals comparison", "sort_priority": 13},
+            {"label": ">", "kind": "operator", "insert_text": "> ",
+                "documentation": "Greater than comparison", "sort_priority": 14},
+            {"label": ">=", "kind": "operator", "insert_text": ">= ",
+                "documentation": "Greater than or equals comparison", "sort_priority": 15},
+            {"label": "between", "kind": "keyword", "insert_text": "between ",
+                "documentation": "Range comparison: between X and Y", "sort_priority": 20},
+            {"label": "in", "kind": "keyword", "insert_text": "in (",
+                "documentation": "Collection membership: in (val1, val2, ...)", "sort_priority": 21},
+            {"label": "=~", "kind": "operator", "insert_text": "=~ /",
+                "documentation": "Regex pattern match", "sort_priority": 22},
+        );
+
+        #! Logical operators with descriptions
+        const LogicalOperators = (
+            {"label": "&&", "kind": "operator", "insert_text": " && ",
+                "documentation": "Logical AND", "sort_priority": 30},
+            {"label": "||", "kind": "operator", "insert_text": " || ",
+                "documentation": "Logical OR", "sort_priority": 31},
+        );
+
+        #! Keyword completions
+        const Keywords = (
+            {"label": "true", "kind": "keyword", "insert_text": "true",
+                "documentation": "Boolean true value", "sort_priority": 50},
+            {"label": "false", "kind": "keyword", "insert_text": "false",
+                "documentation": "Boolean false value", "sort_priority": 51},
+            {"label": "null", "kind": "keyword", "insert_text": "null",
+                "documentation": "Null/nothing value", "sort_priority": 52},
+            {"label": "and", "kind": "keyword", "insert_text": "and ",
+                "documentation": "Used in 'between X and Y'", "sort_priority": 53},
+        );
+    }
+
+    #! Creates a completion provider with optional expression map
+    /** @param expressions optional map of expression names to their info
+    */
+    constructor(*hash<string, hash<DataProviderExpressionInfo>> expressions) {
+        self.expressions = expressions;
+    }
+
+    #! Gets completions at the given position
+    /** @param text the DPQL expression text
+        @param position cursor position (0-based character offset)
+        @param fields available fields for completion
+        @return a list of completion items
+    */
+    list<hash<DpqlCompletionItem>> getCompletions(string text, int position,
+            hash<string, AbstractDataField> fields) {
+        return getCompletionsWithContext(<DpqlCompletionContext>{
+            "text": text,
+            "position": position,
+            "fields": fields,
+            "expressions": expressions,
+        });
+    }
+
+    #! Gets completions with full context
+    /** @param ctx the completion context
+        @return a list of completion items
+    */
+    list<hash<DpqlCompletionItem>> getCompletionsWithContext(hash<DpqlCompletionContext> ctx) {
+        # Analyze context to determine what completions are appropriate
+        hash<auto> analysis = analyzeContext(ctx.text, ctx.position);
+
+        list<hash<DpqlCompletionItem>> items = ();
+
+        switch (analysis.ctx) {
+            case DPQL_CTX_START:
+            case DPQL_CTX_AFTER_OP:
+            case DPQL_CTX_IN_PAREN:
+                # Can start with field, literal, function, or NOT
+                items += getFieldCompletions(ctx.fields, analysis.prefix);
+                items += getValueCompletions(analysis.prefix);
+                items += getFunctionCompletions(analysis.prefix);
+                if (!analysis.prefix || index("!", analysis.prefix) == 0) {
+                    items += <DpqlCompletionItem>{
+                        "label": "!",
+                        "kind": "operator",
+                        "insert_text": "!",
+                        "documentation": "Logical NOT",
+                        "sort_priority": 5,
+                    };
+                }
+                break;
+
+            case DPQL_CTX_IN_FIELD:
+                # Completing field name after @
+                items += getFieldCompletions(ctx.fields, analysis.prefix);
+                break;
+
+            case DPQL_CTX_AFTER_FIELD:
+                # After field, suggest comparison operators
+                items += getOperatorCompletions(analysis.prefix, True);
+                break;
+
+            case DPQL_CTX_AFTER_VALUE:
+                # After value, suggest logical operators or more comparisons
+                items += getOperatorCompletions(analysis.prefix, False);
+                break;
+
+            case DPQL_CTX_IN_STRING:
+                # Inside string - no completions
+                break;
+        }
+
+        # Sort by priority
+        items = sort(items, int sub (hash<DpqlCompletionItem> a, hash<DpqlCompletionItem> b) {
+            return a.sort_priority <=> b.sort_priority;
+        });
+
+        return items;
+    }
+
+    #! Analyzes the context at the given position
+    private hash<auto> analyzeContext(string text, int position) {
+        # Ensure position is within bounds
+        if (position > text.size()) {
+            position = text.size();
+        }
+
+        string before = position > 0 ? substr(text, 0, position) : "";
+        string prefix = "";
+
+        # Check if we're inside a string
+        int in_string = checkInString(before);
+        if (in_string) {
+            return {
+                "ctx": DPQL_CTX_IN_STRING,
+                "prefix": "",
+            };
+        }
+
+        # Find the start of the current token
+        int token_start = position;
+        while (token_start > 0 && before[token_start - 1] !~ /[\s(),]/) {
+            --token_start;
+        }
+
+        if (token_start < position) {
+            prefix = substr(before, token_start);
+        }
+
+        # Check if we're in a field reference (after @)
+        if (prefix =~ /^@/) {
+            return {
+                "ctx": DPQL_CTX_IN_FIELD,
+                "prefix": prefix.size() > 1 ? substr(prefix, 1) : "",
+            };
+        }
+
+        # Look at what came before (ignoring whitespace)
+        string trimmed = rtrim(before);
+        if (!trimmed) {
+            return {
+                "ctx": DPQL_CTX_START,
+                "prefix": prefix,
+            };
+        }
+
+        # Check the last non-whitespace character/token
+        *string last_char = trimmed.size() > 0 ? trimmed[trimmed.size() - 1] : NOTHING;
+
+        # After opening paren
+        if (last_char == "(") {
+            return {
+                "ctx": DPQL_CTX_IN_PAREN,
+                "prefix": prefix,
+            };
+        }
+
+        # After comma
+        if (last_char == ",") {
+            return {
+                "ctx": DPQL_CTX_AFTER_OP,
+                "prefix": prefix,
+            };
+        }
+
+        # Check if last token was a field reference
+        if (trimmed =~ /@[a-zA-Z0-9_."]+\s*$/) {
+            return {
+                "ctx": DPQL_CTX_AFTER_FIELD,
+                "prefix": prefix,
+            };
+        }
+
+        # Check if last token was an operator
+        if (trimmed =~ /(==|!=|<=|>=|<|>|&&|\|\||=~|between|in|and)\s*$/) {
+            return {
+                "ctx": DPQL_CTX_AFTER_OP,
+                "prefix": prefix,
+            };
+        }
+
+        # Check if last token was a value (string, number, boolean, null)
+        if (trimmed =~ /("[^"]*"|'[^']*'|-?[0-9]+\.?[0-9]*|true|false|null|\))\s*$/) {
+            return {
+                "ctx": DPQL_CTX_AFTER_VALUE,
+                "prefix": prefix,
+            };
+        }
+
+        # Default to start context
+        return {
+            "ctx": DPQL_CTX_START,
+            "prefix": prefix,
+        };
+    }
+
+    #! Checks if position is inside a string literal
+    private int checkInString(string text) {
+        bool in_double = False;
+        bool in_single = False;
+        bool escaped = False;
+
+        for (int i = 0; i < text.size(); ++i) {
+            string c = text[i];
+            if (escaped) {
+                escaped = False;
+                continue;
+            }
+            if (c == "\\") {
+                escaped = True;
+                continue;
+            }
+            if (c == '"' && !in_single) {
+                in_double = !in_double;
+            } else if (c == "'" && !in_double) {
+                in_single = !in_single;
+            }
+        }
+
+        return in_double || in_single ? 1 : 0;
+    }
+
+    #! Gets field completions
+    private list<hash<DpqlCompletionItem>> getFieldCompletions(
+            hash<string, AbstractDataField> fields, string prefix) {
+        list<hash<DpqlCompletionItem>> items = ();
+        string lwr_prefix = prefix.lwr();
+
+        foreach string field_name in (keys fields) {
+            if (!prefix || index(field_name.lwr(), lwr_prefix) == 0) {
+                AbstractDataField field = fields{field_name};
+                *hash<DataFieldInfo> info = field.getInfo();
+
+                # Determine if field name needs quoting
+                string insert_text;
+                if (field_name =~ /[^a-zA-Z0-9_.]/ || field_name =~ /^[0-9]/) {
+                    insert_text = '@"' + replace(field_name, '"', '\\"') + '"';
+                } else {
+                    insert_text = "@" + field_name;
+                }
+
+                items += <DpqlCompletionItem>{
+                    "label": field_name,
+                    "kind": "field",
+                    "insert_text": insert_text,
+                    "documentation": info.short_desc ?? info.desc,
+                    "sort_priority": 1,
+                };
+            }
+        }
+
+        return items;
+    }
+
+    #! Gets operator completions
+    private list<hash<DpqlCompletionItem>> getOperatorCompletions(string prefix, bool comparison) {
+        list<hash<DpqlCompletionItem>> items = ();
+        string lwr_prefix = prefix.lwr();
+
+        if (comparison) {
+            foreach hash<auto> op in (ComparisonOperators) {
+                if (!prefix || index(op.label.lwr(), lwr_prefix) == 0) {
+                    items += cast<hash<DpqlCompletionItem>>(op);
+                }
+            }
+        }
+
+        foreach hash<auto> op in (LogicalOperators) {
+            if (!prefix || index(op.label.lwr(), lwr_prefix) == 0) {
+                items += cast<hash<DpqlCompletionItem>>(op);
+            }
+        }
+
+        return items;
+    }
+
+    #! Gets value completions (true, false, null)
+    private list<hash<DpqlCompletionItem>> getValueCompletions(string prefix) {
+        list<hash<DpqlCompletionItem>> items = ();
+        string lwr_prefix = prefix.lwr();
+
+        foreach hash<auto> kw in (Keywords) {
+            if (!prefix || index(kw.label.lwr(), lwr_prefix) == 0) {
+                items += cast<hash<DpqlCompletionItem>>(kw);
+            }
+        }
+
+        return items;
+    }
+
+    #! Gets function completions
+    private list<hash<DpqlCompletionItem>> getFunctionCompletions(string prefix) {
+        list<hash<DpqlCompletionItem>> items = ();
+
+        if (!expressions) {
+            return items;
+        }
+
+        string lwr_prefix = prefix.lwr();
+
+        foreach string name in (keys expressions) {
+            hash<DataProviderExpressionInfo> info = expressions{name};
+            # Only include function-type expressions
+            if (info.type == DET_Function) {
+                if (!prefix || index(name.lwr(), lwr_prefix) == 0) {
+                    items += <DpqlCompletionItem>{
+                        "label": name,
+                        "kind": "function",
+                        "insert_text": name + "(",
+                        "documentation": info.short_desc ?? info.desc,
+                        "sort_priority": 40,
+                    };
+                }
+            }
+        }
+
+        return items;
+    }
+}
+
+} # namespace DataProvider

--- a/qlib/DataProvider/DpqlParser.qc
+++ b/qlib/DataProvider/DpqlParser.qc
@@ -1,0 +1,769 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! @file DpqlParser.qc DPQL parser implementation
+
+/*  DpqlParser.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the DataProvider module
+public namespace DataProvider {
+
+#! DPQL Parse result structure
+/** Contains the result of parsing a DPQL expression, including the parsed expression,
+    any diagnostic messages, and the token stream for syntax highlighting.
+*/
+public hashdecl DpqlParseResult {
+    #! The parsed expression, if parsing was successful
+    *hash<DataProviderExpression> expression;
+    #! List of diagnostic messages (errors and warnings)
+    list<hash<DpqlDiagnostic>> diagnostics;
+    #! True if parsing was successful with no errors
+    bool success;
+    #! Token stream for syntax highlighting
+    list<hash<DpqlTokenInfo>> tokens;
+}
+
+#! Parser for DPQL (Data Provider Query Language) expressions
+/** This class provides parsing of DPQL query expressions into DataProviderExpression
+    structures. It implements a recursive descent parser for the DPQL grammar.
+
+    The parser supports:
+    - Comparison operators: ==, !=, <, <=, >, >=
+    - Logical operators: &&, ||, !
+    - Range operators: between X and Y
+    - Collection operators: in (val1, val2, ...)
+    - Regex matching: =~ /pattern/flags
+    - Function calls: func(arg1, arg2, ...)
+    - Field references: @field, @"field with spaces"
+    - Literals: strings, numbers, booleans, null
+
+    @par Example:
+    @code{.py}
+DpqlParser parser();
+hash<DataProviderExpression> exp = parser.parse('@name == "John" && @age > 18');
+# Returns: {"exp": "&&", "args": [{"exp": "==", "args": [{"field": "name"}, "John"]}, ...]}
+    @endcode
+*/
+public class DpqlParser {
+    private {
+        #! Tokenizer instance
+        DpqlTokenizer tokenizer;
+        #! Collected errors
+        list<hash<DpqlDiagnostic>> errors = ();
+        #! Token stream for result
+        list<hash<DpqlTokenInfo>> tokens = ();
+        #! Available expressions (for validation)
+        *hash<string, hash<DataProviderExpressionInfo>> expressions;
+        #! Current line number for error reporting
+        int line = 1;
+        #! Current column number for error reporting
+        int column = 1;
+    }
+
+    #! Creates a parser with optional expression map for validation
+    /** @param expressions optional map of expression names to their info for validation
+    */
+    constructor(*hash<string, hash<DataProviderExpressionInfo>> expressions) {
+        self.expressions = expressions;
+    }
+
+    #! Parses a DPQL expression string
+    /** @param text the DPQL expression to parse
+        @return the parsed DataProviderExpression
+
+        @throw DPQL-PARSE-ERROR if the expression contains syntax errors
+    */
+    hash<DataProviderExpression> parse(string text) {
+        hash<DpqlParseResult> result = parseWithInfo(text);
+        if (!result.success) {
+            string msg = "DPQL parse error";
+            if (result.diagnostics) {
+                msg += ": " + result.diagnostics[0].message;
+                msg += sprintf(" at line %d, column %d", result.diagnostics[0].line,
+                    result.diagnostics[0].column);
+            }
+            throw "DPQL-PARSE-ERROR", msg, result.diagnostics;
+        }
+        return result.expression;
+    }
+
+    #! Parses a DPQL expression with full diagnostic information
+    /** @param text the DPQL expression to parse
+        @return a DpqlParseResult containing the expression, diagnostics, and tokens
+    */
+    hash<DpqlParseResult> parseWithInfo(string text) {
+        # Reset state
+        errors = ();
+        tokens = ();
+
+        # Initialize tokenizer
+        tokenizer = new DpqlTokenizer(text);
+
+        # Collect all tokens first for syntax highlighting
+        tokens = tokenizer.getAllTokens();
+
+        # Get tokenizer errors from full scan (these should come first)
+        list<hash<DpqlDiagnostic>> tokenizer_errors = tokenizer.getErrors();
+
+        # Reset tokenizer for parsing
+        tokenizer = new DpqlTokenizer(text);
+
+        # Parse the expression
+        *hash<DataProviderExpression> exp;
+        bool parse_failed = False;
+        try {
+            skipWhitespace();
+            if (!atEnd()) {
+                exp = parseOrExpr();
+                skipWhitespace();
+                if (!atEnd()) {
+                    hash<DpqlTokenInfo> tok = peek();
+                    addError(sprintf("Unexpected token '%s' after expression", tok.value),
+                        "DPQL-E001", tok);
+                }
+            }
+        } catch (hash<ExceptionInfo> ex) {
+            parse_failed = True;
+            if (ex.err != "DPQL-PARSE-ERROR") {
+                addError(sprintf("Internal parser error: %s", ex.desc), "DPQL-E001",
+                    line, column, line, column);
+            }
+        }
+
+        # Prepend tokenizer errors (they should come first)
+        errors = tokenizer_errors + errors;
+
+        return <DpqlParseResult>{
+            "expression": exp,
+            "diagnostics": errors,
+            "success": !parse_failed && !errors,
+            "tokens": tokens,
+        };
+    }
+
+    #! Validates an expression against available fields
+    /** @param exp the expression to validate
+        @param fields the available fields
+        @return a list of diagnostic messages for any validation errors
+    */
+    list<hash<DpqlDiagnostic>> validate(hash<DataProviderExpression> exp,
+            hash<string, AbstractDataField> fields) {
+        list<hash<DpqlDiagnostic>> diags = ();
+        validateExprRecursive(exp, fields, \diags);
+        return diags;
+    }
+
+    #! Recursively validates an expression
+    private validateExprRecursive(hash<DataProviderExpression> exp,
+            hash<string, AbstractDataField> fields, reference<list<hash<DpqlDiagnostic>>> diags) {
+        # Validate each argument
+        foreach auto arg in (exp.args) {
+            if (arg.typeCode() == NT_HASH) {
+                if (arg.hasKey("field")) {
+                    # Field reference - validate field exists
+                    string field_name = arg.field;
+                    # Handle dotted field names
+                    int dot_pos = index(field_name, ".");
+                    string base_field = dot_pos >= 0 ? substr(field_name, 0, dot_pos) : field_name;
+                    if (!fields.hasKey(base_field)) {
+                        diags += <DpqlDiagnostic>{
+                            "severity": "error",
+                            "message": sprintf("Unknown field '%s'", field_name),
+                            "code": "DPQL-E010",
+                            "line": 1,
+                            "column": 1,
+                            "end_line": 1,
+                            "end_column": 1,
+                        };
+                    }
+                } else if (arg.hasKey("exp")) {
+                    # Nested expression
+                    validateExprRecursive(arg, fields, \diags);
+                }
+            }
+        }
+    }
+
+    #! Returns True if at end of input (ignoring whitespace)
+    private bool atEnd() {
+        return tokenizer.atEnd();
+    }
+
+    #! Peeks at the next non-whitespace token
+    private hash<DpqlTokenInfo> peek() {
+        hash<DpqlTokenInfo> tok = tokenizer.peek();
+        line = tok.line;
+        column = tok.column;
+        return tok;
+    }
+
+    #! Gets the next non-whitespace token
+    private hash<DpqlTokenInfo> nextToken() {
+        hash<DpqlTokenInfo> tok = tokenizer.next();
+        line = tok.line;
+        column = tok.column;
+        return tok;
+    }
+
+    #! Skips whitespace tokens
+    private skipWhitespace() {
+        while (!tokenizer.atEnd()) {
+            hash<DpqlTokenInfo> tok = tokenizer.peek();
+            if (tok.type != DPQL_TOK_WHITESPACE && tok.type != DPQL_TOK_NEWLINE) {
+                break;
+            }
+            tokenizer.next();
+        }
+    }
+
+    #! Adds an error diagnostic
+    private addError(string message, string code, hash<DpqlTokenInfo> tok) {
+        errors += <DpqlDiagnostic>{
+            "severity": "error",
+            "message": message,
+            "code": code,
+            "line": tok.line,
+            "column": tok.column,
+            "end_line": tok.end_line,
+            "end_column": tok.end_column,
+        };
+    }
+
+    #! Adds an error diagnostic with explicit position
+    private addError(string message, string code, int start_line, int start_col,
+            int end_line, int end_col) {
+        errors += <DpqlDiagnostic>{
+            "severity": "error",
+            "message": message,
+            "code": code,
+            "line": start_line,
+            "column": start_col,
+            "end_line": end_line,
+            "end_column": end_col,
+        };
+    }
+
+    #! Expects a specific token type and returns it
+    private hash<DpqlTokenInfo> expect(int token_type, string description) {
+        skipWhitespace();
+        if (atEnd()) {
+            addError(sprintf("Unexpected end of input, expected %s", description),
+                "DPQL-E001", line, column, line, column);
+            throw "DPQL-PARSE-ERROR", "Unexpected end of input";
+        }
+        hash<DpqlTokenInfo> tok = nextToken();
+        if (tok.type != token_type) {
+            addError(sprintf("Expected %s, got '%s'", description, tok.value),
+                "DPQL-E001", tok);
+            throw "DPQL-PARSE-ERROR", sprintf("Expected %s", description);
+        }
+        return tok;
+    }
+
+    #! Parses or_expr: and_expr { "||" and_expr }
+    private auto parseOrExpr() {
+        auto left = parseAndExpr();
+        skipWhitespace();
+
+        list<auto> args = (left,);
+        while (!atEnd()) {
+            hash<DpqlTokenInfo> tok = peek();
+            if (tok.type != DPQL_TOK_OP_OR) {
+                break;
+            }
+            nextToken();  # consume ||
+            skipWhitespace();
+            args += parseAndExpr();
+            skipWhitespace();
+        }
+
+        if (args.size() == 1) {
+            # Return single value/expression as-is
+            # Field references, expressions, and bare values are all returned unchanged
+            return args[0];
+        }
+
+        return <DataProviderExpression>{
+            "exp": DP_OP_OR,
+            "args": args,
+        };
+    }
+
+    #! Parses and_expr: unary_expr { "&&" unary_expr }
+    private auto parseAndExpr() {
+        auto left = parseUnaryExpr();
+        skipWhitespace();
+
+        list<auto> args = (left,);
+        while (!atEnd()) {
+            hash<DpqlTokenInfo> tok = peek();
+            if (tok.type != DPQL_TOK_OP_AND) {
+                break;
+            }
+            nextToken();  # consume &&
+            skipWhitespace();
+            args += parseUnaryExpr();
+            skipWhitespace();
+        }
+
+        if (args.size() == 1) {
+            return args[0];
+        }
+
+        return <DataProviderExpression>{
+            "exp": DP_OP_AND,
+            "args": args,
+        };
+    }
+
+    #! Parses unary_expr: "!" unary_expr | primary_expr
+    private auto parseUnaryExpr() {
+        skipWhitespace();
+        if (atEnd()) {
+            addError("Unexpected end of input", "DPQL-E001", line, column, line, column);
+            throw "DPQL-PARSE-ERROR", "Unexpected end of input";
+        }
+
+        hash<DpqlTokenInfo> tok = peek();
+        if (tok.type == DPQL_TOK_OP_NOT) {
+            nextToken();  # consume !
+            skipWhitespace();
+            auto operand = parseUnaryExpr();
+            return <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_NOT,
+                "args": (operand,),
+            };
+        }
+
+        return parsePrimaryExpr();
+    }
+
+    #! Parses primary_expr: comparison (which handles values, function calls, subexpressions)
+    private auto parsePrimaryExpr() {
+        skipWhitespace();
+        if (atEnd()) {
+            addError("Unexpected end of input", "DPQL-E001", line, column, line, column);
+            throw "DPQL-PARSE-ERROR", "Unexpected end of input";
+        }
+
+        # parseComparison handles all primary expression types via parseValue
+        return parseComparison();
+    }
+
+    #! Parses a comparison expression
+    private auto parseComparison() {
+        auto left = parseValue();
+        skipWhitespace();
+
+        if (atEnd()) {
+            return left;
+        }
+
+        hash<DpqlTokenInfo> tok = peek();
+
+        # Check for comparison operators
+        switch (tok.type) {
+            case DPQL_TOK_OP_EQ:
+                nextToken();
+                skipWhitespace();
+                return <DataProviderExpression>{
+                    "exp": DP_SEARCH_OP_EQ,
+                    "args": (left, parseValue()),
+                };
+
+            case DPQL_TOK_OP_NE:
+                nextToken();
+                skipWhitespace();
+                return <DataProviderExpression>{
+                    "exp": DP_SEARCH_OP_NE,
+                    "args": (left, parseValue()),
+                };
+
+            case DPQL_TOK_OP_LT:
+                nextToken();
+                skipWhitespace();
+                return <DataProviderExpression>{
+                    "exp": DP_SEARCH_OP_LT,
+                    "args": (left, parseValue()),
+                };
+
+            case DPQL_TOK_OP_LE:
+                nextToken();
+                skipWhitespace();
+                return <DataProviderExpression>{
+                    "exp": DP_SEARCH_OP_LE,
+                    "args": (left, parseValue()),
+                };
+
+            case DPQL_TOK_OP_GT:
+                nextToken();
+                skipWhitespace();
+                return <DataProviderExpression>{
+                    "exp": DP_SEARCH_OP_GT,
+                    "args": (left, parseValue()),
+                };
+
+            case DPQL_TOK_OP_GE:
+                nextToken();
+                skipWhitespace();
+                return <DataProviderExpression>{
+                    "exp": DP_SEARCH_OP_GE,
+                    "args": (left, parseValue()),
+                };
+
+            case DPQL_TOK_OP_REGEX:
+                nextToken();  # consume =~
+                skipWhitespace();
+                return parseRegexExpr(left);
+
+            case DPQL_TOK_IDENTIFIER: {
+                string kw = tok.value.lwr();
+                if (kw == "between") {
+                    nextToken();  # consume 'between'
+                    skipWhitespace();
+                    auto low = parseValue();
+                    skipWhitespace();
+                    # Expect 'and'
+                    hash<DpqlTokenInfo> and_tok = peek();
+                    if (and_tok.type != DPQL_TOK_IDENTIFIER || and_tok.value.lwr() != "and") {
+                        addError("Expected 'and' in between expression", "DPQL-E001", and_tok);
+                        throw "DPQL-PARSE-ERROR", "Expected 'and'";
+                    }
+                    nextToken();  # consume 'and'
+                    skipWhitespace();
+                    auto high = parseValue();
+                    return <DataProviderExpression>{
+                        "exp": DP_SEARCH_OP_BETWEEN,
+                        "args": (left, low, high),
+                    };
+                }
+                if (kw == "in") {
+                    nextToken();  # consume 'in'
+                    skipWhitespace();
+                    expect(DPQL_TOK_LPAREN, "'('");
+                    skipWhitespace();
+                    list<auto> values = parseValueList();
+                    skipWhitespace();
+                    expect(DPQL_TOK_RPAREN, "')'");
+                    return <DataProviderExpression>{
+                        "exp": DP_SEARCH_OP_IN,
+                        "args": (left,) + values,
+                    };
+                }
+                # Not a keyword we recognize here
+                break;
+            }
+        }
+
+        # No operator - return the value as-is
+        return left;
+    }
+
+    #! Parses a regex expression after =~
+    private hash<DataProviderExpression> parseRegexExpr(auto left) {
+        if (atEnd()) {
+            addError("Expected regex pattern after '=~'", "DPQL-E009", line, column, line, column);
+            throw "DPQL-PARSE-ERROR", "Expected regex pattern";
+        }
+
+        hash<DpqlTokenInfo> tok = peek();
+        if (tok.type != DPQL_TOK_REGEX) {
+            addError("Expected regex pattern after '=~'", "DPQL-E009", tok);
+            throw "DPQL-PARSE-ERROR", "Expected regex pattern";
+        }
+
+        nextToken();  # consume regex
+        string pattern = tok.value;
+
+        # Parse the regex: /pattern/flags
+        # Extract pattern and flags
+        if (pattern.size() < 2 || pattern[0] != "/") {
+            addError("Invalid regex pattern", "DPQL-E009", tok);
+            throw "DPQL-PARSE-ERROR", "Invalid regex pattern";
+        }
+
+        int last_slash = rindex(pattern, "/");
+        if (last_slash <= 0) {
+            addError("Invalid regex pattern", "DPQL-E009", tok);
+            throw "DPQL-PARSE-ERROR", "Invalid regex pattern";
+        }
+
+        string regex_pattern = substr(pattern, 1, last_slash - 1);
+        string flags = substr(pattern, last_slash + 1);
+
+        list<auto> args = (left, regex_pattern);
+
+        # Convert flags to regex option constants
+        if (flags) {
+            for (int i = 0; i < flags.size(); ++i) {
+                string flag = flags[i];
+                switch (flag) {
+                    case "i":
+                        args += RE_Caseless;
+                        break;
+                    case "s":
+                        args += RE_DotAll;
+                        break;
+                    case "m":
+                        args += RE_MultiLine;
+                        break;
+                    case "x":
+                        args += RE_Extended;
+                        break;
+                    case "u":
+                        args += RE_Unicode;
+                        break;
+                    default:
+                        addError(sprintf("Unknown regex flag '%s'", flag), "DPQL-E009", tok);
+                }
+            }
+        }
+
+        return <DataProviderExpression>{
+            "exp": DP_SEARCH_OP_REGEX,
+            "args": args,
+        };
+    }
+
+    #! Parses a value (field ref, literal, function call, or grouped expression)
+    private auto parseValue() {
+        skipWhitespace();
+        if (atEnd()) {
+            addError("Unexpected end of input, expected value", "DPQL-E001",
+                line, column, line, column);
+            throw "DPQL-PARSE-ERROR", "Expected value";
+        }
+
+        hash<DpqlTokenInfo> tok = peek();
+
+        switch (tok.type) {
+            case DPQL_TOK_FIELD:
+                return parseFieldRef();
+
+            case DPQL_TOK_STRING:
+                return parseStringLiteral();
+
+            case DPQL_TOK_NUMBER:
+                return parseNumberLiteral();
+
+            case DPQL_TOK_BOOLEAN:
+                nextToken();
+                return tok.value.lwr() == "true";
+
+            case DPQL_TOK_NULL:
+                nextToken();
+                return NOTHING;
+
+            case DPQL_TOK_LPAREN:
+                # Could be grouped expression or function call
+                nextToken();  # consume (
+                skipWhitespace();
+                auto exp = parseOrExpr();
+                skipWhitespace();
+                expect(DPQL_TOK_RPAREN, "')'");
+                return exp;
+
+            case DPQL_TOK_IDENTIFIER: {
+                hash<DpqlTokenInfo> id_tok = nextToken();
+                skipWhitespace();
+                # Check for function call
+                if (!atEnd() && peek().type == DPQL_TOK_LPAREN) {
+                    return parseFunctionCall(id_tok.value);
+                }
+                # Check for keywords that can be values
+                string lwr = id_tok.value.lwr();
+                if (lwr == "true") {
+                    return True;
+                }
+                if (lwr == "false") {
+                    return False;
+                }
+                if (lwr == "null") {
+                    return NOTHING;
+                }
+                # Unknown identifier as value
+                addError(sprintf("Unexpected identifier '%s' in value position", id_tok.value),
+                    "DPQL-E001", id_tok);
+                throw "DPQL-PARSE-ERROR", "Unexpected identifier";
+            }
+
+            case DPQL_TOK_ERROR:
+                # Error token from tokenizer - don't add another error, just throw
+                nextToken();  # consume the error token
+                throw "DPQL-PARSE-ERROR", "Tokenizer error";
+
+            default:
+                addError(sprintf("Unexpected token '%s' in value position", tok.value),
+                    "DPQL-E001", tok);
+                throw "DPQL-PARSE-ERROR", "Unexpected token";
+        }
+    }
+
+    #! Parses a field reference
+    private hash<DataProviderFieldReference> parseFieldRef() {
+        hash<DpqlTokenInfo> tok = nextToken();
+        string value = tok.value;
+
+        # Extract field name from @field or @"field"
+        string field_name;
+        if (value.size() > 1) {
+            if (value[1] == '"') {
+                # Quoted field: @"field name"
+                # Remove @" prefix and " suffix
+                field_name = substr(value, 2, value.size() - 3);
+                # Process escape sequences
+                field_name = replace(replace(field_name, "\\\"", "\""), "\\\\", "\\");
+            } else {
+                # Unquoted field: @field
+                field_name = substr(value, 1);
+            }
+        } else {
+            addError("Invalid field reference", "DPQL-E003", tok);
+            throw "DPQL-PARSE-ERROR", "Invalid field reference";
+        }
+
+        return <DataProviderFieldReference>{
+            "field": field_name,
+        };
+    }
+
+    #! Parses a string literal
+    private string parseStringLiteral() {
+        hash<DpqlTokenInfo> tok = nextToken();
+        string value = tok.value;
+
+        # Remove quotes and process escapes
+        string quote = value[0];
+        string content = substr(value, 1, value.size() - 2);
+
+        # Process escape sequences
+        string result = "";
+        int i = 0;
+        while (i < content.size()) {
+            if (content[i] == "\\") {
+                if (i + 1 < content.size()) {
+                    string next = content[i + 1];
+                    switch (next) {
+                        case "n":
+                            result += "\n";
+                            break;
+                        case "r":
+                            result += "\r";
+                            break;
+                        case "t":
+                            result += "\t";
+                            break;
+                        case "\\":
+                            result += "\\";
+                            break;
+                        case "'":
+                            result += "'";
+                            break;
+                        case '"':
+                            result += '"';
+                            break;
+                        default:
+                            result += next;
+                    }
+                    i += 2;
+                } else {
+                    result += "\\";
+                    ++i;
+                }
+            } else {
+                result += content[i];
+                ++i;
+            }
+        }
+
+        return result;
+    }
+
+    #! Parses a numeric literal
+    private auto parseNumberLiteral() {
+        hash<DpqlTokenInfo> tok = nextToken();
+        string value = tok.value;
+
+        # Determine if float or int
+        if (index(value, ".") >= 0 || index(value, "e") >= 0 || index(value, "E") >= 0) {
+            return value.toFloat();
+        }
+        return value.toInt();
+    }
+
+    #! Parses a function call
+    private hash<DataProviderExpression> parseFunctionCall(string name) {
+        expect(DPQL_TOK_LPAREN, "'('");
+        skipWhitespace();
+
+        list<auto> args = ();
+        if (!atEnd() && peek().type != DPQL_TOK_RPAREN) {
+            args = parseArgList();
+        }
+
+        skipWhitespace();
+        expect(DPQL_TOK_RPAREN, "')'");
+
+        return <DataProviderExpression>{
+            "exp": name,
+            "args": args,
+        };
+    }
+
+    #! Parses an argument list
+    private list<auto> parseArgList() {
+        list<auto> args = ();
+
+        # First argument
+        args += parseOrExpr();
+        skipWhitespace();
+
+        # Additional arguments
+        while (!atEnd() && peek().type == DPQL_TOK_COMMA) {
+            nextToken();  # consume comma
+            skipWhitespace();
+            args += parseOrExpr();
+            skipWhitespace();
+        }
+
+        return args;
+    }
+
+    #! Parses a value list (for 'in' operator)
+    private list<auto> parseValueList() {
+        list<auto> values = ();
+
+        # First value
+        values += parseValue();
+        skipWhitespace();
+
+        # Additional values
+        while (!atEnd() && peek().type == DPQL_TOK_COMMA) {
+            nextToken();  # consume comma
+            skipWhitespace();
+            values += parseValue();
+            skipWhitespace();
+        }
+
+        return values;
+    }
+}
+
+} # namespace DataProvider

--- a/qlib/DataProvider/DpqlSerializer.qc
+++ b/qlib/DataProvider/DpqlSerializer.qc
@@ -1,0 +1,368 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! @file DpqlSerializer.qc DPQL serializer implementation
+
+/*  DpqlSerializer.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the DataProvider module
+public namespace DataProvider {
+
+#! Operator precedence levels (lower = binds tighter)
+const DPQL_PREC_PRIMARY = 0;
+const DPQL_PREC_UNARY = 1;
+const DPQL_PREC_COMPARISON = 2;
+const DPQL_PREC_AND = 3;
+const DPQL_PREC_OR = 4;
+
+#! Serializer for DPQL (Data Provider Query Language) expressions
+/** This class converts DataProviderExpression hashes back into human-readable
+    DPQL query strings.
+
+    @par Example:
+    @code{.py}
+DpqlSerializer ser();
+hash<DataProviderExpression> exp = <DataProviderExpression>{
+    "exp": "&&",
+    "args": (
+        <DataProviderExpression>{
+            "exp": "==",
+            "args": (<DataProviderFieldReference>{"field": "name"}, "John"),
+        },
+        <DataProviderExpression>{
+            "exp": ">",
+            "args": (<DataProviderFieldReference>{"field": "age"}, 18),
+        },
+    ),
+};
+string dpql = ser.serialize(exp);
+# Result: @name == "John" && @age > 18
+    @endcode
+*/
+public class DpqlSerializer {
+    private {
+        #! Expression map for rendering
+        *hash<string, hash<DataProviderExpressionInfo>> expressions;
+
+        #! Map of operators to their precedence
+        const OperatorPrecedence = {
+            DP_OP_OR: DPQL_PREC_OR,
+            DP_OP_AND: DPQL_PREC_AND,
+            DP_SEARCH_OP_EQ: DPQL_PREC_COMPARISON,
+            DP_SEARCH_OP_NE: DPQL_PREC_COMPARISON,
+            DP_SEARCH_OP_LT: DPQL_PREC_COMPARISON,
+            DP_SEARCH_OP_LE: DPQL_PREC_COMPARISON,
+            DP_SEARCH_OP_GT: DPQL_PREC_COMPARISON,
+            DP_SEARCH_OP_GE: DPQL_PREC_COMPARISON,
+            DP_SEARCH_OP_BETWEEN: DPQL_PREC_COMPARISON,
+            DP_SEARCH_OP_IN: DPQL_PREC_COMPARISON,
+            DP_SEARCH_OP_REGEX: DPQL_PREC_COMPARISON,
+            DP_SEARCH_OP_NOT: DPQL_PREC_UNARY,
+        };
+
+        #! Map of operators to their DPQL symbols
+        const OperatorSymbols = {
+            DP_OP_OR: "||",
+            DP_OP_AND: "&&",
+            DP_SEARCH_OP_EQ: "==",
+            DP_SEARCH_OP_NE: "!=",
+            DP_SEARCH_OP_LT: "<",
+            DP_SEARCH_OP_LE: "<=",
+            DP_SEARCH_OP_GT: ">",
+            DP_SEARCH_OP_GE: ">=",
+            DP_SEARCH_OP_NOT: "!",
+        };
+    }
+
+    #! Creates a serializer with optional expression map
+    /** @param expressions optional map of expression names to their info
+    */
+    constructor(*hash<string, hash<DataProviderExpressionInfo>> expressions) {
+        self.expressions = expressions;
+    }
+
+    #! Serializes an expression to DPQL string
+    /** @param exp the expression to serialize
+        @return the DPQL string representation
+    */
+    string serialize(hash<DataProviderExpression> exp) {
+        return serializeExpr(exp, DPQL_PREC_OR + 1);
+    }
+
+    #! Serializes an expression with context precedence
+    /** @param exp the expression to serialize
+        @param context_prec the precedence of the surrounding context
+        @return the DPQL string representation
+    */
+    private string serializeExpr(hash<DataProviderExpression> exp, int context_prec) {
+        string op = exp.exp;
+        int prec = OperatorPrecedence{op} ?? DPQL_PREC_PRIMARY;
+        bool need_parens = prec > context_prec;
+
+        string result;
+
+        switch (op) {
+            case DP_OP_OR:
+                result = serializeBinaryOp(exp.args, "||", DPQL_PREC_OR);
+                break;
+
+            case DP_OP_AND:
+                result = serializeBinaryOp(exp.args, "&&", DPQL_PREC_AND);
+                break;
+
+            case DP_SEARCH_OP_EQ:
+            case DP_SEARCH_OP_NE:
+            case DP_SEARCH_OP_LT:
+            case DP_SEARCH_OP_LE:
+            case DP_SEARCH_OP_GT:
+            case DP_SEARCH_OP_GE:
+                result = serializeComparisonOp(exp.args, OperatorSymbols{op});
+                break;
+
+            case DP_SEARCH_OP_NOT:
+                result = serializeNotOp(exp.args);
+                break;
+
+            case DP_SEARCH_OP_BETWEEN:
+                result = serializeBetweenOp(exp.args);
+                break;
+
+            case DP_SEARCH_OP_IN:
+                result = serializeInOp(exp.args);
+                break;
+
+            case DP_SEARCH_OP_REGEX:
+                result = serializeRegexOp(exp.args);
+                break;
+
+            default:
+                # Unknown operator - treat as function call
+                result = serializeFunctionCall(op, exp.args);
+        }
+
+        if (need_parens) {
+            return "(" + result + ")";
+        }
+        return result;
+    }
+
+    #! Serializes a binary operator with multiple arguments (&&, ||)
+    private string serializeBinaryOp(list<auto> args, string symbol, int prec) {
+        list<string> parts = ();
+        foreach auto arg in (args) {
+            parts += serializeArg(arg, prec);
+        }
+        return parts.join(" " + symbol + " ");
+    }
+
+    #! Serializes a comparison operator
+    private string serializeComparisonOp(list<auto> args, string symbol) {
+        if (args.size() < 2) {
+            return "";
+        }
+        return serializeArg(args[0], DPQL_PREC_COMPARISON) + " " + symbol + " " +
+            serializeArg(args[1], DPQL_PREC_COMPARISON);
+    }
+
+    #! Serializes the NOT operator
+    private string serializeNotOp(list<auto> args) {
+        if (!args) {
+            return "!";
+        }
+        # serializeArg already adds parentheses based on precedence
+        return "!" + serializeArg(args[0], DPQL_PREC_UNARY);
+    }
+
+    #! Serializes the BETWEEN operator
+    private string serializeBetweenOp(list<auto> args) {
+        if (args.size() < 3) {
+            return "";
+        }
+        return serializeArg(args[0], DPQL_PREC_COMPARISON) + " between " +
+            serializeArg(args[1], DPQL_PREC_COMPARISON) + " and " +
+            serializeArg(args[2], DPQL_PREC_COMPARISON);
+    }
+
+    #! Serializes the IN operator
+    private string serializeInOp(list<auto> args) {
+        if (!args) {
+            return "";
+        }
+        string field = serializeArg(args[0], DPQL_PREC_COMPARISON);
+        list<string> values = ();
+        for (int i = 1; i < args.size(); ++i) {
+            values += serializeArg(args[i], DPQL_PREC_PRIMARY);
+        }
+        return field + " in (" + values.join(", ") + ")";
+    }
+
+    #! Serializes the REGEX operator
+    private string serializeRegexOp(list<auto> args) {
+        if (args.size() < 2) {
+            return "";
+        }
+        string field = serializeArg(args[0], DPQL_PREC_COMPARISON);
+        string pattern = args[1].type() == "string" ? args[1] : string(args[1]);
+
+        # Escape forward slashes in pattern
+        pattern = replace(pattern, "/", "\\/");
+
+        # Build flags from remaining args
+        string flags = "";
+        for (int i = 2; i < args.size(); ++i) {
+            if (args[i].typeCode() == NT_INT) {
+                switch (args[i]) {
+                    case RE_Caseless:
+                        flags += "i";
+                        break;
+                    case RE_DotAll:
+                        flags += "s";
+                        break;
+                    case RE_MultiLine:
+                        flags += "m";
+                        break;
+                    case RE_Extended:
+                        flags += "x";
+                        break;
+                    case RE_Unicode:
+                        flags += "u";
+                        break;
+                }
+            }
+        }
+
+        return field + " =~ /" + pattern + "/" + flags;
+    }
+
+    #! Serializes a function call
+    private string serializeFunctionCall(string name, list<auto> args) {
+        list<string> arg_strs = ();
+        foreach auto arg in (args) {
+            arg_strs += serializeArg(arg, DPQL_PREC_OR + 1);
+        }
+        return name + "(" + arg_strs.join(", ") + ")";
+    }
+
+    #! Serializes an argument (value, field ref, or expression)
+    private string serializeArg(auto arg, int context_prec) {
+        if (arg === NOTHING) {
+            return "null";
+        }
+
+        switch (arg.typeCode()) {
+            case NT_HASH:
+                if (arg.hasKey("field")) {
+                    return serializeFieldRef(arg);
+                }
+                if (arg.hasKey("exp")) {
+                    return serializeExpr(arg, context_prec);
+                }
+                # Unknown hash - serialize as JSON-like
+                return serializeLiteral(arg);
+
+            case NT_LIST:
+                # List literal
+                list<string> items = ();
+                foreach auto item in (arg) {
+                    items += serializeArg(item, DPQL_PREC_PRIMARY);
+                }
+                return "(" + items.join(", ") + ")";
+
+            default:
+                return serializeLiteral(arg);
+        }
+    }
+
+    #! Serializes a field reference
+    private string serializeFieldRef(hash<auto> ref) {
+        string field = ref.field;
+
+        # Check if field name needs quoting
+        if (field =~ /[^a-zA-Z0-9_.]/ || field =~ /^[0-9]/) {
+            # Escape special characters
+            field = replace(replace(field, "\\", "\\\\"), '"', '\\"');
+            return '@"' + field + '"';
+        }
+
+        return "@" + field;
+    }
+
+    #! Serializes a literal value
+    private string serializeLiteral(auto value) {
+        if (value === NOTHING) {
+            return "null";
+        }
+
+        switch (value.typeCode()) {
+            case NT_STRING:
+                return serializeString(value);
+
+            case NT_INT:
+            case NT_FLOAT:
+            case NT_NUMBER:
+                return string(value);
+
+            case NT_BOOLEAN:
+                return value ? "true" : "false";
+
+            case NT_DATE:
+                # Serialize dates as ISO strings
+                return serializeString(value.format("YYYY-MM-DDTHH:mm:SS.xxZ"));
+
+            case NT_BINARY:
+                # Serialize binary as base64 string
+                return serializeString(value.toBase64());
+
+            default:
+                # For other types, try to convert to string
+                return serializeString(string(value));
+        }
+    }
+
+    #! Serializes a string with proper escaping
+    private string serializeString(string value) {
+        string result = '"';
+        for (int i = 0; i < value.size(); ++i) {
+            string c = value[i];
+            switch (c) {
+                case '"':
+                    result += '\\"';
+                    break;
+                case "\\":
+                    result += "\\\\";
+                    break;
+                case "\n":
+                    result += "\\n";
+                    break;
+                case "\r":
+                    result += "\\r";
+                    break;
+                case "\t":
+                    result += "\\t";
+                    break;
+                default:
+                    result += c;
+            }
+        }
+        return result + '"';
+    }
+}
+
+} # namespace DataProvider

--- a/qlib/DataProvider/DpqlTokenizer.qc
+++ b/qlib/DataProvider/DpqlTokenizer.qc
@@ -1,0 +1,690 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! @file DpqlTokenizer.qc DPQL tokenizer implementation
+
+/*  DpqlTokenizer.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the DataProvider module
+public namespace DataProvider {
+
+/** @defgroup dpql_token_types DPQL Token Type Constants
+    These constants define the different token types recognized by @ref DpqlTokenizer
+*/
+#!@{
+
+#! Field reference (@field or @"quoted field")
+public const DPQL_TOK_FIELD = 1;
+#! String literal ("string" or 'string')
+public const DPQL_TOK_STRING = 2;
+#! Numeric literal (123, 45.67, -123)
+public const DPQL_TOK_NUMBER = 3;
+#! Boolean literal (true, false)
+public const DPQL_TOK_BOOLEAN = 4;
+#! Null literal
+public const DPQL_TOK_NULL = 5;
+#! Identifier (function names, keywords like between, and, in)
+public const DPQL_TOK_IDENTIFIER = 6;
+#! Equals operator (==)
+public const DPQL_TOK_OP_EQ = 10;
+#! Not equals operator (!=)
+public const DPQL_TOK_OP_NE = 11;
+#! Less than operator (<)
+public const DPQL_TOK_OP_LT = 12;
+#! Less than or equals operator (<=)
+public const DPQL_TOK_OP_LE = 13;
+#! Greater than operator (>)
+public const DPQL_TOK_OP_GT = 14;
+#! Greater than or equals operator (>=)
+public const DPQL_TOK_OP_GE = 15;
+#! Logical AND operator (&&)
+public const DPQL_TOK_OP_AND = 16;
+#! Logical OR operator (||)
+public const DPQL_TOK_OP_OR = 17;
+#! Logical NOT operator (!)
+public const DPQL_TOK_OP_NOT = 18;
+#! Regex match operator (=~)
+public const DPQL_TOK_OP_REGEX = 19;
+#! Regex pattern (/pattern/flags)
+public const DPQL_TOK_REGEX = 20;
+#! Left parenthesis
+public const DPQL_TOK_LPAREN = 30;
+#! Right parenthesis
+public const DPQL_TOK_RPAREN = 31;
+#! Comma
+public const DPQL_TOK_COMMA = 32;
+#! Whitespace (spaces, tabs)
+public const DPQL_TOK_WHITESPACE = 40;
+#! Newline character
+public const DPQL_TOK_NEWLINE = 41;
+#! End of input
+public const DPQL_TOK_EOF = 50;
+#! Error token (invalid input)
+public const DPQL_TOK_ERROR = 99;
+
+#!@}
+
+#! Maps token type codes to human-readable names
+public const DpqlTokenTypeNames = {
+    DPQL_TOK_FIELD: "field",
+    DPQL_TOK_STRING: "string",
+    DPQL_TOK_NUMBER: "number",
+    DPQL_TOK_BOOLEAN: "boolean",
+    DPQL_TOK_NULL: "null",
+    DPQL_TOK_IDENTIFIER: "identifier",
+    DPQL_TOK_OP_EQ: "==",
+    DPQL_TOK_OP_NE: "!=",
+    DPQL_TOK_OP_LT: "<",
+    DPQL_TOK_OP_LE: "<=",
+    DPQL_TOK_OP_GT: ">",
+    DPQL_TOK_OP_GE: ">=",
+    DPQL_TOK_OP_AND: "&&",
+    DPQL_TOK_OP_OR: "||",
+    DPQL_TOK_OP_NOT: "!",
+    DPQL_TOK_OP_REGEX: "=~",
+    DPQL_TOK_REGEX: "regex",
+    DPQL_TOK_LPAREN: "(",
+    DPQL_TOK_RPAREN: ")",
+    DPQL_TOK_COMMA: ",",
+    DPQL_TOK_WHITESPACE: "whitespace",
+    DPQL_TOK_NEWLINE: "newline",
+    DPQL_TOK_EOF: "eof",
+    DPQL_TOK_ERROR: "error",
+};
+
+#! DPQL Token information structure
+/** This structure contains information about a single token including its type,
+    value, and position in the source text.
+*/
+public hashdecl DpqlTokenInfo {
+    #! Token type (one of the DPQL_TOK_* constants)
+    int type;
+    #! The actual text of the token
+    string value;
+    #! Line number where the token starts (1-based)
+    int line;
+    #! Column number where the token starts (1-based)
+    int column;
+    #! Line number where the token ends (1-based)
+    int end_line;
+    #! Column number where the token ends (1-based)
+    int end_column;
+}
+
+#! DPQL Diagnostic message structure
+/** Contains information about errors, warnings, or informational messages
+    generated during tokenization or parsing.
+*/
+public hashdecl DpqlDiagnostic {
+    #! Severity: "error", "warning", or "info"
+    string severity;
+    #! Human-readable message
+    string message;
+    #! Error code for categorization (e.g., "DPQL-E001")
+    string code;
+    #! Start line number (1-based)
+    int line;
+    #! Start column number (1-based)
+    int column;
+    #! End line number (1-based)
+    int end_line;
+    #! End column number (1-based)
+    int end_column;
+}
+
+#! Tokenizer for DPQL (Data Provider Query Language) expressions
+/** This class provides lexical analysis of DPQL query expressions, correctly handling:
+    - Field references (@field or @"field with spaces")
+    - String literals (single and double quoted)
+    - Numeric literals (integers, decimals, negative numbers)
+    - Boolean and null literals
+    - Comparison operators (==, !=, <, <=, >, >=)
+    - Logical operators (&&, ||, !)
+    - Regex match operator (=~) and patterns
+    - Keywords (between, and, in, true, false, null)
+
+    @par Example:
+    @code{.py}
+DpqlTokenizer tok('@name == "John" && @age > 18');
+while (!tok.atEnd()) {
+    hash<DpqlTokenInfo> t = tok.next();
+    printf("Token: type=%s value=%y line=%d col=%d\n",
+        DpqlTokenTypeNames{t.type}, t.value, t.line, t.column);
+}
+    @endcode
+*/
+public class DpqlTokenizer {
+    private {
+        #! Input text
+        string input;
+        #! Current position (character index)
+        int pos = 0;
+        #! Current line number (1-based)
+        int line = 1;
+        #! Current column number (1-based)
+        int column = 1;
+        #! Input length in characters
+        int len;
+        #! Cached next token for peek()
+        *hash<DpqlTokenInfo> peeked;
+        #! Collected errors during tokenization
+        list<hash<DpqlDiagnostic>> errors = ();
+    }
+
+    #! Creates a tokenizer for the given DPQL expression
+    /** @param text the DPQL expression to tokenize
+    */
+    constructor(string text) {
+        input = text;
+        len = text.length();
+    }
+
+    #! Returns True if at end of input
+    bool atEnd() {
+        return !peeked && pos >= len;
+    }
+
+    #! Returns the next token without consuming it
+    /** @return the next token, or a DPQL_TOK_EOF token if at end of input
+    */
+    hash<DpqlTokenInfo> peek() {
+        if (!peeked) {
+            peeked = scanToken();
+        }
+        return peeked;
+    }
+
+    #! Returns the next token and advances the position
+    /** @return the next token, or a DPQL_TOK_EOF token if at end of input
+    */
+    hash<DpqlTokenInfo> next() {
+        if (peeked) {
+            hash<DpqlTokenInfo> result = peeked;
+            delete peeked;
+            return result;
+        }
+        return scanToken();
+    }
+
+    #! Returns all tokens as a list (for syntax highlighting)
+    /** @return a list of all tokens in the input
+    */
+    list<hash<DpqlTokenInfo>> getAllTokens() {
+        list<hash<DpqlTokenInfo>> tokens = ();
+        while (!atEnd()) {
+            tokens += next();
+        }
+        return tokens;
+    }
+
+    #! Returns collected tokenization errors
+    /** @return a list of diagnostic messages for any errors encountered
+    */
+    list<hash<DpqlDiagnostic>> getErrors() {
+        return errors;
+    }
+
+    #! Returns the current line number
+    int getLine() {
+        return line;
+    }
+
+    #! Returns the current column number
+    int getColumn() {
+        return column;
+    }
+
+    #! Returns the character at the current position, or NOTHING if at end
+    private:internal *string currentChar() {
+        if (pos >= len) {
+            return NOTHING;
+        }
+        return input[pos];
+    }
+
+    #! Returns the character at offset from current position, or NOTHING if out of bounds
+    private:internal *string peekChar(int offset = 1) {
+        int p = pos + offset;
+        if (p >= len || p < 0) {
+            return NOTHING;
+        }
+        return input[p];
+    }
+
+    #! Advances position by count characters, updating line/column
+    private:internal advance(int count = 1) {
+        for (int i = 0; i < count && pos < len; ++i) {
+            if (input[pos] == "\n") {
+                ++line;
+                column = 1;
+            } else {
+                ++column;
+            }
+            ++pos;
+        }
+    }
+
+    #! Creates a token with the given type and value
+    private:internal hash<DpqlTokenInfo> makeToken(int type, string value, int start_line, int start_column) {
+        return <DpqlTokenInfo>{
+            "type": type,
+            "value": value,
+            "line": start_line,
+            "column": start_column,
+            "end_line": line,
+            "end_column": column,
+        };
+    }
+
+    #! Adds an error diagnostic
+    private:internal addError(string message, string code, int start_line, int start_column,
+            int end_line, int end_column) {
+        errors += <DpqlDiagnostic>{
+            "severity": "error",
+            "message": message,
+            "code": code,
+            "line": start_line,
+            "column": start_column,
+            "end_line": end_line,
+            "end_column": end_column,
+        };
+    }
+
+    #! Scans and returns the next token
+    private:internal hash<DpqlTokenInfo> scanToken() {
+        if (pos >= len) {
+            return makeToken(DPQL_TOK_EOF, "", line, column);
+        }
+
+        int start_line = line;
+        int start_column = column;
+        *string c = currentChar();
+
+        # Newline
+        if (c == "\n") {
+            advance();
+            return makeToken(DPQL_TOK_NEWLINE, "\n", start_line, start_column);
+        }
+
+        # Whitespace (not newline)
+        if (c == " " || c == "\t" || c == "\r") {
+            string ws = "";
+            while (pos < len) {
+                c = currentChar();
+                if (c != " " && c != "\t" && c != "\r") {
+                    break;
+                }
+                ws += c;
+                advance();
+            }
+            return makeToken(DPQL_TOK_WHITESPACE, ws, start_line, start_column);
+        }
+
+        # Field reference
+        if (c == "@") {
+            return scanFieldRef();
+        }
+
+        # Single-quoted string
+        if (c == "'") {
+            return scanString("'");
+        }
+
+        # Double-quoted string
+        if (c == '"') {
+            return scanString('"');
+        }
+
+        # Regex pattern (after =~ operator context, or standalone)
+        if (c == "/") {
+            return scanRegex();
+        }
+
+        # Number (including negative)
+        if (c =~ /[0-9]/ || (c == "-" && peekChar() =~ /[0-9]/)) {
+            return scanNumber();
+        }
+
+        # Operators
+        if (c == "=") {
+            if (peekChar() == "=") {
+                advance(2);
+                return makeToken(DPQL_TOK_OP_EQ, "==", start_line, start_column);
+            }
+            if (peekChar() == "~") {
+                advance(2);
+                return makeToken(DPQL_TOK_OP_REGEX, "=~", start_line, start_column);
+            }
+            # Single = is not valid in DPQL
+            advance();
+            addError("Invalid operator '=', did you mean '=='?", "DPQL-E004",
+                start_line, start_column, line, column);
+            return makeToken(DPQL_TOK_ERROR, "=", start_line, start_column);
+        }
+
+        if (c == "!") {
+            if (peekChar() == "=") {
+                advance(2);
+                return makeToken(DPQL_TOK_OP_NE, "!=", start_line, start_column);
+            }
+            # Single ! is logical NOT
+            advance();
+            return makeToken(DPQL_TOK_OP_NOT, "!", start_line, start_column);
+        }
+
+        if (c == "<") {
+            if (peekChar() == "=") {
+                advance(2);
+                return makeToken(DPQL_TOK_OP_LE, "<=", start_line, start_column);
+            }
+            advance();
+            return makeToken(DPQL_TOK_OP_LT, "<", start_line, start_column);
+        }
+
+        if (c == ">") {
+            if (peekChar() == "=") {
+                advance(2);
+                return makeToken(DPQL_TOK_OP_GE, ">=", start_line, start_column);
+            }
+            advance();
+            return makeToken(DPQL_TOK_OP_GT, ">", start_line, start_column);
+        }
+
+        if (c == "&") {
+            if (peekChar() == "&") {
+                advance(2);
+                return makeToken(DPQL_TOK_OP_AND, "&&", start_line, start_column);
+            }
+            # Single & is invalid
+            advance();
+            addError("Invalid operator '&', did you mean '&&'?", "DPQL-E004",
+                start_line, start_column, line, column);
+            return makeToken(DPQL_TOK_ERROR, "&", start_line, start_column);
+        }
+
+        if (c == "|") {
+            if (peekChar() == "|") {
+                advance(2);
+                return makeToken(DPQL_TOK_OP_OR, "||", start_line, start_column);
+            }
+            # Single | is invalid
+            advance();
+            addError("Invalid operator '|', did you mean '||'?", "DPQL-E004",
+                start_line, start_column, line, column);
+            return makeToken(DPQL_TOK_ERROR, "|", start_line, start_column);
+        }
+
+        # Punctuation
+        if (c == "(") {
+            advance();
+            return makeToken(DPQL_TOK_LPAREN, "(", start_line, start_column);
+        }
+
+        if (c == ")") {
+            advance();
+            return makeToken(DPQL_TOK_RPAREN, ")", start_line, start_column);
+        }
+
+        if (c == ",") {
+            advance();
+            return makeToken(DPQL_TOK_COMMA, ",", start_line, start_column);
+        }
+
+        # Identifier (function names, keywords)
+        if (c =~ /[a-zA-Z_]/) {
+            return scanIdentifier();
+        }
+
+        # Unknown character
+        advance();
+        addError(sprintf("Unexpected character '%s'", c), "DPQL-E001",
+            start_line, start_column, line, column);
+        return makeToken(DPQL_TOK_ERROR, c, start_line, start_column);
+    }
+
+    #! Scans a field reference (@field or @"quoted")
+    private:internal hash<DpqlTokenInfo> scanFieldRef() {
+        int start_line = line;
+        int start_column = column;
+        string value = "@";
+        advance();  # skip @
+
+        if (pos >= len) {
+            addError("Incomplete field reference", "DPQL-E003",
+                start_line, start_column, line, column);
+            return makeToken(DPQL_TOK_ERROR, value, start_line, start_column);
+        }
+
+        *string c = currentChar();
+
+        # Quoted field name
+        if (c == '"') {
+            value += '"';
+            advance();
+            while (pos < len) {
+                c = currentChar();
+                if (c == '"') {
+                    value += c;
+                    advance();
+                    return makeToken(DPQL_TOK_FIELD, value, start_line, start_column);
+                }
+                if (c == "\\") {
+                    value += c;
+                    advance();
+                    if (pos < len) {
+                        value += currentChar();
+                        advance();
+                    }
+                } else if (c == "\n") {
+                    # Newline in field name is invalid
+                    addError("Unterminated quoted field reference", "DPQL-E003",
+                        start_line, start_column, line, column);
+                    return makeToken(DPQL_TOK_ERROR, value, start_line, start_column);
+                } else {
+                    value += c;
+                    advance();
+                }
+            }
+            # Reached end without closing quote
+            addError("Unterminated quoted field reference", "DPQL-E003",
+                start_line, start_column, line, column);
+            return makeToken(DPQL_TOK_ERROR, value, start_line, start_column);
+        }
+
+        # Unquoted field name (identifier)
+        if (c =~ /[a-zA-Z_]/) {
+            while (pos < len) {
+                c = currentChar();
+                if (c !~ /[a-zA-Z0-9_.]/) {
+                    break;
+                }
+                value += c;
+                advance();
+            }
+            return makeToken(DPQL_TOK_FIELD, value, start_line, start_column);
+        }
+
+        # Invalid field reference
+        addError(sprintf("Invalid field reference: expected identifier or quoted string after '@', got '%s'", c),
+            "DPQL-E003", start_line, start_column, line, column);
+        return makeToken(DPQL_TOK_ERROR, value, start_line, start_column);
+    }
+
+    #! Scans a string literal
+    private:internal hash<DpqlTokenInfo> scanString(string quote) {
+        int start_line = line;
+        int start_column = column;
+        string value = quote;
+        advance();  # skip opening quote
+
+        while (pos < len) {
+            *string c = currentChar();
+            if (c == quote) {
+                value += c;
+                advance();
+                return makeToken(DPQL_TOK_STRING, value, start_line, start_column);
+            }
+            if (c == "\\") {
+                value += c;
+                advance();
+                if (pos < len) {
+                    value += currentChar();
+                    advance();
+                }
+            } else if (c == "\n") {
+                # Allow multi-line strings
+                value += c;
+                advance();
+            } else {
+                value += c;
+                advance();
+            }
+        }
+
+        # Reached end without closing quote
+        addError("Unterminated string literal", "DPQL-E002",
+            start_line, start_column, line, column);
+        return makeToken(DPQL_TOK_ERROR, value, start_line, start_column);
+    }
+
+    #! Scans a numeric literal
+    private:internal hash<DpqlTokenInfo> scanNumber() {
+        int start_line = line;
+        int start_column = column;
+        string value = "";
+
+        # Handle negative sign
+        if (currentChar() == "-") {
+            value += "-";
+            advance();
+        }
+
+        # Integer part
+        while (pos < len && currentChar() =~ /[0-9]/) {
+            value += currentChar();
+            advance();
+        }
+
+        # Decimal part
+        if (pos < len && currentChar() == "." && peekChar() =~ /[0-9]/) {
+            value += ".";
+            advance();
+            while (pos < len && currentChar() =~ /[0-9]/) {
+                value += currentChar();
+                advance();
+            }
+        }
+
+        # Exponent part (optional)
+        if (pos < len && currentChar() =~ /[eE]/) {
+            string exp = currentChar();
+            advance();
+            if (pos < len && currentChar() =~ /[+\-]/) {
+                exp += currentChar();
+                advance();
+            }
+            if (pos < len && currentChar() =~ /[0-9]/) {
+                value += exp;
+                while (pos < len && currentChar() =~ /[0-9]/) {
+                    value += currentChar();
+                    advance();
+                }
+            } else {
+                # Invalid exponent - revert
+                addError("Invalid numeric literal: incomplete exponent", "DPQL-E001",
+                    start_line, start_column, line, column);
+            }
+        }
+
+        return makeToken(DPQL_TOK_NUMBER, value, start_line, start_column);
+    }
+
+    #! Scans an identifier (keyword or function name)
+    private:internal hash<DpqlTokenInfo> scanIdentifier() {
+        int start_line = line;
+        int start_column = column;
+        string value = "";
+
+        while (pos < len && currentChar() =~ /[a-zA-Z0-9_]/) {
+            value += currentChar();
+            advance();
+        }
+
+        # Check for keywords
+        switch (value.lwr()) {
+            case "true":
+            case "false":
+                return makeToken(DPQL_TOK_BOOLEAN, value, start_line, start_column);
+
+            case "null":
+                return makeToken(DPQL_TOK_NULL, value, start_line, start_column);
+
+            default:
+                # Regular identifier (between, and, in, or function name)
+                return makeToken(DPQL_TOK_IDENTIFIER, value, start_line, start_column);
+        }
+    }
+
+    #! Scans a regex pattern (/pattern/flags)
+    private:internal hash<DpqlTokenInfo> scanRegex() {
+        int start_line = line;
+        int start_column = column;
+        string value = "/";
+        advance();  # skip opening /
+
+        # Scan pattern
+        while (pos < len) {
+            *string c = currentChar();
+            if (c == "/") {
+                value += c;
+                advance();
+                # Scan optional flags
+                while (pos < len && currentChar() =~ /[gimsxu]/) {
+                    value += currentChar();
+                    advance();
+                }
+                return makeToken(DPQL_TOK_REGEX, value, start_line, start_column);
+            }
+            if (c == "\\") {
+                value += c;
+                advance();
+                if (pos < len) {
+                    value += currentChar();
+                    advance();
+                }
+            } else if (c == "\n") {
+                # Newline in regex is invalid
+                addError("Unterminated regex pattern", "DPQL-E009",
+                    start_line, start_column, line, column);
+                return makeToken(DPQL_TOK_ERROR, value, start_line, start_column);
+            } else {
+                value += c;
+                advance();
+            }
+        }
+
+        # Reached end without closing /
+        addError("Unterminated regex pattern", "DPQL-E009",
+            start_line, start_column, line, column);
+        return makeToken(DPQL_TOK_ERROR, value, start_line, start_column);
+    }
+}
+
+} # namespace DataProvider


### PR DESCRIPTION
## Summary

DPQL is a human/AI-readable query language for DataProvider expressions that converts text like `@name == "John" && @age > 18` into `hash<DataProviderExpression>` structures and vice versa.

## New Classes

- **DpqlTokenizer**: Lexical analysis with token types for syntax highlighting
- **DpqlParser**: Parse DPQL strings to DataProviderExpression with diagnostics
- **DpqlSerializer**: Convert expressions back to DPQL strings
- **DpqlCompletionProvider**: Context-aware autocomplete for IDE integration

## Static API Methods

- `DataProvider::parseDpqlExpression()`
- `DataProvider::parseDpqlExpressionWithInfo()`
- `DataProvider::serializeDpqlExpression()`
- `DataProvider::getDpqlTokens()`
- `DataProvider::getDpqlCompletions()`
- `DataProvider::validateDpqlExpression()`

## DPQL Syntax Examples

```
@name == "John"
@age > 18 && @status == "active"
@role in ("admin", "editor")
@age between 18 and 65
@email =~ /pattern/i
!(@deleted)
```

## Also Includes

- Added missing factory registrations (tar, zip, webdavclient, mcpclient)
- Updated release notes and module documentation

## Test plan

- [x] All 11 DPQL test cases pass (183 assertions)
- [x] All 9 DataProvider test cases pass (775 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)