### PR TITLE
Improve process execution latency

### DIFF
--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -943,12 +943,6 @@ HTML_COLORSTYLE_SAT    = 220
 
 HTML_COLORSTYLE_GAMMA  = 100
 
-# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
-# page will contain the date and time when the page was generated. Setting
-# this to NO can help when comparing the output of multiple runs.
-
-HTML_TIMESTAMP         = YES
-
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the
 # page has loaded.

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -483,6 +483,11 @@ code<int(string)> func = int sub(int x) { return x; };  # PARSE-TYPE-ERROR: para
       - fall back to HTTP/1.1 when HTTP/2 WebSocket CONNECT returns 501 (HTTP/2 WebSocket disabled)
     - Core language
       - fixed union type resolution order to honor the first matching type in the declaration
+      - improved @ref Qore::system() "system()" on Linux to use \c posix_spawn(), restore an unblocked signal mask
+        in child processes, and terminate the entire process group on sandbox interrupts
+      - improved @ref Qore::backquote() "backquote()" and the @ref backquote_operator "backquote operator" on Linux
+        to use \c posix_spawn(), restore an unblocked signal mask in child processes, and terminate the entire process
+        group on sandbox interrupts
     - @ref RestClient "RestClient" module
       - fixed non-blocking polling with connections that use basic auth
         (<a href="https://github.com/qoretechnologies/qore/issues/5001">issue 5001</a>)

--- a/doxygen/lang/Doxyfile.in
+++ b/doxygen/lang/Doxyfile.in
@@ -943,12 +943,6 @@ HTML_COLORSTYLE_SAT    = 220
 
 HTML_COLORSTYLE_GAMMA  = 100
 
-# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
-# page will contain the date and time when the page was generated. Setting
-# this to NO can help when comparing the output of multiple runs.
-
-HTML_TIMESTAMP         = YES
-
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the
 # page has loaded.

--- a/doxygen/lib/Doxyfile.in
+++ b/doxygen/lib/Doxyfile.in
@@ -848,12 +848,6 @@ HTML_COLORSTYLE_SAT    = 220
 
 HTML_COLORSTYLE_GAMMA  = 100
 
-# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
-# page will contain the date and time when the page was generated. Setting
-# this to NO can help when comparing the output of multiple runs.
-
-HTML_TIMESTAMP         = YES
-
 # If the HTML_ALIGN_MEMBERS tag is set to YES, the members of classes,
 # files or namespaces will be aligned in HTML using tables. If set to
 # NO a bullet list will be used.

--- a/doxygen/modules/Doxyfile.in
+++ b/doxygen/modules/Doxyfile.in
@@ -944,12 +944,6 @@ HTML_COLORSTYLE_SAT    = 220
 
 HTML_COLORSTYLE_GAMMA  = 100
 
-# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
-# page will contain the date and time when the page was generated. Setting
-# this to NO can help when comparing the output of multiple runs.
-
-HTML_TIMESTAMP         = YES
-
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the
 # page has loaded.

--- a/doxygen/qlib/Doxyfile.in
+++ b/doxygen/qlib/Doxyfile.in
@@ -849,12 +849,6 @@ HTML_COLORSTYLE_SAT    = 220
 
 HTML_COLORSTYLE_GAMMA  = 100
 
-# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
-# page will contain the date and time when the page was generated. Setting
-# this to NO can help when comparing the output of multiple runs.
-
-HTML_TIMESTAMP         = YES
-
 # If the HTML_ALIGN_MEMBERS tag is set to YES, the members of classes,
 # files or namespaces will be aligned in HTML using tables. If set to
 # NO a bullet list will be used.

--- a/examples/test/qore/functions/system.qtest
+++ b/examples/test/qore/functions/system.qtest
@@ -11,6 +11,11 @@
 class SystemCallTest inherits QUnit::Test {
     constructor() : Test("SystemCallTest", "1.0") {
         addTestCase("system() test", \testMethod());
+        addTestCase("system() exit code", \testExitCode());
+        addTestCase("system() command not found", \testCommandNotFound());
+        addTestCase("system() SIGINT handling", \testSignalHandling());
+        addTestCase("system() interrupt kills process group", \testInterruptKillsProcessGroup());
+        addTestCase("system() restricted access", \testRestrictedAccess());
 
         # Return for compatibility with test harness that checks return value
         set_return_value(main());
@@ -26,5 +31,119 @@ class SystemCallTest inherits QUnit::Test {
         on_exit unlink(file);
 
         assertEq("OUTPUT", chomp(ReadOnlyFile::readTextFile(file)));
+    }
+
+    testExitCode() {
+%ifdef Windows
+        testSkip("Windows");
+%endif
+        int rc = system("exit 7");
+        assertEq(7, rc, "system() should return the command exit code");
+    }
+
+    testCommandNotFound() {
+%ifdef Windows
+        testSkip("Windows");
+%endif
+        int rc = system("command_should_not_exist_12345");
+        assertEq(127, rc, "system() should return 127 for command not found");
+    }
+
+    testSignalHandling() {
+%ifdef Windows
+        testSkip("Windows");
+%endif
+        int rc = system("trap 'exit 42' INT; kill -s INT $$; sleep 1; exit 0");
+        assertEq(42, rc, "system() child should handle SIGINT");
+    }
+
+    testInterruptKillsProcessGroup() {
+%ifdef Windows
+        testSkip("Windows");
+%endif
+        string pid_file = tmp_location() + "/system_pid_" + string(getpid());
+        on_exit {
+            if (is_file(pid_file)) {
+                unlink(pid_file);
+            }
+        }
+
+        SandboxManager sm();
+        Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+        p.setSandboxManager(sm);
+
+        p.parse("
+%modern
+
+int sub run_system(string cmd) {
+    return system(cmd);
+}
+        ", "system_interrupt_test");
+
+        Counter done(1);
+        bool caught = False;
+        string ex_err;
+        int rc = -999;
+
+        string cmd = "echo $$ > " + pid_file + "; sleep 30 & wait";
+        background sub() {
+            try {
+                rc = p.callFunction("run_system", cmd);
+            } catch (hash<ExceptionInfo> ex) {
+                caught = True;
+                ex_err = ex.err;
+                rc = -1;
+            }
+            done.dec();
+        }();
+
+        int wait_attempts = 200;
+        while (!is_file(pid_file) && wait_attempts-- > 0) {
+            usleep(10000);
+        }
+        assertTrue(is_file(pid_file), "pid file created");
+
+        string pid_str = chomp(ReadOnlyFile::readTextFile(pid_file));
+        int pgid = pid_str.toInt();
+        assertTrue(pgid > 0, "process group id captured");
+
+        sm.requestInterrupt();
+        done.waitForZero(5s);
+
+        assertEq(-1, rc, "system() should return -1 on interrupt");
+        assertEq(True, caught, "system() call interrupted");
+        assertEq("PROGRAM-INTERRUPTED", ex_err, "system() raised PROGRAM-INTERRUPTED");
+
+        int krc = 0;
+        int kill_attempts = 50;
+        while (kill_attempts-- > 0) {
+            krc = kill(-pgid, 0);
+            if (krc == -1) {
+                break;
+            }
+            usleep(10000);
+        }
+        assertEq(-1, krc, "process group should be gone");
+    }
+
+    testRestrictedAccess() {
+%ifdef Windows
+        testSkip("Windows");
+%endif
+        Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES | PO_NO_EXTERNAL_PROCESS);
+        bool parse_caught = False;
+        try {
+            p.parse("
+%modern
+
+int sub run_system() {
+    return system(\":\");
+}
+            ", "system_restricted");
+        } catch (hash<ExceptionInfo> ex) {
+            parse_caught = True;
+            assertEq("PARSE-EXCEPTION", ex.err, "system() blocked by PO_NO_EXTERNAL_PROCESS");
+        }
+        assertTrue(parse_caught, "system() should be blocked by PO_NO_EXTERNAL_PROCESS");
     }
 }

--- a/examples/test/qore/misc/backquote.qtest
+++ b/examples/test/qore/misc/backquote.qtest
@@ -4,18 +4,25 @@
 %modern
 
 %requires ../../../../qlib/QUnit.qm
+%requires ../../../../qlib/Util.qm
 
 %exec-class BackquoteTest
 
 class BackquoteTest inherits QUnit::Test {
     constructor() : QUnit::Test("Backquote test", "1.0") {
         addTestCase("Backquote test", \testBackquote());
+        addTestCase("Backquote empty output", \testEmptyOutput());
+        addTestCase("Backquote command not found", \testCommandNotFound());
+        addTestCase("Backquote SIGINT handling", \testSignalHandling());
+        addTestCase("Backquote interrupt kills process group", \testInterruptKillsProcessGroup());
+        addTestCase("Backquote restricted access", \testRestrictedAccess());
         set_return_value(main());
     }
 
     testBackquote() {
-        if (PlatformOS == "Windows")
+        if (PlatformOS == "Windows") {
             testSkip("skipping because the test is being run on Windows");
+        }
 
         assertEq("1", chomp(`/bin/echo 1`), "backquotes 1");
         assertEq("Qore is great!", chomp(`/bin/echo "Qore is great!"`), "backquotes 2");
@@ -28,5 +35,147 @@ class BackquoteTest inherits QUnit::Test {
         backquote("cat /abcDefGHm54sdvdsCE54dfhbgzgGH45J5g4bbg4dfwrtEFG5 2>nul", \rc);
 %endif
         assertEq(1, rc);
+    }
+
+    testEmptyOutput() {
+        if (PlatformOS == "Windows") {
+            testSkip("skipping because the test is being run on Windows");
+        }
+
+        int rc;
+        string out = backquote(":", \rc);
+        assertEq("", out, "backquote should return empty output");
+        assertEq(0, rc, "backquote should return zero exit code");
+    }
+
+    testCommandNotFound() {
+        if (PlatformOS == "Windows") {
+            testSkip("skipping because the test is being run on Windows");
+        }
+
+        int rc = 0;
+        string out = backquote("command_should_not_exist_12345", \rc);
+        assertEq("", out, "backquote should return empty output on command not found");
+        assertEq(127, rc, "backquote should return 127 for command not found");
+    }
+
+    testSignalHandling() {
+        if (PlatformOS == "Windows") {
+            testSkip("skipping because the test is being run on Windows");
+        }
+
+        int rc;
+        backquote("trap 'exit 42' INT; kill -s INT $$; exit 0", \rc);
+        assertEq(42, rc, "backquote child should handle SIGINT");
+    }
+
+    testInterruptKillsProcessGroup() {
+        if (PlatformOS == "Windows") {
+            testSkip("skipping because the test is being run on Windows");
+        }
+
+        string pid_file = tmp_location() + "/backquote_pid_" + string(getpid());
+        on_exit {
+            if (is_file(pid_file)) {
+                unlink(pid_file);
+            }
+        }
+
+        SandboxManager sm();
+        Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+        p.setSandboxManager(sm);
+
+        p.parse("
+%modern
+
+int sub run_backquote_rc(string cmd) {
+    int lrc = 0;
+    backquote(cmd, \\lrc);
+    return lrc;
+}
+        ", "backquote_interrupt_test");
+
+        Counter done(1);
+        bool caught = False;
+        string ex_err;
+        int rc = -999;
+
+        string cmd = "echo $$ > " + pid_file + "; sleep 30 & wait";
+        background sub() {
+            try {
+                rc = p.callFunction("run_backquote_rc", cmd);
+            } catch (hash<ExceptionInfo> ex) {
+                caught = True;
+                ex_err = ex.err;
+                rc = -1;
+            }
+            done.dec();
+        }();
+
+        int wait_attempts = 200;
+        while (!is_file(pid_file) && wait_attempts-- > 0) {
+            usleep(10000);
+        }
+        assertTrue(is_file(pid_file), "pid file created");
+
+        string pid_str = chomp(ReadOnlyFile::readTextFile(pid_file));
+        int pgid = pid_str.toInt();
+        assertTrue(pgid > 0, "process group id captured");
+
+        sm.requestInterrupt();
+        done.waitForZero(5s);
+
+        assertEq(-1, rc, "backquote() should return -1 on interrupt");
+        assertEq(True, caught, "backquote() call interrupted");
+        assertEq("PROGRAM-INTERRUPTED", ex_err, "backquote() raised PROGRAM-INTERRUPTED");
+
+        int krc = 0;
+        int kill_attempts = 50;
+        while (kill_attempts-- > 0) {
+            krc = kill(-pgid, 0);
+            if (krc == -1) {
+                break;
+            }
+            usleep(10000);
+        }
+        assertEq(-1, krc, "process group should be gone");
+    }
+
+    testRestrictedAccess() {
+        if (PlatformOS == "Windows") {
+            testSkip("skipping because the test is being run on Windows");
+        }
+
+        Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES | PO_NO_EXTERNAL_PROCESS);
+        bool parse_caught = False;
+        try {
+            p.parse("
+%modern
+
+string sub run_backquote() {
+    return backquote(\":\");
+}
+            ", "backquote_restricted");
+        } catch (hash<ExceptionInfo> ex) {
+            parse_caught = True;
+            assertEq("PARSE-EXCEPTION", ex.err, "backquote() blocked by PO_NO_EXTERNAL_PROCESS");
+        }
+        assertTrue(parse_caught, "backquote() should be blocked by PO_NO_EXTERNAL_PROCESS");
+
+        Program p2(PO_NEW_STYLE | PO_NO_EXTERNAL_PROCESS);
+        bool parse_op_caught = False;
+        try {
+            p2.parse("
+%modern
+
+string sub run_backquote_op() {
+    return `/bin/echo 1`;
+}
+            ", "backquote_op_restricted");
+        } catch (hash<ExceptionInfo> ex) {
+            parse_op_caught = True;
+            assertEq("PARSE-EXCEPTION", ex.err, "backquote operator blocked at parse time");
+        }
+        assertTrue(parse_op_caught, "backquote operator should be blocked by PO_NO_EXTERNAL_PROCESS");
     }
 }

--- a/include/qore/intern/RuntimeConfig.h
+++ b/include/qore/intern/RuntimeConfig.h
@@ -192,7 +192,8 @@ public:
     DLLLOCAL RuntimeConfigLocationHelper(RuntimeConfig& rc,
         const QoreProgramLocation* new_loc,
         const AbstractStatement* new_stmt = nullptr,
-        int64_t new_po = -1,
+        bool has_po = false,
+        int64_t new_po = 0,
         ExceptionSink* xsink = nullptr);
     DLLLOCAL ~RuntimeConfigLocationHelper();
 

--- a/lib/AbstractStatement.cpp
+++ b/lib/AbstractStatement.cpp
@@ -3,7 +3,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -92,7 +92,7 @@ int AbstractStatement::exec(QoreValue& return_value, ExceptionSink *xsink) {
 int AbstractStatement::exec(RuntimeConfig& rc, QoreValue& return_value, ExceptionSink* xsink) {
     //QORE_TRACE("AbstractStatement::exec()");
     printd(1, "AbstractStatement::exec() this: %p file: %s:%d\n", this, loc->getFile(), loc->start_line);
-    RuntimeConfigLocationHelper loc_helper(rc, loc, this, pwo.parse_options, xsink);
+    RuntimeConfigLocationHelper loc_helper(rc, loc, this, true, pwo.parse_options, xsink);
     //pthread_testcancel();
     if (*xsink) {
         return 0;

--- a/lib/BackquoteNode.cpp
+++ b/lib/BackquoteNode.cpp
@@ -34,8 +34,10 @@
 #include <cerrno>
 #include <csignal>
 #include <unistd.h>
-#ifdef __linux__
+#ifdef HAVE_POLL_H
 #include <poll.h>
+#endif
+#ifdef __linux__
 #include <spawn.h>
 #endif
 
@@ -89,7 +91,7 @@ QoreValue BackquoteNode::evalImpl(bool& needs_deref, ExceptionSink* xsink) const
 
 QoreStringNode* backquoteEval(const char* cmd, int& rc, ExceptionSink* xsink) {
     rc = 0;
-#if defined(__linux__) && defined(HAVE_FORK) && defined(HAVE_SIGNAL_HANDLING)
+#if defined(__linux__) && defined(HAVE_FORK) && defined(HAVE_SIGNAL_HANDLING) && defined(HAVE_POLL)
     {
         int pipefd[2];
         if (pipe(pipefd)) {
@@ -111,20 +113,33 @@ QoreStringNode* backquoteEval(const char* cmd, int& rc, ExceptionSink* xsink) {
             }
         }
         if (spawn_rc == 0) {
-            short flags = POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETPGROUP;
-            posix_spawnattr_setflags(&attr, flags);
+            short flags = POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGDEF;
+            spawn_rc = posix_spawnattr_setflags(&attr, flags);
 
-            sigset_t empty;
-            sigemptyset(&empty);
-            posix_spawnattr_setsigmask(&attr, &empty);
-            posix_spawnattr_setpgroup(&attr, 0);
+            if (spawn_rc == 0) {
+                sigset_t empty;
+                sigemptyset(&empty);
+                spawn_rc = posix_spawnattr_setsigmask(&attr, &empty);
+            }
+            if (spawn_rc == 0) {
+                sigset_t def;
+                sigemptyset(&def);
+                sigaddset(&def, SIGINT);
+                sigaddset(&def, SIGQUIT);
+                spawn_rc = posix_spawnattr_setsigdefault(&attr, &def);
+            }
+            if (spawn_rc == 0) {
+                spawn_rc = posix_spawnattr_setpgroup(&attr, 0);
+            }
 
-            posix_spawn_file_actions_adddup2(&actions, pipefd[1], STDOUT_FILENO);
-            posix_spawn_file_actions_addclose(&actions, pipefd[0]);
-            posix_spawn_file_actions_addclose(&actions, pipefd[1]);
+            if (spawn_rc == 0) {
+                posix_spawn_file_actions_adddup2(&actions, pipefd[1], STDOUT_FILENO);
+                posix_spawn_file_actions_addclose(&actions, pipefd[0]);
+                posix_spawn_file_actions_addclose(&actions, pipefd[1]);
 
-            const char* argv[] = {"sh", "-c", cmd, nullptr};
-            spawn_rc = posix_spawn(&pid, "/bin/sh", &actions, &attr, const_cast<char* const*>(argv), environ);
+                const char* argv[] = {"sh", "-c", cmd, nullptr};
+                spawn_rc = posix_spawn(&pid, "/bin/sh", &actions, &attr, const_cast<char* const*>(argv), environ);
+            }
         }
 
         if (spawn_rc != 0) {
@@ -177,14 +192,108 @@ QoreStringNode* backquoteEval(const char* cmd, int& rc, ExceptionSink* xsink) {
             }
 
             int size = read(pipefd[0], buf, READ_BLOCK);
-            if (size <= 0) {
+            if (size == 0) {
+                break;
+            }
+            if (size < 0) {
+#ifdef EINTR
+                if (errno == EINTR) {
+                    continue;
+                }
+#endif
                 break;
             }
 
             s->concat(buf, size);
-            if (size != READ_BLOCK) {
+        }
+
+        close(pipefd[0]);
+        int status;
+        if (waitpid(pid, &status, 0) != pid) {
+            rc = -1;
+            return s.release();
+        }
+        rc = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+        return s.release();
+    }
+#endif
+#if !defined(__linux__) && defined(HAVE_FORK) && defined(HAVE_SIGNAL_HANDLING) && defined(HAVE_POLL)
+    {
+        int pipefd[2];
+        if (pipe(pipefd)) {
+            xsink->raiseException("BACKQUOTE-ERROR", q_strerror(errno));
+            return nullptr;
+        }
+
+        pid_t pid = fork();
+        if (!pid) {
+            setpgid(0, 0);
+
+            sigset_t empty;
+            sigemptyset(&empty);
+            sigprocmask(SIG_SETMASK, &empty, nullptr);
+            signal(SIGINT, SIG_DFL);
+            signal(SIGQUIT, SIG_DFL);
+
+            dup2(pipefd[1], STDOUT_FILENO);
+            close(pipefd[0]);
+            close(pipefd[1]);
+
+            execl("/bin/sh", "sh", "-c", cmd, NULL);
+            fprintf(stderr, "execl() failed in child process for target '/bin/sh' with error code %d: %s\n", errno,
+                strerror(errno));
+            _Exit(-1);
+        }
+        if (pid == -1) {
+            close(pipefd[0]);
+            close(pipefd[1]);
+            xsink->raiseException("BACKQUOTE-ERROR", q_strerror(errno));
+            return nullptr;
+        }
+        close(pipefd[1]);
+
+        QoreStringNodeHolder s(new QoreStringNode);
+        char buf[READ_BLOCK];
+        while (true) {
+            if (qore_check_io_interrupt(xsink, "backquote read")) {
+                kill(-pid, SIGKILL);
+                waitpid(pid, &rc, 0);
+                close(pipefd[0]);
+                rc = -1;
+                return nullptr;
+            }
+
+            struct pollfd pfd;
+            pfd.fd = pipefd[0];
+            pfd.events = POLLIN;
+            pfd.revents = 0;
+            int prc = poll(&pfd, 1, QORE_IO_POLL_INTERVAL_MS);
+            if (prc == 0) {
+                continue;
+            }
+            if (prc < 0) {
+#ifdef EINTR
+                if (errno == EINTR) {
+                    continue;
+                }
+#endif
                 break;
             }
+
+            int size = read(pipefd[0], buf, READ_BLOCK);
+            if (size == 0) {
+                break;
+            }
+            if (size < 0) {
+#ifdef EINTR
+                if (errno == EINTR) {
+                    continue;
+                }
+#endif
+                break;
+            }
+
+            s->concat(buf, size);
         }
 
         close(pipefd[0]);

--- a/lib/BackquoteNode.cpp
+++ b/lib/BackquoteNode.cpp
@@ -113,7 +113,7 @@ QoreStringNode* backquoteEval(const char* cmd, int& rc, ExceptionSink* xsink) {
             }
         }
         if (spawn_rc == 0) {
-            short flags = POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGDEF;
+            short flags = static_cast<short>(POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGDEF);
             spawn_rc = posix_spawnattr_setflags(&attr, flags);
 
             if (spawn_rc == 0) {
@@ -167,6 +167,7 @@ QoreStringNode* backquoteEval(const char* cmd, int& rc, ExceptionSink* xsink) {
         char buf[READ_BLOCK];
         while (true) {
             if (qore_check_io_interrupt(xsink, "backquote read")) {
+                // Use SIGKILL to enforce immediate termination on interrupt.
                 kill(-pid, SIGKILL);
                 waitpid(pid, &rc, 0);
                 close(pipefd[0]);
@@ -256,6 +257,7 @@ QoreStringNode* backquoteEval(const char* cmd, int& rc, ExceptionSink* xsink) {
         char buf[READ_BLOCK];
         while (true) {
             if (qore_check_io_interrupt(xsink, "backquote read")) {
+                // Use SIGKILL to enforce immediate termination on interrupt.
                 kill(-pid, SIGKILL);
                 waitpid(pid, &rc, 0);
                 close(pipefd[0]);

--- a/lib/BackquoteNode.cpp
+++ b/lib/BackquoteNode.cpp
@@ -3,7 +3,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -32,6 +32,16 @@
 #include <qore/QoreSandboxManager.h>
 
 #include <cerrno>
+#include <csignal>
+#include <unistd.h>
+#ifdef __linux__
+#include <poll.h>
+#include <spawn.h>
+#endif
+
+#ifdef __linux__
+extern char **environ;
+#endif
 #ifdef HAVE_SYS_WAIT_H
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -79,6 +89,115 @@ QoreValue BackquoteNode::evalImpl(bool& needs_deref, ExceptionSink* xsink) const
 
 QoreStringNode* backquoteEval(const char* cmd, int& rc, ExceptionSink* xsink) {
     rc = 0;
+#if defined(__linux__) && defined(HAVE_FORK) && defined(HAVE_SIGNAL_HANDLING)
+    {
+        int pipefd[2];
+        if (pipe(pipefd)) {
+            xsink->raiseException("BACKQUOTE-ERROR", q_strerror(errno));
+            return nullptr;
+        }
+
+        pid_t pid = -1;
+        posix_spawn_file_actions_t actions;
+        posix_spawnattr_t attr;
+        bool actions_inited = false;
+        bool attr_inited = false;
+        int spawn_rc = posix_spawn_file_actions_init(&actions);
+        if (spawn_rc == 0) {
+            actions_inited = true;
+            spawn_rc = posix_spawnattr_init(&attr);
+            if (spawn_rc == 0) {
+                attr_inited = true;
+            }
+        }
+        if (spawn_rc == 0) {
+            short flags = POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETPGROUP;
+            posix_spawnattr_setflags(&attr, flags);
+
+            sigset_t empty;
+            sigemptyset(&empty);
+            posix_spawnattr_setsigmask(&attr, &empty);
+            posix_spawnattr_setpgroup(&attr, 0);
+
+            posix_spawn_file_actions_adddup2(&actions, pipefd[1], STDOUT_FILENO);
+            posix_spawn_file_actions_addclose(&actions, pipefd[0]);
+            posix_spawn_file_actions_addclose(&actions, pipefd[1]);
+
+            const char* argv[] = {"sh", "-c", cmd, nullptr};
+            spawn_rc = posix_spawn(&pid, "/bin/sh", &actions, &attr, const_cast<char* const*>(argv), environ);
+        }
+
+        if (spawn_rc != 0) {
+            close(pipefd[0]);
+            close(pipefd[1]);
+            if (spawn_rc == -1) {
+                xsink->raiseException("BACKQUOTE-ERROR", q_strerror(errno));
+            } else {
+                xsink->raiseException("BACKQUOTE-ERROR", q_strerror(spawn_rc));
+            }
+            if (actions_inited) {
+                posix_spawn_file_actions_destroy(&actions);
+            }
+            if (attr_inited) {
+                posix_spawnattr_destroy(&attr);
+            }
+            return nullptr;
+        }
+
+        posix_spawn_file_actions_destroy(&actions);
+        posix_spawnattr_destroy(&attr);
+        close(pipefd[1]);
+
+        QoreStringNodeHolder s(new QoreStringNode);
+        char buf[READ_BLOCK];
+        while (true) {
+            if (qore_check_io_interrupt(xsink, "backquote read")) {
+                kill(-pid, SIGKILL);
+                waitpid(pid, &rc, 0);
+                close(pipefd[0]);
+                rc = -1;
+                return nullptr;
+            }
+
+            struct pollfd pfd;
+            pfd.fd = pipefd[0];
+            pfd.events = POLLIN;
+            pfd.revents = 0;
+            int prc = poll(&pfd, 1, QORE_IO_POLL_INTERVAL_MS);
+            if (prc == 0) {
+                continue;
+            }
+            if (prc < 0) {
+#ifdef EINTR
+                if (errno == EINTR) {
+                    continue;
+                }
+#endif
+                break;
+            }
+
+            int size = read(pipefd[0], buf, READ_BLOCK);
+            if (size <= 0) {
+                break;
+            }
+
+            s->concat(buf, size);
+            if (size != READ_BLOCK) {
+                break;
+            }
+        }
+
+        close(pipefd[0]);
+        int status;
+        if (waitpid(pid, &status, 0) != pid) {
+            rc = -1;
+            return s.release();
+        }
+        rc = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+        return s.release();
+    }
+#endif
+
     // execute command in a new process and read stdout in parent
     FILE* p = popen(cmd, "r");
     if (!p) {

--- a/lib/RuntimeConfig.cpp
+++ b/lib/RuntimeConfig.cpp
@@ -109,16 +109,17 @@ RuntimeConfigHelper::~RuntimeConfigHelper() {
 RuntimeConfigLocationHelper::RuntimeConfigLocationHelper(RuntimeConfig& rc,
         const QoreProgramLocation* new_loc,
         const AbstractStatement* new_stmt,
+        bool has_po,
         int64_t new_po,
         ExceptionSink* xsink)
     : rc(rc), old_loc(rc.loc), old_stmt(rc.stmt), old_po(rc.po),
       tls_old_loc(rc.loc), tls_old_stmt(rc.stmt), tls_old_po(rc.po),
-      restore_po(new_po >= 0), used_swap(false) {
+      restore_po(has_po), used_swap(false) {
     rc.loc = new_loc;
     if (new_stmt) {
         rc.stmt = new_stmt;
     }
-    if (new_po >= 0) {
+    if (has_po) {
         rc.po = new_po;
     }
     // Sync to TLS so code that falls back to TLS (like rc_get_current() from contexts

--- a/lib/ql_lib.qpp
+++ b/lib/ql_lib.qpp
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2025 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -46,6 +46,11 @@
 #include <sys/param.h>
 #include <sys/types.h>
 #include <unistd.h>
+#ifdef __linux__
+#include <poll.h>
+#include <spawn.h>
+#include <sys/syscall.h>
+#endif
 
 #ifdef HAVE_GRP_H
 #include <grp.h>
@@ -83,6 +88,9 @@
 #define MAX_GIDS 100
 
 extern bool threads_initialized;
+#ifdef __linux__
+extern char **environ;
+#endif
 
 AbstractQoreNode* missing_function_error(const char* func, ExceptionSink* xsink) {
    QoreString have(func);
@@ -284,10 +292,119 @@ int rc = system("ls -l");
     - @ref backquote_operator "the backquote operator"
  */
 int system(string command) [dom=EXTERNAL_PROCESS] {
+    auto wait_for_process = [&](pid_t pid) -> int {
+        int status = 0;
+#ifdef __linux__
+        auto pidfd_open = [](pid_t target_pid) -> int {
+#ifdef SYS_pidfd_open
+            return syscall(SYS_pidfd_open, target_pid, 0);
+#else
+            return -1;
+#endif
+        };
+        int pidfd = pidfd_open(pid);
+        if (pidfd >= 0) {
+            while (true) {
+                if (qore_check_io_interrupt(xsink, "process wait")) {
+                    kill(-pid, SIGKILL);
+                    waitpid(pid, &status, 0);
+                    close(pidfd);
+                    return -1;
+                }
+
+                struct pollfd pfd;
+                pfd.fd = pidfd;
+                pfd.events = POLLIN;
+                pfd.revents = 0;
+                // Use a shorter interval here to reduce system() latency without changing global defaults.
+                const int system_poll_ms = 50;
+                int rc = poll(&pfd, 1, system_poll_ms);
+                if (rc > 0) {
+                    break;
+                }
+                if (rc == 0) {
+                    continue;
+                }
+#ifdef EINTR
+                if (errno == EINTR) {
+                    continue;
+                }
+#endif
+                break;
+            }
+            close(pidfd);
+            if (waitpid(pid, &status, 0) != pid) {
+                return -1;
+            }
+            return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+        }
+#endif
+
+        while (true) {
+            // check for sandbox interrupt
+            if (qore_check_io_interrupt(xsink, "process wait")) {
+                // kill the child process group on interrupt
+                kill(-pid, SIGKILL);
+                waitpid(pid, &status, 0);
+                return -1;
+            }
+
+            // use WNOHANG for non-blocking check
+            int rc = waitpid(pid, &status, WNOHANG);
+            if (rc == pid) {
+                // child has exited
+                break;
+            }
+            if (rc == 0) {
+                // child still running, sleep briefly and retry
+                // Use a shorter interval here to reduce system() latency without changing global defaults.
+                const int system_poll_ms = 50;
+                usleep(system_poll_ms * 1000);
+                continue;
+            }
+#ifdef EINTR
+            if (rc == -1 && errno == EINTR) {
+                continue;
+            }
+#endif
+            // error
+            return -1;
+        }
+        return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    };
+
+#if defined(__linux__) && defined(HAVE_FORK) && defined(HAVE_SIGNAL_HANDLING)
+    pid_t spawn_pid = -1;
+    int spawn_rc = 0;
+    posix_spawnattr_t attr;
+    spawn_rc = posix_spawnattr_init(&attr);
+    if (spawn_rc == 0) {
+        short flags = POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETPGROUP;
+        posix_spawnattr_setflags(&attr, flags);
+
+        sigset_t empty;
+        sigemptyset(&empty);
+        posix_spawnattr_setsigmask(&attr, &empty);
+        posix_spawnattr_setpgroup(&attr, 0);
+
+        const char* argv[] = {"sh", "-c", command->c_str(), nullptr};
+        spawn_rc = posix_spawn(&spawn_pid, "/bin/sh", nullptr, &attr, const_cast<char* const*>(argv), environ);
+        posix_spawnattr_destroy(&attr);
+    }
+    if (spawn_rc == 0) {
+        return wait_for_process(spawn_pid);
+    }
+#endif
 #if defined(HAVE_FORK) && defined(HAVE_SIGNAL_HANDLING)
     // on platforms with fork(2) and signal handling, we need to fork, enable all signals, then execl()
     pid_t pid;
     if (!(pid = fork())) {
+        setpgid(0, 0);
+
+        sigset_t empty;
+        sigemptyset(&empty);
+        sigprocmask(SIG_SETMASK, &empty, nullptr);
+
         // exec pgm like system(): sh -c "command"
         execl("/bin/sh", "sh", "-c", command->c_str(), NULL);
         fprintf(stderr, "execl() failed in child process for target '/bin/sh' with error code %d: %s\n", errno,
@@ -298,38 +415,10 @@ int system(string command) [dom=EXTERNAL_PROCESS] {
     if (pid == -1) {
         return -1;
     }
+    setpgid(pid, pid);
 
     // wait for child to exit with interrupt checking
-    int status;
-    while (true) {
-        // check for sandbox interrupt
-        if (qore_check_io_interrupt(xsink, "process wait")) {
-            // kill the child process on interrupt
-            kill(pid, SIGKILL);
-            waitpid(pid, &status, 0);
-            return -1;
-        }
-
-        // use WNOHANG for non-blocking check
-        int rc = waitpid(pid, &status, WNOHANG);
-        if (rc == pid) {
-            // child has exited
-            break;
-        }
-        if (rc == 0) {
-            // child still running, sleep briefly and retry
-            usleep(QORE_IO_POLL_INTERVAL_MS * 1000);
-            continue;
-        }
-#ifdef EINTR
-        if (rc == -1 && errno == EINTR) {
-            continue;
-        }
-#endif
-        // error
-        break;
-    }
-    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    return wait_for_process(pid);
 #elif defined(HAVE_SYSTEM)
     return system(command->c_str());
 #else

--- a/lib/ql_lib.qpp
+++ b/lib/ql_lib.qpp
@@ -379,16 +379,29 @@ int system(string command) [dom=EXTERNAL_PROCESS] {
     posix_spawnattr_t attr;
     spawn_rc = posix_spawnattr_init(&attr);
     if (spawn_rc == 0) {
-        short flags = POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETPGROUP;
-        posix_spawnattr_setflags(&attr, flags);
+        short flags = POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGDEF;
+        spawn_rc = posix_spawnattr_setflags(&attr, flags);
 
-        sigset_t empty;
-        sigemptyset(&empty);
-        posix_spawnattr_setsigmask(&attr, &empty);
-        posix_spawnattr_setpgroup(&attr, 0);
+        if (spawn_rc == 0) {
+            sigset_t empty;
+            sigemptyset(&empty);
+            spawn_rc = posix_spawnattr_setsigmask(&attr, &empty);
+        }
+        if (spawn_rc == 0) {
+            sigset_t def;
+            sigemptyset(&def);
+            sigaddset(&def, SIGINT);
+            sigaddset(&def, SIGQUIT);
+            spawn_rc = posix_spawnattr_setsigdefault(&attr, &def);
+        }
+        if (spawn_rc == 0) {
+            spawn_rc = posix_spawnattr_setpgroup(&attr, 0);
+        }
 
-        const char* argv[] = {"sh", "-c", command->c_str(), nullptr};
-        spawn_rc = posix_spawn(&spawn_pid, "/bin/sh", nullptr, &attr, const_cast<char* const*>(argv), environ);
+        if (spawn_rc == 0) {
+            const char* argv[] = {"sh", "-c", command->c_str(), nullptr};
+            spawn_rc = posix_spawn(&spawn_pid, "/bin/sh", nullptr, &attr, const_cast<char* const*>(argv), environ);
+        }
         posix_spawnattr_destroy(&attr);
     }
     if (spawn_rc == 0) {
@@ -404,6 +417,8 @@ int system(string command) [dom=EXTERNAL_PROCESS] {
         sigset_t empty;
         sigemptyset(&empty);
         sigprocmask(SIG_SETMASK, &empty, nullptr);
+        signal(SIGINT, SIG_DFL);
+        signal(SIGQUIT, SIG_DFL);
 
         // exec pgm like system(): sh -c "command"
         execl("/bin/sh", "sh", "-c", command->c_str(), NULL);

--- a/lib/ql_lib.qpp
+++ b/lib/ql_lib.qpp
@@ -292,20 +292,28 @@ int rc = system("ls -l");
     - @ref backquote_operator "the backquote operator"
  */
 int system(string command) [dom=EXTERNAL_PROCESS] {
-    auto wait_for_process = [&](pid_t pid) -> int {
+#ifdef __linux__
+    auto pidfd_open = [](pid_t target_pid) -> int {
+#ifdef SYS_pidfd_open
+        return syscall(SYS_pidfd_open, target_pid, 0);
+#else
+        return -1;
+#endif
+    };
+#endif
+
+    auto wait_for_process = [&xsink
+#ifdef __linux__
+        , &pidfd_open
+#endif
+    ](pid_t pid) -> int {
         int status = 0;
 #ifdef __linux__
-        auto pidfd_open = [](pid_t target_pid) -> int {
-#ifdef SYS_pidfd_open
-            return syscall(SYS_pidfd_open, target_pid, 0);
-#else
-            return -1;
-#endif
-        };
         int pidfd = pidfd_open(pid);
         if (pidfd >= 0) {
             while (true) {
                 if (qore_check_io_interrupt(xsink, "process wait")) {
+                    // Use SIGKILL to enforce immediate termination on interrupt.
                     kill(-pid, SIGKILL);
                     waitpid(pid, &status, 0);
                     close(pidfd);
@@ -343,7 +351,7 @@ int system(string command) [dom=EXTERNAL_PROCESS] {
         while (true) {
             // check for sandbox interrupt
             if (qore_check_io_interrupt(xsink, "process wait")) {
-                // kill the child process group on interrupt
+                // Use SIGKILL to enforce immediate termination on interrupt.
                 kill(-pid, SIGKILL);
                 waitpid(pid, &status, 0);
                 return -1;
@@ -379,7 +387,7 @@ int system(string command) [dom=EXTERNAL_PROCESS] {
     posix_spawnattr_t attr;
     spawn_rc = posix_spawnattr_init(&attr);
     if (spawn_rc == 0) {
-        short flags = POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGDEF;
+        short flags = static_cast<short>(POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGDEF);
         spawn_rc = posix_spawnattr_setflags(&attr, flags);
 
         if (spawn_rc == 0) {
@@ -430,7 +438,13 @@ int system(string command) [dom=EXTERNAL_PROCESS] {
     if (pid == -1) {
         return -1;
     }
-    setpgid(pid, pid);
+    if (setpgid(pid, pid) == -1) {
+#ifdef EACCES
+        if (errno != EACCES) {
+            // Ignore unexpected errors to preserve existing behavior.
+        }
+#endif
+    }
 
     // wait for child to exit with interrupt checking
     return wait_for_process(pid);

--- a/modules/logger_bin/src/QC_LoggerLevel.qpp
+++ b/modules/logger_bin/src/QC_LoggerLevel.qpp
@@ -3,7 +3,7 @@
 /*
     Qore Programming Language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -60,7 +60,8 @@ static void LoggerLevel_deserializer(QoreObject& self, const QoreHashNode* sdata
             return;
         }
 
-        self.setPrivate(CID_LOGGERLEVEL, new QoreLoggerLevel(code, val.get<const QoreStringNode>()));
+        self.setPrivate(CID_LOGGERLEVEL,
+            new QoreLoggerLevel(code, new QoreStringNode(*val.get<const QoreStringNode>())));
         return;
     }
 
@@ -77,7 +78,7 @@ qclass LoggerLevel [ns=Qore::Logger; arg=QoreLoggerLevel* level; vparent=Seriali
     @param level string log level value
 */
 LoggerLevel::constructor(int code, string level) {
-    self->setPrivate(CID_LOGGERLEVEL, new QoreLoggerLevel(code, level));
+    self->setPrivate(CID_LOGGERLEVEL, new QoreLoggerLevel(code, new QoreStringNode(*level)));
 }
 
 //! Gets the level code value

--- a/qlib/WebSocketClient.qm
+++ b/qlib/WebSocketClient.qm
@@ -1466,6 +1466,11 @@ ws.setEventQueue();
             }
         }
 
+        if (hc.isOpen()) {
+            hc.shutdown();
+            hc.close();
+        }
+
         # call the callback with NOTHING to signal that the connection has been closed
         try {
             # issue #3225 catch and log any exeptions in the closing callback
@@ -1479,10 +1484,6 @@ ws.setEventQueue();
                 }
                 rethrow;
             }
-        }
-        if (hc.isOpen()) {
-            hc.shutdown();
-            hc.close();
         }
 
         if (!self) {


### PR DESCRIPTION
## Summary
- optimize system() wait polling interval for lower latency on non-Linux platforms
- improve system()/backquote process handling and interrupt semantics on Linux
- extend backquote signal handling/interrupt path to non-Linux Unix platforms
- fix parse-options propagation for full 64-bit values
- fix LoggerLevel string ownership during serialization/deserialization
- ensure WebSocketClient closes the connection before emitting closed events
- add tests for system()/backquote interrupts, restricted access, and negative cases
- update release notes

## Testing
- QUnit Test "Logger" v1.0
Ran 16 test cases, 16 succeeded (991 assertions)
- QUnit Test "Logger" v1.0
Ran 16 test cases, 16 succeeded (991 assertions)
- QUnit Test "SystemCallTest" v1.0
Ran 6 test cases, 6 succeeded (13 assertions)
- QUnit Test "Backquote test" v1.0
Ran 6 test cases, 6 succeeded (20 assertions)
- QUnit Test "Backquote test" v1.0
Ran 6 test cases, 6 succeeded (20 assertions)
- QUnit Test "Recursive dependency test" v1.0
Ran 1 test case, 1 succeeded (2 assertions)
- Using qore: build-debug/qore
Using libqore: build-debug/libqore.so
QORE_INCLUDE_DIR=/home/david/src/Qorus/current/qlib:/opt/qorus/dev01/qlib
QORE_MODULE_DIR=./qlib:build-debug/modules/reflection:build-debug/modules/logger_bin:build-debug/modules/astparser
LD_PRELOAD=build-debug/libqore.so
LD_LIBRARY_PATH=build-debug/libqore.so:./lib/.libs:./qlib::/usr/local/lib64:/usr/local/lib
QORE_DB_CONNSTR: 
QORE_DB_CONNSTR_FREETDS: freetds:test/Test1234@rippy
QORE_DB_CONNSTR_MYSQL: mysql:omquser/omquser@omquser%rippy
QORE_DB_CONNSTR_PGSQL: pgsql:omquser/omquser@omquser
QORE_DB_CONNSTR_ORACLE: oracle:omquser/omquser@rippy
REDIS_URL: 

=====================================
Running test (1/1): ./examples/test/qlib/WebSocketClient/WebSocketClient.qtest
-------------------------------------
cmdline: build-debug/qore -penable-debug ./examples/test/qlib/WebSocketClient/WebSocketClient.qtest 
-------------------------------------
QUnit Test "WebSocketClientTest" v1.0
external ws: spawn at 2026-01-16 22:06:37.579627 Fri +01:00 (CET)
Skipped: HTTP/2 WebSocket external server tests: 0 assertions
2026-01-16 22:06:37.585557: Skip requested at ./examples/test/qlib/WebSocketClient/WebSocketClient.qtest:753 [WebSocketClientTest::http2WebSocketExternalTests()] <- ./examples/test/qlib/WebSocketClient/WebSocketClient.qtest:221 [WebSocketClientTest::constructor()]
-----
	>> External HTTP/2 WebSocket server not available
-----
Ran 7 test cases, 7 succeeded (61 assertions)
-------------------------------------


*************************************
TESTING RESULT: Success.
Passed 1 out of 1 tests. 0 tests failed.
*************************************