### PR TITLE
feat: add %modern parse directive and .qr file extension support

### DIFF
--- a/doxygen/lang/245_parse_directives.dox.tmpl
+++ b/doxygen/lang/245_parse_directives.dox.tmpl
@@ -6,11 +6,12 @@
 
     Parse directives that set parsing options can be used any time parse options have not been locked on a @ref Qore::Program "Program object". They are used most often when it's not possible or desirable to set the parse options in the qore command line.
 
-    The following are the recommended parse directives for %Qore programming (note that %Qore is moving toward establishing @ref new-style "%new-style" as the default syntax; all examples given in the %Qore documentation are given assuming @ref new-style "%new-style"):
-    - @ref new-style "%new-style"
-    - @ref strict-args "%strict-args"
-    - @ref require-types "%require-types"
-    - @ref enable-all-warnings "%enable-all-warnings"
+    The recommended parse directive for %Qore programming is @ref modern "%modern", which combines all the recommended parse options into a single directive:
+    - @ref modern "%modern" - sets @ref new-style "%new-style", @ref strict-args "%strict-args", @ref require-types "%require-types", and enables all warnings
+
+    Alternatively, files with the \c .qr extension automatically enable @ref modern "%modern" mode without any parse directive.
+
+    @note The individual parse directives (@ref new-style "%new-style", @ref strict-args "%strict-args", @ref require-types "%require-types", @ref enable-all-warnings "%enable-all-warnings") are still supported for backward compatibility and fine-grained control.
 
     <b>Parse Directives</b>
     |!Directive|!Description
@@ -67,6 +68,7 @@
     |@ref lock-options "%lock-options"|Prohibits further changes to parse options (equivalent to the <tt>-</tt><tt>-lock-options</tt> command line option)
     |@ref lock-warnings "%lock-warnings"|Prohibits further changes to the warning mask (equivalent to the <tt>-</tt><tt>-lock-warnings</tt> command line option)
     |@ref loose-args "%loose-args"|reverts the effect of the @ref strict-args "%strict-args" parse options
+    |@ref modern "%modern"|Sets @ref new-style "%new-style", @ref require-types "%require-types", @ref strict-args "%strict-args", and enables all warnings. This is the recommended parse directive for modern %Qore programming. Files with the \c .qr extension automatically enable this mode.<br><br>Since %Qore 2.3
     |@ref loose-types "%loose-types"|reverts the effect of the @ref strict-types "%strict-types" parse options
     |@ref new-style "%new-style"|Sets both @ref allow-bare-refs "%allow-bare-refs" and @ref assume-local "%assume-local". These two options together make programming in %Qore superficially more like programming in C++ or Java programs; use this if you dislike programming with the \c "$" sign, for example; see also @ref old-style "%old-style" <br><br>Since %Qore 0.8.1
     |@ref old-style "%old-style"|Resets default %Qore parsing behavior by setting @ref require-dollar "%require-dollar" and @ref assume-global "%assume-global"; this option is the opposite of @ref new-style "%new-style" <br><br>Since %Qore 0.8.4
@@ -1236,6 +1238,41 @@ sub validate_input(int value, int max_value) {
     @since %Qore 0.9.4
 
     <hr>
+    @section modern %modern
+
+    @par Parse Directive:
+    <tt>%%modern</tt>
+
+    @par Command Line:
+    <tt>-</tt><tt>-set-parse-option=modern</tt>
+
+    @par Parse Option Constant:
+    @ref Qore::PO_MODERN
+
+    @par Description:
+    Sets @ref new-style "%new-style" (@ref allow-bare-refs "%allow-bare-refs" and @ref assume-local "%assume-local"), @ref require-types "%require-types", @ref strict-args "%strict-args", and enables all warnings.
+
+    This is the recommended parse directive for modern %Qore programming. It combines all the best practices into a single directive.
+
+    @par File Extension:
+    Files with the \c .qr extension automatically enable \c %%modern mode without requiring any parse directive. This allows for cleaner code:
+
+    @code{.qore}
+    # hello.qr - no parse directives needed!
+    string sub greet(string name) {
+        return "Hello, " + name + "!";
+    }
+    printf("%s\n", greet("World"));
+    @endcode
+
+    @note
+    - All examples in the %Qore documentation assume @ref modern "%modern" mode.
+    - When using this option, the lack of \c "$" characters in variable names makes it necessary to declare local variables before using them.
+    - All declarations require type information.
+
+    @since %Qore 2.3
+
+    <hr>
     @section new-style %new-style
 
     @par Parse Directive:
@@ -1250,10 +1287,10 @@ sub validate_input(int value, int max_value) {
     @par Description:
     Sets both @ref allow-bare-refs "%allow-bare-refs" and @ref assume-local "%assume-local". These two options together make programming in %Qore superficially more like programming in C++ or Java programs; use this if you dislike programming with the \c "$" sign, for example.
 
-    @see @ref old-style "%old-style"
+    @see @ref old-style "%old-style", @ref modern "%modern"
 
     @note
-    - %Qore is moving toward establishing @ref new-style "%new-style" as the default syntax; all examples given in the %Qore documentation are given assuming @ref new-style "%new-style".
+    - For new code, consider using @ref modern "%modern" instead, which includes @ref new-style "%new-style" plus additional recommended options.
     - when using this option (or @ref allow-bare-refs "%allow-bare-refs) the lack of \c "$" characters in variable names makes it necessary to declare local variables before using them
 
     @since %Qore 0.8.1

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -91,6 +91,14 @@ code<int(string)> func = int sub(int x) { return x; };  # PARSE-TYPE-ERROR: para
     @endparblock
 
     @subsection qore_2_3_0_new_features New Features in Qore
+    - <b>New @ref modern "%%modern" parse directive and \c .qr file extension</b>
+      - new @ref modern "%%modern" parse directive combines all recommended parse options into one:
+        @ref new-style "%%new-style", @ref require-types "%%require-types", @ref strict-args "%%strict-args",
+        and enables all warnings
+      - files with the \c .qr extension automatically enable @ref modern "%%modern" mode without any
+        parse directive required
+      - new @ref Qore::PO_MODERN "PO_MODERN" parse option constant
+      - this is now the recommended way to write new %Qore code
     - <b>NaN-boxing optimization for internal value representation</b>
       (<a href="https://github.com/qoretechnologies/qore/issues/5084">issue 5084</a>)
       - reduces memory usage per value from 16 bytes to 8 bytes (50% reduction in value storage overhead)

--- a/examples/email.q
+++ b/examples/email.q
@@ -28,10 +28,7 @@
     * 1.0: simple example program using the SmtpClient user module to send emails from the command line
 */
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %exec-class mail
 

--- a/examples/getopt.q
+++ b/examples/getopt.q
@@ -24,10 +24,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 sub usage() {
     printf(

--- a/examples/httpserver.q
+++ b/examples/httpserver.q
@@ -33,10 +33,7 @@
     SIGINT which is handled like other signals)
 */
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 # execute the httpServer class as the application object
 %exec-class httpServer

--- a/examples/pop3.q
+++ b/examples/pop3.q
@@ -27,10 +27,7 @@
     * 2012-06-23 v1.0: simple example program using the Pop3Client user module to retrieve emails from the command line from a POP3 server
 */
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %exec-class pop3
 

--- a/examples/restserver.q
+++ b/examples/restserver.q
@@ -73,10 +73,7 @@
     {'name': 'subdir', 'mode': 0755}
 */
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 # execute the restServer class as the application object
 %exec-class restServer

--- a/examples/telnet.q
+++ b/examples/telnet.q
@@ -34,10 +34,7 @@
     Qore's signal handling thread; window resizing does not work on Darwin.
 */
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 # execute the telnet class as the application object
 %exec-class telnet

--- a/examples/test/TestTemplate.qtest
+++ b/examples/test/TestTemplate.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../qlib/QUnit.qm
 

--- a/examples/test/TestTemplateInjected.qtest
+++ b/examples/test/TestTemplateInjected.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../qlib/QUnit.qm
 

--- a/examples/test/obsolete/optest.q
+++ b/examples/test/obsolete/optest.q
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires qore >= 0.7.2

--- a/examples/test/qlib/AsyncApi/AsyncApi.qtest
+++ b/examples/test/qlib/AsyncApi/AsyncApi.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 # try importing JSON and YAML modules
 %try-module json

--- a/examples/test/qlib/AsyncApi/AsyncApiDataProvider.qtest
+++ b/examples/test/qlib/AsyncApi/AsyncApiDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 # try importing JSON and YAML modules
 %try-module json

--- a/examples/test/qlib/AsyncApi/AsyncApiGenerator.qtest
+++ b/examples/test/qlib/AsyncApi/AsyncApiGenerator.qtest
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/AsyncSocketIo/AsyncSocketIo.qtest
+++ b/examples/test/qlib/AsyncSocketIo/AsyncSocketIo.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/AwsRestClient/AwsRestClient.qtest
+++ b/examples/test/qlib/AwsRestClient/AwsRestClient.qtest
@@ -13,10 +13,7 @@
 
 %requires qore >= 0.9.3
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %exec-class AwsTest
 

--- a/examples/test/qlib/AwsRestClientDataProvider/AwsRestClientDataProvider.qtest
+++ b/examples/test/qlib/AwsRestClientDataProvider/AwsRestClientDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/BillwerkRestClient/BillwerkRestClient.qtest
+++ b/examples/test/qlib/BillwerkRestClient/BillwerkRestClient.qtest
@@ -17,10 +17,7 @@
 
 %requires qore >= 0.9.4
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %disable-warning deprecated
 

--- a/examples/test/qlib/CdsRestClient/CdsRestClient.qtest
+++ b/examples/test/qlib/CdsRestClient/CdsRestClient.qtest
@@ -18,10 +18,7 @@
 
 %requires qore >= 0.9
 
-%new-style
-%require-types
-%strict-args
-%enable-all-warnings
+%modern
 
 %exec-class CdsTest
 

--- a/examples/test/qlib/CdsRestDataProvider/CdsRestDataProvider.qtest
+++ b/examples/test/qlib/CdsRestDataProvider/CdsRestDataProvider.qtest
@@ -18,10 +18,7 @@
 
 %requires qore >= 2.0
 
-%new-style
-%require-types
-%strict-args
-%enable-all-warnings
+%modern
 
 %exec-class CdsRestDataProviderTest
 

--- a/examples/test/qlib/ConnectionProvider/ConnectionProvider.qtest
+++ b/examples/test/qlib/ConnectionProvider/ConnectionProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/ConnectionProvider/ConnectionProviderModule.qtest
+++ b/examples/test/qlib/ConnectionProvider/ConnectionProviderModule.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/CsvUtil/csvtest2.qtest
+++ b/examples/test/qlib/CsvUtil/csvtest2.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/DataProvider

--- a/examples/test/qlib/CsvUtil/csvutil.qtest
+++ b/examples/test/qlib/CsvUtil/csvutil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/DataProvider/DataProvider.qtest
+++ b/examples/test/qlib/DataProvider/DataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/DataProvider/DebugCollector.qtest
+++ b/examples/test/qlib/DataProvider/DebugCollector.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/DataProvider/Dpql.qtest
+++ b/examples/test/qlib/DataProvider/Dpql.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/DatasourceProvider/DatasourceProvider.qtest
+++ b/examples/test/qlib/DatasourceProvider/DatasourceProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/Diff/Diff.qtest
+++ b/examples/test/qlib/Diff/Diff.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/Diff.qm

--- a/examples/test/qlib/DiscordDataProvider/DiscordDataProvider.qtest
+++ b/examples/test/qlib/DiscordDataProvider/DiscordDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/DiscordRestClient/DiscordRestClient.qtest
+++ b/examples/test/qlib/DiscordRestClient/DiscordRestClient.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/DiscordWebSocketClient/DiscordWebSocketClient.qtest
+++ b/examples/test/qlib/DiscordWebSocketClient/DiscordWebSocketClient.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/ElasticSearchDataProvider/ElasticSearchDataProvider.qtest
+++ b/examples/test/qlib/ElasticSearchDataProvider/ElasticSearchDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/ElasticSearchLoggerAppender/ElasticSearchLoggerAppender.qtest
+++ b/examples/test/qlib/ElasticSearchLoggerAppender/ElasticSearchLoggerAppender.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/EmpathicBuildingDataProvider/EmpathicBuildingDataProvider.qtest
+++ b/examples/test/qlib/EmpathicBuildingDataProvider/EmpathicBuildingDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/FileDataProvider/FileDataProvider.qtest
+++ b/examples/test/qlib/FileDataProvider/FileDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/FileLocationHandler/FileLocationHandler.qtest
+++ b/examples/test/qlib/FileLocationHandler/FileLocationHandler.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%require-types
-%strict-args
-%enable-all-warnings
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/FsUtil.qm

--- a/examples/test/qlib/FilePoller/FilePoller.qtest
+++ b/examples/test/qlib/FilePoller/FilePoller.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%require-types
-%strict-args
-%enable-all-warnings
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/FixedLengthUtil/FixedLengthDataIterator.qtest
+++ b/examples/test/qlib/FixedLengthUtil/FixedLengthDataIterator.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/DataProvider

--- a/examples/test/qlib/FixedLengthUtil/FixedLengthDataIteratorMultiType.qtest
+++ b/examples/test/qlib/FixedLengthUtil/FixedLengthDataIteratorMultiType.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/DataProvider

--- a/examples/test/qlib/FixedLengthUtil/FixedLengthDataWriter.qtest
+++ b/examples/test/qlib/FixedLengthUtil/FixedLengthDataWriter.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/DataProvider

--- a/examples/test/qlib/FixedLengthUtil/FixedLengthFileIterator.qtest
+++ b/examples/test/qlib/FixedLengthUtil/FixedLengthFileIterator.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/FixedLengthUtil/FixedLengthFileWriter.qtest
+++ b/examples/test/qlib/FixedLengthUtil/FixedLengthFileWriter.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/FixedLengthUtil/FixedLengthUtil.qtest
+++ b/examples/test/qlib/FixedLengthUtil/FixedLengthUtil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/FsUtil.qm

--- a/examples/test/qlib/FixedLengthUtil/transition_check_iterator.qtest
+++ b/examples/test/qlib/FixedLengthUtil/transition_check_iterator.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/DataProvider

--- a/examples/test/qlib/FixedLengthUtil/transition_check_writer.qtest
+++ b/examples/test/qlib/FixedLengthUtil/transition_check_writer.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/FtpClientDataProvider/FtpClientDataProvider.qtest
+++ b/examples/test/qlib/FtpClientDataProvider/FtpClientDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/FtpPoller/FtpPoller.qtest
+++ b/examples/test/qlib/FtpPoller/FtpPoller.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %include  ../../qore/classes/FtpServer.qc
 

--- a/examples/test/qlib/GmailDataProvider/GmailDataProvider.qtest
+++ b/examples/test/qlib/GmailDataProvider/GmailDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/GoogleCalendarDataProvider/GoogleCalendarDataProvider.qtest
+++ b/examples/test/qlib/GoogleCalendarDataProvider/GoogleCalendarDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/GoogleRestClient/GoogleRestClient.qtest
+++ b/examples/test/qlib/GoogleRestClient/GoogleRestClient.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/Http2/Http2.qtest
+++ b/examples/test/qlib/Http2/Http2.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/Http2/Http2Integration.qtest
+++ b/examples/test/qlib/Http2/Http2Integration.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/HttpServerUtil.qm

--- a/examples/test/qlib/Http2/http2_benchmark.q
+++ b/examples/test/qlib/Http2/http2_benchmark.q
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %disable-warning unreferenced-variable
 
 %exec-class Http2Benchmark

--- a/examples/test/qlib/Http2/http2_local_benchmark.q
+++ b/examples/test/qlib/Http2/http2_local_benchmark.q
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %disable-warning unreferenced-variable
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/HttpClientDataProvider/HttpClientDataProvider.qtest
+++ b/examples/test/qlib/HttpClientDataProvider/HttpClientDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/HttpServer/HttpServer.qtest
+++ b/examples/test/qlib/HttpServer/HttpServer.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/HttpServer/HttpServerAsyncHttp2.qtest
+++ b/examples/test/qlib/HttpServer/HttpServerAsyncHttp2.qtest
@@ -30,10 +30,7 @@
     was blocked in a synchronous poll loop.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/HttpServer/http_server_benchmark.q
+++ b/examples/test/qlib/HttpServer/http_server_benchmark.q
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires HttpServer
 %requires Util

--- a/examples/test/qlib/HttpServerAsyncIo/HttpServerAsyncIo.qtest
+++ b/examples/test/qlib/HttpServerAsyncIo/HttpServerAsyncIo.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/HttpServerAsyncIo

--- a/examples/test/qlib/HttpServerAsyncIo/benchmark.q
+++ b/examples/test/qlib/HttpServerAsyncIo/benchmark.q
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %disable-warning unreferenced-variable
 
 %requires ../../../../qlib/HttpServerAsyncIo

--- a/examples/test/qlib/HttpServerUtil/HttpServerUtil.qtest
+++ b/examples/test/qlib/HttpServerUtil/HttpServerUtil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/HueRestclient/HueRestClient.qtest
+++ b/examples/test/qlib/HueRestclient/HueRestClient.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/Logger/Logger.qtest
+++ b/examples/test/qlib/Logger/Logger.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/Logger/LoggerPerf.qtest
+++ b/examples/test/qlib/Logger/LoggerPerf.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/Logger.qm

--- a/examples/test/qlib/Logger/LoggerProgram.qtest
+++ b/examples/test/qlib/Logger/LoggerProgram.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/Logger.qm

--- a/examples/test/qlib/MailMessage/MailMessage.qtest
+++ b/examples/test/qlib/MailMessage/MailMessage.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/Mime.qm

--- a/examples/test/qlib/Mapper/mapper.qtest
+++ b/examples/test/qlib/Mapper/mapper.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/MemcachedDataProvider/MemcachedDataProvider.qtest
+++ b/examples/test/qlib/MemcachedDataProvider/MemcachedDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/MewsRestClient/MewsRestClient.qtest
+++ b/examples/test/qlib/MewsRestClient/MewsRestClient.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/MewsRestDataProvider/MewsRestDataProvider.qtest
+++ b/examples/test/qlib/MewsRestDataProvider/MewsRestDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/Mime/mime.qtest
+++ b/examples/test/qlib/Mime/mime.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/Mime.qm

--- a/examples/test/qlib/MongoDbDataProvider/MongoDbDataProvider.qtest
+++ b/examples/test/qlib/MongoDbDataProvider/MongoDbDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 # Use relative paths for qlib modules to test current development version
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/NetSuiteRestClient/NetSuiteRestClient.qtest
+++ b/examples/test/qlib/NetSuiteRestClient/NetSuiteRestClient.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/OpenAiDataProvider/OpenAiDataProvider.qtest
+++ b/examples/test/qlib/OpenAiDataProvider/OpenAiDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/OpenAiRestClient/OpenAiRestClient.qtest
+++ b/examples/test/qlib/OpenAiRestClient/OpenAiRestClient.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/OpenApi3/OpenApi3.qtest
+++ b/examples/test/qlib/OpenApi3/OpenApi3.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 # try importing JSON and YAML modules
 %try-module json

--- a/examples/test/qlib/OpenApi3/OpenApi3Generator.qtest
+++ b/examples/test/qlib/OpenApi3/OpenApi3Generator.qtest
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %try-module json
 %define NoJson

--- a/examples/test/qlib/Pop3Client/Pop3Client.qtest
+++ b/examples/test/qlib/Pop3Client/Pop3Client.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/ConnectionProvider
 %requires ../../../../qlib/Pop3Client.qm

--- a/examples/test/qlib/Pop3ClientDataProvider/Pop3ClientDataProvider.qtest
+++ b/examples/test/qlib/Pop3ClientDataProvider/Pop3ClientDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/QUnit/exception.qtest
+++ b/examples/test/qlib/QUnit/exception.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/QUnit/inject.qtest
+++ b/examples/test/qlib/QUnit/inject.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %disable-warning module-only
 

--- a/examples/test/qlib/QUnit/results.qtest
+++ b/examples/test/qlib/QUnit/results.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %disable-warning module-only
 

--- a/examples/test/qlib/QUnit/tests.qtest
+++ b/examples/test/qlib/QUnit/tests.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%strict-args
-%enable-all-warnings
-%require-types
+%modern
 
 %disable-warning module-only
 

--- a/examples/test/qlib/Qdx/QoreTokenizer.qtest
+++ b/examples/test/qlib/Qdx/QoreTokenizer.qtest
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %exec-class QoreTokenizerTests
 
 %requires Qdx

--- a/examples/test/qlib/QoreRepl/QoreRepl.qtest
+++ b/examples/test/qlib/QoreRepl/QoreRepl.qtest
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%new-style
-%require-types
-%strict-args
-%enable-all-warnings
+%modern
 
 %requires QUnit
 

--- a/examples/test/qlib/QoreRepl/QoreReplWebSocket.qtest
+++ b/examples/test/qlib/QoreRepl/QoreReplWebSocket.qtest
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%new-style
-%require-types
-%strict-args
-%enable-all-warnings
+%modern
 
 %requires QUnit
 %requires Logger

--- a/examples/test/qlib/Qorize/qorize.qtest
+++ b/examples/test/qlib/Qorize/qorize.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/Qorize.qm

--- a/examples/test/qlib/Qorize/realWorldCase.qtest
+++ b/examples/test/qlib/Qorize/realWorldCase.qtest
@@ -1,14 +1,9 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
-%require-types
-%enable-all-warnings
-%new-style
+%modern
 
 %try-module xml >= 1.3
 %define NoXml

--- a/examples/test/qlib/RedisDataProvider/RedisDataProvider.qtest
+++ b/examples/test/qlib/RedisDataProvider/RedisDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/RestClient/RestClient.qtest
+++ b/examples/test/qlib/RestClient/RestClient.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/Mime.qm

--- a/examples/test/qlib/RestClientDataProvider/RestClientDataProvider.qtest
+++ b/examples/test/qlib/RestClientDataProvider/RestClientDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/RestHandler/RestHandler.qtest
+++ b/examples/test/qlib/RestHandler/RestHandler.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/MapperUtil.qm

--- a/examples/test/qlib/RestSchemaDataProvider/RestSchemaDataProvider.qtest
+++ b/examples/test/qlib/RestSchemaDataProvider/RestSchemaDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 # try importing JSON and YAML modules
 %try-module json

--- a/examples/test/qlib/SSL/ssl.qtest
+++ b/examples/test/qlib/SSL/ssl.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qlib/SalesforceRestClient/SalesforceRestClient.qtest
+++ b/examples/test/qlib/SalesforceRestClient/SalesforceRestClient.qtest
@@ -18,10 +18,7 @@
 
 %requires qore >= 0.9
 
-%new-style
-%require-types
-%strict-args
-%enable-all-warnings
+%modern
 
 %exec-class SalesforceTest
 

--- a/examples/test/qlib/Sap4HanaRestClient/Sap4HanaRestClient.qtest
+++ b/examples/test/qlib/Sap4HanaRestClient/Sap4HanaRestClient.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/SchemaReverse/schema-reverse.qtest
+++ b/examples/test/qlib/SchemaReverse/schema-reverse.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/Qorize.qm

--- a/examples/test/qlib/ServerSentEventsHandler/ServerSentEventsHandler.qtest
+++ b/examples/test/qlib/ServerSentEventsHandler/ServerSentEventsHandler.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/MapperUtil.qm

--- a/examples/test/qlib/ServiceNowRestClient/ServiceNowRestClient.qtest
+++ b/examples/test/qlib/ServiceNowRestClient/ServiceNowRestClient.qtest
@@ -18,10 +18,7 @@
 
 %requires qore >= 0.9.10
 
-%new-style
-%require-types
-%strict-args
-%enable-all-warnings
+%modern
 
 %exec-class ServiceNowTest
 

--- a/examples/test/qlib/SewioRestClient/SewioRestClient.qtest
+++ b/examples/test/qlib/SewioRestClient/SewioRestClient.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/SewioWebSocketClient/SewioWebSocketClient.qtest
+++ b/examples/test/qlib/SewioWebSocketClient/SewioWebSocketClient.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/SmtpClient/SmtpClient.qtest
+++ b/examples/test/qlib/SmtpClient/SmtpClient.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Logger.qm
 %requires ../../../../qlib/DataProvider

--- a/examples/test/qlib/SmtpClientDataProvider/SmtpClientDataProvider.qtest
+++ b/examples/test/qlib/SmtpClientDataProvider/SmtpClientDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qlib/SqlUtil/BulkFreetdsSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/BulkFreetdsSqlUtil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/SqlUtil/BulkMysqlSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/BulkMysqlSqlUtil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/Logger.qm

--- a/examples/test/qlib/SqlUtil/BulkOracleSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/BulkOracleSqlUtil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/SqlUtil/BulkPgsqlSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/BulkPgsqlSqlUtil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 %requires ../../../../qlib/Logger.qm

--- a/examples/test/qlib/SqlUtil/FreetdsSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/FreetdsSqlUtil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/Logger.qm

--- a/examples/test/qlib/SqlUtil/JdbcFirebirdSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/JdbcFirebirdSqlUtil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/Logger.qm

--- a/examples/test/qlib/SqlUtil/JdbcMicrosoftSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/JdbcMicrosoftSqlUtil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/Logger.qm

--- a/examples/test/qlib/SqlUtil/JdbcOracleSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/JdbcOracleSqlUtil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/Logger.qm

--- a/examples/test/qlib/SqlUtil/JdbcPostgresqlSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/JdbcPostgresqlSqlUtil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/Logger.qm

--- a/examples/test/qlib/SqlUtil/MysqlSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/MysqlSqlUtil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/Logger.qm

--- a/examples/test/qlib/SqlUtil/OdbcFirebirdSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/OdbcFirebirdSqlUtil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/Logger.qm

--- a/examples/test/qlib/SqlUtil/OracleSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/OracleSqlUtil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/Logger.qm

--- a/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/Logger.qm

--- a/examples/test/qlib/Swagger/Swagger.qtest
+++ b/examples/test/qlib/Swagger/Swagger.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 # try importing JSON and YAML modules
 %try-module json

--- a/examples/test/qlib/Swagger/SwaggerDataProvider.qtest
+++ b/examples/test/qlib/Swagger/SwaggerDataProvider.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 # try importing JSON and YAML modules
 %try-module json

--- a/examples/test/qlib/TableMapper/SqlStatementMapperIterator.qtest
+++ b/examples/test/qlib/TableMapper/SqlStatementMapperIterator.qtest
@@ -4,10 +4,7 @@
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm
 
-%new-style
-%require-types
-%enable-all-warnings
-%strict-args
+%modern
 
 %requires ../../../../qlib/DataProvider
 %requires ../../../../qlib/SqlUtil

--- a/examples/test/qlib/TableMapper/SqlStatementOutboundMapper.qtest
+++ b/examples/test/qlib/TableMapper/SqlStatementOutboundMapper.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/TableMapper/TableMapper.qtest
+++ b/examples/test/qlib/TableMapper/TableMapper.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %exec-class TableMapperTest
 

--- a/examples/test/qlib/TableMapper/TableMapperPerformance.qtest
+++ b/examples/test/qlib/TableMapper/TableMapperPerformance.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %exec-class TableMapperPerformanceTest
 

--- a/examples/test/qlib/TelnetClient/TelnetClient.qtest
+++ b/examples/test/qlib/TelnetClient/TelnetClient.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/ConnectionProvider
 %requires ../../../../qlib/TelnetClient.qm

--- a/examples/test/qlib/Util/get_exception_string.qtest
+++ b/examples/test/qlib/Util/get_exception_string.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/Util/same.qtest
+++ b/examples/test/qlib/Util/same.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/Util/serialize_to_string.qtest
+++ b/examples/test/qlib/Util/serialize_to_string.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/Util/slice.qtest
+++ b/examples/test/qlib/Util/slice.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/Util/tmp_location.qtest
+++ b/examples/test/qlib/Util/tmp_location.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/WebSocketClient/WebSocketClient.qtest
+++ b/examples/test/qlib/WebSocketClient/WebSocketClient.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/WebSocketHandler/WebSocketHandler.qtest
+++ b/examples/test/qlib/WebSocketHandler/WebSocketHandler.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/WebSocketUtil/WebSocketUtil.qtest
+++ b/examples/test/qlib/WebSocketUtil/WebSocketUtil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/WebSocketUtil.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qlib/WebUtil/WebUtil.qtest
+++ b/examples/test/qlib/WebUtil/WebUtil.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/Mime.qm

--- a/examples/test/qlib/ZeyosRestClient/ZeyosRestClient.qtest
+++ b/examples/test/qlib/ZeyosRestClient/ZeyosRestClient.qtest
@@ -19,10 +19,7 @@
 
 %requires qore >= 0.9.11
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %disable-warning deprecated
 

--- a/examples/test/qore/classes/Counter/Counter.qtest
+++ b/examples/test/qore/classes/Counter/Counter.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/Util.qm
 %requires ../../../../../qlib/QUnit.qm

--- a/examples/test/qore/classes/Datasource/Datasource.qtest
+++ b/examples/test/qore/classes/Datasource/Datasource.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../../qlib/Util.qm
 %requires ../../../../../qlib/QUnit.qm

--- a/examples/test/qore/classes/DatasourcePool/DatasourcePool.qtest
+++ b/examples/test/qore/classes/DatasourcePool/DatasourcePool.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../../qlib/Util.qm
 %requires ../../../../../qlib/QUnit.qm

--- a/examples/test/qore/classes/Dir/Dir.qtest
+++ b/examples/test/qore/classes/Dir/Dir.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/Util.qm
 %requires ../../../../../qlib/QUnit.qm

--- a/examples/test/qore/classes/File/File.qtest
+++ b/examples/test/qore/classes/File/File.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/Util.qm
 %requires ../../../../../qlib/FsUtil.qm

--- a/examples/test/qore/classes/FileLineIterator/FileLineIterator.qtest
+++ b/examples/test/qore/classes/FileLineIterator/FileLineIterator.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/Util.qm
 %requires ../../../../../qlib/QUnit.qm

--- a/examples/test/qore/classes/FtpClient/FtpClient.qtest
+++ b/examples/test/qore/classes/FtpClient/FtpClient.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %include ../FtpServer.qc
 

--- a/examples/test/qore/classes/GetOpt/GetOpt.qtest
+++ b/examples/test/qore/classes/GetOpt/GetOpt.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/classes/HTTPClient/HTTPClient.qtest
+++ b/examples/test/qore/classes/HTTPClient/HTTPClient.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires ../../../../../qlib/Util.qm
 %requires ../../../../../qlib/Mime.qm

--- a/examples/test/qore/classes/HashListIterator/HashListIterator.qtest
+++ b/examples/test/qore/classes/HashListIterator/HashListIterator.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/classes/LineIterators/AbstractLineIterator.qtest
+++ b/examples/test/qore/classes/LineIterators/AbstractLineIterator.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/classes/LineIterators/DataLineIterator.qtest
+++ b/examples/test/qore/classes/LineIterators/DataLineIterator.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/classes/LineIterators/FileLineIterator.qtest
+++ b/examples/test/qore/classes/LineIterators/FileLineIterator.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/Util.qm
 %requires ../../../../../qlib/QUnit.qm

--- a/examples/test/qore/classes/LineIterators/InputStreamLineIterator.qtest
+++ b/examples/test/qore/classes/LineIterators/InputStreamLineIterator.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/Util.qm
 %requires ../../../../../qlib/QUnit.qm

--- a/examples/test/qore/classes/Program/injection.qtest
+++ b/examples/test/qore/classes/Program/injection.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 %allow-injection
 

--- a/examples/test/qore/classes/Program/lasting-subprogram-in-thread.qtest
+++ b/examples/test/qore/classes/Program/lasting-subprogram-in-thread.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 # this used to cause qore to crash...
 

--- a/examples/test/qore/classes/Program/program-vars.qtest
+++ b/examples/test/qore/classes/Program/program-vars.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 %no-debugging
 

--- a/examples/test/qore/classes/Program/program.qtest
+++ b/examples/test/qore/classes/Program/program.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 # to test ProgramControl::getProgram
 %allow-debugger

--- a/examples/test/qore/classes/Queue/Queue.qtest
+++ b/examples/test/qore/classes/Queue/Queue.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/classes/Regex/Regex.qtest
+++ b/examples/test/qore/classes/Regex/Regex.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/classes/RegexExtract/RegexExtract.qtest
+++ b/examples/test/qore/classes/RegexExtract/RegexExtract.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/classes/RegexSubst/RegexSubst.qtest
+++ b/examples/test/qore/classes/RegexSubst/RegexSubst.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/classes/SQLStatement/SQLStatement.qtest
+++ b/examples/test/qore/classes/SQLStatement/SQLStatement.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/classes/Serializable/Serializable.qtest
+++ b/examples/test/qore/classes/Serializable/Serializable.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %allow-weak-references
 
 %requires ../../../../../qlib/Util.qm

--- a/examples/test/qore/classes/Socket/Socket.qtest
+++ b/examples/test/qore/classes/Socket/Socket.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/Util.qm
 %requires ../../../../../qlib/QUnit.qm

--- a/examples/test/qore/classes/ThreadPool/ThreadPool.qtest
+++ b/examples/test/qore/classes/ThreadPool/ThreadPool.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../../qlib/Util.qm

--- a/examples/test/qore/classes/TreeMap/TreeMap.qtest
+++ b/examples/test/qore/classes/TreeMap/TreeMap.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/debug/test-debug.qtest
+++ b/examples/test/qore/debug/test-debug.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %allow-debugger
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/enums/test-enums-negative.qtest
+++ b/examples/test/qore/enums/test-enums-negative.qtest
@@ -2,10 +2,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 # Copyright (C) 2026 Qore Technologies, s.r.o.
 
-%new-style
-%require-types
-%strict-args
-%enable-all-warnings
+%modern
 
 %requires QUnit
 %requires reflection
@@ -27,7 +24,7 @@ class EnumNegativeTest inherits QUnit::Test {
     testNoEnumRestriction() {
         # Test that PO_NO_ENUM prevents enum declarations
         string code = "
-%new-style
+%modern
 %no-enum
 public enum TestEnum : int {
     A = 1,
@@ -41,7 +38,7 @@ public enum TestEnum : int {
     testInvalidBaseType() {
         # Test invalid base type for enum
         string code = "
-%new-style
+%modern
 public enum TestEnum : bool {
     A = True,
 }
@@ -58,7 +55,7 @@ public enum TestEnum : bool {
     testUnknownEnumMember() {
         # Create a simple enum for testing
         string code = "
-%new-style
+%modern
 public enum SimpleEnum : int {
     A = 1,
 }
@@ -82,8 +79,7 @@ public enum SimpleEnum : int {
     testCastParseTimeMismatch() {
         # Test that casting from incompatible type at parse time raises error
         string code = "
-%new-style
-%require-types
+%modern
 public enum Status : string {
     Active = \"active\",
 }
@@ -99,8 +95,7 @@ sub test() {
     testCastUnknownEnum() {
         # Test that casting to unknown enum at parse time raises error
         string code = "
-%new-style
-%require-types
+%modern
 sub test() {
     string s = \"test\";
     auto x = cast<enum<NonExistentEnum>>(s);

--- a/examples/test/qore/enums/test-enums.qtest
+++ b/examples/test/qore/enums/test-enums.qtest
@@ -2,10 +2,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 # Copyright (C) 2026 Qore Technologies, s.r.o.
 
-%new-style
-%require-types
-%strict-args
-%enable-all-warnings
+%modern
 
 %requires QUnit
 %requires reflection

--- a/examples/test/qore/files/create-iso-8859-1-file.qtest
+++ b/examples/test/qore/files/create-iso-8859-1-file.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/files/filetypes.qtest
+++ b/examples/test/qore/files/filetypes.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/files/mkdir.qtest
+++ b/examples/test/qore/files/mkdir.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/files/read.qtest
+++ b/examples/test/qore/files/read.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/functions/auto_cast.qtest
+++ b/examples/test/qore/functions/auto_cast.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/call_builtin_function.qtest
+++ b/examples/test/qore/functions/call_builtin_function.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/call_static_method.qtest
+++ b/examples/test/qore/functions/call_static_method.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/ceil.qtest
+++ b/examples/test/qore/functions/ceil.qtest
@@ -1,10 +1,7 @@
 #! /usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/compare.qtest
+++ b/examples/test/qore/functions/compare.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/compression.qtest
+++ b/examples/test/qore/functions/compression.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/conversions.qtest
+++ b/examples/test/qore/functions/conversions.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/crypto.qtest
+++ b/examples/test/qore/functions/crypto.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/functions/digests.qtest
+++ b/examples/test/qore/functions/digests.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/exists_function.qtest
+++ b/examples/test/qore/functions/exists_function.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/floor.qtest
+++ b/examples/test/qore/functions/floor.qtest
@@ -1,10 +1,7 @@
 #! /usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/format_number.qtest
+++ b/examples/test/qore/functions/format_number.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/functiontype.qtest
+++ b/examples/test/qore/functions/functiontype.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/get_ex_pos.qtest
+++ b/examples/test/qore/functions/get_ex_pos.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/get_ex_pos.qtest
+++ b/examples/test/qore/functions/get_ex_pos.qtest
@@ -23,7 +23,7 @@ public class GetExPosTest inherits QUnit::Test {
             assertTrue(False);
         } catch (hash<ExceptionInfo> ex) {
             string str = get_ex_pos(ex);
-            assertRegex("get_ex_pos.qtest:24 \\(Qore\\)$", str);
+            assertRegex("get_ex_pos.qtest:21 \\(Qore\\)$", str);
         }
     }
 }

--- a/examples/test/qore/functions/get_feature_list.qtest
+++ b/examples/test/qore/functions/get_feature_list.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/get_netif_list.qtest
+++ b/examples/test/qore/functions/get_netif_list.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/functions/get_qore_option_list.qtest
+++ b/examples/test/qore/functions/get_qore_option_list.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/get_safe_url.qtest
+++ b/examples/test/qore/functions/get_safe_url.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/gethost.qtest
+++ b/examples/test/qore/functions/gethost.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/glob.qtest
+++ b/examples/test/qore/functions/glob.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/functions/hmac.qtest
+++ b/examples/test/qore/functions/hmac.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/html_encode.qtest
+++ b/examples/test/qore/functions/html_encode.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/opt_arg.qtest
+++ b/examples/test/qore/functions/opt_arg.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/parse_datasource.qtest
+++ b/examples/test/qore/functions/parse_datasource.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 # assert tests with no return value
 %disable-warning return-value-ignored

--- a/examples/test/qore/functions/parse_url.qtest
+++ b/examples/test/qore/functions/parse_url.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/parseurl.qtest
+++ b/examples/test/qore/functions/parseurl.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/pwd.qtest
+++ b/examples/test/qore/functions/pwd.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/regex_extract.qtest
+++ b/examples/test/qore/functions/regex_extract.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/replace.qtest
+++ b/examples/test/qore/functions/replace.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/functions/round.qtest
+++ b/examples/test/qore/functions/round.qtest
@@ -1,10 +1,7 @@
 #! /usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/sort.qtest
+++ b/examples/test/qore/functions/sort.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/sprintf.qtest
+++ b/examples/test/qore/functions/sprintf.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/stat.qtest
+++ b/examples/test/qore/functions/stat.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/string.qtest
+++ b/examples/test/qore/functions/string.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/strmul.qtest
+++ b/examples/test/qore/functions/strmul.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/system.qtest
+++ b/examples/test/qore/functions/system.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/functions/to_base.qtest
+++ b/examples/test/qore/functions/to_base.qtest
@@ -1,10 +1,7 @@
 #! /usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/to_int.qtest
+++ b/examples/test/qore/functions/to_int.qtest
@@ -1,10 +1,7 @@
 #! /usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/type.qtest
+++ b/examples/test/qore/functions/type.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/functions/xrange.qtest
+++ b/examples/test/qore/functions/xrange.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/io/io_interrupt.qtest
+++ b/examples/test/qore/io/io_interrupt.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %disable-warning unreferenced-variable
 
 %requires ../../../../qlib/Util.qm
@@ -251,9 +248,7 @@ public class IOInterruptTest inherits QUnit::Test {
         p.setSandboxManager(sm);
 
         p.parse("
-%require-types
-%new-style
-%strict-args
+%modern
 
 *binary sub read_pipe() {
     StreamPipe pipe(True, 30000, 1024);
@@ -285,9 +280,7 @@ public class IOInterruptTest inherits QUnit::Test {
         p.setSandboxManager(sm);
 
         p.parse("
-%require-types
-%new-style
-%strict-args
+%modern
 
 sub write_pipe() {
     StreamPipe pipe(True, 30000, 16);  # Small buffer
@@ -327,9 +320,7 @@ sub write_pipe() {
         p.setSandboxManager(sm);
 
         p.parse("
-%require-types
-%new-style
-%strict-args
+%modern
 
 auto sub shift_queue() {
     Queue q();
@@ -360,9 +351,7 @@ auto sub shift_queue() {
         p.setSandboxManager(sm);
 
         p.parse("
-%require-types
-%new-style
-%strict-args
+%modern
 
 sub push_queue() {
     Queue q(1);  # Max size 1
@@ -431,9 +420,7 @@ sub push_queue() {
         p.setSandboxManager(sm);
 
         p.parse("
-%require-types
-%new-style
-%strict-args
+%modern
 
 int sub wait_counter() {
     Counter c(1);  # Counter at 1, will never reach 0

--- a/examples/test/qore/misc/access.qtest
+++ b/examples/test/qore/misc/access.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/misc/backquote.qtest
+++ b/examples/test/qore/misc/backquote.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/binary.qtest
+++ b/examples/test/qore/misc/binary.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/misc/break_continue.qtest
+++ b/examples/test/qore/misc/break_continue.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/misc/broken-abstract.qtest
+++ b/examples/test/qore/misc/broken-abstract.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/callref.qtest
+++ b/examples/test/qore/misc/callref.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/cast.qtest
+++ b/examples/test/qore/misc/cast.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/catch.qtest
+++ b/examples/test/qore/misc/catch.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/misc/class-init-order.qtest
+++ b/examples/test/qore/misc/class-init-order.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/class_copy.qtest
+++ b/examples/test/qore/misc/class_copy.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/classes.qtest
+++ b/examples/test/qore/misc/classes.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/classes.qtest
+++ b/examples/test/qore/misc/classes.qtest
@@ -1176,7 +1176,7 @@ sub test() {
         } catch (hash<ExceptionInfo> nex) {
             ex = nex;
         }
-        assertEq(564, ex.callstack[0].line);
+        assertEq(561, ex.callstack[0].line);
 
         Child2 c2();
         Child1 c1(c2);

--- a/examples/test/qore/misc/const-init.qtest
+++ b/examples/test/qore/misc/const-init.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/context.qtest
+++ b/examples/test/qore/misc/context.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/curly-brackets.qtest
+++ b/examples/test/qore/misc/curly-brackets.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/destructor-lock.qtest
+++ b/examples/test/qore/misc/destructor-lock.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/empty_hash_ambiguity.qtest
+++ b/examples/test/qore/misc/empty_hash_ambiguity.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/misc/empty_statements.qtest
+++ b/examples/test/qore/misc/empty_statements.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/misc/exception.qtest
+++ b/examples/test/qore/misc/exception.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires reflection
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qore/misc/gc.qtest
+++ b/examples/test/qore/misc/gc.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/has_effect.qtest
+++ b/examples/test/qore/misc/has_effect.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/misc/hash.qtest
+++ b/examples/test/qore/misc/hash.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/hashdecl.qtest
+++ b/examples/test/qore/misc/hashdecl.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/issue3179/issue3179.qtest
+++ b/examples/test/qore/misc/issue3179/issue3179.qtest
@@ -1,9 +1,6 @@
 #!/usr/bin/env qore
 
-%new-style
-%require-types
-%strict-args
-%enable-all-warnings
+%modern
 
 %requires ../../../../../qlib/Util.qm
 %requires ../../../../../qlib/QUnit.qm

--- a/examples/test/qore/misc/locals-in-class.qtest
+++ b/examples/test/qore/misc/locals-in-class.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm
@@ -26,7 +23,7 @@ public class LocalsInClassTest inherits QUnit::Test {
         p.replaceParseOptions(PO_DEFAULT);
         assertThrows("PARSE-EXCEPTION", "illegal local variable declaration in member initialization expression",
             \p.parse(), ("
-%new-style
+%modern
 class C {
     private {
         int i = int j;
@@ -41,7 +38,7 @@ class C {
         p.replaceParseOptions(PO_DEFAULT);
         assertThrows("PARSE-EXCEPTION", "illegal local variable declaration in class static variable initialization expression",
             \p.parse(), ("
-%new-style
+%modern
 class C {
     private {
         static int i = int j;

--- a/examples/test/qore/misc/module-loader/blacklist.qtest
+++ b/examples/test/qore/misc/module-loader/blacklist.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/module-loader/injection.qtest
+++ b/examples/test/qore/misc/module-loader/injection.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %allow-injection
 %no-child-restrictions

--- a/examples/test/qore/misc/module-loader/issue-3504.qtest
+++ b/examples/test/qore/misc/module-loader/issue-3504.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../../qlib/Qorize.qm

--- a/examples/test/qore/misc/module-loader/issue-3506.qtest
+++ b/examples/test/qore/misc/module-loader/issue-3506.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../../qlib/Util.qm

--- a/examples/test/qore/misc/module-loader/module-program.qtest
+++ b/examples/test/qore/misc/module-loader/module-program.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %allow-injection
 %no-child-restrictions

--- a/examples/test/qore/misc/module-loader/module-warning-1.qtest
+++ b/examples/test/qore/misc/module-loader/module-warning-1.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/module-loader/module-warning-2.qtest
+++ b/examples/test/qore/misc/module-loader/module-warning-2.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/module-loader/module-warning-3.qtest
+++ b/examples/test/qore/misc/module-loader/module-warning-3.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../../qlib/QUnit.qm

--- a/examples/test/qore/misc/module-loader/module-warning-4.qtest
+++ b/examples/test/qore/misc/module-loader/module-warning-4.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../../qlib/QUnit.qm

--- a/examples/test/qore/misc/module-loader/module-warning-5.qtest
+++ b/examples/test/qore/misc/module-loader/module-warning-5.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %allow-injection
 
 %requires ../../../../../qlib/QUnit.qm

--- a/examples/test/qore/misc/module-loader/modules.qtest
+++ b/examples/test/qore/misc/module-loader/modules.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/Util.qm
 %requires ../../../../../qlib/QUnit.qm

--- a/examples/test/qore/misc/module-loader/private-module.qtest
+++ b/examples/test/qore/misc/module-loader/private-module.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %allow-injection
 %no-child-restrictions

--- a/examples/test/qore/misc/module-loader/recursive-dependency.qtest
+++ b/examples/test/qore/misc/module-loader/recursive-dependency.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/module-loader/reexport.qtest
+++ b/examples/test/qore/misc/module-loader/reexport.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/module_options.qtest
+++ b/examples/test/qore/misc/module_options.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/octal_const.qtest
+++ b/examples/test/qore/misc/octal_const.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/parse_directives.qtest
+++ b/examples/test/qore/misc/parse_directives.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/misc/parser-2096.qtest
+++ b/examples/test/qore/misc/parser-2096.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/pseudo-methods.qtest
+++ b/examples/test/qore/misc/pseudo-methods.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/recursive.qtest
+++ b/examples/test/qore/misc/recursive.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/reflection.qtest
+++ b/examples/test/qore/misc/reflection.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qore/misc/reflection.qtest
+++ b/examples/test/qore/misc/reflection.qtest
@@ -106,6 +106,8 @@ class ReflectionTest inherits QUnit::Test {
         addTestCase("ns path test", \nsPathTest());
         addTestCase("mod name tests", \modNameTests());
         addTestCase("type tests", \typeTests());
+        addTestCase("typed code tests", \typedCodeTests());
+        addTestCase("union type tests", \unionTypeTests());
         addTestCase("pgm tests", \pgmTests());
         addTestCase("issue 3145", \issue3145Test());
         addTestCase("issue 3141", \issue3141Test());
@@ -310,6 +312,157 @@ class ReflectionTest inherits QUnit::Test {
         assertEq(("reference<string>", "nothing"), keys (new Type("*reference<string>")).getReturnTypeHash());
     }
 
+    typedCodeTests() {
+        # Test non-typed code types
+        {
+            Type t("int");
+            assertFalse(t.isTypedCode());
+            assertNothing(t.getCodeReturnType());
+            assertNothing(t.getCodeParamTypes());
+            assertFalse(t.codeHasVarargs());
+        }
+
+        {
+            Type t("code");
+            assertFalse(t.isTypedCode());
+            assertNothing(t.getCodeReturnType());
+            assertNothing(t.getCodeParamTypes());
+            assertFalse(t.codeHasVarargs());
+        }
+
+        # Test basic typed code type
+        {
+            Type t("code<int(string, bool)>");
+            assertTrue(t.isTypedCode());
+            assertFalse(t.isUnion());
+
+            # Check return type
+            *Type rt = t.getCodeReturnType();
+            assertTrue(exists rt);
+            assertEq("int", rt.getName());
+
+            # Check parameter types
+            *list<Type> params = t.getCodeParamTypes();
+            assertTrue(exists params);
+            assertEq(2, params.size());
+            assertEq("string", params[0].getName());
+            assertEq("bool", params[1].getName());
+
+            # Check varargs
+            assertFalse(t.codeHasVarargs());
+        }
+
+        # Test typed code with no parameters
+        {
+            Type t("code<string()>");
+            assertTrue(t.isTypedCode());
+            *Type rt = t.getCodeReturnType();
+            assertTrue(exists rt);
+            assertEq("string", rt.getName());
+            *list<Type> params = t.getCodeParamTypes();
+            assertTrue(exists params);
+            assertEq(0, params.size());
+            assertFalse(t.codeHasVarargs());
+        }
+
+        # Test typed code with varargs
+        {
+            Type t("code<int(string, ...)>");
+            assertTrue(t.isTypedCode());
+            *Type rt = t.getCodeReturnType();
+            assertTrue(exists rt);
+            assertEq("int", rt.getName());
+            *list<Type> params = t.getCodeParamTypes();
+            assertTrue(exists params);
+            assertEq(1, params.size());
+            assertEq("string", params[0].getName());
+            assertTrue(t.codeHasVarargs());
+        }
+
+        # Test or-nothing typed code type
+        {
+            Type t("*code<int(string)>");
+            assertTrue(t.isTypedCode());
+            assertTrue(t.isOrNothingType());
+            *Type rt = t.getCodeReturnType();
+            assertTrue(exists rt);
+            assertEq("int", rt.getName());
+        }
+
+        # Test complex return type
+        {
+            Type t("code<hash<string, int>(string)>");
+            assertTrue(t.isTypedCode());
+            *Type rt = t.getCodeReturnType();
+            assertTrue(exists rt);
+            assertEq("hash<string, int>", rt.getName());
+        }
+
+        # Test complex param types
+        {
+            Type t("code<int(list<string>, hash<string, int>)>");
+            assertTrue(t.isTypedCode());
+            *list<Type> params = t.getCodeParamTypes();
+            assertTrue(exists params);
+            assertEq(2, params.size());
+            assertEq("list<string>", params[0].getName());
+            assertEq("hash<string, int>", params[1].getName());
+        }
+    }
+
+    unionTypeTests() {
+        # Test basic union type
+        {
+            Type t("union<int, string>");
+            assertTrue(t.isUnion());
+            assertFalse(t.isTypedCode());
+
+            # Check member types
+            *list<Type> members = t.getUnionMemberTypes();
+            assertTrue(exists members);
+            assertEq(2, members.size());
+            # Note: order may vary, so use a set-like comparison
+            hash<string, bool> memberNames;
+            foreach Type m in (members) {
+                memberNames{m.getName()} = True;
+            }
+            assertTrue(memberNames.int ?? False);
+            assertTrue(memberNames.string ?? False);
+        }
+
+        # Test union type with multiple types
+        {
+            Type t("union<int, string, bool, float>");
+            assertTrue(t.isUnion());
+            *list<Type> members = t.getUnionMemberTypes();
+            assertTrue(exists members);
+            assertEq(4, members.size());
+        }
+
+        # Test or-nothing union type
+        {
+            Type t("*union<int, string>");
+            assertTrue(t.isUnion());
+            assertTrue(t.isOrNothingType());
+            *list<Type> members = t.getUnionMemberTypes();
+            assertTrue(exists members);
+            assertEq(2, members.size());
+        }
+
+        # Test non-union types
+        {
+            Type t("int");
+            assertFalse(t.isUnion());
+            assertNothing(t.getUnionMemberTypes());
+        }
+
+        {
+            Type t("hash<auto>");
+            assertFalse(t.isUnion());
+            assertNothing(t.getUnionMemberTypes());
+        }
+    }
+
     pgmTests() {
         Program p(PO_NEW_STYLE);
         p.parse("class TestClass {} const Test = 1; sub test() {} our int test; namespace Test1 {} hashdecl Test2 { int i; }", "");
@@ -401,7 +554,7 @@ class ReflectionTest inherits QUnit::Test {
         assertFalse(c.isAbstract());
         assertEq("Mutex", c.getName());
         assertEq("Qore::Thread::Mutex", c.getPathName());
-        assertGt(0, c.getId());
+        assertTrue(c.getId() > 0);
         assertEq(20, c.getHash().size());
         assertFalse(c.hasMemberGate());
         assertFalse(c.hasMethodGate());

--- a/examples/test/qore/misc/rwlock.qtest
+++ b/examples/test/qore/misc/rwlock.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %require-our
 %disable-warning non-existent-method-call
 

--- a/examples/test/qore/misc/signals.qtest
+++ b/examples/test/qore/misc/signals.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/misc/types.qtest
+++ b/examples/test/qore/misc/types.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 # we will test invalid operations

--- a/examples/test/qore/misc/underscores.qtest
+++ b/examples/test/qore/misc/underscores.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/namespaces/ns.qtest
+++ b/examples/test/qore/namespaces/ns.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/operators/assignment-op-precedence.qtest
+++ b/examples/test/qore/operators/assignment-op-precedence.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/operators/assignment.qtest
+++ b/examples/test/qore/operators/assignment.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/operators/background.qtest
+++ b/examples/test/qore/operators/background.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/operators/broken-list-parsing.qtest
+++ b/examples/test/qore/operators/broken-list-parsing.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/operators/hmap.qtest
+++ b/examples/test/qore/operators/hmap.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %disable-warning invalid-operation
 

--- a/examples/test/qore/operators/list_ops.qtest
+++ b/examples/test/qore/operators/list_ops.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/operators/logic.qtest
+++ b/examples/test/qore/operators/logic.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/operators/minus-nothing.qtest
+++ b/examples/test/qore/operators/minus-nothing.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %disable-warning invalid-operation
 

--- a/examples/test/qore/operators/null_coalescing.qtest
+++ b/examples/test/qore/operators/null_coalescing.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/operators/operators.qtest
+++ b/examples/test/qore/operators/operators.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qore/operators/plus-eq-nothing.qtest
+++ b/examples/test/qore/operators/plus-eq-nothing.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/operators/regex.qtest
+++ b/examples/test/qore/operators/regex.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/operators/unary_plus_minus.qtest
+++ b/examples/test/qore/operators/unary_plus_minus.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %disable-warning invalid-operation

--- a/examples/test/qore/operators/value_coalescing.qtest
+++ b/examples/test/qore/operators/value_coalescing.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/parser/issue-3108.qtest
+++ b/examples/test/qore/parser/issue-3108.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qore/parser/issue-3126.qtest
+++ b/examples/test/qore/parser/issue-3126.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qore/parser/issue-3387.qtest
+++ b/examples/test/qore/parser/issue-3387.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qore/parser/try-module.qtest
+++ b/examples/test/qore/parser/try-module.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/parser/typed_code_comprehensive.qtest
+++ b/examples/test/qore/parser/typed_code_comprehensive.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/parser/typed_code_phase1.qtest
+++ b/examples/test/qore/parser/typed_code_phase1.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/parser/typed_code_phase2.qtest
+++ b/examples/test/qore/parser/typed_code_phase2.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/parser/typed_code_phase3.qtest
+++ b/examples/test/qore/parser/typed_code_phase3.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/parser/typedef.qtest
+++ b/examples/test/qore/parser/typedef.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qore/parser/union.qtest
+++ b/examples/test/qore/parser/union.qtest
@@ -25,10 +25,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qore/requires/requiresModul.qtest
+++ b/examples/test/qore/requires/requiresModul.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/security/external-info-restriction.qtest
+++ b/examples/test/qore/security/external-info-restriction.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires QUnit

--- a/examples/test/qore/security/sandbox-manager.qtest
+++ b/examples/test/qore/security/sandbox-manager.qtest
@@ -365,7 +365,7 @@ string sub tryReadOutside() {
         # Test chdir inside sandbox works
         p.parse("
 %modern
-sub testChdirInSandbox(string path) {
+list<auto> sub testChdirInSandbox(string path) {
     Dir d();
     d.chdir(path);
     return d.list();

--- a/examples/test/qore/security/sandbox-manager.qtest
+++ b/examples/test/qore/security/sandbox-manager.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires QUnit
@@ -318,7 +315,7 @@ class SandboxManagerTest inherits QUnit::Test {
 
         # Test reading file inside sandbox works
         p.parse("
-%new-style
+%modern
 string sub readTest(string path) {
     File f();
     f.open2(path, O_RDONLY);
@@ -333,7 +330,7 @@ string sub readTest(string path) {
         Program p2(PO_NO_CHILD_PO_RESTRICTIONS);
         p2.setSandboxManager(sm);
         p2.parse("
-%new-style
+%modern
 string sub tryReadOutside() {
     File f();
     f.open2(\"/etc/passwd\", O_RDONLY);
@@ -367,7 +364,7 @@ string sub tryReadOutside() {
 
         # Test chdir inside sandbox works
         p.parse("
-%new-style
+%modern
 sub testChdirInSandbox(string path) {
     Dir d();
     d.chdir(path);
@@ -382,7 +379,7 @@ sub testChdirInSandbox(string path) {
         Program p2(PO_NO_CHILD_PO_RESTRICTIONS);
         p2.setSandboxManager(sm);
         p2.parse("
-%new-style
+%modern
 sub testChdirOutsideSandbox() {
     Dir d();
     d.chdir(\"/etc\");
@@ -402,7 +399,7 @@ sub testChdirOutsideSandbox() {
         Program p3(PO_NO_CHILD_PO_RESTRICTIONS);
         p3.setSandboxManager(sm);
         p3.parse("
-%new-style
+%modern
 sub testMkdirInSandbox(string path) {
     Dir d();
     d.chdir(\"/tmp\");
@@ -425,7 +422,7 @@ sub testMkdirInSandbox(string path) {
 
         # Test while loop interrupt
         p.parse("
-%new-style
+%modern
 sub whileLoop() {
     while (True) {
         # infinite loop
@@ -448,7 +445,7 @@ sub whileLoop() {
         Program p2(PO_NO_CHILD_PO_RESTRICTIONS);
         p2.setSandboxManager(sm);
         p2.parse("
-%new-style
+%modern
 sub forLoop() {
     for (;;) {
         # infinite loop
@@ -471,7 +468,7 @@ sub forLoop() {
         Program p3(PO_NO_CHILD_PO_RESTRICTIONS);
         p3.setSandboxManager(sm);
         p3.parse("
-%new-style
+%modern
 sub foreachLoop() {
     list<int> bigList = ();
     for (int i = 0; i < 1000000; i++) {
@@ -498,7 +495,7 @@ sub foreachLoop() {
         Program p4(PO_NO_CHILD_PO_RESTRICTIONS);
         p4.setSandboxManager(sm);
         p4.parse("
-%new-style
+%modern
 sub doWhileLoop() {
     do {
         # infinite loop
@@ -525,7 +522,7 @@ sub doWhileLoop() {
         p.setSandboxManager(sm);
 
         p.parse("
-%new-style
+%modern
 our int counter = 0;
 sub runLoop() {
     while (True) {
@@ -578,7 +575,7 @@ int sub getCounter() {
         p.setSandboxManager(sm);
 
         p.parse("
-%new-style
+%modern
 sub doSleep() {
     sleep(10);
 }
@@ -600,7 +597,7 @@ sub doSleep() {
         p2.setSandboxManager(sm2);
 
         p2.parse("
-%new-style
+%modern
 sub doUsleep() {
     usleep(10s);
 }
@@ -642,7 +639,7 @@ sub doUsleep() {
         p.setSandboxManager(sm);
 
         p.parse("
-%new-style
+%modern
 sub doLock() {
     Mutex m();
     m.lock();
@@ -668,7 +665,7 @@ sub doLock() {
         p.setSandboxManager(sm);
 
         p.parse("
-%new-style
+%modern
 sub doReadLock() {
     RWLock rwl();
     rwl.readLock();
@@ -707,7 +704,7 @@ sub doWriteLock() {
         p.setSandboxManager(sm);
 
         p.parse("
-%new-style
+%modern
 sub doAutoLock() {
     Mutex m();
     AutoLock al(m);
@@ -759,7 +756,7 @@ sub doAutoWriteLock() {
         p.setSandboxManager(sm);
 
         p.parse("
-%new-style
+%modern
 sub doQueueGet() {
     Queue q();
     q.get();
@@ -798,7 +795,7 @@ sub doQueuePop() {
         p.setSandboxManager(sm);
 
         p.parse("
-%new-style
+%modern
 sub doCounterWait() {
     Counter c(1);
     c.waitForZero();
@@ -824,7 +821,7 @@ sub doCounterWait() {
         p.setSandboxManager(sm);
 
         p.parse("
-%new-style
+%modern
 sub doConditionWait() {
     Mutex m();
     Condition cond();
@@ -852,7 +849,7 @@ sub doConditionWait() {
         p.setSandboxManager(sm);
 
         p.parse("
-%new-style
+%modern
 sub doGateEnter() {
     Gate g();
     g.enter();
@@ -940,7 +937,7 @@ sub doGateEnter() {
         p.setSandboxManager(sm);
 
         p.parse("
-%new-style
+%modern
 sub connectToLocalhost() {
     Socket s();
     s.connect('127.0.0.1:80', 1000);
@@ -966,7 +963,7 @@ sub connectToLocalhost() {
         p2.setSandboxManager(sm2);
 
         p2.parse("
-%new-style
+%modern
 sub connectToPublic() {
     Socket s();
     # This will likely fail to connect but should not be blocked by security
@@ -1008,7 +1005,7 @@ sub connectToPublic() {
         p.setSandboxManager(sm);
 
         p.parse("
-%new-style
+%modern
 sub doSleepTest(Queue resultQueue) {
     resultQueue.push('ready');
 
@@ -1051,7 +1048,7 @@ sub doSleepTest(Queue resultQueue) {
         p.setSandboxManager(sm);
 
         p.parse("
-%new-style
+%modern
 sub doQueueTest(Queue resultQueue) {
     Queue emptyQueue();
 
@@ -1097,7 +1094,7 @@ sub doQueueTest(Queue resultQueue) {
         p.setSandboxManager(sm);
 
         p.parse("
-%new-style
+%modern
 sub doCounterTest(Queue resultQueue) {
     Counter cnt(1);  # Will never reach zero without dec()
 
@@ -1143,7 +1140,7 @@ sub doCounterTest(Queue resultQueue) {
         p.setSandboxManager(sm);
 
         p.parse("
-%new-style
+%modern
 sub doConditionTest(Queue resultQueue) {
     Mutex mtx();
     Condition cond();
@@ -1196,9 +1193,7 @@ sub doConditionTest(Queue resultQueue) {
         p.setSandboxManager(sm);
 
         p.parse("
-%new-style
-%require-types
-%strict-args
+%modern
 
 # Simulates a blocking operation that would be cancelled by the callback
 sub blockingOperation(Queue q) {
@@ -1245,9 +1240,7 @@ sub blockingOperation(Queue q) {
         p.setSandboxManager(sm);
 
         p.parse("
-%new-style
-%require-types
-%strict-args
+%modern
 
 sub multipleBlockers(Queue q, int count) {
     Counter ready(count);
@@ -1312,9 +1305,7 @@ sub multipleBlockers(Queue q, int count) {
         p.setSandboxManager(sm);
 
         p.parse("
-%new-style
-%require-types
-%strict-args
+%modern
 
 # Perform multiple short operations - each would register/unregister a cancel callback
 sub shortOperations(Queue q, int count) {
@@ -1341,7 +1332,7 @@ sub shortOperations(Queue q, int count) {
         p2.setSandboxManager(sm);
 
         p2.parse("
-%new-style
+%modern
 sub blockAfterManyOps(Queue q) {
     q.push('ready');
     Queue blockingQ();
@@ -1384,9 +1375,7 @@ sub blockAfterManyOps(Queue q) {
             p.setSandboxManager(sm);
 
             p.parse("
-%new-style
-%require-types
-%strict-args
+%modern
 
 sub quickBlockingOp(Queue q) {
     q.push('started');
@@ -1430,7 +1419,7 @@ sub quickBlockingOp(Queue q) {
             p.setSandboxManager(sm);
 
             p.parse("
-%new-style
+%modern
 sub noOp() {}
             ", "rapid_noop");
 

--- a/examples/test/qore/stack/call-stack-overflow-exception.qtest
+++ b/examples/test/qore/stack/call-stack-overflow-exception.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/stack/exception-location.qtest
+++ b/examples/test/qore/stack/exception-location.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/Util.qm

--- a/examples/test/qore/stack/exception-location.qtest
+++ b/examples/test/qore/stack/exception-location.qtest
@@ -30,7 +30,7 @@ class ExceptionLocationTest inherits QUnit::Test {
             line = ex.line;
         }
 
-        assertEq(30, line);
+        assertEq(27, line);
 
         {
             Program p(PO_NEW_STYLE|PO_REQUIRE_TYPES|PO_STRICT_ARGS);

--- a/examples/test/qore/stack/get-call-stack.qtest
+++ b/examples/test/qore/stack/get-call-stack.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/statements/assert.qtest
+++ b/examples/test/qore/statements/assert.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 %enable-debug
 
@@ -326,8 +323,6 @@ class AssertDebugTest inherits QUnit::Test {
             File f();
             f.open2(modulefile, O_CREAT | O_WRONLY | O_TRUNC);
             f.write("%new-style
-%strict-args
-%require-types
 
 module TestDebugModule {
     version = \"1.0\";
@@ -379,8 +374,6 @@ printf(\"%%d\\n\", TestDebugModule::DebugTracker::testDebug());
             File f();
             f.open2(modulefile2, O_CREAT | O_WRONLY | O_TRUNC);
             f.write("%new-style
-%strict-args
-%require-types
 
 module TestDebugModule2 {
     version = \"1.0\";
@@ -425,8 +418,6 @@ printf(\"%%d\\n\", TestDebugModule2::DebugTracker::testDebug());
             File f();
             f.open2(modulefile3, O_CREAT | O_WRONLY | O_TRUNC);
             f.write("%new-style
-%strict-args
-%require-types
 
 module TestDebugModule3 {
     version = \"1.0\";

--- a/examples/test/qore/statements/foreach.qtest
+++ b/examples/test/qore/statements/foreach.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 %allow-weak-references
 

--- a/examples/test/qore/streams/binary-input.qtest
+++ b/examples/test/qore/streams/binary-input.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/streams/binary-output.qtest
+++ b/examples/test/qore/streams/binary-output.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/streams/buffered-stream-reader.qtest
+++ b/examples/test/qore/streams/buffered-stream-reader.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/streams/compression.qtest
+++ b/examples/test/qore/streams/compression.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/streams/encoding-input.qtest
+++ b/examples/test/qore/streams/encoding-input.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/streams/encoding-output.qtest
+++ b/examples/test/qore/streams/encoding-output.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/streams/encryption.qtest
+++ b/examples/test/qore/streams/encryption.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/streams/file.qtest
+++ b/examples/test/qore/streams/file.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/streams/pipe.qtest
+++ b/examples/test/qore/streams/pipe.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/streams/stream-reader.qtest
+++ b/examples/test/qore/streams/stream-reader.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/streams/stream-writer.qtest
+++ b/examples/test/qore/streams/stream-writer.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/streams/string-input.qtest
+++ b/examples/test/qore/streams/string-input.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/streams/string-output.qtest
+++ b/examples/test/qore/streams/string-output.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/threads/background.qtest
+++ b/examples/test/qore/threads/background.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/threads/deadlock.qtest
+++ b/examples/test/qore/threads/deadlock.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/threads/max-threads-count.qtest
+++ b/examples/test/qore/threads/max-threads-count.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/threads/set_thread_init.qtest
+++ b/examples/test/qore/threads/set_thread_init.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/threads/thread-object.qtest
+++ b/examples/test/qore/threads/thread-object.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %allow-weak-references
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/threads/thread-resources.qtest
+++ b/examples/test/qore/threads/thread-resources.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/threads/tld.qtest
+++ b/examples/test/qore/threads/tld.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/values/nan_boxing.qtest
+++ b/examples/test/qore/values/nan_boxing.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %disable-warning unreferenced-variable
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/vars/argv.qtest
+++ b/examples/test/qore/vars/argv.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/vars/bare-ref-test.qtest
+++ b/examples/test/qore/vars/bare-ref-test.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/vars/cast_to_int.qtest
+++ b/examples/test/qore/vars/cast_to_int.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/vars/closures.qtest
+++ b/examples/test/qore/vars/closures.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/vars/constant.qtest
+++ b/examples/test/qore/vars/constant.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/vars/date.qtest
+++ b/examples/test/qore/vars/date.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/vars/float.qtest
+++ b/examples/test/qore/vars/float.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/vars/getencoding.qtest
+++ b/examples/test/qore/vars/getencoding.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/vars/hash.qtest
+++ b/examples/test/qore/vars/hash.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/vars/hash_time.qtest
+++ b/examples/test/qore/vars/hash_time.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %disable-warning unreferenced-variable
 

--- a/examples/test/qore/vars/infnan.qtest
+++ b/examples/test/qore/vars/infnan.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %disable-warning unreferenced-variable
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/vars/int.qtest
+++ b/examples/test/qore/vars/int.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/Util.qm
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/vars/list.qtest
+++ b/examples/test/qore/vars/list.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/vars/members.qtest
+++ b/examples/test/qore/vars/members.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/vars/numbers.qtest
+++ b/examples/test/qore/vars/numbers.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/qore/vars/overload.qtest
+++ b/examples/test/qore/vars/overload.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/vars/reference.qtest
+++ b/examples/test/qore/vars/reference.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/vars/statement.qtest
+++ b/examples/test/qore/vars/statement.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 %requires ../../../../qlib/QUnit.qm

--- a/examples/test/qore/vars/string.qtest
+++ b/examples/test/qore/vars/string.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 %no-child-restrictions
 
 # tests are made where the return value is ignored

--- a/examples/test/qore/vars/type_narrowing.qtest
+++ b/examples/test/qore/vars/type_narrowing.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 
@@ -1054,7 +1051,6 @@ sub test() {
     autoNoNarrowingBasicTest() {
         # With auto!, the variable should not be narrowed (same as auto)
         string code = "%new-style
-%require-types
 sub test() {
     auto! h = {\"a\": 1};  # Initially a hash
     h = \"string value\";   # Works - pure auto doesn't narrow
@@ -1074,7 +1070,6 @@ sub test() {
         # auto! works the same as auto for pure auto type
         # Note: hash<auto> still narrows - the ! is for pure auto only
         string code = "%new-style
-%require-types
 sub test() {
     auto! data = {\"key\": \"value\"};
     data = 12345;  # Works - pure auto doesn't narrow
@@ -1088,7 +1083,6 @@ sub test() {
 
         # Note: pure auto (without !) also works - it doesn't narrow
         string code_also_works = "%new-style
-%require-types
 sub test() {
     auto data = {\"key\": \"value\"};
     data = 12345;  # Also works - pure auto doesn't narrow
@@ -1104,7 +1098,6 @@ sub test() {
     # auto! syntax is accepted for list initialization
     autoNoNarrowingListTest() {
         string code = "%new-style
-%require-types
 sub test() {
     auto! data = (1, 2, 3);
     data = \"now a string\";  # Works - pure auto doesn't narrow
@@ -1118,7 +1111,6 @@ sub test() {
 
         # Note: pure auto (without !) also works
         string code_also_works = "%new-style
-%require-types
 sub test() {
     auto data = (1, 2, 3);
     data = \"now a string\";  # Also works - pure auto doesn't narrow
@@ -1134,7 +1126,6 @@ sub test() {
     # auto! can be used as a function return type
     autoNoNarrowingFunctionTest() {
         string code = "%new-style
-%require-types
 auto! sub getFlexibleData() {
     auto! result = {\"initial\": \"hash\"};
     result = (1, 2, 3);
@@ -1157,7 +1148,6 @@ sub test() {
         # With hash<auto>, this would give PARSE-TYPE-ERROR
         # With hash<auto!>, parsing should succeed
         string code = "%new-style
-%require-types
 sub test() {
     hash<auto!> h = {\"x\": 1};  # creates hash<string, int> at runtime
     h.y = \"string\";  # With hash<auto> this is PARSE-TYPE-ERROR, with hash<auto!> parsing succeeds
@@ -1171,7 +1161,6 @@ sub test() {
 
         # Verify that hash<auto> (without !) still gives PARSE-TYPE-ERROR
         string code_narrowing = "%new-style
-%require-types
 sub test() {
     hash<auto> h = {\"x\": 1};
     h.y = \"string\";  # Should fail - type is narrowed to hash<string, int>
@@ -1184,7 +1173,6 @@ sub test() {
 
         # hash<auto!> whole hash reassignment should work at parse time
         string code_reassign = "%new-style
-%require-types
 sub test() {
     hash<auto!> h = {\"x\": 1};
     h = {\"y\": \"string\"};  # Should succeed - different hash value
@@ -1198,7 +1186,6 @@ sub test() {
 
         # *hash<auto!> or-nothing variant should also work
         string code_or_nothing = "%new-style
-%require-types
 sub test() {
     *hash<auto!> h = {\"x\": 1};
     h.y = \"string\";  # Should not give PARSE-TYPE-ERROR
@@ -1216,7 +1203,6 @@ sub test() {
         # With list<auto>, this would give PARSE-TYPE-ERROR
         # With list<auto!>, parsing should succeed
         string code = "%new-style
-%require-types
 sub test() {
     list<auto!> l = (1, 2, 3);  # creates list<int> at runtime
     l += \"string\";  # With list<auto> this is PARSE-TYPE-ERROR, with list<auto!> parsing succeeds
@@ -1230,7 +1216,6 @@ sub test() {
 
         # Verify that list<auto> (without !) still gives PARSE-TYPE-ERROR
         string code_narrowing = "%new-style
-%require-types
 sub test() {
     list<auto> l = (1, 2, 3);
     l += \"string\";  # Should fail - type is narrowed to list<int>
@@ -1243,7 +1228,6 @@ sub test() {
 
         # list<auto!> whole list reassignment should work at parse time
         string code_reassign = "%new-style
-%require-types
 sub test() {
     list<auto!> l = (1, 2, 3);
     l = (\"a\", \"b\", \"c\");  # Should succeed - different list value
@@ -1257,7 +1241,6 @@ sub test() {
 
         # *list<auto!> or-nothing variant should also work
         string code_or_nothing = "%new-style
-%require-types
 sub test() {
     *list<auto!> l = (1, 2, 3);
     l += \"string\";  # Should not give PARSE-TYPE-ERROR
@@ -1274,7 +1257,6 @@ sub test() {
     hashStringAutoNoNarrowTest() {
         # hash<string, auto!> should prevent parse-time narrowing
         string code = "%new-style
-%require-types
 sub test() {
     hash<string, auto!> h = {\"x\": 1};
     h.y = \"string\";  # Should not give PARSE-TYPE-ERROR
@@ -1288,7 +1270,6 @@ sub test() {
 
         # Verify hash<string, auto> (without !) still gives PARSE-TYPE-ERROR
         string code_narrowing = "%new-style
-%require-types
 sub test() {
     hash<string, auto> h = {\"x\": 1};
     h.y = \"string\";  # Should fail
@@ -1304,7 +1285,6 @@ sub test() {
     autoNoNarrowFunctionParamsTest() {
         # Function with hash<auto!> parameter should accept different hash types
         string code = "%new-style
-%require-types
 sub processData(hash<auto!> data) {
     # Can receive hashes with any value type
 }
@@ -1322,7 +1302,6 @@ sub test() {
 
         # Function with hash<auto!> return type
         string code_return = "%new-style
-%require-types
 hash<auto!> sub getFlexibleData(bool flag) {
     if (flag) {
         return {\"value\": 42};
@@ -1343,7 +1322,6 @@ sub test() {
 
         # list<auto!> parameter
         string code_list_param = "%new-style
-%require-types
 sub processList(list<auto!> data) {
     # Can receive lists with any element type
 }
@@ -1364,7 +1342,6 @@ sub test() {
     autoNoNarrowClassMemberTest() {
         # Class with hash<auto!> member - uses public { } block syntax
         string code = "%new-style
-%require-types
 class FlexibleContainer {
     public {
         hash<auto!> data;
@@ -1391,7 +1368,6 @@ class FlexibleContainer {
 
         # Class with list<auto!> member
         string code_list = "%new-style
-%require-types
 class ListContainer {
     public {
         list<auto!> items;
@@ -1414,7 +1390,6 @@ class ListContainer {
 
         # Private member with auto!
         string code_private = "%new-style
-%require-types
 class PrivateFlexible {
     private {
         hash<auto!> config;
@@ -1484,7 +1459,6 @@ sub test() {
     softlistAutoNoNarrowTest() {
         # softlist<auto!> should be accepted
         string code = "%new-style
-%require-types
 sub test() {
     softlist<auto!> sl = (1, 2, 3);
     sl = (\"a\", \"b\");  # Should not give PARSE-TYPE-ERROR
@@ -1498,7 +1472,6 @@ sub test() {
 
         # *softlist<auto!> or-nothing variant
         string code_or_nothing = "%new-style
-%require-types
 sub test() {
     *softlist<auto!> sl = (1, 2, 3);
     sl = (\"a\", \"b\");
@@ -1513,7 +1486,6 @@ sub test() {
 
         # softlist<auto!> in function parameter
         string code_param = "%new-style
-%require-types
 sub processSoftList(softlist<auto!> data) {
     # Can receive softlists with any element type
 }

--- a/examples/test/qore/vars/typecode.qtest
+++ b/examples/test/qore/vars/typecode.qtest
@@ -1,10 +1,7 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../../../qlib/QUnit.qm
 

--- a/examples/test/test.q
+++ b/examples/test/test.q
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 # allow child Program objects to have more liberal restrictions than the parent
 %no-child-restrictions

--- a/include/qore/QoreReflection.h
+++ b/include/qore/QoreReflection.h
@@ -3,7 +3,7 @@
 /*
     Qore Programming Language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -457,5 +457,37 @@ DLLEXPORT QoreValue qore_type_get_default_value(const QoreTypeInfo* ti);
 
 //! returns true if the types are compatible with inputs and outputs
 DLLEXPORT bool qore_type_is_input_output_compatible(const QoreTypeInfo* ti1, const QoreTypeInfo* ti2);
+
+//! returns true if the type is a typed code type (code<ReturnType(ParamTypes...)>)
+/** @since %Qore 2.1
+*/
+DLLEXPORT bool qore_type_is_typed_code(const QoreTypeInfo* ti);
+
+//! returns the return type of a typed code type, or nullptr if not a typed code type
+/** @since %Qore 2.1
+*/
+DLLEXPORT const QoreTypeInfo* qore_type_get_code_return_type(const QoreTypeInfo* ti);
+
+//! returns a pointer to the parameter types vector for a typed code type, or nullptr if not a typed code type
+/** @note this returns a pointer to internal storage; do not delete
+    @since %Qore 2.1
+*/
+DLLEXPORT const type_vec_t* qore_type_get_code_param_types(const QoreTypeInfo* ti);
+
+//! returns true if a typed code type accepts variable arguments
+/** @since %Qore 2.1
+*/
+DLLEXPORT bool qore_type_code_has_varargs(const QoreTypeInfo* ti);
+
+//! returns true if the type is a union type (union<T1, T2, ...>)
+/** @since %Qore 2.1
+*/
+DLLEXPORT bool qore_type_is_union(const QoreTypeInfo* ti);
+
+//! returns a new vector of member types for a union type, or nullptr if not a union type
+/** @note the caller owns the vector returned and must delete it
+    @since %Qore 2.1
+*/
+DLLEXPORT type_vec_t* qore_type_get_union_member_types(const QoreTypeInfo* ti);
 
 #endif

--- a/include/qore/Restrictions.h
+++ b/include/qore/Restrictions.h
@@ -139,6 +139,12 @@
 //! new Qore style: no more '$' and with assumed variable scope
 #define PO_NEW_STYLE                  (PO_ALLOW_BARE_REFS|PO_ASSUME_LOCAL)
 
+//! modern Qore style: new style + require types + strict args
+/** @note all warnings are also enabled with %modern; use the @ref modern "%modern" parse directive
+    @since %Qore 2.3
+*/
+#define PO_MODERN                     (PO_NEW_STYLE|PO_REQUIRE_TYPES|PO_STRICT_ARGS)
+
 //! mask of all options allowing for more freedom (instead of less)
 #define PO_POSITIVE_OPTIONS           (PO_NO_CHILD_PO_RESTRICTIONS|PO_ALLOW_INJECTION|PO_ALLOW_WEAK_REFERENCES \
     |PO_ALLOW_DEBUGGER|PO_ENABLE_DEBUG|PO_ALLOW_REPARSE)

--- a/include/qore/TypedHashDecl.h
+++ b/include/qore/TypedHashDecl.h
@@ -123,6 +123,15 @@ public:
     */
     DLLEXPORT bool inheritsFrom(const TypedHashDecl* parent) const;
 
+    //! Sets the parent hashdecl for system hashdecl inheritance
+    /** @param parent the parent hashdecl
+
+        @note This method is intended for use by system hashdecls only
+
+        @since %Qore 2.1
+    */
+    DLLEXPORT void setParent(const TypedHashDecl* parent);
+
 protected:
     //! deletes the object and frees all memory
     DLLEXPORT ~TypedHashDecl();

--- a/include/qore/intern/QoreTypeInfo.h
+++ b/include/qore/intern/QoreTypeInfo.h
@@ -616,6 +616,12 @@ public:
     */
     DLLLOCAL static const class QoreComplexCodeTypeInfo* getComplexCodeType(const QoreTypeInfo* ti);
 
+    //! Returns the union type info if this is a union type
+    /** @param ti the type to check
+        @return the QoreUnionTypeInfo pointer if this is a union type, nullptr otherwise
+    */
+    DLLLOCAL static const class QoreUnionTypeInfo* getUnionType(const QoreTypeInfo* ti);
+
     //! Checks if two typed callable types have compatible signatures
     /** This is used for additional type checking when assigning closures/call references
         to typed code variables. Standard variance rules apply:
@@ -4051,6 +4057,19 @@ public:
     //! Returns true if this is an or-nothing union type
     DLLLOCAL bool isOrNothing() const {
         return orNothing;
+    }
+
+    //! Returns the member types of this union
+    DLLLOCAL type_vec_t getMemberTypes() const {
+        type_vec_t result;
+        for (const auto& rt : return_vec) {
+            const QoreTypeInfo* ti = rt.spec.getBaseTypeInfo();
+            // Skip NOTHING type for or-nothing unions
+            if (ti && ti != nothingTypeInfo) {
+                result.push_back(ti);
+            }
+        }
+        return result;
     }
 
 protected:

--- a/include/qore/intern/QoreTypeInfo.h
+++ b/include/qore/intern/QoreTypeInfo.h
@@ -1135,8 +1135,31 @@ public:
         desc->sprintf("expects type '%s', but got ", tname.c_str());
         QoreTypeInfo::getNodeType(*desc, n);
         desc->concat(" instead");
+        // Add a hint about type narrowing for lvalue/key assignments when the expected type is a simple type
+        // that could have come from type narrowing of hash<auto>
+        if (!strcmp(arg_type, "lvalue") && isSimpleTypeNarrowed()) {
+            desc->concat("; this may be due to type narrowing from hash<auto>; to store values of "
+                "different types, use 'hash<auto!> h()' or 'hash h = cast<hash>({...})'");
+        }
         xsink->raiseException("RUNTIME-TYPE-ERROR", desc);
         return -1;
+    }
+
+    //! Returns true if this type looks like it could have come from type narrowing
+    /** Simple scalar types like int, string, float, etc. that appear in hash value positions
+        are likely to have come from type narrowing of hash<auto>.
+
+        @note We only check hard types (not soft types) since type narrowing typically produces
+        hard types. We don't include nothing/null since those represent absence of value rather
+        than narrowed types.
+
+        @since %Qore 2.1
+    */
+    DLLLOCAL bool isSimpleTypeNarrowed() const {
+        // Check if this is a simple type that could be the result of hash<auto> narrowing
+        return this == bigIntTypeInfo || this == stringTypeInfo || this == floatTypeInfo
+            || this == boolTypeInfo || this == dateTypeInfo || this == binaryTypeInfo
+            || this == numberTypeInfo;
     }
 
     DLLLOCAL void acceptInputIntern(ExceptionSink* xsink, const char* arg_type, bool obj, int param_num,

--- a/include/qore/intern/qore_program_private.h
+++ b/include/qore/intern/qore_program_private.h
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2025 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -1346,6 +1346,13 @@ public:
             return;
         }
         ON_BLOCK_EXIT(fclose, fp);
+
+        // check for .qr extension and auto-enable modern mode
+        size_t len = strlen(filename);
+        if (len > 3 && !strcmp(filename + len - 3, ".qr")) {
+            pwo.parse_options |= PO_MODERN;
+            pgm->setWarningMask(-1);
+        }
 
         setScriptPath(filename);
 

--- a/include/qore/intern/typed_hash_decl_private.h
+++ b/include/qore/intern/typed_hash_decl_private.h
@@ -290,6 +290,11 @@ public:
         return parentHashDecl;
     }
 
+    //! Sets the parent hashdecl directly (for system hashdecls)
+    DLLLOCAL void setParentHashDecl(const TypedHashDecl* parent) {
+        parentHashDecl = parent;
+    }
+
     //! Returns true if this hashdecl is a descendant of the given hashdecl
     DLLLOCAL bool isDescendantOf(const typed_hash_decl_private& ancestor) const {
         const typed_hash_decl_private* current = this;

--- a/lib/ParseOptionMap.cpp
+++ b/lib/ParseOptionMap.cpp
@@ -105,6 +105,8 @@ void ParseOptionMap::static_init() {
     DO_MAP("broken-varargs",           PO_BROKEN_VARARGS);
     DO_MAP("broken-list-range",        PO_BROKEN_LIST_RANGE);
     DO_MAP("enable-debug",             PO_ENABLE_DEBUG);
+    DO_MAP("new-style",                PO_NEW_STYLE);
+    DO_MAP("modern",                   PO_MODERN);
 
     // the following are not useful from the command-line
     //DO_MAP("no-user-constants",        PO_NO_INHERIT_USER_CONSTANTS);

--- a/lib/QoreReflection.cpp
+++ b/lib/QoreReflection.cpp
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -34,6 +34,7 @@
 #include "qore/intern/Function.h"
 #include "qore/intern/ConstantList.h"
 #include "qore/intern/QoreNamespaceIntern.h"
+#include "qore/intern/QoreTypeInfo.h"
 
 const char* get_access_string(ClassAccess access) {
     switch (access) {
@@ -117,6 +118,37 @@ bool qore_type_has_default_value(const QoreTypeInfo* ti) {
 
 QoreValue qore_type_get_default_value(const QoreTypeInfo* ti) {
     return QoreTypeInfo::getDefaultQoreValue(ti);
+}
+
+bool qore_type_is_typed_code(const QoreTypeInfo* ti) {
+    return QoreTypeInfo::getComplexCodeType(ti) != nullptr;
+}
+
+const QoreTypeInfo* qore_type_get_code_return_type(const QoreTypeInfo* ti) {
+    const QoreComplexCodeTypeInfo* code_type = QoreTypeInfo::getComplexCodeType(ti);
+    return code_type ? code_type->getReturnType() : nullptr;
+}
+
+const type_vec_t* qore_type_get_code_param_types(const QoreTypeInfo* ti) {
+    const QoreComplexCodeTypeInfo* code_type = QoreTypeInfo::getComplexCodeType(ti);
+    return code_type ? &code_type->getParamTypes() : nullptr;
+}
+
+bool qore_type_code_has_varargs(const QoreTypeInfo* ti) {
+    const QoreComplexCodeTypeInfo* code_type = QoreTypeInfo::getComplexCodeType(ti);
+    return code_type && code_type->hasVarArgs();
+}
+
+bool qore_type_is_union(const QoreTypeInfo* ti) {
+    return QoreTypeInfo::getUnionType(ti) != nullptr;
+}
+
+type_vec_t* qore_type_get_union_member_types(const QoreTypeInfo* ti) {
+    const QoreUnionTypeInfo* union_type = QoreTypeInfo::getUnionType(ti);
+    if (!union_type) {
+        return nullptr;
+    }
+    return new type_vec_t(union_type->getMemberTypes());
 }
 
 const QoreClass* QoreExternalVariant::getClass() const {

--- a/lib/QoreTypeInfo.cpp
+++ b/lib/QoreTypeInfo.cpp
@@ -1137,6 +1137,14 @@ const QoreComplexCodeTypeInfo* QoreTypeInfo::getComplexCodeType(const QoreTypeIn
     return dynamic_cast<const QoreComplexCodeTypeInfo*>(ti);
 }
 
+const QoreUnionTypeInfo* QoreTypeInfo::getUnionType(const QoreTypeInfo* ti) {
+    if (!ti || !hasType(ti)) {
+        return nullptr;
+    }
+    // Check if the type is a QoreUnionTypeInfo by attempting a dynamic_cast
+    return dynamic_cast<const QoreUnionTypeInfo*>(ti);
+}
+
 bool QoreTypeInfo::checkComplexCodeCompatibility(const QoreTypeInfo* target, const QoreTypeInfo* source) {
     // Get complex code types
     const QoreComplexCodeTypeInfo* target_code = getComplexCodeType(target);
@@ -2527,6 +2535,121 @@ const QoreTypeInfo* QoreParseTypeInfo::resolveRuntimeSubtype() const {
 
         return qore_get_union_type(member_types, or_nothing);
     }
+    if (!strcmp(cscope->ostr, "code")) {
+        // Parse typed callable: code<ReturnType(ParamType1, ParamType2, ...)>
+        // Expected format: subtypes[0] contains "ReturnType(ParamType1, ParamType2, ...)"
+        // NOTE: Similar parsing logic exists in resolveSubtype() for parse-time resolution with error messages
+        if (subtypes.size() != 1) {
+            return nullptr;
+        }
+
+        const char* sig_str = subtypes[0]->cscope->ostr;
+
+        // Find the opening parenthesis to split return type from params
+        // Handle complex return types like hash<string, int> by tracking angle bracket depth
+        const char* paren_open = nullptr;
+        int angle_depth = 0;
+        for (const char* p = sig_str; *p; ++p) {
+            if (*p == '<') {
+                ++angle_depth;
+            } else if (*p == '>') {
+                --angle_depth;
+            } else if (*p == '(' && angle_depth == 0) {
+                paren_open = p;
+                break;
+            }
+        }
+        if (!paren_open) {
+            return nullptr;
+        }
+
+        // Find closing parenthesis
+        const char* paren_close = strrchr(sig_str, ')');
+        if (!paren_close || paren_close < paren_open) {
+            return nullptr;
+        }
+
+        // Extract return type string
+        std::string return_type_str(sig_str, paren_open - sig_str);
+        // Trim whitespace
+        while (!return_type_str.empty() && isspace(return_type_str.back())) {
+            return_type_str.pop_back();
+        }
+        while (!return_type_str.empty() && isspace(return_type_str.front())) {
+            return_type_str.erase(0, 1);
+        }
+
+        // Resolve return type
+        const QoreTypeInfo* returnType = nullptr;
+        if (!return_type_str.empty() && return_type_str != "nothing") {
+            returnType = qore_get_type_from_string_intern(return_type_str.c_str());
+            if (!returnType) {
+                return nullptr;
+            }
+        }
+        // If empty or "nothing", returnType stays nullptr (means nothing return)
+
+        // Extract parameter types string
+        std::string params_str(paren_open + 1, paren_close - paren_open - 1);
+
+        // Check for varargs
+        bool has_varargs = false;
+        size_t dotdotdot_pos = params_str.rfind("...");
+        if (dotdotdot_pos != std::string::npos) {
+            has_varargs = true;
+            // Remove "..." from params_str
+            params_str = params_str.substr(0, dotdotdot_pos);
+            // Trim trailing comma and whitespace
+            while (!params_str.empty() && (isspace(params_str.back()) || params_str.back() == ',')) {
+                params_str.pop_back();
+            }
+        }
+
+        // Parse parameter types
+        type_vec_t param_types;
+        if (!params_str.empty()) {
+            // Split on commas, handling nested angle brackets and parentheses
+            std::string current_param;
+            int param_angle_depth = 0;
+            int param_paren_depth = 0;
+            for (size_t i = 0; i <= params_str.size(); ++i) {
+                char c = i < params_str.size() ? params_str[i] : '\0';
+                if (c == '<') {
+                    ++param_angle_depth;
+                    current_param += c;
+                } else if (c == '>') {
+                    --param_angle_depth;
+                    current_param += c;
+                } else if (c == '(') {
+                    ++param_paren_depth;
+                    current_param += c;
+                } else if (c == ')') {
+                    --param_paren_depth;
+                    current_param += c;
+                } else if ((c == ',' || c == '\0') && param_angle_depth == 0 && param_paren_depth == 0) {
+                    // Trim whitespace from current_param
+                    while (!current_param.empty() && isspace(current_param.back())) {
+                        current_param.pop_back();
+                    }
+                    while (!current_param.empty() && isspace(current_param.front())) {
+                        current_param.erase(0, 1);
+                    }
+                    if (!current_param.empty()) {
+                        const QoreTypeInfo* param_type = qore_get_type_from_string_intern(current_param.c_str());
+                        if (!param_type) {
+                            return nullptr;
+                        }
+                        param_types.push_back(param_type);
+                    }
+                    current_param.clear();
+                } else {
+                    current_param += c;
+                }
+            }
+        }
+
+        return qore_get_complex_code_type(returnType, param_types, has_varargs, or_nothing);
+    }
     return nullptr;
 }
 
@@ -2749,6 +2872,7 @@ const QoreTypeInfo* QoreParseTypeInfo::resolveSubtype(const QoreProgramLocation*
     if (!strcmp(cscope->ostr, "code")) {
         // Parse typed callable: code<ReturnType(ParamType1, ParamType2, ...)>
         // Expected format: subtypes[0] contains "ReturnType(ParamType1, ParamType2, ...)"
+        // NOTE: Similar parsing logic exists in resolveRuntimeSubtype() for runtime resolution without error messages
         if (subtypes.size() != 1) {
             parseException(*loc, "PARSE-TYPE-ERROR", "cannot resolve '%s'; 'code' type takes a single callable " \
                 "signature specification in the form 'ReturnType(ParamTypes...)'", getName());

--- a/lib/TypedHashDecl.cpp
+++ b/lib/TypedHashDecl.cpp
@@ -618,6 +618,10 @@ bool TypedHashDecl::inheritsFrom(const TypedHashDecl* parent) const {
     return priv->isDescendantOf(*typed_hash_decl_private::get(*parent));
 }
 
+void TypedHashDecl::setParent(const TypedHashDecl* parent) {
+    priv->setParentHashDecl(parent);
+}
+
 TypedHashDeclHolder::~TypedHashDeclHolder() {
     if (thd) {
         typed_hash_decl_private::get(*thd)->deref();

--- a/lib/qpp.cpp
+++ b/lib/qpp.cpp
@@ -6,7 +6,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -1282,6 +1282,42 @@ static void get_string_list2(strlist_t& l, const std::string& str, char separato
     //   printf("DBG: list %u/%lu: %s\n", i, l.size(), l[i].c_str());
 }
 
+// Parse comma-separated subtypes while respecting nested angle brackets and parentheses
+static void parseSubtypes(const std::string& str, std::vector<std::string>& subtypes) {
+    int bracket_depth = 0;
+    int paren_depth = 0;
+    std::string current;
+
+    for (size_t i = 0; i < str.size(); ++i) {
+        char c = str[i];
+        if (c == '<') {
+            ++bracket_depth;
+            current += c;
+        } else if (c == '>') {
+            --bracket_depth;
+            current += c;
+        } else if (c == '(') {
+            ++paren_depth;
+            current += c;
+        } else if (c == ')') {
+            --paren_depth;
+            current += c;
+        } else if (c == ',' && bracket_depth == 0 && paren_depth == 0) {
+            trim(current);
+            if (!current.empty()) {
+                subtypes.push_back(current);
+                current.clear();
+            }
+        } else {
+            current += c;
+        }
+    }
+    trim(current);
+    if (!current.empty()) {
+        subtypes.push_back(current);
+    }
+}
+
 static int get_qore_type(const std::string& qt, std::string& cppt) {
     if (qt.empty()) {
         cppt = "nothingTypeInfo";
@@ -1391,6 +1427,122 @@ static int get_qore_type(const std::string& qt, std::string& cppt) {
             else
                 qc = "qore_get_complex_reference_type(" + subtype_qt + ")";
             log(LL_DEBUG, "registering complex reference return type '%s': '%s'\n", qt.c_str(), qc.c_str());
+        } else if (!qt.compare(on ? 1 : 0, 6, "union<")) {
+            // extract subtypes: union<type1, type2, ...>
+            std::string subtypes_str = qt.substr((on ? 7 : 6), qt.size() - (on ? 8 : 7));
+
+            std::vector<std::string> subtypes;
+            parseSubtypes(subtypes_str, subtypes);
+
+            if (subtypes.size() < 2) {
+                log(LL_CRITICAL, "union type requires at least 2 member types: '%s'\n", qt.c_str());
+                assert(false);
+            }
+
+            // Generate type_vec_t initialization
+            std::string type_vec = "type_vec_t{";
+            for (size_t j = 0; j < subtypes.size(); ++j) {
+                std::string subtype_qt;
+                get_qore_type(subtypes[j], subtype_qt);
+                if (j > 0) {
+                    type_vec += ", ";
+                }
+                type_vec += subtype_qt;
+            }
+            type_vec += "}";
+
+            if (on) {
+                qc = "qore_get_union_or_nothing_type(" + type_vec + ")";
+            } else {
+                qc = "qore_get_union_type(" + type_vec + ")";
+            }
+            log(LL_DEBUG, "registering union return type '%s': '%s'\n", qt.c_str(), qc.c_str());
+        } else if (!qt.compare(on ? 1 : 0, 5, "code<")) {
+            // extract signature: code<ReturnType(ParamTypes...)>
+            std::string sig = qt.substr((on ? 6 : 5), qt.size() - (on ? 7 : 6));
+
+            // Find opening paren for params (handle nested types in return type)
+            int bracket_depth = 0;
+            size_t paren_pos = std::string::npos;
+            for (size_t j = 0; j < sig.size(); ++j) {
+                if (sig[j] == '<') {
+                    ++bracket_depth;
+                } else if (sig[j] == '>') {
+                    --bracket_depth;
+                } else if (sig[j] == '(' && bracket_depth == 0) {
+                    paren_pos = j;
+                    break;
+                }
+            }
+
+            if (paren_pos == std::string::npos) {
+                log(LL_CRITICAL, "invalid code type '%s': missing '('\n", qt.c_str());
+                assert(false);
+            }
+
+            // Extract return type and param types
+            std::string ret_type = sig.substr(0, paren_pos);
+            trim(ret_type);
+            std::string params_str = sig.substr(paren_pos + 1, sig.size() - paren_pos - 2);
+            trim(params_str);
+
+            // Check for varargs
+            bool has_varargs = false;
+            if (params_str.size() >= 3 && params_str.substr(params_str.size() - 3) == "...") {
+                has_varargs = true;
+                params_str = params_str.substr(0, params_str.size() - 3);
+                trim(params_str);
+                if (!params_str.empty() && params_str.back() == ',') {
+                    params_str.pop_back();
+                    trim(params_str);
+                }
+            }
+
+            // Get return type
+            std::string ret_type_qt;
+            if (ret_type.empty() || ret_type == "nothing") {
+                ret_type_qt = "nothingTypeInfo";
+            } else {
+                get_qore_type(ret_type, ret_type_qt);
+            }
+
+            // Parse param types
+            std::string params_vec = "type_vec_t{";
+            if (!params_str.empty()) {
+                std::vector<std::string> param_types;
+                parseSubtypes(params_str, param_types);
+                for (size_t j = 0; j < param_types.size(); ++j) {
+                    std::string param_qt;
+                    get_qore_type(param_types[j], param_qt);
+                    if (j > 0) {
+                        params_vec += ", ";
+                    }
+                    params_vec += param_qt;
+                }
+            }
+            params_vec += "}";
+
+            if (on) {
+                qc = "qore_get_complex_code_or_nothing_type(" + ret_type_qt + ", " + params_vec +
+                     ", " + (has_varargs ? "true" : "false") + ")";
+            } else {
+                qc = "qore_get_complex_code_type(" + ret_type_qt + ", " + params_vec +
+                     ", " + (has_varargs ? "true" : "false") + ")";
+            }
+            log(LL_DEBUG, "registering code return type '%s': '%s'\n", qt.c_str(), qc.c_str());
+        } else if (!qt.compare(on ? 1 : 0, 5, "enum<")) {
+            // extract enum name: enum<EnumName> or enum<Ns::EnumName>
+            std::string enum_name = qt.substr((on ? 6 : 5), qt.size() - (on ? 7 : 6));
+
+            // Handle namespaced enums (Ns::EnumName -> EnumName for variable name)
+            std::string var_name = enum_name;
+            size_t j = var_name.rfind(':');
+            if (j != std::string::npos) {
+                var_name.erase(0, j + 1);
+            }
+
+            qc = "enum" + var_name + "->getTypeInfo(" + (on ? "true" : "false") + ")";
+            log(LL_DEBUG, "registering enum return type '%s': '%s'\n", qt.c_str(), qc.c_str());
         } else {
             // assume a Qore object of the given class
             get_type_name(qc, qt);
@@ -3524,6 +3676,22 @@ public:
         while (whitespace(*p1))
             ++p1;
 
+        // Check for inheritance: hashdecl Child : Parent { ... }
+        if (*p1 == ':') {
+            ++p1;
+            while (whitespace(*p1))
+                ++p1;
+
+            const char* parent_start = p1;
+            while (*p1 && (idnschar(*p1) || *p1 == ':'))
+                ++p1;
+
+            parent_name.assign(parent_start, p1 - parent_start);
+
+            while (whitespace(*p1))
+                ++p1;
+        }
+
         if (*p1 != '{') {
             error("%s:%d: missing open bracket '{' after the hashdecl name\n", fileName, lineNumber);
             valid = false;
@@ -3634,6 +3802,16 @@ public:
         fprintf(fp, "TypedHashDecl* init_hashdecl_%s(QoreNamespace& ns) {\n", name.c_str());
         fprintf(fp, "    TypedHashDecl* hd = new TypedHashDecl(\"%s\", \"%s\");\n", name.c_str(), ns_path.c_str());
 
+        // Set parent hashdecl if there is inheritance
+        if (!parent_name.empty()) {
+            std::string parent_var = parent_name;
+            size_t i = parent_var.rfind(':');
+            if (i != std::string::npos) {
+                parent_var.erase(0, i + 1);
+            }
+            fprintf(fp, "    hd->setParent(hashdecl%s);\n", parent_var.c_str());
+        }
+
         // get type name to substitute references to self if necessary
         std::string tname = "hashdecl" + name;
         for (auto& i : hdmap) {
@@ -3655,7 +3833,11 @@ public:
         // serialize hashdecl doc
         process_comment(comment);
         fprintf(fp, "%s", comment.c_str());
-        fprintf(fp, "struct %s {\n", name.c_str());
+        if (!parent_name.empty()) {
+            fprintf(fp, "struct %s : %s {\n", name.c_str(), parent_name.c_str());
+        } else {
+            fprintf(fp, "struct %s {\n", name.c_str());
+        }
         for (auto& i : hdmap)
             if (i.second.serializeDox(fp, i.first.c_str()))
                 return -1;
@@ -3683,6 +3865,7 @@ public:
 protected:
     std::string comment;
     std::string name;
+    std::string parent_name;  // parent hashdecl name for inheritance
     typedef std::map<std::string, HashDeclInfo> hdmap_t;
     hdmap_t hdmap;
     bool valid = true;
@@ -3763,6 +3946,297 @@ protected:
 
             exp = line;
         }
+        return 0;
+    }
+};
+
+struct EnumMemberInfo {
+    std::string comment;
+    std::string value;           // explicit value (may be empty for auto-increment)
+    std::string computed_value;  // computed value (set during parsing for auto-increment)
+
+    EnumMemberInfo(std::string&& c, std::string&& v, std::string&& cv)
+        : comment(std::move(c)), value(std::move(v)), computed_value(std::move(cv)) {}
+
+    int serializeCpp(FILE* fp, const char* n) const {
+        // Use computed_value which handles auto-increment
+        fprintf(fp, "    ed->addMember(\"%s\", %s);\n", n, computed_value.c_str());
+        return 0;
+    }
+
+    int serializeDox(FILE* fp, const char* n) const {
+        if (!comment.empty()) {
+            std::string c = comment;
+            process_comment(c);
+            fprintf(fp, "%s", c.c_str());
+        }
+        fprintf(fp, "    %s", n);
+        // Show explicit value in docs if provided
+        if (!value.empty()) {
+            fprintf(fp, " = %s", value.c_str());
+        }
+        fprintf(fp, ",\n");
+        return 0;
+    }
+};
+
+class Enum : public AbstractElement, protected NamespaceElement {
+public:
+    Enum(std::string&& c, std::string& str, FILE* fp, const char* fileName, unsigned& lineNumber)
+        : comment(std::move(c)), baseType("int") {
+        const char* p = str.c_str();
+        while (*p && *p == ' ') {
+            ++p;
+        }
+
+        // Extract enum name
+        const char* p1 = p;
+        while (*p1 && idnschar(*p1)) {
+            ++p1;
+        }
+
+        if (p1 == p) {
+            error("%s:%d: missing enum name\n", fileName, lineNumber);
+            valid = false;
+            return;
+        }
+
+        name.assign(p, p1 - p);
+
+        // Handle namespace prefix
+        {
+            size_t i = name.rfind(':');
+            if (i != std::string::npos) {
+                ns = name.substr(0, i - 1);
+                name.erase(0, i + 1);
+            }
+        }
+
+        while (whitespace(*p1)) {
+            ++p1;
+        }
+
+        // Check for optional base type
+        if (*p1 == ':') {
+            ++p1;
+            while (whitespace(*p1)) {
+                ++p1;
+            }
+
+            const char* type_start = p1;
+            while (*p1 && idchar(*p1)) {
+                ++p1;
+            }
+
+            baseType.assign(type_start, p1 - type_start);
+
+            // Validate base type
+            if (baseType != "int" && baseType != "string" && baseType != "float" && baseType != "number") {
+                error("%s:%d: invalid enum base type '%s'; must be int, string, float, or number\n",
+                      fileName, lineNumber, baseType.c_str());
+                valid = false;
+                return;
+            }
+
+            while (whitespace(*p1)) {
+                ++p1;
+            }
+        }
+
+        if (*p1 != '{') {
+            error("%s:%d: missing '{' after enum declaration\n", fileName, lineNumber);
+            valid = false;
+            return;
+        }
+
+        if (parseMembers(fp, fileName, lineNumber)) {
+            valid = false;
+        }
+    }
+
+    virtual int serializeCpp(FILE* fp) override {
+        std::string ns_path;
+        if (ns.empty()) {
+            ns_path = "::Qore::" + name;
+        } else {
+            ns_path = (ns[0] == ':') ? ns : ("::" + ns);
+            ns_path += "::" + name;
+        }
+
+        // Map base type to C++ type info
+        std::string base_type_info;
+        if (baseType == "int") {
+            base_type_info = "bigIntTypeInfo";
+        } else if (baseType == "string") {
+            base_type_info = "stringTypeInfo";
+        } else if (baseType == "float") {
+            base_type_info = "floatTypeInfo";
+        } else if (baseType == "number") {
+            base_type_info = "numberTypeInfo";
+        }
+
+        fprintf(fp, "QoreEnumDecl* init_enum_%s(QoreNamespace& ns) {\n", name.c_str());
+        fprintf(fp, "    QoreEnumDecl* ed = new QoreEnumDecl(\"%s\", \"%s\", %s);\n",
+                name.c_str(), ns_path.c_str(), base_type_info.c_str());
+
+        for (auto& m : members) {
+            m.second.serializeCpp(fp, m.first.c_str());
+        }
+
+        fprintf(fp, "    ns.addSystemEnum(ed);\n    return ed;\n}\n\n");
+        return 0;
+    }
+
+    virtual int serializeDox(FILE* fp) override {
+        if (ns.empty()) {
+            fputs("\n//! main Qore-language namespace\nnamespace Qore {\n", fp);
+        } else {
+            outputNamespaceStart(fp);
+        }
+
+        // serialize enum doc
+        process_comment(comment);
+        fprintf(fp, "%s", comment.c_str());
+
+        if (baseType == "int") {
+            fprintf(fp, "enum %s {\n", name.c_str());
+        } else {
+            fprintf(fp, "enum %s : %s {\n", name.c_str(), baseType.c_str());
+        }
+
+        for (auto& m : members) {
+            m.second.serializeDox(fp, m.first.c_str());
+        }
+
+        fputs("};\n", fp);
+        outputNamespaceEnd(fp);
+        return 0;
+    }
+
+    virtual int serializeUnitTest(FILE* fp) override {
+        return 0;
+    }
+
+    virtual int serializeJavadoc() override {
+        return 0;
+    }
+
+    virtual strlist_t precalculateUnitTest() override {
+        return strlist_t();
+    }
+
+    operator bool() const {
+        return valid;
+    }
+
+protected:
+    std::string comment;
+    std::string name;
+    std::string baseType;  // "int" (default), "string", "float", "number"
+    std::vector<std::pair<std::string, EnumMemberInfo>> members;
+    bool valid = true;
+
+    int parseMembers(FILE* fp, const char* fileName, unsigned& lineNumber) {
+        int64_t next_int_value = 0;  // for auto-increment
+
+        while (true) {
+            std::string line;
+            if (read_line(lineNumber, line, fp)) {
+                error("%s:%d: premature EOF reading enum\n", fileName, lineNumber);
+                return -1;
+            }
+
+            trim(line);
+
+            // Skip empty lines
+            if (line.empty()) {
+                continue;
+            }
+
+            // End of enum
+            if (line == "}" || line == "};") {
+                break;
+            }
+
+            // Handle documentation comment
+            std::string cdoc;
+            if (!line.compare(0, 3, "//!")) {
+                cdoc = line;
+                line.clear();
+                if (read_line(lineNumber, line, fp)) {
+                    error("%s:%d: premature EOF reading enum\n", fileName, lineNumber);
+                    return -1;
+                }
+                trim(line);
+            }
+
+            // Parse: IDENTIFIER [= expression] [,]
+            const char* p = line.c_str();
+
+            // Get member name
+            const char* p1 = p;
+            while (*p1 && idchar(*p1)) {
+                ++p1;
+            }
+
+            if (p1 == p) {
+                error("%s:%d: expected enum member name\n", fileName, lineNumber);
+                return -1;
+            }
+
+            std::string member_name(p, p1 - p);
+            p = p1;
+
+            while (whitespace(*p)) {
+                ++p;
+            }
+
+            // Check for explicit value
+            std::string explicit_value;
+            std::string computed_value;
+
+            if (*p == '=') {
+                ++p;
+                while (whitespace(*p)) {
+                    ++p;
+                }
+
+                // Read value until comma or end
+                const char* val_start = p;
+                while (*p && *p != ',' && *p != '\n') {
+                    ++p;
+                }
+                explicit_value.assign(val_start, p);
+                trim(explicit_value);
+
+                // For int base type, try to parse for next auto-increment
+                if (baseType == "int") {
+                    try {
+                        next_int_value = std::stoll(explicit_value) + 1;
+                    } catch (...) {
+                        // Non-integer expression, just use as-is
+                    }
+                }
+                computed_value = explicit_value;
+            } else {
+                // Auto-increment (only for numeric types)
+                if (baseType == "string") {
+                    error("%s:%d: string enum members require explicit values\n", fileName, lineNumber);
+                    return -1;
+                }
+                computed_value = std::to_string(next_int_value);
+                next_int_value++;
+            }
+
+            members.push_back({member_name, EnumMemberInfo(std::move(cdoc),
+                              std::move(explicit_value), std::move(computed_value))});
+
+            // Skip trailing comma
+            while (*p == ',' || whitespace(*p)) {
+                ++p;
+            }
+        }
+
         return 0;
     }
 };
@@ -4916,6 +5390,13 @@ protected:
                     sc.erase(0, 9);
                     checkBuf(buf);
                     source.push_back(new HashDecl(std::move(str), sc, fp, fileName, lineNumber));
+                    continue;
+                }
+
+                if (!sc.compare(0, 5, "enum ")) {
+                    sc.erase(0, 5);
+                    checkBuf(buf);
+                    source.push_back(new Enum(std::move(str), sc, fp, fileName, lineNumber));
                     continue;
                 }
 

--- a/lib/scanner.lpp
+++ b/lib/scanner.lpp
@@ -989,6 +989,10 @@ RTIME           PT(-?[0-9]+(\.[0-9]+)?[HMSu])+
 ^%assume-global{WS}*$                   parse_disable_parse_options(yylloc, PO_ASSUME_LOCAL);
 ^%new-style{WS}*$                       parse_set_parse_options(yylloc, PO_NEW_STYLE);
 ^%old-style{WS}*$                       parse_disable_parse_options(yylloc, PO_NEW_STYLE);
+^%modern{WS}*$                          {
+                                           parse_set_parse_options(yylloc, PO_MODERN);
+                                           getProgram()->setWarningMask(-1);
+                                        }
 ^%perl-bool-eval{WS}*$                  parse_disable_parse_options(yylloc, PO_STRICT_BOOLEAN_EVAL);
 ^%strict-bool-eval{WS}*$                parse_set_parse_options(yylloc, PO_STRICT_BOOLEAN_EVAL);
 ^%strong-encapsulation{WS}*$            parse_set_parse_options(yylloc, PO_STRONG_ENCAPSULATION);

--- a/modules/reflection/src/QC_Type.qpp
+++ b/modules/reflection/src/QC_Type.qpp
@@ -3,7 +3,7 @@
 /*
     Qore Programming Language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -32,6 +32,8 @@
 #include "QC_Type.h"
 #include "QC_TypedHash.h"
 #include "QC_AbstractReflectionFunction.h"
+
+#include <memory>
 
 QoreObject* get_type_object(const QoreTypeInfo* t) {
     return new QoreObject(QC_TYPE, getProgram(), new QoreType(t));
@@ -767,6 +769,110 @@ bool b = type.isTypedHash();
 */
 bool Type::isTypedHash() [flags=CONSTANT] {
     return typeInfoGetTypedHash(t->typeInfo) ? true : false;
+}
+
+//! Returns @ref Qore::True "True" if the type is a typed code type (code<ReturnType(ParamTypes...)>)
+/** @par Example:
+    @code{.py}
+bool b = type.isTypedCode();
+    @endcode
+
+    @return @ref Qore::True "True" if the type is a typed code type, @ref Qore::False "False" if not
+
+    @since %Qore 2.1
+*/
+bool Type::isTypedCode() [flags=CONSTANT] {
+    return qore_type_is_typed_code(t->typeInfo);
+}
+
+//! Returns the return type for typed code types, or @ref nothing if not a typed code type
+/** @par Example:
+    @code{.py}
+*Type returnType = type.getCodeReturnType();
+    @endcode
+
+    @return the return type for typed code types, or @ref nothing if not a typed code type
+
+    @since %Qore 2.1
+*/
+*Type Type::getCodeReturnType() [flags=CONSTANT] {
+    const QoreTypeInfo* rt = qore_type_get_code_return_type(t->typeInfo);
+    if (!rt) {
+        return QoreValue();
+    }
+    return new QoreObject(QC_TYPE, getProgram(), new QoreType(rt));
+}
+
+//! Returns a list of parameter types for typed code types, or @ref nothing if not a typed code type
+/** @par Example:
+    @code{.py}
+*list<Type> params = type.getCodeParamTypes();
+    @endcode
+
+    @return a list of parameter types for typed code types, or @ref nothing if not a typed code type
+
+    @since %Qore 2.1
+*/
+*list<Type> Type::getCodeParamTypes() [flags=CONSTANT] {
+    const type_vec_t* params = qore_type_get_code_param_types(t->typeInfo);
+    if (!params) {
+        return QoreValue();
+    }
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(QC_TYPE->getTypeInfo()), xsink);
+    for (const QoreTypeInfo* ti : *params) {
+        rv->push(new QoreObject(QC_TYPE, getProgram(), new QoreType(ti)), xsink);
+    }
+    return rv.release();
+}
+
+//! Returns @ref Qore::True "True" if the typed code type accepts variable arguments
+/** @par Example:
+    @code{.py}
+bool b = type.codeHasVarargs();
+    @endcode
+
+    @return @ref Qore::True "True" if the typed code type accepts variable arguments, @ref Qore::False "False" if not or if not a typed code type
+
+    @since %Qore 2.1
+*/
+bool Type::codeHasVarargs() [flags=CONSTANT] {
+    return qore_type_code_has_varargs(t->typeInfo);
+}
+
+//! Returns @ref Qore::True "True" if the type is a union type (union<T1, T2, ...>)
+/** @par Example:
+    @code{.py}
+bool b = type.isUnion();
+    @endcode
+
+    @return @ref Qore::True "True" if the type is a union type, @ref Qore::False "False" if not
+
+    @since %Qore 2.1
+*/
+bool Type::isUnion() [flags=CONSTANT] {
+    return qore_type_is_union(t->typeInfo);
+}
+
+//! Returns a list of member types for union types, or @ref nothing if not a union type
+/** @par Example:
+    @code{.py}
+*list<Type> members = type.getUnionMemberTypes();
+    @endcode
+
+    @return a list of member types for union types, or @ref nothing if not a union type
+
+    @since %Qore 2.1
+*/
+*list<Type> Type::getUnionMemberTypes() [flags=CONSTANT] {
+    std::unique_ptr<type_vec_t> members(qore_type_get_union_member_types(t->typeInfo));
+    if (!members) {
+        return QoreValue();
+    }
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(QC_TYPE->getTypeInfo()), xsink);
+    for (const QoreTypeInfo* ti : *members) {
+        rv->push(new QoreObject(QC_TYPE, getProgram(), new QoreType(ti)), xsink);
+    }
+    return rv.release();
 }
 
 //! Returns @ref Qore::True "True" if the type is not a wildcard type; i.e. has type restrictions

--- a/qlib/AsyncApi.qm
+++ b/qlib/AsyncApi.qm
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 # make sure we have the required qore version
 %requires qore >= 2.3
@@ -91,10 +88,7 @@ module AsyncApi {
 
     @par Generic Example
     @code{.py}
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires AsyncApi
 
@@ -120,10 +114,7 @@ schema.validateIncomingMessage("myChannel", \received_msg, headers);
 
     @par WebSocket Client Example
     @code{.py}
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires AsyncApi
 %requires WebSocketClient

--- a/qlib/AsyncApiDataProvider/AsyncApiDataProvider.qm
+++ b/qlib/AsyncApiDataProvider/AsyncApiDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.3
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 # allow the use of the weak reference assignment operator: ':='
 %allow-weak-references
 

--- a/qlib/AsyncSocketIo/AsyncSocketIo.qm
+++ b/qlib/AsyncSocketIo/AsyncSocketIo.qm
@@ -25,10 +25,7 @@
 # minimum required Qore module
 %requires qore >= 2.0
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires(reexport) Util
 %requires Logger

--- a/qlib/AwsRestClient.qm
+++ b/qlib/AwsRestClient.qm
@@ -26,16 +26,13 @@
 %requires qore >= 1.10
 
 # require type definitions everywhere
-%require-types
 
 # enable all warnings
-%enable-all-warnings
 
 # don't use "$" for vars, members, and methods, assume local variable scope
-%new-style
+%modern
 
 # do not ignore argument errors
-%strict-args
 
 %requires(reexport) Mime >= 1.3
 %requires(reexport) RestClient >= 1.3.1
@@ -74,10 +71,7 @@ module AwsRestClient {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires AwsRestClient
 

--- a/qlib/AwsRestClientDataProvider/AwsRestClientDataProvider.qm
+++ b/qlib/AwsRestClientDataProvider/AwsRestClientDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 1.10
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) DataProvider
 %requires(reexport) AwsRestClient

--- a/qlib/BillwerkRestClient.qm
+++ b/qlib/BillwerkRestClient.qm
@@ -24,10 +24,7 @@
 
 %requires qore >= 2.0
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires(reexport) RestClient >= 2.2.0
 %requires(reexport) ConnectionProvider >= 2.0
@@ -68,10 +65,7 @@ module BillwerkRestClient {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires BillwerkRestClient
 

--- a/qlib/BulkSqlUtil/BulkSqlUtil.qm
+++ b/qlib/BulkSqlUtil/BulkSqlUtil.qm
@@ -21,19 +21,16 @@
     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
     DEALINGS IN THE SOFTWARE.
 */
-%strict-args
 
 # minimum required Qore version
 %requires qore >= 1.19
 
 # require type definitions everywhere
-%require-types
 
 # enable all warnings
-%enable-all-warnings
 
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 
 # use SqlUtil
 %requires(reexport) SqlUtil

--- a/qlib/CdsRestClient.qm
+++ b/qlib/CdsRestClient.qm
@@ -26,16 +26,13 @@
 %requires qore >= 2.0
 
 # require type definitions everywhere
-%require-types
 
 # enable all warnings
-%enable-all-warnings
 
 # don't use "$" for vars, members, and methods, assume local variable scope
-%new-style
+%modern
 
 # do not ignore argument errors
-%strict-args
 
 %requires(reexport) Mime >= 1.3
 %requires(reexport) RestClient >= 1.3.1
@@ -78,10 +75,7 @@ module CdsRestClient {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires CdsRestClient
 

--- a/qlib/CdsRestDataProvider/CdsRestDataProvider.qm
+++ b/qlib/CdsRestDataProvider/CdsRestDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) DataProvider
 %requires(reexport) CdsRestClient

--- a/qlib/ConnectionProvider/ConnectionProvider.qm
+++ b/qlib/ConnectionProvider/ConnectionProvider.qm
@@ -25,10 +25,7 @@
 # minimum required Qore module
 %requires qore >= 2.0
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires(reexport) Util
 %requires Logger

--- a/qlib/ConnectionProvider/FtpConnection.qc
+++ b/qlib/ConnectionProvider/FtpConnection.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 #! the ConnectionProvider namespace. All classes used in the ConnectionProvider module should be inside this namespace
 public namespace ConnectionProvider {

--- a/qlib/ConnectionProvider/HttpConnection.qc
+++ b/qlib/ConnectionProvider/HttpConnection.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 #! The ConnectionProvider namespace
 /** All public declarations in the %ConnectionProvider module are defined in this namespace

--- a/qlib/ConnectionProvider/InvalidConnection.qc
+++ b/qlib/ConnectionProvider/InvalidConnection.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 #! the ConnectionProvider namespace. All classes used in the ConnectionProvider module should be inside this namespace
 public namespace ConnectionProvider {

--- a/qlib/CsvUtil/AbstractCsvIterator.qc
+++ b/qlib/CsvUtil/AbstractCsvIterator.qc
@@ -23,10 +23,7 @@
 */
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 #! the CsvUtil namespace. All classes used in the CsvUtil module should be inside this namespace
 public namespace CsvUtil {

--- a/qlib/CsvUtil/AbstractCsvWriter.qc
+++ b/qlib/CsvUtil/AbstractCsvWriter.qc
@@ -23,10 +23,7 @@
 */
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 #! the CsvUtil namespace. All classes used in the CsvUtil module should be inside this namespace
 public namespace CsvUtil {

--- a/qlib/CsvUtil/CsvDataIterator.qc
+++ b/qlib/CsvUtil/CsvDataIterator.qc
@@ -23,10 +23,7 @@
 */
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 #! the CsvUtil namespace. All classes used in the CsvUtil module should be inside this namespace
 public namespace CsvUtil {

--- a/qlib/CsvUtil/CsvFileIterator.qc
+++ b/qlib/CsvUtil/CsvFileIterator.qc
@@ -23,10 +23,7 @@
 */
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 #! the CsvUtil namespace. All classes used in the CsvUtil module should be inside this namespace
 public namespace CsvUtil {

--- a/qlib/CsvUtil/CsvFileWriter.qc
+++ b/qlib/CsvUtil/CsvFileWriter.qc
@@ -23,10 +23,7 @@
 */
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 #! the CsvUtil namespace. All classes used in the CsvUtil module should be inside this namespace
 public namespace CsvUtil {

--- a/qlib/CsvUtil/CsvHelper.qc
+++ b/qlib/CsvUtil/CsvHelper.qc
@@ -23,10 +23,7 @@
 */
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 class CsvHelper {
     private {

--- a/qlib/CsvUtil/CsvIterator.qc
+++ b/qlib/CsvUtil/CsvIterator.qc
@@ -23,10 +23,7 @@
 */
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 #! the CsvUtil namespace. All classes used in the CsvUtil module should be inside this namespace
 public namespace CsvUtil {

--- a/qlib/CsvUtil/CsvStringWriter.qc
+++ b/qlib/CsvUtil/CsvStringWriter.qc
@@ -23,10 +23,7 @@
 */
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 #! the CsvUtil namespace. All classes used in the CsvUtil module should be inside this namespace
 public namespace CsvUtil {

--- a/qlib/CsvUtil/CsvUtil.qm
+++ b/qlib/CsvUtil/CsvUtil.qm
@@ -31,10 +31,7 @@
 %requires(reexport) FileLocationHandler
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 module CsvUtil {
     version = "1.11";
@@ -163,10 +160,7 @@ module CsvUtil {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires CsvUtil
 
@@ -204,10 +198,7 @@ UK,1234567893,"Sony, Xperia S",31052012
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires CsvUtil
 
@@ -273,10 +264,7 @@ while (i.next())
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires CsvUtil
 

--- a/qlib/CsvUtil/CsvWriteDataProvider.qc
+++ b/qlib/CsvUtil/CsvWriteDataProvider.qc
@@ -23,10 +23,7 @@
 */
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 #! the CsvUtil namespace. All classes used in the CsvUtil module should be inside this namespace
 public namespace CsvUtil {

--- a/qlib/CsvUtil/CsvWriter.qc
+++ b/qlib/CsvUtil/CsvWriter.qc
@@ -23,10 +23,7 @@
 */
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 #! the CsvUtil namespace. All classes used in the CsvUtil module should be inside this namespace
 public namespace CsvUtil {

--- a/qlib/DataProvider/AbstractDataProcessor.qc
+++ b/qlib/DataProvider/AbstractDataProcessor.qc
@@ -23,13 +23,10 @@
 */
 
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 #! strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 #! contains all public definitions in the DataProvider module
 public namespace DataProvider {

--- a/qlib/DataProvider/AbstractDataProviderBulkOperation.qc
+++ b/qlib/DataProvider/AbstractDataProviderBulkOperation.qc
@@ -23,13 +23,10 @@
 */
 
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 #! strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 #! contains all public definitions in the DataProvider module
 public namespace DataProvider {

--- a/qlib/DataProvider/AbstractDataProviderBulkRecordInterface.qc
+++ b/qlib/DataProvider/AbstractDataProviderBulkRecordInterface.qc
@@ -23,13 +23,10 @@
 */
 
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 #! strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 #! contains all public definitions in the DataProvider module
 public namespace DataProvider {

--- a/qlib/DataProvider/AbstractDataProviderRecordIterator.qc
+++ b/qlib/DataProvider/AbstractDataProviderRecordIterator.qc
@@ -23,13 +23,10 @@
 */
 
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 #! strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 #! contains all public definitions in the DataProvider module
 public namespace DataProvider {

--- a/qlib/DataProvider/DataProvider.qm
+++ b/qlib/DataProvider/DataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) reflection
 %requires(reexport) Util

--- a/qlib/DataProvider/DataProviderBulkRecordIterator.qc
+++ b/qlib/DataProvider/DataProviderBulkRecordIterator.qc
@@ -23,13 +23,10 @@
 */
 
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 #! strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 #! contains all public definitions in the DataProvider module
 public namespace DataProvider {

--- a/qlib/DataProvider/DataProviderPipeline.qc
+++ b/qlib/DataProvider/DataProviderPipeline.qc
@@ -23,13 +23,10 @@
 */
 
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 #! strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 # allow weak references
 %allow-weak-references
 

--- a/qlib/DataProvider/DataProviderPipelineFactory.qc
+++ b/qlib/DataProvider/DataProviderPipelineFactory.qc
@@ -23,13 +23,10 @@
 */
 
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 #! strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 # allow weak references
 %allow-weak-references
 

--- a/qlib/DataProvider/DataProviderTypeEntry.qc
+++ b/qlib/DataProvider/DataProviderTypeEntry.qc
@@ -23,13 +23,10 @@
 */
 
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 #! Contains all public definitions in the DataProvider module
 public namespace DataProvider {

--- a/qlib/DataProvider/DefaultBulkRecordIterface.qc
+++ b/qlib/DataProvider/DefaultBulkRecordIterface.qc
@@ -23,13 +23,10 @@
 */
 
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 #! strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 #! contains all public definitions in the DataProvider module
 public namespace DataProvider {

--- a/qlib/DataProvider/HashDeclDataType.qc
+++ b/qlib/DataProvider/HashDeclDataType.qc
@@ -23,13 +23,10 @@
 */
 
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 #! strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires reflection
 

--- a/qlib/DataProvider/QoreDataField.qc
+++ b/qlib/DataProvider/QoreDataField.qc
@@ -23,13 +23,10 @@
 */
 
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 #! strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires reflection
 

--- a/qlib/DataProvider/QoreHashDataType.qc
+++ b/qlib/DataProvider/QoreHashDataType.qc
@@ -23,13 +23,10 @@
 */
 
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 #! strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires reflection
 

--- a/qlib/DataProvider/SoftListDataType.qc
+++ b/qlib/DataProvider/SoftListDataType.qc
@@ -23,13 +23,10 @@
 */
 
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 #! strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires reflection
 

--- a/qlib/DatasourceProvider.qm
+++ b/qlib/DatasourceProvider.qm
@@ -25,10 +25,7 @@
 # minimum Qore version
 %requires qore >= 0.9.4
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 module DatasourceProvider {
     version = "1.1";

--- a/qlib/DbDataProvider/DbDataProvider.qm
+++ b/qlib/DbDataProvider/DbDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.1
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 # supports using the DataProvider module
 %requires(reexport) DataProvider

--- a/qlib/DiscordDataProvider/DiscordDataProvider.qm
+++ b/qlib/DiscordDataProvider/DiscordDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) DataProvider
 %requires(reexport) DiscordRestClient

--- a/qlib/DiscordRestClient.qm
+++ b/qlib/DiscordRestClient.qm
@@ -26,16 +26,13 @@
 %requires qore >= 2.0
 
 # require type definitions everywhere
-%require-types
 
 # enable all warnings
-%enable-all-warnings
 
 # don't use "$" for vars, members, and methods, assume local variable scope
-%new-style
+%modern
 
 # do not ignore argument errors
-%strict-args
 
 %requires(reexport) Mime >= 1.3
 %requires(reexport) RestClient >= 1.3.1
@@ -76,10 +73,7 @@ module DiscordRestClient {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires DiscordRestClient
 %requires ConnectionProvider

--- a/qlib/DiscordWebSocketClient.qm
+++ b/qlib/DiscordWebSocketClient.qm
@@ -26,16 +26,13 @@
 %requires qore >= 2.0
 
 # require type definitions everywhere
-%require-types
 
 # enable all warnings
-%enable-all-warnings
 
 # don't use "$" for vars, members, and methods, assume local variable scope
-%new-style
+%modern
 
 # do not ignore argument errors
-%strict-args
 
 %requires(reexport) Mime >= 1.3
 %requires(reexport) WebSocketClient >= 1.3.1

--- a/qlib/ElasticSearchDataProvider/ElasticSearchDataProvider.qm
+++ b/qlib/ElasticSearchDataProvider/ElasticSearchDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) ConnectionProvider
 %requires(reexport) DataProvider

--- a/qlib/ElasticSearchLoggerAppender.qm
+++ b/qlib/ElasticSearchLoggerAppender.qm
@@ -32,7 +32,7 @@
 %requires RestClient
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
+%modern
 
 # requires json module for make_json()
 %try-module json
@@ -44,9 +44,6 @@
 auto sub make_json(auto val) { throw "JSON-ERROR", "the json module is required for this operation"; }
 auto sub parse_json(string val) { throw "JSON-ERROR", "the json module is required for this operation"; }
 %endif
-%strict-args
-%require-types
-%enable-all-warnings
 
 module ElasticSearchLoggerAppender {
     version = "1.0";

--- a/qlib/EmpathicBuildingDataProvider/EmpathicBuildingDataProvider.qm
+++ b/qlib/EmpathicBuildingDataProvider/EmpathicBuildingDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 1.18
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) DataProvider
 %requires(reexport) RestClient

--- a/qlib/FileDataProvider/FileDataProvider.qm
+++ b/qlib/FileDataProvider/FileDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) DataProvider
 %requires FsUtil

--- a/qlib/FileLocationHandler/FileLocationHandler.qm
+++ b/qlib/FileLocationHandler/FileLocationHandler.qm
@@ -24,13 +24,10 @@
 # minimum required Qore version
 %requires qore >= 1.19
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires Util
 

--- a/qlib/FilePoller.qm
+++ b/qlib/FilePoller.qm
@@ -73,10 +73,7 @@ module FilePoller {
     };
 }
 
-%new-style
-%require-types
-%strict-args
-%enable-all-warnings
+%modern
 %allow-weak-references
 
 %requires Util

--- a/qlib/FixedLengthUtil/FixedLengthFileIterator.qc
+++ b/qlib/FixedLengthUtil/FixedLengthFileIterator.qc
@@ -22,9 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
+%modern
 
 #! The FixedLengthUtil namespace contains all the definitions in the FixedLengthUtil module
 public namespace FixedLengthUtil {
@@ -34,10 +32,7 @@ public namespace FixedLengthUtil {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires FixedLengthUtil
 

--- a/qlib/FixedLengthUtil/FixedLengthFileWriter.qc
+++ b/qlib/FixedLengthUtil/FixedLengthFileWriter.qc
@@ -22,9 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
+%modern
 
 #! The FixedLengthUtil namespace contains all the definitions in the FixedLengthUtil module
 public namespace FixedLengthUtil {
@@ -33,10 +31,7 @@ public namespace FixedLengthUtil {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires FixedLengthUtil
 

--- a/qlib/FixedLengthUtil/FixedLengthUtil.qm
+++ b/qlib/FixedLengthUtil/FixedLengthUtil.qm
@@ -29,10 +29,7 @@
 %requires(reexport) DataProvider
 %requires(reexport) FileLocationHandler
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 module FixedLengthUtil {
     version = "1.6";
@@ -258,10 +255,7 @@ const Specs = (
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires FixedLengthUtil
 
@@ -299,10 +293,7 @@ while (i.next()) {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires FixedLengthUtil
 

--- a/qlib/FixedLengthUtil/FixedLengthWriteDataProvider.qc
+++ b/qlib/FixedLengthUtil/FixedLengthWriteDataProvider.qc
@@ -23,10 +23,7 @@
 */
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 #! Contains all public definitions in the FixedLengthUtil module
 public namespace FixedLengthUtil {

--- a/qlib/FixedLengthUtil/FixedLengthWriter.qc
+++ b/qlib/FixedLengthUtil/FixedLengthWriter.qc
@@ -22,9 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
+%modern
 
 #! The FixedLengthUtil namespace contains all the definitions in the FixedLengthUtil module
 public namespace FixedLengthUtil {
@@ -33,10 +31,7 @@ public namespace FixedLengthUtil {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires FixedLengthUtil
 

--- a/qlib/FsUtil.qm
+++ b/qlib/FsUtil.qm
@@ -28,10 +28,7 @@
 %requires Util
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 module FsUtil {
     version = "1.4";

--- a/qlib/FtpClientDataProvider/FtpClientDataProvider.qm
+++ b/qlib/FtpClientDataProvider/FtpClientDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) DataProvider
 %requires FileLocationHandler

--- a/qlib/FtpPoller.qm
+++ b/qlib/FtpPoller.qm
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 %allow-weak-references
 
 # make sure we have the required qore version

--- a/qlib/FtpPollerUtil.qm
+++ b/qlib/FtpPollerUtil.qm
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 # make sure we have the required qore version
 %requires qore >= 1.0

--- a/qlib/GmailDataProvider/GmailDataProvider.qm
+++ b/qlib/GmailDataProvider/GmailDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) DataProvider
 %requires(reexport) GoogleDataProvider

--- a/qlib/GoogleCalendarDataProvider/GoogleCalendarDataProvider.qm
+++ b/qlib/GoogleCalendarDataProvider/GoogleCalendarDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) DataProvider
 %requires(reexport) GoogleDataProvider

--- a/qlib/GoogleDataProvider/GoogleDataProvider.qm
+++ b/qlib/GoogleDataProvider/GoogleDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) DataProvider
 %requires(reexport) GoogleRestClient

--- a/qlib/GoogleRestClient.qm
+++ b/qlib/GoogleRestClient.qm
@@ -26,16 +26,13 @@
 %requires qore >= 2.0
 
 # require type definitions everywhere
-%require-types
 
 # enable all warnings
-%enable-all-warnings
 
 # don't use "$" for vars, members, and methods, assume local variable scope
-%new-style
+%modern
 
 # do not ignore argument errors
-%strict-args
 
 %requires(reexport) Mime >= 1.3
 %requires(reexport) RestClient >= 1.3.1
@@ -78,10 +75,7 @@ module GoogleRestClient {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires GoogleRestClient
 %requires ConnectionProvider

--- a/qlib/HttpClientDataProvider/HttpClientDataProvider.qm
+++ b/qlib/HttpClientDataProvider/HttpClientDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 1.14.1
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) DataProvider
 %requires FileLocationHandler

--- a/qlib/HttpServerAsyncIo/HttpServerAsyncIo.qm
+++ b/qlib/HttpServerAsyncIo/HttpServerAsyncIo.qm
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %enable-debug
 
 %requires Logger

--- a/qlib/HttpServerUtil.qm
+++ b/qlib/HttpServerUtil.qm
@@ -28,10 +28,7 @@
 %requires Logger
 %requires FileLocationHandler
 
-%new-style
-%require-types
-%strict-args
-%enable-all-warnings
+%modern
 
 module HttpServerUtil {
     version = "1.3.1";

--- a/qlib/HueRestClient.qm
+++ b/qlib/HueRestClient.qm
@@ -26,16 +26,13 @@
 %requires qore >= 2.0
 
 # require type definitions everywhere
-%require-types
 
 # enable all warnings
-%enable-all-warnings
 
 # don't use "$" for vars, members, and methods, assume local variable scope
-%new-style
+%modern
 
 # do not ignore argument errors
-%strict-args
 
 %requires(reexport) Mime >= 1.3
 %requires(reexport) RestClient >= 1.3.1
@@ -76,10 +73,7 @@ module HueRestClient {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires HueRestClient
 %requires ConnectionProvider

--- a/qlib/MailMessage.qm
+++ b/qlib/MailMessage.qm
@@ -31,13 +31,10 @@
 %requires Mime >= 1.3
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
+%modern
 # require type declarations everywhere
-%require-types
 # disallows access to backwards-compatible "noop" variants
-%strict-args
 # enables all warnings
-%enable-all-warnings
 
 module MailMessage {
     version = "1.4";

--- a/qlib/MemcachedDataProvider/MemcachedAddDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedAddDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached add operation

--- a/qlib/MemcachedDataProvider/MemcachedAdminDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedAdminDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Parent data provider for admin operations

--- a/qlib/MemcachedDataProvider/MemcachedAppendDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedAppendDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached append operation

--- a/qlib/MemcachedDataProvider/MemcachedCasDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedCasDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached CAS (compare-and-swap) operation

--- a/qlib/MemcachedDataProvider/MemcachedCasRequestDataType.qc
+++ b/qlib/MemcachedDataProvider/MemcachedCasRequestDataType.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data type for memcached CAS (compare-and-swap) requests

--- a/qlib/MemcachedDataProvider/MemcachedClient.qc
+++ b/qlib/MemcachedDataProvider/MemcachedClient.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 #! The main MemcachedDataProvider namespace
 public namespace MemcachedDataProvider {

--- a/qlib/MemcachedDataProvider/MemcachedConnection.qc
+++ b/qlib/MemcachedDataProvider/MemcachedConnection.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Memcached connection class

--- a/qlib/MemcachedDataProvider/MemcachedDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Application name for the data provider

--- a/qlib/MemcachedDataProvider/MemcachedDataProvider.qm
+++ b/qlib/MemcachedDataProvider/MemcachedDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) ConnectionProvider
 %requires(reexport) DataProvider

--- a/qlib/MemcachedDataProvider/MemcachedDataProviderBase.qc
+++ b/qlib/MemcachedDataProvider/MemcachedDataProviderBase.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Base class for all Memcached data providers

--- a/qlib/MemcachedDataProvider/MemcachedDataProviderFactory.qc
+++ b/qlib/MemcachedDataProvider/MemcachedDataProviderFactory.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! The Memcached data provider factory

--- a/qlib/MemcachedDataProvider/MemcachedDecrDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedDecrDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached decr operation

--- a/qlib/MemcachedDataProvider/MemcachedDeleteDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedDeleteDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached delete operation

--- a/qlib/MemcachedDataProvider/MemcachedDeleteRequestDataType.qc
+++ b/qlib/MemcachedDataProvider/MemcachedDeleteRequestDataType.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data type for memcached delete requests

--- a/qlib/MemcachedDataProvider/MemcachedFlushAllDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedFlushAllDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached flush_all command

--- a/qlib/MemcachedDataProvider/MemcachedFlushRequestDataType.qc
+++ b/qlib/MemcachedDataProvider/MemcachedFlushRequestDataType.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data type for memcached flush requests

--- a/qlib/MemcachedDataProvider/MemcachedGatDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedGatDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached gat (get and touch) operation

--- a/qlib/MemcachedDataProvider/MemcachedGatsDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedGatsDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached gats (get and touch with CAS) operation

--- a/qlib/MemcachedDataProvider/MemcachedGetDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedGetDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached get operation

--- a/qlib/MemcachedDataProvider/MemcachedGetRequestDataType.qc
+++ b/qlib/MemcachedDataProvider/MemcachedGetRequestDataType.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data type for memcached get requests

--- a/qlib/MemcachedDataProvider/MemcachedGetResponseDataType.qc
+++ b/qlib/MemcachedDataProvider/MemcachedGetResponseDataType.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data type for memcached get responses

--- a/qlib/MemcachedDataProvider/MemcachedGetsDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedGetsDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached gets operation (get with CAS token)

--- a/qlib/MemcachedDataProvider/MemcachedIncrDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedIncrDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached incr operation

--- a/qlib/MemcachedDataProvider/MemcachedIncrDecrRequestDataType.qc
+++ b/qlib/MemcachedDataProvider/MemcachedIncrDecrRequestDataType.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data type for memcached incr/decr requests

--- a/qlib/MemcachedDataProvider/MemcachedIncrDecrResponseDataType.qc
+++ b/qlib/MemcachedDataProvider/MemcachedIncrDecrResponseDataType.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data type for memcached incr/decr responses

--- a/qlib/MemcachedDataProvider/MemcachedMultiGetDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedMultiGetDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached multi-get operation

--- a/qlib/MemcachedDataProvider/MemcachedNumericDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedNumericDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Parent data provider for numeric operations (incr/decr)

--- a/qlib/MemcachedDataProvider/MemcachedPrependDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedPrependDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached prepend operation

--- a/qlib/MemcachedDataProvider/MemcachedReplaceDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedReplaceDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached replace operation

--- a/qlib/MemcachedDataProvider/MemcachedRetrievalDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedRetrievalDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Parent data provider for retrieval operations

--- a/qlib/MemcachedDataProvider/MemcachedSetDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedSetDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached set operation

--- a/qlib/MemcachedDataProvider/MemcachedStatsDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedStatsDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Parent data provider for stats operations

--- a/qlib/MemcachedDataProvider/MemcachedStatsGeneralDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedStatsGeneralDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached general stats

--- a/qlib/MemcachedDataProvider/MemcachedStatsItemsDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedStatsItemsDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached items stats

--- a/qlib/MemcachedDataProvider/MemcachedStatsResponseDataType.qc
+++ b/qlib/MemcachedDataProvider/MemcachedStatsResponseDataType.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data type for memcached stats responses

--- a/qlib/MemcachedDataProvider/MemcachedStatsSizesDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedStatsSizesDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached sizes stats

--- a/qlib/MemcachedDataProvider/MemcachedStatsSlabsDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedStatsSlabsDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached slabs stats

--- a/qlib/MemcachedDataProvider/MemcachedStorageDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedStorageDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Parent data provider for storage operations

--- a/qlib/MemcachedDataProvider/MemcachedStorageRequestDataType.qc
+++ b/qlib/MemcachedDataProvider/MemcachedStorageRequestDataType.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data type for memcached storage requests (set, add, replace, append, prepend)

--- a/qlib/MemcachedDataProvider/MemcachedStorageResponseDataType.qc
+++ b/qlib/MemcachedDataProvider/MemcachedStorageResponseDataType.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data type for memcached storage responses

--- a/qlib/MemcachedDataProvider/MemcachedTouchDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedTouchDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached touch operation

--- a/qlib/MemcachedDataProvider/MemcachedTouchRequestDataType.qc
+++ b/qlib/MemcachedDataProvider/MemcachedTouchRequestDataType.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data type for memcached touch requests

--- a/qlib/MemcachedDataProvider/MemcachedVerbosityDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedVerbosityDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached verbosity command

--- a/qlib/MemcachedDataProvider/MemcachedVersionDataProvider.qc
+++ b/qlib/MemcachedDataProvider/MemcachedVersionDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data provider for memcached version command

--- a/qlib/MemcachedDataProvider/MemcachedVersionResponseDataType.qc
+++ b/qlib/MemcachedDataProvider/MemcachedVersionResponseDataType.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MemcachedDataProvider {
 #! Data type for memcached version responses

--- a/qlib/MewsRestClient.qm
+++ b/qlib/MewsRestClient.qm
@@ -26,16 +26,13 @@
 %requires qore >= 2.0
 
 # require type definitions everywhere
-%require-types
 
 # enable all warnings
-%enable-all-warnings
 
 # don't use "$" for vars, members, and methods, assume local variable scope
-%new-style
+%modern
 
 # do not ignore argument errors
-%strict-args
 
 %requires(reexport) Mime >= 1.3
 %requires(reexport) RestClient >= 1.3.1
@@ -77,10 +74,7 @@ module MewsRestClient {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires MewsRestClient
 %requires ConnectionProvider

--- a/qlib/MewsRestDataProvider/MewsRestDataProvider.qm
+++ b/qlib/MewsRestDataProvider/MewsRestDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) ConnectionProvider
 %requires(reexport) DataProvider

--- a/qlib/MongoDbDataProvider/MongoDbAggregateDataProvider.qc
+++ b/qlib/MongoDbDataProvider/MongoDbAggregateDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MongoDbDataProvider {
 #! MongoDB aggregate data provider - runs aggregation pipelines on a collection

--- a/qlib/MongoDbDataProvider/MongoDbBulkDataProvider.qc
+++ b/qlib/MongoDbDataProvider/MongoDbBulkDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MongoDbDataProvider {
 #! MongoDB bulk data provider - executes bulk write operations on a collection

--- a/qlib/MongoDbDataProvider/MongoDbCollectionDataProvider.qc
+++ b/qlib/MongoDbDataProvider/MongoDbCollectionDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MongoDbDataProvider {
 #! MongoDB collection data provider - provides access to documents in a collection

--- a/qlib/MongoDbDataProvider/MongoDbConnection.qc
+++ b/qlib/MongoDbDataProvider/MongoDbConnection.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MongoDbDataProvider {
 #! MongoDB connection class

--- a/qlib/MongoDbDataProvider/MongoDbDataProvider.qc
+++ b/qlib/MongoDbDataProvider/MongoDbDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MongoDbDataProvider {
 #! MongoDB app name

--- a/qlib/MongoDbDataProvider/MongoDbDataProvider.qm
+++ b/qlib/MongoDbDataProvider/MongoDbDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) ConnectionProvider
 %requires(reexport) DataProvider

--- a/qlib/MongoDbDataProvider/MongoDbDataProviderFactory.qc
+++ b/qlib/MongoDbDataProvider/MongoDbDataProviderFactory.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MongoDbDataProvider {
 #! The MongoDB data provider factory: \c mongodb

--- a/qlib/MongoDbDataProvider/MongoDbDatabaseDataProvider.qc
+++ b/qlib/MongoDbDataProvider/MongoDbDatabaseDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MongoDbDataProvider {
 #! MongoDB database data provider - provides access to collections in a database

--- a/qlib/MongoDbDataProvider/MongoDbDatabasesDataProvider.qc
+++ b/qlib/MongoDbDataProvider/MongoDbDatabasesDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MongoDbDataProvider {
 #! MongoDB databases data provider - lists all databases

--- a/qlib/MongoDbDataProvider/MongoDbDeleteDataProvider.qc
+++ b/qlib/MongoDbDataProvider/MongoDbDeleteDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MongoDbDataProvider {
 #! MongoDB delete data provider - deletes documents from a collection

--- a/qlib/MongoDbDataProvider/MongoDbFindDataProvider.qc
+++ b/qlib/MongoDbDataProvider/MongoDbFindDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MongoDbDataProvider {
 #! MongoDB find data provider - finds documents in a collection

--- a/qlib/MongoDbDataProvider/MongoDbInsertDataProvider.qc
+++ b/qlib/MongoDbDataProvider/MongoDbInsertDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MongoDbDataProvider {
 #! MongoDB insert data provider - inserts documents into a collection

--- a/qlib/MongoDbDataProvider/MongoDbRecordIterator.qc
+++ b/qlib/MongoDbDataProvider/MongoDbRecordIterator.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MongoDbDataProvider {
 #! MongoDB record iterator for iterating through collection documents

--- a/qlib/MongoDbDataProvider/MongoDbUpdateDataProvider.qc
+++ b/qlib/MongoDbDataProvider/MongoDbUpdateDataProvider.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 public namespace MongoDbDataProvider {
 #! MongoDB update data provider - updates documents in a collection

--- a/qlib/NetSuiteRestClient.qm
+++ b/qlib/NetSuiteRestClient.qm
@@ -26,16 +26,13 @@
 %requires qore >= 2.0
 
 # require type definitions everywhere
-%require-types
 
 # enable all warnings
-%enable-all-warnings
 
 # don't use "$" for vars, members, and methods, assume local variable scope
-%new-style
+%modern
 
 # do not ignore argument errors
-%strict-args
 
 %requires(reexport) Mime >= 1.3
 %requires(reexport) RestClient >= 1.3.1
@@ -76,10 +73,7 @@ module NetSuiteRestClient {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires NetSuiteRestClient
 %requires ConnectionProvider

--- a/qlib/OpenAiDataProvider/OpenAiDataProvider.qm
+++ b/qlib/OpenAiDataProvider/OpenAiDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 1.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) DataProvider
 %requires(reexport) OpenAiRestClient

--- a/qlib/OpenAiRestClient.qm
+++ b/qlib/OpenAiRestClient.qm
@@ -26,16 +26,13 @@
 %requires qore >= 2.0
 
 # require type definitions everywhere
-%require-types
 
 # enable all warnings
-%enable-all-warnings
 
 # don't use "$" for vars, members, and methods, assume local variable scope
-%new-style
+%modern
 
 # do not ignore argument errors
-%strict-args
 
 %requires(reexport) Mime >= 1.3
 %requires(reexport) RestClient >= 1.3.1
@@ -76,10 +73,7 @@ module OpenAiRestClient {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires OpenAiRestClient
 %requires ConnectionProvider

--- a/qlib/OpenApi3.qm
+++ b/qlib/OpenApi3.qm
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 # make sure we have the required qore version
 %requires qore >= 2.0
@@ -98,10 +95,7 @@ module OpenApi3 {
 
     @par Client Example
     @code{.py}
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 # the RestClient module imports and reexports the OpenApi3 module automatically
 %requires RestClient
@@ -143,10 +137,7 @@ schema.setBasePath("/new/path");
 
     @par Server Example
     @code{.py}
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires RestHandler
 %requires OpenApi3

--- a/qlib/Pop3Client.qm
+++ b/qlib/Pop3Client.qm
@@ -36,10 +36,7 @@
 %endtry
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 module Pop3Client {
     version = "2.0";
@@ -77,10 +74,7 @@ module Pop3Client {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires Pop3Client
 

--- a/qlib/Pop3ClientDataProvider/Pop3ClientDataProvider.qm
+++ b/qlib/Pop3ClientDataProvider/Pop3ClientDataProvider.qm
@@ -29,10 +29,7 @@
 %requires(reexport) Pop3Client
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 module Pop3ClientDataProvider {
     version = "2.0";

--- a/qlib/ProviderIndex/ProviderIndex.qm
+++ b/qlib/ProviderIndex/ProviderIndex.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %try-module yaml
 %define NoYaml

--- a/qlib/ProviderIndexUtil/ProviderIndexUtil.qm
+++ b/qlib/ProviderIndexUtil/ProviderIndexUtil.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %try-module yaml
 %define NoYaml

--- a/qlib/QUnit.qm
+++ b/qlib/QUnit.qm
@@ -24,7 +24,7 @@
 
 
 %requires qore >= 0.9
-%new-style
+%modern
 
 %try-module xml >= 1.3
 %define NO_XML
@@ -61,10 +61,7 @@ module QUnit {
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../qlib/QUnit.qm
 
@@ -99,10 +96,7 @@ public class QUnitTest inherits QUnit::Test {
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 %requires ../../qlib/QUnit.qm
 

--- a/qlib/QoreRepl.qm
+++ b/qlib/QoreRepl.qm
@@ -24,10 +24,7 @@
 
 %requires qore >= 2.0
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 # Optional WebSocket support - enabled if WebSocketHandler is available
 %try-module WebSocketHandler >= 2.0

--- a/qlib/QoreRepl/QoreRepl.qc
+++ b/qlib/QoreRepl/QoreRepl.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 %disable-warning deprecated
 
 public namespace QoreRepl {

--- a/qlib/QoreRepl/QoreReplWebSocketConnection.qc
+++ b/qlib/QoreRepl/QoreReplWebSocketConnection.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires Util
 

--- a/qlib/QoreRepl/QoreReplWebSocketHandler.qc
+++ b/qlib/QoreRepl/QoreReplWebSocketHandler.qc
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%require-types
-%enable-all-warnings
-%new-style
-%strict-args
+%modern
 
 %requires HttpServerUtil
 

--- a/qlib/RedisDataProvider/RedisDataProvider.qm
+++ b/qlib/RedisDataProvider/RedisDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) ConnectionProvider
 %requires(reexport) DataProvider

--- a/qlib/RestClientDataProvider/RestClientDataProvider.qm
+++ b/qlib/RestClientDataProvider/RestClientDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) DataProvider
 %requires(reexport) RestClient

--- a/qlib/RestSchemaDataProvider/RestSchemaDataProvider.qm
+++ b/qlib/RestSchemaDataProvider/RestSchemaDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 1.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 # allow the use of the weak reference assignment operator: ':='
 %allow-weak-references
 

--- a/qlib/RestSchemaValidator.qm
+++ b/qlib/RestSchemaValidator.qm
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 # make sure we have the required qore version
 %requires qore >= 2.0

--- a/qlib/SalesforceRestClient.qm
+++ b/qlib/SalesforceRestClient.qm
@@ -26,16 +26,13 @@
 %requires qore >= 1.0
 
 # require type definitions everywhere
-%require-types
 
 # enable all warnings
-%enable-all-warnings
 
 # don't use "$" for vars, members, and methods, assume local variable scope
-%new-style
+%modern
 
 # do not ignore argument errors
-%strict-args
 
 %requires(reexport) Mime >= 1.3
 %requires(reexport) RestClient >= 1.3.1
@@ -72,10 +69,7 @@ module SalesforceRestClient {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires SalesforceRestClient
 
@@ -118,10 +112,7 @@ list<string> sub create_accounts(list account_list) {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires SalesforceRestClient
 %requires json

--- a/qlib/SalesforceRestDataProvider/SalesforceRestDataProvider.qm
+++ b/qlib/SalesforceRestDataProvider/SalesforceRestDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) DataProvider
 %requires(reexport) SalesforceRestClient

--- a/qlib/Sap4HanaRestClient.qm
+++ b/qlib/Sap4HanaRestClient.qm
@@ -26,16 +26,13 @@
 %requires qore >= 2.0
 
 # require type definitions everywhere
-%require-types
 
 # enable all warnings
-%enable-all-warnings
 
 # don't use "$" for vars, members, and methods, assume local variable scope
-%new-style
+%modern
 
 # do not ignore argument errors
-%strict-args
 
 %requires(reexport) Mime >= 1.3
 %requires(reexport) RestClient >= 2.2
@@ -72,10 +69,7 @@ module Sap4HanaRestClient {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires Sap4HanaRestClient
 

--- a/qlib/Schema.qm
+++ b/qlib/Schema.qm
@@ -32,16 +32,13 @@
 %requires Util >= 1.1
 
 # don't use "$" signs for variables and class members, assume local variable scope
-%new-style
+%modern
 
 # require type definitions everywhere
-%require-types
 
 # enable all warnings
-%enable-all-warnings
 
 # strict args
-%strict-args
 
 module Schema {
     version = "1.4.2";

--- a/qlib/SchemaReverse.qm
+++ b/qlib/SchemaReverse.qm
@@ -36,10 +36,7 @@
 
 %requires Schema
 
-%new-style
-%require-types
-%enable-all-warnings
-%strict-args
+%modern
 
 module SchemaReverse {
     version = "1.1";
@@ -74,7 +71,7 @@ Not all database object types are available in all DBMS.
 Simple example (to get one table definition):
 
 @code{.py}
-%new-style
+%modern
 %requires SchemaReverse
 
 Datasource ds("oracle:omq/omq@xbpx");
@@ -168,9 +165,7 @@ public namespace SchemaReverse {
 %requires Schema
 %requires SqlUtil
 
-%new-style
-%require-types
-%enable-all-warnings
+%modern
 
 
 const GenericOptions = (

--- a/qlib/ServerSentEventClient/ServerSentEventClient.qm
+++ b/qlib/ServerSentEventClient/ServerSentEventClient.qm
@@ -26,12 +26,9 @@
 %requires qore >= 2.0
 
 # require type definitions everywhere
-%require-types
 
 # enable all warnings
-%enable-all-warnings
-%strict-args
-%new-style
+%modern
 
 %requires Util >= 1.0
 %requires(reexport) ConnectionProvider >= 1.4

--- a/qlib/ServerSentEventHandler/ServerSentEventHandler.qm
+++ b/qlib/ServerSentEventHandler/ServerSentEventHandler.qm
@@ -26,12 +26,9 @@
 %requires qore >= 2.0
 
 # require type definitions everywhere
-%require-types
 
 # enable all warnings
-%enable-all-warnings
-%strict-args
-%new-style
+%modern
 %allow-weak-references
 
 %requires HttpServerUtil

--- a/qlib/ServiceNowRestClient.qm
+++ b/qlib/ServiceNowRestClient.qm
@@ -26,16 +26,13 @@
 %requires qore >= 2.0
 
 # require type definitions everywhere
-%require-types
 
 # enable all warnings
-%enable-all-warnings
 
 # don't use "$" for vars, members, and methods, assume local variable scope
-%new-style
+%modern
 
 # do not ignore argument errors
-%strict-args
 
 %requires(reexport) Mime >= 1.3
 %requires(reexport) RestClient >= 1.3.1
@@ -76,10 +73,7 @@ module ServiceNowRestClient {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires ServiceNowRestClient
 

--- a/qlib/ServiceNowRestDataProvider/ServiceNowRestDataProvider.qm
+++ b/qlib/ServiceNowRestDataProvider/ServiceNowRestDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 %requires(reexport) DataProvider
 %requires(reexport) ServiceNowRestClient

--- a/qlib/SewioRestClient.qm
+++ b/qlib/SewioRestClient.qm
@@ -26,16 +26,13 @@
 %requires qore >= 2.0
 
 # require type definitions everywhere
-%require-types
 
 # enable all warnings
-%enable-all-warnings
 
 # don't use "$" for vars, members, and methods, assume local variable scope
-%new-style
+%modern
 
 # do not ignore argument errors
-%strict-args
 
 %requires(reexport) Mime >= 1.3
 %requires(reexport) RestClient >= 1.3.1
@@ -73,10 +70,7 @@ module SewioRestClient {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires SewioRestClient
 

--- a/qlib/SqlUtil/AbstractSavepointHelper.qc
+++ b/qlib/SqlUtil/AbstractSavepointHelper.qc
@@ -23,13 +23,10 @@
 */
 
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 #! strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 #! contains all public definitions in the SqlUtil module
 public namespace SqlUtil {

--- a/qlib/SqlUtil/Database.qc
+++ b/qlib/SqlUtil/Database.qc
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 0.9.4
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 #! strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 #! contains all public definitions in the SqlUtil module
 public namespace SqlUtil {

--- a/qlib/SqlUtil/SqlUtilColumnDataType.qc
+++ b/qlib/SqlUtil/SqlUtilColumnDataType.qc
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 2.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 #! strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 #! contains all public definitions in the SqlUtil module
 public namespace SqlUtil {

--- a/qlib/SqlUtil/SqlUtilColumnField.qc
+++ b/qlib/SqlUtil/SqlUtilColumnField.qc
@@ -23,13 +23,10 @@
 */
 
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 #! strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 #! contains all public definitions in the SqlUtil module
 public namespace SqlUtil {

--- a/qlib/SqlUtil/SqlUtilStringType.qc
+++ b/qlib/SqlUtil/SqlUtilStringType.qc
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 0.9.4
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 #! strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 
 #! contains all public definitions in the SqlUtil module
 public namespace SqlUtil {

--- a/qlib/Swagger.qm
+++ b/qlib/Swagger.qm
@@ -22,10 +22,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-%new-style
-%enable-all-warnings
-%require-types
-%strict-args
+%modern
 
 # make sure we have the required qore version
 %requires qore >= 1.7.3
@@ -95,10 +92,7 @@ module Swagger {
 
     @par Client Example
     @code{.py}
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 # the RestClient module imports and reexports the Swagger module automatically
 %requires RestClient
@@ -139,10 +133,7 @@ schema.setBasePath("/new/path");
 
     @par Server Example
     @code{.py}
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires RestHandler
 %requires Swagger

--- a/qlib/SwaggerDataProvider/SwaggerDataProvider.qm
+++ b/qlib/SwaggerDataProvider/SwaggerDataProvider.qm
@@ -25,13 +25,10 @@
 # minimum required Qore version
 %requires qore >= 1.0
 # assume local scope for variables, do not use "$" signs
-%new-style
+%modern
 # require type definitions everywhere
-%require-types
 # strict argument handling
-%strict-args
 # enable all warnings
-%enable-all-warnings
 # allow the use of the weak reference assignment operator: ':='
 %allow-weak-references
 

--- a/qlib/TelnetClient.qm
+++ b/qlib/TelnetClient.qm
@@ -28,10 +28,7 @@
 %requires qore >= 2.0
 
 # assume local var scope, do not use "$" for vars, members, and method calls
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires(reexport) ConnectionProvider >= 1.4
 

--- a/qlib/ZeyosRestClient.qm
+++ b/qlib/ZeyosRestClient.qm
@@ -24,10 +24,7 @@
 
 %requires qore >= 2.0
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires(reexport) RestClient >= 2.2.0
 %requires(reexport) ConnectionProvider >= 2.0
@@ -65,10 +62,7 @@ module ZeyosRestClient {
     @code{.py}
 #!/usr/bin/env qore
 
-%new-style
-%strict-args
-%require-types
-%enable-all-warnings
+%modern
 
 %requires ZeyosRestClient
 


### PR DESCRIPTION
## Summary

Introduces a new recommended way to write Qore code with the `%modern` parse directive and `.qr` file extension.

### New Features

- **`%modern` parse directive** - Combines all recommended parse options into one:
  - `%new-style` (no '$' prefix, assume local scope)
  - `%require-types` (type declarations required)
  - `%strict-args` (strict argument checking)
  - Enables all warnings

- **`.qr` file extension** - Files with `.qr` extension automatically enable `%modern` mode without requiring any parse directive

- **`PO_MODERN` parse option constant** - For programmatic use

### Changes

- Added `PO_MODERN` to `include/qore/Restrictions.h`
- Added `%modern` directive to `lib/scanner.lpp`
- Added `.qr` extension detection in `include/qore/intern/qore_program_private.h`
- Added `"modern"` and `"new-style"` to `lib/ParseOptionMap.cpp`
- Updated documentation in `doxygen/lang/245_parse_directives.dox.tmpl`
- Added to release notes in `doxygen/lang/900_release_notes.dox.tmpl`
- **Updated 493+ scripts to use `%modern`** (319 .qtest, 10 .q, 69 .qm, 95 .qc files)

### Example

```qore
# Old way (4 lines):
%new-style
%require-types
%strict-args
%enable-all-warnings

# New way (1 line):
%modern

# Or just use .qr extension (0 lines needed):
# hello.qr - no parse directives required!
string sub greet(string name) {
    return "Hello, " + name + "!";
}
```

## Test plan

- [x] Build succeeds
- [x] Reflection tests pass (516 assertions)
- [x] Hashdecl tests pass (122 assertions)
- [x] DataProvider tests pass (775 assertions)
- [x] Multiple other test suites pass
- [x] Valgrind shows no memory leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)