### PR TITLE
fix: race condition in max-threads-count.qtest

### DIFF
--- a/examples/test/qore/threads/max-threads-count.qtest
+++ b/examples/test/qore/threads/max-threads-count.qtest
@@ -48,6 +48,9 @@ public class MaxThreadCountTest inherits QUnit::Test {
             while (True) {
                 c0.inc();
                 on_error {
+                    # Capture thread count BEFORE signaling threads to exit
+                    # This fixes race condition where threads exit before we can count them
+                    limit = num_threads();
                     c.dec();
                     c0.dec();
                 }
@@ -55,7 +58,6 @@ public class MaxThreadCountTest inherits QUnit::Test {
             }
         } catch (hash<ExceptionInfo> ex) {
             assertEq("THREAD-CREATION-FAILURE", ex.err, "found thread count limit");
-            limit = num_threads();
             # Log diagnostic info when thread limit is suspiciously low
             if (limit < 100) {
                 printf("WARNING: low thread limit detected: %d\n", limit);


### PR DESCRIPTION
## Summary

Fixes the race condition in `max-threads-count.qtest` that causes sporadic CI failures.

Fixes #5123

## Root Cause

The test was capturing `num_threads()` AFTER calling `c.dec()` which signals all waiting threads to exit. By the time `num_threads()` was called, threads may have already exited, causing the test to report a very low thread count (like 1) even though thousands of threads were created.

## Fix

Moved the `num_threads()` call into the `on_error` block BEFORE `c.dec()` is called, so we capture the thread count while threads are still blocked waiting.

## Test plan

- [x] Test passes consistently (verified with 5 consecutive runs)
- [x] No memory leaks introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)