### PR TITLE
fix: restore subprocess signal behavior

### DIFF
--- a/doxygen/lang/222_sandboxing.dox.tmpl
+++ b/doxygen/lang/222_sandboxing.dox.tmpl
@@ -394,6 +394,10 @@ sm.clearInterrupt();
     - **Database operations**: Datasource transaction lock acquisition (polled at I/O poll interval)
 
     When interrupted, a \c PROGRAM-INTERRUPTED exception is raised.
+    For external process functions (system(), backquote(), and the backquote operator), a SandboxManager also
+    starts the child in a new process group so that requestInterrupt() can terminate the entire process group.
+    Without a SandboxManager, children remain in the current process group and receive terminal signals (for example,
+    Ctrl-C) along with the parent.
 
     @subsection sandbox_interrupt_polling Polling Mechanism
 

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -570,6 +570,9 @@ code<int(string)> func = int sub(int x) { return x; };  # PARSE-TYPE-ERROR: para
       - improved @ref Qore::backquote() "backquote()" and the @ref backquote_operator "backquote operator" on Linux
         to use \c posix_spawn(), restore an unblocked signal mask in child processes, and terminate the entire process
         group on sandbox interrupts
+      - system(), backquote(), and the backquote operator now start children in a new process group only when a
+        @ref Qore::SandboxManager "SandboxManager" is attached; otherwise they stay in the current process group so
+        terminal signals (for example, Ctrl-C) propagate to children as before
       - fixed bareword resolution in constructors and class scopes
         (<a href="https://github.com/qoretechnologies/qore/issues/40">issue 40</a>)
       - fixed calls to member closures defined as class fields

--- a/lib/BackquoteNode.cpp
+++ b/lib/BackquoteNode.cpp
@@ -91,6 +91,7 @@ QoreValue BackquoteNode::evalImpl(bool& needs_deref, ExceptionSink* xsink) const
 
 QoreStringNode* backquoteEval(const char* cmd, int& rc, ExceptionSink* xsink) {
     rc = 0;
+    const bool use_pgroup = runtime_get_sandbox_manager() != nullptr;
 #if defined(__linux__) && defined(HAVE_FORK) && defined(HAVE_SIGNAL_HANDLING) && defined(HAVE_POLL)
     {
         int pipefd[2];
@@ -113,7 +114,10 @@ QoreStringNode* backquoteEval(const char* cmd, int& rc, ExceptionSink* xsink) {
             }
         }
         if (spawn_rc == 0) {
-            short flags = static_cast<short>(POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGDEF);
+            short flags = static_cast<short>(POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSIGDEF);
+            if (use_pgroup) {
+                flags |= POSIX_SPAWN_SETPGROUP;
+            }
             spawn_rc = posix_spawnattr_setflags(&attr, flags);
 
             if (spawn_rc == 0) {
@@ -128,7 +132,7 @@ QoreStringNode* backquoteEval(const char* cmd, int& rc, ExceptionSink* xsink) {
                 sigaddset(&def, SIGQUIT);
                 spawn_rc = posix_spawnattr_setsigdefault(&attr, &def);
             }
-            if (spawn_rc == 0) {
+            if (spawn_rc == 0 && use_pgroup) {
                 spawn_rc = posix_spawnattr_setpgroup(&attr, 0);
             }
 
@@ -162,13 +166,20 @@ QoreStringNode* backquoteEval(const char* cmd, int& rc, ExceptionSink* xsink) {
         posix_spawn_file_actions_destroy(&actions);
         posix_spawnattr_destroy(&attr);
         close(pipefd[1]);
+        bool pgroup_ok = false;
+        if (use_pgroup) {
+            // Best-effort safeguard in case POSIX_SPAWN_SETPGROUP is not applied.
+            if (setpgid(pid, pid) == 0 || errno == EACCES) {
+                pgroup_ok = true;
+            }
+        }
 
         QoreStringNodeHolder s(new QoreStringNode);
         char buf[READ_BLOCK];
         while (true) {
             if (qore_check_io_interrupt(xsink, "backquote read")) {
                 // Use SIGKILL to enforce immediate termination on interrupt.
-                kill(-pid, SIGKILL);
+                kill((use_pgroup && pgroup_ok) ? -pid : pid, SIGKILL);
                 waitpid(pid, &rc, 0);
                 close(pipefd[0]);
                 rc = -1;
@@ -227,8 +238,11 @@ QoreStringNode* backquoteEval(const char* cmd, int& rc, ExceptionSink* xsink) {
         }
 
         pid_t pid = fork();
+        bool pgroup_ok = false;
         if (!pid) {
-            setpgid(0, 0);
+            if (use_pgroup) {
+                setpgid(0, 0);
+            }
 
             sigset_t empty;
             sigemptyset(&empty);
@@ -251,6 +265,9 @@ QoreStringNode* backquoteEval(const char* cmd, int& rc, ExceptionSink* xsink) {
             xsink->raiseException("BACKQUOTE-ERROR", q_strerror(errno));
             return nullptr;
         }
+        if (use_pgroup && (setpgid(pid, pid) == 0 || errno == EACCES)) {
+            pgroup_ok = true;
+        }
         close(pipefd[1]);
 
         QoreStringNodeHolder s(new QoreStringNode);
@@ -258,7 +275,7 @@ QoreStringNode* backquoteEval(const char* cmd, int& rc, ExceptionSink* xsink) {
         while (true) {
             if (qore_check_io_interrupt(xsink, "backquote read")) {
                 // Use SIGKILL to enforce immediate termination on interrupt.
-                kill(-pid, SIGKILL);
+                kill((use_pgroup && pgroup_ok) ? -pid : pid, SIGKILL);
                 waitpid(pid, &rc, 0);
                 close(pipefd[0]);
                 rc = -1;

--- a/lib/ql_lib.qpp
+++ b/lib/ql_lib.qpp
@@ -233,12 +233,6 @@ hashdecl ExceptionInfo {
 //! Exits the program with the return code passed (this function does not return)
 /** @param rc the return code for the process (0 = no error; success)
 
-    @par Process group behavior:
-    - With a @ref Qore::SandboxManager "SandboxManager" attached, the child process is started in a new process group so
-      that @ref Qore::SandboxManager::requestInterrupt() "requestInterrupt()" can terminate the entire process group.
-    - Without a SandboxManager, the child stays in the current process group, so terminal signals (for example, Ctrl-C)
-      are delivered to both the parent and child as usual.
-
     @par Example:
     @code{.py}
 exit(0);
@@ -287,6 +281,12 @@ nothing exec(string command) [dom=EXTERNAL_PROCESS,PROCESS] {
     @param command the command to execute with %system() (3)
 
     @return the exit code of the process executed
+
+    @par Process group behavior:
+    - With a @ref Qore::SandboxManager "SandboxManager" attached, the child process is started in a new process group so
+      that @ref Qore::SandboxManager::requestInterrupt() "requestInterrupt()" can terminate the entire process group.
+    - Without a SandboxManager, the child stays in the current process group, so terminal signals (for example, Ctrl-C)
+      are delivered to both the parent and child as usual.
 
     @par Example:
     @code{.py}

--- a/lib/ql_lib.qpp
+++ b/lib/ql_lib.qpp
@@ -233,6 +233,12 @@ hashdecl ExceptionInfo {
 //! Exits the program with the return code passed (this function does not return)
 /** @param rc the return code for the process (0 = no error; success)
 
+    @par Process group behavior:
+    - With a @ref Qore::SandboxManager "SandboxManager" attached, the child process is started in a new process group so
+      that @ref Qore::SandboxManager::requestInterrupt() "requestInterrupt()" can terminate the entire process group.
+    - Without a SandboxManager, the child stays in the current process group, so terminal signals (for example, Ctrl-C)
+      are delivered to both the parent and child as usual.
+
     @par Example:
     @code{.py}
 exit(0);
@@ -292,6 +298,7 @@ int rc = system("ls -l");
     - @ref backquote_operator "the backquote operator"
  */
 int system(string command) [dom=EXTERNAL_PROCESS] {
+    const bool use_pgroup = runtime_get_sandbox_manager() != nullptr;
 #ifdef __linux__
     auto pidfd_open = [](pid_t target_pid) -> int {
 #ifdef SYS_pidfd_open
@@ -302,11 +309,11 @@ int system(string command) [dom=EXTERNAL_PROCESS] {
     };
 #endif
 
-    auto wait_for_process = [&xsink
+    auto wait_for_process = [&xsink, use_pgroup
 #ifdef __linux__
         , &pidfd_open
 #endif
-    ](pid_t pid) -> int {
+    ](pid_t pid, bool pgroup_ok) -> int {
         int status = 0;
 #ifdef __linux__
         int pidfd = pidfd_open(pid);
@@ -314,7 +321,7 @@ int system(string command) [dom=EXTERNAL_PROCESS] {
             while (true) {
                 if (qore_check_io_interrupt(xsink, "process wait")) {
                     // Use SIGKILL to enforce immediate termination on interrupt.
-                    kill(-pid, SIGKILL);
+                    kill((use_pgroup && pgroup_ok) ? -pid : pid, SIGKILL);
                     waitpid(pid, &status, 0);
                     close(pidfd);
                     return -1;
@@ -352,7 +359,7 @@ int system(string command) [dom=EXTERNAL_PROCESS] {
             // check for sandbox interrupt
             if (qore_check_io_interrupt(xsink, "process wait")) {
                 // Use SIGKILL to enforce immediate termination on interrupt.
-                kill(-pid, SIGKILL);
+                kill((use_pgroup && pgroup_ok) ? -pid : pid, SIGKILL);
                 waitpid(pid, &status, 0);
                 return -1;
             }
@@ -383,11 +390,15 @@ int system(string command) [dom=EXTERNAL_PROCESS] {
 
 #if defined(__linux__) && defined(HAVE_FORK) && defined(HAVE_SIGNAL_HANDLING)
     pid_t spawn_pid = -1;
+    bool spawn_pgroup_ok = false;
     int spawn_rc = 0;
     posix_spawnattr_t attr;
     spawn_rc = posix_spawnattr_init(&attr);
     if (spawn_rc == 0) {
-        short flags = static_cast<short>(POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGDEF);
+        short flags = static_cast<short>(POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSIGDEF);
+        if (use_pgroup) {
+            flags |= POSIX_SPAWN_SETPGROUP;
+        }
         spawn_rc = posix_spawnattr_setflags(&attr, flags);
 
         if (spawn_rc == 0) {
@@ -402,7 +413,7 @@ int system(string command) [dom=EXTERNAL_PROCESS] {
             sigaddset(&def, SIGQUIT);
             spawn_rc = posix_spawnattr_setsigdefault(&attr, &def);
         }
-        if (spawn_rc == 0) {
+        if (spawn_rc == 0 && use_pgroup) {
             spawn_rc = posix_spawnattr_setpgroup(&attr, 0);
         }
 
@@ -413,14 +424,22 @@ int system(string command) [dom=EXTERNAL_PROCESS] {
         posix_spawnattr_destroy(&attr);
     }
     if (spawn_rc == 0) {
-        return wait_for_process(spawn_pid);
+        if (use_pgroup) {
+            if (setpgid(spawn_pid, spawn_pid) == 0 || errno == EACCES) {
+                spawn_pgroup_ok = true;
+            }
+        }
+        return wait_for_process(spawn_pid, spawn_pgroup_ok);
     }
 #endif
 #if defined(HAVE_FORK) && defined(HAVE_SIGNAL_HANDLING)
     // on platforms with fork(2) and signal handling, we need to fork, enable all signals, then execl()
     pid_t pid;
+    bool pgroup_ok = false;
     if (!(pid = fork())) {
-        setpgid(0, 0);
+        if (use_pgroup) {
+            setpgid(0, 0);
+        }
 
         sigset_t empty;
         sigemptyset(&empty);
@@ -438,16 +457,12 @@ int system(string command) [dom=EXTERNAL_PROCESS] {
     if (pid == -1) {
         return -1;
     }
-    if (setpgid(pid, pid) == -1) {
-#ifdef EACCES
-        if (errno != EACCES) {
-            // Ignore unexpected errors to preserve existing behavior.
-        }
-#endif
+    if (use_pgroup && (setpgid(pid, pid) == 0 || errno == EACCES)) {
+        pgroup_ok = true;
     }
 
     // wait for child to exit with interrupt checking
-    return wait_for_process(pid);
+    return wait_for_process(pid, pgroup_ok);
 #elif defined(HAVE_SYSTEM)
     return system(command->c_str());
 #else

--- a/lib/ql_misc.qpp
+++ b/lib/ql_misc.qpp
@@ -595,12 +595,6 @@ const SignalToName = (
     @param signal The signal number to process, see @ref signal_constants for possible values
     @param f The code to execute when the signal is caught; this should accept an integer argument giving the signal number
 
-    @par Process group behavior:
-    - With a @ref Qore::SandboxManager "SandboxManager" attached, the child process is started in a new process group so
-      that @ref Qore::SandboxManager::requestInterrupt() "requestInterrupt()" can terminate the entire process group.
-    - Without a SandboxManager, the child stays in the current process group, so terminal signals (for example, Ctrl-C)
-      are delivered to both the parent and child as usual.
-
     @par Example:
     @code{.py}
 set_signal_handler(SIGINT, \signal_handler());
@@ -1300,6 +1294,12 @@ nothing parseURL() [flags=RUNTIME_NOOP] {
     @param rc an optional reference to an integer to return the return code of the process
 
     @return The stdout of the shell command that was executed
+
+    @par Process group behavior:
+    - With a @ref Qore::SandboxManager "SandboxManager" attached, the child process is started in a new process group so
+      that @ref Qore::SandboxManager::requestInterrupt() "requestInterrupt()" can terminate the entire process group.
+    - Without a SandboxManager, the child stays in the current process group, so terminal signals (for example, Ctrl-C)
+      are delivered to both the parent and child as usual.
 
     @par Example:
     @code{.py}

--- a/lib/ql_misc.qpp
+++ b/lib/ql_misc.qpp
@@ -595,6 +595,12 @@ const SignalToName = (
     @param signal The signal number to process, see @ref signal_constants for possible values
     @param f The code to execute when the signal is caught; this should accept an integer argument giving the signal number
 
+    @par Process group behavior:
+    - With a @ref Qore::SandboxManager "SandboxManager" attached, the child process is started in a new process group so
+      that @ref Qore::SandboxManager::requestInterrupt() "requestInterrupt()" can terminate the entire process group.
+    - Without a SandboxManager, the child stays in the current process group, so terminal signals (for example, Ctrl-C)
+      are delivered to both the parent and child as usual.
+
     @par Example:
     @code{.py}
 set_signal_handler(SIGINT, \signal_handler());


### PR DESCRIPTION
## Summary
- restore Ctrl-C propagation for non-sandboxed system()/backquote()
- keep process-group termination for SandboxManager interrupts
- document process-group behavior in sandboxing guide and release notes

## Testing
- ./run_tests.sh -d qore/functions
