### PR TITLE
fix: fix WebSocket extension handling and sendAll() per-connection transforms

### DIFF
--- a/examples/test/qlib/WebSocketHandler/WebSocketHandler.qtest
+++ b/examples/test/qlib/WebSocketHandler/WebSocketHandler.qtest
@@ -144,6 +144,14 @@ class MyWsConnection inherits WebSocketConnection {
                 # echo the message back
                 send(msg.substr(4), WSOP_Text, True);
                 break;
+            case =~ /^BROADCAST/:
+                # broadcast message to all connections via handler
+                handler.sendAll(msg.substr(9));
+                break;
+            case =~ /^BCASTBIN/:
+                # broadcast binary message to all connections via handler
+                handler.sendAll(binary(msg.substr(8)));
+                break;
             case "WAIT":
                 send(strmul("x", 1024 * 1024 * 5), WSOP_Text, True);
                 break;
@@ -223,6 +231,7 @@ class WebSocketHandlerTest inherits QUnit::Test {
         addTestCase("WebSocketHandler tests", \webSocketHandlerTests());
         addTestCase("extension tests", \extensionTests());
         addTestCase("extension negative tests", \extensionNegativeTests());
+        addTestCase("sendAll extension tests", \sendAllExtensionTests());
 
         logger = new Logger("test", m_options.verbose > 3 ? LoggerLevel::LevelDebug : LoggerLevel::LevelInfo);
         if (m_options.verbose > 2) {
@@ -491,8 +500,196 @@ class WebSocketHandlerTest inherits QUnit::Test {
         }
     }
 
+    sendAllExtensionTests() {
+        # Create extension-enabled handler
+        MyWsHandlerWithExtensions extHandler({
+            "extensions": ("permessage-deflate",),
+            "logger": logger,
+            "heartbeat": 30,
+        });
+        mServer.setHandler("ws-sendall-ext", "/sendall-ext", NOTHING, extHandler);
+
+        # Test 1: sendAll with two extension clients
+        {
+            Queue msgs1();
+            Queue msgs2();
+            WebSocketClient wsc1(sub (*data msg) { msgs1.push(msg); }, {
+                "url": "ws://localhost:" + port + "/sendall-ext",
+                "extensions": (new PerMessageDeflateExtension(),),
+                "logger": logger,
+            });
+            WebSocketClient wsc2(sub (*data msg) { msgs2.push(msg); }, {
+                "url": "ws://localhost:" + port + "/sendall-ext",
+                "extensions": (new PerMessageDeflateExtension(),),
+                "logger": logger,
+            });
+            wsc1.connect();
+            wsc2.connect();
+            on_exit {
+                wsc1.disconnect();
+                wsc2.disconnect();
+            }
+            assertTrue(wsc1.isOpen());
+            assertTrue(wsc2.isOpen());
+            assertTrue(wsc1.hasPerMessageDeflate());
+            assertTrue(wsc2.hasPerMessageDeflate());
+
+            # Round-trip echo to confirm both are registered
+            wsc1.send("ECHO ping1");
+            assertEq(" ping1", msgs1.get(5s));
+            wsc2.send("ECHO ping2");
+            assertEq(" ping2", msgs2.get(5s));
+
+            # Trigger broadcast from wsc1 — small message
+            wsc1.send("BROADCAST hello all");
+            assertEq(" hello all", msgs1.get(5s));
+            assertEq(" hello all", msgs2.get(5s));
+
+            # Trigger broadcast — large message (well above compression threshold)
+            string large_msg = strmul("X", 4096);
+            wsc2.send("BROADCAST " + large_msg);
+            assertEq(" " + large_msg, msgs1.get(5s));
+            assertEq(" " + large_msg, msgs2.get(5s));
+        }
+
+        # Test 2: sendAll without extensions (backward compatibility)
+        {
+            Queue msgs1();
+            Queue msgs2();
+            WebSocketClient wsc1(sub (*data msg) { msgs1.push(msg); }, {
+                "url": "ws://localhost:" + port,
+                "logger": logger,
+            });
+            WebSocketClient wsc2(sub (*data msg) { msgs2.push(msg); }, {
+                "url": "ws://localhost:" + port,
+                "logger": logger,
+            });
+            wsc1.connect();
+            wsc2.connect();
+            on_exit {
+                wsc1.disconnect();
+                wsc2.disconnect();
+            }
+            assertTrue(wsc1.isOpen());
+            assertTrue(wsc2.isOpen());
+
+            # Round-trip echo to confirm both are registered
+            wsc1.send("ECHO ping1");
+            assertEq(" ping1", msgs1.get(5s));
+            wsc2.send("ECHO ping2");
+            assertEq(" ping2", msgs2.get(5s));
+
+            # Trigger broadcast
+            wsc1.send("BROADCAST no-ext test");
+            assertEq(" no-ext test", msgs1.get(5s));
+            assertEq(" no-ext test", msgs2.get(5s));
+        }
+
+        # Test 3: sendAll with mixed connections (one with extensions, one without)
+        {
+            Queue msgs1();
+            Queue msgs2();
+            # Client with permessage-deflate
+            WebSocketClient wsc1(sub (*data msg) { msgs1.push(msg); }, {
+                "url": "ws://localhost:" + port + "/sendall-ext",
+                "extensions": (new PerMessageDeflateExtension(),),
+                "logger": logger,
+            });
+            # Client without extensions
+            WebSocketClient wsc2(sub (*data msg) { msgs2.push(msg); }, {
+                "url": "ws://localhost:" + port + "/sendall-ext",
+                "logger": logger,
+            });
+            wsc1.connect();
+            wsc2.connect();
+            on_exit {
+                wsc1.disconnect();
+                wsc2.disconnect();
+            }
+            assertTrue(wsc1.isOpen());
+            assertTrue(wsc2.isOpen());
+            assertTrue(wsc1.hasPerMessageDeflate());
+
+            # Round-trip echo to confirm both are registered
+            wsc1.send("ECHO ping1");
+            assertEq(" ping1", msgs1.get(5s));
+            wsc2.send("ECHO ping2");
+            assertEq(" ping2", msgs2.get(5s));
+
+            # Trigger broadcast — small message
+            wsc1.send("BROADCAST mixed small");
+            assertEq(" mixed small", msgs1.get(5s));
+            assertEq(" mixed small", msgs2.get(5s));
+
+            # Trigger broadcast — large message
+            string large_msg = strmul("Y", 4096);
+            wsc2.send("BROADCAST " + large_msg);
+            assertEq(" " + large_msg, msgs1.get(5s));
+            assertEq(" " + large_msg, msgs2.get(5s));
+        }
+
+        # Test 4: sendAll with binary data (mixed clients)
+        {
+            Queue msgs1();
+            Queue msgs2();
+            WebSocketClient wsc1(sub (*data msg) { msgs1.push(msg); }, {
+                "url": "ws://localhost:" + port + "/sendall-ext",
+                "extensions": (new PerMessageDeflateExtension(),),
+                "logger": logger,
+            });
+            WebSocketClient wsc2(sub (*data msg) { msgs2.push(msg); }, {
+                "url": "ws://localhost:" + port + "/sendall-ext",
+                "logger": logger,
+            });
+            wsc1.connect();
+            wsc2.connect();
+            on_exit {
+                wsc1.disconnect();
+                wsc2.disconnect();
+            }
+            assertTrue(wsc1.isOpen());
+            assertTrue(wsc2.isOpen());
+
+            # Round-trip echo to confirm both are registered
+            wsc1.send("ECHO ping1");
+            assertEq(" ping1", msgs1.get(5s));
+            wsc2.send("ECHO ping2");
+            assertEq(" ping2", msgs2.get(5s));
+
+            # Trigger binary broadcast
+            wsc1.send("BCASTBIN\x00\x01\x02\x03test binary");
+            binary expected = binary("\x00\x01\x02\x03test binary");
+            assertEq(expected, msgs1.get(5s));
+            assertEq(expected, msgs2.get(5s));
+        }
+
+        # Test 5: sendOne with extensions (end-to-end)
+        {
+            Queue msgs1();
+            WebSocketClient wsc1(sub (*data msg) { msgs1.push(msg); }, {
+                "url": "ws://localhost:" + port + "/sendall-ext",
+                "extensions": (new PerMessageDeflateExtension(),),
+                "logger": logger,
+            });
+            wsc1.connect();
+            on_exit wsc1.disconnect();
+            assertTrue(wsc1.isOpen());
+            assertTrue(wsc1.hasPerMessageDeflate());
+
+            # The ECHO command triggers send() on the connection, which goes through sendWithExtensions
+            wsc1.send("ECHO sendOne ext test");
+            assertEq(" sendOne ext test", msgs1.get(5s));
+
+            # Large message to exercise compression
+            string large_msg = strmul("Z", 4096);
+            wsc1.send("ECHO " + large_msg);
+            assertEq(" " + large_msg, msgs1.get(5s));
+        }
+    }
+
     private log(string str) {
-        if (m_options.verbose > 2)
+        if (m_options.verbose > 2) {
             vprintf(str + "\n", argv);
+        }
     }
 }

--- a/qlib/WebSocketHandler.qm
+++ b/qlib/WebSocketHandler.qm
@@ -73,6 +73,13 @@ module WebSocketHandler {
     @section websockethandler_relnotes WebSocketHandler Release History
 
     @subsection websockethandler_v2_3 Version 2.3
+    - fixed @ref WebSocketHandler::WebSocketHandler::sendAll() "WebSocketHandler::sendAll()" to apply
+      per-connection extension transforms (e.g., permessage-deflate) instead of pre-encoding a single frame
+      for all connections
+    - fixed server-side extension negotiation to properly propagate negotiated extensions from
+      @ref WebSocketHandler::WebSocketHandler::handleRequest() "handleRequest()" to
+      @ref WebSocketHandler::WebSocketHandler "startImpl()" so that per-connection extension transforms
+      (e.g., permessage-deflate compression/decompression) are actually applied
     - added WebSocket extension support (RFC 6455 Section 9) with permessage-deflate (RFC 7692)
       (<a href="https://github.com/qoretechnologies/qore/issues/5065">issue 5065</a>)
     - added @ref WebSocketHandler::WebSocketHandler "WebSocketHandler" constructor option \c "extensions" to enable
@@ -350,6 +357,8 @@ public class WebSocketConnection {
         @since WebSocketHandler 2.3
     */
     private binary sendWithExtensions(data msg, *int op, bool fin = True) {
+        # Determine the opcode before extension transforms may change the message type
+        int actual_op = op ?? (msg.typeCode() == NT_STRING ? WSOP_Text : WSOP_Binary);
         int rsv_bits = 0;
 
         # Apply outgoing transforms from active extensions
@@ -357,7 +366,7 @@ public class WebSocketConnection {
         # as specified in RFC 6455 Section 9.2 and RFC 7692 Section 8
         if (active_extensions) {
             hash<auto> ctx = {
-                "op": op ?? (msg.typeCode() == NT_STRING ? WSOP_Text : WSOP_Binary),
+                "op": actual_op,
                 "fin": fin,
             };
             foreach AbstractWebSocketExtension ext in (active_extensions) {
@@ -367,7 +376,7 @@ public class WebSocketConnection {
             }
         }
 
-        return ws_encode_message(msg, op, NOTHING, fin, rsv_bits);
+        return ws_encode_message(msg, actual_op, NOTHING, fin, rsv_bits);
     }
 
     #! This method is called when messages from the client are received
@@ -693,6 +702,11 @@ public class WebSocketHandler inherits HttpServer::AbstractHttpSocketHandler, Lo
         /** @since WebSocketHandler 2.3
         */
         *list<string> supported_extensions;
+
+        #! Pending negotiated extensions keyed by connection ID, to be consumed by startImpl()
+        /** @since WebSocketHandler 2.3
+        */
+        hash<string, hash<auto>> pending_extensions;
     }
 
     private:internal {
@@ -907,10 +921,13 @@ public class WebSocketHandler inherits HttpServer::AbstractHttpSocketHandler, Lo
             if (ext_result.response_header) {
                 rhdr."sec-websocket-extensions" = ext_result.response_header;
             }
-            # Store negotiated extensions in hdr for startImpl to access
+            # Store negotiated extensions on the handler for startImpl to access
             if (ext_result.extensions) {
-                hdr."_ws_negotiated_extensions" = ext_result.extensions;
-                hdr."_ws_extension_rsv_mask" = ext_result.rsv_mask;
+                string cid = cx.id.toString();
+                pending_extensions{cid} = {
+                    "extensions": ext_result.extensions,
+                    "rsv_mask": ext_result.rsv_mask,
+                };
             }
 
             # RFC 8441: Return 200 OK for HTTP/2 WebSocket CONNECT
@@ -941,10 +958,13 @@ public class WebSocketHandler inherits HttpServer::AbstractHttpSocketHandler, Lo
         if (ext_result.response_header) {
             rhdr."Sec-WebSocket-Extensions" = ext_result.response_header;
         }
-        # Store negotiated extensions in hdr for startImpl to access
+        # Store negotiated extensions on the handler for startImpl to access
         if (ext_result.extensions) {
-            hdr."_ws_negotiated_extensions" = ext_result.extensions;
-            hdr."_ws_extension_rsv_mask" = ext_result.rsv_mask;
+            string cid = cx.id.toString();
+            pending_extensions{cid} = {
+                "extensions": ext_result.extensions,
+                "rsv_mask": ext_result.rsv_mask,
+            };
         }
 
         return {
@@ -1009,11 +1029,12 @@ public class WebSocketHandler inherits HttpServer::AbstractHttpSocketHandler, Lo
             wsc.setHttp2StreamContext(new AsyncSocketIo::Http2StreamContext(sock, h2_stream_id, True));
         }
 
-        # Set negotiated extensions on the connection
-        if (hdr."_ws_negotiated_extensions") {
-            wsc.setExtensions(hdr."_ws_negotiated_extensions", hdr."_ws_extension_rsv_mask" ?? 0);
+        # Set negotiated extensions on the connection (stored by handleRequest)
+        *hash<auto> ext_data = remove pending_extensions{cid};
+        if (ext_data) {
+            wsc.setExtensions(ext_data.extensions, ext_data.rsv_mask ?? 0);
             logDebug("WebSocketHandler::startImpl() cid: %y extensions: %y", cx.id,
-                (map $1.getName(), hdr."_ws_negotiated_extensions"));
+                (map $1.getName(), ext_data.extensions));
         }
 
         try {
@@ -1039,6 +1060,8 @@ public class WebSocketHandler inherits HttpServer::AbstractHttpSocketHandler, Lo
             rwl.writeLock();
             on_exit rwl.writeUnlock();
             remove ch{cid};
+            # Safety net: clean up any pending extension data for this connection
+            remove pending_extensions{cid};
         }
 
         # issue #2887 timestamp of last traffic
@@ -1403,16 +1426,19 @@ public class WebSocketHandler inherits HttpServer::AbstractHttpSocketHandler, Lo
     #! sends a message to all connected clients
     /** @param d the data to send
 
-        Messages are automatically encoded with @ref WebSocketUtil::ws_encode_message() before sending.
+        Messages are encoded via each connection's
+        @ref WebSocketHandler::WebSocketConnection::send() "WebSocketConnection::send()" method, which
+        applies per-connection extension transforms (e.g., permessage-deflate) and AsyncAPI validation
+        before encoding with @ref WebSocketUtil::ws_encode_message().
+
+        @since WebSocketHandler 2.3 per-connection extension transforms are now properly applied
     */
     sendAll(data d) {
-        binary msg = ws_encode_message(d);
-
         rwl.readLock();
         on_exit rwl.readUnlock();
 
         # push the data on all connection queues
-        map $1.sendEncoded(msg), ch.iterator();
+        map $1.send(d), ch.iterator();
 
         #if (ch) logDebug("sending data to connections: %y", ch.keys());
     }

--- a/qlib/WebSocketHandler.qm
+++ b/qlib/WebSocketHandler.qm
@@ -317,6 +317,23 @@ public class WebSocketConnection {
         queue.push(msg);
     }
 
+    #! Returns True if this connection requires per-connection encoding
+    /** Connections with active extensions or an AsyncAPI validator cannot share a pre-encoded frame
+        and must encode individually via @ref send().
+
+        @return True if per-connection encoding is needed, False if a shared pre-encoded frame can be used
+
+        @since WebSocketHandler 2.3
+    */
+    bool needsPerConnectionEncoding() {
+%ifndef NoAsyncApi
+        if (asyncapi_validator && asyncapi_channel) {
+            return True;
+        }
+%endif
+        return exists active_extensions;
+    }
+
     #! Pushes an unencoded message on the connection's message queue
     /** The message will be encoded with @ref WebSocketUtil::ws_encode_message() before sending
 
@@ -1426,10 +1443,10 @@ public class WebSocketHandler inherits HttpServer::AbstractHttpSocketHandler, Lo
     #! sends a message to all connected clients
     /** @param d the data to send
 
-        Messages are encoded via each connection's
-        @ref WebSocketHandler::WebSocketConnection::send() "WebSocketConnection::send()" method, which
-        applies per-connection extension transforms (e.g., permessage-deflate) and AsyncAPI validation
-        before encoding with @ref WebSocketUtil::ws_encode_message().
+        Connections without active extensions or an AsyncAPI validator share a single pre-encoded frame
+        for efficiency.  Connections that need per-connection transforms (e.g., permessage-deflate) are
+        encoded individually via @ref WebSocketHandler::WebSocketConnection::send()
+        "WebSocketConnection::send()".
 
         @since WebSocketHandler 2.3 per-connection extension transforms are now properly applied
     */
@@ -1437,8 +1454,15 @@ public class WebSocketHandler inherits HttpServer::AbstractHttpSocketHandler, Lo
         rwl.readLock();
         on_exit rwl.readUnlock();
 
+        # pre-encode once for connections that need no per-connection transforms
+        *binary encoded;
+
         # push the data on all connection queues
-        map $1.send(d), ch.iterator();
+        map (
+            $1.needsPerConnectionEncoding()
+                ? $1.send(d)
+                : $1.sendEncoded(encoded ?? (encoded = ws_encode_message(d)))
+        ), ch.iterator();
 
         #if (ch) logDebug("sending data to connections: %y", ch.keys());
     }

--- a/qlib/WebSocketUtil.qm
+++ b/qlib/WebSocketUtil.qm
@@ -68,6 +68,9 @@ module WebSocketUtil {
     @section websocketutil_relnotes WebSocketUtil Module Release History
 
     @subsection wsu_v16 v1.6
+    - fixed @ref WebSocketUtil::PerMessageDeflateExtension::transformIncoming()
+      "PerMessageDeflateExtension::transformIncoming()" to return string (not binary) for text frames after
+      decompression, preserving the correct message type for \c gotMessage() dispatch
     - added pluggable WebSocket extension framework
       (<a href="https://github.com/qoretechnologies/qore/issues/5065">issue 5065</a>)
       - added \c WsExtensionParamInfo hashdecl for extension parameters
@@ -1271,8 +1274,12 @@ hash<WsMsgInfo> h = ws_read_message(sock);
                 return msg;
             }
 
-            # Decompress the message
-            return decompressData(msg);
+            # Decompress the message; convert back to string for text frames
+            binary decompressed = decompressData(msg);
+            if (ctx.op == WSOP_Text) {
+                return decompressed.toString("UTF-8");
+            }
+            return decompressed;
         }
 
         #! Validates RSV bits for incoming frames


### PR DESCRIPTION
## Summary

- **`sendAll()` bypassed per-connection extensions**: Pre-encoded a single frame for all connections via `sendEncoded()`, skipping per-connection extension transforms. Now calls `send()` on each connection, routing through `sendWithExtensions()`.
- **Extension negotiation data lost between `handleRequest()` and `startImpl()`**: `handleRequest()` stored negotiated extensions in its local `hdr` parameter, but Qore's pass-by-value semantics meant modifications never reached `startImpl()`. Server-side extensions were negotiated in the HTTP handshake but never actually set on connections. Fixed by storing pending extensions on the handler keyed by connection ID.
- **`sendWithExtensions()` used wrong opcode after compression**: Compressed TEXT frames were misidentified as `WSOP_Binary` because the opcode was inferred from the post-compression binary type. Fixed by determining the opcode before extension transforms.
- **`PerMessageDeflateExtension::transformIncoming()` returned binary for TEXT frames**: `inflate_raw_to_binary()` always returns binary, so decompressed TEXT frames dispatched to `gotMessage(binary)` instead of `gotMessage(string)`. Fixed to convert to UTF-8 string for text frames.

## Test plan

- [x] New `sendAllExtensionTests()` with 5 sub-tests (35 assertions):
  - Two extension clients receiving broadcast (small + large)
  - Two plain clients on non-extension handler (backward compatibility)
  - Mixed connections (one with extensions, one without) on extension handler
  - Binary data broadcast to mixed clients
  - `sendOne()` with extensions end-to-end (small + large)
- [x] All existing WebSocketHandler tests pass (no regressions)
- [x] All WebSocketUtil tests pass
- [x] All WebSocketClient tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)