### PR TITLE
feat: add GeneratorDataProvider module and AST parser improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1583,6 +1583,7 @@ qore_user_module("qlib/ServiceNowRestDataProvider" "RestClient;ServiceNowRestCli
 qore_user_module("qlib/RestClientDataProvider" "RestClient;DataProvider" "webhook-logo.svg")
 qore_user_module("qlib/ElasticSearchDataProvider" "RestClient;DataProvider" "elastic-logo.svg")
 qore_user_module("qlib/EmpathicBuildingDataProvider" "RestClient;DataProvider" "Haltian-EmpathicBuilding.svg")
+qore_user_module("qlib/GeneratorDataProvider" "DataProvider" "generator-logo.svg")
 qore_user_module("qlib/MemcachedDataProvider" "DataProvider" "memcached-logo.svg")
 qore_user_module("qlib/MongoDbDataProvider" "DataProvider;ConnectionProvider" "mongodb-logo.svg")
 qore_user_module("qlib/RedisDataProvider" "DataProvider;ConnectionProvider" "redis-logo.svg")

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,7 @@ DOX_SRC_SPLIT_MODULES = \
     qlib/DbDataProvider \
     qlib/ElasticSearchDataProvider \
     qlib/EmpathicBuildingDataProvider \
+    qlib/GeneratorDataProvider \
     qlib/FileLocationHandler \
     qlib/GoogleDataProvider \
     qlib/ProviderIndexUtil \
@@ -151,6 +152,7 @@ DiscordDataProvider_modverdir = $(modverdir)/DiscordDataProvider
 LinearDataProvider_modverdir = $(modverdir)/LinearDataProvider
 ElasticSearchDataProvider_modverdir = $(modverdir)/ElasticSearchDataProvider
 EmpathicBuildingDataProvider_modverdir = $(modverdir)/EmpathicBuildingDataProvider
+GeneratorDataProvider_modverdir = $(modverdir)/GeneratorDataProvider
 FileLocationHandler_modverdir = $(modverdir)/FileLocationHandler
 FixedLengthUtil_modverdir = $(modverdir)/FixedLengthUtil
 FileDataProvider_modverdir = $(modverdir)/FileDataProvider
@@ -193,6 +195,7 @@ dist_DiscordDataProvider_modver_DATA = $(wildcard qlib/DiscordDataProvider/*.q[c
 dist_LinearDataProvider_modver_DATA = $(wildcard qlib/LinearDataProvider/*.q[cm])
 dist_ElasticSearchDataProvider_modver_DATA = $(wildcard qlib/ElasticSearchDataProvider/*.q[cm])
 dist_EmpathicBuildingDataProvider_modver_DATA = $(wildcard qlib/EmpathicBuildingDataProvider/*.q[cm])
+dist_GeneratorDataProvider_modver_DATA = $(wildcard qlib/GeneratorDataProvider/*.q[cm])
 dist_FileDataProvider_modver_DATA = $(wildcard qlib/FileDataProvider/*.q[cm])
 dist_FileLocationHandler_modver_DATA = $(wildcard qlib/FileLocationHandler/*.q[cm])
 dist_FixedLengthUtil_modver_DATA = $(wildcard qlib/FixedLengthUtil/*.q[cm])
@@ -1153,6 +1156,7 @@ EXTRA_DIST = next_build.sh run_tests.sh ABOUT RELEASE-NOTES \
 	qlib/LinearDataProvider/linear-logo.svg \
 	qlib/ElasticSearchDataProvider/elastic-logo.svg \
 	qlib/EmpathicBuildingDataProvider/Haltian-EmpathicBuilding.svg \
+	qlib/GeneratorDataProvider/generator-logo.svg \
 	qlib/FileDataProvider/file-logo-white.svg \
 	qlib/FileDataProvider/file-logo-black.svg \
 	qlib/FtpClientDataProvider/ftp-logo-white.svg \
@@ -1353,6 +1357,10 @@ doxygen/qlib/Doxyfile.FsUtil: doxygen/qlib/Doxyfile.tmpl $(QDX_DEP)
 # to provide the graphic file
 doxygen/qlib/Doxyfile.ElasticSearchDataProvider: doxygen/qlib/Doxyfile.tmpl $(QDX_DEP)
 	$(QDX) -M=qlib/ElasticSearchDataProvider:doxygen/qlib/ElasticSearchDataProvider -tDataProvider.tag=../../DataProvider/html -tRestClient.tag=../../RestClient/html -X=doxygen/ -E=elastic-logo.svg $< $@
+
+# to provide the graphic file
+doxygen/qlib/Doxyfile.GeneratorDataProvider: doxygen/qlib/Doxyfile.tmpl $(QDX_DEP)
+	$(QDX) -M=qlib/GeneratorDataProvider:doxygen/qlib/GeneratorDataProvider -tDataProvider.tag=../../DataProvider/html -X=doxygen/ -E=generator-logo.svg $< $@
 
 doxygen/qlib/Doxyfile.ElasticSearchLoggerAppender: doxygen/qlib/Doxyfile.tmpl $(QDX_DEP)
 	$(QDX) -M=qlib/ElasticSearchLoggerAppender.qm:doxygen/qlib/ElasticSearchLoggerAppender.qm -tLogger.tag=../../Logger/html -tRestClient.tag=../../RestClient/html -X=doxygen/ -E=elastic-logo.svg $< $@

--- a/bin/qdp
+++ b/bin/qdp
@@ -615,9 +615,9 @@ class QdpCmd {
     static getInfo(AbstractDataProvider provider) {
         hash<DataProviderInfo> info = provider.getInfo();
 
-        # For JSON/YAML output, just dump the raw info
+        # For JSON/YAML output, convert type objects to serializable data
         if (opts.json || opts.yaml) {
-            output(info);
+            output(provider.getInfoAsData());
             return;
         }
 
@@ -631,6 +631,26 @@ class QdpCmd {
         printf("  %s: %s\n", color.key("Type"), color.type(info.type));
         if (info.short_desc) {
             printf("  %s: %s\n", color.key("Description"), info.short_desc);
+        }
+
+        # Constructor options
+        if (info.constructor_options) {
+            printf("%s\n", color.bold("Constructor Options"));
+            foreach hash<auto> opt in (info.constructor_options.pairIterator()) {
+                string type_str = (map $1.getName(), opt.value.type).join("|");
+                string req = opt.value.required ? color.error(" (required)") : "";
+                printf("  %s [%s]%s\n", color.key(opt.key), color.type(type_str), req);
+                if (opt.value.short_desc) {
+                    printf("    %s\n", opt.value.short_desc);
+                }
+                if (opt.value.allowed_values) {
+                    printf("    %s: %s\n", color.dim("values"),
+                        (map $1.value, opt.value.allowed_values).join(", "));
+                }
+                if (exists opt.value.default_value) {
+                    printf("    %s: %y\n", color.dim("default"), opt.value.default_value);
+                }
+            }
         }
 
         # Capabilities section
@@ -1887,13 +1907,25 @@ class QdpCmd {
             if (conn) {
                 prov = conn.getDataProvider(action.subtype);
             } else if (action.cls) {
-                prov = DataProviderActionCatalog::getDataProviderForAction(action, \options);
+                # load the module into qdp's program space so Class::forName() can resolve the class;
+                # the module was already loaded by ProviderIndexUtil into the DataProvider module's
+                # program context, but Class::forName() resolves in the calling program's context,
+                # so we must load the module here and do the class resolution in qdp's context
+                string mod_name = (action.cls.split("::")[0]);
+                load_module(mod_name);
+                hash<auto> constructor_opts;
+                map constructor_opts{$1.key} = remove options{$1.key}, action.options.pairIterator(),
+                    $1.value.loc == "constructor" && options.hasKey($1.key);
+                prov = Class::forName(action.cls).newObject(constructor_opts);
             }
             # set logger on data provider
             prov.setLogger(logger);
 
             DataProviderDataContextHelper dch(options);
             foreach string seg in (action.path[1..].split("/")) {
+                if (!seg.val()) {
+                    continue;
+                }
                 if (*string var = (seg =~ x/^\{([^\}]+)\}$/)[0]) {
                     seg = remove options{var};
                 }
@@ -2295,7 +2327,7 @@ class QdpCmd {
 %endif
         } else if (opts.yaml) {
 %ifndef NoYaml
-            printf("%s", make_yaml(data));
+            printf("%s", make_yaml(data, YAML::BlockStyle));
 %else
             error("YAML output requested but yaml module is not available");
 %endif

--- a/doxygen/lang/120_modules.dox.tmpl
+++ b/doxygen/lang/120_modules.dox.tmpl
@@ -119,6 +119,9 @@ ModuleName/
         remote directory with the FTP protocol
     |user|<a href="../../modules/FtpPollerUtil/html/index.html#ftppollerutilintro">FtpPollerUtil</a>|Provides definitions for the \
         <a href="../../modules/FtpPoller/html/index.html#ftppollerintro">FtpPoller</a> module
+    |user|<a href="../../modules/GeneratorDataProvider/html/index.html#generatordataproviderintro">GeneratorDataProvider</a>|Provides a \
+        <a href="../../modules/DataProvider/html/index.html#dataproviderintro">data provider</a> API for generating configurable test \
+        record streams for data pipeline testing
     |user|<a href="../../modules/GmailDataProvider/html/index.html#gmaildataproviderintro">GmailDataProvider</a>|Provides \
         a <a href="../../modules/DataProvider/html/index.html#dataproviderintro">data provider</a> API for Gmail operations
     |user|<a href="../../modules/GoogleCalendarDataProvider/html/index.html#googlecalendardataproviderintro">GoogleCalendarDataProvider</a>|Provides \

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -445,6 +445,11 @@ code<int(string)> func = int sub(int x) { return x; };  # PARSE-TYPE-ERROR: para
         (<a href="https://github.com/qoretechnologies/qore/issues/5016">issue 5016</a>)
       - enabled bulk operations on ElasticSearchIndexTableDataProvider
         (<a href="https://github.com/qoretechnologies/qore/issues/5016">issue 5016</a>)
+    - @ref generatordataproviderintro "GeneratorDataProvider" module
+      - new module providing a data provider API for generating configurable test record streams for data
+        pipeline testing with no external dependencies
+      - supports configurable record count, field schema, sequential and random generation strategies,
+        template-based record generation, null injection, and reproducible output via random seeds
     - @ref elasticsearchloggerappenderintro "ElasticSearchLoggerAppender" module
       - new module providing a logger appender that sends log events to ElasticSearch using the Bulk API with
         batching support, configurable batch size and flush interval, date-based index patterns, and thread-safe

--- a/examples/test/qlib/GeneratorDataProvider/GeneratorDataProvider.qtest
+++ b/examples/test/qlib/GeneratorDataProvider/GeneratorDataProvider.qtest
@@ -1,0 +1,731 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+# Copyright 2026 Qore Technologies, s.r.o.
+
+%modern
+
+%requires ../../../../qlib/Util.qm
+%requires ../../../../qlib/QUnit.qm
+%requires ../../../../qlib/Logger.qm
+%requires ../../../../qlib/DataProvider
+%requires ../../../../qlib/GeneratorDataProvider
+
+%exec-class GeneratorDataProviderTest
+
+public class GeneratorDataProviderTest inherits QUnit::Test {
+    constructor() : Test("GeneratorDataProvider Test", "1.0") {
+        addTestCase("generate-records default schema", \testGenerateRecordsDefault());
+        addTestCase("generate-records custom schema", \testGenerateRecordsCustomSchema());
+        addTestCase("generate-records sequential strategy", \testGenerateRecordsSequential());
+        addTestCase("generate-records random with seed reproducibility", \testGenerateRecordsRandomSeed());
+        addTestCase("generate-records include nulls", \testGenerateRecordsIncludeNulls());
+        addTestCase("generate-from-template basic", \testGenerateFromTemplateBasic());
+        addTestCase("generate-from-template sequential variation", \testGenerateFromTemplateSequential());
+        addTestCase("generate-from-template type inference", \testGenerateFromTemplateTypeInference());
+        addTestCase("generate-from-template random strategy", \testGenerateFromTemplateRandom());
+        addTestCase("seed date determinism", \testSeedDateDeterminism());
+        addTestCase("seed does not pollute global RNG", \testSeedIsolation());
+        addTestCase("factory registration", \testFactoryRegistration());
+        addTestCase("child provider navigation", \testChildProviderNavigation());
+        addTestCase("record iterator direct", \testRecordIteratorDirect());
+        addTestCase("bulk record interface", \testBulkRecordInterface());
+        addTestCase("edge case: count 0", \testEdgeCaseCountZero());
+        addTestCase("edge case: count 1", \testEdgeCaseCountOne());
+        addTestCase("enum values", \testEnumValues());
+        addTestCase("record type from custom fields", \testRecordTypeCustomFields());
+        addTestCase("record type from template", \testRecordTypeFromTemplate());
+        addTestCase("template with include_nulls", \testTemplateIncludeNulls());
+        addTestCase("bulk record interface for template", \testBulkRecordInterfaceTemplate());
+        addTestCase("negative count validation", \testNegativeCount());
+        addTestCase("unsupported template type", \testUnsupportedTemplateType());
+        addTestCase("empty template", \testEmptyTemplate());
+        addTestCase("action: app registration", \testActionAppRegistration());
+        addTestCase("action: generate-records registration", \testActionGenerateRecordsRegistration());
+        addTestCase("action: generate-records option metadata", \testActionGenerateRecordsOptionMetadata());
+        addTestCase("action: generate-from-template registration", \testActionGenerateFromTemplateRegistration());
+        addTestCase("action: generate-from-template option metadata", \testActionGenerateFromTemplateOptionMetadata());
+        addTestCase("action: generate-records option allowed values", \testActionGenerateRecordsAllowedValues());
+        addTestCase("action: generate-from-template option allowed values", \testActionFromTemplateAllowedValues());
+        addTestCase("action: all actions retrievable", \testActionAllActionsRetrievable());
+
+        set_return_value(main());
+    }
+
+    #! Helper: collect all records from a provider's record stream into a list
+    static list<hash<auto>> readAllRecords(AbstractDataProvider prov) {
+        list<hash<auto>> result = ();
+        AbstractDataProviderRecordIterator it = prov.searchRecords();
+        while (it.next()) {
+            result += it.getValue();
+        }
+        return result;
+    }
+
+    private testGenerateRecordsDefault() {
+        GeneratorGenerateRecordsDataProvider prov({"count": 5});
+        list<hash<auto>> result = readAllRecords(prov);
+        assertEq(5, result.size());
+
+        # verify default schema fields
+        hash<auto> rec = result[0];
+        assertTrue(rec.hasKey("id"));
+        assertTrue(rec.hasKey("name"));
+        assertTrue(rec.hasKey("value"));
+        assertTrue(rec.hasKey("active"));
+        assertTrue(rec.hasKey("created"));
+
+        # verify types
+        assertEq("integer", rec.id.type());
+        assertEq("string", rec.name.type());
+        assertEq("float", rec.value.type());
+        assertEq("bool", rec.active.type());
+        assertEq("date", rec.created.type());
+    }
+
+    private testGenerateRecordsCustomSchema() {
+        list<auto> fields = (
+            {"name": "order_id", "type": GeneratorFieldType::Int},
+            {"name": "product", "type": GeneratorFieldType::String},
+            {"name": "price", "type": GeneratorFieldType::Float},
+        );
+        GeneratorGenerateRecordsDataProvider prov({"count": 3, "fields": fields});
+        list<hash<auto>> result = readAllRecords(prov);
+        assertEq(3, result.size());
+
+        hash<auto> rec = result[0];
+        assertTrue(rec.hasKey("order_id"));
+        assertTrue(rec.hasKey("product"));
+        assertTrue(rec.hasKey("price"));
+        assertFalse(rec.hasKey("id"));
+        assertFalse(rec.hasKey("name"));
+
+        assertEq("integer", rec.order_id.type());
+        assertEq("string", rec.product.type());
+        assertEq("float", rec.price.type());
+    }
+
+    private testGenerateRecordsSequential() {
+        GeneratorGenerateRecordsDataProvider prov({
+            "count": 3,
+            "strategy": GeneratorStrategy::Sequential,
+        });
+        list<hash<auto>> result = readAllRecords(prov);
+        assertEq(3, result.size());
+
+        # sequential: id should be 0, 1, 2
+        assertEq(0, result[0].id);
+        assertEq(1, result[1].id);
+        assertEq(2, result[2].id);
+
+        # sequential: name should be "name_0", "name_1", "name_2"
+        assertEq("name_0", result[0].name);
+        assertEq("name_1", result[1].name);
+        assertEq("name_2", result[2].name);
+
+        # sequential: value should be 0.0, 1.0, 2.0
+        assertEq(0.0, result[0].value);
+        assertEq(1.0, result[1].value);
+        assertEq(2.0, result[2].value);
+
+        # sequential: active alternates (even=True)
+        assertTrue(result[0].active);
+        assertFalse(result[1].active);
+        assertTrue(result[2].active);
+    }
+
+    private testGenerateRecordsRandomSeed() {
+        hash<auto> opts = {
+            "count": 10,
+            "strategy": GeneratorStrategy::Random,
+            "seed": 12345,
+        };
+
+        list<hash<auto>> result1 = readAllRecords(new GeneratorGenerateRecordsDataProvider(opts));
+        list<hash<auto>> result2 = readAllRecords(new GeneratorGenerateRecordsDataProvider(opts));
+
+        assertEq(10, result1.size());
+        assertEq(10, result2.size());
+
+        # same seed should produce identical results
+        for (int i = 0; i < 10; i++) {
+            assertEq(result1[i].id, result2[i].id);
+            assertEq(result1[i].name, result2[i].name);
+        }
+    }
+
+    private testGenerateRecordsIncludeNulls() {
+        GeneratorGenerateRecordsDataProvider prov({
+            "count": 200,
+            "strategy": GeneratorStrategy::Random,
+            "include_nulls": True,
+            "seed": 99,
+        });
+        list<hash<auto>> result = readAllRecords(prov);
+        assertEq(200, result.size());
+
+        # with 200 records and 5 fields each (~1000 values), ~10% should be null
+        int null_count = 0;
+        foreach hash<auto> rec in (result) {
+            foreach string key in (keys rec) {
+                if (!exists rec{key}) {
+                    null_count++;
+                }
+            }
+        }
+        assertTrue(null_count > 0, "expected some null values with include_nulls=True");
+    }
+
+    private testGenerateFromTemplateBasic() {
+        hash<auto> tpl = {"id": 100, "name": "test", "score": 99.5};
+        GeneratorGenerateFromTemplateDataProvider prov({"template": tpl, "count": 3});
+        list<hash<auto>> result = readAllRecords(prov);
+        assertEq(3, result.size());
+
+        # all records should have template keys
+        foreach hash<auto> rec in (result) {
+            assertTrue(rec.hasKey("id"));
+            assertTrue(rec.hasKey("name"));
+            assertTrue(rec.hasKey("score"));
+        }
+    }
+
+    private testGenerateFromTemplateSequential() {
+        hash<auto> tpl = {"id": 100, "name": "item", "price": 10.0};
+        GeneratorGenerateFromTemplateDataProvider prov({
+            "template": tpl,
+            "count": 3,
+            "strategy": GeneratorStrategy::Sequential,
+        });
+        list<hash<auto>> result = readAllRecords(prov);
+
+        # int: template + idx
+        assertEq(100, result[0].id);
+        assertEq(101, result[1].id);
+        assertEq(102, result[2].id);
+
+        # string: template + "_" + idx
+        assertEq("item_0", result[0].name);
+        assertEq("item_1", result[1].name);
+        assertEq("item_2", result[2].name);
+
+        # float: template + idx * 0.1
+        assertEq(10.0, result[0].price);
+        assertEq(10.1, result[1].price);
+        assertEq(10.2, result[2].price);
+    }
+
+    private testGenerateFromTemplateTypeInference() {
+        # verify that type inference works correctly for all supported types
+        assertEq(GeneratorFieldType::Int,
+            GeneratorGenerateFromTemplateDataProvider::inferType(42));
+        assertEq(GeneratorFieldType::Float,
+            GeneratorGenerateFromTemplateDataProvider::inferType(3.14));
+        assertEq(GeneratorFieldType::Bool,
+            GeneratorGenerateFromTemplateDataProvider::inferType(True));
+        assertEq(GeneratorFieldType::Date,
+            GeneratorGenerateFromTemplateDataProvider::inferType(now()));
+        assertEq(GeneratorFieldType::String,
+            GeneratorGenerateFromTemplateDataProvider::inferType("hello"));
+    }
+
+    private testGenerateFromTemplateRandom() {
+        hash<auto> tpl = {"id": 100, "name": "item", "price": 10.0, "active": True};
+
+        # random with seed for reproducibility
+        hash<auto> opts = {
+            "template": tpl,
+            "count": 20,
+            "strategy": GeneratorStrategy::Random,
+            "seed": 777,
+        };
+        list<hash<auto>> result1 = readAllRecords(new GeneratorGenerateFromTemplateDataProvider(opts));
+        list<hash<auto>> result2 = readAllRecords(new GeneratorGenerateFromTemplateDataProvider(opts));
+        assertEq(20, result1.size());
+        assertEq(20, result2.size());
+
+        # same seed should produce identical results
+        for (int i = 0; i < 20; i++) {
+            assertEq(result1[i].id, result2[i].id);
+            assertEq(result1[i].name, result2[i].name);
+            assertEq(result1[i].price, result2[i].price);
+            assertEq(result1[i].active, result2[i].active);
+        }
+
+        # random strategy should produce varied values (not just sequential idx offsets)
+        bool found_non_sequential = False;
+        for (int i = 0; i < 20; i++) {
+            if (result1[i].id != 100 + i) {
+                found_non_sequential = True;
+                break;
+            }
+        }
+        assertTrue(found_non_sequential, "random template variation should differ from sequential");
+
+        # names should have random suffixes, not just _0, _1, ...
+        bool found_random_name = False;
+        for (int i = 0; i < 20; i++) {
+            if (result1[i].name != "item_" + string(i)) {
+                found_random_name = True;
+                break;
+            }
+        }
+        assertTrue(found_random_name, "random template names should differ from sequential pattern");
+    }
+
+    private testSeedDateDeterminism() {
+        # with base_date + seed, date fields are fully deterministic across any invocation
+        date fixed_date = 2025-06-15;
+        hash<auto> opts = {
+            "count": 5,
+            "strategy": GeneratorStrategy::Random,
+            "seed": 55555,
+            "base_date": fixed_date,
+        };
+        list<hash<auto>> result1 = readAllRecords(new GeneratorGenerateRecordsDataProvider(opts));
+        list<hash<auto>> result2 = readAllRecords(new GeneratorGenerateRecordsDataProvider(opts));
+
+        # date values must be identical across runs with the same seed + base_date
+        for (int i = 0; i < 5; i++) {
+            assertEq(result1[i].created, result2[i].created);
+        }
+
+        # also verify that the dates are relative to the fixed base_date, not now()
+        for (int i = 0; i < 5; i++) {
+            assertTrue(result1[i].created <= fixed_date,
+                "generated date should be on or before base_date");
+        }
+
+        # without base_date, dates will differ across invocations due to now_us() advancing;
+        # this is expected — use base_date for full cross-run reproducibility
+    }
+
+    private testSeedIsolation() {
+        # calling with a seed should not permanently alter the global RNG
+        # we verify by checking that non-seeded random calls after a seeded run still produce
+        # varied output (not stuck in a deterministic sequence)
+
+        # seeded run
+        readAllRecords(new GeneratorGenerateRecordsDataProvider({
+            "count": 10,
+            "strategy": GeneratorStrategy::Random,
+            "seed": 12345,
+        }));
+
+        # two non-seeded runs should produce different output
+        list<hash<auto>> r1 = readAllRecords(new GeneratorGenerateRecordsDataProvider({
+            "count": 5,
+            "strategy": GeneratorStrategy::Random,
+        }));
+        list<hash<auto>> r2 = readAllRecords(new GeneratorGenerateRecordsDataProvider({
+            "count": 5,
+            "strategy": GeneratorStrategy::Random,
+        }));
+
+        # at least some values should differ (extremely unlikely to be identical without
+        # a deterministic seed)
+        bool found_diff = False;
+        for (int i = 0; i < 5; i++) {
+            if (r1[i].id != r2[i].id) {
+                found_diff = True;
+                break;
+            }
+        }
+        assertTrue(found_diff, "non-seeded runs after a seeded run should produce different output");
+    }
+
+    private testFactoryRegistration() {
+        AbstractDataProviderFactory factory = DataProvider::getFactoryEx("generator");
+        assertEq("generator", factory.getName());
+
+        hash<auto> info = factory.getInfo();
+        assertEq("generator", info.name);
+        assertTrue(info.children_can_support_records);
+    }
+
+    private testChildProviderNavigation() {
+        GeneratorDataProvider root();
+        *list<string> children = root.getChildProviderNames();
+        assertEq(2, children.size());
+        assertTrue(children.contains("generate-records"));
+        assertTrue(children.contains("generate-from-template"));
+
+        AbstractDataProvider child1 = root.getChildProviderEx("generate-records");
+        assertEq("generate-records", child1.getName());
+
+        # generate-from-template requires a "template" option, so verify it throws without one
+        assertThrows("CONSTRUCTOR-ERROR", sub () { root.getChildProviderEx("generate-from-template"); });
+    }
+
+    private testRecordIteratorDirect() {
+        list<auto> fields = (
+            {"name": "x", "type": GeneratorFieldType::Int},
+            {"name": "y", "type": GeneratorFieldType::String},
+        );
+        GeneratorRecordIterator it(5, fields);
+
+        int count = 0;
+        while (it.next()) {
+            hash<auto> rec = it.getValue();
+            assertTrue(rec.hasKey("x"));
+            assertTrue(rec.hasKey("y"));
+            assertEq("integer", rec.x.type());
+            assertEq("string", rec.y.type());
+            count++;
+        }
+        assertEq(5, count);
+        assertFalse(it.valid());
+
+        # verify record type
+        *hash<string, AbstractDataField> rt = it.getRecordType();
+        assertTrue(exists rt);
+        assertTrue(rt.hasKey("x"));
+        assertTrue(rt.hasKey("y"));
+    }
+
+    private testBulkRecordInterface() {
+        GeneratorGenerateRecordsDataProvider prov({"count": 25});
+
+        # get bulk interface with block size 10
+        AbstractDataProviderBulkRecordInterface bulk = prov.getBulkRecordInterface(10);
+
+        int total = 0;
+        while (*hash<auto> block = bulk.getValue()) {
+            # block is a hash of lists (column-oriented)
+            # all lists should be the same length
+            *list<auto> first_col = block{block.firstKey()};
+            if (!first_col) {
+                break;
+            }
+            total += first_col.size();
+        }
+        assertEq(25, total);
+    }
+
+    private testEdgeCaseCountZero() {
+        GeneratorGenerateRecordsDataProvider prov({"count": 0});
+        list<hash<auto>> result = readAllRecords(prov);
+        assertEq(0, result.size());
+    }
+
+    private testEdgeCaseCountOne() {
+        GeneratorGenerateRecordsDataProvider prov({"count": 1});
+        list<hash<auto>> result = readAllRecords(prov);
+        assertEq(1, result.size());
+        assertTrue(result[0].hasKey("id"));
+    }
+
+    private testEnumValues() {
+        # verify enum values are correct strings
+        assertEq("sequential", GeneratorStrategy::Sequential);
+        assertEq("random", GeneratorStrategy::Random);
+
+        assertEq("string", GeneratorFieldType::String);
+        assertEq("int", GeneratorFieldType::Int);
+        assertEq("float", GeneratorFieldType::Float);
+        assertEq("bool", GeneratorFieldType::Bool);
+        assertEq("date", GeneratorFieldType::Date);
+    }
+
+    private testRecordTypeCustomFields() {
+        list<auto> fields = (
+            {"name": "order_id", "type": GeneratorFieldType::Int},
+            {"name": "product", "type": GeneratorFieldType::String},
+        );
+        GeneratorGenerateRecordsDataProvider prov({"count": 1, "fields": fields});
+
+        # verify record type matches custom fields
+        *hash<string, AbstractDataField> rt = prov.getRecordType();
+        assertTrue(exists rt);
+        assertEq(2, rt.size());
+        assertTrue(rt.hasKey("order_id"));
+        assertTrue(rt.hasKey("product"));
+        assertFalse(rt.hasKey("id"));
+        assertFalse(rt.hasKey("name"));
+
+        # verify default schema record type
+        GeneratorGenerateRecordsDataProvider prov2({"count": 1});
+        *hash<string, AbstractDataField> rt2 = prov2.getRecordType();
+        assertTrue(exists rt2);
+        assertEq(5, rt2.size());
+        assertTrue(rt2.hasKey("id"));
+        assertTrue(rt2.hasKey("name"));
+        assertTrue(rt2.hasKey("value"));
+        assertTrue(rt2.hasKey("active"));
+        assertTrue(rt2.hasKey("created"));
+    }
+
+    private testRecordTypeFromTemplate() {
+        hash<auto> tpl = {"x": 1, "y": "hello", "z": 3.14};
+        GeneratorGenerateFromTemplateDataProvider prov({"template": tpl, "count": 1});
+
+        *hash<string, AbstractDataField> rt = prov.getRecordType();
+        assertTrue(exists rt);
+        assertEq(3, rt.size());
+        assertTrue(rt.hasKey("x"));
+        assertTrue(rt.hasKey("y"));
+        assertTrue(rt.hasKey("z"));
+    }
+
+    private testTemplateIncludeNulls() {
+        hash<auto> tpl = {"id": 1, "name": "test", "score": 5.0, "active": True, "ts": now()};
+        GeneratorGenerateFromTemplateDataProvider prov({
+            "template": tpl,
+            "count": 200,
+            "strategy": GeneratorStrategy::Random,
+            "include_nulls": True,
+            "seed": 99,
+        });
+        list<hash<auto>> result = readAllRecords(prov);
+        assertEq(200, result.size());
+
+        int null_count = 0;
+        foreach hash<auto> rec in (result) {
+            foreach string key in (keys rec) {
+                if (!exists rec{key}) {
+                    null_count++;
+                }
+            }
+        }
+        assertTrue(null_count > 0, "expected some null values with include_nulls=True on template provider");
+    }
+
+    private testBulkRecordInterfaceTemplate() {
+        hash<auto> tpl = {"id": 1, "label": "item"};
+        GeneratorGenerateFromTemplateDataProvider prov({"template": tpl, "count": 25});
+
+        AbstractDataProviderBulkRecordInterface bulk = prov.getBulkRecordInterface(10);
+
+        int total = 0;
+        while (*hash<auto> block = bulk.getValue()) {
+            *list<auto> first_col = block{block.firstKey()};
+            if (!first_col) {
+                break;
+            }
+            total += first_col.size();
+        }
+        assertEq(25, total);
+    }
+
+    private testNegativeCount() {
+        assertThrows("CONSTRUCTOR-ERROR", sub () {
+            new GeneratorGenerateRecordsDataProvider({"count": -1});
+        });
+        assertThrows("CONSTRUCTOR-ERROR", sub () {
+            new GeneratorGenerateFromTemplateDataProvider({"template": {"id": 1}, "count": -5});
+        });
+    }
+
+    private testUnsupportedTemplateType() {
+        assertThrows("TEMPLATE-ERROR", sub () {
+            new GeneratorGenerateFromTemplateDataProvider({"template": {"data": {"nested": 1}}});
+        });
+        assertThrows("TEMPLATE-ERROR", sub () {
+            new GeneratorGenerateFromTemplateDataProvider({"template": {"items": (1, 2, 3)}});
+        });
+    }
+
+    private testEmptyTemplate() {
+        # empty template hash should be accepted (not rejected by exists check)
+        GeneratorGenerateFromTemplateDataProvider prov({"template": {}, "count": 3});
+        list<hash<auto>> result = readAllRecords(prov);
+        assertEq(3, result.size());
+    }
+
+    private testActionAppRegistration() {
+        *hash<DataProviderAppInfo> app_info = DataProviderActionCatalog::getApp(GeneratorDataProvider::AppName);
+        assertTrue(exists app_info, "DataGenerator app should be registered");
+        assertEq("DataGenerator", app_info.name);
+        assertEq("Data Generator", app_info.display_name);
+        assertTrue(exists app_info.logo, "app should have a logo");
+        assertTrue(app_info.logo.size() > 0, "logo should not be empty");
+    }
+
+    private testActionGenerateRecordsRegistration() {
+        *hash<DataProviderActionInfo> action = DataProviderActionCatalog::getAppAction(
+            GeneratorDataProvider::AppName, "generate-records");
+        assertTrue(exists action, "generate-records action should be registered");
+        assertEq("generate-records", action.action);
+        assertEq(DPAT_FIND, action.action_code);
+        assertEq("Generate Records", action.display_name);
+        assertTrue(action.short_desc.val(), "action should have a short description");
+        assertTrue(action.desc.val(), "action should have a description");
+        assertEq("/", action.path);
+        assertEq("GeneratorDataProvider::GeneratorGenerateRecordsDataProvider", action.cls);
+
+        # verify all expected options are present
+        assertTrue(exists action.options, "action should have options");
+        list<string> expected_opts = ("count", "strategy", "fields", "include_nulls", "seed", "base_date");
+        foreach string opt_name in (expected_opts) {
+            assertTrue(action.options.hasKey(opt_name),
+                sprintf("generate-records action should have '%s' option", opt_name));
+        }
+    }
+
+    private testActionGenerateRecordsOptionMetadata() {
+        hash<DataProviderActionInfo> action = DataProviderActionCatalog::getAppActionEx(
+            GeneratorDataProvider::AppName, "generate-records");
+
+        # count: required, preselected, int type
+        hash<ActionOptionInfo> count_opt = action.options.count;
+        assertTrue(count_opt.required, "count should be required");
+        assertTrue(count_opt.preselected, "count should be preselected");
+        assertEq("Record Count", count_opt.display_name);
+        assertTrue(count_opt.short_desc.val(), "count should have short_desc");
+        assertTrue(count_opt.desc.val(), "count should have desc");
+        assertEq("int", count_opt.type.getName());
+        assertEq(10, count_opt.default_value);
+
+        # strategy: not required, string type, has allowed_values
+        hash<ActionOptionInfo> strat_opt = action.options.strategy;
+        assertFalse(strat_opt.required, "strategy should not be required");
+        assertEq("string", strat_opt.type.getName());
+        assertEq("sequential", strat_opt.default_value);
+        assertTrue(strat_opt.short_desc.val(), "strategy should have short_desc");
+
+        # fields: not required, any type
+        hash<ActionOptionInfo> fields_opt = action.options.fields;
+        assertFalse(fields_opt.required, "fields should not be required");
+        assertTrue(fields_opt.short_desc.val(), "fields should have short_desc");
+
+        # include_nulls: not required, bool type
+        hash<ActionOptionInfo> nulls_opt = action.options.include_nulls;
+        assertFalse(nulls_opt.required, "include_nulls should not be required");
+        assertEq("bool", nulls_opt.type.getName());
+        assertEq(False, nulls_opt.default_value);
+
+        # seed: not required, int type
+        hash<ActionOptionInfo> seed_opt = action.options.seed;
+        assertFalse(seed_opt.required, "seed should not be required");
+        assertEq("int", seed_opt.type.getName());
+
+        # base_date: not required, date type
+        hash<ActionOptionInfo> date_opt = action.options.base_date;
+        assertFalse(date_opt.required, "base_date should not be required");
+        assertEq("date", date_opt.type.getName());
+
+        # all options should have loc=constructor
+        foreach hash<auto> opt in (action.options.pairIterator()) {
+            assertEq("constructor", opt.value.loc,
+                sprintf("option '%s' should have loc=constructor", opt.key));
+        }
+    }
+
+    private testActionGenerateFromTemplateRegistration() {
+        *hash<DataProviderActionInfo> action = DataProviderActionCatalog::getAppAction(
+            GeneratorDataProvider::AppName, "generate-from-template");
+        assertTrue(exists action, "generate-from-template action should be registered");
+        assertEq("generate-from-template", action.action);
+        assertEq(DPAT_FIND, action.action_code);
+        assertEq("Generate From Template", action.display_name);
+        assertTrue(action.short_desc.val(), "action should have a short description");
+        assertTrue(action.desc.val(), "action should have a description");
+        assertEq("/", action.path);
+        assertEq("GeneratorDataProvider::GeneratorGenerateFromTemplateDataProvider", action.cls);
+
+        # verify all expected options are present
+        assertTrue(exists action.options, "action should have options");
+        list<string> expected_opts = ("template", "count", "strategy", "include_nulls", "seed", "base_date");
+        foreach string opt_name in (expected_opts) {
+            assertTrue(action.options.hasKey(opt_name),
+                sprintf("generate-from-template action should have '%s' option", opt_name));
+        }
+    }
+
+    private testActionGenerateFromTemplateOptionMetadata() {
+        hash<DataProviderActionInfo> action = DataProviderActionCatalog::getAppActionEx(
+            GeneratorDataProvider::AppName, "generate-from-template");
+
+        # template: required, preselected, hash type
+        hash<ActionOptionInfo> tpl_opt = action.options.template;
+        assertTrue(tpl_opt.required, "template should be required");
+        assertTrue(tpl_opt.preselected, "template should be preselected");
+        assertEq("Template Record", tpl_opt.display_name);
+        assertTrue(tpl_opt.short_desc.val(), "template should have short_desc");
+        assertTrue(tpl_opt.desc.val(), "template should have desc");
+
+        # count: required, preselected, int type with default
+        hash<ActionOptionInfo> count_opt = action.options.count;
+        assertTrue(count_opt.required, "count should be required");
+        assertTrue(count_opt.preselected, "count should be preselected");
+        assertEq("int", count_opt.type.getName());
+        assertEq(10, count_opt.default_value);
+
+        # strategy: not required, string type with default and allowed_values
+        hash<ActionOptionInfo> strat_opt = action.options.strategy;
+        assertFalse(strat_opt.required, "strategy should not be required");
+        assertEq("string", strat_opt.type.getName());
+        assertEq("sequential", strat_opt.default_value);
+
+        # include_nulls: not required, bool type with default
+        hash<ActionOptionInfo> nulls_opt = action.options.include_nulls;
+        assertFalse(nulls_opt.required, "include_nulls should not be required");
+        assertEq(False, nulls_opt.default_value);
+
+        # all options should have loc=constructor
+        foreach hash<auto> opt in (action.options.pairIterator()) {
+            assertEq("constructor", opt.value.loc,
+                sprintf("option '%s' should have loc=constructor", opt.key));
+        }
+    }
+
+    private testActionGenerateRecordsAllowedValues() {
+        hash<DataProviderActionInfo> action = DataProviderActionCatalog::getAppActionEx(
+            GeneratorDataProvider::AppName, "generate-records");
+
+        # strategy should have exactly 2 allowed values
+        hash<ActionOptionInfo> strat_opt = action.options.strategy;
+        assertTrue(exists strat_opt.allowed_values, "strategy should have allowed_values");
+        assertEq(2, strat_opt.allowed_values.size());
+
+        # extract values
+        list<auto> values = map $1.value, strat_opt.allowed_values;
+        assertTrue(values.contains("sequential"), "allowed values should include 'sequential'");
+        assertTrue(values.contains("random"), "allowed values should include 'random'");
+
+        # each allowed value should have a description
+        foreach hash<auto> av in (strat_opt.allowed_values) {
+            assertTrue(av.desc.val(),
+                sprintf("allowed value '%s' should have a description", av.value));
+        }
+    }
+
+    private testActionFromTemplateAllowedValues() {
+        hash<DataProviderActionInfo> action = DataProviderActionCatalog::getAppActionEx(
+            GeneratorDataProvider::AppName, "generate-from-template");
+
+        # strategy should have exactly 2 allowed values
+        hash<ActionOptionInfo> strat_opt = action.options.strategy;
+        assertTrue(exists strat_opt.allowed_values, "strategy should have allowed_values");
+        assertEq(2, strat_opt.allowed_values.size());
+
+        list<auto> values = map $1.value, strat_opt.allowed_values;
+        assertTrue(values.contains("sequential"), "allowed values should include 'sequential'");
+        assertTrue(values.contains("random"), "allowed values should include 'random'");
+
+        foreach hash<auto> av in (strat_opt.allowed_values) {
+            assertTrue(av.desc.val(),
+                sprintf("allowed value '%s' should have a description", av.value));
+        }
+    }
+
+    private testActionAllActionsRetrievable() {
+        # verify both actions are returned when querying all actions for the app
+        *list<hash<DataProviderActionInfo>> actions = DataProviderActionCatalog::getActions(
+            GeneratorDataProvider::AppName);
+        assertTrue(exists actions, "should have actions for DataGenerator app");
+        assertEq(2, actions.size());
+
+        list<string> action_names = map $1.action, actions;
+        assertTrue(action_names.contains("generate-records"),
+            "actions should include generate-records");
+        assertTrue(action_names.contains("generate-from-template"),
+            "actions should include generate-from-template");
+
+        # verify all actions have DPAT_FIND code
+        foreach hash<DataProviderActionInfo> act in (actions) {
+            assertEq(DPAT_FIND, act.action_code,
+                sprintf("action '%s' should have DPAT_FIND action_code", act.action));
+        }
+    }
+}

--- a/modules/astparser/src/AstTreePrinter.cpp
+++ b/modules/astparser/src/AstTreePrinter.cpp
@@ -206,6 +206,21 @@ void AstTreePrinter::printDeclaration(std::ostream& os, ASTDeclaration* decl, in
             printName(os, d->typeName, indent+1, true, true, "typeName: ");
             break;
         }
+        case ASTDeclarationKind::ADK_Module: {
+            ASTModuleDeclaration* d = static_cast<ASTModuleDeclaration*>(decl);
+            printString(os, "ModuleDecl ", indent);
+            printLocation(os, d->loc, 0);
+            printName(os, d->name, indent+1);
+            if (d->attributes.size() > 0) {
+                printString(os, "attributes:\n", indent+1);
+                for (size_t i = 0, count = d->attributes.size(); i < count; i++) {
+                    printIndent(os, indent+2);
+                    os << d->attributes[i].key << " =\n";
+                    printExpression(os, d->attributes[i].value.get(), indent+3);
+                }
+            }
+            break;
+        }
         default:
             break;
     }

--- a/modules/astparser/src/QC_AstTreeSearcher.qpp
+++ b/modules/astparser/src/QC_AstTreeSearcher.qpp
@@ -69,6 +69,8 @@ int64_t getSymbolKind(ASTDeclaration* decl) {
             break;
         case ASTDeclarationKind::ADK_Typedef:
             return static_cast<int64_t>(ASYK_TypeAlias);
+        case ASTDeclarationKind::ADK_Module:
+            return static_cast<int64_t>(ASYK_Module);
         default:
             break;
     }

--- a/modules/astparser/src/ast/AST.h
+++ b/modules/astparser/src/ast/AST.h
@@ -55,6 +55,7 @@
 #include "ast/declarations/ASTConstantDeclaration.h"
 #include "ast/declarations/ASTEnumDeclaration.h"
 #include "ast/declarations/ASTEnumMemberDeclaration.h"
+#include "ast/declarations/ASTModuleDeclaration.h"
 #include "ast/declarations/ASTFunctionDeclaration.h"
 #include "ast/declarations/ASTHashDeclaration.h"
 #include "ast/declarations/ASTHashMemberDeclaration.h"

--- a/modules/astparser/src/ast/ASTDeclarationKind.h
+++ b/modules/astparser/src/ast/ASTDeclarationKind.h
@@ -49,6 +49,7 @@ enum ASTDeclarationKind {
     ADK_Typedef = 12,       //!< Identifies instances of \ref ASTTypedefDeclaration.
     ADK_Enum = 13,          //!< Identifies instances of \ref ASTEnumDeclaration.
     ADK_EnumMember = 14,    //!< Identifies instances of \ref ASTEnumMemberDeclaration.
+    ADK_Module = 15,        //!< Identifies instances of \ref ASTModuleDeclaration.
 };
 
 #endif // _QLS_AST_ASTDECLARATIONKIND_H

--- a/modules/astparser/src/ast/ASTSymbolUsageKind.h
+++ b/modules/astparser/src/ast/ASTSymbolUsageKind.h
@@ -49,6 +49,7 @@ enum ASTSymbolUsageKind {
     ASUK_HashMemberName = 109,
     ASUK_TypedefDeclName = 110,
     ASUK_TypedefTypeName = 111,
+    ASUK_ModuleDeclName = 112,
 
     // Expressions.
     ASUK_AccessVariable = 200,

--- a/modules/astparser/src/ast/declarations/ASTModuleDeclaration.h
+++ b/modules/astparser/src/ast/declarations/ASTModuleDeclaration.h
@@ -1,0 +1,94 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+  ASTModuleDeclaration.h
+
+  Qore AST Parser
+
+  Copyright (C) 2023 - 2026 Qore Technologies, s.r.o.
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+
+  Note that the Qore library is released under a choice of three open-source
+  licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+  information.
+*/
+
+#ifndef _QLS_AST_DECLARATIONS_ASTMODULEDECLARATION_H
+#define _QLS_AST_DECLARATIONS_ASTMODULEDECLARATION_H
+
+#include <string>
+#include <vector>
+#include <utility>
+
+#include "ast/ASTDeclaration.h"
+#include "ast/ASTExpression.h"
+#include "ast/ASTName.h"
+
+//! Represents a module declaration with metadata attributes.
+/**
+    Example:
+    @code
+    module TestWorkflow2 {
+        version = "1.0";
+        desc = "workflow dev extension test module";
+        author = "Qore Technologies <info@qoretechnologies.com>";
+        url = "http://www.qoretechnologies.com";
+    }
+    @endcode
+*/
+class ASTModuleDeclaration : public ASTDeclaration {
+public:
+    //! A single module attribute (key = value).
+    struct Attribute {
+        std::string key;
+        ASTExpression::Ptr value;
+
+        Attribute(const std::string& k, ASTExpression* v) : key(k), value(v) {}
+        Attribute(std::string&& k, ASTExpression* v) : key(std::move(k)), value(v) {}
+    };
+
+    //! Name of the module.
+    ASTName name;
+
+    //! Module attributes (version, desc, author, url, etc.).
+    std::vector<Attribute> attributes;
+
+public:
+    ASTModuleDeclaration(ASTName&& n) :
+        ASTDeclaration(),
+        name(std::move(n)) {}
+
+    ASTModuleDeclaration(const ASTName& n) :
+        ASTDeclaration(),
+        name(n) {}
+
+    void addAttribute(const std::string& key, ASTExpression* value) {
+        attributes.emplace_back(key, value);
+    }
+
+    void addAttribute(std::string&& key, ASTExpression* value) {
+        attributes.emplace_back(std::move(key), value);
+    }
+
+    virtual ASTDeclarationKind getKind() const override {
+        return ASTDeclarationKind::ADK_Module;
+    }
+};
+
+#endif // _QLS_AST_DECLARATIONS_ASTMODULEDECLARATION_H

--- a/modules/astparser/src/ast_parser.ypp
+++ b/modules/astparser/src/ast_parser.ypp
@@ -154,6 +154,8 @@ typedef void* yyscan_t;
     std::vector<ASTSuperclassDeclaration*>* sclist;
     ASTStatement* statement;
     ASTSwitchBodyExpression* switchexpr;
+    ASTModuleDeclaration* moduledecl;
+    std::pair<std::string, ASTExpression*>* moduleattr;
 }
 
 %{
@@ -272,7 +274,7 @@ extern std::string* takeSubDocComment();
 %token TOK_INHERITS "inherits"
 %token TOK_ELSE "else"
 %token TOK_STATIC "static"
-%token TOK_MODULE "module"
+%token <string> TOK_MODULE "module"
 %token TOK_FINAL "final"
 %token TOK_ABSTRACT "abstract"
 %token TOK_HASHDECL "hashdecl"
@@ -510,6 +512,8 @@ extern std::string* takeSubDocComment();
 %type <sclist>         superclass_list
 %type <statement>      switch_statement
 %type <astnode>        top_level_command
+%type <moduledecl>    module_decls
+%type <moduleattr>    module_decl
 %type <nsdecl>         top_namespace_decl
 %type <statement>      try_statement
 %type <String>         uncqtypedef
@@ -519,6 +523,8 @@ extern std::string* takeSubDocComment();
 %destructor { delete $$; $$ = nullptr; } DOT_KW_IDENTIFIER PARSE_OPTION_END PARSE_OPTION_FULL QUOTED_WORD REGEX REGEX_EXTRACT REGEX_SUBST REGEX_TRANS alt_hash base_constructor base_constructor_list block case_block case_code classvardecl class_def context_mod enum_def enum_member exp exp_c exp_n exp_nl gvardecl hash hash_element hashdecl_def hashdecl_inherits hashdecl_member immediate_typed_hash inline_methoddef internal_member_list list list_item list_item_n list_n member member2 myexp namespace_decl optname outofline_methoddef parse_option private_member_list public_member_list qtypedef return_statement return_value scalar scoped_const_decl scoped_sub_def statement statements statement_or_block string sub_def superclass switch_statement top_level_command top_namespace_decl transient_member transient_member2 try_statement typedef_def uncqtypedef unscoped_const_decl
 %destructor { free($$); $$ = nullptr; } ANGLE_IDENTIFIER BACKQUOTE BASE_CLASS_CALL BINARY CLASS_SCOPED_REF CLASS_STRING COMPLEX_CONTEXT_REF CONTEXT_REF DATETIME HASHDECL_IDENTIFIER_OPENCURLY IDENTIFIER KW_IDENTIFIER_OPENPAREN NAMESPACE NUMBER QORE_CAST SCOPED_REF SCOPED_VREF SELF_REF VAR_REF ident_openparen
 %destructor { if ($$) { for (int i = 0, count = $$->size(); i < count; i++) {delete (*$$)[i];} delete $$; } $$ = nullptr; } base_constructors class_attributes context_mods enum_members hashdecl_attributes inheritance_list member_list member_list2 namespace_decls superclass_list
+%destructor { delete $$; $$ = nullptr; } module_decls
+%destructor { if ($$) { delete $$->second; delete $$; } $$ = nullptr; } module_decl
 
 %code top {
 #if defined(__GNUC__)
@@ -591,7 +597,20 @@ top_level_command:
             ATTACH_DOC_COMMENT($1);
             $$ = $1;
         }
-        | TOK_MODULE '{' module_decls '}' { $$ = nullptr; }
+        | TOK_MODULE '{' module_decls '}' {
+            ASTName modname($1, ASTNameKind::ANK_None);
+            // Set name location to just the identifier, not the full "module <name>" token.
+            size_t nameLen = strlen($1);
+            modname.loc = @1;
+            modname.loc.firstCol = @1.lastCol - static_cast<ast_loc_t>(nameLen);
+            free($1);
+            ASTModuleDeclaration* md = new ASTModuleDeclaration(std::move(modname));
+            md->attributes.swap($3->attributes);
+            delete $3;
+            md->loc.set(@1, @4);
+            ATTACH_DOC_COMMENT(md);
+            $$ = md;
+        }
         | parse_option {
             // Allow directives inside module blocks for doc-only builds.
             delete $1;
@@ -612,19 +631,31 @@ parse_option:
 
 module_decls:
         module_decl {
+            // Create the module declaration with a placeholder name (set by the parent rule).
+            $$ = new ASTModuleDeclaration(ASTName());
+            if ($1) {
+                $$->addAttribute(std::move($1->first), $1->second);
+                delete $1;
+            }
         }
         | module_decls module_decl {
+            $$ = $1;
+            if ($2) {
+                $$->addAttribute(std::move($2->first), $2->second);
+                delete $2;
+            }
         }
         ;
 
 module_decl:
         IDENTIFIER '=' exp ';' {
+            $$ = new std::pair<std::string, ASTExpression*>(std::string($1), $3);
             free($1);
-            delete $3;
         }
         | parse_option {
             // Ignore parse directives inside module declarations.
             delete $1;
+            $$ = nullptr;
         }
         ;
 

--- a/modules/astparser/src/ast_scanner.lpp
+++ b/modules/astparser/src/ast_scanner.lpp
@@ -1653,7 +1653,7 @@ class{WS}+({WORD}::)+{WORD}             { claimClassDocComment(); yylval->string
 class{WS}+(::{WORD})+                   { claimClassDocComment(); yylval->string = trim(yytext + 6); return CLASS_SCOPED_REF; }
 class{WS}+{WORD}                        { claimClassDocComment(); yylval->string = trim(yytext + 6); return CLASS_STRING; }
 namespace{WS}+{WORD}                    { claimNamespaceDocComment(); yylval->string = trim(yytext + 10); return NAMESPACE; }
-module{WS}+{WORD}                       { /* TODO const char* mod = trim_inplace(yytext + 7); */ return TOK_MODULE; }
+module{WS}+{WORD}                       { yylval->string = trim(yytext + 7); return TOK_MODULE; }
 {WORD}                                  { yylval->string = strdup(yytext); return IDENTIFIER; }
 \<({WORD}::)+{WORD}\>\{                 {
                                             yylval->string = strdup(yytext + 1);

--- a/modules/astparser/src/ql_ast.qpp
+++ b/modules/astparser/src/ql_ast.qpp
@@ -98,6 +98,9 @@ const ADK_VarList = ADK_VarList;
 
 //! Typedef declaration kind.
 const ADK_Typedef = ADK_Typedef;
+
+//! Module declaration kind.
+const ADK_Module = ADK_Module;
 ///@}
 
 /** @defgroup astparser_expression_kind_constants AST Expression Kind Constants
@@ -502,4 +505,7 @@ const ASUK_AssertStmtExpr = ASUK_AssertStmtExpr;
 
 //! Symbol usage kind for expressions in \c @@debug statements.
 const ASUK_DebugStmtExpr = ASUK_DebugStmtExpr;
+
+//! Symbol usage kind for module names in module declarations.
+const ASUK_ModuleDeclName = ASUK_ModuleDeclName;
 ///@}

--- a/modules/astparser/src/queries/FindNodeAndParentsQuery.cpp
+++ b/modules/astparser/src/queries/FindNodeAndParentsQuery.cpp
@@ -153,6 +153,16 @@ std::vector<ASTNode*>* FindNodeAndParentsQuery::inDeclaration(ASTDeclaration* de
             if (result) { result->push_back(decl); return result; }
             break;
         }
+        case ASTDeclarationKind::ADK_Module: {
+            ASTModuleDeclaration* d = static_cast<ASTModuleDeclaration*>(decl);
+            result = inName(d->name, line, col);
+            if (result) { result->push_back(decl); return result; }
+            for (size_t i = 0, count = d->attributes.size(); i < count; i++) {
+                result = inExpression(d->attributes[i].value.get(), line, col);
+                if (result) { result->push_back(decl); return result; }
+            }
+            break;
+        }
         default:
             break;
     }

--- a/modules/astparser/src/queries/FindNodeQuery.cpp
+++ b/modules/astparser/src/queries/FindNodeQuery.cpp
@@ -147,6 +147,16 @@ ASTNode* FindNodeQuery::inDeclaration(ASTDeclaration* decl, ast_loc_t line, ast_
             if (result) return result;
             break;
         }
+        case ASTDeclarationKind::ADK_Module: {
+            ASTModuleDeclaration* d = static_cast<ASTModuleDeclaration*>(decl);
+            result = inName(d->name, line, col);
+            if (result) return result;
+            for (size_t i = 0, count = d->attributes.size(); i < count; i++) {
+                result = inExpression(d->attributes[i].value.get(), line, col);
+                if (result) return result;
+            }
+            break;
+        }
         default:
             break;
     }

--- a/modules/astparser/src/queries/FindReferencesQuery.cpp
+++ b/modules/astparser/src/queries/FindReferencesQuery.cpp
@@ -115,6 +115,14 @@ void FindReferencesQuery::inDeclaration(std::vector<ASTNode*>* vec, ASTDeclarati
             inName(vec, d->typeName, name);
             break;
         }
+        case ASTDeclarationKind::ADK_Module: {
+            ASTModuleDeclaration* d = static_cast<ASTModuleDeclaration*>(decl);
+            inName(vec, d->name, name);
+            for (size_t i = 0, count = d->attributes.size(); i < count; i++) {
+                inExpression(vec, d->attributes[i].value.get(), name);
+            }
+            break;
+        }
         default:
             break;
     }

--- a/modules/astparser/src/queries/FindSymbolInfoQuery.cpp
+++ b/modules/astparser/src/queries/FindSymbolInfoQuery.cpp
@@ -139,6 +139,12 @@ ASTSymbolInfo FindSymbolInfoQuery::inDeclaration(std::vector<ASTNode*>* nodes, a
                 return ASTSymbolInfo(ASYK_Class, ASUK_TypedefTypeName, d->typeName.loc, d->typeName.name);
             break;
         }
+        case ASTDeclarationKind::ADK_Module: {
+            ASTModuleDeclaration* d = static_cast<ASTModuleDeclaration*>(decl);
+            if (d->name.loc.inside(line, col))
+                return ASTSymbolInfo(ASYK_Module, ASUK_ModuleDeclName, d->name.loc, d->name.name);
+            break;
+        }
         default:
             break;
     }

--- a/modules/astparser/src/queries/FindSymbolsQuery.cpp
+++ b/modules/astparser/src/queries/FindSymbolsQuery.cpp
@@ -135,6 +135,14 @@ void FindSymbolsQuery::inDeclaration(std::vector<ASTSymbolInfo>* vec, ASTDeclara
             }
             break;
         }
+        case ASTDeclarationKind::ADK_Module: {
+            ASTModuleDeclaration* d = static_cast<ASTModuleDeclaration*>(decl);
+            vec->push_back(ASTSymbolInfo(ASYK_Module, &d->name));
+            if (d->hasDocComment()) {
+                vec->back().docComment = *d->getDocComment();
+            }
+            break;
+        }
         default:
             break;
     }

--- a/modules/astparser/src/queries/GetNodesInfoQuery.cpp
+++ b/modules/astparser/src/queries/GetNodesInfoQuery.cpp
@@ -165,6 +165,23 @@ QoreHashNode* GetNodesInfoQuery::getDeclaration(ASTTree* tree, ASTDeclaration* d
             nodeInfo->setKeyValue("typeName", getName(tree, d->typeName, xsink), xsink);
             break;
         }
+        case ASTDeclarationKind::ADK_Module: {
+            ASTModuleDeclaration* d = static_cast<ASTModuleDeclaration*>(decl);
+            nodeInfo->setKeyValue("name", getName(tree, d->name, xsink), xsink);
+            ReferenceHolder<QoreListNode> attrs(new QoreListNode, xsink);
+            if (*xsink)
+                return nullptr;
+            for (size_t i = 0, count = d->attributes.size(); i < count; i++) {
+                ReferenceHolder<QoreHashNode> attr(new QoreHashNode, xsink);
+                if (*xsink)
+                    return nullptr;
+                attr->setKeyValue("key", new QoreStringNode(d->attributes[i].key), xsink);
+                attr->setKeyValue("value", getExpression(tree, d->attributes[i].value.get(), xsink), xsink);
+                attrs->push(attr.release(), xsink);
+            }
+            nodeInfo->setKeyValue("attributes", attrs.release(), xsink);
+            break;
+        }
         default:
             break;
     }
@@ -335,7 +352,7 @@ QoreHashNode* GetNodesInfoQuery::getExpression(ASTTree* tree, ASTExpression* exp
                     break;
                 case ALEK_String:
                     nodeInfo->setKeyValue("literalKind", new QoreStringNode("string"), xsink);
-                    nodeInfo->setKeyValue("value", new QoreStringNode(e->value.stdstr), xsink);
+                    nodeInfo->setKeyValue("value", new QoreStringNode(*e->value.stdstr), xsink);
                     break;
                 default:
                     break;

--- a/modules/astparser/test/astparser.qtest
+++ b/modules/astparser/test/astparser.qtest
@@ -327,6 +327,19 @@ public hashdecl DateInfo {
         addTestCase("Doc comments edge cases", \testDocCommentsEdgeCases());
         addTestCase("Date subtype parsing", \testDateSubtypeParsing());
         addTestCase("Conditional directives with comments", \testConditionalDirectivesWithComments());
+        addTestCase("Module metadata getNodesInfo", \testModuleMetadataGetNodesInfo());
+        addTestCase("Module metadata symbols", \testModuleMetadataSymbols());
+        addTestCase("Module metadata doc comment", \testModuleMetadataDocComment());
+        addTestCase("Module with no attributes", \testModuleNoAttributes());
+        addTestCase("Module constants", \testModuleConstants());
+        addTestCase("Module name location", \testModuleNameLocation());
+        addTestCase("Module findSymbolInfo", \testModuleFindSymbolInfo());
+        addTestCase("Module findReferences", \testModuleFindReferences());
+        addTestCase("Module attr expr traversal", \testModuleAttrExprTraversal());
+        addTestCase("Module with following code", \testModuleWithFollowingCode());
+        addTestCase("Module single attribute", \testModuleSingleAttribute());
+        addTestCase("Module special chars in values", \testModuleSpecialCharsInValues());
+        addTestCase("Module init/del attributes", \testModuleInitDelAttributes());
 %endif
         set_return_value(main());
     }
@@ -1539,5 +1552,318 @@ class Used {}
         assertEq(True, exists(tree), "parseString returns tree for mixed comments");
         assertEq(0, parser.getErrorCount(), "no parse errors for mixed comments");
     }
+    testModuleMetadataGetNodesInfo() {
+        string code = "%modern\nmodule TestModule {\n    version = \"1.0\";\n    desc = \"test module\";\n    author = \"tester\";\n    url = \"http://example\";\n}\n";
+        AstParser parser();
+        *AstTree tree = parser.parseString(code);
+        assertTrue(exists(tree), "parseString returns tree");
+        assertEq(0, parser.getErrorCount(), "no parse errors");
+
+        list nodes = tree.getNodesInfo();
+        assertGt(0, nodes.size(), "nodes found");
+
+        *hash modNode;
+        foreach auto node in (nodes) {
+            if (node.kind == ADK_Module) {
+                modNode = node;
+                break;
+            }
+        }
+        assertTrue(exists(modNode), "module node found in getNodesInfo");
+
+        # Verify module name
+        assertEq("TestModule", modNode.name.name, "module name");
+
+        # Verify attribute count
+        assertEq(4, modNode.attributes.size(), "module has 4 attributes");
+
+        # Verify attribute keys
+        assertEq("version", modNode.attributes[0].key, "first attribute key");
+        assertEq("desc", modNode.attributes[1].key, "second attribute key");
+        assertEq("author", modNode.attributes[2].key, "third attribute key");
+        assertEq("url", modNode.attributes[3].key, "fourth attribute key");
+
+        # Verify attribute values are literal string expressions with correct content
+        assertEq(AEK_Literal, modNode.attributes[0].value.kind, "version is literal expression");
+        assertEq("string", modNode.attributes[0].value.literalKind, "version is string literal");
+        assertEq("1.0", modNode.attributes[0].value.value, "version value");
+        assertEq("test module", modNode.attributes[1].value.value, "desc value");
+        assertEq("tester", modNode.attributes[2].value.value, "author value");
+        assertEq("http://example", modNode.attributes[3].value.value, "url value");
+
+        # Verify location info is set
+        assertTrue(exists(modNode.loc), "module has location");
+        assertTrue(exists(modNode.name.loc), "module name has location");
+    }
+
+    testModuleMetadataSymbols() {
+        string code = "%modern\nmodule TestModule {\n    version = \"1.0\";\n    desc = \"test module\";\n}\n";
+        AstParser parser();
+        *AstTree tree = parser.parseString(code);
+        assertEq(0, parser.getErrorCount(), "no parse errors");
+
+        AstTreeSearcher searcher();
+        list symbols = searcher.findSymbols(tree, "test.q");
+
+        # Module should appear as a symbol with kind ASYK_Module
+        *hash modSym;
+        foreach auto sym in (symbols) {
+            if (sym.kind == ASYK_Module && sym.name == "TestModule") {
+                modSym = sym;
+                break;
+            }
+        }
+        assertTrue(exists(modSym), "module found in symbols");
+        assertEq(ASYK_Module, modSym.kind, "module symbol kind");
+        assertEq("TestModule", modSym.name, "module symbol name");
+    }
+
+    testModuleMetadataDocComment() {
+        # Test that doc comments on modules are captured
+        string code = "%modern\n#! This is a test module\nmodule DocModule {\n    version = \"1.0\";\n    desc = \"documented module\";\n}\n";
+        AstParser parser();
+        *AstTree tree = parser.parseString(code);
+        assertEq(0, parser.getErrorCount(), "no parse errors");
+
+        list nodes = tree.getNodesInfo();
+        *hash modNode;
+        foreach auto node in (nodes) {
+            if (node.kind == ADK_Module) {
+                modNode = node;
+                break;
+            }
+        }
+        assertTrue(exists(modNode), "documented module found in getNodesInfo");
+        assertEq("DocModule", modNode.name.name, "module name");
+        assertTrue(exists(modNode.docComment), "module has docComment");
+        assertRegex("test module", modNode.docComment, "docComment has expected content");
+    }
+
+    testModuleNoAttributes() {
+        # Module with empty body (only parse options, no key=value attributes)
+        string code = "%modern\nmodule EmptyModule {\n%disable-warning deprecated\n}\n";
+        AstParser parser();
+        *AstTree tree = parser.parseString(code);
+        assertTrue(exists(tree), "parseString returns tree");
+        assertEq(0, parser.getErrorCount(), "no parse errors");
+
+        list nodes = tree.getNodesInfo();
+        *hash modNode;
+        foreach auto node in (nodes) {
+            if (node.kind == ADK_Module) {
+                modNode = node;
+                break;
+            }
+        }
+        assertTrue(exists(modNode), "empty module found in getNodesInfo");
+        assertEq("EmptyModule", modNode.name.name, "module name");
+        assertEq(0, modNode.attributes.size(), "module has no key=value attributes");
+    }
+
+    testModuleConstants() {
+        # Verify ADK_Module and ASUK_ModuleDeclName constants
+        assertEq(15, ADK_Module, "ADK_Module value");
+        assertEq(112, ASUK_ModuleDeclName, "ASUK_ModuleDeclName value");
+    }
+
+    testModuleNameLocation() {
+        # Verify the module name location covers only the identifier, not "module <name>"
+        # Line 1 (0-indexed): "module TestModule {"
+        #   "module " = 7 chars, "TestModule" = 10 chars
+        #   So name should start at col 7 and end at col 17
+        string code = "%modern\nmodule TestModule {\n    version = \"1.0\";\n}\n";
+        AstParser parser();
+        *AstTree tree = parser.parseString(code);
+        assertEq(0, parser.getErrorCount(), "no parse errors");
+
+        list nodes = tree.getNodesInfo();
+        *hash modNode;
+        foreach auto node in (nodes) {
+            if (node.kind == ADK_Module) {
+                modNode = node;
+                break;
+            }
+        }
+        assertTrue(exists(modNode), "module found");
+
+        # Name location should not start at col 0 (which would be the 'm' in 'module')
+        assertEq(1, modNode.name.loc.start_line, "name on correct line");
+        assertGt(0, modNode.name.loc.start_column, "name start_column > 0 (not at 'module' keyword)");
+        assertEq(7, modNode.name.loc.start_column, "name starts at col 7 (after 'module ')");
+
+        # Module decl location should span the full declaration
+        assertEq(1, modNode.loc.start_line, "decl starts on line 1");
+        assertEq(0, modNode.loc.start_column, "decl starts at col 0");
+    }
+
+    testModuleFindSymbolInfo() {
+        # Test findSymbolInfo on the module name position
+        # Line 1 (0-indexed): "module TestModule {" — name at cols 7..17
+        string code = "%modern\nmodule TestModule {\n    version = \"1.0\";\n}\n";
+        AstParser parser();
+        *AstTree tree = parser.parseString(code);
+        assertEq(0, parser.getErrorCount(), "no parse errors");
+
+        AstTreeSearcher searcher();
+
+        # Position on the module name itself
+        *hash info = searcher.findSymbolInfo(tree, 1, 10);
+        assertTrue(exists(info), "findSymbolInfo returns result for module name");
+        assertEq(ASYK_Module, info.kind, "symbol info kind is module");
+
+        # Position on the "module" keyword (col 0-6) should NOT match the name
+        *hash kwInfo = searcher.findSymbolInfo(tree, 1, 3);
+        # Should either be NOTHING or not match the name location
+        if (kwInfo) {
+            # If it returns something, it shouldn't be specifically the module name symbol
+            # (it may return the module decl itself)
+        }
+    }
+
+    testModuleFindReferences() {
+        # Test findReferences on the module name position
+        string code = "%modern\nmodule TestModule {\n    version = \"1.0\";\n}\n";
+        AstParser parser();
+        *AstTree tree = parser.parseString(code);
+        assertEq(0, parser.getErrorCount(), "no parse errors");
+
+        AstTreeSearcher searcher();
+        *list refs = searcher.findReferences(tree, "test.q", 1, 10, True);
+        # Module name should have at least one reference (its own declaration)
+        assertTrue(exists(refs), "findReferences returns result for module name");
+        assertGt(0, refs.size(), "found references to module name");
+    }
+
+    testModuleAttrExprTraversal() {
+        # Test that query walkers descend into attribute value expressions.
+        # Position the cursor on the string literal inside an attribute value
+        # and verify findSymbolInfo/findNode can locate the expression node.
+        # Line 2 (0-indexed): "    version = \"1.0\";"
+        #   The string literal "1.0" is at approximately cols 14..19
+        string code = "%modern\nmodule TestModule {\n    version = \"1.0\";\n    desc = \"test module\";\n}\n";
+        AstParser parser();
+        *AstTree tree = parser.parseString(code);
+        assertEq(0, parser.getErrorCount(), "no parse errors");
+
+        AstTreeSearcher searcher();
+        # findSymbolInfo at the string literal position inside module attr
+        *hash info = searcher.findSymbolInfo(tree, 2, 16);
+        # The lookup should NOT return the module declaration itself;
+        # it should either return info about the expression or nothing.
+        # The key assertion is that it doesn't crash and it reaches the expression.
+
+        # Verify attribute expression has correct location info via getNodesInfo
+        list nodes = tree.getNodesInfo();
+        *hash modNode;
+        foreach auto node in (nodes) {
+            if (node.kind == ADK_Module) {
+                modNode = node;
+                break;
+            }
+        }
+        assertTrue(exists(modNode), "module found");
+        # The version attribute value should have location info inside the module body
+        hash verLoc = modNode.attributes[0].value.loc;
+        assertEq(2, verLoc.start_line, "version value on line 2");
+        assertGt(0, verLoc.start_column, "version value has non-zero start column");
+    }
+
+    testModuleWithFollowingCode() {
+        # Module declaration followed by namespace and function code
+        string code = "%modern\nmodule TestModule {\n    version = \"1.0\";\n    desc = \"test module\";\n    author = \"tester\";\n    url = \"http://example\";\n    license = \"MIT\";\n}\npublic namespace TestModule {\n    public int sub getValue() {\n        return 1;\n    }\n}\n";
+        AstParser parser();
+        *AstTree tree = parser.parseString(code);
+        assertTrue(exists(tree), "parseString returns tree");
+        assertEq(0, parser.getErrorCount(), "no parse errors");
+
+        list nodes = tree.getNodesInfo();
+        # Should have both module and namespace declarations
+        bool foundModule = False;
+        bool foundNamespace = False;
+        foreach auto node in (nodes) {
+            if (node.kind == ADK_Module) {
+                foundModule = True;
+                assertEq(5, node.attributes.size(), "module has 5 attributes including license");
+                assertEq("license", node.attributes[4].key, "fifth attribute is license");
+                assertEq("MIT", node.attributes[4].value.value, "license value");
+            }
+            if (node.kind == ADK_Namespace)
+                foundNamespace = True;
+        }
+        assertTrue(foundModule, "module declaration found");
+        assertTrue(foundNamespace, "namespace declaration found after module");
+    }
+
+    testModuleSingleAttribute() {
+        # Module with just one attribute
+        string code = "%modern\nmodule MinModule {\n    version = \"0.1\";\n}\n";
+        AstParser parser();
+        *AstTree tree = parser.parseString(code);
+        assertEq(0, parser.getErrorCount(), "no parse errors");
+
+        list nodes = tree.getNodesInfo();
+        *hash modNode;
+        foreach auto node in (nodes) {
+            if (node.kind == ADK_Module) {
+                modNode = node;
+                break;
+            }
+        }
+        assertTrue(exists(modNode), "module found");
+        assertEq("MinModule", modNode.name.name, "module name");
+        assertEq(1, modNode.attributes.size(), "exactly one attribute");
+        assertEq("version", modNode.attributes[0].key, "attribute key");
+        assertEq("0.1", modNode.attributes[0].value.value, "attribute value");
+    }
+
+    testModuleSpecialCharsInValues() {
+        # Module with special characters in attribute values
+        string code = "%modern\nmodule SpecialModule {\n    version = \"2.0.1-beta\";\n    desc = \"module with <special> & \\\"chars\\\"\";\n    author = \"Name <email@example.com>\";\n}\n";
+        AstParser parser();
+        *AstTree tree = parser.parseString(code);
+        assertEq(0, parser.getErrorCount(), "no parse errors");
+
+        list nodes = tree.getNodesInfo();
+        *hash modNode;
+        foreach auto node in (nodes) {
+            if (node.kind == ADK_Module) {
+                modNode = node;
+                break;
+            }
+        }
+        assertTrue(exists(modNode), "module found");
+        assertEq("SpecialModule", modNode.name.name, "module name");
+        assertEq(3, modNode.attributes.size(), "3 attributes");
+        assertEq("2.0.1-beta", modNode.attributes[0].value.value, "version with hyphens");
+    }
+
+    testModuleInitDelAttributes() {
+        # init and del attributes accept code/closure expressions
+        string code = "%modern\nmodule TestModule {\n    version = \"1.0\";\n    init = sub () { printf(\"init\\n\"); };\n    del = sub () { printf(\"del\\n\"); };\n}\n";
+        AstParser parser();
+        *AstTree tree = parser.parseString(code);
+        # init/del with closures should parse without errors
+        assertTrue(exists(tree), "parseString returns tree for init/del module");
+        assertEq(0, parser.getErrorCount(), "no parse errors for init/del attributes");
+
+        list nodes = tree.getNodesInfo();
+        *hash modNode;
+        foreach auto node in (nodes) {
+            if (node.kind == ADK_Module) {
+                modNode = node;
+                break;
+            }
+        }
+        assertTrue(exists(modNode), "module found");
+        assertEq("TestModule", modNode.name.name, "module name");
+        assertEq(3, modNode.attributes.size(), "3 attributes (version, init, del)");
+        assertEq("version", modNode.attributes[0].key, "first attr is version");
+        assertEq("init", modNode.attributes[1].key, "second attr is init");
+        assertEq("del", modNode.attributes[2].key, "third attr is del");
+        # init/del values should be closure expressions, not literal strings
+        assertNeq(AEK_Literal, modNode.attributes[1].value.kind, "init is not a literal");
+        assertNeq(AEK_Literal, modNode.attributes[2].value.kind, "del is not a literal");
+    }
+
 %endif
 }

--- a/qlib/DataProvider/DataProvider.qc
+++ b/qlib/DataProvider/DataProvider.qc
@@ -93,6 +93,7 @@ public class DataProvider {
             "ftpclient": "FtpClientDataProvider",
             "ftppoller": "FtpPoller",
             "gcal": "GoogleCalendarDataProvider",
+            "generator": "GeneratorDataProvider",
             "gmail": "GmailDataProvider",
             "httpclient": "HttpClientDataProvider",
             "jotform": "JotformDataProvider",

--- a/qlib/GeneratorDataProvider/GeneratorDataProvider.qc
+++ b/qlib/GeneratorDataProvider/GeneratorDataProvider.qc
@@ -1,0 +1,116 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GeneratorDataProvider class definition
+
+/** GeneratorDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GeneratorDataProvider module
+public namespace GeneratorDataProvider {
+
+#! Generator app name
+public const AppName = "DataGenerator";
+
+#! The root data generator data provider class
+/** Provides child data providers for generating test record streams
+*/
+public class GeneratorDataProvider inherits DataProvider::AbstractDataProvider {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "type": "GeneratorDataProvider",
+            "supports_read": False,
+            "supports_create": False,
+            "supports_update": False,
+            "supports_upsert": False,
+            "supports_delete": False,
+            "supports_native_search": False,
+            "supports_bulk_create": False,
+            "supports_bulk_upsert": False,
+            "supports_children": True,
+            "constructor_options": ConstructorOptions,
+            "search_options": NOTHING,
+            "create_options": NOTHING,
+            "upsert_options": NOTHING,
+            "transaction_management": False,
+            "supports_schema": False,
+            "children_can_support_apis": False,
+            "children_can_support_records": True,
+            "children_can_support_observers": False,
+        };
+
+        #! Constructor options passed through to child providers
+        const ConstructorOptions = GeneratorGenerateRecordsDataProvider::ConstructorOptions
+            + GeneratorGenerateFromTemplateDataProvider::ConstructorOptions;
+    }
+
+    private {
+        #! Child provider map
+        const ChildMap = {
+            "generate-records": Class::forName(
+                "GeneratorDataProvider::GeneratorGenerateRecordsDataProvider"),
+            "generate-from-template": Class::forName(
+                "GeneratorDataProvider::GeneratorGenerateFromTemplateDataProvider"),
+        };
+
+        #! Options to forward to child providers
+        *hash<auto> child_opts;
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        child_opts = options;
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return "generator";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return "Data generator provider for generating test record streams for data pipeline testing";
+    }
+
+    #! Return data provider summary info
+    *list<hash<DataProvider::DataProviderSummaryInfo>> getChildProviderSummaryInfo() {
+        return map $1.getConstant("ProviderSummaryInfo").getValue(), ChildMap.iterator();
+    }
+
+    #! Returns a list of child data provider names, if any
+    private *list<string> getChildProviderNamesImpl() {
+        return keys ChildMap;
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    private *DataProvider::AbstractDataProvider getChildProviderImpl(string name) {
+        *Class cls = ChildMap{name};
+        if (!cls) {
+            return;
+        }
+        return cls.newObject(child_opts);
+    }
+
+    #! Returns data provider static info
+    private hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/GeneratorDataProvider/GeneratorDataProvider.qm
+++ b/qlib/GeneratorDataProvider/GeneratorDataProvider.qm
@@ -1,0 +1,174 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GeneratorDataProvider module definition
+
+/** GeneratorDataProvider.qm Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+# minimum required Qore version
+%requires qore >= 2.0
+# assume local scope for variables, do not use "$" signs
+%modern
+
+%requires(reexport) DataProvider
+
+module GeneratorDataProvider {
+    version = "1.0";
+    desc = "user module providing a data provider API for generating test record streams";
+    author = "David Nichols <david@qore.org>";
+    url = "http://qore.org";
+    license = "MIT";
+    init = sub () {
+        # register the data provider factory
+        DataProvider::registerFactory(new GeneratorDataProviderFactory());
+
+        # register the data provider application
+        DataProviderActionCatalog::registerApp(<DataProviderAppInfo>{
+            "name": GeneratorDataProvider::AppName,
+            "display_name": "Data Generator",
+            "short_desc": "Generate test record streams",
+            "desc": "Generate configurable record streams for testing data pipelines without any external "
+                "service connections",
+            "logo": GeneratorLogo,
+            "logo_file_name": "generator-logo.svg",
+            "logo_mime_type": MimeTypeSvg,
+            "groups": (DataProvider::AppGroup::DataTransformation,),
+        });
+
+        # register all supported actions
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": GeneratorDataProvider::AppName,
+            "path": "/",
+            "action": "generate-records",
+            "display_name": "Generate Records",
+            "short_desc": "Generate a stream of records with a configurable schema",
+            "desc": "Generate a stream of records with configurable count, field types, and data generation "
+                "strategy for testing data pipelines",
+            "action_code": DPAT_FIND,
+            "cls": "GeneratorDataProvider::GeneratorGenerateRecordsDataProvider",
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                GeneratorGenerateRecordsDataProvider::ConstructorOptions{"count",}, {
+                    "preselected": True,
+                    "required": True,
+                    "loc": "constructor",
+                }
+            ) + DataProviderActionCatalog::getActionOptionFromFields(
+                GeneratorGenerateRecordsDataProvider::ConstructorOptions
+                    - ("count",), {
+                    "loc": "constructor",
+                }
+            ),
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": GeneratorDataProvider::AppName,
+            "path": "/",
+            "action": "generate-from-template",
+            "display_name": "Generate From Template",
+            "short_desc": "Generate records based on a template record",
+            "desc": "Generate a stream of records by repeating and varying a template record with optional "
+                "randomization for testing data pipelines",
+            "action_code": DPAT_FIND,
+            "cls": "GeneratorDataProvider::GeneratorGenerateFromTemplateDataProvider",
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                GeneratorGenerateFromTemplateDataProvider::ConstructorOptions{"template", "count"}, {
+                    "preselected": True,
+                    "required": True,
+                    "loc": "constructor",
+                }
+            ) + DataProviderActionCatalog::getActionOptionFromFields(
+                GeneratorGenerateFromTemplateDataProvider::ConstructorOptions
+                    - ("template", "count"), {
+                    "loc": "constructor",
+                }
+            ),
+        });
+    };
+}
+
+/** @mainpage GeneratorDataProvider Module
+
+    @tableofcontents
+
+    @section generatordataproviderintro Introduction to the GeneratorDataProvider Module
+
+    The %GeneratorDataProvider module provides a \c dataproviderintro "data provider" API for generating
+    configurable test record streams for data pipeline testing.  It requires no external connections and
+    generates data purely in-memory.
+
+    This data provider provides the following actions:
+    - <b><tt>@ref GeneratorDataProvider::GeneratorGenerateRecordsDataProvider "generate-records"</tt></b>:
+      Generate a stream of records with a configurable or default schema
+    - <b><tt>@ref GeneratorDataProvider::GeneratorGenerateFromTemplateDataProvider "generate-from-template"</tt></b>:
+      Generate records by varying a template record
+
+    @section generatordataprovider_factory Generator Data Provider Factory
+
+    The name of the generator data provider factory is <b><tt>generator</tt></b>.
+
+    @section generatordataprovider_examples Generator Data Provider Examples
+
+    These examples are with \c qdp, the command-line interface to the Data Provider API.
+
+    @par Generate 100 Records with Default Schema
+    @verbatim qdp 'generator/generate-records' count=100
+    @endverbatim
+
+    @par Generate Records with Custom Schema
+    @verbatim qdp 'generator/generate-records' count=50,strategy=random,seed=42,fields='({name=id,type=int},{name=label,type=string})'
+    @endverbatim
+
+    @par Generate Records from Template
+    @verbatim qdp 'generator/generate-from-template' count=10,template='{id=1,name=test,score=99.5}'
+    @endverbatim
+
+    @section generatordataprovider_relnotes Release Notes
+
+    @subsection generatordataprovider_v1_0 GeneratorDataProvider v1.0
+    - initial release of the module
+*/
+
+#! Contains all public definitions in the GeneratorDataProvider module
+public namespace GeneratorDataProvider {
+#! Generator logo
+public const GeneratorLogo = File::readTextFile(get_script_dir() + "/generator-logo.svg");
+
+#! Data generation strategy constants
+public enum GeneratorStrategy : string {
+    #! Sequential: deterministic values based on record index
+    Sequential = "sequential",
+    #! Random: pseudo-random values
+    Random = "random",
+}
+
+#! Field type constants for generator schema definitions
+public enum GeneratorFieldType : string {
+    #! String field type
+    String = "string",
+    #! Integer field type
+    Int = "int",
+    #! Float field type
+    Float = "float",
+    #! Boolean field type
+    Bool = "bool",
+    #! Date field type
+    Date = "date",
+}
+}

--- a/qlib/GeneratorDataProvider/GeneratorDataProviderFactory.qc
+++ b/qlib/GeneratorDataProvider/GeneratorDataProviderFactory.qc
@@ -1,0 +1,57 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GeneratorDataProviderFactory class definition
+
+/** GeneratorDataProviderFactory.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GeneratorDataProvider module
+public namespace GeneratorDataProvider {
+
+#! The data generator data provider factory: \c generator
+public class GeneratorDataProviderFactory inherits DataProvider::AbstractDataProviderFactory {
+    private {
+        #! Data provider type info
+        static Class cls = new Class("GeneratorDataProvider");
+
+        #! Factory info
+        const FactoryInfo = <DataProviderFactoryInfo>{
+            "name": "generator",
+            "desc": "Data generator data provider factory for generating test record streams",
+            "children_can_support_records": True,
+        };
+    }
+
+    #! Returns static factory information without \a provider_info
+    private hash<DataProvider::DataProviderFactoryInfo> getInfoImpl() {
+        return FactoryInfo;
+    }
+
+    #! Returns static provider information
+    private hash<DataProvider::DataProviderInfo> getProviderInfoImpl() {
+        return GeneratorDataProvider::ProviderInfo;
+    }
+
+    #! Returns the class for the data provider object
+    private Qore::Reflection::Class getClassImpl() {
+        return cls;
+    }
+}
+}

--- a/qlib/GeneratorDataProvider/GeneratorFieldDefinitionDataType.qc
+++ b/qlib/GeneratorDataProvider/GeneratorFieldDefinitionDataType.qc
@@ -1,0 +1,85 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GeneratorFieldDefinitionDataType class definition
+
+/** GeneratorFieldDefinitionDataType.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GeneratorDataProvider module
+public namespace GeneratorDataProvider {
+
+#! Data type for a single field definition in the generator schema
+/** Each field definition has a required name and type, and an optional description.
+*/
+public class GeneratorFieldDefinitionDataType inherits DataProvider::HashDataType {
+    public {
+        #! Field definition fields
+        const Fields = {
+            "name": {
+                "display_name": "Field Name",
+                "short_desc": "The name of the field",
+                "desc": "The name of the field in the generated record",
+                "type": AbstractDataProviderTypeMap."string",
+                "required": True,
+            },
+            "type": {
+                "display_name": "Field Type",
+                "short_desc": "The data type of the field",
+                "desc": "The data type of the field; determines the kind of values generated",
+                "type": AbstractDataProviderTypeMap."string",
+                "required": True,
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "value": GeneratorFieldType::String,
+                        "desc": "String values",
+                    },
+                    <AllowedValueInfo>{
+                        "value": GeneratorFieldType::Int,
+                        "desc": "Integer values",
+                    },
+                    <AllowedValueInfo>{
+                        "value": GeneratorFieldType::Float,
+                        "desc": "Floating-point values",
+                    },
+                    <AllowedValueInfo>{
+                        "value": GeneratorFieldType::Bool,
+                        "desc": "Boolean values",
+                    },
+                    <AllowedValueInfo>{
+                        "value": GeneratorFieldType::Date,
+                        "desc": "Date/time values",
+                    },
+                ),
+            },
+            "desc": {
+                "display_name": "Description",
+                "short_desc": "An optional description of the field",
+                "desc": "An optional human-readable description of the field",
+                "type": AbstractDataProviderTypeMap."*string",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() : HashDataType("GeneratorFieldDefinition") {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/GeneratorDataProvider/GeneratorGenerateFromTemplateDataProvider.qc
+++ b/qlib/GeneratorDataProvider/GeneratorGenerateFromTemplateDataProvider.qc
@@ -1,0 +1,229 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GeneratorGenerateFromTemplateDataProvider class definition
+
+/** GeneratorGenerateFromTemplateDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GeneratorDataProvider module
+public namespace GeneratorDataProvider {
+
+#! Data provider for the generate-from-template action
+/** Generates a record stream by varying a template record with optional randomization for testing data pipelines.
+
+    Generation parameters are set via constructor options; records are read via the record-based read API
+    (searchRecords / searchRecordsBulk / getBulkRecordInterface).
+*/
+public class GeneratorGenerateFromTemplateDataProvider inherits DataProvider::AbstractDataProvider {
+    public {
+        #! Constructor options for configuring generation
+        const ConstructorOptions = {
+            "template": <DataProviderOptionInfo>{
+                "display_name": "Template Record",
+                "short_desc": "A sample record to use as a template",
+                "desc": "A hash representing a single record whose structure and values will be used as the "
+                    "basis for all generated records; field types are inferred from the template values; each "
+                    "generated record varies the template values based on the record index or randomly",
+                "type": AbstractDataProviderTypeMap."hash",
+                "required": True,
+            },
+            "count": <DataProviderOptionInfo>{
+                "display_name": "Record Count",
+                "short_desc": "Number of records to generate",
+                "desc": "The total number of records to generate from the template; must be a non-negative "
+                    "integer; defaults to 10",
+                "type": AbstractDataProviderTypeMap."int",
+                "required": False,
+                "default_value": 10,
+            },
+            "strategy": <DataProviderOptionInfo>{
+                "display_name": "Generation Strategy",
+                "short_desc": "How template values are varied",
+                "desc": "The strategy for varying template values across generated records; 'sequential' adds "
+                    "the record index to numeric values and appends it as a suffix to strings; 'random' "
+                    "applies random variations; defaults to 'sequential'",
+                "type": AbstractDataProviderTypeMap."string",
+                "default_value": GeneratorStrategy::Sequential,
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "value": GeneratorStrategy::Sequential,
+                        "desc": "Vary template values deterministically by record index",
+                    },
+                    <AllowedValueInfo>{
+                        "value": GeneratorStrategy::Random,
+                        "desc": "Apply random variations to template values",
+                    },
+                ),
+            },
+            "include_nulls": <DataProviderOptionInfo>{
+                "display_name": "Include Nulls",
+                "short_desc": "Whether to randomly include null values",
+                "desc": "When True and strategy is 'random', approximately 10% of field values will be set to "
+                    "NOTHING (null); useful for testing null handling in data pipelines; defaults to False",
+                "type": AbstractDataProviderTypeMap."bool",
+                "default_value": False,
+            },
+            "seed": <DataProviderOptionInfo>{
+                "display_name": "Random Seed",
+                "short_desc": "Seed for reproducible random generation",
+                "desc": "An integer seed for the random number generator for reproducible output; only "
+                    "effective with 'random' strategy",
+                "type": AbstractDataProviderTypeMap."int",
+            },
+            "base_date": <DataProviderOptionInfo>{
+                "display_name": "Base Date",
+                "short_desc": "Fixed base date for date field generation",
+                "desc": "A fixed date/time value used as the reference point for generating date fields; "
+                    "when provided with a seed, this ensures full cross-run reproducibility of date "
+                    "fields; if not provided, the current date/time at the start of generation is used",
+                "type": AbstractDataProviderTypeMap."date",
+            },
+        };
+
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "generate-from-template",
+            "desc": "Generate a record stream by repeating and varying a template record with optional "
+                "randomization for testing data pipelines",
+            "type": "GeneratorGenerateFromTemplateDataProvider",
+            "supports_read": True,
+            "supports_bulk_read": True,
+            "has_record": True,
+            "constructor_options": ConstructorOptions,
+            "search_options": GenericRecordSearchOptions,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+    }
+
+    private {
+        #! Template record
+        hash<auto> template_record;
+
+        #! Inferred field definitions
+        list<auto> fields;
+
+        #! Record count
+        int count = 10;
+
+        #! Generation strategy
+        string strategy = GeneratorStrategy::Sequential;
+
+        #! Include nulls flag
+        bool include_nulls = False;
+
+        #! Random seed
+        *int seed;
+
+        #! Base date for date generation
+        *date base_date;
+    }
+
+    #! Creates the object
+    constructor(*hash<auto> options) {
+        *hash<auto> copts = checkOptions("CONSTRUCTOR-ERROR", ConstructorOptions, options);
+        if (!exists copts.template) {
+            throw "CONSTRUCTOR-ERROR", "the 'template' option is required";
+        }
+        template_record = copts.template;
+
+        # Infer field types from template values
+        fields = ();
+        foreach hash<auto> pair in (template_record.pairIterator()) {
+            fields += {"name": pair.key, "type": inferType(pair.value)};
+        }
+
+        if (exists copts.count) {
+            if (copts.count < 0) {
+                throw "CONSTRUCTOR-ERROR", sprintf("'count' must be a non-negative integer; got %d", copts.count);
+            }
+            count = copts.count;
+        }
+        if (exists copts.strategy) {
+            strategy = copts.strategy;
+        }
+        if (exists copts.include_nulls) {
+            include_nulls = copts.include_nulls;
+        }
+        seed = copts.seed;
+        base_date = copts.base_date;
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return ProviderInfo.desc;
+    }
+
+    #! Infers a GeneratorFieldType string from a Qore runtime value
+    static string inferType(auto val) {
+        switch (val.type()) {
+            case "integer":
+                return GeneratorFieldType::Int;
+            case "float":
+            case "number":
+                return GeneratorFieldType::Float;
+            case "bool":
+                return GeneratorFieldType::Bool;
+            case "date":
+                return GeneratorFieldType::Date;
+            case "string":
+            case "NULL":
+                return GeneratorFieldType::String;
+        }
+        throw "TEMPLATE-ERROR", sprintf("unsupported template value type %y; supported types: string, int, "
+            "float, bool, date", val.type());
+    }
+
+    #! Creates a record iterator for the configured generation parameters
+    private GeneratorRecordIterator makeIterator() {
+        return new GeneratorRecordIterator(count, fields, strategy, include_nulls, seed, template_record,
+            base_date);
+    }
+
+    #! Returns an iterator for zero or more records matching the search options
+    /** @param where_cond ignored; generation does not filter
+        @param search_options search options (supports generic options like \c max_records and \c limit)
+
+        @return a record iterator that generates the configured number of records
+    */
+    private DataProvider::AbstractDataProviderRecordIterator searchRecordsImpl(*hash<auto> where_cond,
+            *hash<auto> search_options) {
+        return makeIterator();
+    }
+
+    #! Returns the record type for the generated records
+    private *hash<string, DataProvider::AbstractDataField> getRecordTypeImpl(*hash<auto> search_options) {
+        return makeIterator().getRecordType();
+    }
+
+    #! Returns data provider static info
+    private hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/GeneratorDataProvider/GeneratorGenerateRecordsDataProvider.qc
+++ b/qlib/GeneratorDataProvider/GeneratorGenerateRecordsDataProvider.qc
@@ -1,0 +1,198 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GeneratorGenerateRecordsDataProvider class definition
+
+/** GeneratorGenerateRecordsDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GeneratorDataProvider module
+public namespace GeneratorDataProvider {
+
+#! Data provider for the generate-records action
+/** Generates a configurable record stream with a given or auto-generated schema for testing data pipelines.
+
+    Generation parameters are set via constructor options; records are read via the record-based read API
+    (searchRecords / searchRecordsBulk / getBulkRecordInterface).
+*/
+public class GeneratorGenerateRecordsDataProvider inherits DataProvider::AbstractDataProvider {
+    public {
+        #! Constructor options for configuring generation
+        const ConstructorOptions = {
+            "count": <DataProviderOptionInfo>{
+                "display_name": "Record Count",
+                "short_desc": "Number of records to generate",
+                "desc": "The total number of records to generate in the output stream; must be a non-negative "
+                    "integer; defaults to 10",
+                "type": AbstractDataProviderTypeMap."int",
+                "required": False,
+                "default_value": 10,
+            },
+            "strategy": <DataProviderOptionInfo>{
+                "display_name": "Generation Strategy",
+                "short_desc": "How field values are generated",
+                "desc": "The strategy used to generate field values; 'sequential' produces deterministic values "
+                    "based on the record index; 'random' produces pseudo-random values; defaults to 'sequential'",
+                "type": AbstractDataProviderTypeMap."string",
+                "default_value": GeneratorStrategy::Sequential,
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "value": GeneratorStrategy::Sequential,
+                        "desc": "Generate deterministic values incrementing with each record index",
+                    },
+                    <AllowedValueInfo>{
+                        "value": GeneratorStrategy::Random,
+                        "desc": "Generate pseudo-random values for each field",
+                    },
+                ),
+            },
+            "fields": <DataProviderOptionInfo>{
+                "display_name": "Field Definitions",
+                "short_desc": "Schema definition for generated records",
+                "desc": "A list of field definition hashes, each with keys: 'name' (string, the field name), "
+                    "'type' (string, one of: 'string', 'int', 'float', 'bool', 'date'), and optionally 'desc' "
+                    "(string, field description); if not provided, a default schema is used with fields: "
+                    "'id' (int), 'name' (string), 'value' (float), 'active' (bool), 'created' (date)",
+                "type": new ListDataType("*softlist<GeneratorFieldDefinition>",
+                    new GeneratorFieldDefinitionDataType(), True),
+            },
+            "include_nulls": <DataProviderOptionInfo>{
+                "display_name": "Include Nulls",
+                "short_desc": "Whether to randomly include null values",
+                "desc": "When True and strategy is 'random', approximately 10% of field values will be set to "
+                    "NOTHING (null); useful for testing null handling in data pipelines; defaults to False",
+                "type": AbstractDataProviderTypeMap."bool",
+                "default_value": False,
+            },
+            "seed": <DataProviderOptionInfo>{
+                "display_name": "Random Seed",
+                "short_desc": "Seed for reproducible random generation",
+                "desc": "An integer seed for the random number generator; when provided, the same seed will "
+                    "always produce the same sequence of records, enabling reproducible test data; only "
+                    "effective with 'random' strategy",
+                "type": AbstractDataProviderTypeMap."int",
+            },
+            "base_date": <DataProviderOptionInfo>{
+                "display_name": "Base Date",
+                "short_desc": "Fixed base date for date field generation",
+                "desc": "A fixed date/time value used as the reference point for generating date fields; "
+                    "when provided with a seed, this ensures full cross-run reproducibility of date fields; "
+                    "if not provided, the current date/time at the start of generation is used",
+                "type": AbstractDataProviderTypeMap."date",
+            },
+        };
+
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "generate-records",
+            "desc": "Generate a record stream with configurable schema, count, and data generation strategy "
+                "for testing data pipelines",
+            "type": "GeneratorGenerateRecordsDataProvider",
+            "supports_read": True,
+            "supports_bulk_read": True,
+            "has_record": True,
+            "constructor_options": ConstructorOptions,
+            "search_options": GenericRecordSearchOptions,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+    }
+
+    private {
+        #! Record count
+        int count = 10;
+
+        #! Generation strategy
+        string strategy = GeneratorStrategy::Sequential;
+
+        #! Field definitions
+        list<auto> fields = DefaultFields;
+
+        #! Include nulls flag
+        bool include_nulls = False;
+
+        #! Random seed
+        *int seed;
+
+        #! Base date for date generation
+        *date base_date;
+    }
+
+    #! Creates the object
+    constructor(*hash<auto> options) {
+        *hash<auto> copts = checkOptions("CONSTRUCTOR-ERROR", ConstructorOptions, options);
+        if (exists copts.count) {
+            if (copts.count < 0) {
+                throw "CONSTRUCTOR-ERROR", sprintf("'count' must be a non-negative integer; got %d", copts.count);
+            }
+            count = copts.count;
+        }
+        if (exists copts.strategy) {
+            strategy = copts.strategy;
+        }
+        if (exists copts.fields) {
+            fields = copts.fields;
+        }
+        if (exists copts.include_nulls) {
+            include_nulls = copts.include_nulls;
+        }
+        seed = copts.seed;
+        base_date = copts.base_date;
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return ProviderInfo.desc;
+    }
+
+    #! Creates a record iterator for the configured generation parameters
+    private GeneratorRecordIterator makeIterator() {
+        return new GeneratorRecordIterator(count, fields, strategy, include_nulls, seed, NOTHING, base_date);
+    }
+
+    #! Returns an iterator for zero or more records matching the search options
+    /** @param where_cond ignored; generation does not filter
+        @param search_options search options (supports generic options like \c max_records and \c limit)
+
+        @return a record iterator that generates the configured number of records
+    */
+    private DataProvider::AbstractDataProviderRecordIterator searchRecordsImpl(*hash<auto> where_cond,
+            *hash<auto> search_options) {
+        return makeIterator();
+    }
+
+    #! Returns the record type for the generated records
+    private *hash<string, DataProvider::AbstractDataField> getRecordTypeImpl(*hash<auto> search_options) {
+        return makeIterator().getRecordType();
+    }
+
+    #! Returns data provider static info
+    private hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/GeneratorDataProvider/GeneratorRecordIterator.qc
+++ b/qlib/GeneratorDataProvider/GeneratorRecordIterator.qc
@@ -1,0 +1,225 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GeneratorRecordIterator class definition
+
+/** GeneratorRecordIterator.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GeneratorDataProvider module
+public namespace GeneratorDataProvider {
+
+#! Type map from generator field type strings to DataProvider types
+const GeneratorTypeMap = {
+    GeneratorFieldType::String: AbstractDataProviderTypeMap."string",
+    GeneratorFieldType::Int: AbstractDataProviderTypeMap."int",
+    GeneratorFieldType::Float: AbstractDataProviderTypeMap."float",
+    GeneratorFieldType::Bool: AbstractDataProviderTypeMap."bool",
+    GeneratorFieldType::Date: AbstractDataProviderTypeMap."date",
+};
+
+#! Default field definitions used when no custom schema is provided
+const DefaultFields = (
+    {"name": "id", "type": GeneratorFieldType::Int, "desc": "Record identifier"},
+    {"name": "name", "type": GeneratorFieldType::String, "desc": "Record name"},
+    {"name": "value", "type": GeneratorFieldType::Float, "desc": "Numeric value"},
+    {"name": "active", "type": GeneratorFieldType::Bool, "desc": "Active flag"},
+    {"name": "created", "type": GeneratorFieldType::Date, "desc": "Creation date"},
+);
+
+#! Record iterator that generates configurable test records in-memory
+public class GeneratorRecordIterator inherits DataProvider::AbstractDataProviderRecordIterator {
+    private:internal {
+        #! Total records to generate
+        int count;
+
+        #! Current record index (0-based)
+        int current = -1;
+
+        #! Field definitions: list of hashes with "name", "type", and optionally "desc"
+        list<auto> fields;
+
+        #! Data generation strategy
+        string strategy;
+
+        #! Whether to include null values randomly
+        bool include_nulls;
+
+        #! Template record for template-based generation
+        *hash<auto> template_record;
+
+        #! Record type definition
+        hash<string, DataProvider::AbstractDataField> record_type;
+
+        #! Fixed base date captured at construction time for deterministic date generation
+        date base_date;
+
+        #! Local PRNG state for seeded generation; avoids mutating global RNG via srand()
+        *int prng_state;
+    }
+
+    #! Creates the iterator
+    /** @param count the number of records to generate
+        @param fields list of field definition hashes with "name" and "type" keys
+        @param strategy the generation strategy: GeneratorStrategy::Sequential or GeneratorStrategy::Random
+        @param include_nulls if True and strategy is "random", ~10% of values will be NOTHING
+        @param seed optional random seed for reproducible output
+        @param template_record optional template record for template-based generation
+        @param base_date optional fixed base date for date field generation; when provided, date values are
+        computed relative to this date for full cross-run reproducibility; when not provided, the current
+        date/time is used
+    */
+    constructor(int count, list<auto> fields, string strategy = GeneratorStrategy::Sequential,
+            bool include_nulls = False, *int seed, *hash<auto> template_record,
+            *date base_date) {
+        self.count = count;
+        self.fields = fields;
+        self.strategy = strategy;
+        self.include_nulls = include_nulls;
+        self.template_record = template_record;
+        self.base_date = base_date ?? now_us();
+
+        if (exists seed) {
+            # initialize local PRNG state from seed; uses a simple LCG to avoid
+            # polluting the global RNG state via srand()
+            prng_state = seed;
+        }
+
+        # Build record type from field definitions
+        map record_type{$1.name} = makeFieldDef($1), fields;
+    }
+
+    #! Returns @ref True if the iterator is valid
+    bool valid() {
+        return current >= 0 && current < count;
+    }
+
+    #! Returns the current record
+    /** @throw INVALID-ITERATOR the iterator is not pointing at a valid element
+    */
+    hash<auto> getValue() {
+        if (!valid()) {
+            throw "INVALID-ITERATOR", "iterator is not pointing at a valid element";
+        }
+        return generateRecord(current);
+    }
+
+    #! Returns the record description, if available
+    *hash<string, DataProvider::AbstractDataField> getRecordType() {
+        return record_type;
+    }
+
+    #! Increments the row pointer
+    /** @return @ref True if there is a row to retrieve, @ref False if not
+    */
+    private bool nextImpl() {
+        return ++current < count;
+    }
+
+    #! Returns the next pseudo-random non-negative int
+    /** When a seed was provided, uses a local linear congruential generator (LCG) that does not
+        touch the global RNG state.  Otherwise falls back to the global rand().
+    */
+    private int nextRand() {
+        if (exists prng_state) {
+            # LCG parameters from Numerical Recipes
+            prng_state = (prng_state * 1664525 + 1013904223) & 0x7fffffff;
+            return prng_state;
+        }
+        return rand();
+    }
+
+    #! Generates a single record for the given index
+    private hash<auto> generateRecord(int idx) {
+        hash<auto> rec = {};
+        foreach hash<auto> field in (fields) {
+            if (include_nulls && strategy == GeneratorStrategy::Random && nextRand() % 10 == 0) {
+                rec{field.name} = NOTHING;
+                continue;
+            }
+            rec{field.name} = template_record
+                ? varyValue(template_record{field.name}, idx, field)
+                : generateValue(field, idx);
+        }
+        return rec;
+    }
+
+    #! Generates a value based on field type and strategy
+    private auto generateValue(hash<auto> field, int idx) {
+        switch (field.type) {
+            case GeneratorFieldType::String:
+                return strategy == GeneratorStrategy::Random
+                    ? sprintf("str_%d_%d", idx, nextRand())
+                    : sprintf("%s_%d", field.name, idx);
+            case GeneratorFieldType::Int:
+                return strategy == GeneratorStrategy::Random ? nextRand() % 100000 : idx;
+            case GeneratorFieldType::Float:
+                return strategy == GeneratorStrategy::Random
+                    ? (nextRand() % 100000).toFloat() / 100.0
+                    : idx.toFloat();
+            case GeneratorFieldType::Bool:
+                return strategy == GeneratorStrategy::Random ? (nextRand() % 2 == 0) : (idx % 2 == 0);
+            case GeneratorFieldType::Date:
+                return strategy == GeneratorStrategy::Random
+                    ? base_date - days(nextRand() % 3650)
+                    : base_date - days(idx);
+        }
+        # fallback for unknown types
+        return sprintf("val_%d", idx);
+    }
+
+    #! Varies a template value for template-based generation
+    private auto varyValue(auto val, int idx, hash<auto> field) {
+        if (strategy == GeneratorStrategy::Random) {
+            switch (field.type) {
+                case GeneratorFieldType::String:
+                    return val + "_" + string(nextRand() % 10000);
+                case GeneratorFieldType::Int:
+                    return val + nextRand() % 1000;
+                case GeneratorFieldType::Float:
+                    return val + (nextRand() % 10000).toFloat() / 100.0;
+                case GeneratorFieldType::Bool:
+                    return nextRand() % 2 == 0;
+                case GeneratorFieldType::Date:
+                    return val + days(nextRand() % 365);
+            }
+            return val;
+        }
+        switch (field.type) {
+            case GeneratorFieldType::String:
+                return val + "_" + string(idx);
+            case GeneratorFieldType::Int:
+                return val + idx;
+            case GeneratorFieldType::Float:
+                return val + idx.toFloat() * 0.1;
+            case GeneratorFieldType::Bool:
+                return idx % 2 == 0 ? val : !val;
+            case GeneratorFieldType::Date:
+                return val + days(idx);
+        }
+        return val;
+    }
+
+    #! Creates a DataField from a field definition hash
+    private DataProvider::AbstractDataField makeFieldDef(hash<auto> field) {
+        return new QoreDataField(field.name, field.desc ?? field.name,
+            GeneratorTypeMap{field.type} ?? AbstractDataProviderTypeMap."string");
+    }
+}
+}

--- a/qlib/GeneratorDataProvider/generator-logo.svg
+++ b/qlib/GeneratorDataProvider/generator-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <!-- Generator Data Provider Icon - Purple variant 2 -->
+  <circle cx="50" cy="50" r="40" fill="none" stroke="#8E4585" stroke-width="10"/>
+  <path d="M72 35 A26 26 0 1 0 72 65 L72 50 L50 50" 
+        fill="none" stroke="#8E4585" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- **GeneratorDataProvider module**: New data provider for generating configurable test record streams without external dependencies. Includes `generate-records` (schema-based) and `generate-from-template` (template-based) actions with full option metadata, structured type definitions, factory registration, and comprehensive tests (33 cases, 345 assertions).
- **qdp fixes**: Constructor options display in `info`, JSON/YAML serialization via `getInfoAsData()`, YAML block style, and action class resolution for dynamically-loaded modules.
- **AST parser**: Captures module metadata declarations and traverses attribute expressions.

## Test plan
- [x] `GeneratorDataProvider.qtest` — 33 test cases, 345 assertions all passing
- [x] Verify `qdp generator{}/generate-records info` displays proper type info
- [x] Verify `qdp @DataGenerator/generate-records{count=2} se` executes correctly
- [x] Verify AST parser tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)