### PR TITLE
feat: add QdrantDataProvider module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1621,6 +1621,7 @@ qore_user_module("qlib/CdsRestDataProvider" "RestClient;CdsRestClient;RestSchema
 qore_user_module("qlib/ServiceNowRestDataProvider" "RestClient;ServiceNowRestClient;RestSchemaValidator;DataProvider" "servicenow-logo-white.svg;servicenow-logo-black.svg")
 qore_user_module("qlib/RestClientDataProvider" "RestClient;DataProvider" "webhook-logo.svg")
 qore_user_module("qlib/ElasticSearchDataProvider" "RestClient;DataProvider" "elastic-logo.svg")
+qore_user_module("qlib/QdrantDataProvider" "RestClient;DataProvider" "qdrant-logo.svg")
 qore_user_module("qlib/EmpathicBuildingDataProvider" "RestClient;DataProvider" "Haltian-EmpathicBuilding.svg")
 qore_user_module("qlib/GeneratorDataProvider" "DataProvider" "generator-logo.svg")
 qore_user_module("qlib/MemcachedDataProvider" "DataProvider" "memcached-logo.svg")

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,6 +50,7 @@ DOX_SRC_SPLIT_MODULES = \
     qlib/DataProviderML \
     qlib/DbDataProvider \
     qlib/ElasticSearchDataProvider \
+    qlib/QdrantDataProvider \
     qlib/EmpathicBuildingDataProvider \
     qlib/GeneratorDataProvider \
     qlib/FileLocationHandler \
@@ -185,6 +186,7 @@ FreshBooksDataProvider_modverdir = $(modverdir)/FreshBooksDataProvider
 LinearDataProvider_modverdir = $(modverdir)/LinearDataProvider
 WaveDataProvider_modverdir = $(modverdir)/WaveDataProvider
 ElasticSearchDataProvider_modverdir = $(modverdir)/ElasticSearchDataProvider
+QdrantDataProvider_modverdir = $(modverdir)/QdrantDataProvider
 EmpathicBuildingDataProvider_modverdir = $(modverdir)/EmpathicBuildingDataProvider
 GeneratorDataProvider_modverdir = $(modverdir)/GeneratorDataProvider
 FileLocationHandler_modverdir = $(modverdir)/FileLocationHandler
@@ -246,6 +248,7 @@ dist_FreshBooksDataProvider_modver_DATA = $(wildcard qlib/FreshBooksDataProvider
 dist_LinearDataProvider_modver_DATA = $(wildcard qlib/LinearDataProvider/*.q[cm])
 dist_WaveDataProvider_modver_DATA = $(wildcard qlib/WaveDataProvider/*.q[cm])
 dist_ElasticSearchDataProvider_modver_DATA = $(wildcard qlib/ElasticSearchDataProvider/*.q[cm])
+dist_QdrantDataProvider_modver_DATA = $(wildcard qlib/QdrantDataProvider/*.q[cm])
 dist_EmpathicBuildingDataProvider_modver_DATA = $(wildcard qlib/EmpathicBuildingDataProvider/*.q[cm])
 dist_GeneratorDataProvider_modver_DATA = $(wildcard qlib/GeneratorDataProvider/*.q[cm])
 dist_FileDataProvider_modver_DATA = $(wildcard qlib/FileDataProvider/*.q[cm])
@@ -1233,6 +1236,7 @@ EXTRA_DIST = next_build.sh run_tests.sh ABOUT RELEASE-NOTES \
 	qlib/WaveDataProvider/wave-logo.svg \
 	qlib/ZohoInventoryDataProvider/zohoinventory-logo.svg \
 	qlib/ElasticSearchDataProvider/elastic-logo.svg \
+	qlib/QdrantDataProvider/qdrant-logo.svg \
 	qlib/EmpathicBuildingDataProvider/Haltian-EmpathicBuilding.svg \
 	qlib/GeneratorDataProvider/generator-logo.svg \
 	qlib/FileDataProvider/file-logo-white.svg \
@@ -1440,6 +1444,10 @@ doxygen/qlib/Doxyfile.FsUtil: doxygen/qlib/Doxyfile.tmpl $(QDX_DEP)
 # to provide the graphic file
 doxygen/qlib/Doxyfile.ElasticSearchDataProvider: doxygen/qlib/Doxyfile.tmpl $(QDX_DEP)
 	$(QDX) -M=qlib/ElasticSearchDataProvider:doxygen/qlib/ElasticSearchDataProvider -tDataProvider.tag=../../DataProvider/html -tRestClient.tag=../../RestClient/html -X=doxygen/ -E=elastic-logo.svg $< $@
+
+# to provide the graphic file
+doxygen/qlib/Doxyfile.QdrantDataProvider: doxygen/qlib/Doxyfile.tmpl $(QDX_DEP)
+	$(QDX) -M=qlib/QdrantDataProvider:doxygen/qlib/QdrantDataProvider -tDataProvider.tag=../../DataProvider/html -tRestClient.tag=../../RestClient/html -X=doxygen/ -E=qdrant-logo.svg $< $@
 
 # to provide the graphic file
 doxygen/qlib/Doxyfile.GeneratorDataProvider: doxygen/qlib/Doxyfile.tmpl $(QDX_DEP)

--- a/design/data-provider-development-guide.md
+++ b/design/data-provider-development-guide.md
@@ -380,6 +380,435 @@ private *AbstractDataProviderType getRequestTypeWithDataImpl(auto req) {
 
 ---
 
+## Table Data Providers (Record-Based CRUD)
+
+Table data providers expose a collection/table as a record-based interface with support for search
+(DPAT_FIND), create, upsert, update, delete, and bulk operations. The key class is
+`AbstractDataProvider` with its `*Impl` methods.
+
+### Provider Info Declaration
+
+Declare capabilities in `ProviderInfo`:
+
+```qore
+const ProviderInfo = <DataProviderInfo>{
+    "desc": "My collection table data provider",
+    "type": "MyCollectionTableDataProvider",
+    "has_record": True,
+    "supports_read": True,
+    "supports_native_search": True,
+    "supports_create": True,
+    "supports_upsert": True,
+    "supports_update": True,
+    "supports_delete": True,
+    "supports_bulk_create": True,
+    "supports_bulk_upsert": True,
+    "search_options": GenericRecordSearchOptions{"columns", "limit", "offset", "requires_result"} + {
+        "query": <DataProviderOptionInfo>{...},
+        "filter": <DataProviderOptionInfo>{...},
+    },
+    "create_options": WriteOptions,
+    "upsert_options": WriteOptions,
+};
+```
+
+### Record Type
+
+Define the record type as a `HashDataType` subclass:
+
+```qore
+public class MyScoredPointRecordType inherits DataProvider::HashDataType {
+    private {
+        const Fields = {
+            "id": {"type": AbstractDataProviderTypeMap."auto", ...},
+            "score": {"type": SoftFloatOrNothingType, ...},
+            "payload": {"type": AutoHashOrNothingType, ...},
+        };
+    }
+
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+```
+
+### Key Implementation Methods
+
+| Method | Purpose |
+|--------|---------|
+| `searchRecordsImpl(*hash<auto> where_cond, *hash<auto> search_options)` | Returns `AbstractDataProviderRecordIterator` |
+| `createRecordImpl(hash<auto> rec, *hash<auto> create_options)` | Creates a record, returns it |
+| `upsertRecordImpl(hash<auto> rec, *hash<auto> upsert_options)` | Upserts, returns `UpsertResultInserted` or `UpsertResultUpdated` |
+| `updateRecordsImpl(hash<auto> set, *hash<auto> where_cond, *hash<auto> search_options)` | Returns count updated |
+| `deleteRecordsImpl(*hash<auto> where_cond, *hash<auto> search_options)` | Returns count deleted |
+| `getRecordTypeImpl(*hash<auto> search_options)` | Returns record field definitions |
+| `getStaticInfoImpl()` | Returns `ProviderInfo` |
+
+### Record Iterator Pattern
+
+The iterator wraps backend query results:
+
+```qore
+public class MySearchRecordIterator inherits DataProvider::AbstractDataProviderRecordIterator {
+    private:internal {
+        const RecordType = new MyScoredPointRecordType();
+        Qore::ListHashIterator i;
+    }
+
+    constructor(RestClient rest, string collection, *hash<auto> where_cond,
+            *hash<auto> search_options)
+            : AbstractDataProviderRecordIterator(search_options.requires_result) {
+        hash<auto> body = buildRequestBody(search_options);
+        // ... process where_cond, merge with body ...
+        *list<auto> results = rest.post(uri, body).body.result.items;
+        i = new ListHashIterator(results);
+    }
+
+    bool valid() { return i.valid(); }
+    hash<auto> getValue() { return i.getValue(); }
+    *hash<string, DataProvider::AbstractDataField> getRecordType() { return RecordType.getFields(); }
+    private bool nextImpl() { return i.next(); }
+}
+```
+
+### Bulk Operations
+
+Implement `getBulkInserter()` and `getBulkUpserter()` returning
+`AbstractDataProviderBulkOperation` subclasses. The bulk operation collects records via
+`queueData()` and sends them in batches via `flushImpl()`.
+
+### Tables Container Pattern
+
+A parent "tables" provider lists available tables/collections as child providers:
+
+```qore
+public class MyTablesDataProvider inherits MyDataProviderBase {
+    public {
+        const ProviderInfo = <DataProviderInfo>{
+            "supports_children": True,
+            "children_can_support_records": True,
+        };
+    }
+
+    private *list<string> getChildProviderNamesImpl() {
+        return map $1.name, rest.get("/collections").body.result.collections;
+    }
+
+    private *AbstractDataProvider getChildProviderImpl(string name) {
+        // Verify collection exists before returning provider
+        if (!collectionExists(name)) { return; }
+        return new MyCollectionTableDataProvider(rest, name);
+    }
+}
+```
+
+---
+
+## Server-Side Search Expressions
+
+Search expressions enable the standard DataProvider expression interface (`where_cond` with
+expression trees) for backend-specific query languages. This is a critical feature for integrating
+with the DPQL query language and UI-driven search builders.
+
+### Architecture
+
+The pattern has three components:
+
+1. **Expression definitions** (`*Defs.qc`): A constant mapping DP operator names to expression
+   metadata (`exp`) and implementation closures (`impl`)
+2. **Provider info**: Declares supported expressions and `supports_search_expressions: True`
+3. **Iterator**: `processExpressionArg()` method that walks the expression tree and calls `impl`
+   closures to build the backend-specific query
+
+### How the Framework Processes where_cond
+
+The `AbstractDataProvider` base class has two overloads for each search/update/delete method:
+
+- `*hash<DataProviderExpression> where_cond` — for pre-built expression trees; calls
+  `processSearchParameters()` to validate, then passes through to `*Impl()`
+- `*hash<auto> where_cond` — for plain hashes; calls `getSearchExpression()` which:
+  - If `supports_search_expressions` is True: converts plain hash to expression tree (each
+    `key: value` pair becomes a `DP_SEARCH_OP_EQ` expression, multiple pairs wrapped in `DP_OP_AND`)
+  - Otherwise: calls `processFieldValues()` for simple field validation
+
+**Important**: When `supports_search_expressions` is True, ALL `*Impl()` methods receive
+`DataProviderExpression` where_cond, even for update and delete. Your implementation must handle
+this (see "Update/Delete with Expressions" below).
+
+### Expression Definitions File
+
+Create a `*Defs.qc` file with the expression mapping. Each entry has:
+- `"exp"`: The expression info from `AbstractDataProvider::GenericExpressions{DP_OP_*}`
+- `"impl"`: A closure that builds the backend-specific query structure
+
+**Example** (Qdrant vector database → JSON filters):
+
+```qore
+public const MyExpressions = {
+    DP_OP_AND: {
+        "exp": AbstractDataProvider::GenericExpressions{DP_OP_AND},
+        "impl": hash<auto> sub (MyRecordIterator iter, list<auto> args) {
+            return {"must": map iter.processExpressionArg($1), args};
+        },
+    },
+    DP_OP_OR: {
+        "exp": AbstractDataProvider::GenericExpressions{DP_OP_OR},
+        "impl": hash<auto> sub (MyRecordIterator iter, list<auto> args) {
+            return {"should": map iter.processExpressionArg($1), args};
+        },
+    },
+    DP_SEARCH_OP_EQ: {
+        "exp": AbstractDataProvider::GenericExpressions{DP_SEARCH_OP_EQ},
+        "impl": hash<auto> sub (string field, auto value) {
+            return {"key": field, "match": {"value": value}};
+        },
+    },
+    // ... other operators ...
+};
+```
+
+**Example** (Salesforce → SOQL strings):
+
+```qore
+public const SoqlExpressions = {
+    DP_OP_AND: {
+        "exp": AbstractDataProvider::GenericExpressions{DP_OP_AND},
+        "impl": string sub (object iter, list<auto> args) {
+            list<string> clauses = map iter.processExpressionArg($1), args;
+            return "(" + (foldl $1 + " and " + $2, clauses) + ")";
+        },
+    },
+    DP_SEARCH_OP_EQ: {
+        "exp": AbstractDataProvider::GenericExpressions{DP_SEARCH_OP_EQ},
+        "impl": string sub (object iter, string field, auto value) {
+            return sprintf("%s = %s", field, iter.getArgValue(field, value));
+        },
+    },
+    // ...
+};
+```
+
+### Declaring Expressions in ProviderInfo
+
+```qore
+const ProviderInfo = <DataProviderInfo>{
+    // ... other fields ...
+    "expressions": cast<hash<string, hash<DataProviderExpressionInfo>>>(
+        map {$1.key: $1.value.exp}, MyExpressions.pairIterator()
+    ),
+    "supports_search_expressions": True,
+};
+```
+
+### processExpressionArg() Method
+
+The record iterator needs a public `processExpressionArg()` method that logical operator `impl`
+closures can call recursively:
+
+```qore
+hash<auto> processExpressionArg(hash<DataProviderExpression> exp) {
+    *hash<auto> expinfo = MyExpressions{exp.exp};
+    if (!expinfo) {
+        throw "WHERE-ERROR", sprintf("unknown operator %y; known: %y", exp.exp, keys MyExpressions);
+    }
+
+    # Logical operators (AND, OR, NOT): pass all args to impl for recursive processing
+    if (exp.exp == DP_OP_AND || exp.exp == DP_OP_OR || exp.exp == DP_SEARCH_OP_NOT) {
+        return call_function_args(expinfo.impl, (self, exp.args));
+    }
+
+    # Comparison operators: first arg is field reference, rest are values
+    string field = cast<hash<DataProviderFieldReference>>(exp.args[0]).field;
+
+    # IN operator: collect all value args into a list
+    if (exp.exp == DP_SEARCH_OP_IN) {
+        list<auto> values;
+        for (int j = 1; j < exp.args.size(); ++j) {
+            if (exp.args[j].typeCode() == NT_LIST) {
+                values += exp.args[j];
+            } else {
+                push values, exp.args[j];
+            }
+        }
+        return call_function_args(expinfo.impl, (field, values));
+    }
+
+    # BETWEEN: field + lo + hi
+    if (exp.exp == DP_SEARCH_OP_BETWEEN) {
+        return call_function_args(expinfo.impl, (field, exp.args[1], exp.args[2]));
+    }
+
+    # Standard comparison: field + value
+    return call_function_args(expinfo.impl, (field, exp.args[1]));
+}
+```
+
+### Processing where_cond in the Iterator
+
+The iterator constructor processes `where_cond` to build the backend filter:
+
+```qore
+constructor(RestClient rest, string collection, *hash<auto> where_cond,
+        *hash<auto> search_options) {
+    // ... build body from search_options ...
+
+    if (where_cond) {
+        *hash<auto> where_filter = processWhereCondition(where_cond);
+        if (where_filter) {
+            where_filter = ensureValidFilter(where_filter);
+            if (body.filter) {
+                // Merge with search_options filter using AND
+                body.filter = {"must": (where_filter, body.filter)};
+            } else {
+                body.filter = where_filter;
+            }
+        }
+    }
+}
+
+private *hash<auto> processWhereCondition(hash<auto> where_cond) {
+    if (where_cond.exp) {
+        return processExpressionArg(cast<hash<DataProviderExpression>>(where_cond));
+    }
+    // Plain hash: convert each key: value to equality conditions
+    list<auto> conditions;
+    foreach hash<auto> pair in (where_cond.pairIterator()) {
+        push conditions, {"key": pair.key, "match": {"value": pair.value}};
+    }
+    if (conditions.size() == 1) { return conditions[0]; }
+    return {"must": conditions};
+}
+```
+
+### Update/Delete with Expressions
+
+When `supports_search_expressions` is True, the framework converts ALL where_cond hashes to
+`DataProviderExpression` objects — including for update and delete operations. If your update/delete
+methods extract fields from where_cond (e.g., `where_cond.id`), you must handle the
+`DataProviderExpression` case:
+
+```qore
+private list<auto> getPointIds(*hash<auto> where_cond, string operation) {
+    if (!where_cond) {
+        throw "ERROR", "missing 'id' in where_cond";
+    }
+
+    # Handle DataProviderExpression (from framework expression conversion)
+    if (where_cond instanceof hash<DataProviderExpression>) {
+        return extractIdsFromExpression(
+            cast<hash<DataProviderExpression>>(where_cond), operation);
+    }
+
+    # Plain hash fallback
+    return where_cond.id.typeCode() == NT_LIST ? where_cond.id : (where_cond.id,);
+}
+
+private list<auto> extractIdsFromExpression(hash<DataProviderExpression> exp, string op) {
+    switch (exp.exp) {
+        case DP_SEARCH_OP_EQ: {
+            if (exp.args[0] instanceof hash<DataProviderFieldReference>
+                    && cast<hash<DataProviderFieldReference>>(exp.args[0]).field == "id") {
+                auto val = exp.args[1];
+                return val.typeCode() == NT_LIST ? val : (val,);
+            }
+            break;
+        }
+        case DP_OP_AND: {
+            foreach auto arg in (exp.args) {
+                if (arg instanceof hash<DataProviderExpression>) {
+                    try { return extractIdsFromExpression(cast<hash<DataProviderExpression>>(arg), op); }
+                    catch () {}
+                }
+            }
+            break;
+        }
+    }
+    throw "ERROR", sprintf("where_cond must reference 'id' field for %s", op);
+}
+```
+
+### Dynamic Payload Fields
+
+If your backend has dynamic/schemaless fields (e.g., Qdrant payloads, MongoDB documents), override
+`searchAcceptsForeignField()` to allow field names not in the record type:
+
+```qore
+bool searchAcceptsForeignField(string field) {
+    return True;
+}
+```
+
+Without this, the framework rejects plain hash where_cond keys that aren't in the declared record
+type.
+
+### Supported Operators
+
+The standard DataProvider operators available in `AbstractDataProvider::GenericExpressions`:
+
+| Operator | Constant | Expression Args | Description |
+|----------|----------|-----------------|-------------|
+| AND | `DP_OP_AND` | `(expr, expr, ...)` | Logical AND of sub-expressions |
+| OR | `DP_OP_OR` | `(expr, expr, ...)` | Logical OR of sub-expressions |
+| NOT | `DP_SEARCH_OP_NOT` | `(expr,)` | Logical negation |
+| EQ | `DP_SEARCH_OP_EQ` | `(field_ref, value)` | Equality |
+| NE | `DP_SEARCH_OP_NE` | `(field_ref, value)` | Not equal |
+| LT | `DP_SEARCH_OP_LT` | `(field_ref, value)` | Less than |
+| LE | `DP_SEARCH_OP_LE` | `(field_ref, value)` | Less than or equal |
+| GT | `DP_SEARCH_OP_GT` | `(field_ref, value)` | Greater than |
+| GE | `DP_SEARCH_OP_GE` | `(field_ref, value)` | Greater than or equal |
+| BETWEEN | `DP_SEARCH_OP_BETWEEN` | `(field_ref, lo, hi)` | Range (exclusive) |
+| IN | `DP_SEARCH_OP_IN` | `(field_ref, val, ...)` | Value in list |
+| REGEX | `DP_SEARCH_OP_REGEX` | `(field_ref, pattern)` | Regex match |
+
+### Constructing Expression Trees in Tests
+
+```qore
+# Simple equality
+hash<DataProviderExpression> eq_expr = <DataProviderExpression>{
+    "exp": DP_SEARCH_OP_EQ,
+    "args": (
+        <DataProviderFieldReference>{"field": "city"},
+        "Berlin",
+    ),
+};
+
+# Compound: AND(EQ, GT)
+hash<DataProviderExpression> and_expr = <DataProviderExpression>{
+    "exp": DP_OP_AND,
+    "args": (
+        <DataProviderExpression>{
+            "exp": DP_SEARCH_OP_EQ,
+            "args": (<DataProviderFieldReference>{"field": "country"}, "Germany"),
+        },
+        <DataProviderExpression>{
+            "exp": DP_SEARCH_OP_GT,
+            "args": (<DataProviderFieldReference>{"field": "population"}, 1000000),
+        },
+    ),
+};
+
+# IN with multiple values
+hash<DataProviderExpression> in_expr = <DataProviderExpression>{
+    "exp": DP_SEARCH_OP_IN,
+    "args": (
+        <DataProviderFieldReference>{"field": "city"},
+        ("Berlin", "Paris", "Moscow"),
+    ),
+};
+
+# Plain hash where_cond (implicit EQ, framework converts to expressions)
+AbstractDataProviderRecordIterator iter = prov.searchRecords({"city": "Berlin"}, {"limit": 10});
+```
+
+### Reference Implementations
+
+- **Qdrant** (JSON filters): `qlib/QdrantDataProvider/QdrantDataProviderDefs.qc`,
+  `QdrantSearchRecordIterator.qc`, `QdrantCollectionTableDataProvider.qc`
+- **Salesforce** (SOQL strings): `qlib/SalesforceRestDataProvider/SalesforceRestDataProviderDefs.qc`,
+  `SalesforceRestRecordIterator.qc`, `SalesforceRestObjectDataProvider.qc`
+
+---
+
 ## Common Pitfalls
 
 ### 1. Using `token` instead of `apikey`

--- a/doxygen/lang/120_modules.dox.tmpl
+++ b/doxygen/lang/120_modules.dox.tmpl
@@ -96,6 +96,8 @@ ModuleName/
         event-driven client API for connecting with the Discord WebSocket API gateway
     |user|<a href="../../modules/ElasticSearchDataProvider/html/index.html#elasticsearchdataproviderintro">ElasticSearchDataProvider</a>|Provides a \
         <a href="../../modules/DataProvider/html/index.html#dataproviderintro">data provider</a> API for ElasticSearch services
+    |user|<a href="../../modules/QdrantDataProvider/html/index.html#qdrantdataproviderintro">QdrantDataProvider</a>|Provides a \
+        <a href="../../modules/DataProvider/html/index.html#dataproviderintro">data provider</a> API for Qdrant vector database instances
     |user|<a href="../../modules/ElasticSearchLoggerAppender/html/index.html#elasticsearchloggerappenderintro">ElasticSearchLoggerAppender</a>|Provides \
         a logger appender that sends log events to ElasticSearch using the Bulk API with batching support
     |user|<a href="../../modules/EdifactUtil/html/index.html#edifactutilintro">EdifactUtil</a>|Provides functionality for parsing and \

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -510,6 +510,10 @@ cargo install tree-sitter-cli@0.26.5
         (<a href="https://github.com/qoretechnologies/qore/issues/5016">issue 5016</a>)
       - enabled bulk operations on ElasticSearchIndexTableDataProvider
         (<a href="https://github.com/qoretechnologies/qore/issues/5016">issue 5016</a>)
+    - @ref qdrantdataproviderintro "QdrantDataProvider" module
+      - new module providing a data provider API for Qdrant vector database instances
+      - supports collection management, point CRUD, vector search (query API), alias management,
+        snapshot management, cluster management, and service health endpoints
     - @ref generatordataproviderintro "GeneratorDataProvider" module
       - new module providing a data provider API for generating configurable test record streams for data
         pipeline testing with no external dependencies

--- a/examples/test/qlib/QdrantDataProvider/QdrantDataProvider.qtest
+++ b/examples/test/qlib/QdrantDataProvider/QdrantDataProvider.qtest
@@ -1,0 +1,1769 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%modern
+%allow-injection
+
+%requires ../../../../qlib/Util.qm
+%requires ../../../../qlib/QUnit.qm
+%requires ../../../../qlib/Logger.qm
+%requires ../../../../qlib/DataProvider
+%requires ../../../../qlib/RestClient.qm
+%requires ../../../../qlib/ConnectionProvider
+%requires ../../../../qlib/QdrantDataProvider
+
+%try-module json >= 1.5
+%define NoJson
+%endtry
+
+%exec-class QdrantDataProviderTest
+
+public class QdrantDataProviderTest inherits QUnit::Test {
+    private {
+        RestClient rest;
+
+        # command-line options
+        const MyOpts = Opts + {
+            "url": "u,url=s",
+        };
+
+        const OptionColumn = 22;
+    }
+
+    # checkModule helper
+    static checkModule(Test test) {
+%ifdef NoJson
+        test.testSkip("no json module");
+%endif
+    }
+
+    constructor() : Test("QdrantDataProvider Test", "1.0", \ARGV, MyOpts) {
+        addTestCase("serviceTest", \serviceTest());
+        addTestCase("collectionsTest", \collectionsTest());
+        addTestCase("pointsTest", \pointsTest());
+        addTestCase("searchTest", \searchTest());
+        addTestCase("aliasesTest", \aliasesTest());
+        addTestCase("snapshotsTest", \snapshotsTest());
+        addTestCase("clusterTest", \clusterTest());
+        addTestCase("tablesTest", \tablesTest());
+        addTestCase("tablesCrudTest", \tablesCrudTest());
+        addTestCase("connectionTest", \connectionTest());
+        addTestCase("factoryTest", \factoryTest());
+        addTestCase("providerHierarchyTest", \providerHierarchyTest());
+        addTestCase("negativeTests", \negativeTests());
+
+        setupConnection();
+
+        # Return for compatibility with test harness that checks return value.
+        set_return_value(main());
+    }
+
+    #! Test service endpoints (health, liveness, readiness, telemetry, metrics, issues)
+    private serviceTest() {
+        checkModule(self);
+        if (!rest) {
+            testSkip("no connection to server");
+        }
+
+        # Test health endpoint
+        QdrantServiceHealthDataProvider health(rest);
+        auto h = health.doRequest();
+        assertEq(Type::Hash, h.type());
+        assertTrue(h.hasKey("title"));
+
+        # Test liveness - returns plain text
+        QdrantServiceLivenessDataProvider liveness(rest);
+        h = liveness.doRequest();
+        assertEq(Type::String, h.type());
+
+        # Test readiness - returns plain text
+        QdrantServiceReadinessDataProvider readiness(rest);
+        h = readiness.doRequest();
+        assertEq(Type::String, h.type());
+
+        # Test telemetry
+        QdrantServiceTelemetryDataProvider telemetry(rest);
+        h = telemetry.doRequest();
+        assertEq(Type::Hash, h.type());
+
+        # Test telemetry with details_level
+        h = telemetry.doRequest({"details_level": 0});
+        assertEq(Type::Hash, h.type());
+
+        # Test metrics
+        QdrantServiceMetricsDataProvider metrics(rest);
+        h = metrics.doRequest();
+        # metrics returns Prometheus text format, check it's non-empty
+        assertTrue(h.val());
+
+        # Test issues - returns .result which has issues key
+        QdrantServiceIssuesDataProvider issues(rest);
+        h = issues.doRequest();
+        assertEq(Type::Hash, h.type());
+    }
+
+    #! Test collection lifecycle: create → exists → get → list → update → create-index → delete-index → delete
+    private collectionsTest() {
+        checkModule(self);
+        if (!rest) {
+            testSkip("no connection to server");
+        }
+
+        string collection = "test_" + get_random_string(8);
+        collection =~ tr/A-Z/a-z/;
+
+        # Create collection
+        QdrantCollectionsCreateDataProvider create(rest);
+        auto h = create.doRequest({
+            "collection": collection,
+            "vectors": {
+                "size": 4,
+                "distance": "Cosine",
+            },
+        });
+        assertTrue(h);
+
+        on_exit {
+            # Delete collection
+            QdrantCollectionsDeleteDataProvider del(rest);
+            try {
+                del.doRequest({"collection": collection});
+            } catch () {
+                # ignore errors during cleanup
+            }
+        }
+
+        # Check collection exists
+        QdrantCollectionsExistsDataProvider exists_prov(rest);
+        h = exists_prov.doRequest({"collection": collection});
+        assertEq(Type::Hash, h.type());
+        assertTrue(h.exists);
+
+        # Get collection info
+        QdrantCollectionsGetDataProvider get_prov(rest);
+        h = get_prov.doRequest({"collection": collection});
+        assertEq(Type::Hash, h.type());
+        assertEq("green", h.status);
+
+        # List collections
+        QdrantCollectionsListDataProvider list_prov(rest);
+        h = list_prov.doRequest();
+        assertEq(Type::Hash, h.type());
+        assertTrue(h.hasKey("collections"));
+        assertTrue(h.collections.size() > 0);
+        # verify our collection is in the list
+        bool found = False;
+        foreach hash<auto> c in (h.collections) {
+            if (c.name == collection) {
+                found = True;
+                break;
+            }
+        }
+        assertTrue(found);
+
+        # Update collection (change optimizer settings)
+        QdrantCollectionsUpdateDataProvider update(rest);
+        h = update.doRequest({
+            "collection": collection,
+            "optimizers_config": {
+                "indexing_threshold": 10000,
+            },
+        });
+        assertTrue(h);
+
+        # Create payload index
+        QdrantCollectionsCreateIndexDataProvider create_idx(rest);
+        h = create_idx.doRequest({
+            "collection": collection,
+            "field_name": "color",
+            "field_schema": "keyword",
+            "wait": True,
+        });
+        assertEq(Type::Hash, h.type());
+
+        # Verify index was created
+        h = get_prov.doRequest({"collection": collection});
+        assertTrue(h.payload_schema.hasKey("color"));
+
+        # Delete payload index
+        QdrantCollectionsDeleteIndexDataProvider del_idx(rest);
+        h = del_idx.doRequest({
+            "collection": collection,
+            "field_name": "color",
+            "wait": True,
+        });
+        assertEq(Type::Hash, h.type());
+
+        # Verify non-existent collection does not exist
+        h = exists_prov.doRequest({"collection": "nonexistent_collection_xyz_12345"});
+        assertFalse(h.exists);
+    }
+
+    #! Test point operations: upsert, get, scroll, count, payload CRUD, delete
+    private pointsTest() {
+        checkModule(self);
+        if (!rest) {
+            testSkip("no connection to server");
+        }
+
+        string collection = "test_points_" + get_random_string(8);
+        collection =~ tr/A-Z/a-z/;
+
+        # Create collection with named vectors
+        QdrantCollectionsCreateDataProvider create_col(rest);
+        create_col.doRequest({
+            "collection": collection,
+            "vectors": {
+                "size": 4,
+                "distance": "Cosine",
+            },
+        });
+
+        on_exit {
+            QdrantCollectionsDeleteDataProvider del_col(rest);
+            try {
+                del_col.doRequest({"collection": collection});
+            } catch () {
+                # ignore errors during cleanup
+            }
+        }
+
+        # Upsert points
+        QdrantPointsUpsertDataProvider upsert(rest);
+        auto h = upsert.doRequest({
+            "collection": collection,
+            "wait": True,
+            "points": (
+                {
+                    "id": 1,
+                    "vector": (0.05, 0.61, 0.76, 0.74),
+                    "payload": {"city": "Berlin", "country": "Germany", "population": 3644826},
+                },
+                {
+                    "id": 2,
+                    "vector": (0.19, 0.81, 0.75, 0.11),
+                    "payload": {"city": "London", "country": "UK", "population": 8982000},
+                },
+                {
+                    "id": 3,
+                    "vector": (0.36, 0.55, 0.47, 0.94),
+                    "payload": {"city": "Paris", "country": "France", "population": 2161000},
+                },
+                {
+                    "id": 4,
+                    "vector": (0.18, 0.01, 0.85, 0.80),
+                    "payload": {"city": "Moscow", "country": "Russia", "population": 11920000},
+                },
+                {
+                    "id": 5,
+                    "vector": (0.24, 0.18, 0.22, 0.44),
+                    "payload": {"city": "New York", "country": "USA", "population": 8336817},
+                },
+            ),
+        });
+        assertEq("completed", h.status);
+
+        # Get points by ID
+        QdrantPointsGetDataProvider get_pts(rest);
+        h = get_pts.doRequest({
+            "collection": collection,
+            "ids": (1, 2),
+            "with_payload": True,
+            "with_vector": True,
+        });
+        assertEq(Type::List, h.type());
+        assertEq(2, h.size());
+        assertEq(1, h[0].id);
+        assertEq("Berlin", h[0].payload.city);
+        assertEq(4, h[0].vector.size());
+
+        # Count points
+        QdrantPointsCountDataProvider count(rest);
+        h = count.doRequest({
+            "collection": collection,
+            "exact": True,
+        });
+        assertEq(5, h.count);
+
+        # Count with filter
+        h = count.doRequest({
+            "collection": collection,
+            "filter": {
+                "must": ({
+                    "key": "country",
+                    "match": {"value": "Germany"},
+                },),
+            },
+            "exact": True,
+        });
+        assertEq(1, h.count);
+
+        # Scroll points
+        QdrantPointsScrollDataProvider scroll(rest);
+        h = scroll.doRequest({
+            "collection": collection,
+            "limit": 2,
+            "with_payload": True,
+        });
+        assertEq(Type::Hash, h.type());
+        assertTrue(h.hasKey("points"));
+        assertEq(2, h.points.size());
+        assertTrue(h.hasKey("next_page_offset"));
+
+        # Scroll next page
+        h = scroll.doRequest({
+            "collection": collection,
+            "limit": 2,
+            "offset": h.next_page_offset,
+            "with_payload": True,
+        });
+        assertEq(2, h.points.size());
+
+        # Set payload
+        QdrantPointsSetPayloadDataProvider set_payload(rest);
+        h = set_payload.doRequest({
+            "collection": collection,
+            "wait": True,
+            "payload": {"language": "German"},
+            "points": (1,),
+        });
+        assertEq("completed", h.status);
+
+        # Verify payload was set
+        h = get_pts.doRequest({
+            "collection": collection,
+            "ids": (1,),
+            "with_payload": True,
+        });
+        assertEq("German", h[0].payload.language);
+        assertEq("Berlin", h[0].payload.city);  # existing payload preserved
+
+        # Overwrite payload (replaces entirely)
+        QdrantPointsOverwritePayloadDataProvider overwrite_payload(rest);
+        h = overwrite_payload.doRequest({
+            "collection": collection,
+            "wait": True,
+            "payload": {"new_field": "value"},
+            "points": (2,),
+        });
+        assertEq("completed", h.status);
+
+        # Verify payload was overwritten (old payload gone)
+        h = get_pts.doRequest({
+            "collection": collection,
+            "ids": (2,),
+            "with_payload": True,
+        });
+        assertEq("value", h[0].payload.new_field);
+        assertFalse(h[0].payload.hasKey("city"));
+
+        # Delete payload keys
+        QdrantPointsDeletePayloadDataProvider del_payload(rest);
+        h = del_payload.doRequest({
+            "collection": collection,
+            "wait": True,
+            "keys": ("language",),
+            "points": (1,),
+        });
+        assertEq("completed", h.status);
+
+        # Verify payload key was deleted
+        h = get_pts.doRequest({
+            "collection": collection,
+            "ids": (1,),
+            "with_payload": True,
+        });
+        assertFalse(h[0].payload.hasKey("language"));
+        assertEq("Berlin", h[0].payload.city);  # other keys preserved
+
+        # Clear all payload
+        QdrantPointsClearPayloadDataProvider clear_payload(rest);
+        h = clear_payload.doRequest({
+            "collection": collection,
+            "wait": True,
+            "points": (3,),
+        });
+        assertEq("completed", h.status);
+
+        # Verify payload was cleared
+        h = get_pts.doRequest({
+            "collection": collection,
+            "ids": (3,),
+            "with_payload": True,
+        });
+        assertEq(0, h[0].payload.size());
+
+        # Delete points by ID
+        QdrantPointsDeleteDataProvider del_pts(rest);
+        h = del_pts.doRequest({
+            "collection": collection,
+            "wait": True,
+            "points": (4, 5),
+        });
+        assertEq("completed", h.status);
+
+        # Verify points were deleted
+        h = count.doRequest({
+            "collection": collection,
+            "exact": True,
+        });
+        assertEq(3, h.count);
+
+        # Delete by filter
+        h = del_pts.doRequest({
+            "collection": collection,
+            "wait": True,
+            "filter": {
+                "must": ({
+                    "key": "city",
+                    "match": {"value": "Berlin"},
+                },),
+            },
+        });
+        assertEq("completed", h.status);
+
+        # Verify filter delete worked
+        h = count.doRequest({
+            "collection": collection,
+            "exact": True,
+        });
+        assertEq(2, h.count);
+
+        # Test batch update: upsert + set payload in one request
+        QdrantPointsBatchUpdateDataProvider batch_update(rest);
+        h = batch_update.doRequest({
+            "collection": collection,
+            "wait": True,
+            "operations": (
+                {"upsert": {"points": (
+                    {"id": 100, "vector": (0.9, 0.8, 0.7, 0.6), "payload": {"city": "Oslo"}},
+                    {"id": 101, "vector": (0.6, 0.7, 0.8, 0.9), "payload": {"city": "Helsinki"}},
+                )}},
+                {"set_payload": {"payload": {"batch": True}, "points": (100, 101)}},
+            ),
+        });
+        assertEq(Type::List, h.type());
+        assertEq(2, h.size());
+        assertEq("completed", h[0].status);
+        assertEq("completed", h[1].status);
+
+        # Verify batch results
+        h = get_pts.doRequest({
+            "collection": collection,
+            "ids": (100, 101),
+            "with_payload": True,
+        });
+        assertEq(2, h.size());
+        assertTrue(h[0].payload.batch);
+        assertTrue(h[1].payload.batch);
+
+        # Clean up batch points
+        h = del_pts.doRequest({
+            "collection": collection,
+            "wait": True,
+            "points": (100, 101),
+        });
+        assertEq("completed", h.status);
+
+        # Test UUID point IDs
+        string uuid1 = "550e8400-e29b-41d4-a716-446655440000";
+        string uuid2 = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+        h = upsert.doRequest({
+            "collection": collection,
+            "wait": True,
+            "points": (
+                {
+                    "id": uuid1,
+                    "vector": (0.11, 0.22, 0.33, 0.44),
+                    "payload": {"city": "Tokyo", "country": "Japan"},
+                },
+                {
+                    "id": uuid2,
+                    "vector": (0.55, 0.66, 0.77, 0.88),
+                    "payload": {"city": "Seoul", "country": "South Korea"},
+                },
+            ),
+        });
+        assertEq("completed", h.status);
+
+        # Get UUID points
+        h = get_pts.doRequest({
+            "collection": collection,
+            "ids": (uuid1, uuid2),
+            "with_payload": True,
+            "with_vector": True,
+        });
+        assertEq(Type::List, h.type());
+        assertEq(2, h.size());
+        assertEq("Tokyo", h[0].payload.city);
+        assertEq(4, h[0].vector.size());
+
+        # Delete UUID points
+        h = del_pts.doRequest({
+            "collection": collection,
+            "wait": True,
+            "points": (uuid1, uuid2),
+        });
+        assertEq("completed", h.status);
+
+        # Get points without payload (with_payload=False)
+        h = get_pts.doRequest({
+            "collection": collection,
+            "ids": (2,),
+            "with_payload": False,
+            "with_vector": False,
+        });
+        assertEq(Type::List, h.type());
+        assertEq(1, h.size());
+        assertEq(2, h[0].id);
+    }
+
+    #! Test search (query) operations
+    private searchTest() {
+        checkModule(self);
+        if (!rest) {
+            testSkip("no connection to server");
+        }
+
+        string collection = "test_search_" + get_random_string(8);
+        collection =~ tr/A-Z/a-z/;
+
+        # Create collection
+        QdrantCollectionsCreateDataProvider create_col(rest);
+        create_col.doRequest({
+            "collection": collection,
+            "vectors": {
+                "size": 4,
+                "distance": "Cosine",
+            },
+        });
+
+        on_exit {
+            QdrantCollectionsDeleteDataProvider del_col(rest);
+            try {
+                del_col.doRequest({"collection": collection});
+            } catch () {
+                # ignore errors during cleanup
+            }
+        }
+
+        # Upsert test points
+        QdrantPointsUpsertDataProvider upsert(rest);
+        upsert.doRequest({
+            "collection": collection,
+            "wait": True,
+            "points": (
+                {
+                    "id": 1,
+                    "vector": (0.05, 0.61, 0.76, 0.74),
+                    "payload": {"city": "Berlin", "category": "A"},
+                },
+                {
+                    "id": 2,
+                    "vector": (0.19, 0.81, 0.75, 0.11),
+                    "payload": {"city": "London", "category": "A"},
+                },
+                {
+                    "id": 3,
+                    "vector": (0.36, 0.55, 0.47, 0.94),
+                    "payload": {"city": "Paris", "category": "B"},
+                },
+                {
+                    "id": 4,
+                    "vector": (0.18, 0.01, 0.85, 0.80),
+                    "payload": {"city": "Moscow", "category": "B"},
+                },
+                {
+                    "id": 5,
+                    "vector": (0.24, 0.18, 0.22, 0.44),
+                    "payload": {"city": "New York", "category": "C"},
+                },
+            ),
+        });
+
+        # Basic vector search
+        QdrantSearchQueryDataProvider query(rest);
+        auto h = query.doRequest({
+            "collection": collection,
+            "query": (0.2, 0.1, 0.9, 0.7),
+            "limit": 3,
+            "with_payload": True,
+        });
+        assertEq(Type::Hash, h.type());
+        assertTrue(h.hasKey("points"));
+        assertTrue(h.points.size() <= 3);
+        assertTrue(h.points.size() > 0);
+        # results should have score
+        assertTrue(h.points[0].hasKey("score"));
+
+        # Filtered search
+        h = query.doRequest({
+            "collection": collection,
+            "query": (0.2, 0.1, 0.9, 0.7),
+            "filter": {
+                "must": ({
+                    "key": "category",
+                    "match": {"value": "A"},
+                },),
+            },
+            "limit": 10,
+            "with_payload": True,
+        });
+        assertTrue(h.points.size() > 0);
+        foreach hash<auto> pt in (h.points) {
+            assertEq("A", pt.payload.category);
+        }
+
+        # Search with with_vector to return vectors
+        h = query.doRequest({
+            "collection": collection,
+            "query": (0.2, 0.1, 0.9, 0.7),
+            "limit": 2,
+            "with_payload": True,
+            "with_vector": True,
+        });
+        assertTrue(h.points.size() > 0);
+        # verify vectors are returned
+        assertTrue(h.points[0].hasKey("vector"));
+        assertEq(4, h.points[0].vector.size());
+
+        # Search with offset for pagination
+        h = query.doRequest({
+            "collection": collection,
+            "query": (0.2, 0.1, 0.9, 0.7),
+            "limit": 2,
+            "offset": 0,
+            "with_payload": True,
+        });
+        assertTrue(h.points.size() > 0);
+        auto first_page_id = h.points[0].id;
+        # Get second page
+        h = query.doRequest({
+            "collection": collection,
+            "query": (0.2, 0.1, 0.9, 0.7),
+            "limit": 2,
+            "offset": 2,
+            "with_payload": True,
+        });
+        assertEq(Type::Hash, h.type());
+        # second page should have different results or be shorter
+        if (h.points.size() > 0) {
+            assertNeq(first_page_id, h.points[0].id);
+        }
+
+        # Search with score threshold
+        h = query.doRequest({
+            "collection": collection,
+            "query": (0.2, 0.1, 0.9, 0.7),
+            "score_threshold": 0.99,
+            "with_payload": True,
+        });
+        # with a very high threshold, we may get fewer or no results
+        assertEq(Type::Hash, h.type());
+
+        # Search with impossible filter (should return empty)
+        h = query.doRequest({
+            "collection": collection,
+            "query": (0.2, 0.1, 0.9, 0.7),
+            "filter": {
+                "must": ({
+                    "key": "category",
+                    "match": {"value": "NONEXISTENT_CATEGORY_XYZ"},
+                },),
+            },
+            "limit": 10,
+            "with_payload": True,
+        });
+        assertEq(Type::Hash, h.type());
+        assertEq(0, h.points.size());
+
+        # Batch query
+        QdrantSearchQueryBatchDataProvider batch(rest);
+        h = batch.doRequest({
+            "collection": collection,
+            "searches": (
+                {
+                    "query": (0.2, 0.1, 0.9, 0.7),
+                    "limit": 2,
+                    "with_payload": True,
+                },
+                {
+                    "query": (0.05, 0.61, 0.76, 0.74),
+                    "limit": 2,
+                    "with_payload": True,
+                },
+            ),
+        });
+        assertEq(Type::List, h.type());
+        assertEq(2, h.size());
+
+        # Create payload index for group search
+        QdrantCollectionsCreateIndexDataProvider create_idx(rest);
+        create_idx.doRequest({
+            "collection": collection,
+            "field_name": "category",
+            "field_schema": "keyword",
+        });
+
+        # Search with groups
+        QdrantSearchQueryGroupsDataProvider groups(rest);
+        h = groups.doRequest({
+            "collection": collection,
+            "query": (0.2, 0.1, 0.9, 0.7),
+            "group_by": "category",
+            "group_size": 1,
+            "limit": 3,
+            "with_payload": True,
+        });
+        assertEq(Type::Hash, h.type());
+        assertTrue(h.hasKey("groups"));
+        assertTrue(h.groups.size() > 0);
+    }
+
+    #! Test alias operations
+    private aliasesTest() {
+        checkModule(self);
+        if (!rest) {
+            testSkip("no connection to server");
+        }
+
+        string collection = "test_alias_" + get_random_string(8);
+        collection =~ tr/A-Z/a-z/;
+        string alias_name = "alias_" + get_random_string(8);
+        alias_name =~ tr/A-Z/a-z/;
+
+        # Create collection
+        QdrantCollectionsCreateDataProvider create_col(rest);
+        create_col.doRequest({
+            "collection": collection,
+            "vectors": {
+                "size": 4,
+                "distance": "Cosine",
+            },
+        });
+
+        on_exit {
+            # Clean up alias first, then collection
+            QdrantAliasesUpdateDataProvider update_alias(rest);
+            try {
+                update_alias.doRequest({
+                    "actions": ({
+                        "delete_alias": {
+                            "alias_name": alias_name,
+                        },
+                    },),
+                });
+            } catch () {
+                # ignore
+            }
+            QdrantCollectionsDeleteDataProvider del_col(rest);
+            try {
+                del_col.doRequest({"collection": collection});
+            } catch () {
+                # ignore
+            }
+        }
+
+        # Create alias
+        QdrantAliasesUpdateDataProvider update_alias(rest);
+        auto h = update_alias.doRequest({
+            "actions": ({
+                "create_alias": {
+                    "collection_name": collection,
+                    "alias_name": alias_name,
+                },
+            },),
+        });
+        assertTrue(h);
+
+        # List all aliases
+        QdrantAliasesListAllDataProvider list_all(rest);
+        h = list_all.doRequest();
+        assertEq(Type::Hash, h.type());
+        assertTrue(h.hasKey("aliases"));
+        bool found = False;
+        foreach hash<auto> a in (h.aliases) {
+            if (a.alias_name == alias_name) {
+                assertEq(collection, a.collection_name);
+                found = True;
+                break;
+            }
+        }
+        assertTrue(found);
+
+        # List collection aliases
+        QdrantAliasesListCollectionDataProvider list_col(rest);
+        h = list_col.doRequest({"collection": collection});
+        assertEq(Type::Hash, h.type());
+        assertTrue(h.hasKey("aliases"));
+        assertTrue(h.aliases.size() > 0);
+        assertEq(alias_name, h.aliases[0].alias_name);
+
+        # Rename alias (delete + create new)
+        string alias_name2 = "alias2_" + get_random_string(8);
+        alias_name2 =~ tr/A-Z/a-z/;
+        h = update_alias.doRequest({
+            "actions": (
+                {
+                    "delete_alias": {
+                        "alias_name": alias_name,
+                    },
+                },
+                {
+                    "create_alias": {
+                        "collection_name": collection,
+                        "alias_name": alias_name2,
+                    },
+                },
+            ),
+        });
+        assertTrue(h);
+
+        # Verify old alias gone, new alias exists
+        h = list_col.doRequest({"collection": collection});
+        assertEq(1, h.aliases.size());
+        assertEq(alias_name2, h.aliases[0].alias_name);
+
+        # Clean up: update alias_name for on_exit cleanup
+        alias_name = alias_name2;
+    }
+
+    #! Test snapshot operations
+    private snapshotsTest() {
+        checkModule(self);
+        if (!rest) {
+            testSkip("no connection to server");
+        }
+
+        string collection = "test_snap_" + get_random_string(8);
+        collection =~ tr/A-Z/a-z/;
+
+        # Create collection
+        QdrantCollectionsCreateDataProvider create_col(rest);
+        create_col.doRequest({
+            "collection": collection,
+            "vectors": {
+                "size": 4,
+                "distance": "Cosine",
+            },
+        });
+
+        on_exit {
+            QdrantCollectionsDeleteDataProvider del_col(rest);
+            try {
+                del_col.doRequest({"collection": collection});
+            } catch () {
+                # ignore
+            }
+        }
+
+        # Create a collection snapshot
+        QdrantSnapshotsCreateCollectionDataProvider create_snap(rest);
+        auto h = create_snap.doRequest({"collection": collection, "wait": True});
+        assertEq(Type::Hash, h.type());
+        assertTrue(h.hasKey("name"));
+        string snap_name = h.name;
+
+        # List collection snapshots
+        QdrantSnapshotsListCollectionDataProvider list_snap(rest);
+        h = list_snap.doRequest({"collection": collection});
+        assertEq(Type::List, h.type());
+        assertTrue(h.size() > 0);
+        bool found = False;
+        foreach hash<auto> s in (h) {
+            if (s.name == snap_name) {
+                found = True;
+                break;
+            }
+        }
+        assertTrue(found);
+
+        # Delete collection snapshot
+        QdrantSnapshotsDeleteCollectionDataProvider del_snap(rest);
+        h = del_snap.doRequest({
+            "collection": collection,
+            "snapshot_name": snap_name,
+        });
+        assertTrue(h);
+
+        # Verify snapshot was deleted
+        h = list_snap.doRequest({"collection": collection});
+        found = False;
+        foreach hash<auto> s in (h) {
+            if (s.name == snap_name) {
+                found = True;
+                break;
+            }
+        }
+        assertFalse(found);
+
+        # Test snapshot recover: create a snapshot, add data, recover from snapshot
+        create_snap = new QdrantSnapshotsCreateCollectionDataProvider(rest);
+        h = create_snap.doRequest({"collection": collection, "wait": True});
+        assertEq(Type::Hash, h.type());
+        string recover_snap = h.name;
+
+        # Add a point after the snapshot
+        QdrantPointsUpsertDataProvider upsert(rest);
+        upsert.doRequest({
+            "collection": collection,
+            "wait": True,
+            "points": ({
+                "id": 1,
+                "vector": (0.1, 0.2, 0.3, 0.4),
+                "payload": {"key": "after_snapshot"},
+            },),
+        });
+
+        # Recover from snapshot (restores the collection to snapshot state)
+        QdrantSnapshotsRecoverDataProvider recover(rest);
+        h = recover.doRequest({
+            "collection": collection,
+            "location": sprintf("file:///qdrant/snapshots/%s/%s", collection, recover_snap),
+            "wait": True,
+        });
+        assertTrue(h);
+
+        # After recovery, the point we added should be gone
+        QdrantPointsCountDataProvider count_prov(rest);
+        h = count_prov.doRequest({
+            "collection": collection,
+            "exact": True,
+        });
+        assertEq(0, h.count);
+
+        # Clean up the recover snapshot
+        del_snap = new QdrantSnapshotsDeleteCollectionDataProvider(rest);
+        try {
+            del_snap.doRequest({
+                "collection": collection,
+                "snapshot_name": recover_snap,
+            });
+        } catch () {
+            # ignore
+        }
+
+        # Test full storage snapshot operations
+        QdrantSnapshotsCreateStorageDataProvider create_storage(rest);
+        h = create_storage.doRequest({"wait": True});
+        assertEq(Type::Hash, h.type());
+        assertTrue(h.hasKey("name"));
+        string storage_snap = h.name;
+
+        QdrantSnapshotsListStorageDataProvider list_storage(rest);
+        h = list_storage.doRequest();
+        assertEq(Type::List, h.type());
+        assertTrue(h.size() > 0);
+
+        QdrantSnapshotsDeleteStorageDataProvider del_storage(rest);
+        h = del_storage.doRequest({"snapshot_name": storage_snap});
+        assertTrue(h);
+    }
+
+    #! Test cluster info
+    private clusterTest() {
+        checkModule(self);
+        if (!rest) {
+            testSkip("no connection to server");
+        }
+
+        # Get cluster info (works even in single-node mode)
+        QdrantClusterInfoDataProvider cluster_info(rest);
+        auto h = cluster_info.doRequest();
+        assertEq(Type::Hash, h.type());
+        assertTrue(h.hasKey("status"));
+
+        # Collection cluster info
+        string collection = "test_cluster_" + get_random_string(8);
+        collection =~ tr/A-Z/a-z/;
+
+        QdrantCollectionsCreateDataProvider create_col(rest);
+        create_col.doRequest({
+            "collection": collection,
+            "vectors": {
+                "size": 4,
+                "distance": "Cosine",
+            },
+        });
+
+        on_exit {
+            QdrantCollectionsDeleteDataProvider del_col(rest);
+            try {
+                del_col.doRequest({"collection": collection});
+            } catch () {
+                # ignore
+            }
+        }
+
+        QdrantClusterCollectionInfoDataProvider col_cluster(rest);
+        h = col_cluster.doRequest({"collection": collection});
+        assertEq(Type::Hash, h.type());
+
+        # Test cluster recover (triggers Raft consensus recovery; returns 500 on standalone mode)
+        QdrantClusterRecoverDataProvider cluster_recover(rest);
+        try {
+            h = cluster_recover.doRequest();
+            assertTrue(h);
+        } catch (hash<ExceptionInfo> ex) {
+            # Expected on standalone Qdrant instances
+            assertEq("HTTP-CLIENT-RECEIVE-ERROR", ex.err);
+        }
+
+        # Test cluster hierarchy navigation
+        QdrantDataProvider root({"restclient": rest});
+        AbstractDataProvider cluster_parent = root.getChildProvider("cluster");
+        *list<string> cluster_children = cluster_parent.getChildProviderNames();
+        assertTrue(cluster_children.contains("info"));
+        assertTrue(cluster_children.contains("recover"));
+        assertTrue(cluster_children.contains("remove-peer"));
+        assertTrue(cluster_children.contains("collection-info"));
+        assertTrue(cluster_children.contains("update-collection"));
+        assertTrue(cluster_children.contains("create-shard-key"));
+        assertTrue(cluster_children.contains("delete-shard-key"));
+    }
+
+    #! Test tables (record-based search) provider
+    private tablesTest() {
+        checkModule(self);
+        if (!rest) {
+            testSkip("no connection to server");
+        }
+
+        string collection = "test_tables_" + get_random_string(8);
+        collection =~ tr/A-Z/a-z/;
+
+        # Create collection
+        QdrantCollectionsCreateDataProvider create_col(rest);
+        create_col.doRequest({
+            "collection": collection,
+            "vectors": {
+                "size": 4,
+                "distance": "Cosine",
+            },
+        });
+
+        on_exit {
+            QdrantCollectionsDeleteDataProvider del_col(rest);
+            try {
+                del_col.doRequest({"collection": collection});
+            } catch () {
+                # ignore errors during cleanup
+            }
+        }
+
+        # Upsert test points
+        QdrantPointsUpsertDataProvider upsert(rest);
+        upsert.doRequest({
+            "collection": collection,
+            "wait": True,
+            "points": (
+                {
+                    "id": 1,
+                    "vector": (0.05, 0.61, 0.76, 0.74),
+                    "payload": {"city": "Berlin", "category": "A"},
+                },
+                {
+                    "id": 2,
+                    "vector": (0.19, 0.81, 0.75, 0.11),
+                    "payload": {"city": "London", "category": "A"},
+                },
+                {
+                    "id": 3,
+                    "vector": (0.36, 0.55, 0.47, 0.94),
+                    "payload": {"city": "Paris", "category": "B"},
+                },
+                {
+                    "id": 4,
+                    "vector": (0.18, 0.01, 0.85, 0.80),
+                    "payload": {"city": "Moscow", "category": "B"},
+                },
+                {
+                    "id": 5,
+                    "vector": (0.24, 0.18, 0.22, 0.44),
+                    "payload": {"city": "New York", "category": "C"},
+                },
+            ),
+        });
+
+        # Navigate to the tables provider and verify test collection appears as child
+        QdrantDataProvider root({"restclient": rest});
+        AbstractDataProvider tables = root.getChildProvider("tables");
+        *list<string> table_children = tables.getChildProviderNames();
+        assertTrue(table_children.contains(collection));
+
+        # Get the collection table provider
+        AbstractDataProvider col_prov = tables.getChildProvider(collection);
+        assertEq(collection, col_prov.getName());
+
+        # Verify provider info
+        hash<DataProvider::DataProviderInfo> info = col_prov.getInfo();
+        assertTrue(info.has_record);
+        assertTrue(info.supports_read);
+        assertTrue(info.supports_native_search);
+
+        # Basic search with query vector
+        AbstractDataProviderRecordIterator iter = col_prov.searchRecords(NOTHING, {
+            "query": (0.2, 0.1, 0.9, 0.7),
+            "limit": 3,
+        });
+        int count = 0;
+        while (iter.next()) {
+            hash<auto> rec = iter.getValue();
+            assertTrue(rec.hasKey("id"));
+            assertTrue(rec.hasKey("score"));
+            assertTrue(rec.hasKey("payload"));
+            ++count;
+        }
+        assertTrue(count > 0);
+        assertTrue(count <= 3);
+
+        # Test limit option
+        iter = col_prov.searchRecords(NOTHING, {
+            "query": (0.2, 0.1, 0.9, 0.7),
+            "limit": 2,
+        });
+        count = 0;
+        while (iter.next()) {
+            ++count;
+        }
+        assertTrue(count <= 2);
+
+        # Test offset option
+        iter = col_prov.searchRecords(NOTHING, {
+            "query": (0.2, 0.1, 0.9, 0.7),
+            "limit": 2,
+            "offset": 0,
+        });
+        list<auto> first_page = ();
+        while (iter.next()) {
+            first_page += iter.getValue();
+        }
+        iter = col_prov.searchRecords(NOTHING, {
+            "query": (0.2, 0.1, 0.9, 0.7),
+            "limit": 2,
+            "offset": 2,
+        });
+        list<auto> second_page = ();
+        while (iter.next()) {
+            second_page += iter.getValue();
+        }
+        if (first_page && second_page) {
+            assertNeq(first_page[0].id, second_page[0].id);
+        }
+
+        # Test filter search option
+        iter = col_prov.searchRecords(NOTHING, {
+            "query": (0.2, 0.1, 0.9, 0.7),
+            "filter": {
+                "must": ({
+                    "key": "category",
+                    "match": {"value": "A"},
+                },),
+            },
+            "limit": 10,
+        });
+        while (iter.next()) {
+            assertEq("A", iter.getValue().payload.category);
+        }
+
+        # Test with_vector option
+        iter = col_prov.searchRecords(NOTHING, {
+            "query": (0.2, 0.1, 0.9, 0.7),
+            "limit": 2,
+            "with_vector": True,
+        });
+        assertTrue(iter.next());
+        hash<auto> rec = iter.getValue();
+        assertTrue(rec.hasKey("vector"));
+        assertEq(4, rec.vector.size());
+
+        # Test impossible filter returns empty results
+        iter = col_prov.searchRecords(NOTHING, {
+            "query": (0.2, 0.1, 0.9, 0.7),
+            "filter": {
+                "must": ({
+                    "key": "category",
+                    "match": {"value": "NONEXISTENT_CATEGORY_XYZ"},
+                },),
+            },
+            "limit": 10,
+        });
+        count = 0;
+        while (iter.next()) {
+            ++count;
+        }
+        assertEq(0, count);
+
+        # Test non-existent collection returns NOTHING
+        *AbstractDataProvider no_prov = tables.getChildProvider("nonexistent_collection_xyz_999");
+        assertNothing(no_prov);
+
+        # Test record type
+        *hash<string, AbstractDataField> rec_type = col_prov.getRecordType();
+        assertTrue(rec_type.hasKey("id"));
+        assertTrue(rec_type.hasKey("score"));
+        assertTrue(rec_type.hasKey("payload"));
+        assertTrue(rec_type.hasKey("vector"));
+        assertTrue(rec_type.hasKey("version"));
+        assertTrue(rec_type.hasKey("shard_key"));
+    }
+
+    #! Test table CRUD operations (create, upsert, update, delete, bulk)
+    private tablesCrudTest() {
+        checkModule(self);
+        if (!rest) {
+            testSkip("no connection to server");
+        }
+
+        string collection = "test_crud_" + get_random_string(8);
+        collection =~ tr/A-Z/a-z/;
+
+        # Create collection
+        QdrantCollectionsCreateDataProvider create_col(rest);
+        create_col.doRequest({
+            "collection": collection,
+            "vectors": {
+                "size": 4,
+                "distance": "Cosine",
+            },
+        });
+
+        on_exit {
+            QdrantCollectionsDeleteDataProvider del_col(rest);
+            try {
+                del_col.doRequest({"collection": collection});
+            } catch () {
+                # ignore errors during cleanup
+            }
+        }
+
+        # Get the collection table provider
+        QdrantDataProvider root({"restclient": rest});
+        AbstractDataProvider col_prov = root.getChildProviderEx("tables").getChildProviderEx(collection);
+
+        # Verify provider info includes CRUD capabilities
+        hash<DataProvider::DataProviderInfo> info = col_prov.getInfo();
+        assertTrue(info.supports_create);
+        assertTrue(info.supports_upsert);
+        assertTrue(info.supports_update);
+        assertTrue(info.supports_delete);
+        assertTrue(info.supports_bulk_create);
+        assertTrue(info.supports_bulk_upsert);
+
+        # ---- CREATE ----
+        *hash<auto> created = col_prov.createRecord({
+            "id": 1,
+            "vector": (0.05, 0.61, 0.76, 0.74),
+            "payload": {"city": "Berlin", "category": "A"},
+        }, {"wait": True});
+        assertEq(1, created.id);
+        assertEq("Berlin", created.payload.city);
+
+        # Create more points
+        col_prov.createRecord({
+            "id": 2,
+            "vector": (0.19, 0.81, 0.75, 0.11),
+            "payload": {"city": "London", "category": "A"},
+        }, {"wait": True});
+        col_prov.createRecord({
+            "id": 3,
+            "vector": (0.36, 0.55, 0.47, 0.94),
+            "payload": {"city": "Paris", "category": "B"},
+        }, {"wait": True});
+
+        # Verify created points via search
+        AbstractDataProviderRecordIterator iter = col_prov.searchRecords(NOTHING, {
+            "query": (0.05, 0.61, 0.76, 0.74),
+            "limit": 10,
+        });
+        int count = 0;
+        while (iter.next()) {
+            ++count;
+        }
+        assertEq(3, count);
+
+        # ---- UPSERT ----
+        # Upsert a new point
+        string upsert_result = col_prov.upsertRecord({
+            "id": 4,
+            "vector": (0.18, 0.01, 0.85, 0.80),
+            "payload": {"city": "Moscow", "category": "B"},
+        }, {"wait": True});
+        assertEq(UpsertResultInserted, upsert_result);
+
+        # Upsert overwrites existing point
+        col_prov.upsertRecord({
+            "id": 1,
+            "vector": (0.99, 0.88, 0.77, 0.66),
+            "payload": {"city": "Berlin", "category": "A", "updated": True},
+        }, {"wait": True});
+
+        # Verify upsert overwrote point 1
+        QdrantPointsGetDataProvider get_pts(rest);
+        auto h = get_pts.doRequest({
+            "collection": collection,
+            "ids": (1,),
+            "with_payload": True,
+            "with_vector": True,
+        });
+        assertTrue(h[0].payload.updated);
+        # verify vector was replaced
+        assertEq(4, h[0].vector.size());
+
+        # ---- UPDATE payload only ----
+        int updated_count = col_prov.updateRecords(
+            {"payload": {"language": "German"}},
+            {"id": 1},
+            {"wait": True},
+        );
+        assertEq(1, updated_count);
+
+        # Verify payload was merged (not replaced)
+        h = get_pts.doRequest({
+            "collection": collection,
+            "ids": (1,),
+            "with_payload": True,
+        });
+        assertEq("German", h[0].payload.language);
+        assertEq("Berlin", h[0].payload.city);  # existing payload preserved
+
+        # ---- UPDATE vector only ----
+        list<float> new_vector = (0.11, 0.22, 0.33, 0.44);
+        updated_count = col_prov.updateRecords(
+            {"vector": new_vector},
+            {"id": 2},
+            {"wait": True},
+        );
+        assertEq(1, updated_count);
+
+        # Verify vector was updated
+        h = get_pts.doRequest({
+            "collection": collection,
+            "ids": (2,),
+            "with_vector": True,
+        });
+        assertEq(4, h[0].vector.size());
+
+        # ---- UPDATE both vector and payload (batch API) ----
+        updated_count = col_prov.updateRecords(
+            {
+                "vector": (0.55, 0.66, 0.77, 0.88),
+                "payload": {"city": "London", "updated_both": True},
+            },
+            {"id": 2},
+            {"wait": True},
+        );
+        assertEq(1, updated_count);
+
+        # Verify both updated
+        h = get_pts.doRequest({
+            "collection": collection,
+            "ids": (2,),
+            "with_payload": True,
+            "with_vector": True,
+        });
+        assertTrue(h[0].payload.updated_both);
+        assertEq("London", h[0].payload.city);
+        assertEq(4, h[0].vector.size());
+
+        # ---- DELETE ----
+        int deleted_count = col_prov.deleteRecords({"id": 4}, {"wait": True});
+        assertEq(1, deleted_count);
+
+        # Verify point was deleted
+        QdrantPointsCountDataProvider count_prov(rest);
+        h = count_prov.doRequest({
+            "collection": collection,
+            "exact": True,
+        });
+        assertEq(3, h.count);
+
+        # Delete multiple points
+        deleted_count = col_prov.deleteRecords({"id": (2, 3)}, {"wait": True});
+        assertEq(2, deleted_count);
+
+        h = count_prov.doRequest({
+            "collection": collection,
+            "exact": True,
+        });
+        assertEq(1, h.count);
+
+        # ---- BULK UPSERT ----
+        # Clean up remaining point first
+        col_prov.deleteRecords({"id": 1}, {"wait": True});
+
+        {
+            AbstractDataProviderBulkOperation bulk = col_prov.getBulkUpserter();
+            on_success bulk.flush();
+            on_error bulk.discard();
+
+            for (int i = 1; i <= 20; ++i) {
+                bulk.queueData({
+                    "id": i,
+                    "vector": (i * 0.01, i * 0.02, i * 0.03, i * 0.04),
+                    "payload": {"index": i},
+                });
+            }
+        }
+
+        # Verify all bulk points were created
+        h = count_prov.doRequest({
+            "collection": collection,
+            "exact": True,
+        });
+        assertEq(20, h.count);
+
+        # Verify bulk data integrity
+        h = get_pts.doRequest({
+            "collection": collection,
+            "ids": (1, 10, 20),
+            "with_payload": True,
+            "with_vector": True,
+        });
+        assertEq(3, h.size());
+
+        # ---- BULK INSERT (same as upsert for Qdrant) ----
+        {
+            AbstractDataProviderBulkOperation bulk = col_prov.getBulkInserter();
+            on_success bulk.flush();
+            on_error bulk.discard();
+
+            # Overwrite first 5 points with new data
+            for (int i = 1; i <= 5; ++i) {
+                bulk.queueData({
+                    "id": i,
+                    "vector": (0.9, 0.8, 0.7, 0.6),
+                    "payload": {"index": i, "bulk_insert": True},
+                });
+            }
+        }
+
+        # Verify bulk insert overwrote existing points
+        h = get_pts.doRequest({
+            "collection": collection,
+            "ids": (1,),
+            "with_payload": True,
+        });
+        assertTrue(h[0].payload.bulk_insert);
+
+        # Verify total count unchanged (overwrite, not duplicates)
+        h = count_prov.doRequest({
+            "collection": collection,
+            "exact": True,
+        });
+        assertEq(20, h.count);
+
+        # ---- NEGATIVE: update without id ----
+        try {
+            col_prov.updateRecords({"payload": {"x": 1}}, NOTHING, {"wait": True});
+            fail("Expected exception for missing id");
+        } catch (hash<ExceptionInfo> ex) {
+            assertTrue(ex.err == "QDRANT-UPDATE-ERROR" || ex.err == "UPDATE-RECORDS-ERROR");
+        }
+
+        # ---- NEGATIVE: delete without id ----
+        try {
+            col_prov.deleteRecords(NOTHING, {"wait": True});
+            fail("Expected exception for missing id");
+        } catch (hash<ExceptionInfo> ex) {
+            assertTrue(ex.err == "QDRANT-DELETE-ERROR" || ex.err == "DELETE-RECORDS-ERROR");
+        }
+
+        # ---- NEGATIVE: update with no payload or vector ----
+        try {
+            col_prov.updateRecords({"score": 0.5}, {"id": 1}, {"wait": True});
+            fail("Expected exception for empty update");
+        } catch (hash<ExceptionInfo> ex) {
+            assertTrue(ex.err == "QDRANT-UPDATE-ERROR" || ex.err == "UPDATE-RECORDS-ERROR");
+        }
+    }
+
+    #! Test connection class
+    private connectionTest() {
+        checkModule(self);
+        if (!rest) {
+            testSkip("no connection to server");
+        }
+
+        *string url = m_options.url ?? ENV.QDRANT_URL;
+        if (!url) {
+            testSkip("no connection URL");
+        }
+
+        # Test connection
+        QdrantRestConnection conn("test", "test connection", url);
+        assertEq("qdrantrest", conn.getType());
+        AbstractDataProvider prov = conn.getDataProvider();
+        assertEq("qdrant", prov.getName());
+
+        # Test connection scheme info has ping defaults
+        hash<auto> scheme = QdrantRestConnection::ConnectionScheme;
+        assertEq("GET", scheme.options.ping_method.default_value);
+        assertEq("/", scheme.options.ping_path.default_value);
+
+        # Test connection with API key option
+        QdrantRestConnection conn_api("test_api", "test api key connection", url, {},
+            {"api_key": "test_key_12345"});
+        assertEq("qdrantrest", conn_api.getType());
+    }
+
+    #! Test factory
+    private factoryTest() {
+        checkModule(self);
+
+        QdrantDataProviderFactory factory();
+        assertEq("qdrant", factory.getName());
+        hash<DataProviderFactoryInfo> info = factory.getInfo();
+        assertEq("qdrant", info.name);
+    }
+
+    #! Test provider hierarchy navigation
+    private providerHierarchyTest() {
+        checkModule(self);
+        if (!rest) {
+            testSkip("no connection to server");
+        }
+
+        # Test root provider
+        QdrantDataProvider root({"restclient": rest});
+        assertEq("qdrant", root.getName());
+        *list<string> children = root.getChildProviderNames();
+        assertTrue(children.size() >= 8);
+        assertTrue(children.contains("collections"));
+        assertTrue(children.contains("points"));
+        assertTrue(children.contains("search"));
+        assertTrue(children.contains("aliases"));
+        assertTrue(children.contains("snapshots"));
+        assertTrue(children.contains("cluster"));
+        assertTrue(children.contains("service"));
+        assertTrue(children.contains("tables"));
+
+        # Test navigating to children
+        AbstractDataProvider collections = root.getChildProvider("collections");
+        *list<string> col_children = collections.getChildProviderNames();
+        assertTrue(col_children.contains("create"));
+        assertTrue(col_children.contains("list"));
+        assertTrue(col_children.contains("get"));
+        assertTrue(col_children.contains("delete"));
+        assertTrue(col_children.contains("exists"));
+        assertTrue(col_children.contains("update"));
+        assertTrue(col_children.contains("create-index"));
+        assertTrue(col_children.contains("delete-index"));
+
+        AbstractDataProvider points = root.getChildProvider("points");
+        *list<string> pts_children = points.getChildProviderNames();
+        assertTrue(pts_children.contains("upsert"));
+        assertTrue(pts_children.contains("get"));
+        assertTrue(pts_children.contains("delete"));
+        assertTrue(pts_children.contains("scroll"));
+        assertTrue(pts_children.contains("count"));
+        assertTrue(pts_children.contains("set-payload"));
+        assertTrue(pts_children.contains("overwrite-payload"));
+        assertTrue(pts_children.contains("delete-payload"));
+        assertTrue(pts_children.contains("clear-payload"));
+        assertTrue(pts_children.contains("batch-update"));
+
+        AbstractDataProvider search = root.getChildProvider("search");
+        *list<string> search_children = search.getChildProviderNames();
+        assertTrue(search_children.contains("query"));
+        assertTrue(search_children.contains("query-batch"));
+        assertTrue(search_children.contains("query-groups"));
+
+        AbstractDataProvider service = root.getChildProvider("service");
+        *list<string> svc_children = service.getChildProviderNames();
+        assertTrue(svc_children.contains("health"));
+        assertTrue(svc_children.contains("liveness"));
+        assertTrue(svc_children.contains("readiness"));
+        assertTrue(svc_children.contains("telemetry"));
+        assertTrue(svc_children.contains("metrics"));
+        assertTrue(svc_children.contains("issues"));
+
+        AbstractDataProvider aliases = root.getChildProvider("aliases");
+        *list<string> alias_children = aliases.getChildProviderNames();
+        assertTrue(alias_children.contains("list-all"));
+        assertTrue(alias_children.contains("list-collection"));
+        assertTrue(alias_children.contains("update"));
+
+        AbstractDataProvider snapshots = root.getChildProvider("snapshots");
+        *list<string> snap_children = snapshots.getChildProviderNames();
+        assertTrue(snap_children.contains("list-collection"));
+        assertTrue(snap_children.contains("create-collection"));
+        assertTrue(snap_children.contains("delete-collection"));
+        assertTrue(snap_children.contains("recover"));
+        assertTrue(snap_children.contains("list-storage"));
+        assertTrue(snap_children.contains("create-storage"));
+        assertTrue(snap_children.contains("delete-storage"));
+
+        # Test that leaf providers report correct static info
+        AbstractDataProvider health_prov = service.getChildProvider("health");
+        hash<DataProvider::DataProviderInfo> health_info = health_prov.getInfo();
+        assertEq("health", health_info.name);
+        assertTrue(health_info.supports_request);
+    }
+
+    #! Negative tests
+    private negativeTests() {
+        checkModule(self);
+        if (!rest) {
+            testSkip("no connection to server");
+        }
+
+        # Test getting a non-existent collection
+        QdrantCollectionsGetDataProvider get_prov(rest);
+        try {
+            get_prov.doRequest({"collection": "nonexistent_collection_xyz_999"});
+            fail("Expected exception for non-existent collection");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("HTTP-CLIENT-RECEIVE-ERROR", ex.err);
+        }
+
+        # Test deleting a non-existent collection (idempotent - returns false, no error)
+        QdrantCollectionsDeleteDataProvider del_prov(rest);
+        auto del_result = del_prov.doRequest({"collection": "nonexistent_collection_xyz_999"});
+        assertFalse(del_result);
+
+        # Test duplicate collection creation
+        string collection = "test_neg_" + get_random_string(8);
+        collection =~ tr/A-Z/a-z/;
+        QdrantCollectionsCreateDataProvider create_prov(rest);
+        create_prov.doRequest({
+            "collection": collection,
+            "vectors": {
+                "size": 4,
+                "distance": "Cosine",
+            },
+        });
+        on_exit {
+            try {
+                del_prov.doRequest({"collection": collection});
+            } catch () {
+                # ignore
+            }
+        }
+
+        try {
+            create_prov.doRequest({
+                "collection": collection,
+                "vectors": {
+                    "size": 4,
+                    "distance": "Cosine",
+                },
+            });
+            fail("Expected exception for duplicate collection");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("HTTP-CLIENT-RECEIVE-ERROR", ex.err);
+        }
+
+        # Test getting points from non-existent collection
+        QdrantPointsGetDataProvider get_pts(rest);
+        try {
+            get_pts.doRequest({
+                "collection": "nonexistent_collection_xyz_999",
+                "ids": (1,),
+            });
+            fail("Expected exception for non-existent collection");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("HTTP-CLIENT-RECEIVE-ERROR", ex.err);
+        }
+
+        # Test search on non-existent collection
+        QdrantSearchQueryDataProvider query_prov(rest);
+        try {
+            query_prov.doRequest({
+                "collection": "nonexistent_collection_xyz_999",
+                "query": (0.1, 0.2, 0.3, 0.4),
+                "limit": 10,
+            });
+            fail("Expected exception for non-existent collection");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("HTTP-CLIENT-RECEIVE-ERROR", ex.err);
+        }
+
+        # Test upsert with wrong vector dimensions
+        QdrantPointsUpsertDataProvider upsert_prov(rest);
+        try {
+            upsert_prov.doRequest({
+                "collection": collection,
+                "wait": True,
+                "points": ({
+                    "id": 999,
+                    "vector": (0.1, 0.2),  # collection expects 4 dimensions
+                },),
+            });
+            fail("Expected exception for wrong vector dimensions");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("HTTP-CLIENT-RECEIVE-ERROR", ex.err);
+        }
+
+        # Test scroll on non-existent collection
+        QdrantPointsScrollDataProvider scroll_prov(rest);
+        try {
+            scroll_prov.doRequest({
+                "collection": "nonexistent_collection_xyz_999",
+                "limit": 10,
+            });
+            fail("Expected exception for non-existent collection");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("HTTP-CLIENT-RECEIVE-ERROR", ex.err);
+        }
+
+        # Test count on non-existent collection
+        QdrantPointsCountDataProvider count_prov(rest);
+        try {
+            count_prov.doRequest({
+                "collection": "nonexistent_collection_xyz_999",
+                "exact": True,
+            });
+            fail("Expected exception for non-existent collection");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("HTTP-CLIENT-RECEIVE-ERROR", ex.err);
+        }
+
+        # Test creating index on non-existent collection
+        QdrantCollectionsCreateIndexDataProvider idx_prov(rest);
+        try {
+            idx_prov.doRequest({
+                "collection": "nonexistent_collection_xyz_999",
+                "field_name": "test",
+                "field_schema": "keyword",
+            });
+            fail("Expected exception for non-existent collection");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("HTTP-CLIENT-RECEIVE-ERROR", ex.err);
+        }
+
+        # Test aliases on non-existent collection (Qdrant returns empty list, not error)
+        QdrantAliasesListCollectionDataProvider alias_list(rest);
+        hash<auto> alias_result = alias_list.doRequest({"collection": "nonexistent_collection_xyz_999"});
+        assertEq(0, alias_result.aliases.size());
+
+        # Test snapshot operations on non-existent collection
+        QdrantSnapshotsCreateCollectionDataProvider snap_create(rest);
+        try {
+            snap_create.doRequest({"collection": "nonexistent_collection_xyz_999"});
+            fail("Expected exception for non-existent collection");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("HTTP-CLIENT-RECEIVE-ERROR", ex.err);
+        }
+    }
+
+    private usageIntern() {
+        TestReporter::usageIntern(OptionColumn);
+        printOption("-u,--url=ARG", "URL for the Qdrant server instance", OptionColumn);
+    }
+
+    private setupConnection() {
+        *string url = m_options.url ?? ENV.QDRANT_URL;
+        if (!url) {
+            return;
+        }
+
+        try {
+            rest = new RestClient({"url": url});
+        } catch (hash<ExceptionInfo> ex) {
+            if (m_options.verbose) {
+                stderr.printf("%s: %s\n", ex.err, ex.desc);
+            }
+        }
+    }
+}

--- a/examples/test/qlib/QdrantDataProvider/QdrantDataProvider.qtest
+++ b/examples/test/qlib/QdrantDataProvider/QdrantDataProvider.qtest
@@ -885,7 +885,7 @@ public class QdrantDataProviderTest inherits QUnit::Test {
             "collection": collection,
             "snapshot_name": snap_name,
         });
-        assertTrue(h);
+        assertTrue(h.result);
 
         # Verify snapshot was deleted
         h = list_snap.doRequest({"collection": collection});
@@ -923,7 +923,7 @@ public class QdrantDataProviderTest inherits QUnit::Test {
             "location": sprintf("file:///qdrant/snapshots/%s/%s", collection, recover_snap),
             "wait": True,
         });
-        assertTrue(h);
+        assertTrue(h.result);
 
         # After recovery, the point we added should be gone
         QdrantPointsCountDataProvider count_prov(rest);
@@ -958,7 +958,7 @@ public class QdrantDataProviderTest inherits QUnit::Test {
 
         QdrantSnapshotsDeleteStorageDataProvider del_storage(rest);
         h = del_storage.doRequest({"snapshot_name": storage_snap});
-        assertTrue(h);
+        assertTrue(h.result);
     }
 
     #! Test cluster info

--- a/examples/test/qlib/QdrantDataProvider/QdrantDataProvider.qtest
+++ b/examples/test/qlib/QdrantDataProvider/QdrantDataProvider.qtest
@@ -47,6 +47,7 @@ public class QdrantDataProviderTest inherits QUnit::Test {
         addTestCase("clusterTest", \clusterTest());
         addTestCase("tablesTest", \tablesTest());
         addTestCase("tablesCrudTest", \tablesCrudTest());
+        addTestCase("tablesExpressionTest", \tablesExpressionTest());
         addTestCase("connectionTest", \connectionTest());
         addTestCase("factoryTest", \factoryTest());
         addTestCase("providerHierarchyTest", \providerHierarchyTest());
@@ -1475,6 +1476,466 @@ public class QdrantDataProviderTest inherits QUnit::Test {
             fail("Expected exception for empty update");
         } catch (hash<ExceptionInfo> ex) {
             assertTrue(ex.err == "QDRANT-UPDATE-ERROR" || ex.err == "UPDATE-RECORDS-ERROR");
+        }
+    }
+
+    #! Test table search expression support (where_cond with DataProvider expressions)
+    private tablesExpressionTest() {
+        checkModule(self);
+        if (!rest) {
+            testSkip("no connection to server");
+        }
+
+        string collection = "test_expr_" + get_random_string(8);
+        collection =~ tr/A-Z/a-z/;
+
+        # Create collection
+        QdrantCollectionsCreateDataProvider create_col(rest);
+        create_col.doRequest({
+            "collection": collection,
+            "vectors": {
+                "size": 4,
+                "distance": "Cosine",
+            },
+        });
+
+        on_exit {
+            QdrantCollectionsDeleteDataProvider del_col(rest);
+            try {
+                del_col.doRequest({"collection": collection});
+            } catch () {
+                # ignore errors during cleanup
+            }
+        }
+
+        # Upsert test points with varied payload
+        QdrantPointsUpsertDataProvider upsert(rest);
+        upsert.doRequest({
+            "collection": collection,
+            "wait": True,
+            "points": (
+                {
+                    "id": 1,
+                    "vector": (0.05, 0.61, 0.76, 0.74),
+                    "payload": {"city": "Berlin", "country": "Germany", "population": 3644826},
+                },
+                {
+                    "id": 2,
+                    "vector": (0.19, 0.81, 0.75, 0.11),
+                    "payload": {"city": "London", "country": "UK", "population": 8982000},
+                },
+                {
+                    "id": 3,
+                    "vector": (0.36, 0.55, 0.47, 0.94),
+                    "payload": {"city": "Paris", "country": "France", "population": 2161000},
+                },
+                {
+                    "id": 4,
+                    "vector": (0.18, 0.01, 0.85, 0.80),
+                    "payload": {"city": "Moscow", "country": "Russia", "population": 11920000},
+                },
+                {
+                    "id": 5,
+                    "vector": (0.24, 0.18, 0.22, 0.44),
+                    "payload": {"city": "New York", "country": "USA", "population": 8336817},
+                },
+            ),
+        });
+
+        # Create payload indexes required for filtering
+        QdrantCollectionsCreateIndexDataProvider create_idx(rest);
+        create_idx.doRequest({
+            "collection": collection,
+            "field_name": "city",
+            "field_schema": "keyword",
+            "wait": True,
+        });
+        create_idx.doRequest({
+            "collection": collection,
+            "field_name": "country",
+            "field_schema": "keyword",
+            "wait": True,
+        });
+        create_idx.doRequest({
+            "collection": collection,
+            "field_name": "population",
+            "field_schema": "integer",
+            "wait": True,
+        });
+
+        # Get the table data provider
+        QdrantDataProvider root({"restclient": rest});
+        AbstractDataProvider col_prov = root.getChildProviderEx("tables").getChildProviderEx(collection);
+
+        # Verify expression support is declared in provider info
+        hash<DataProvider::DataProviderInfo> info = col_prov.getInfo();
+        assertTrue(info.supports_search_expressions);
+        assertTrue(info.expressions.hasKey(DP_SEARCH_OP_EQ));
+        assertTrue(info.expressions.hasKey(DP_OP_AND));
+        assertTrue(info.expressions.hasKey(DP_OP_OR));
+        assertTrue(info.expressions.hasKey(DP_SEARCH_OP_NOT));
+        assertTrue(info.expressions.hasKey(DP_SEARCH_OP_IN));
+        assertTrue(info.expressions.hasKey(DP_SEARCH_OP_BETWEEN));
+
+        # ---- TEST EQ expression ----
+        {
+            hash<DataProviderExpression> eq_expr = <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_EQ,
+                "args": (
+                    <DataProviderFieldReference>{"field": "city"},
+                    "Berlin",
+                ),
+            };
+            AbstractDataProviderRecordIterator iter = col_prov.searchRecords(eq_expr, {"limit": 10});
+            list<auto> results = ();
+            while (iter.next()) {
+                push results, iter.getValue();
+            }
+            assertEq(1, results.size());
+            assertEq("Berlin", results[0].payload.city);
+        }
+
+        # ---- TEST NE expression ----
+        {
+            hash<DataProviderExpression> ne_expr = <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_NE,
+                "args": (
+                    <DataProviderFieldReference>{"field": "city"},
+                    "Berlin",
+                ),
+            };
+            AbstractDataProviderRecordIterator iter = col_prov.searchRecords(ne_expr, {"limit": 10});
+            list<auto> results = ();
+            while (iter.next()) {
+                push results, iter.getValue();
+            }
+            assertEq(4, results.size());
+            foreach hash<auto> rec in (results) {
+                assertNeq("Berlin", rec.payload.city);
+            }
+        }
+
+        # ---- TEST GT expression ----
+        {
+            hash<DataProviderExpression> gt_expr = <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_GT,
+                "args": (
+                    <DataProviderFieldReference>{"field": "population"},
+                    8500000,
+                ),
+            };
+            AbstractDataProviderRecordIterator iter = col_prov.searchRecords(gt_expr, {"limit": 10});
+            list<auto> results = ();
+            while (iter.next()) {
+                push results, iter.getValue();
+            }
+            # London (8982000) and Moscow (11920000) have population > 8500000
+            assertEq(2, results.size());
+            foreach hash<auto> rec in (results) {
+                assertTrue(rec.payload.population > 8500000);
+            }
+        }
+
+        # ---- TEST GE expression ----
+        {
+            hash<DataProviderExpression> ge_expr = <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_GE,
+                "args": (
+                    <DataProviderFieldReference>{"field": "population"},
+                    8982000,
+                ),
+            };
+            AbstractDataProviderRecordIterator iter = col_prov.searchRecords(ge_expr, {"limit": 10});
+            list<auto> results = ();
+            while (iter.next()) {
+                push results, iter.getValue();
+            }
+            # London (8982000) and Moscow (11920000)
+            assertEq(2, results.size());
+        }
+
+        # ---- TEST LT expression ----
+        {
+            hash<DataProviderExpression> lt_expr = <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_LT,
+                "args": (
+                    <DataProviderFieldReference>{"field": "population"},
+                    3000000,
+                ),
+            };
+            AbstractDataProviderRecordIterator iter = col_prov.searchRecords(lt_expr, {"limit": 10});
+            list<auto> results = ();
+            while (iter.next()) {
+                push results, iter.getValue();
+            }
+            # Only Paris (2161000) has population < 3000000
+            assertEq(1, results.size());
+            assertEq("Paris", results[0].payload.city);
+        }
+
+        # ---- TEST LE expression ----
+        {
+            hash<DataProviderExpression> le_expr = <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_LE,
+                "args": (
+                    <DataProviderFieldReference>{"field": "population"},
+                    3644826,
+                ),
+            };
+            AbstractDataProviderRecordIterator iter = col_prov.searchRecords(le_expr, {"limit": 10});
+            list<auto> results = ();
+            while (iter.next()) {
+                push results, iter.getValue();
+            }
+            # Paris (2161000) and Berlin (3644826)
+            assertEq(2, results.size());
+        }
+
+        # ---- TEST BETWEEN expression ----
+        {
+            hash<DataProviderExpression> between_expr = <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_BETWEEN,
+                "args": (
+                    <DataProviderFieldReference>{"field": "population"},
+                    3000000,
+                    9000000,
+                ),
+            };
+            AbstractDataProviderRecordIterator iter = col_prov.searchRecords(between_expr, {"limit": 10});
+            list<auto> results = ();
+            while (iter.next()) {
+                push results, iter.getValue();
+            }
+            # Berlin (3644826), London (8982000), NYC (8336817) have 3000000 < pop < 9000000
+            assertEq(3, results.size());
+            foreach hash<auto> rec in (results) {
+                assertTrue(rec.payload.population > 3000000);
+                assertTrue(rec.payload.population < 9000000);
+            }
+        }
+
+        # ---- TEST IN expression ----
+        {
+            hash<DataProviderExpression> in_expr = <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_IN,
+                "args": (
+                    <DataProviderFieldReference>{"field": "city"},
+                    ("Berlin", "Paris", "Moscow"),
+                ),
+            };
+            AbstractDataProviderRecordIterator iter = col_prov.searchRecords(in_expr, {"limit": 10});
+            list<auto> results = ();
+            while (iter.next()) {
+                push results, iter.getValue();
+            }
+            assertEq(3, results.size());
+            list<string> cities = map $1.payload.city, results;
+            assertTrue(cities.contains("Berlin"));
+            assertTrue(cities.contains("Paris"));
+            assertTrue(cities.contains("Moscow"));
+        }
+
+        # ---- TEST AND expression ----
+        {
+            hash<DataProviderExpression> and_expr = <DataProviderExpression>{
+                "exp": DP_OP_AND,
+                "args": (
+                    <DataProviderExpression>{
+                        "exp": DP_SEARCH_OP_EQ,
+                        "args": (
+                            <DataProviderFieldReference>{"field": "country"},
+                            "Germany",
+                        ),
+                    },
+                    <DataProviderExpression>{
+                        "exp": DP_SEARCH_OP_GT,
+                        "args": (
+                            <DataProviderFieldReference>{"field": "population"},
+                            1000000,
+                        ),
+                    },
+                ),
+            };
+            AbstractDataProviderRecordIterator iter = col_prov.searchRecords(and_expr, {"limit": 10});
+            list<auto> results = ();
+            while (iter.next()) {
+                push results, iter.getValue();
+            }
+            assertEq(1, results.size());
+            assertEq("Berlin", results[0].payload.city);
+        }
+
+        # ---- TEST OR expression ----
+        {
+            hash<DataProviderExpression> or_expr = <DataProviderExpression>{
+                "exp": DP_OP_OR,
+                "args": (
+                    <DataProviderExpression>{
+                        "exp": DP_SEARCH_OP_EQ,
+                        "args": (
+                            <DataProviderFieldReference>{"field": "city"},
+                            "Berlin",
+                        ),
+                    },
+                    <DataProviderExpression>{
+                        "exp": DP_SEARCH_OP_EQ,
+                        "args": (
+                            <DataProviderFieldReference>{"field": "city"},
+                            "Paris",
+                        ),
+                    },
+                ),
+            };
+            AbstractDataProviderRecordIterator iter = col_prov.searchRecords(or_expr, {"limit": 10});
+            list<auto> results = ();
+            while (iter.next()) {
+                push results, iter.getValue();
+            }
+            assertEq(2, results.size());
+            list<string> cities = map $1.payload.city, results;
+            assertTrue(cities.contains("Berlin"));
+            assertTrue(cities.contains("Paris"));
+        }
+
+        # ---- TEST NOT expression ----
+        {
+            hash<DataProviderExpression> not_expr = <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_NOT,
+                "args": (
+                    <DataProviderExpression>{
+                        "exp": DP_SEARCH_OP_EQ,
+                        "args": (
+                            <DataProviderFieldReference>{"field": "city"},
+                            "Berlin",
+                        ),
+                    },
+                ),
+            };
+            AbstractDataProviderRecordIterator iter = col_prov.searchRecords(not_expr, {"limit": 10});
+            list<auto> results = ();
+            while (iter.next()) {
+                push results, iter.getValue();
+            }
+            assertEq(4, results.size());
+            foreach hash<auto> rec in (results) {
+                assertNeq("Berlin", rec.payload.city);
+            }
+        }
+
+        # ---- TEST plain hash where_cond (implicit equality) ----
+        {
+            AbstractDataProviderRecordIterator iter = col_prov.searchRecords(
+                {"city": "Berlin"},
+                {"limit": 10},
+            );
+            list<auto> results = ();
+            while (iter.next()) {
+                push results, iter.getValue();
+            }
+            assertEq(1, results.size());
+            assertEq("Berlin", results[0].payload.city);
+        }
+
+        # ---- TEST plain hash where_cond with multiple keys (AND semantics) ----
+        {
+            AbstractDataProviderRecordIterator iter = col_prov.searchRecords(
+                {"city": "Berlin", "country": "Germany"},
+                {"limit": 10},
+            );
+            list<auto> results = ();
+            while (iter.next()) {
+                push results, iter.getValue();
+            }
+            assertEq(1, results.size());
+            assertEq("Berlin", results[0].payload.city);
+        }
+
+        # ---- TEST where_cond + search_options.filter merge ----
+        {
+            # where_cond filters by country=Germany, search_options filters population > 1000000
+            # Both should apply (AND semantics)
+            AbstractDataProviderRecordIterator iter = col_prov.searchRecords(
+                {"country": "Germany"},
+                {
+                    "limit": 10,
+                    "filter": {
+                        "must": ({"key": "population", "range": {"gt": 1000000}},),
+                    },
+                },
+            );
+            list<auto> results = ();
+            while (iter.next()) {
+                push results, iter.getValue();
+            }
+            assertEq(1, results.size());
+            assertEq("Berlin", results[0].payload.city);
+        }
+
+        # ---- TEST empty where_cond (NOTHING) returns all ----
+        {
+            AbstractDataProviderRecordIterator iter = col_prov.searchRecords(NOTHING, {"limit": 10});
+            int count = 0;
+            while (iter.next()) {
+                ++count;
+            }
+            assertEq(5, count);
+        }
+
+        # ---- TEST nested expression: AND(OR(...), GT(...)) ----
+        {
+            hash<DataProviderExpression> nested_expr = <DataProviderExpression>{
+                "exp": DP_OP_AND,
+                "args": (
+                    <DataProviderExpression>{
+                        "exp": DP_OP_OR,
+                        "args": (
+                            <DataProviderExpression>{
+                                "exp": DP_SEARCH_OP_EQ,
+                                "args": (
+                                    <DataProviderFieldReference>{"field": "city"},
+                                    "Berlin",
+                                ),
+                            },
+                            <DataProviderExpression>{
+                                "exp": DP_SEARCH_OP_EQ,
+                                "args": (
+                                    <DataProviderFieldReference>{"field": "city"},
+                                    "Moscow",
+                                ),
+                            },
+                        ),
+                    },
+                    <DataProviderExpression>{
+                        "exp": DP_SEARCH_OP_GT,
+                        "args": (
+                            <DataProviderFieldReference>{"field": "population"},
+                            5000000,
+                        ),
+                    },
+                ),
+            };
+            AbstractDataProviderRecordIterator iter = col_prov.searchRecords(nested_expr, {"limit": 10});
+            list<auto> results = ();
+            while (iter.next()) {
+                push results, iter.getValue();
+            }
+            # Berlin (3644826) < 5000000, Moscow (11920000) > 5000000 → only Moscow
+            assertEq(1, results.size());
+            assertEq("Moscow", results[0].payload.city);
+        }
+
+        # ---- NEGATIVE: unknown expression operator ----
+        {
+            try {
+                col_prov.searchRecords(<DataProviderExpression>{
+                    "exp": "unknown_op",
+                    "args": (),
+                }, {"limit": 10});
+                fail("Expected exception for unknown operator");
+            } catch (hash<ExceptionInfo> ex) {
+                assertTrue(ex.err == "WHERE-ERROR" || ex.err == "SEARCH-RECORDS-ERROR"
+                    || ex.err == "DATA-PROVIDER-EXPRESSION-ERROR");
+            }
         }
     }
 

--- a/qlib/ConnectionProvider/ConnectionSchemeCache.qc
+++ b/qlib/ConnectionProvider/ConnectionSchemeCache.qc
@@ -105,6 +105,9 @@ public class ConnectionSchemeCache {
 
             "freshbooks": "FreshBooksRestClient",
 
+            "qdrantrest": "QdrantDataProvider",
+            "qdrantrests": "QdrantDataProvider",
+
             "gcal": "GoogleRestClient",
             "gmail": "GoogleRestClient",
             "grests": "GoogleRestClient",

--- a/qlib/DataProvider/DataProvider.qc
+++ b/qlib/DataProvider/DataProvider.qc
@@ -120,6 +120,7 @@ public class DataProvider {
 
             "openai": "OpenAiDataProvider",
             "pop3": "Pop3ClientDataProvider",
+            "qdrant": "QdrantDataProvider",
             "redis": "RedisDataProvider",
             "restclient": "RestClientDataProvider",
             "restschema": "RestSchemaDataProvider",

--- a/qlib/Http2ClientIo/Http2ClientConnectionManager.qc
+++ b/qlib/Http2ClientIo/Http2ClientConnectionManager.qc
@@ -384,16 +384,24 @@ public class Http2ClientConnectionManager {
             int current_count = pool.hasKey(key) ? pool{key}.size() : 0;
             if (current_count >= opts.max_connections_per_host) {
                 # All connections are at capacity, pick the one with fewest streams
-                Http2ClientConnection best;
+                # When multiple connections have the same minimum count (e.g. all 0 during
+                # connection establishment), collect all ties and distribute evenly to avoid
+                # piling all threads onto the first connection (thundering herd)
+                list<Http2ClientConnection> candidates;
                 int min_streams = 2147483647;
                 foreach Http2ClientConnection conn in (pool{key}) {
                     int streams = conn.getActiveStreamCount();
                     if (streams < min_streams) {
                         min_streams = streams;
-                        best = conn;
+                        candidates = (conn,);
+                    } else if (streams == min_streams) {
+                        push candidates, conn;
                     }
                 }
-                if (best) {
+                if (candidates) {
+                    Http2ClientConnection best = candidates.size() == 1
+                        ? candidates[0]
+                        : candidates[rand() % candidates.size()];
                     log(LoggerLevel::DEBUG, "using connection %d with %d streams to %s (all at capacity)",
                         best.getConnectionId(), min_streams, key);
                     return best;

--- a/qlib/QdrantDataProvider/QdrantAliasesDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantAliasesDataProvider.qc
@@ -1,0 +1,100 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantAliasesDataProvider class definition
+
+/** QdrantAliasesDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant aliases API data provider
+/** This data provider provides children that are API data providers for Qdrant alias management
+*/
+public class QdrantAliasesDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "aliases",
+            "desc": "Qdrant aliases data provider; provides access to collection alias operations",
+            "type": "QdrantAliasesDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_children": True,
+            "children_can_support_apis": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+    }
+
+    private {
+        const ChildMap = {
+            "list-all": Class::forName("QdrantDataProvider::QdrantAliasesListAllDataProvider"),
+            "list-collection": Class::forName("QdrantDataProvider::QdrantAliasesListCollectionDataProvider"),
+            "update": Class::forName("QdrantDataProvider::QdrantAliasesUpdateDataProvider"),
+        };
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant %s data provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Return data provider summary info
+    *list<hash<DataProvider::DataProviderSummaryInfo>> getChildProviderSummaryInfo() {
+        return map $1.getConstant("ProviderSummaryInfo").getValue(), ChildMap.iterator();
+    }
+
+    #! Returns a list of child data provider names, if any
+    private *list<string> getChildProviderNamesImpl() {
+        return keys ChildMap;
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    private *DataProvider::AbstractDataProvider getChildProviderImpl(string name) {
+        *Class cls = ChildMap{name};
+        if (!cls) {
+            return;
+        }
+        return cls.newObject(rest);
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantAliasesListAllDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantAliasesListAllDataProvider.qc
@@ -27,14 +27,14 @@ public namespace QdrantDataProvider {
 #! The Qdrant list all aliases API data provider
 /** This API lists all aliases in the Qdrant instance
 
-    @note Corresponds to: GET /collections/aliases
+    @note Corresponds to: GET /aliases
 */
 public class QdrantAliasesListAllDataProvider inherits QdrantDataProviderBase {
     public {
         #! Provider info
         const ProviderInfo = <DataProviderInfo>{
             "name": "list-all",
-            "desc": "Qdrant list all aliases API data provider (`GET /collections/aliases`)",
+            "desc": "Qdrant list all aliases API data provider (`GET /aliases`)",
             "type": "QdrantAliasesListAllDataProvider",
             "constructor_options": QdrantDataProvider::ConstructorOptions,
             "supports_request": True,

--- a/qlib/QdrantDataProvider/QdrantAliasesListAllDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantAliasesListAllDataProvider.qc
@@ -1,0 +1,125 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantAliasesListAllDataProvider class definition
+
+/** QdrantAliasesListAllDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant list all aliases API data provider
+/** This API lists all aliases in the Qdrant instance
+
+    @note Corresponds to: GET /collections/aliases
+*/
+public class QdrantAliasesListAllDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "list-all",
+            "desc": "Qdrant list all aliases API data provider (`GET /collections/aliases`)",
+            "type": "QdrantAliasesListAllDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = AbstractDataProviderTypeMap."nothing";
+
+        #! Response type
+        const ResponseType = new QdrantAliasesListAllResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant aliases %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request (ignored)
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return doQdrantGet("/aliases");
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant list all aliases response data type
+public class QdrantAliasesListAllResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "aliases": {
+                "type": AutoListOrNothingType,
+                "display_name": "Aliases",
+                "short_desc": "List of alias descriptions",
+                "desc": "A list of alias description objects with alias names and collection names",
+                "example_value": ({"alias_name": "my_alias", "collection_name": "my_collection"},),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantAliasesListCollectionDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantAliasesListCollectionDataProvider.qc
@@ -1,0 +1,146 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantAliasesListCollectionDataProvider class definition
+
+/** QdrantAliasesListCollectionDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant list collection aliases API data provider
+/** This API lists all aliases for a given collection
+
+    @note Corresponds to: GET /collections/{name}/aliases
+*/
+public class QdrantAliasesListCollectionDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "list-collection",
+            "desc": "Qdrant list collection aliases API data provider (`GET /collections/{name}/aliases`)",
+            "type": "QdrantAliasesListCollectionDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantAliasesListCollectionRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantAliasesListCollectionResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant aliases %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return doQdrantGet(collectionPath(remove req.collection, "/aliases"));
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant list collection aliases request data type
+public class QdrantAliasesListCollectionRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection to list aliases for",
+                "example_value": "my_collection",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant list collection aliases response data type
+public class QdrantAliasesListCollectionResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "aliases": {
+                "type": AutoListOrNothingType,
+                "display_name": "Aliases",
+                "short_desc": "List of alias descriptions",
+                "desc": "A list of alias description objects with alias names and collection names",
+                "example_value": ({"alias_name": "my_alias", "collection_name": "my_collection"},),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantAliasesUpdateDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantAliasesUpdateDataProvider.qc
@@ -1,0 +1,174 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantAliasesUpdateDataProvider class definition
+
+/** QdrantAliasesUpdateDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant update aliases API data provider
+/** This API updates aliases by performing alias actions (create, delete, rename)
+
+    @note Corresponds to: POST /collections/aliases
+*/
+public class QdrantAliasesUpdateDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "update",
+            "desc": "Qdrant update aliases API data provider (`POST /collections/aliases`)",
+            "type": "QdrantAliasesUpdateDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantAliasesUpdateRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantAliasesUpdateResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("timeout",);
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant aliases %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string uri_path = "/collections/aliases";
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantPost(uri_path, req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant update aliases request data type
+public class QdrantAliasesUpdateRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "actions": {
+                "type": AutoListType,
+                "display_name": "Actions",
+                "short_desc": "List of alias actions",
+                "desc": "A list of alias action objects; each action can be one of `create_alias` (with "
+                    "`collection_name` and `alias_name`), `delete_alias` (with `alias_name`), or `rename_alias` "
+                    "(with `old_alias_name` and `new_alias_name`)",
+                "example_value": ({"create_alias": {"collection_name": "my_collection",
+                    "alias_name": "my_alias"}},),
+            },
+            "timeout": {
+                "type": IntOrNothingType,
+                "display_name": "Timeout",
+                "short_desc": "Operation timeout in seconds",
+                "desc": "Wait for operation commit timeout in seconds. If the timeout is reached, the request "
+                    "will return with a service error",
+                "example_value": 30,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant update aliases response data type
+public class QdrantAliasesUpdateResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "result": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Result",
+                "short_desc": "Operation result",
+                "desc": "Returns `true` if the alias actions were applied successfully",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantClusterCollectionInfoDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantClusterCollectionInfoDataProvider.qc
@@ -1,0 +1,171 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantClusterCollectionInfoDataProvider class definition
+
+/** QdrantClusterCollectionInfoDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant cluster collection info API data provider
+/** This API retrieves cluster information for a specific collection
+
+    @note Corresponds to: GET /collections/{name}/cluster
+*/
+public class QdrantClusterCollectionInfoDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "collection-info",
+            "desc": "Qdrant cluster collection info API data provider (`GET /collections/{name}/cluster`)",
+            "type": "QdrantClusterCollectionInfoDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantClusterCollectionInfoRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantClusterCollectionInfoResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant cluster collection info provider for `%s`", rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return doQdrantGet(collectionPath(remove req.collection, "/cluster"));
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant cluster collection info request data type
+public class QdrantClusterCollectionInfoRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection to retrieve cluster information for",
+                "example_value": "my_collection",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant cluster collection info response data type
+public class QdrantClusterCollectionInfoResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "peer_id": {
+                "type": IntOrNothingType,
+                "display_name": "Peer ID",
+                "short_desc": "Current peer ID",
+                "desc": "The ID of the current peer in the cluster",
+                "example_value": 1,
+            },
+            "shard_count": {
+                "type": IntOrNothingType,
+                "display_name": "Shard Count",
+                "short_desc": "Number of shards",
+                "desc": "The total number of shards for the collection",
+                "example_value": 2,
+            },
+            "local_shards": {
+                "type": AutoListOrNothingType,
+                "display_name": "Local Shards",
+                "short_desc": "Local shard information",
+                "desc": "Information about shards located on the current peer",
+            },
+            "remote_shards": {
+                "type": AutoListOrNothingType,
+                "display_name": "Remote Shards",
+                "short_desc": "Remote shard information",
+                "desc": "Information about shards located on remote peers",
+            },
+            "shard_transfers": {
+                "type": AutoListOrNothingType,
+                "display_name": "Shard Transfers",
+                "short_desc": "Active shard transfers",
+                "desc": "Information about any active shard transfer operations",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantClusterCreateShardKeyDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantClusterCreateShardKeyDataProvider.qc
@@ -1,0 +1,200 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantClusterCreateShardKeyDataProvider class definition
+
+/** QdrantClusterCreateShardKeyDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant create shard key API data provider
+/** This API creates a new shard key for a collection
+
+    @note Corresponds to: PUT /collections/{name}/shards
+*/
+public class QdrantClusterCreateShardKeyDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "create-shard-key",
+            "desc": "Qdrant create shard key API data provider (`PUT /collections/{name}/shards`)",
+            "type": "QdrantClusterCreateShardKeyDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantClusterCreateShardKeyRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantClusterCreateShardKeyResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("timeout",);
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant create shard key provider for `%s`", rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string uri_path = collectionPath(collection, "/shards");
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantPut(uri_path, req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant create shard key request data type
+public class QdrantClusterCreateShardKeyRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection to create a shard key for",
+                "example_value": "my_collection",
+            },
+            "shard_key": {
+                "type": StringType,
+                "display_name": "Shard Key",
+                "short_desc": "Shard key value",
+                "desc": "The shard key to create; a string value that identifies the shard key",
+                "example_value": "my_shard_key",
+            },
+            "shards_number": {
+                "type": IntOrNothingType,
+                "display_name": "Shards Number",
+                "short_desc": "Number of shards",
+                "desc": "The number of shards to create for this shard key",
+                "example_value": 1,
+            },
+            "replication_factor": {
+                "type": IntOrNothingType,
+                "display_name": "Replication Factor",
+                "short_desc": "Replication factor",
+                "desc": "The number of replicas for each shard created with this shard key",
+                "example_value": 1,
+            },
+            "placement": {
+                "type": AutoListOrNothingType,
+                "display_name": "Placement",
+                "short_desc": "Peer placement list",
+                "desc": "List of peer IDs where the shards should be placed",
+                "example_value": (1, 2),
+            },
+            "timeout": {
+                "type": IntOrNothingType,
+                "display_name": "Timeout",
+                "short_desc": "Operation timeout in seconds",
+                "desc": "Wait for operation commit timeout in seconds. If the timeout is reached, the request "
+                    "will return with a service error",
+                "example_value": 30,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant create shard key response data type
+public class QdrantClusterCreateShardKeyResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "result": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Result",
+                "short_desc": "Operation result",
+                "desc": "Returns `true` if the shard key was created successfully",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantClusterDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantClusterDataProvider.qc
@@ -1,0 +1,104 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantClusterDataProvider class definition
+
+/** QdrantClusterDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant cluster API data provider
+/** This data provider provides children that are API data providers for Qdrant cluster management
+*/
+public class QdrantClusterDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "cluster",
+            "desc": "Qdrant cluster data provider; provides access to cluster management operations",
+            "type": "QdrantClusterDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_children": True,
+            "children_can_support_apis": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+    }
+
+    private {
+        const ChildMap = {
+            "info": Class::forName("QdrantDataProvider::QdrantClusterInfoDataProvider"),
+            "recover": Class::forName("QdrantDataProvider::QdrantClusterRecoverDataProvider"),
+            "remove-peer": Class::forName("QdrantDataProvider::QdrantClusterRemovePeerDataProvider"),
+            "collection-info": Class::forName("QdrantDataProvider::QdrantClusterCollectionInfoDataProvider"),
+            "update-collection": Class::forName("QdrantDataProvider::QdrantClusterUpdateCollectionDataProvider"),
+            "create-shard-key": Class::forName("QdrantDataProvider::QdrantClusterCreateShardKeyDataProvider"),
+            "delete-shard-key": Class::forName("QdrantDataProvider::QdrantClusterDeleteShardKeyDataProvider"),
+        };
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant %s data provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Return data provider summary info
+    *list<hash<DataProvider::DataProviderSummaryInfo>> getChildProviderSummaryInfo() {
+        return map $1.getConstant("ProviderSummaryInfo").getValue(), ChildMap.iterator();
+    }
+
+    #! Returns a list of child data provider names, if any
+    private *list<string> getChildProviderNamesImpl() {
+        return keys ChildMap;
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    private *DataProvider::AbstractDataProvider getChildProviderImpl(string name) {
+        *Class cls = ChildMap{name};
+        if (!cls) {
+            return;
+        }
+        return cls.newObject(rest);
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantClusterDeleteShardKeyDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantClusterDeleteShardKeyDataProvider.qc
@@ -1,0 +1,179 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantClusterDeleteShardKeyDataProvider class definition
+
+/** QdrantClusterDeleteShardKeyDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant delete shard key API data provider
+/** This API deletes an existing shard key from a collection
+
+    @note Corresponds to: POST /collections/{name}/shards/delete
+*/
+public class QdrantClusterDeleteShardKeyDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "delete-shard-key",
+            "desc": "Qdrant delete shard key API data provider (`POST /collections/{name}/shards/delete`)",
+            "type": "QdrantClusterDeleteShardKeyDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantClusterDeleteShardKeyRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantClusterDeleteShardKeyResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("timeout",);
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant delete shard key provider for `%s`", rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string uri_path = collectionPath(collection, "/shards/delete");
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantPost(uri_path, req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant delete shard key request data type
+public class QdrantClusterDeleteShardKeyRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection to delete the shard key from",
+                "example_value": "my_collection",
+            },
+            "shard_key": {
+                "type": StringType,
+                "display_name": "Shard Key",
+                "short_desc": "Shard key value",
+                "desc": "The shard key to delete; a string value that identifies the shard key",
+                "example_value": "my_shard_key",
+            },
+            "timeout": {
+                "type": IntOrNothingType,
+                "display_name": "Timeout",
+                "short_desc": "Operation timeout in seconds",
+                "desc": "Wait for operation commit timeout in seconds. If the timeout is reached, the request "
+                    "will return with a service error",
+                "example_value": 30,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant delete shard key response data type
+public class QdrantClusterDeleteShardKeyResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "result": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Result",
+                "short_desc": "Operation result",
+                "desc": "Returns `true` if the shard key was deleted successfully",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantClusterInfoDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantClusterInfoDataProvider.qc
@@ -1,0 +1,156 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantClusterInfoDataProvider class definition
+
+/** QdrantClusterInfoDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant cluster info API data provider
+/** This API retrieves cluster status and information
+
+    @note Corresponds to: GET /cluster
+*/
+public class QdrantClusterInfoDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "info",
+            "desc": "Qdrant cluster info API data provider (`GET /cluster`)",
+            "type": "QdrantClusterInfoDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = AbstractDataProviderTypeMap."nothing";
+
+        #! Response type
+        const ResponseType = new QdrantClusterInfoResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant cluster info provider for `%s`", rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request (ignored)
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return doQdrantGet("/cluster");
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant cluster info response data type
+public class QdrantClusterInfoResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "status": {
+                "type": StringType,
+                "display_name": "Status",
+                "short_desc": "Cluster status",
+                "desc": "The current status of the cluster (e.g. `enabled` or `disabled`)",
+                "example_value": "enabled",
+            },
+            "peer_id": {
+                "type": IntOrNothingType,
+                "display_name": "Peer ID",
+                "short_desc": "Current peer ID",
+                "desc": "The ID of the current peer in the cluster",
+                "example_value": 1,
+            },
+            "peers": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Peers",
+                "short_desc": "Cluster peers",
+                "desc": "Information about all peers in the cluster, keyed by peer ID",
+            },
+            "raft_info": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Raft Info",
+                "short_desc": "Raft consensus info",
+                "desc": "Information about the Raft consensus state including term, commit, and leader",
+            },
+            "consensus_thread_status": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Consensus Thread Status",
+                "short_desc": "Consensus thread status",
+                "desc": "Status information about the consensus thread",
+            },
+            "message_send_failures": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Message Send Failures",
+                "short_desc": "Message send failures",
+                "desc": "Information about message send failures between peers",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantClusterRecoverDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantClusterRecoverDataProvider.qc
@@ -1,0 +1,125 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantClusterRecoverDataProvider class definition
+
+/** QdrantClusterRecoverDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant cluster recover API data provider
+/** This API triggers the cluster recovery process
+
+    @note Corresponds to: POST /cluster/recover
+*/
+public class QdrantClusterRecoverDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "recover",
+            "desc": "Qdrant cluster recover API data provider (`POST /cluster/recover`)",
+            "type": "QdrantClusterRecoverDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = AbstractDataProviderTypeMap."nothing";
+
+        #! Response type
+        const ResponseType = new QdrantClusterRecoverResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant cluster recover provider for `%s`", rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request (ignored)
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return doQdrantPost("/cluster/recover", NOTHING);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant cluster recover response data type
+public class QdrantClusterRecoverResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "result": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Result",
+                "short_desc": "Operation result",
+                "desc": "Returns `true` if the cluster recovery was triggered successfully",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantClusterRemovePeerDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantClusterRemovePeerDataProvider.qc
@@ -1,0 +1,171 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantClusterRemovePeerDataProvider class definition
+
+/** QdrantClusterRemovePeerDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant cluster remove peer API data provider
+/** This API removes a peer from the cluster
+
+    @note Corresponds to: DELETE /cluster/peer/{peer_id}
+*/
+public class QdrantClusterRemovePeerDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "remove-peer",
+            "desc": "Qdrant cluster remove peer API data provider (`DELETE /cluster/peer/{peer_id}`)",
+            "type": "QdrantClusterRemovePeerDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantClusterRemovePeerRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantClusterRemovePeerResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("force",);
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant cluster remove peer provider for `%s`", rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        int peer_id = remove req.peer_id;
+        string uri_path = sprintf("/cluster/peer/%d", peer_id);
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantDelete(uri_path);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant cluster remove peer request data type
+public class QdrantClusterRemovePeerRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "peer_id": {
+                "type": IntType,
+                "display_name": "Peer ID",
+                "short_desc": "ID of the peer to remove",
+                "desc": "The ID of the peer to remove from the cluster",
+                "example_value": 1,
+            },
+            "force": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Force",
+                "short_desc": "Force remove the peer",
+                "desc": "If `true`, the peer will be removed even if it is not in a dead state",
+                "example_value": False,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant cluster remove peer response data type
+public class QdrantClusterRemovePeerResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "result": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Result",
+                "short_desc": "Operation result",
+                "desc": "Returns `true` if the peer was removed successfully",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantClusterUpdateCollectionDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantClusterUpdateCollectionDataProvider.qc
@@ -1,0 +1,219 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantClusterUpdateCollectionDataProvider class definition
+
+/** QdrantClusterUpdateCollectionDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant update collection cluster setup API data provider
+/** This API updates the cluster setup for a collection
+
+    @note Corresponds to: POST /collections/{name}/cluster
+*/
+public class QdrantClusterUpdateCollectionDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "update-collection",
+            "desc": "Qdrant update collection cluster setup API data provider "
+                "(`POST /collections/{name}/cluster`)",
+            "type": "QdrantClusterUpdateCollectionDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantClusterUpdateCollectionRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantClusterUpdateCollectionResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("timeout",);
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant cluster update collection provider for `%s`", rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string uri_path = collectionPath(collection, "/cluster");
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantPost(uri_path, req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant cluster update collection request data type
+public class QdrantClusterUpdateCollectionRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection to update cluster setup for",
+                "example_value": "my_collection",
+            },
+            "move_shard": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Move Shard",
+                "short_desc": "Move shard operation",
+                "desc": "Configuration for moving a shard from one peer to another (includes `shard_id`, "
+                    "`from_peer_id`, `to_peer_id`)",
+            },
+            "replicate_shard": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Replicate Shard",
+                "short_desc": "Replicate shard operation",
+                "desc": "Configuration for replicating a shard to another peer (includes `shard_id`, "
+                    "`from_peer_id`, `to_peer_id`)",
+            },
+            "abort_transfer": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Abort Transfer",
+                "short_desc": "Abort shard transfer",
+                "desc": "Configuration for aborting an ongoing shard transfer (includes `shard_id`, "
+                    "`from_peer_id`, `to_peer_id`)",
+            },
+            "drop_replica": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Drop Replica",
+                "short_desc": "Drop shard replica",
+                "desc": "Configuration for dropping a shard replica from a peer (includes `shard_id`, `peer_id`)",
+            },
+            "create_sharding_key": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Create Sharding Key",
+                "short_desc": "Create sharding key",
+                "desc": "Configuration for creating a new sharding key (includes `shard_key`)",
+            },
+            "drop_sharding_key": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Drop Sharding Key",
+                "short_desc": "Drop sharding key",
+                "desc": "Configuration for dropping an existing sharding key (includes `shard_key`)",
+            },
+            "restart_transfer": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Restart Transfer",
+                "short_desc": "Restart shard transfer",
+                "desc": "Configuration for restarting a shard transfer (includes `shard_id`, "
+                    "`from_peer_id`, `to_peer_id`)",
+            },
+            "timeout": {
+                "type": IntOrNothingType,
+                "display_name": "Timeout",
+                "short_desc": "Operation timeout in seconds",
+                "desc": "Wait for operation commit timeout in seconds. If the timeout is reached, the request "
+                    "will return with a service error",
+                "example_value": 30,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant cluster update collection response data type
+public class QdrantClusterUpdateCollectionResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "result": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Result",
+                "short_desc": "Operation result",
+                "desc": "Returns `true` if the collection cluster setup was updated successfully",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantCollectionBulkOperation.qc
+++ b/qlib/QdrantDataProvider/QdrantCollectionBulkOperation.qc
@@ -1,0 +1,131 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantCollectionBulkOperation class definition
+
+/** QdrantCollectionBulkOperation.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! Bulk insert/upsert operation for a Qdrant collection
+/** Buffers point records and flushes them as batch upserts via `PUT /collections/{name}/points`.
+
+    This class uses a row-oriented buffer (list of point hashes) rather than the column-oriented buffer
+    from the base class, because Qdrant point records contain list-valued fields (vectors) that would be
+    misinterpreted as column data by the column-oriented buffering logic.
+*/
+public class QdrantCollectionBulkOperation inherits DataProvider::AbstractDataProviderBulkOperation {
+    private {
+        #! The REST client for Qdrant
+        RestClient rest;
+
+        #! Pre-built URI for the upsert endpoint
+        string uri;
+
+        #! Row-oriented record buffer
+        list<hash<auto>> row_buf;
+
+        #! Block size for flushing
+        int row_block_size;
+
+        #! Record count
+        int row_count = 0;
+    }
+
+    #! Creates the bulk operation object
+    /** @param provider the data provider for the operation
+        @param rest the REST client for Qdrant
+        @param collection_name the collection name for the bulk operations
+        @param block_size the block size for bulk operations (default: 1000)
+    */
+    constructor(DataProvider::AbstractDataProvider provider, RestClient rest, string collection_name,
+            *int block_size)
+            : AbstractDataProviderBulkOperation(provider, "upsert", block_size ?? DefaultBlockSize) {
+        self.rest = rest;
+        uri = sprintf("/collections/%s/points?wait=true", encode_url(collection_name, True));
+        row_block_size = block_size ?? DefaultBlockSize;
+    }
+
+    #! Queues a single record for bulk upsert
+    /** @param rec the record to queue; must contain `id` and `vector`, optionally `payload`
+    */
+    queueData(hash<auto> rec) {
+        push row_buf, rec;
+        if (row_buf.size() >= row_block_size) {
+            flushRows();
+        }
+    }
+
+    #! Queues multiple records for bulk upsert
+    /** @param recs a list of records to queue
+    */
+    queueData(list<hash<auto>> recs) {
+        foreach hash<auto> rec in (recs) {
+            push row_buf, rec;
+            if (row_buf.size() >= row_block_size) {
+                flushRows();
+            }
+        }
+    }
+
+    #! Flushes any remaining buffered data
+    flush() {
+        if (row_buf) {
+            flushRows();
+        }
+    }
+
+    #! Discards any buffered data
+    discard() {
+        delete row_buf;
+    }
+
+    #! Returns the record count
+    int getRecordCount() {
+        return row_count;
+    }
+
+    #! Flushes row buffer to Qdrant
+    private flushRows() {
+        if (!row_buf) {
+            return;
+        }
+
+        list<hash<auto>> points;
+        foreach hash<auto> rec in (row_buf) {
+            hash<auto> point = {"id": rec.id, "vector": rec.vector};
+            if (rec.payload) {
+                point.payload = rec.payload;
+            }
+            push points, point;
+        }
+
+        rest.put(uri, {"points": points});
+
+        int bs = row_buf.size();
+        row_count += bs;
+        delete row_buf;
+    }
+
+    #! Not used — overridden by row-oriented methods above
+    private flushImpl() {
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantCollectionTableDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantCollectionTableDataProvider.qc
@@ -86,6 +86,10 @@ public class QdrantCollectionTableDataProvider inherits QdrantDataProviderBase {
             "supports_delete": True,
             "supports_bulk_create": True,
             "supports_bulk_upsert": True,
+            "expressions": cast<hash<string, hash<DataProviderExpressionInfo>>>(
+                map {$1.key: $1.value.exp}, QdrantExpressions.pairIterator()
+            ),
+            "supports_search_expressions": True,
             "create_options": WriteOptions,
             "upsert_options": WriteOptions,
             "search_options": GenericRecordSearchOptions{"columns", "limit", "offset", "requires_result"} + {
@@ -305,14 +309,31 @@ public class QdrantCollectionTableDataProvider inherits QdrantDataProviderBase {
         return ProviderInfo;
     }
 
+    #! Accepts foreign field names since Qdrant payload fields are dynamic and not part of the record type
+    bool searchAcceptsForeignField(string field) {
+        return True;
+    }
+
     #! Extracts and validates point ID(s) from where_cond
-    /** @param where_cond the where condition; must contain `id`
+    /** @param where_cond the where condition; must contain \c id — can be a plain hash or a
+        \c DataProviderExpression (when \c supports_search_expressions is True, the framework
+        converts plain hashes to expressions before calling the implementation)
         @param operation the operation name for error messages
 
         @return a list of point IDs
     */
     private list<auto> getPointIds(*hash<auto> where_cond, string operation) {
-        if (!where_cond || !exists where_cond.id) {
+        if (!where_cond) {
+            throw "QDRANT-" + operation.upr() + "-ERROR", sprintf("missing 'id' field in where_cond to identify "
+                "point(s) to %s in collection %y", operation, collection_name);
+        }
+
+        # Handle DataProviderExpression where_cond (from framework search expression conversion)
+        if (where_cond instanceof hash<DataProviderExpression>) {
+            return extractIdsFromExpression(cast<hash<DataProviderExpression>>(where_cond), operation);
+        }
+
+        if (!exists where_cond.id) {
             throw "QDRANT-" + operation.upr() + "-ERROR", sprintf("missing 'id' field in where_cond to identify "
                 "point(s) to %s in collection %y", operation, collection_name);
         }
@@ -321,6 +342,68 @@ public class QdrantCollectionTableDataProvider inherits QdrantDataProviderBase {
                 "for %s in collection %y; got fields: %y", operation, collection_name, keys where_cond);
         }
         return where_cond.id.typeCode() == NT_LIST ? where_cond.id : (where_cond.id,);
+    }
+
+    #! Extracts point IDs from a DataProviderExpression
+    /** @param exp the expression to extract IDs from; must reference the \c id field
+        @param operation the operation name for error messages
+
+        @return a list of point IDs
+    */
+    private list<auto> extractIdsFromExpression(hash<DataProviderExpression> exp, string operation) {
+        switch (exp.exp) {
+            case DP_SEARCH_OP_EQ: {
+                if (exp.args.size() >= 2
+                        && (exp.args[0] instanceof hash<DataProviderFieldReference>)
+                        && cast<hash<DataProviderFieldReference>>(exp.args[0]).field == "id") {
+                    auto val = exp.args[1];
+                    return val.typeCode() == NT_LIST ? val : (val,);
+                }
+                break;
+            }
+            case DP_SEARCH_OP_IN: {
+                if (exp.args.size() >= 2
+                        && (exp.args[0] instanceof hash<DataProviderFieldReference>)
+                        && cast<hash<DataProviderFieldReference>>(exp.args[0]).field == "id") {
+                    list<auto> ids;
+                    for (int j = 1; j < exp.args.size(); ++j) {
+                        if (exp.args[j].typeCode() == NT_LIST) {
+                            ids += exp.args[j];
+                        } else {
+                            push ids, exp.args[j];
+                        }
+                    }
+                    return ids;
+                }
+                break;
+            }
+            case DP_OP_AND: {
+                # AND wrapping a single ID expression
+                foreach auto arg in (exp.args) {
+                    if (arg instanceof hash<DataProviderExpression>) {
+                        *list<auto> ids = extractIdsFromExpressionSafe(
+                            cast<hash<DataProviderExpression>>(arg), operation);
+                        if (ids) {
+                            return ids;
+                        }
+                    }
+                }
+                break;
+            }
+        }
+
+        throw "QDRANT-" + operation.upr() + "-ERROR",
+            sprintf("where_cond expression must reference the 'id' field for %s in collection %y; "
+                "got expression: %y", operation, collection_name, exp);
+    }
+
+    #! Safe version of extractIdsFromExpression that returns NOTHING instead of throwing
+    private *list<auto> extractIdsFromExpressionSafe(hash<DataProviderExpression> exp, string operation) {
+        try {
+            return extractIdsFromExpression(exp, operation);
+        } catch () {
+            # not an ID expression
+        }
     }
 
     #! Builds a collection URI with write query parameters (wait, ordering)

--- a/qlib/QdrantDataProvider/QdrantCollectionTableDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantCollectionTableDataProvider.qc
@@ -1,0 +1,347 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantCollectionTableDataProvider class definition
+
+/** QdrantCollectionTableDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! Per-collection data provider implementing record-based CRUD and vector search
+/** Exposes a Qdrant collection as a record-based data provider with support for:
+    - \b Search (DPAT_FIND): vector similarity search with filtering and pagination
+    - \b Create/Upsert: insert or replace points with vectors and payloads
+    - \b Update: modify payload and/or vector data on existing points
+    - \b Delete: remove points by ID
+    - \b Bulk create/upsert: batch point upserts for high-throughput ingestion
+
+    Use the \c filter search option to pass Qdrant filter conditions (\c must, \c should, \c must_not clauses).
+
+    The \c where_cond for update and delete operations must contain the \c id field to identify the point(s) to
+    modify.
+
+    @note Corresponds to: POST /collections/{name}/points/query (search),
+    PUT /collections/{name}/points (create/upsert),
+    POST /collections/{name}/points/payload (update payload),
+    PUT /collections/{name}/points/vectors (update vectors),
+    POST /collections/{name}/points/delete (delete)
+*/
+public class QdrantCollectionTableDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Write operation query parameter names
+        const WriteQueryArgs = ("wait", "ordering");
+
+        #! Write operation options (shared by create, upsert, update, delete)
+        const WriteOptions = {
+            "wait": <DataProviderOptionInfo>{
+                "display_name": "Wait",
+                "short_desc": "Wait for operation to complete",
+                "type": AbstractDataProviderTypeMap."*softbool",
+                "desc": "If true, wait for changes to actually happen; if false (default), the request "
+                    "returns immediately after acknowledging",
+            },
+            "ordering": <DataProviderOptionInfo>{
+                "display_name": "Ordering",
+                "short_desc": "Write ordering guarantees",
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "The write ordering guarantees for the operation",
+                "allowed_values": (
+                    <AllowedValueInfo>{"value": "weak", "desc": "Weak ordering; fastest, no guarantees"},
+                    <AllowedValueInfo>{"value": "medium", "desc": "Medium ordering; wait for local persistence"},
+                    <AllowedValueInfo>{"value": "strong", "desc": "Strong ordering; wait for all replicas"},
+                ),
+            },
+        };
+
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "desc": "Qdrant collection table data provider; provides record-based CRUD operations on a "
+                "Qdrant collection including vector similarity search, point create/upsert/update/delete, "
+                "and bulk operations. Use the `filter` search option to pass Qdrant filter conditions",
+            "type": "QdrantCollectionTableDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "has_record": True,
+            "supports_read": True,
+            "supports_native_search": True,
+            "supports_create": True,
+            "supports_upsert": True,
+            "supports_update": True,
+            "supports_delete": True,
+            "supports_bulk_create": True,
+            "supports_bulk_upsert": True,
+            "create_options": WriteOptions,
+            "upsert_options": WriteOptions,
+            "search_options": GenericRecordSearchOptions{"columns", "limit", "offset", "requires_result"} + {
+                "query": <DataProviderOptionInfo>{
+                    "display_name": "Query",
+                    "short_desc": "Query vector for similarity search",
+                    "type": AbstractDataProviderTypeMap."*softlist",
+                    "desc": "The query vector to use for similarity search",
+                    "example_value": (0.2, 0.1, 0.9, 0.7),
+                },
+                "using": <DataProviderOptionInfo>{
+                    "display_name": "Using",
+                    "short_desc": "Named vector to query against",
+                    "type": AbstractDataProviderTypeMap."*string",
+                    "desc": "The name of the named vector to use for the search; if not specified, the default "
+                        "vector is used",
+                },
+                "filter": <DataProviderOptionInfo>{
+                    "display_name": "Filter",
+                    "short_desc": "Qdrant filter conditions",
+                    "type": AbstractDataProviderTypeMap."*hash",
+                    "desc": "Qdrant filter conditions with `must`, `should`, and `must_not` clauses",
+                },
+                "score_threshold": <DataProviderOptionInfo>{
+                    "display_name": "Score Threshold",
+                    "short_desc": "Minimum score cutoff",
+                    "type": AbstractDataProviderTypeMap."*float",
+                    "desc": "The minimum score threshold; points with a score below this value will be excluded",
+                },
+                "prefetch": <DataProviderOptionInfo>{
+                    "display_name": "Prefetch",
+                    "short_desc": "Prefetch config for hybrid/multi-stage search",
+                    "type": AbstractDataProviderTypeMap."auto",
+                    "desc": "Prefetch queries for hybrid search; can be a list of query objects or a single query "
+                        "object for multi-stage search pipelines",
+                },
+                "params": <DataProviderOptionInfo>{
+                    "display_name": "Params",
+                    "short_desc": "Search engine params",
+                    "type": AbstractDataProviderTypeMap."*hash",
+                    "desc": "Additional search parameters such as `hnsw_ef`, `exact`, `quantization`, and other "
+                        "engine-specific options",
+                },
+                "with_payload": <DataProviderOptionInfo>{
+                    "display_name": "With Payload",
+                    "short_desc": "Include payload in results",
+                    "type": AbstractDataProviderTypeMap."*softbool",
+                    "desc": "Whether to return payload data with results; default: True",
+                },
+                "with_vector": <DataProviderOptionInfo>{
+                    "display_name": "With Vector",
+                    "short_desc": "Include vectors in results",
+                    "type": AbstractDataProviderTypeMap."*softbool",
+                    "desc": "Whether to return vectors with results",
+                },
+                "lookup_from": <DataProviderOptionInfo>{
+                    "display_name": "Lookup From",
+                    "short_desc": "Lookup vectors from another collection",
+                    "type": AbstractDataProviderTypeMap."*hash",
+                    "desc": "Configuration to look up vectors from another collection for the search",
+                },
+            } + WriteOptions,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Record type
+        const RecordType = new QdrantScoredPointRecordType();
+    }
+
+    private {
+        #! The collection name
+        string collection_name;
+    }
+
+    #! Creates the object from a REST connection and collection name
+    constructor(RestClient::RestClient rest, string collection_name) : QdrantDataProviderBase(rest) {
+        self.collection_name = collection_name;
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return collection_name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant collection %y table data provider for `%s`", collection_name, rest.getSafeURL());
+    }
+
+    #! Returns an iterator for zero or more records matching the search options
+    /** @param where_cond the search criteria
+        @param search_options the search options after processing by validateSearchOptions()
+    */
+    private DataProvider::AbstractDataProviderRecordIterator searchRecordsImpl(*hash<auto> where_cond,
+            *hash<auto> search_options) {
+        return new QdrantSearchRecordIterator(rest, collection_name, where_cond, search_options);
+    }
+
+    #! Creates a new point in the collection
+    /** @param rec the record to create; must contain `id` and `vector`, optionally `payload`
+        @param create_options the create options after processing by validateCreateOptions()
+
+        @return the record as created
+    */
+    private *hash<auto> createRecordImpl(hash<auto> rec, *hash<auto> create_options) {
+        hash<auto> point = {"id": rec.id, "vector": rec.vector};
+        if (rec.payload) {
+            point.payload = rec.payload;
+        }
+        string uri = buildWriteUri("/points", create_options);
+        rest.put(uri, {"points": (point,)});
+        return rec;
+    }
+
+    #! Upserts a point in the collection (same as create for Qdrant)
+    /** @param rec the record to upsert; must contain `id` and `vector`, optionally `payload`
+        @param upsert_options the upsert options after processing by validateUpsertOptions()
+
+        @return the upsert result string
+    */
+    private string upsertRecordImpl(hash<auto> rec, *hash<auto> upsert_options) {
+        createRecordImpl(rec, upsert_options);
+        return UpsertResultInserted;
+    }
+
+    #! Updates one or more points in the collection
+    /** @param set the hash of field data to set; supports `payload` (hash) and/or `vector` (list).
+        When both are present, a single batch request is used to update both atomically.
+        @param where_cond a hash identifying the point(s) to update; must contain `id`
+        @param search_options the search options after processing by validateSearchOptions()
+
+        @return the number of records updated
+    */
+    private int updateRecordsImpl(hash<auto> set, *hash<auto> where_cond, *hash<auto> search_options) {
+        list<auto> id_list = getPointIds(where_cond, "update");
+
+        *hash<auto> payload_data = set.payload;
+        *auto vector_data = set.vector;
+
+        if (!exists vector_data && !payload_data) {
+            throw "QDRANT-UPDATE-ERROR", sprintf("nothing to update in collection %y; 'set' must contain "
+                "'payload' and/or 'vector' fields", collection_name);
+        }
+
+        if (exists vector_data && payload_data) {
+            # Use batch API to update both vector and payload in one request
+            list<hash<auto>> vector_points;
+            foreach auto id in (id_list) {
+                push vector_points, {"id": id, "vector": vector_data};
+            }
+            list<hash<auto>> operations = (
+                {"update_vectors": {"points": vector_points}},
+                {"set_payload": {"payload": payload_data, "points": id_list}},
+            );
+            string uri = buildWriteUri("/points/batch", search_options);
+            rest.post(uri, {"operations": operations});
+        } else if (exists vector_data) {
+            list<hash<auto>> vector_points;
+            foreach auto id in (id_list) {
+                push vector_points, {"id": id, "vector": vector_data};
+            }
+            string uri = buildWriteUri("/points/vectors", search_options);
+            rest.put(uri, {"points": vector_points});
+        } else {
+            string uri = buildWriteUri("/points/payload", search_options);
+            rest.post(uri, {"payload": payload_data, "points": id_list});
+        }
+
+        return id_list.size();
+    }
+
+    #! Deletes one or more points from the collection
+    /** @param where_cond a hash identifying the point(s) to delete; must contain `id`
+        @param search_options the search options after processing by validateSearchOptions()
+
+        @return the number of records deleted
+    */
+    private int deleteRecordsImpl(*hash<auto> where_cond, *hash<auto> search_options) {
+        list<auto> id_list = getPointIds(where_cond, "delete");
+        string uri = buildWriteUri("/points/delete", search_options);
+        rest.post(uri, {"points": id_list});
+        return id_list.size();
+    }
+
+    #! Returns a bulk insert operation object for this data provider
+    /** @param block_size the number of records in a block
+
+        @return a bulk insert operation object for this data provider
+    */
+    DataProvider::AbstractDataProviderBulkOperation getBulkInserter(*int block_size) {
+        return new QdrantCollectionBulkOperation(self, rest, collection_name, block_size);
+    }
+
+    #! Returns a bulk upsert operation object for this data provider
+    /** @param block_size the number of records in a block
+
+        @return a bulk upsert operation object for this data provider
+
+        @note In Qdrant, the upsert endpoint has insert-or-replace semantics, so both bulk insert
+        and bulk upsert use the same operation
+    */
+    DataProvider::AbstractDataProviderBulkOperation getBulkUpserter(*int block_size) {
+        return new QdrantCollectionBulkOperation(self, rest, collection_name, block_size);
+    }
+
+    #! Returns the record type
+    private *hash<string, DataProvider::AbstractDataField> getRecordTypeImpl(*hash<auto> search_options) {
+        return RecordType.getFields();
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+
+    #! Extracts and validates point ID(s) from where_cond
+    /** @param where_cond the where condition; must contain `id`
+        @param operation the operation name for error messages
+
+        @return a list of point IDs
+    */
+    private list<auto> getPointIds(*hash<auto> where_cond, string operation) {
+        if (!where_cond || !exists where_cond.id) {
+            throw "QDRANT-" + operation.upr() + "-ERROR", sprintf("missing 'id' field in where_cond to identify "
+                "point(s) to %s in collection %y", operation, collection_name);
+        }
+        if (where_cond.size() > 1) {
+            throw "QDRANT-" + operation.upr() + "-ERROR", sprintf("only 'id' field is supported in where_cond "
+                "for %s in collection %y; got fields: %y", operation, collection_name, keys where_cond);
+        }
+        return where_cond.id.typeCode() == NT_LIST ? where_cond.id : (where_cond.id,);
+    }
+
+    #! Builds a collection URI with write query parameters (wait, ordering)
+    /** @param suffix the path suffix after the collection path
+        @param options the options hash (create_options, upsert_options, or search_options)
+
+        @return the complete URI path with query parameters
+    */
+    private string buildWriteUri(string suffix, *hash<auto> options) {
+        string uri = collectionPath(collection_name, suffix);
+        list<string> params;
+        if (exists options.wait) {
+            push params, "wait=" + QdrantDataProviderBase::formatQueryValue(boolean(options.wait));
+        }
+        if (options.ordering) {
+            push params, "ordering=" + options.ordering;
+        }
+        if (params) {
+            uri += "?" + params.join("&");
+        }
+        return uri;
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantCollectionsCreateDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantCollectionsCreateDataProvider.qc
@@ -1,0 +1,260 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantCollectionsCreateDataProvider class definition
+
+/** QdrantCollectionsCreateDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant collection create API data provider
+/** This API creates a new collection in the Qdrant instance
+
+    @note Corresponds to: PUT /collections/{name}
+*/
+public class QdrantCollectionsCreateDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "create",
+            "desc": "Qdrant collection create data provider (`PUT /collections/{name}`)",
+            "type": "QdrantCollectionsCreateDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantCollectionsCreateRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantCollectionsCreateResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("timeout",);
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant collections %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string uri_path = collectionPath(collection);
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantPut(uri_path, req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant collection create request data type
+public class QdrantCollectionsCreateRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name to create",
+                "desc": "The name of the collection to create",
+                "example_value": "my_collection",
+            },
+            "vectors": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Vectors",
+                "short_desc": "Vector configuration",
+                "desc": "Vector configuration for the collection, including vector size, distance metric, and other "
+                    "parameters (e.g. `size`, `distance`)",
+                "example_value": {"size": 128, "distance": "Cosine"},
+            },
+            "sparse_vectors": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Sparse Vectors",
+                "short_desc": "Sparse vector configuration",
+                "desc": "Sparse vector configuration for the collection",
+            },
+            "shard_number": {
+                "type": IntOrNothingType,
+                "display_name": "Shard Number",
+                "short_desc": "Number of shards",
+                "desc": "The number of shards for the collection. A higher number of shards can improve "
+                    "performance for large collections",
+                "example_value": 1,
+            },
+            "sharding_method": {
+                "type": StringOrNothingType,
+                "display_name": "Sharding Method",
+                "short_desc": "Sharding method",
+                "desc": "The sharding method to use for the collection",
+                "example_value": "auto",
+                "allowed_values": (
+                    <AllowedValueInfo>{"value": "auto", "desc": "Automatic sharding managed by Qdrant"},
+                    <AllowedValueInfo>{"value": "custom", "desc": "Custom sharding with user-defined shard keys"},
+                ),
+            },
+            "replication_factor": {
+                "type": IntOrNothingType,
+                "display_name": "Replication Factor",
+                "short_desc": "Replication factor",
+                "desc": "The number of replicas for each shard in the collection",
+                "example_value": 1,
+            },
+            "write_consistency_factor": {
+                "type": IntOrNothingType,
+                "display_name": "Write Consistency Factor",
+                "short_desc": "Write consistency factor",
+                "desc": "The minimum number of replicas that must acknowledge a write operation before it is "
+                    "considered successful",
+                "example_value": 1,
+            },
+            "on_disk_payload": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "On Disk Payload",
+                "short_desc": "Store payload on disk",
+                "desc": "If `true`, the payload will be stored on disk rather than in memory. This can reduce "
+                    "memory usage for large payloads",
+                "example_value": False,
+            },
+            "hnsw_config": {
+                "type": AutoHashOrNothingType,
+                "display_name": "HNSW Config",
+                "short_desc": "HNSW index configuration",
+                "desc": "Configuration for the HNSW (Hierarchical Navigable Small World) index algorithm",
+            },
+            "wal_config": {
+                "type": AutoHashOrNothingType,
+                "display_name": "WAL Config",
+                "short_desc": "WAL configuration",
+                "desc": "Configuration for the Write-Ahead Log (WAL)",
+            },
+            "optimizers_config": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Optimizers Config",
+                "short_desc": "Optimizer settings",
+                "desc": "Configuration for the collection optimizers, controlling indexing and merging behavior",
+            },
+            "init_from": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Init From",
+                "short_desc": "Initialize from another collection",
+                "desc": "Initialize the collection from another existing collection by specifying the source "
+                    "collection name",
+                "example_value": {"collection": "source_collection"},
+            },
+            "quantization_config": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Quantization Config",
+                "short_desc": "Quantization settings",
+                "desc": "Configuration for vector quantization to reduce memory usage and improve search speed",
+            },
+            "timeout": {
+                "type": IntOrNothingType,
+                "display_name": "Timeout",
+                "short_desc": "Operation timeout in seconds",
+                "desc": "Wait for operation commit timeout in seconds. If the timeout is reached, the request "
+                    "will return with a service error",
+                "example_value": 30,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant collection create response data type
+public class QdrantCollectionsCreateResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "result": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Result",
+                "short_desc": "Operation result",
+                "desc": "Returns `true` if the collection was created successfully",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantCollectionsCreateIndexDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantCollectionsCreateIndexDataProvider.qc
@@ -1,0 +1,215 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantCollectionsCreateIndexDataProvider class definition
+
+/** QdrantCollectionsCreateIndexDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant collection create index API data provider
+/** This API creates a payload field index for a collection
+
+    @note Corresponds to: PUT /collections/{name}/index
+*/
+public class QdrantCollectionsCreateIndexDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "create-index",
+            "desc": "Qdrant collection create index data provider (`PUT /collections/{name}/index`)",
+            "type": "QdrantCollectionsCreateIndexDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantCollectionsCreateIndexRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantCollectionsCreateIndexResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("wait", "ordering");
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant collections %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string uri_path = collectionPath(collection, "/index");
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantPut(uri_path, req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant collection create index request data type
+public class QdrantCollectionsCreateIndexRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection to create the payload field index for",
+                "example_value": "my_collection",
+            },
+            "field_name": {
+                "type": StringType,
+                "display_name": "Field Name",
+                "short_desc": "Payload field name to index",
+                "desc": "The name of the payload field to create an index for",
+                "example_value": "city",
+            },
+            "field_schema": {
+                "type": StringOrNothingType,
+                "display_name": "Field Schema",
+                "short_desc": "Field index schema type",
+                "desc": "The type name for the field index",
+                "example_value": "keyword",
+                "allowed_values": (
+                    <AllowedValueInfo>{"value": "keyword", "desc": "Keyword index for exact match filtering"},
+                    <AllowedValueInfo>{"value": "integer", "desc": "Integer index for range filtering"},
+                    <AllowedValueInfo>{"value": "float", "desc": "Float index for range filtering"},
+                    <AllowedValueInfo>{"value": "geo", "desc": "Geo index for geographic filtering"},
+                    <AllowedValueInfo>{"value": "text", "desc": "Full-text index for text search"},
+                    <AllowedValueInfo>{"value": "bool", "desc": "Boolean index for boolean filtering"},
+                    <AllowedValueInfo>{"value": "datetime", "desc": "Datetime index for date range filtering"},
+                    <AllowedValueInfo>{"value": "uuid", "desc": "UUID index for UUID filtering"},
+                ),
+            },
+            "wait": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Wait",
+                "short_desc": "Wait for operation completion",
+                "desc": "If `true`, the request will wait for the operation to complete before returning. "
+                    "Default is `false`",
+                "example_value": True,
+            },
+            "ordering": {
+                "type": StringOrNothingType,
+                "display_name": "Ordering",
+                "short_desc": "Write ordering guarantees",
+                "desc": "The write ordering guarantees for the operation",
+                "example_value": "weak",
+                "allowed_values": (
+                    <AllowedValueInfo>{"value": "weak", "desc": "Weak ordering; fastest, no guarantees"},
+                    <AllowedValueInfo>{"value": "medium", "desc": "Medium ordering; wait for local persistence"},
+                    <AllowedValueInfo>{"value": "strong", "desc": "Strong ordering; wait for all replicas"},
+                ),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant collection create index response data type
+public class QdrantCollectionsCreateIndexResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "operation_id": {
+                "type": IntOrNothingType,
+                "display_name": "Operation ID",
+                "short_desc": "Operation identifier",
+                "desc": "The identifier of the index creation operation",
+                "example_value": 0,
+            },
+            "status": {
+                "type": StringOrNothingType,
+                "display_name": "Status",
+                "short_desc": "Operation status",
+                "desc": "The status of the index creation operation (e.g. `acknowledged`, `completed`)",
+                "example_value": "completed",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantCollectionsDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantCollectionsDataProvider.qc
@@ -1,0 +1,111 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantCollectionsDataProvider class definition
+
+/** QdrantCollectionsDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant collections API data provider
+/** This data provider provides children that are API data providers for Qdrant collection management
+*/
+public class QdrantCollectionsDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "collections",
+            "desc": "Qdrant collections data provider; provides access to collection management operations",
+            "type": "QdrantCollectionsDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_children": True,
+            "children_can_support_apis": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+    }
+
+    private {
+        const ChildMap = {
+            "list": Class::forName("QdrantDataProvider::QdrantCollectionsListDataProvider"),
+            "create": Class::forName("QdrantDataProvider::QdrantCollectionsCreateDataProvider"),
+            "get": Class::forName("QdrantDataProvider::QdrantCollectionsGetDataProvider"),
+            "update": Class::forName("QdrantDataProvider::QdrantCollectionsUpdateDataProvider"),
+            "delete": Class::forName("QdrantDataProvider::QdrantCollectionsDeleteDataProvider"),
+            "exists": Class::forName("QdrantDataProvider::QdrantCollectionsExistsDataProvider"),
+            "create-index": Class::forName("QdrantDataProvider::QdrantCollectionsCreateIndexDataProvider"),
+            "delete-index": Class::forName("QdrantDataProvider::QdrantCollectionsDeleteIndexDataProvider"),
+        };
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant %s data provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Return data provider summary info
+    *list<hash<DataProvider::DataProviderSummaryInfo>> getChildProviderSummaryInfo() {
+        return map $1.getConstant("ProviderSummaryInfo").getValue(), ChildMap.iterator();
+    }
+
+    #! Returns a list of child data provider names, if any
+    /** @return a list of child data provider names, if any
+    */
+    private *list<string> getChildProviderNamesImpl() {
+        return keys ChildMap;
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    /** @return the given child provider or @ref nothing if the given child is unknown
+
+        @see getChildProviderEx()
+    */
+    private *DataProvider::AbstractDataProvider getChildProviderImpl(string name) {
+        *Class cls = ChildMap{name};
+        if (!cls) {
+            return;
+        }
+        return cls.newObject(rest);
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantCollectionsDeleteDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantCollectionsDeleteDataProvider.qc
@@ -1,0 +1,172 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantCollectionsDeleteDataProvider class definition
+
+/** QdrantCollectionsDeleteDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant collection delete API data provider
+/** This API deletes a collection from the Qdrant instance
+
+    @note Corresponds to: DELETE /collections/{name}
+*/
+public class QdrantCollectionsDeleteDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "delete",
+            "desc": "Qdrant collection delete data provider (`DELETE /collections/{name}`)",
+            "type": "QdrantCollectionsDeleteDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantCollectionsDeleteRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantCollectionsDeleteResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("timeout",);
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant collections %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string uri_path = collectionPath(collection);
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantDelete(uri_path);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant collection delete request data type
+public class QdrantCollectionsDeleteRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name to delete",
+                "desc": "The name of the collection to delete",
+                "example_value": "my_collection",
+            },
+            "timeout": {
+                "type": IntOrNothingType,
+                "display_name": "Timeout",
+                "short_desc": "Operation timeout in seconds",
+                "desc": "Wait for operation commit timeout in seconds. If the timeout is reached, the request "
+                    "will return with a service error",
+                "example_value": 30,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant collection delete response data type
+public class QdrantCollectionsDeleteResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "result": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Result",
+                "short_desc": "Operation result",
+                "desc": "Returns `true` if the collection was deleted successfully",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantCollectionsDeleteIndexDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantCollectionsDeleteIndexDataProvider.qc
@@ -1,0 +1,200 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantCollectionsDeleteIndexDataProvider class definition
+
+/** QdrantCollectionsDeleteIndexDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant collection delete index API data provider
+/** This API deletes a payload field index from a collection
+
+    @note Corresponds to: DELETE /collections/{name}/index/{field}
+*/
+public class QdrantCollectionsDeleteIndexDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "delete-index",
+            "desc": "Qdrant collection delete index data provider "
+                "(`DELETE /collections/{name}/index/{field}`)",
+            "type": "QdrantCollectionsDeleteIndexDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantCollectionsDeleteIndexRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantCollectionsDeleteIndexResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("wait", "ordering");
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant collections %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string field_name = remove req.field_name;
+        string uri_path = collectionPath(collection, "/index/" + encode_url(field_name, True));
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantDelete(uri_path);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant collection delete index request data type
+public class QdrantCollectionsDeleteIndexRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection to delete the payload field index from",
+                "example_value": "my_collection",
+            },
+            "field_name": {
+                "type": StringType,
+                "display_name": "Field Name",
+                "short_desc": "Payload field name",
+                "desc": "The name of the payload field index to delete",
+                "example_value": "city",
+            },
+            "wait": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Wait",
+                "short_desc": "Wait for operation completion",
+                "desc": "If `true`, the request will wait for the operation to complete before returning. "
+                    "Default is `false`",
+                "example_value": True,
+            },
+            "ordering": {
+                "type": StringOrNothingType,
+                "display_name": "Ordering",
+                "short_desc": "Write ordering guarantees",
+                "desc": "The write ordering guarantees for the operation",
+                "example_value": "weak",
+                "allowed_values": (
+                    <AllowedValueInfo>{"value": "weak", "desc": "Weak ordering; fastest, no guarantees"},
+                    <AllowedValueInfo>{"value": "medium", "desc": "Medium ordering; wait for local persistence"},
+                    <AllowedValueInfo>{"value": "strong", "desc": "Strong ordering; wait for all replicas"},
+                ),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant collection delete index response data type
+public class QdrantCollectionsDeleteIndexResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "operation_id": {
+                "type": IntOrNothingType,
+                "display_name": "Operation ID",
+                "short_desc": "Operation identifier",
+                "desc": "The identifier of the index deletion operation",
+                "example_value": 0,
+            },
+            "status": {
+                "type": StringOrNothingType,
+                "display_name": "Status",
+                "short_desc": "Operation status",
+                "desc": "The status of the index deletion operation (e.g. `acknowledged`, `completed`)",
+                "example_value": "completed",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantCollectionsExistsDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantCollectionsExistsDataProvider.qc
@@ -1,0 +1,146 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantCollectionsExistsDataProvider class definition
+
+/** QdrantCollectionsExistsDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant collection exists API data provider
+/** This API checks if a collection exists in the Qdrant instance
+
+    @note Corresponds to: GET /collections/{name}/exists
+*/
+public class QdrantCollectionsExistsDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "exists",
+            "desc": "Qdrant collection exists data provider (`GET /collections/{name}/exists`)",
+            "type": "QdrantCollectionsExistsDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantCollectionsExistsRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantCollectionsExistsResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant collections %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return doQdrantGet(collectionPath(remove req.collection, "/exists"));
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant collection exists request data type
+public class QdrantCollectionsExistsRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name to check",
+                "desc": "The name of the collection to check for existence",
+                "example_value": "my_collection",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant collection exists response data type
+public class QdrantCollectionsExistsResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "exists": {
+                "type": SoftBoolType,
+                "display_name": "Exists",
+                "short_desc": "Whether the collection exists",
+                "desc": "Returns `true` if the collection exists, `false` otherwise",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantCollectionsGetDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantCollectionsGetDataProvider.qc
@@ -1,0 +1,195 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantCollectionsGetDataProvider class definition
+
+/** QdrantCollectionsGetDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant collection get API data provider
+/** This API retrieves information about a specific collection
+
+    @note Corresponds to: GET /collections/{name}
+*/
+public class QdrantCollectionsGetDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "get",
+            "desc": "Qdrant collection get data provider (`GET /collections/{name}`)",
+            "type": "QdrantCollectionsGetDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantCollectionsGetRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantCollectionsGetResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant collections %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return doQdrantGet(collectionPath(remove req.collection));
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant collection get request data type
+public class QdrantCollectionsGetRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection to retrieve information for",
+                "example_value": "my_collection",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant collection get response data type
+public class QdrantCollectionsGetResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "status": {
+                "type": StringOrNothingType,
+                "display_name": "Status",
+                "short_desc": "Collection status",
+                "desc": "The current status of the collection (e.g. `green`, `yellow`, `red`)",
+                "example_value": "green",
+            },
+            "optimizer_status": {
+                "type": StringOrNothingType,
+                "display_name": "Optimizer Status",
+                "short_desc": "Optimizer status",
+                "desc": "The current status of the collection optimizer; returns `ok` when the optimizer is "
+                    "idle, or a status string when the optimizer is running",
+                "example_value": "ok",
+            },
+            "vectors_count": {
+                "type": IntOrNothingType,
+                "display_name": "Vectors Count",
+                "short_desc": "Total number of vectors",
+                "desc": "The approximate total number of vectors in the collection",
+                "example_value": 1000,
+            },
+            "indexed_vectors_count": {
+                "type": IntOrNothingType,
+                "display_name": "Indexed Vectors Count",
+                "short_desc": "Number of indexed vectors",
+                "desc": "The approximate number of indexed vectors in the collection",
+                "example_value": 1000,
+            },
+            "points_count": {
+                "type": IntOrNothingType,
+                "display_name": "Points Count",
+                "short_desc": "Total number of points",
+                "desc": "The approximate total number of points in the collection",
+                "example_value": 1000,
+            },
+            "segments_count": {
+                "type": IntOrNothingType,
+                "display_name": "Segments Count",
+                "short_desc": "Number of segments",
+                "desc": "The number of segments in the collection",
+                "example_value": 2,
+            },
+            "config": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Config",
+                "short_desc": "Collection configuration",
+                "desc": "The collection configuration including vector parameters, HNSW, WAL, and optimizer settings",
+            },
+            "payload_schema": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Payload Schema",
+                "short_desc": "Payload schema",
+                "desc": "The payload field schema with field types and index information",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+        setDefaultOtherFieldType(AbstractDataProviderTypeMap."auto");
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantCollectionsListDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantCollectionsListDataProvider.qc
@@ -1,0 +1,125 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantCollectionsListDataProvider class definition
+
+/** QdrantCollectionsListDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant collections list API data provider
+/** This API lists all collections in the Qdrant instance
+
+    @note Corresponds to: GET /collections
+*/
+public class QdrantCollectionsListDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "list",
+            "desc": "Qdrant collections list data provider (`GET /collections`)",
+            "type": "QdrantCollectionsListDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = AbstractDataProviderTypeMap."nothing";
+
+        #! Response type
+        const ResponseType = new QdrantCollectionsListResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant collections %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request (ignored)
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return doQdrantGet("/collections");
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant collections list response data type
+public class QdrantCollectionsListResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collections": {
+                "type": AutoListOrNothingType,
+                "display_name": "Collections",
+                "short_desc": "List of collection descriptions",
+                "desc": "A list of collection description objects with collection names and metadata",
+                "example_value": ({"name": "my_collection"},),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantCollectionsUpdateDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantCollectionsUpdateDataProvider.qc
@@ -1,0 +1,199 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantCollectionsUpdateDataProvider class definition
+
+/** QdrantCollectionsUpdateDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant collection update API data provider
+/** This API updates parameters of an existing collection
+
+    @note Corresponds to: PATCH /collections/{name}
+*/
+public class QdrantCollectionsUpdateDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "update",
+            "desc": "Qdrant collection update data provider (`PATCH /collections/{name}`)",
+            "type": "QdrantCollectionsUpdateDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantCollectionsUpdateRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantCollectionsUpdateResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("timeout",);
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant collections %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string uri_path = collectionPath(collection);
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantPatch(uri_path, req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant collection update request data type
+public class QdrantCollectionsUpdateRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name to update",
+                "desc": "The name of the collection to update",
+                "example_value": "my_collection",
+            },
+            "optimizers_config": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Optimizers Config",
+                "short_desc": "Optimizer settings",
+                "desc": "Updated configuration for the collection optimizers, controlling indexing and merging "
+                    "behavior",
+            },
+            "hnsw_config": {
+                "type": AutoHashOrNothingType,
+                "display_name": "HNSW Config",
+                "short_desc": "HNSW index configuration",
+                "desc": "Updated configuration for the HNSW (Hierarchical Navigable Small World) index algorithm",
+            },
+            "quantization_config": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Quantization Config",
+                "short_desc": "Quantization settings",
+                "desc": "Updated configuration for vector quantization to reduce memory usage and improve "
+                    "search speed",
+            },
+            "params": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Params",
+                "short_desc": "Collection parameters",
+                "desc": "Additional collection parameters to update (e.g. replication factor, write consistency "
+                    "factor)",
+            },
+            "timeout": {
+                "type": IntOrNothingType,
+                "display_name": "Timeout",
+                "short_desc": "Operation timeout in seconds",
+                "desc": "Wait for operation commit timeout in seconds. If the timeout is reached, the request "
+                    "will return with a service error",
+                "example_value": 30,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant collection update response data type
+public class QdrantCollectionsUpdateResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "result": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Result",
+                "short_desc": "Operation result",
+                "desc": "Returns `true` if the collection was updated successfully",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantDataProvider.qc
@@ -1,0 +1,170 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantDataProvider class definition
+
+/** QdrantDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! Qdrant app name
+const AppName = "Qdrant";
+
+#! The Qdrant data provider class
+public class QdrantDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "type": "QdrantDataProvider",
+            "supports_read": False,
+            "supports_create": False,
+            "supports_update": False,
+            "supports_upsert": False,
+            "supports_delete": False,
+            "supports_native_search": False,
+            "supports_bulk_create": False,
+            "supports_bulk_upsert": False,
+            "supports_children": True,
+            "constructor_options": ConstructorOptions,
+            "search_options": NOTHING,
+            "create_options": NOTHING,
+            "upsert_options": NOTHING,
+            "transaction_management": False,
+            "supports_schema": False,
+            "children_can_support_apis": True,
+            "children_can_support_records": True,
+            "children_can_support_observers": False,
+        };
+
+        #! Constructor options
+        const ConstructorOptions = {
+            "restclient": <DataProviderOptionInfo>{
+                "display_name": "REST Client",
+                "short_desc": "The REST client for accessing the Qdrant server",
+                "type": AbstractDataProviderType::get(new Type("RestClient")),
+                "desc": "The REST client for accessing the Qdrant server",
+            },
+            "url": <DataProviderOptionInfo>{
+                "display_name": "URL",
+                "short_desc": "The URL to the Qdrant server",
+                "type": AbstractDataProviderTypeMap."string",
+                "desc": "The URL to the Qdrant REST server; overrides any URL in any RestClient object passed "
+                    "as an option",
+            },
+            "restclient_options": <DataProviderOptionInfo>{
+                "display_name": "REST Client Options",
+                "short_desc": "Options to any REST client created",
+                "type": AbstractDataProviderTypeMap."*hash",
+                "desc": "Options to the `RestClient` constructor; only used if a `RestClient` object is created for "
+                    "a call to the Qdrant server",
+            },
+        };
+    }
+
+    private {
+        const ChildMap = {
+            "collections": Class::forName("QdrantDataProvider::QdrantCollectionsDataProvider"),
+            "aliases": Class::forName("QdrantDataProvider::QdrantAliasesDataProvider"),
+            "points": Class::forName("QdrantDataProvider::QdrantPointsDataProvider"),
+            "search": Class::forName("QdrantDataProvider::QdrantSearchDataProvider"),
+            "snapshots": Class::forName("QdrantDataProvider::QdrantSnapshotsDataProvider"),
+            "cluster": Class::forName("QdrantDataProvider::QdrantClusterDataProvider"),
+            "service": Class::forName("QdrantDataProvider::QdrantServiceDataProvider"),
+            "tables": Class::forName("QdrantDataProvider::QdrantTablesDataProvider"),
+        };
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        *hash<auto> copts = checkOptions("CONSTRUCTOR-ERROR", ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(copts);
+    }
+
+    #! Accepts a LoggerInterface object for logging (or clears it)
+    setLogger(*LoggerInterface logger) {
+        rest.setLogger(logger);
+        LoggerWrapper::setLogger(logger);
+    }
+
+    #! Returns a REST connection from the given options
+    static RestClient::RestClient getRestConnection(*hash<auto> options) {
+        RestClient rest;
+        if (options.restclient) {
+            rest = options.restclient;
+            if (options.url) {
+                rest.setURL(options.url);
+            }
+        } else {
+            if (!options.url && !options.restclient_options) {
+                throw "CONSTRUCTOR-ERROR", "no 'restclient', 'url', or 'restclient_options' option passed; "
+                    "cannot create REST client to Qdrant instance without a URL";
+            }
+
+            hash<auto> opts;
+            opts += options.restclient_options;
+            if (options.url) {
+                opts.url = options.url;
+            }
+            rest = new RestClient(opts);
+        }
+        return rest;
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return "qdrant";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant data provider for `%s`", rest.getSafeURL());
+    }
+
+    #! Return data provider summary info
+    *list<hash<DataProvider::DataProviderSummaryInfo>> getChildProviderSummaryInfo() {
+        return map $1.getConstant("ProviderSummaryInfo").getValue(), ChildMap.iterator();
+    }
+
+    #! Returns a list of child data provider names, if any
+    /** @return a list of child data provider names, if any
+    */
+    private *list<string> getChildProviderNamesImpl() {
+        return keys ChildMap;
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    /** @return the given child provider or @ref nothing if the given child is unknown
+
+        @see getChildProviderEx()
+    */
+    private *DataProvider::AbstractDataProvider getChildProviderImpl(string name) {
+        *Class cls = ChildMap{name};
+        if (!cls) {
+            return;
+        }
+        return cls.newObject(rest);
+    }
+
+    #! Returns data provider static info
+    private hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantDataProvider.qm
+++ b/qlib/QdrantDataProvider/QdrantDataProvider.qm
@@ -1,0 +1,394 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantDataProvider module definition
+
+/*  QdrantDataProvider.qm Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+# minimum required Qore version
+%requires qore >= 2.0
+# assume local scope for variables, do not use "$" signs
+%modern
+
+%requires(reexport) ConnectionProvider
+%requires(reexport) DataProvider
+%requires(reexport) RestClient
+
+module QdrantDataProvider {
+    version = "1.0";
+    desc = "user module providing a data provider API for Qdrant vector database instances";
+    author = "David Nichols <david@qore.org>";
+    url = "http://qore.org";
+    license = "MIT";
+    init = sub () {
+        # register the connection schemes
+        ConnectionSchemeCache::registerScheme("qdrantrest", QdrantRestConnection::ConnectionScheme);
+        ConnectionSchemeCache::registerScheme("qdrantrests", QdrantRestConnection::ConnectionScheme);
+
+        # register the data provider factory
+        DataProvider::registerFactory(new QdrantDataProviderFactory());
+
+        # register the data provider application
+        DataProviderActionCatalog::registerApp(<DataProviderAppInfo>{
+            "name": QdrantDataProvider::AppName,
+            "display_name": "Qdrant Vector Database",
+            "short_desc": "Qdrant vector database for similarity search and RAG",
+            "desc": "Qdrant vector database providing similarity search, hybrid search, "
+                "and vector CRUD operations for AI/ML and RAG pipelines",
+            "scheme": "qdrantrest",
+            "logo": QdrantLogo,
+            "logo_file_name": "qdrant-logo.svg",
+            "logo_mime_type": MimeTypeSvg,
+            "groups": (DataProvider::AppGroup::Databases, DataProvider::AppGroup::AiLlm,),
+        });
+
+        # register all supported actions
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/search/query",
+            "action": "query-points",
+            "display_name": "Query Points",
+            "short_desc": "Query points using vector similarity search",
+            "desc": "Perform vector similarity search, filtering, and hybrid search on a Qdrant collection",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/points/upsert",
+            "action": "upsert-points",
+            "display_name": "Upsert Points",
+            "short_desc": "Insert or update points in a collection",
+            "desc": "Insert or update points with vectors and optional payloads in a Qdrant collection",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/collections/create",
+            "action": "create-collection",
+            "display_name": "Create Collection",
+            "short_desc": "Create a new Qdrant collection",
+            "desc": "Create a new vector collection with configurable vector parameters and distance metrics",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/collections/list",
+            "action": "list-collections",
+            "display_name": "List Collections",
+            "short_desc": "List all Qdrant collections",
+            "desc": "Retrieve a list of all collections in the Qdrant instance",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/points/count",
+            "action": "count-points",
+            "display_name": "Count Points",
+            "short_desc": "Count points in a collection",
+            "desc": "Count the number of points in a Qdrant collection, optionally with a filter",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/service/health",
+            "action": "health-check",
+            "display_name": "Health Check",
+            "short_desc": "Check Qdrant server health",
+            "desc": "Check the health status of the Qdrant server",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/points/delete",
+            "action": "delete-points",
+            "display_name": "Delete Points",
+            "short_desc": "Delete points from a collection",
+            "desc": "Delete points from a Qdrant collection by point IDs or by filter conditions",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/points/get",
+            "action": "get-points",
+            "display_name": "Get Points",
+            "short_desc": "Get specific points by ID",
+            "desc": "Retrieve specific points from a Qdrant collection by their IDs, including vectors "
+                "and payloads",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/points/scroll",
+            "action": "scroll-points",
+            "display_name": "Scroll Points",
+            "short_desc": "Scroll through points in a collection",
+            "desc": "Iterate through all points in a Qdrant collection using scroll-based pagination "
+                "with optional filtering",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/collections/get",
+            "action": "get-collection",
+            "display_name": "Get Collection",
+            "short_desc": "Get collection info",
+            "desc": "Retrieve detailed information about a specific Qdrant collection, including its "
+                "configuration and status",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/collections/delete",
+            "action": "delete-collection",
+            "display_name": "Delete Collection",
+            "short_desc": "Delete a Qdrant collection",
+            "desc": "Delete a collection and all its data from the Qdrant instance",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/collections/exists",
+            "action": "collection-exists",
+            "display_name": "Collection Exists",
+            "short_desc": "Check if a collection exists",
+            "desc": "Check whether a specific collection exists in the Qdrant instance",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/search/query-batch",
+            "action": "query-batch-points",
+            "display_name": "Query Batch Points",
+            "short_desc": "Perform batch vector similarity searches",
+            "desc": "Execute multiple vector similarity search queries in a single batch request "
+                "against a Qdrant collection",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/search/query-groups",
+            "action": "query-groups-points",
+            "display_name": "Query Grouped Points",
+            "short_desc": "Perform grouped vector similarity search",
+            "desc": "Execute a vector similarity search on a Qdrant collection with results grouped "
+                "by a specified payload field",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/aliases/list-all",
+            "action": "list-all-aliases",
+            "display_name": "List All Aliases",
+            "short_desc": "List all collection aliases",
+            "desc": "Retrieve a list of all aliases and their associated collections in the Qdrant "
+                "instance",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/aliases/update",
+            "action": "update-aliases",
+            "display_name": "Update Aliases",
+            "short_desc": "Update collection aliases",
+            "desc": "Create, rename, or delete collection aliases in the Qdrant instance",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/points/set-payload",
+            "action": "set-payload",
+            "display_name": "Set Payload",
+            "short_desc": "Set payload on points",
+            "desc": "Set or update payload key-value pairs on points in a Qdrant collection by point "
+                "IDs or filter conditions",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/service/liveness",
+            "action": "liveness-check",
+            "display_name": "Liveness Check",
+            "short_desc": "Check Qdrant server liveness",
+            "desc": "Check if the Qdrant server is alive and responsive",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/points/batch-update",
+            "action": "batch-update-points",
+            "display_name": "Batch Update Points",
+            "short_desc": "Apply multiple point operations in a single batch",
+            "desc": "Execute a batch of heterogeneous point operations (upsert, delete, set/overwrite/"
+                "delete/clear payload, update/delete vectors) in a single request for high-performance "
+                "bulk updates",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/tables",
+            "action": "search-points",
+            "display_name": "Search Points",
+            "short_desc": "Search points with record streaming",
+            "desc": "Vector similarity search on a Qdrant collection returning results as a "
+                "record stream for efficient pipeline processing",
+            "action_code": DPAT_FIND,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": QdrantDataProvider::AppName,
+            "path": "/tables",
+            "action": "create-point",
+            "display_name": "Create/Upsert Point",
+            "short_desc": "Create or upsert a point in a collection",
+            "desc": "Create or upsert a point with a vector and optional payload in a Qdrant collection",
+            "action_code": DPAT_CREATE,
+        });
+    };
+}
+
+/** @mainpage QdrantDataProvider Module
+
+    @tableofcontents
+
+    @section qdrantdataproviderintro Introduction to the QdrantDataProvider Module
+
+    @htmlonly
+    <div class="image">
+      <img src="qdrant-logo.svg" alt="Qdrant Logo" style="width:40%;">
+    </div>
+    @endhtmlonly
+
+    The %QdrantDataProvider module provides a \c dataproviderintro "data provider" API for Qdrant vector database
+    instances.  It provides a comprehensive API for collection management, point operations (vector CRUD), similarity
+    search, and cluster administration.
+
+    This data provider provides Qdrant API access to:
+    - collections: <b><tt>collections/{@ref QdrantDataProvider::QdrantCollectionsListDataProvider "list",
+      @ref QdrantDataProvider::QdrantCollectionsCreateDataProvider "create",
+      @ref QdrantDataProvider::QdrantCollectionsGetDataProvider "get",
+      @ref QdrantDataProvider::QdrantCollectionsUpdateDataProvider "update",
+      @ref QdrantDataProvider::QdrantCollectionsDeleteDataProvider "delete",
+      @ref QdrantDataProvider::QdrantCollectionsExistsDataProvider "exists",
+      @ref QdrantDataProvider::QdrantCollectionsCreateIndexDataProvider "create-index",
+      @ref QdrantDataProvider::QdrantCollectionsDeleteIndexDataProvider "delete-index"}</tt></b>
+    - points: <b><tt>points/{@ref QdrantDataProvider::QdrantPointsUpsertDataProvider "upsert",
+      @ref QdrantDataProvider::QdrantPointsGetDataProvider "get",
+      @ref QdrantDataProvider::QdrantPointsDeleteDataProvider "delete",
+      @ref QdrantDataProvider::QdrantPointsScrollDataProvider "scroll",
+      @ref QdrantDataProvider::QdrantPointsCountDataProvider "count",
+      @ref QdrantDataProvider::QdrantPointsSetPayloadDataProvider "set-payload",
+      @ref QdrantDataProvider::QdrantPointsOverwritePayloadDataProvider "overwrite-payload",
+      @ref QdrantDataProvider::QdrantPointsDeletePayloadDataProvider "delete-payload",
+      @ref QdrantDataProvider::QdrantPointsClearPayloadDataProvider "clear-payload"}</tt></b>
+    - search: <b><tt>search/{@ref QdrantDataProvider::QdrantSearchQueryDataProvider "query",
+      @ref QdrantDataProvider::QdrantSearchQueryBatchDataProvider "query-batch",
+      @ref QdrantDataProvider::QdrantSearchQueryGroupsDataProvider "query-groups"}</tt></b>
+    - aliases: <b><tt>aliases/{@ref QdrantDataProvider::QdrantAliasesListAllDataProvider "list-all",
+      @ref QdrantDataProvider::QdrantAliasesListCollectionDataProvider "list-collection",
+      @ref QdrantDataProvider::QdrantAliasesUpdateDataProvider "update"}</tt></b>
+    - snapshots: <b><tt>snapshots/{@ref QdrantDataProvider::QdrantSnapshotsListCollectionDataProvider "list-collection",
+      @ref QdrantDataProvider::QdrantSnapshotsCreateCollectionDataProvider "create-collection",
+      @ref QdrantDataProvider::QdrantSnapshotsDeleteCollectionDataProvider "delete-collection",
+      @ref QdrantDataProvider::QdrantSnapshotsRecoverDataProvider "recover",
+      @ref QdrantDataProvider::QdrantSnapshotsListStorageDataProvider "list-storage",
+      @ref QdrantDataProvider::QdrantSnapshotsCreateStorageDataProvider "create-storage",
+      @ref QdrantDataProvider::QdrantSnapshotsDeleteStorageDataProvider "delete-storage"}</tt></b>
+    - cluster: <b><tt>cluster/{@ref QdrantDataProvider::QdrantClusterInfoDataProvider "info",
+      @ref QdrantDataProvider::QdrantClusterRecoverDataProvider "recover",
+      @ref QdrantDataProvider::QdrantClusterRemovePeerDataProvider "remove-peer",
+      @ref QdrantDataProvider::QdrantClusterCollectionInfoDataProvider "collection-info",
+      @ref QdrantDataProvider::QdrantClusterUpdateCollectionDataProvider "update-collection",
+      @ref QdrantDataProvider::QdrantClusterCreateShardKeyDataProvider "create-shard-key",
+      @ref QdrantDataProvider::QdrantClusterDeleteShardKeyDataProvider "delete-shard-key"}</tt></b>
+    - service: <b><tt>service/{@ref QdrantDataProvider::QdrantServiceHealthDataProvider "health",
+      @ref QdrantDataProvider::QdrantServiceLivenessDataProvider "liveness",
+      @ref QdrantDataProvider::QdrantServiceReadinessDataProvider "readiness",
+      @ref QdrantDataProvider::QdrantServiceTelemetryDataProvider "telemetry",
+      @ref QdrantDataProvider::QdrantServiceMetricsDataProvider "metrics",
+      @ref QdrantDataProvider::QdrantServiceIssuesDataProvider "issues"}</tt></b>
+    - tables: <b><tt>tables/{collection-name}</tt></b> — record-based access to Qdrant collections providing
+      DPAT_FIND vector similarity search with record streaming (see
+      @ref QdrantDataProvider::QdrantCollectionTableDataProvider)
+
+    @section qdrantdataprovider_factory Qdrant Data Provider Factory
+
+    The name of the Qdrant data provider factory is <b><tt>qdrant</tt></b>.
+
+    @section qdrantdataprovider_examples Qdrant Data Provider Examples
+
+    These examples are with \c qdp, the command-line interface to the Data Provider API.
+
+    @par API Example: List All Collections
+    @verbatim qdp 'qdrant{url=http://localhost:6333}/collections/list'
+    @endverbatim
+
+    @par API Example: Create a Collection
+    @verbatim qdp 'qdrant{url=http://localhost:6333}/collections/create' \
+      collection=my-collection,'vectors={size=384,distance=Cosine}'
+    @endverbatim
+
+    @par API Example: Upsert Points
+    @verbatim qdp 'qdrant{url=http://localhost:6333}/points/upsert' \
+      collection=my-collection,'points=[{id=1,vector=[0.1,0.2,0.3],payload={text="hello"}}]'
+    @endverbatim
+
+    @par API Example: Query Points (Vector Search)
+    @verbatim qdp 'qdrant{url=http://localhost:6333}/search/query' \
+      collection=my-collection,'query=[0.1,0.2,0.3]',limit=10
+    @endverbatim
+
+    @par API Example: Delete a Collection
+    @verbatim qdp 'qdrant{url=http://localhost:6333}/collections/delete' collection=my-collection
+    @endverbatim
+
+    @par API Example: Health Check
+    @verbatim qdp 'qdrant{url=http://localhost:6333}/service/health'
+    @endverbatim
+
+    @section qdrantdataprovider_relnotes Release Notes
+
+    @subsection qdrantdataprovider_v1_0 QdrantDataProvider v1.0
+    - initial release of the module
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! Qdrant logo
+public const QdrantLogo = File::readTextFile(get_script_dir() + "/qdrant-logo.svg");
+}

--- a/qlib/QdrantDataProvider/QdrantDataProviderBase.qc
+++ b/qlib/QdrantDataProvider/QdrantDataProviderBase.qc
@@ -1,0 +1,89 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantDataProviderBase class definition
+
+/** QdrantDataProviderBase.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant data provider base class
+public class QdrantDataProviderBase inherits DataProvider::AbstractDataProvider {
+    private {
+        #! The REST client for Qdrant API access
+        RestClient rest;
+    }
+
+    #! Creates the object
+    constructor() {
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient rest) {
+        self.rest = rest;
+    }
+
+    #! Accepts a LoggerInterface object for logging (or clears it)
+    setLogger(*LoggerInterface logger) {
+        rest.setLogger(logger);
+        LoggerWrapper::setLogger(logger);
+    }
+
+    #! Makes a GET request to the Qdrant API and returns the result
+    private auto doQdrantGet(string path) {
+        return rest.get(path).body.result;
+    }
+
+    #! Makes a POST request to the Qdrant API and returns the result
+    private auto doQdrantPost(string path, *hash<auto> body) {
+        return rest.post(path, body).body.result;
+    }
+
+    #! Makes a PUT request to the Qdrant API and returns the result
+    private auto doQdrantPut(string path, *hash<auto> body) {
+        return rest.put(path, body).body.result;
+    }
+
+    #! Makes a PATCH request to the Qdrant API and returns the result
+    private auto doQdrantPatch(string path, *hash<auto> body) {
+        return rest.patch(path, body).body.result;
+    }
+
+    #! Makes a DELETE request to the Qdrant API and returns the result
+    private auto doQdrantDelete(string path, *hash<auto> body) {
+        return rest.del(path, body).body.result;
+    }
+
+    #! Returns a collection path with an optional suffix
+    private string collectionPath(string name, *string suffix) {
+        return sprintf("/collections/%s%s", encode_url(name, True), suffix ?? "");
+    }
+
+    #! Formats a query parameter value for use in a URL
+    /** Booleans are converted to "true"/"false" strings as required by the Qdrant API
+    */
+    static string formatQueryValue(auto val) {
+        if (val.typeCode() == NT_BOOLEAN) {
+            return val ? "true" : "false";
+        }
+        return string(val);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantDataProviderDefs.qc
+++ b/qlib/QdrantDataProvider/QdrantDataProviderDefs.qc
@@ -1,0 +1,105 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantDataProvider definitions
+
+/** QdrantDataProviderDefs.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+
+#! Qdrant filter expression definitions for use with DataProvider search expressions
+/** These expressions enable advanced search functionality with AND/OR/NOT operators
+    and comparison operators that work with the DataProvider expression interface.
+
+    They translate DataProvider expression trees into Qdrant filter JSON structures.
+*/
+public const QdrantExpressions = {
+    # Logical operators with nesting support
+    DP_OP_AND: {
+        "exp": AbstractDataProvider::GenericExpressions{DP_OP_AND},
+        "impl": hash<auto> sub (QdrantSearchRecordIterator iter, list<auto> args) {
+            return {"must": map iter.processExpressionArg($1), args};
+        },
+    },
+    DP_OP_OR: {
+        "exp": AbstractDataProvider::GenericExpressions{DP_OP_OR},
+        "impl": hash<auto> sub (QdrantSearchRecordIterator iter, list<auto> args) {
+            return {"should": map iter.processExpressionArg($1), args};
+        },
+    },
+    DP_SEARCH_OP_NOT: {
+        "exp": AbstractDataProvider::GenericExpressions{DP_SEARCH_OP_NOT},
+        "impl": hash<auto> sub (QdrantSearchRecordIterator iter, list<auto> args) {
+            return {"must_not": map iter.processExpressionArg($1), args};
+        },
+    },
+
+    # Comparison operators
+    DP_SEARCH_OP_EQ: {
+        "exp": AbstractDataProvider::GenericExpressions{DP_SEARCH_OP_EQ},
+        "impl": hash<auto> sub (string field, auto value) {
+            return {"key": field, "match": {"value": value}};
+        },
+    },
+    DP_SEARCH_OP_NE: {
+        "exp": AbstractDataProvider::GenericExpressions{DP_SEARCH_OP_NE},
+        "impl": hash<auto> sub (string field, auto value) {
+            return {"must_not": ({"key": field, "match": {"value": value}},)};
+        },
+    },
+    DP_SEARCH_OP_LT: {
+        "exp": AbstractDataProvider::GenericExpressions{DP_SEARCH_OP_LT},
+        "impl": hash<auto> sub (string field, auto value) {
+            return {"key": field, "range": {"lt": value}};
+        },
+    },
+    DP_SEARCH_OP_LE: {
+        "exp": AbstractDataProvider::GenericExpressions{DP_SEARCH_OP_LE},
+        "impl": hash<auto> sub (string field, auto value) {
+            return {"key": field, "range": {"lte": value}};
+        },
+    },
+    DP_SEARCH_OP_GT: {
+        "exp": AbstractDataProvider::GenericExpressions{DP_SEARCH_OP_GT},
+        "impl": hash<auto> sub (string field, auto value) {
+            return {"key": field, "range": {"gt": value}};
+        },
+    },
+    DP_SEARCH_OP_GE: {
+        "exp": AbstractDataProvider::GenericExpressions{DP_SEARCH_OP_GE},
+        "impl": hash<auto> sub (string field, auto value) {
+            return {"key": field, "range": {"gte": value}};
+        },
+    },
+    DP_SEARCH_OP_BETWEEN: {
+        "exp": AbstractDataProvider::GenericExpressions{DP_SEARCH_OP_BETWEEN},
+        "impl": hash<auto> sub (string field, auto lo, auto hi) {
+            return {"key": field, "range": {"gt": lo, "lt": hi}};
+        },
+    },
+    DP_SEARCH_OP_IN: {
+        "exp": AbstractDataProvider::GenericExpressions{DP_SEARCH_OP_IN},
+        "impl": hash<auto> sub (string field, softlist<auto> values) {
+            return {"key": field, "match": {"any": values}};
+        },
+    },
+};
+}

--- a/qlib/QdrantDataProvider/QdrantDataProviderFactory.qc
+++ b/qlib/QdrantDataProvider/QdrantDataProviderFactory.qc
@@ -1,0 +1,60 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantDataProviderFactory class definition
+
+/** QdrantDataProviderFactory.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant data provider factory: \c qdrant
+public class QdrantDataProviderFactory inherits DataProvider::AbstractDataProviderFactory {
+    private {
+        #! Data provider type info
+        static Class cls = new Class("QdrantDataProvider");
+
+        #! Factory info
+        const FactoryInfo = <DataProviderFactoryInfo>{
+            "name": "qdrant",
+            "desc": "Qdrant vector database API data provider factory",
+            "children_can_support_apis": True,
+        };
+    }
+
+    #! Returns static factory information without \a provider_info
+    /** @return static factory information without \a provider_info which is provided by \c getProviderInfo()
+    */
+    private hash<DataProvider::DataProviderFactoryInfo> getInfoImpl() {
+        return FactoryInfo;
+    }
+
+    #! Returns static provider information
+    /** @note the \c name and \c children attributes are not returned as they are dynamic attributes
+    */
+    private hash<DataProvider::DataProviderInfo> getProviderInfoImpl() {
+        return QdrantDataProvider::ProviderInfo;
+    }
+
+    #! Returns the class for the data provider object
+    private Qore::Reflection::Class getClassImpl() {
+        return cls;
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantPointsBatchUpdateDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantPointsBatchUpdateDataProvider.qc
@@ -1,0 +1,199 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantPointsBatchUpdateDataProvider class definition
+
+/** QdrantPointsBatchUpdateDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant points batch update API data provider
+/** This API applies multiple point operations in a single batch request
+
+    @note Corresponds to: POST /collections/{name}/points/batch
+*/
+public class QdrantPointsBatchUpdateDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "batch-update",
+            "desc": "Qdrant points batch update data provider "
+                "(`POST /collections/{name}/points/batch`)",
+            "type": "QdrantPointsBatchUpdateDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantPointsBatchUpdateRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantPointsBatchUpdateResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("wait", "ordering");
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant points %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string uri_path = collectionPath(collection, "/points/batch");
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantPost(uri_path, req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant points batch update request data type
+public class QdrantPointsBatchUpdateRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection to apply batch operations to",
+                "example_value": "my_collection",
+            },
+            "operations": {
+                "type": AutoListType,
+                "display_name": "Operations",
+                "short_desc": "List of batch operations",
+                "desc": "A list of point operations to apply in sequence; each operation is a hash with "
+                    "one key indicating the operation type (`upsert`, `delete`, `set_payload`, "
+                    "`overwrite_payload`, `delete_payload`, `clear_payload`, `update_vectors`, "
+                    "`delete_vectors`) and a hash value with the operation parameters",
+                "example_value": (
+                    {"upsert": {"points": ({"id": 1, "vector": (0.1, 0.2, 0.3),
+                        "payload": {"text": "hello"}},)}},
+                    {"set_payload": {"payload": {"tag": "updated"}, "points": (1,)}},
+                ),
+            },
+            "wait": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Wait",
+                "short_desc": "Wait for operation to complete",
+                "desc": "If `true`, wait for changes to actually happen; if `false` (default), the request "
+                    "returns immediately after acknowledging",
+                "example_value": True,
+            },
+            "ordering": {
+                "type": StringOrNothingType,
+                "display_name": "Ordering",
+                "short_desc": "Write ordering guarantees",
+                "desc": "The write ordering guarantees for the operation",
+                "example_value": "weak",
+                "allowed_values": (
+                    <AllowedValueInfo>{"value": "weak", "desc": "Weak ordering; fastest, no guarantees"},
+                    <AllowedValueInfo>{"value": "medium", "desc": "Medium ordering; wait for local persistence"},
+                    <AllowedValueInfo>{"value": "strong", "desc": "Strong ordering; wait for all replicas"},
+                ),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant points batch update response data type
+public class QdrantPointsBatchUpdateResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "results": {
+                "type": AutoListOrNothingType,
+                "display_name": "Results",
+                "short_desc": "List of operation results",
+                "desc": "A list of update result objects, one per operation in the batch",
+                "example_value": ({"operation_id": 0, "status": "completed"},),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantPointsClearPayloadDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantPointsClearPayloadDataProvider.qc
@@ -1,0 +1,207 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantPointsClearPayloadDataProvider class definition
+
+/** QdrantPointsClearPayloadDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant points clear payload API data provider
+/** This API clears all payload fields from points in a Qdrant collection
+
+    @note Corresponds to: POST /collections/{name}/points/payload/clear
+*/
+public class QdrantPointsClearPayloadDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "clear-payload",
+            "desc": "Qdrant points clear payload data provider "
+                "(`POST /collections/{name}/points/payload/clear`)",
+            "type": "QdrantPointsClearPayloadDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantPointsClearPayloadRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantPointsClearPayloadResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("wait", "ordering");
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant points %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string uri_path = collectionPath(collection, "/points/payload/clear");
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantPost(uri_path, req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant points clear payload request data type
+public class QdrantPointsClearPayloadRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection containing the points to clear payloads from",
+                "example_value": "my_collection",
+            },
+            "points": {
+                "type": AutoListOrNothingType,
+                "display_name": "Points",
+                "short_desc": "List of point IDs",
+                "desc": "A list of point IDs to clear all payload fields from; IDs can be integers or UUIDs",
+                "example_value": (1, 2, 3),
+            },
+            "filter": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Filter",
+                "short_desc": "Filter conditions",
+                "desc": "Filter conditions to select points for the payload clear operation; alternative to "
+                    "specifying point IDs directly",
+                "example_value": {"must": ({"key": "city", "match": {"value": "London"}},)},
+            },
+            "wait": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Wait",
+                "short_desc": "Wait for operation to complete",
+                "desc": "If `true`, wait for changes to actually happen; if `false` (default), the request "
+                    "returns immediately after acknowledging",
+                "example_value": True,
+            },
+            "ordering": {
+                "type": StringOrNothingType,
+                "display_name": "Ordering",
+                "short_desc": "Write ordering guarantees",
+                "desc": "The write ordering guarantees for the operation",
+                "example_value": "weak",
+                "allowed_values": (
+                    <AllowedValueInfo>{"value": "weak", "desc": "Weak ordering; fastest, no guarantees"},
+                    <AllowedValueInfo>{"value": "medium", "desc": "Medium ordering; wait for local persistence"},
+                    <AllowedValueInfo>{"value": "strong", "desc": "Strong ordering; wait for all replicas"},
+                ),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant points clear payload response data type
+public class QdrantPointsClearPayloadResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "operation_id": {
+                "type": IntOrNothingType,
+                "display_name": "Operation ID",
+                "short_desc": "The operation ID",
+                "desc": "The ID of the operation that was performed",
+                "example_value": 0,
+            },
+            "status": {
+                "type": StringType,
+                "display_name": "Status",
+                "short_desc": "Operation status",
+                "desc": "The status of the operation (e.g. `completed`, `acknowledged`)",
+                "example_value": "completed",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantPointsCountDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantPointsCountDataProvider.qc
@@ -1,0 +1,163 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantPointsCountDataProvider class definition
+
+/** QdrantPointsCountDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant points count API data provider
+/** This API counts points in a Qdrant collection
+
+    @note Corresponds to: POST /collections/{name}/points/count
+*/
+public class QdrantPointsCountDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "count",
+            "desc": "Qdrant points count data provider (`POST /collections/{name}/points/count`)",
+            "type": "QdrantPointsCountDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantPointsCountRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantPointsCountResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant points %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        return doQdrantPost(collectionPath(collection, "/points/count"), req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant points count request data type
+public class QdrantPointsCountRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection to count points in",
+                "example_value": "my_collection",
+            },
+            "filter": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Filter",
+                "short_desc": "Filter conditions",
+                "desc": "Filter conditions to count only matching points; if not provided, all points are "
+                    "counted",
+                "example_value": {"must": ({"key": "city", "match": {"value": "London"}},)},
+            },
+            "exact": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Exact",
+                "short_desc": "Exact count flag",
+                "desc": "If `true`, return an exact count; if `false` (default), return an approximate count "
+                    "which is faster",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant points count response data type
+public class QdrantPointsCountResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "count": {
+                "type": IntType,
+                "display_name": "Count",
+                "short_desc": "Number of points",
+                "desc": "The number of points in the collection matching the filter criteria",
+                "example_value": 42,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantPointsDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantPointsDataProvider.qc
@@ -1,0 +1,107 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantPointsDataProvider class definition
+
+/** QdrantPointsDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant points API data provider
+/** This data provider provides children that are API data providers for Qdrant point operations
+*/
+public class QdrantPointsDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "points",
+            "desc": "Qdrant points data provider; provides access to point CRUD and payload operations",
+            "type": "QdrantPointsDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_children": True,
+            "children_can_support_apis": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+    }
+
+    private {
+        const ChildMap = {
+            "upsert": Class::forName("QdrantDataProvider::QdrantPointsUpsertDataProvider"),
+            "get": Class::forName("QdrantDataProvider::QdrantPointsGetDataProvider"),
+            "delete": Class::forName("QdrantDataProvider::QdrantPointsDeleteDataProvider"),
+            "scroll": Class::forName("QdrantDataProvider::QdrantPointsScrollDataProvider"),
+            "count": Class::forName("QdrantDataProvider::QdrantPointsCountDataProvider"),
+            "set-payload": Class::forName("QdrantDataProvider::QdrantPointsSetPayloadDataProvider"),
+            "overwrite-payload": Class::forName("QdrantDataProvider::QdrantPointsOverwritePayloadDataProvider"),
+            "delete-payload": Class::forName("QdrantDataProvider::QdrantPointsDeletePayloadDataProvider"),
+            "clear-payload": Class::forName("QdrantDataProvider::QdrantPointsClearPayloadDataProvider"),
+            "batch-update": Class::forName("QdrantDataProvider::QdrantPointsBatchUpdateDataProvider"),
+        };
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant %s data provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Return data provider summary info
+    *list<hash<DataProvider::DataProviderSummaryInfo>> getChildProviderSummaryInfo() {
+        return map $1.getConstant("ProviderSummaryInfo").getValue(), ChildMap.iterator();
+    }
+
+    #! Returns a list of child data provider names, if any
+    private *list<string> getChildProviderNamesImpl() {
+        return keys ChildMap;
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    private *DataProvider::AbstractDataProvider getChildProviderImpl(string name) {
+        *Class cls = ChildMap{name};
+        if (!cls) {
+            return;
+        }
+        return cls.newObject(rest);
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantPointsDeleteDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantPointsDeleteDataProvider.qc
@@ -1,0 +1,206 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantPointsDeleteDataProvider class definition
+
+/** QdrantPointsDeleteDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant points delete API data provider
+/** This API deletes points from a Qdrant collection
+
+    @note Corresponds to: POST /collections/{name}/points/delete
+*/
+public class QdrantPointsDeleteDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "delete",
+            "desc": "Qdrant points delete data provider (`POST /collections/{name}/points/delete`)",
+            "type": "QdrantPointsDeleteDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantPointsDeleteRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantPointsDeleteResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("wait", "ordering");
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant points %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string uri_path = collectionPath(collection, "/points/delete");
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantPost(uri_path, req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant points delete request data type
+public class QdrantPointsDeleteRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection to delete points from",
+                "example_value": "my_collection",
+            },
+            "points": {
+                "type": AutoListOrNothingType,
+                "display_name": "Points",
+                "short_desc": "List of point IDs to delete",
+                "desc": "A list of point IDs to delete; IDs can be integers or UUIDs",
+                "example_value": (1, 2, 3),
+            },
+            "filter": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Filter",
+                "short_desc": "Filter conditions for deletion",
+                "desc": "Filter conditions to select points for deletion; allows deleting points matching "
+                    "specific criteria",
+                "example_value": {"must": ({"key": "city", "match": {"value": "London"}},)},
+            },
+            "wait": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Wait",
+                "short_desc": "Wait for operation to complete",
+                "desc": "If `true`, wait for changes to actually happen; if `false` (default), the request "
+                    "returns immediately after acknowledging",
+                "example_value": True,
+            },
+            "ordering": {
+                "type": StringOrNothingType,
+                "display_name": "Ordering",
+                "short_desc": "Write ordering guarantees",
+                "desc": "The write ordering guarantees for the operation",
+                "example_value": "weak",
+                "allowed_values": (
+                    <AllowedValueInfo>{"value": "weak", "desc": "Weak ordering; fastest, no guarantees"},
+                    <AllowedValueInfo>{"value": "medium", "desc": "Medium ordering; wait for local persistence"},
+                    <AllowedValueInfo>{"value": "strong", "desc": "Strong ordering; wait for all replicas"},
+                ),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant points delete response data type
+public class QdrantPointsDeleteResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "operation_id": {
+                "type": IntOrNothingType,
+                "display_name": "Operation ID",
+                "short_desc": "The operation ID",
+                "desc": "The ID of the operation that was performed",
+                "example_value": 0,
+            },
+            "status": {
+                "type": StringType,
+                "display_name": "Status",
+                "short_desc": "Operation status",
+                "desc": "The status of the operation (e.g. `completed`, `acknowledged`)",
+                "example_value": "completed",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantPointsDeletePayloadDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantPointsDeletePayloadDataProvider.qc
@@ -1,0 +1,214 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantPointsDeletePayloadDataProvider class definition
+
+/** QdrantPointsDeletePayloadDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant points delete payload API data provider
+/** This API deletes payload keys from points in a Qdrant collection
+
+    @note Corresponds to: POST /collections/{name}/points/payload/delete
+*/
+public class QdrantPointsDeletePayloadDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "delete-payload",
+            "desc": "Qdrant points delete payload data provider "
+                "(`POST /collections/{name}/points/payload/delete`)",
+            "type": "QdrantPointsDeletePayloadDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantPointsDeletePayloadRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantPointsDeletePayloadResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("wait", "ordering");
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant points %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string uri_path = collectionPath(collection, "/points/payload/delete");
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantPost(uri_path, req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant points delete payload request data type
+public class QdrantPointsDeletePayloadRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection containing the points to update",
+                "example_value": "my_collection",
+            },
+            "keys": {
+                "type": new DataProvider::QoreListDataType(new Type("softlist<string>")),
+                "display_name": "Keys",
+                "short_desc": "Payload keys to delete",
+                "desc": "A list of payload key names to delete from the selected points",
+                "example_value": ("color", "count"),
+            },
+            "points": {
+                "type": AutoListOrNothingType,
+                "display_name": "Points",
+                "short_desc": "List of point IDs",
+                "desc": "A list of point IDs to delete payload keys from; IDs can be integers or UUIDs",
+                "example_value": (1, 2, 3),
+            },
+            "filter": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Filter",
+                "short_desc": "Filter conditions",
+                "desc": "Filter conditions to select points for the payload key deletion; alternative to "
+                    "specifying point IDs directly",
+                "example_value": {"must": ({"key": "city", "match": {"value": "London"}},)},
+            },
+            "wait": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Wait",
+                "short_desc": "Wait for operation to complete",
+                "desc": "If `true`, wait for changes to actually happen; if `false` (default), the request "
+                    "returns immediately after acknowledging",
+                "example_value": True,
+            },
+            "ordering": {
+                "type": StringOrNothingType,
+                "display_name": "Ordering",
+                "short_desc": "Write ordering guarantees",
+                "desc": "The write ordering guarantees for the operation",
+                "example_value": "weak",
+                "allowed_values": (
+                    <AllowedValueInfo>{"value": "weak", "desc": "Weak ordering; fastest, no guarantees"},
+                    <AllowedValueInfo>{"value": "medium", "desc": "Medium ordering; wait for local persistence"},
+                    <AllowedValueInfo>{"value": "strong", "desc": "Strong ordering; wait for all replicas"},
+                ),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant points delete payload response data type
+public class QdrantPointsDeletePayloadResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "operation_id": {
+                "type": IntOrNothingType,
+                "display_name": "Operation ID",
+                "short_desc": "The operation ID",
+                "desc": "The ID of the operation that was performed",
+                "example_value": 0,
+            },
+            "status": {
+                "type": StringType,
+                "display_name": "Status",
+                "short_desc": "Operation status",
+                "desc": "The status of the operation (e.g. `completed`, `acknowledged`)",
+                "example_value": "completed",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantPointsGetDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantPointsGetDataProvider.qc
@@ -48,8 +48,9 @@ public class QdrantPointsGetDataProvider inherits QdrantDataProviderBase {
         #! Request type
         const RequestType = new QdrantPointsGetRequestDataType();
 
-        #! Response type
-        const ResponseType = new QdrantPointsGetResponseDataType();
+        #! Response type - list of point objects (Qdrant returns result as a list directly)
+        const ResponseType = new ListDataType("QdrantPointsGetResponse",
+            new QdrantPointsGetResponseElementDataType(), True);
     }
 
     #! Creates the object from constructor options
@@ -145,17 +146,31 @@ public class QdrantPointsGetRequestDataType inherits DataProvider::HashDataType 
     }
 }
 
-#! Qdrant points get response data type
-public class QdrantPointsGetResponseDataType inherits DataProvider::HashDataType {
+#! Qdrant point element data type for points get response
+public class QdrantPointsGetResponseElementDataType inherits DataProvider::HashDataType {
     private {
         #! Field descriptions
         const Fields = {
-            "points": {
-                "type": AutoListType,
-                "display_name": "Points",
-                "short_desc": "List of retrieved point results",
-                "desc": "A list of point result objects, each containing `id`, `payload`, and optionally `vector`",
-                "example_value": ({"id": 1, "payload": {"text": "hello"}, "vector": (0.1, 0.2, 0.3)},),
+            "id": {
+                "type": AutoType,
+                "display_name": "ID",
+                "short_desc": "Point ID",
+                "desc": "The point ID; can be an integer or a UUID string",
+                "example_value": 1,
+            },
+            "payload": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Payload",
+                "short_desc": "Point payload",
+                "desc": "The payload data stored with the point",
+                "example_value": {"text": "hello"},
+            },
+            "vector": {
+                "type": AutoType,
+                "display_name": "Vector",
+                "short_desc": "Point vector",
+                "desc": "The vector data stored with the point; can be a list of floats or a hash of named vectors",
+                "example_value": (0.1, 0.2, 0.3),
             },
         };
     }
@@ -163,6 +178,7 @@ public class QdrantPointsGetResponseDataType inherits DataProvider::HashDataType
     #! Creates the object
     constructor() {
         addQoreFields(Fields);
+        setDefaultOtherFieldType(AbstractDataProviderTypeMap."auto");
     }
 }
 }

--- a/qlib/QdrantDataProvider/QdrantPointsGetDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantPointsGetDataProvider.qc
@@ -1,0 +1,168 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantPointsGetDataProvider class definition
+
+/** QdrantPointsGetDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant points get API data provider
+/** This API retrieves points by IDs from a Qdrant collection
+
+    @note Corresponds to: POST /collections/{name}/points
+*/
+public class QdrantPointsGetDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "get",
+            "desc": "Qdrant points get data provider (`POST /collections/{name}/points`)",
+            "type": "QdrantPointsGetDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantPointsGetRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantPointsGetResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant points %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        return doQdrantPost(collectionPath(collection, "/points"), req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant points get request data type
+public class QdrantPointsGetRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection to retrieve points from",
+                "example_value": "my_collection",
+            },
+            "ids": {
+                "type": AutoListType,
+                "display_name": "IDs",
+                "short_desc": "List of point IDs to retrieve",
+                "desc": "A list of point IDs to retrieve; IDs can be integers or UUIDs",
+                "example_value": (1, 2, 3),
+            },
+            "with_payload": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "With Payload",
+                "short_desc": "Payload selector",
+                "desc": "Select which payload fields to return; `true` for all, `false` for none",
+                "example_value": True,
+            },
+            "with_vector": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "With Vector",
+                "short_desc": "Vector selector",
+                "desc": "Select which vectors to return; `true` for all, `false` for none",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant points get response data type
+public class QdrantPointsGetResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "points": {
+                "type": AutoListType,
+                "display_name": "Points",
+                "short_desc": "List of retrieved point results",
+                "desc": "A list of point result objects, each containing `id`, `payload`, and optionally `vector`",
+                "example_value": ({"id": 1, "payload": {"text": "hello"}, "vector": (0.1, 0.2, 0.3)},),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantPointsOverwritePayloadDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantPointsOverwritePayloadDataProvider.qc
@@ -1,0 +1,214 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantPointsOverwritePayloadDataProvider class definition
+
+/** QdrantPointsOverwritePayloadDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant points overwrite payload API data provider
+/** This API overwrites the entire payload on points in a Qdrant collection
+
+    @note Corresponds to: PUT /collections/{name}/points/payload
+*/
+public class QdrantPointsOverwritePayloadDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "overwrite-payload",
+            "desc": "Qdrant points overwrite payload data provider (`PUT /collections/{name}/points/payload`)",
+            "type": "QdrantPointsOverwritePayloadDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantPointsOverwritePayloadRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantPointsOverwritePayloadResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("wait", "ordering");
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant points %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string uri_path = collectionPath(collection, "/points/payload");
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantPut(uri_path, req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant points overwrite payload request data type
+public class QdrantPointsOverwritePayloadRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection containing the points to update",
+                "example_value": "my_collection",
+            },
+            "payload": {
+                "type": AutoHashType,
+                "display_name": "Payload",
+                "short_desc": "New payload to set",
+                "desc": "The complete payload hash to overwrite on the selected points; replaces the entire "
+                    "existing payload",
+                "example_value": {"color": "blue", "count": 10},
+            },
+            "points": {
+                "type": AutoListOrNothingType,
+                "display_name": "Points",
+                "short_desc": "List of point IDs",
+                "desc": "A list of point IDs to overwrite the payload on; IDs can be integers or UUIDs",
+                "example_value": (1, 2, 3),
+            },
+            "filter": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Filter",
+                "short_desc": "Filter conditions",
+                "desc": "Filter conditions to select points for the payload overwrite; alternative to "
+                    "specifying point IDs directly",
+                "example_value": {"must": ({"key": "city", "match": {"value": "London"}},)},
+            },
+            "wait": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Wait",
+                "short_desc": "Wait for operation to complete",
+                "desc": "If `true`, wait for changes to actually happen; if `false` (default), the request "
+                    "returns immediately after acknowledging",
+                "example_value": True,
+            },
+            "ordering": {
+                "type": StringOrNothingType,
+                "display_name": "Ordering",
+                "short_desc": "Write ordering guarantees",
+                "desc": "The write ordering guarantees for the operation",
+                "example_value": "weak",
+                "allowed_values": (
+                    <AllowedValueInfo>{"value": "weak", "desc": "Weak ordering; fastest, no guarantees"},
+                    <AllowedValueInfo>{"value": "medium", "desc": "Medium ordering; wait for local persistence"},
+                    <AllowedValueInfo>{"value": "strong", "desc": "Strong ordering; wait for all replicas"},
+                ),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant points overwrite payload response data type
+public class QdrantPointsOverwritePayloadResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "operation_id": {
+                "type": IntOrNothingType,
+                "display_name": "Operation ID",
+                "short_desc": "The operation ID",
+                "desc": "The ID of the operation that was performed",
+                "example_value": 0,
+            },
+            "status": {
+                "type": StringType,
+                "display_name": "Status",
+                "short_desc": "Operation status",
+                "desc": "The status of the operation (e.g. `completed`, `acknowledged`)",
+                "example_value": "completed",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantPointsScrollDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantPointsScrollDataProvider.qc
@@ -1,0 +1,198 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantPointsScrollDataProvider class definition
+
+/** QdrantPointsScrollDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant points scroll API data provider
+/** This API scrolls/iterates over points in a Qdrant collection
+
+    @note Corresponds to: POST /collections/{name}/points/scroll
+*/
+public class QdrantPointsScrollDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "scroll",
+            "desc": "Qdrant points scroll data provider (`POST /collections/{name}/points/scroll`)",
+            "type": "QdrantPointsScrollDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantPointsScrollRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantPointsScrollResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant points %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        return doQdrantPost(collectionPath(collection, "/points/scroll"), req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant points scroll request data type
+public class QdrantPointsScrollRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection to scroll points from",
+                "example_value": "my_collection",
+            },
+            "filter": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Filter",
+                "short_desc": "Filter conditions",
+                "desc": "Filter conditions to select which points to scroll; allows iterating over a subset of "
+                    "points matching specific criteria",
+                "example_value": {"must": ({"key": "city", "match": {"value": "London"}},)},
+            },
+            "limit": {
+                "type": IntOrNothingType,
+                "display_name": "Limit",
+                "short_desc": "Maximum number of points to return",
+                "desc": "The maximum number of points to return per scroll request",
+                "example_value": 10,
+            },
+            "offset": {
+                "type": IntOrNothingType,
+                "display_name": "Offset",
+                "short_desc": "Point ID to start from",
+                "desc": "The point ID to start scrolling from; use the `next_page_offset` from the previous "
+                    "response to paginate",
+                "example_value": 0,
+            },
+            "with_payload": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "With Payload",
+                "short_desc": "Payload selector",
+                "desc": "Select which payload fields to return; `true` for all, `false` for none",
+                "example_value": True,
+            },
+            "with_vector": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "With Vector",
+                "short_desc": "Vector selector",
+                "desc": "Select which vectors to return; `true` for all, `false` for none",
+                "example_value": False,
+            },
+            "order_by": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Order By",
+                "short_desc": "Order by payload key",
+                "desc": "Order the scroll results by a payload key; can be a string key name or an object with "
+                    "key and direction",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant points scroll response data type
+public class QdrantPointsScrollResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "points": {
+                "type": AutoListType,
+                "display_name": "Points",
+                "short_desc": "List of scrolled point results",
+                "desc": "A list of point result objects, each containing `id`, `payload`, and optionally `vector`",
+                "example_value": ({"id": 1, "payload": {"text": "hello"}},),
+            },
+            "next_page_offset": {
+                "type": IntOrNothingType,
+                "display_name": "Next Page Offset",
+                "short_desc": "Offset for the next page",
+                "desc": "The offset to use for the next scroll request; if not present, all points have been "
+                    "returned",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantPointsScrollDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantPointsScrollDataProvider.qc
@@ -131,11 +131,11 @@ public class QdrantPointsScrollRequestDataType inherits DataProvider::HashDataTy
                 "example_value": 10,
             },
             "offset": {
-                "type": IntOrNothingType,
+                "type": AutoType,
                 "display_name": "Offset",
                 "short_desc": "Point ID to start from",
                 "desc": "The point ID to start scrolling from; use the `next_page_offset` from the previous "
-                    "response to paginate",
+                    "response to paginate; can be an integer or a UUID string",
                 "example_value": 0,
             },
             "with_payload": {
@@ -181,11 +181,11 @@ public class QdrantPointsScrollResponseDataType inherits DataProvider::HashDataT
                 "example_value": ({"id": 1, "payload": {"text": "hello"}},),
             },
             "next_page_offset": {
-                "type": IntOrNothingType,
+                "type": AutoType,
                 "display_name": "Next Page Offset",
                 "short_desc": "Offset for the next page",
-                "desc": "The offset to use for the next scroll request; if not present, all points have been "
-                    "returned",
+                "desc": "The offset to use for the next scroll request; can be an integer or a UUID string; "
+                    "if not present, all points have been returned",
             },
         };
     }

--- a/qlib/QdrantDataProvider/QdrantPointsSetPayloadDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantPointsSetPayloadDataProvider.qc
@@ -1,0 +1,221 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantPointsSetPayloadDataProvider class definition
+
+/** QdrantPointsSetPayloadDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant points set payload API data provider
+/** This API sets payload fields on points in a Qdrant collection
+
+    @note Corresponds to: POST /collections/{name}/points/payload
+*/
+public class QdrantPointsSetPayloadDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "set-payload",
+            "desc": "Qdrant points set payload data provider (`POST /collections/{name}/points/payload`)",
+            "type": "QdrantPointsSetPayloadDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantPointsSetPayloadRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantPointsSetPayloadResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("wait", "ordering");
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant points %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string uri_path = collectionPath(collection, "/points/payload");
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantPost(uri_path, req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant points set payload request data type
+public class QdrantPointsSetPayloadRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection containing the points to update",
+                "example_value": "my_collection",
+            },
+            "payload": {
+                "type": AutoHashType,
+                "display_name": "Payload",
+                "short_desc": "Payload fields to set",
+                "desc": "A hash of payload key-value pairs to set on the selected points",
+                "example_value": {"color": "red", "count": 5},
+            },
+            "points": {
+                "type": AutoListOrNothingType,
+                "display_name": "Points",
+                "short_desc": "List of point IDs",
+                "desc": "A list of point IDs to set the payload on; IDs can be integers or UUIDs",
+                "example_value": (1, 2, 3),
+            },
+            "filter": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Filter",
+                "short_desc": "Filter conditions",
+                "desc": "Filter conditions to select points for the payload update; alternative to specifying "
+                    "point IDs directly",
+                "example_value": {"must": ({"key": "city", "match": {"value": "London"}},)},
+            },
+            "key": {
+                "type": StringOrNothingType,
+                "display_name": "Key",
+                "short_desc": "Nested key path",
+                "desc": "A nested key path to set the payload at a specific location within the existing "
+                    "payload structure",
+                "example_value": "metadata.tags",
+            },
+            "wait": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Wait",
+                "short_desc": "Wait for operation to complete",
+                "desc": "If `true`, wait for changes to actually happen; if `false` (default), the request "
+                    "returns immediately after acknowledging",
+                "example_value": True,
+            },
+            "ordering": {
+                "type": StringOrNothingType,
+                "display_name": "Ordering",
+                "short_desc": "Write ordering guarantees",
+                "desc": "The write ordering guarantees for the operation",
+                "example_value": "weak",
+                "allowed_values": (
+                    <AllowedValueInfo>{"value": "weak", "desc": "Weak ordering; fastest, no guarantees"},
+                    <AllowedValueInfo>{"value": "medium", "desc": "Medium ordering; wait for local persistence"},
+                    <AllowedValueInfo>{"value": "strong", "desc": "Strong ordering; wait for all replicas"},
+                ),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant points set payload response data type
+public class QdrantPointsSetPayloadResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "operation_id": {
+                "type": IntOrNothingType,
+                "display_name": "Operation ID",
+                "short_desc": "The operation ID",
+                "desc": "The ID of the operation that was performed",
+                "example_value": 0,
+            },
+            "status": {
+                "type": StringType,
+                "display_name": "Status",
+                "short_desc": "Operation status",
+                "desc": "The status of the operation (e.g. `completed`, `acknowledged`)",
+                "example_value": "completed",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantPointsUpsertDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantPointsUpsertDataProvider.qc
@@ -1,0 +1,205 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantPointsUpsertDataProvider class definition
+
+/** QdrantPointsUpsertDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant points upsert API data provider
+/** This API upserts points in a Qdrant collection
+
+    @note Corresponds to: PUT /collections/{name}/points
+*/
+public class QdrantPointsUpsertDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "upsert",
+            "desc": "Qdrant points upsert data provider (`PUT /collections/{name}/points`)",
+            "type": "QdrantPointsUpsertDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantPointsUpsertRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantPointsUpsertResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("wait", "ordering");
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant points %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string uri_path = collectionPath(collection, "/points");
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantPut(uri_path, req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant points upsert request data type
+public class QdrantPointsUpsertRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection to upsert points into",
+                "example_value": "my_collection",
+            },
+            "points": {
+                "type": AutoListType,
+                "display_name": "Points",
+                "short_desc": "List of point objects to upsert",
+                "desc": "A list of point objects to upsert, each containing an `id`, `vector`, and optional "
+                    "`payload`",
+                "example_value": ({"id": 1, "vector": (0.1, 0.2, 0.3), "payload": {"text": "hello"}},),
+            },
+            "batch": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Batch",
+                "short_desc": "Batch upload format",
+                "desc": "Alternative batch upload format with separate `ids`, `vectors`, and `payloads` lists",
+            },
+            "wait": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Wait",
+                "short_desc": "Wait for operation to complete",
+                "desc": "If `true`, wait for changes to actually happen; if `false` (default), the request "
+                    "returns immediately after acknowledging",
+                "example_value": True,
+            },
+            "ordering": {
+                "type": StringOrNothingType,
+                "display_name": "Ordering",
+                "short_desc": "Write ordering guarantees",
+                "desc": "The write ordering guarantees for the operation",
+                "example_value": "weak",
+                "allowed_values": (
+                    <AllowedValueInfo>{"value": "weak", "desc": "Weak ordering; fastest, no guarantees"},
+                    <AllowedValueInfo>{"value": "medium", "desc": "Medium ordering; wait for local persistence"},
+                    <AllowedValueInfo>{"value": "strong", "desc": "Strong ordering; wait for all replicas"},
+                ),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant points upsert response data type
+public class QdrantPointsUpsertResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "operation_id": {
+                "type": IntOrNothingType,
+                "display_name": "Operation ID",
+                "short_desc": "The operation ID",
+                "desc": "The ID of the operation that was performed",
+                "example_value": 0,
+            },
+            "status": {
+                "type": StringType,
+                "display_name": "Status",
+                "short_desc": "Operation status",
+                "desc": "The status of the operation (e.g. `completed`, `acknowledged`)",
+                "example_value": "completed",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantRestConnection.qc
+++ b/qlib/QdrantDataProvider/QdrantRestConnection.qc
@@ -1,0 +1,139 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantRestConnection class definition
+
+/** QdrantRestConnection.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! Qdrant REST connection
+public class QdrantRestConnection inherits RestClient::RestConnection {
+    public {
+        #! Connection entry info
+        const ConnectionScheme = <ConnectionSchemeInfo>{
+            "display_name": "Qdrant REST Connection",
+            "short_desc": "A connection to a Qdrant vector database server",
+            "desc": "A connection to a Qdrant vector database server",
+            "cls": Class::forName("QdrantRestConnection"),
+            "schemes": {
+                "qdrantrest": True,
+                "qdrantrests": True,
+            },
+            "base_scheme_map": {
+                "https": "qdrantrests",
+                "http": "qdrantrest",
+            },
+            "options": RestConnection::ConnectionScheme.options + {
+                "api_key": <ConnectionOptionInfo>{
+                    "display_name": "API Key",
+                    "short_desc": "The Qdrant API key for authentication",
+                    "type": "string",
+                    "desc": "The API key for authenticating with the Qdrant server; sent as the `api-key` header",
+                    "sensitive": True,
+                },
+                "ping_method": RestConnection::ConnectionScheme.options."ping_method"
+                    + <ConnectionOptionInfo>{
+                    "default_value": "GET",
+                },
+                "ping_path": RestConnection::ConnectionScheme.options."ping_path"
+                    + <ConnectionOptionInfo>{
+                    "default_value": "/",
+                },
+            },
+        };
+    }
+
+    #! Creates the QdrantRestConnection object
+    /** @param name the name of the connection
+        @param description connection description
+        @param url connection URL (potentially with password info)
+        @param attributes various attributes. See below
+        @param options connection options
+
+        See \c AbstractConnection::constructor() for \c attributes and \c options reference.
+
+        @throw CONNECTION-OPTION-ERROR missing or invalid connection option
+    */
+    constructor(string name, string description, string url, hash<auto> attributes = {},
+            hash<auto> options = {})
+            : RestConnection(name, description, url, attributes, options) {
+    }
+
+    #! Creates the QdrantRestConnection object
+    /** @param config with the following keys:
+        - name (required string): the connection name
+        - display_name (optional string): the display name
+        - short_desc (optional string): a short description in plain text
+        - desc (optional string): a long description with markdown formatting
+        - url (required string): the connection URL
+        - opts (optional hash): connection options
+        - logger (optional LoggerInterface object): logger for the connection
+        @param attr optional connection attributes
+        - monitor (optional bool): should the connection be monitored? Default: True
+        - enabled (optional bool): is the connection enabled? Default: True
+        - locked (optional bool): is the connection locked? Default: False
+        - debug_data (optional bool): debug data? Default: False
+        - tags (optional hash): tags for the connection; no default value
+
+        @throw CONNECTION-OPTION-ERROR missing or invalid connection option or attribute
+    */
+    constructor(hash<auto> config, *hash<auto> attr) : RestConnection(config, attr) {
+    }
+
+    #! Returns \c "qdrantrest"
+    string getType() {
+        return "qdrantrest";
+    }
+
+    #! Returns a data provider object for this connection
+    /** @param constructor_options any additional constructor options for the data provider
+
+        @return a data provider object for this connection; the data provider is @ref QdrantDataProvider
+    */
+    DataProvider::AbstractDataProvider getDataProvider(*hash<auto> constructor_options) {
+        return new QdrantDataProvider({"restclient": get()});
+    }
+
+    #! Returns a @ref RestClient::RestClient "RestClient" object
+    /** @param connect if @ref True "True", then the connection is returned already connected
+        @param rtopts this connection type does not accept any runtime options, so this parameter is ignored
+
+        @return a @ref RestClient::RestClient "RestClient" object
+    */
+    private RestClient getImpl(bool connect = True, *hash<auto> rtopts) {
+        return new RestClient(getConnectionOptions(), !connect);
+    }
+
+    #! Returns the ConnectionSchemeInfo hash for this object
+    private hash<ConnectionSchemeInfo> getConnectionSchemeInfoImpl() {
+        return ConnectionScheme;
+    }
+
+    #! Returns connection options with API key header set if configured
+    private hash<auto> getConnectionOptions() {
+        hash<auto> opts = RestConnection::getConnectionOptions();
+        if (opts.api_key) {
+            opts.headers."api-key" = remove opts.api_key;
+        }
+        return opts;
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantScoredPointRecordType.qc
+++ b/qlib/QdrantDataProvider/QdrantScoredPointRecordType.qc
@@ -1,0 +1,78 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantScoredPointRecordType class definition
+
+/** QdrantScoredPointRecordType.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! Shared record type for Qdrant scored point results
+/** Defines the fields returned by Qdrant query/search endpoints for each scored point
+*/
+public class QdrantScoredPointRecordType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "id": {
+                "type": AutoType,
+                "display_name": "ID",
+                "short_desc": "Point ID",
+                "desc": "The point ID (integer or UUID string)",
+            },
+            "version": {
+                "type": IntOrNothingType,
+                "display_name": "Version",
+                "short_desc": "Point version",
+                "desc": "The point version number",
+            },
+            "score": {
+                "type": FloatOrNothingType,
+                "display_name": "Score",
+                "short_desc": "Similarity score",
+                "desc": "The similarity score for the point",
+            },
+            "payload": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Payload",
+                "short_desc": "Point payload",
+                "desc": "The point payload data",
+            },
+            "vector": {
+                "type": AutoType,
+                "display_name": "Vector",
+                "short_desc": "Vector data",
+                "desc": "The vector data if requested",
+            },
+            "shard_key": {
+                "type": AutoType,
+                "display_name": "Shard Key",
+                "short_desc": "Shard key",
+                "desc": "The shard key if applicable",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantSearchDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSearchDataProvider.qc
@@ -1,0 +1,100 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantSearchDataProvider class definition
+
+/** QdrantSearchDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant search API data provider
+/** This data provider provides children that are API data providers for Qdrant search/query operations
+*/
+public class QdrantSearchDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "search",
+            "desc": "Qdrant search data provider; provides access to vector similarity search and query operations",
+            "type": "QdrantSearchDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_children": True,
+            "children_can_support_apis": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+    }
+
+    private {
+        const ChildMap = {
+            "query": Class::forName("QdrantDataProvider::QdrantSearchQueryDataProvider"),
+            "query-batch": Class::forName("QdrantDataProvider::QdrantSearchQueryBatchDataProvider"),
+            "query-groups": Class::forName("QdrantDataProvider::QdrantSearchQueryGroupsDataProvider"),
+        };
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant %s data provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Return data provider summary info
+    *list<hash<DataProvider::DataProviderSummaryInfo>> getChildProviderSummaryInfo() {
+        return map $1.getConstant("ProviderSummaryInfo").getValue(), ChildMap.iterator();
+    }
+
+    #! Returns a list of child data provider names, if any
+    private *list<string> getChildProviderNamesImpl() {
+        return keys ChildMap;
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    private *DataProvider::AbstractDataProvider getChildProviderImpl(string name) {
+        *Class cls = ChildMap{name};
+        if (!cls) {
+            return;
+        }
+        return cls.newObject(rest);
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantSearchQueryBatchDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSearchQueryBatchDataProvider.qc
@@ -1,0 +1,156 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantSearchQueryBatchDataProvider class definition
+
+/** QdrantSearchQueryBatchDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant batch query API data provider
+/** This API performs multiple queries in a single batch request on a Qdrant collection
+
+    @note Corresponds to: POST /collections/{name}/points/query/batch
+*/
+public class QdrantSearchQueryBatchDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "query-batch",
+            "desc": "Qdrant batch query API data provider (`POST /collections/{name}/points/query/batch`)",
+            "type": "QdrantSearchQueryBatchDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantSearchQueryBatchRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantSearchQueryBatchResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant search %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        return doQdrantPost(collectionPath(collection, "/points/query/batch"), req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant search query batch request data type
+public class QdrantSearchQueryBatchRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name to query",
+                "desc": "The name of the collection to query",
+                "example_value": "my-collection",
+            },
+            "searches": {
+                "type": AutoListType,
+                "display_name": "Searches",
+                "short_desc": "List of query request objects",
+                "desc": "A list of query request objects to execute in a single batch; each object follows "
+                    "the same format as the universal query API request",
+                "example_value": ({"query": (0.2, 0.1, 0.9, 0.7), "limit": 10},),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant search query batch response data type
+public class QdrantSearchQueryBatchResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "points": {
+                "type": AutoListType,
+                "display_name": "Points",
+                "short_desc": "List of result lists",
+                "desc": "A list of result lists, one for each query in the batch; each inner list contains "
+                    "scored point results",
+                "example_value": (({"id": 1, "version": 0, "score": 0.95},),),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantSearchQueryBatchDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSearchQueryBatchDataProvider.qc
@@ -48,8 +48,9 @@ public class QdrantSearchQueryBatchDataProvider inherits QdrantDataProviderBase 
         #! Request type
         const RequestType = new QdrantSearchQueryBatchRequestDataType();
 
-        #! Response type
-        const ResponseType = new QdrantSearchQueryBatchResponseDataType();
+        #! Response type - list of query result sets (Qdrant returns result as a list directly)
+        const ResponseType = new ListDataType("QdrantSearchQueryBatchResponse",
+            new QdrantSearchQueryBatchResponseElementDataType(), True);
     }
 
     #! Creates the object from constructor options
@@ -132,18 +133,19 @@ public class QdrantSearchQueryBatchRequestDataType inherits DataProvider::HashDa
     }
 }
 
-#! Qdrant search query batch response data type
-public class QdrantSearchQueryBatchResponseDataType inherits DataProvider::HashDataType {
+#! Qdrant search query batch response element data type
+/** Each element represents the result of a single query in the batch, containing a list of scored points
+*/
+public class QdrantSearchQueryBatchResponseElementDataType inherits DataProvider::HashDataType {
     private {
         #! Field descriptions
         const Fields = {
             "points": {
                 "type": AutoListType,
                 "display_name": "Points",
-                "short_desc": "List of result lists",
-                "desc": "A list of result lists, one for each query in the batch; each inner list contains "
-                    "scored point results",
-                "example_value": (({"id": 1, "version": 0, "score": 0.95},),),
+                "short_desc": "Scored point results for this query",
+                "desc": "A list of scored point results for this query in the batch",
+                "example_value": ({"id": 1, "version": 0, "score": 0.95},),
             },
         };
     }
@@ -151,6 +153,7 @@ public class QdrantSearchQueryBatchResponseDataType inherits DataProvider::HashD
     #! Creates the object
     constructor() {
         addQoreFields(Fields);
+        setDefaultOtherFieldType(AbstractDataProviderTypeMap."auto");
     }
 }
 }

--- a/qlib/QdrantDataProvider/QdrantSearchQueryDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSearchQueryDataProvider.qc
@@ -1,0 +1,228 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantSearchQueryDataProvider class definition
+
+/** QdrantSearchQueryDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant universal query API data provider
+/** This API performs a universal query on a Qdrant collection using vector similarity search
+
+    @note Corresponds to: POST /collections/{name}/points/query
+*/
+public class QdrantSearchQueryDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "query",
+            "desc": "Qdrant universal query API data provider (`POST /collections/{name}/points/query`)",
+            "type": "QdrantSearchQueryDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantSearchQueryRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantSearchQueryResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant search %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        return doQdrantPost(collectionPath(collection, "/points/query"), req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant search query request data type
+public class QdrantSearchQueryRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name to query",
+                "desc": "The name of the collection to query",
+                "example_value": "my-collection",
+            },
+            "prefetch": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Prefetch",
+                "short_desc": "Prefetch queries for hybrid search",
+                "desc": "Prefetch queries for hybrid search; can be a list of query objects or a single query "
+                    "object for multi-stage search pipelines",
+            },
+            "query": {
+                "type": AutoListOrNothingType,
+                "display_name": "Query",
+                "short_desc": "Query vector",
+                "desc": "The query vector to use for the search",
+                "example_value": (0.2, 0.1, 0.9, 0.7),
+            },
+            "using": {
+                "type": StringOrNothingType,
+                "display_name": "Using",
+                "short_desc": "Named vector to use",
+                "desc": "The name of the named vector to use for the search; if not specified, the default "
+                    "vector is used",
+                "example_value": "image-vector",
+            },
+            "filter": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Filter",
+                "short_desc": "Filter conditions for search",
+                "desc": "Filter conditions to apply to the search, using Qdrant filter syntax with `must`, "
+                    "`should`, and `must_not` clauses",
+                "example_value": {"must": ({"key": "city", "match": {"value": "London"}},)},
+            },
+            "score_threshold": {
+                "type": FloatOrNothingType,
+                "display_name": "Score Threshold",
+                "short_desc": "Minimum score threshold",
+                "desc": "The minimum score threshold for results; points with a score below this value will "
+                    "be excluded from the results",
+                "example_value": 0.5,
+            },
+            "params": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Params",
+                "short_desc": "Additional search parameters",
+                "desc": "Additional search parameters such as `hnsw_ef`, `exact`, `quantization`, and other "
+                    "engine-specific options",
+                "example_value": {"hnsw_ef": 128, "exact": False},
+            },
+            "limit": {
+                "type": IntOrNothingType,
+                "display_name": "Limit",
+                "short_desc": "Max results to return",
+                "desc": "The maximum number of results to return",
+                "example_value": 10,
+            },
+            "offset": {
+                "type": IntOrNothingType,
+                "display_name": "Offset",
+                "short_desc": "Offset for pagination",
+                "desc": "The offset of the first result to return; used for pagination",
+                "example_value": 0,
+            },
+            "with_payload": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "With Payload",
+                "short_desc": "Return payload data",
+                "desc": "Whether to return payload data with results",
+                "example_value": True,
+            },
+            "with_vector": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "With Vector",
+                "short_desc": "Return vectors",
+                "desc": "Whether to return vectors with results",
+                "example_value": False,
+            },
+            "lookup_from": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Lookup From",
+                "short_desc": "Lookup vectors from another collection",
+                "desc": "Configuration to look up vectors from another collection for the search",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant search query response data type
+public class QdrantSearchQueryResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "points": {
+                "type": AutoListType,
+                "display_name": "Points",
+                "short_desc": "Scored point results",
+                "desc": "A list of scored point results matching the query, each containing the point ID, "
+                    "score, and optionally payload and vector data",
+                "example_value": ({"id": 1, "version": 0, "score": 0.95, "payload": {"text": "hello"}},),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantSearchQueryGroupsDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSearchQueryGroupsDataProvider.qc
@@ -1,0 +1,236 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantSearchQueryGroupsDataProvider class definition
+
+/** QdrantSearchQueryGroupsDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant grouped query API data provider
+/** This API performs a grouped query on a Qdrant collection, grouping results by a payload field
+
+    @note Corresponds to: POST /collections/{name}/points/query/groups
+*/
+public class QdrantSearchQueryGroupsDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "query-groups",
+            "desc": "Qdrant grouped query API data provider (`POST /collections/{name}/points/query/groups`)",
+            "type": "QdrantSearchQueryGroupsDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantSearchQueryGroupsRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantSearchQueryGroupsResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant search %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        return doQdrantPost(collectionPath(collection, "/points/query/groups"), req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant search query groups request data type
+public class QdrantSearchQueryGroupsRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name to query",
+                "desc": "The name of the collection to query",
+                "example_value": "my-collection",
+            },
+            "prefetch": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Prefetch",
+                "short_desc": "Prefetch queries for hybrid search",
+                "desc": "Prefetch queries for hybrid search; can be a list of query objects or a single query "
+                    "object for multi-stage search pipelines",
+            },
+            "query": {
+                "type": AutoListOrNothingType,
+                "display_name": "Query",
+                "short_desc": "Query vector",
+                "desc": "The query vector to use for the search",
+                "example_value": (0.2, 0.1, 0.9, 0.7),
+            },
+            "using": {
+                "type": StringOrNothingType,
+                "display_name": "Using",
+                "short_desc": "Named vector to use",
+                "desc": "The name of the named vector to use for the search; if not specified, the default "
+                    "vector is used",
+                "example_value": "image-vector",
+            },
+            "filter": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Filter",
+                "short_desc": "Filter conditions for search",
+                "desc": "Filter conditions to apply to the search, using Qdrant filter syntax with `must`, "
+                    "`should`, and `must_not` clauses",
+                "example_value": {"must": ({"key": "city", "match": {"value": "London"}},)},
+            },
+            "score_threshold": {
+                "type": FloatOrNothingType,
+                "display_name": "Score Threshold",
+                "short_desc": "Minimum score threshold",
+                "desc": "The minimum score threshold for results; points with a score below this value will "
+                    "be excluded from the results",
+                "example_value": 0.5,
+            },
+            "params": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Params",
+                "short_desc": "Additional search parameters",
+                "desc": "Additional search parameters such as `hnsw_ef`, `exact`, `quantization`, and other "
+                    "engine-specific options",
+                "example_value": {"hnsw_ef": 128, "exact": False},
+            },
+            "limit": {
+                "type": IntOrNothingType,
+                "display_name": "Limit",
+                "short_desc": "Max groups to return",
+                "desc": "The maximum number of groups to return",
+                "example_value": 10,
+            },
+            "group_size": {
+                "type": IntOrNothingType,
+                "display_name": "Group Size",
+                "short_desc": "Max points per group",
+                "desc": "The maximum number of points to return per group",
+                "example_value": 3,
+            },
+            "group_by": {
+                "type": StringType,
+                "display_name": "Group By",
+                "short_desc": "Payload field to group by",
+                "desc": "The name of the payload field to group results by",
+                "example_value": "category",
+            },
+            "with_payload": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "With Payload",
+                "short_desc": "Return payload data",
+                "desc": "Whether to return payload data with results",
+                "example_value": True,
+            },
+            "with_vector": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "With Vector",
+                "short_desc": "Return vectors",
+                "desc": "Whether to return vectors with results",
+                "example_value": False,
+            },
+            "with_lookup": {
+                "type": AutoHashOrNothingType,
+                "display_name": "With Lookup",
+                "short_desc": "Look up from another collection",
+                "desc": "Configuration to look up additional data from another collection for the grouped "
+                    "results",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant search query groups response data type
+public class QdrantSearchQueryGroupsResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "groups": {
+                "type": AutoListType,
+                "display_name": "Groups",
+                "short_desc": "List of group results",
+                "desc": "A list of group results, each containing the group ID and a list of scored points "
+                    "belonging to that group",
+                "example_value": ({"id": "category_a", "hits": ({"id": 1, "score": 0.95},)},),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantSearchRecordIterator.qc
+++ b/qlib/QdrantDataProvider/QdrantSearchRecordIterator.qc
@@ -1,0 +1,113 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantSearchRecordIterator class definition
+
+/** QdrantSearchRecordIterator.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! Record iterator wrapping Qdrant query results
+/** Calls `POST /collections/{name}/points/query` and iterates over scored point results
+*/
+public class QdrantSearchRecordIterator inherits DataProvider::AbstractDataProviderRecordIterator {
+    private:internal {
+        #! Record type
+        const RecordType = new QdrantScoredPointRecordType();
+
+        #! The underlying list iterator
+        Qore::ListHashIterator i;
+    }
+
+    #! Creates the iterator
+    /** @param rest the REST client connection
+        @param collection_name the name of the collection to query
+        @param where_cond the where clause mapped to Qdrant filter
+        @param search_options search options; assumed to have already been processed for validity
+    */
+    constructor(RestClient::RestClient rest, string collection_name, *hash<auto> where_cond,
+            *hash<auto> search_options)
+            : AbstractDataProviderRecordIterator(search_options.requires_result) {
+        # build request body from search options
+        hash<auto> body;
+        if (search_options.query) {
+            body.query = search_options.query;
+        }
+        if (search_options."using") {
+            body."using" = search_options."using";
+        }
+        if (search_options.filter) {
+            body.filter = search_options.filter;
+        }
+        if (exists search_options.score_threshold) {
+            body.score_threshold = search_options.score_threshold;
+        }
+        if (search_options.prefetch) {
+            body.prefetch = search_options.prefetch;
+        }
+        if (search_options.params) {
+            body.params = search_options.params;
+        }
+        if (exists search_options.limit) {
+            body.limit = search_options.limit;
+        }
+        if (exists search_options.offset) {
+            body.offset = search_options.offset;
+        }
+        if (exists search_options.with_payload) {
+            body.with_payload = boolean(search_options.with_payload);
+        } else {
+            body.with_payload = True;
+        }
+        if (exists search_options.with_vector) {
+            body.with_vector = boolean(search_options.with_vector);
+        }
+        if (search_options.lookup_from) {
+            body.lookup_from = search_options.lookup_from;
+        }
+
+        string uri = sprintf("/collections/%s/points/query", encode_url(collection_name, True));
+        *list<auto> points = rest.post(uri, body).body.result.points;
+        i = new ListHashIterator(points);
+    }
+
+    #! Returns @ref True if the iterator is valid
+    bool valid() {
+        return i.valid();
+    }
+
+    #! Returns a single record if the iterator is valid
+    /** @throw INVALID-ITERATOR the iterator is not pointing at a valid element
+    */
+    hash<auto> getValue() {
+        return i.getValue();
+    }
+
+    #! Returns the record description, if available
+    *hash<string, DataProvider::AbstractDataField> getRecordType() {
+        return RecordType.getFields();
+    }
+
+    #! Increments the row pointer
+    private bool nextImpl() {
+        return i.next();
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantSearchRecordIterator.qc
+++ b/qlib/QdrantDataProvider/QdrantSearchRecordIterator.qc
@@ -39,7 +39,8 @@ public class QdrantSearchRecordIterator inherits DataProvider::AbstractDataProvi
     #! Creates the iterator
     /** @param rest the REST client connection
         @param collection_name the name of the collection to query
-        @param where_cond the where clause mapped to Qdrant filter
+        @param where_cond the where clause mapped to Qdrant filter; supports both DataProvider expression trees
+        (with \c exp key) and plain hash equality conditions
         @param search_options search options; assumed to have already been processed for validity
     */
     constructor(RestClient::RestClient rest, string collection_name, *hash<auto> where_cond,
@@ -83,9 +84,77 @@ public class QdrantSearchRecordIterator inherits DataProvider::AbstractDataProvi
             body.lookup_from = search_options.lookup_from;
         }
 
+        # Process where_cond into a Qdrant filter
+        if (where_cond) {
+            *hash<auto> where_filter = processWhereCondition(where_cond);
+            if (where_filter) {
+                # Ensure the filter is a valid top-level Qdrant filter (must/should/must_not)
+                where_filter = ensureTopLevelFilter(where_filter);
+                if (body.filter) {
+                    # Merge where_cond filter with search_options filter using AND semantics
+                    body.filter = {"must": (where_filter, body.filter)};
+                } else {
+                    body.filter = where_filter;
+                }
+            }
+        }
+
         string uri = sprintf("/collections/%s/points/query", encode_url(collection_name, True));
         *list<auto> points = rest.post(uri, body).body.result.points;
         i = new ListHashIterator(points);
+    }
+
+    #! Processes a DataProvider expression argument and returns the Qdrant filter hash
+    /** @param exp the expression to process
+        @return the Qdrant filter hash for the expression
+    */
+    hash<auto> processExpressionArg(hash<DataProviderExpression> exp) {
+        *hash<auto> expinfo = QdrantExpressions{exp.exp};
+        if (!expinfo) {
+            throw "WHERE-ERROR", sprintf("expression references unknown operator %y; known operators: %y",
+                exp.exp, keys QdrantExpressions);
+        }
+
+        # Handle logical operators (AND, OR, NOT) - pass all args to impl
+        if (exp.exp == DP_OP_AND || exp.exp == DP_OP_OR || exp.exp == DP_SEARCH_OP_NOT) {
+            return call_function_args(expinfo.impl, (self, exp.args));
+        }
+
+        # For comparison operators, first argument must be a field reference
+        if (exp.args.size() < 1 || !(exp.args[0] instanceof hash<DataProviderFieldReference>)) {
+            throw "WHERE-ERROR", sprintf("the first argument to expression %y must be a field reference",
+                exp.exp);
+        }
+        string field = cast<hash<DataProviderFieldReference>>(exp.args[0]).field;
+
+        # For IN operator, collect all values into a single list
+        if (exp.exp == DP_SEARCH_OP_IN) {
+            list<auto> values = ();
+            for (int j = 1; j < exp.args.size(); ++j) {
+                if (exp.args[j].typeCode() == NT_LIST) {
+                    values += exp.args[j];
+                } else {
+                    push values, exp.args[j];
+                }
+            }
+            return call_function_args(expinfo.impl, (field, values));
+        }
+
+        # For BETWEEN, pass field + lo + hi
+        if (exp.exp == DP_SEARCH_OP_BETWEEN) {
+            if (exp.args.size() < 3) {
+                throw "WHERE-ERROR", sprintf("expression %y requires 3 arguments (field reference + lo + hi), "
+                    "but got %d", exp.exp, exp.args.size());
+            }
+            return call_function_args(expinfo.impl, (field, exp.args[1], exp.args[2]));
+        }
+
+        # Standard comparison operators: field + value
+        if (exp.args.size() < 2) {
+            throw "WHERE-ERROR", sprintf("expression %y requires at least 2 arguments (field reference + value), "
+                "but got %d", exp.exp, exp.args.size());
+        }
+        return call_function_args(expinfo.impl, (field, exp.args[1]));
     }
 
     #! Returns @ref True if the iterator is valid
@@ -108,6 +177,41 @@ public class QdrantSearchRecordIterator inherits DataProvider::AbstractDataProvi
     #! Increments the row pointer
     private bool nextImpl() {
         return i.next();
+    }
+
+    #! Ensures a filter hash is a valid top-level Qdrant filter
+    /** Qdrant requires filter objects to have \c must, \c should, or \c must_not at the top level.
+        Comparison conditions (with \c key field) need to be wrapped in a \c must array.
+        @param filter the filter hash to check
+        @return a valid top-level Qdrant filter
+    */
+    private hash<auto> ensureTopLevelFilter(hash<auto> filter) {
+        if (filter.hasKey("must") || filter.hasKey("should") || filter.hasKey("must_not")) {
+            return filter;
+        }
+        return {"must": (filter,)};
+    }
+
+    #! Processes a where_cond hash into a Qdrant filter hash
+    /** @param where_cond the where condition; either a DataProvider expression tree (with \c exp key)
+        or a plain hash of field: value equality conditions
+        @return the Qdrant filter hash
+    */
+    private *hash<auto> processWhereCondition(hash<auto> where_cond) {
+        # Check if this is a DataProvider expression
+        if (where_cond.exp) {
+            return processExpressionArg(cast<hash<DataProviderExpression>>(where_cond));
+        }
+
+        # Plain hash: convert each key: value pair to equality conditions
+        list<auto> conditions;
+        foreach hash<auto> pair in (where_cond.pairIterator()) {
+            push conditions, {"key": pair.key, "match": {"value": pair.value}};
+        }
+        if (conditions.size() == 1) {
+            return conditions[0];
+        }
+        return {"must": conditions};
     }
 }
 }

--- a/qlib/QdrantDataProvider/QdrantServiceDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantServiceDataProvider.qc
@@ -1,0 +1,109 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantServiceDataProvider class definition
+
+/** QdrantServiceDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant service API data provider
+/** This data provider provides children that are API data providers for Qdrant service endpoints
+*/
+public class QdrantServiceDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "service",
+            "desc": "Qdrant service data provider; provides access to service health and diagnostic endpoints",
+            "type": "QdrantServiceDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_children": True,
+            "children_can_support_apis": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+    }
+
+    private {
+        const ChildMap = {
+            "health": Class::forName("QdrantDataProvider::QdrantServiceHealthDataProvider"),
+            "liveness": Class::forName("QdrantDataProvider::QdrantServiceLivenessDataProvider"),
+            "readiness": Class::forName("QdrantDataProvider::QdrantServiceReadinessDataProvider"),
+            "telemetry": Class::forName("QdrantDataProvider::QdrantServiceTelemetryDataProvider"),
+            "metrics": Class::forName("QdrantDataProvider::QdrantServiceMetricsDataProvider"),
+            "issues": Class::forName("QdrantDataProvider::QdrantServiceIssuesDataProvider"),
+        };
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant %s data provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Return data provider summary info
+    *list<hash<DataProvider::DataProviderSummaryInfo>> getChildProviderSummaryInfo() {
+        return map $1.getConstant("ProviderSummaryInfo").getValue(), ChildMap.iterator();
+    }
+
+    #! Returns a list of child data provider names, if any
+    /** @return a list of child data provider names, if any
+    */
+    private *list<string> getChildProviderNamesImpl() {
+        return keys ChildMap;
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    /** @return the given child provider or @ref nothing if the given child is unknown
+
+        @see getChildProviderEx()
+    */
+    private *DataProvider::AbstractDataProvider getChildProviderImpl(string name) {
+        *Class cls = ChildMap{name};
+        if (!cls) {
+            return;
+        }
+        return cls.newObject(rest);
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantServiceHealthDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantServiceHealthDataProvider.qc
@@ -1,0 +1,140 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantServiceHealthDataProvider class definition
+
+/** QdrantServiceHealthDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant service health check API data provider
+/** This API checks the health status of the Qdrant server
+
+    @note Corresponds to: GET /healthz
+*/
+public class QdrantServiceHealthDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "health",
+            "desc": "Qdrant service health check data provider (`GET /healthz`)",
+            "type": "QdrantServiceHealthDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = AbstractDataProviderTypeMap."nothing";
+
+        #! Response type
+        const ResponseType = new QdrantServiceHealthResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant service health check provider for `%s`", rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request (ignored)
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        # Use root endpoint which returns server info (title, version, commit)
+        # The /healthz endpoint returns plain text
+        return rest.get("/").body;
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant service health response data type
+public class QdrantServiceHealthResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "title": {
+                "type": StringOrNothingType,
+                "display_name": "Title",
+                "short_desc": "The health check title",
+                "desc": "The title of the health check response",
+                "example_value": "qdrant - vectorass engine",
+            },
+            "version": {
+                "type": StringOrNothingType,
+                "display_name": "Version",
+                "short_desc": "The Qdrant server version",
+                "desc": "The version of the Qdrant server",
+                "example_value": "1.13.5",
+            },
+            "commit": {
+                "type": StringOrNothingType,
+                "display_name": "Commit",
+                "short_desc": "The Qdrant server commit hash",
+                "desc": "The git commit hash of the Qdrant server build",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantServiceHealthDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantServiceHealthDataProvider.qc
@@ -25,16 +25,17 @@
 #! Contains all public definitions in the QdrantDataProvider module
 public namespace QdrantDataProvider {
 #! The Qdrant service health check API data provider
-/** This API checks the health status of the Qdrant server
+/** This API checks the health status of the Qdrant server by returning server info
+    (title, version, commit) from the root endpoint
 
-    @note Corresponds to: GET /healthz
+    @note Corresponds to: GET /
 */
 public class QdrantServiceHealthDataProvider inherits QdrantDataProviderBase {
     public {
         #! Provider info
         const ProviderInfo = <DataProviderInfo>{
             "name": "health",
-            "desc": "Qdrant service health check data provider (`GET /healthz`)",
+            "desc": "Qdrant service health check data provider (`GET /`)",
             "type": "QdrantServiceHealthDataProvider",
             "constructor_options": QdrantDataProvider::ConstructorOptions,
             "supports_request": True,

--- a/qlib/QdrantDataProvider/QdrantServiceHealthDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantServiceHealthDataProvider.qc
@@ -114,7 +114,7 @@ public class QdrantServiceHealthResponseDataType inherits DataProvider::HashData
                 "display_name": "Title",
                 "short_desc": "The health check title",
                 "desc": "The title of the health check response",
-                "example_value": "qdrant - vectorass engine",
+                "example_value": "qdrant - vector search engine",
             },
             "version": {
                 "type": StringOrNothingType,

--- a/qlib/QdrantDataProvider/QdrantServiceIssuesDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantServiceIssuesDataProvider.qc
@@ -1,0 +1,117 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantServiceIssuesDataProvider class definition
+
+/** QdrantServiceIssuesDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant service issues API data provider
+/** Returns known issues from the Qdrant server
+
+    @note Corresponds to: GET /issues
+*/
+public class QdrantServiceIssuesDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "issues",
+            "desc": "Qdrant service issues data provider (`GET /issues`)",
+            "type": "QdrantServiceIssuesDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = AbstractDataProviderTypeMap."nothing";
+
+        #! Response type
+        const ResponseType = new QdrantServiceIssuesResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant service issues provider for `%s`", rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return doQdrantGet("/issues");
+    }
+
+    #! Returns the description of a successful request message, if any
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant service issues response data type
+public class QdrantServiceIssuesResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "issues": {
+                "type": AutoListOrNothingType,
+                "display_name": "Issues",
+                "short_desc": "List of known issues",
+                "desc": "A list of known issue objects reported by the Qdrant server, each containing "
+                    "details about the issue",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+        setDefaultOtherFieldType(AbstractDataProviderTypeMap."auto");
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantServiceLivenessDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantServiceLivenessDataProvider.qc
@@ -1,0 +1,95 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantServiceLivenessDataProvider class definition
+
+/** QdrantServiceLivenessDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant service liveness check API data provider
+/** Checks if the Qdrant server is alive
+
+    @note Corresponds to: GET /livez
+*/
+public class QdrantServiceLivenessDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "liveness",
+            "desc": "Qdrant service liveness check data provider (`GET /livez`)",
+            "type": "QdrantServiceLivenessDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = AbstractDataProviderTypeMap."nothing";
+
+        #! Response type - plain text liveness response
+        const ResponseType = AbstractDataProviderTypeMap."string";
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant service liveness check provider for `%s`", rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return rest.get("/livez").body;
+    }
+
+    #! Returns the description of a successful request message, if any
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantServiceMetricsDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantServiceMetricsDataProvider.qc
@@ -1,0 +1,95 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantServiceMetricsDataProvider class definition
+
+/** QdrantServiceMetricsDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant service metrics API data provider
+/** Returns Prometheus metrics from the Qdrant server
+
+    @note Corresponds to: GET /metrics
+*/
+public class QdrantServiceMetricsDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "metrics",
+            "desc": "Qdrant service metrics data provider (`GET /metrics`)",
+            "type": "QdrantServiceMetricsDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = AbstractDataProviderTypeMap."nothing";
+
+        #! Response type - Prometheus metrics returned as a string in text/plain format
+        const ResponseType = AbstractDataProviderTypeMap."string";
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant service metrics provider for `%s`", rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return rest.get("/metrics").body;
+    }
+
+    #! Returns the description of a successful request message, if any
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantServiceReadinessDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantServiceReadinessDataProvider.qc
@@ -1,0 +1,95 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantServiceReadinessDataProvider class definition
+
+/** QdrantServiceReadinessDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant service readiness check API data provider
+/** Checks if the Qdrant server is ready to accept requests
+
+    @note Corresponds to: GET /readyz
+*/
+public class QdrantServiceReadinessDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "readiness",
+            "desc": "Qdrant service readiness check data provider (`GET /readyz`)",
+            "type": "QdrantServiceReadinessDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = AbstractDataProviderTypeMap."nothing";
+
+        #! Response type - plain text readiness response
+        const ResponseType = AbstractDataProviderTypeMap."string";
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant service readiness check provider for `%s`", rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return rest.get("/readyz").body;
+    }
+
+    #! Returns the description of a successful request message, if any
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantServiceTelemetryDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantServiceTelemetryDataProvider.qc
@@ -1,0 +1,180 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantServiceTelemetryDataProvider class definition
+
+/** QdrantServiceTelemetryDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant service telemetry API data provider
+/** Returns telemetry data from the Qdrant server
+
+    @note Corresponds to: GET /telemetry
+*/
+public class QdrantServiceTelemetryDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "telemetry",
+            "desc": "Qdrant service telemetry data provider (`GET /telemetry`)",
+            "type": "QdrantServiceTelemetryDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantServiceTelemetryRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantServiceTelemetryResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("details_level",);
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant service telemetry provider for `%s`", rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string uri_path = "/telemetry";
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantGet(uri_path);
+    }
+
+    #! Returns the description of a successful request message, if any
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant service telemetry request data type
+public class QdrantServiceTelemetryRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "details_level": {
+                "type": IntOrNothingType,
+                "display_name": "Details Level",
+                "short_desc": "Level of detail for telemetry data",
+                "desc": "Level of detail for telemetry data (0 = minimal, higher = more detail)",
+                "example_value": 1,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant service telemetry response data type
+public class QdrantServiceTelemetryResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "id": {
+                "type": StringOrNothingType,
+                "display_name": "ID",
+                "short_desc": "Telemetry instance ID",
+                "desc": "The unique identifier for this Qdrant instance in telemetry data",
+            },
+            "app": {
+                "type": AutoHashOrNothingType,
+                "display_name": "App",
+                "short_desc": "Application telemetry",
+                "desc": "Application-level telemetry data including version, features, and startup information",
+            },
+            "collections": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Collections",
+                "short_desc": "Collections telemetry",
+                "desc": "Telemetry data about collections including number of collections and aggregate "
+                    "statistics",
+            },
+            "cluster": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Cluster",
+                "short_desc": "Cluster telemetry",
+                "desc": "Telemetry data about the cluster status and configuration",
+            },
+            "requests": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Requests",
+                "short_desc": "Request statistics",
+                "desc": "Telemetry data about request statistics including REST and gRPC request counts and "
+                    "latencies",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+        setDefaultOtherFieldType(AbstractDataProviderTypeMap."auto");
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantSnapshotsCreateCollectionDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSnapshotsCreateCollectionDataProvider.qc
@@ -1,0 +1,185 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantSnapshotsCreateCollectionDataProvider class definition
+
+/** QdrantSnapshotsCreateCollectionDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant create collection snapshot API data provider
+/** This API creates a snapshot of a specific collection
+
+    @note Corresponds to: POST /collections/{name}/snapshots
+*/
+public class QdrantSnapshotsCreateCollectionDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "create-collection",
+            "desc": "Qdrant create collection snapshot API data provider (`POST /collections/{name}/snapshots`)",
+            "type": "QdrantSnapshotsCreateCollectionDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantSnapshotsCreateCollectionRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantSnapshotsCreateCollectionResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("wait",);
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant snapshots %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string uri_path = collectionPath(collection, "/snapshots");
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantPost(uri_path, NOTHING);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant create collection snapshot request data type
+public class QdrantSnapshotsCreateCollectionRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection to create a snapshot for",
+                "example_value": "my_collection",
+            },
+            "wait": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Wait",
+                "short_desc": "Wait for operation to complete",
+                "desc": "If `true`, the request will wait for the snapshot to be created before returning",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant create collection snapshot response data type
+public class QdrantSnapshotsCreateCollectionResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "name": {
+                "type": StringOrNothingType,
+                "display_name": "Name",
+                "short_desc": "Snapshot name",
+                "desc": "The name of the created snapshot file",
+                "example_value": "my_collection-1234567890-snapshot.snapshot",
+            },
+            "creation_time": {
+                "type": StringOrNothingType,
+                "display_name": "Creation Time",
+                "short_desc": "Snapshot creation time",
+                "desc": "The timestamp when the snapshot was created",
+                "example_value": "2026-01-01T00:00:00",
+            },
+            "size": {
+                "type": IntOrNothingType,
+                "display_name": "Size",
+                "short_desc": "Snapshot size in bytes",
+                "desc": "The size of the snapshot file in bytes",
+                "example_value": 1048576,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantSnapshotsCreateStorageDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSnapshotsCreateStorageDataProvider.qc
@@ -1,0 +1,178 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantSnapshotsCreateStorageDataProvider class definition
+
+/** QdrantSnapshotsCreateStorageDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant create full storage snapshot API data provider
+/** This API creates a full storage snapshot
+
+    @note Corresponds to: POST /snapshots
+*/
+public class QdrantSnapshotsCreateStorageDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "create-storage",
+            "desc": "Qdrant create full storage snapshot API data provider (`POST /snapshots`)",
+            "type": "QdrantSnapshotsCreateStorageDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantSnapshotsCreateStorageRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantSnapshotsCreateStorageResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("wait",);
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant snapshots %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string uri_path = "/snapshots";
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantPost(uri_path, NOTHING);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant create full storage snapshot request data type
+public class QdrantSnapshotsCreateStorageRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "wait": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Wait",
+                "short_desc": "Wait for operation to complete",
+                "desc": "If `true`, the request will wait for the snapshot to be created before returning",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant create full storage snapshot response data type
+public class QdrantSnapshotsCreateStorageResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "name": {
+                "type": StringOrNothingType,
+                "display_name": "Name",
+                "short_desc": "Snapshot name",
+                "desc": "The name of the created full storage snapshot file",
+                "example_value": "full-snapshot-1234567890.snapshot",
+            },
+            "creation_time": {
+                "type": StringOrNothingType,
+                "display_name": "Creation Time",
+                "short_desc": "Snapshot creation time",
+                "desc": "The timestamp when the snapshot was created",
+                "example_value": "2026-01-01T00:00:00",
+            },
+            "size": {
+                "type": IntOrNothingType,
+                "display_name": "Size",
+                "short_desc": "Snapshot size in bytes",
+                "desc": "The size of the snapshot file in bytes",
+                "example_value": 1048576,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+        setDefaultOtherFieldType(AbstractDataProviderTypeMap."auto");
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantSnapshotsDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSnapshotsDataProvider.qc
@@ -1,0 +1,104 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantSnapshotsDataProvider class definition
+
+/** QdrantSnapshotsDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant snapshots API data provider
+/** This data provider provides children that are API data providers for Qdrant snapshot management
+*/
+public class QdrantSnapshotsDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "snapshots",
+            "desc": "Qdrant snapshots data provider; provides access to snapshot management operations",
+            "type": "QdrantSnapshotsDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_children": True,
+            "children_can_support_apis": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+    }
+
+    private {
+        const ChildMap = {
+            "list-collection": Class::forName("QdrantDataProvider::QdrantSnapshotsListCollectionDataProvider"),
+            "create-collection": Class::forName("QdrantDataProvider::QdrantSnapshotsCreateCollectionDataProvider"),
+            "delete-collection": Class::forName("QdrantDataProvider::QdrantSnapshotsDeleteCollectionDataProvider"),
+            "recover": Class::forName("QdrantDataProvider::QdrantSnapshotsRecoverDataProvider"),
+            "list-storage": Class::forName("QdrantDataProvider::QdrantSnapshotsListStorageDataProvider"),
+            "create-storage": Class::forName("QdrantDataProvider::QdrantSnapshotsCreateStorageDataProvider"),
+            "delete-storage": Class::forName("QdrantDataProvider::QdrantSnapshotsDeleteStorageDataProvider"),
+        };
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant %s data provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Return data provider summary info
+    *list<hash<DataProvider::DataProviderSummaryInfo>> getChildProviderSummaryInfo() {
+        return map $1.getConstant("ProviderSummaryInfo").getValue(), ChildMap.iterator();
+    }
+
+    #! Returns a list of child data provider names, if any
+    private *list<string> getChildProviderNamesImpl() {
+        return keys ChildMap;
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    private *DataProvider::AbstractDataProvider getChildProviderImpl(string name) {
+        *Class cls = ChildMap{name};
+        if (!cls) {
+            return;
+        }
+        return cls.newObject(rest);
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantSnapshotsDeleteCollectionDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSnapshotsDeleteCollectionDataProvider.qc
@@ -99,7 +99,7 @@ public class QdrantSnapshotsDeleteCollectionDataProvider inherits QdrantDataProv
             }
             uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
         }
-        return doQdrantDelete(uri_path);
+        return {"result": doQdrantDelete(uri_path)};
     }
 
     #! Returns the description of a successful request message, if any

--- a/qlib/QdrantDataProvider/QdrantSnapshotsDeleteCollectionDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSnapshotsDeleteCollectionDataProvider.qc
@@ -1,0 +1,180 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantSnapshotsDeleteCollectionDataProvider class definition
+
+/** QdrantSnapshotsDeleteCollectionDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant delete collection snapshot API data provider
+/** This API deletes a snapshot of a specific collection
+
+    @note Corresponds to: DELETE /collections/{name}/snapshots/{snapshot_name}
+*/
+public class QdrantSnapshotsDeleteCollectionDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "delete-collection",
+            "desc": "Qdrant delete collection snapshot API data provider "
+                "(`DELETE /collections/{name}/snapshots/{snapshot_name}`)",
+            "type": "QdrantSnapshotsDeleteCollectionDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantSnapshotsDeleteCollectionRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantSnapshotsDeleteCollectionResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("wait",);
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant snapshots %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string snapshot_name = remove req.snapshot_name;
+        string uri_path = collectionPath(collection, "/snapshots/" + encode_url(snapshot_name, True));
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantDelete(uri_path);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant delete collection snapshot request data type
+public class QdrantSnapshotsDeleteCollectionRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection containing the snapshot to delete",
+                "example_value": "my_collection",
+            },
+            "snapshot_name": {
+                "type": StringType,
+                "display_name": "Snapshot Name",
+                "short_desc": "Snapshot name to delete",
+                "desc": "The name of the snapshot file to delete",
+                "example_value": "my_collection-1234567890-snapshot.snapshot",
+            },
+            "wait": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Wait",
+                "short_desc": "Wait for operation to complete",
+                "desc": "If `true`, the request will wait for the snapshot to be deleted before returning",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant delete collection snapshot response data type
+public class QdrantSnapshotsDeleteCollectionResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "result": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Result",
+                "short_desc": "Operation result",
+                "desc": "Returns `true` if the snapshot was deleted successfully",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantSnapshotsDeleteStorageDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSnapshotsDeleteStorageDataProvider.qc
@@ -98,7 +98,7 @@ public class QdrantSnapshotsDeleteStorageDataProvider inherits QdrantDataProvide
             }
             uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
         }
-        return doQdrantDelete(uri_path);
+        return {"result": doQdrantDelete(uri_path)};
     }
 
     #! Returns the description of a successful request message, if any

--- a/qlib/QdrantDataProvider/QdrantSnapshotsDeleteStorageDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSnapshotsDeleteStorageDataProvider.qc
@@ -1,0 +1,172 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantSnapshotsDeleteStorageDataProvider class definition
+
+/** QdrantSnapshotsDeleteStorageDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant delete full storage snapshot API data provider
+/** This API deletes a full storage snapshot
+
+    @note Corresponds to: DELETE /snapshots/{snapshot_name}
+*/
+public class QdrantSnapshotsDeleteStorageDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "delete-storage",
+            "desc": "Qdrant delete full storage snapshot API data provider "
+                "(`DELETE /snapshots/{snapshot_name}`)",
+            "type": "QdrantSnapshotsDeleteStorageDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantSnapshotsDeleteStorageRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantSnapshotsDeleteStorageResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("wait",);
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant snapshots %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string snapshot_name = remove req.snapshot_name;
+        string uri_path = "/snapshots/" + encode_url(snapshot_name, True);
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantDelete(uri_path);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant delete full storage snapshot request data type
+public class QdrantSnapshotsDeleteStorageRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "snapshot_name": {
+                "type": StringType,
+                "display_name": "Snapshot Name",
+                "short_desc": "Snapshot name to delete",
+                "desc": "The name of the full storage snapshot file to delete",
+                "example_value": "full-snapshot-1234567890.snapshot",
+            },
+            "wait": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Wait",
+                "short_desc": "Wait for operation to complete",
+                "desc": "If `true`, the request will wait for the snapshot to be deleted before returning",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant delete full storage snapshot response data type
+public class QdrantSnapshotsDeleteStorageResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "result": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Result",
+                "short_desc": "Operation result",
+                "desc": "Returns `true` if the snapshot was deleted successfully",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantSnapshotsListCollectionDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSnapshotsListCollectionDataProvider.qc
@@ -1,0 +1,149 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantSnapshotsListCollectionDataProvider class definition
+
+/** QdrantSnapshotsListCollectionDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant list collection snapshots API data provider
+/** This API lists all snapshots of a specific collection
+
+    @note Corresponds to: GET /collections/{name}/snapshots
+*/
+public class QdrantSnapshotsListCollectionDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "list-collection",
+            "desc": "Qdrant list collection snapshots API data provider (`GET /collections/{name}/snapshots`)",
+            "type": "QdrantSnapshotsListCollectionDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantSnapshotsListCollectionRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantSnapshotsListCollectionResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant snapshots %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return doQdrantGet(collectionPath(remove req.collection, "/snapshots"));
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant list collection snapshots request data type
+public class QdrantSnapshotsListCollectionRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection to list snapshots for",
+                "example_value": "my_collection",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant list collection snapshots response data type
+public class QdrantSnapshotsListCollectionResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "snapshots": {
+                "type": AutoListOrNothingType,
+                "display_name": "Snapshots",
+                "short_desc": "List of collection snapshots",
+                "desc": "A list of snapshot description objects, each containing `name`, `creation_time`, "
+                    "and `size` fields",
+                "example_value": ({"name": "my_collection-snapshot.snapshot", "creation_time":
+                    "2026-01-01T00:00:00", "size": 1048576},),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+        setDefaultOtherFieldType(AbstractDataProviderTypeMap."auto");
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantSnapshotsListCollectionDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSnapshotsListCollectionDataProvider.qc
@@ -48,8 +48,9 @@ public class QdrantSnapshotsListCollectionDataProvider inherits QdrantDataProvid
         #! Request type
         const RequestType = new QdrantSnapshotsListCollectionRequestDataType();
 
-        #! Response type
-        const ResponseType = new QdrantSnapshotsListCollectionResponseDataType();
+        #! Response type - list of snapshot objects (Qdrant returns result as a list directly)
+        const ResponseType = new ListDataType("QdrantSnapshotsListCollectionResponse",
+            new QdrantSnapshotElementDataType(), True);
     }
 
     #! Creates the object from constructor options
@@ -123,19 +124,31 @@ public class QdrantSnapshotsListCollectionRequestDataType inherits DataProvider:
     }
 }
 
-#! Qdrant list collection snapshots response data type
-public class QdrantSnapshotsListCollectionResponseDataType inherits DataProvider::HashDataType {
+#! Qdrant snapshot element data type for snapshot list responses
+public class QdrantSnapshotElementDataType inherits DataProvider::HashDataType {
     private {
         #! Field descriptions
         const Fields = {
-            "snapshots": {
-                "type": AutoListOrNothingType,
-                "display_name": "Snapshots",
-                "short_desc": "List of collection snapshots",
-                "desc": "A list of snapshot description objects, each containing `name`, `creation_time`, "
-                    "and `size` fields",
-                "example_value": ({"name": "my_collection-snapshot.snapshot", "creation_time":
-                    "2026-01-01T00:00:00", "size": 1048576},),
+            "name": {
+                "type": StringType,
+                "display_name": "Name",
+                "short_desc": "Snapshot file name",
+                "desc": "The name of the snapshot file",
+                "example_value": "my_collection-snapshot.snapshot",
+            },
+            "creation_time": {
+                "type": StringOrNothingType,
+                "display_name": "Creation Time",
+                "short_desc": "Snapshot creation time",
+                "desc": "The date/time when the snapshot was created",
+                "example_value": "2026-01-01T00:00:00",
+            },
+            "size": {
+                "type": IntOrNothingType,
+                "display_name": "Size",
+                "short_desc": "Snapshot size in bytes",
+                "desc": "The size of the snapshot file in bytes",
+                "example_value": 1048576,
             },
         };
     }

--- a/qlib/QdrantDataProvider/QdrantSnapshotsListStorageDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSnapshotsListStorageDataProvider.qc
@@ -48,8 +48,9 @@ public class QdrantSnapshotsListStorageDataProvider inherits QdrantDataProviderB
         #! Request type
         const RequestType = AbstractDataProviderTypeMap."nothing";
 
-        #! Response type
-        const ResponseType = new QdrantSnapshotsListStorageResponseDataType();
+        #! Response type - list of snapshot objects (Qdrant returns result as a list directly)
+        const ResponseType = new ListDataType("QdrantSnapshotsListStorageResponse",
+            new QdrantSnapshotStorageElementDataType(), True);
     }
 
     #! Creates the object from constructor options
@@ -102,19 +103,31 @@ public class QdrantSnapshotsListStorageDataProvider inherits QdrantDataProviderB
     }
 }
 
-#! Qdrant list full storage snapshots response data type
-public class QdrantSnapshotsListStorageResponseDataType inherits DataProvider::HashDataType {
+#! Qdrant storage snapshot element data type for storage snapshot list responses
+public class QdrantSnapshotStorageElementDataType inherits DataProvider::HashDataType {
     private {
         #! Field descriptions
         const Fields = {
-            "snapshots": {
-                "type": AutoListOrNothingType,
-                "display_name": "Snapshots",
-                "short_desc": "List of full storage snapshots",
-                "desc": "A list of snapshot description objects, each containing `name`, `creation_time`, "
-                    "and `size` fields",
-                "example_value": ({"name": "full-snapshot.snapshot", "creation_time":
-                    "2026-01-01T00:00:00", "size": 1048576},),
+            "name": {
+                "type": StringType,
+                "display_name": "Name",
+                "short_desc": "Snapshot file name",
+                "desc": "The name of the full storage snapshot file",
+                "example_value": "full-snapshot.snapshot",
+            },
+            "creation_time": {
+                "type": StringOrNothingType,
+                "display_name": "Creation Time",
+                "short_desc": "Snapshot creation time",
+                "desc": "The date/time when the snapshot was created",
+                "example_value": "2026-01-01T00:00:00",
+            },
+            "size": {
+                "type": IntOrNothingType,
+                "display_name": "Size",
+                "short_desc": "Snapshot size in bytes",
+                "desc": "The size of the snapshot file in bytes",
+                "example_value": 1048576,
             },
         };
     }

--- a/qlib/QdrantDataProvider/QdrantSnapshotsListStorageDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSnapshotsListStorageDataProvider.qc
@@ -1,0 +1,128 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantSnapshotsListStorageDataProvider class definition
+
+/** QdrantSnapshotsListStorageDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant list full storage snapshots API data provider
+/** This API lists all full storage snapshots
+
+    @note Corresponds to: GET /snapshots
+*/
+public class QdrantSnapshotsListStorageDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "list-storage",
+            "desc": "Qdrant list full storage snapshots API data provider (`GET /snapshots`)",
+            "type": "QdrantSnapshotsListStorageDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = AbstractDataProviderTypeMap."nothing";
+
+        #! Response type
+        const ResponseType = new QdrantSnapshotsListStorageResponseDataType();
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant snapshots %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request (ignored)
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return doQdrantGet("/snapshots");
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant list full storage snapshots response data type
+public class QdrantSnapshotsListStorageResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "snapshots": {
+                "type": AutoListOrNothingType,
+                "display_name": "Snapshots",
+                "short_desc": "List of full storage snapshots",
+                "desc": "A list of snapshot description objects, each containing `name`, `creation_time`, "
+                    "and `size` fields",
+                "example_value": ({"name": "full-snapshot.snapshot", "creation_time":
+                    "2026-01-01T00:00:00", "size": 1048576},),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+        setDefaultOtherFieldType(AbstractDataProviderTypeMap."auto");
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantSnapshotsRecoverDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSnapshotsRecoverDataProvider.qc
@@ -1,0 +1,198 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantSnapshotsRecoverDataProvider class definition
+
+/** QdrantSnapshotsRecoverDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! The Qdrant recover collection from snapshot API data provider
+/** This API recovers a collection from a snapshot
+
+    @note Corresponds to: PUT /collections/{name}/snapshots/recover
+*/
+public class QdrantSnapshotsRecoverDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "recover",
+            "desc": "Qdrant recover collection from snapshot API data provider "
+                "(`PUT /collections/{name}/snapshots/recover`)",
+            "type": "QdrantSnapshotsRecoverDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = new QdrantSnapshotsRecoverRequestDataType();
+
+        #! Response type
+        const ResponseType = new QdrantSnapshotsRecoverResponseDataType();
+
+        #! Query args
+        const QueryArgs = ("wait",);
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant snapshots %s provider for `%s`", ProviderInfo.name, rest.getSafeURL());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string collection = remove req.collection;
+        string uri_path = collectionPath(collection, "/snapshots/recover");
+        bool q;
+        foreach string arg in (QueryArgs) {
+            if (!exists req{arg}) {
+                continue;
+            }
+            if (!q) {
+                uri_path += "?";
+                q = True;
+            } else {
+                uri_path += "&";
+            }
+            uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
+        }
+        return doQdrantPut(uri_path, req);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Qdrant recover collection from snapshot request data type
+public class QdrantSnapshotsRecoverRequestDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "collection": {
+                "type": StringType,
+                "display_name": "Collection",
+                "short_desc": "Collection name",
+                "desc": "The name of the collection to recover from the snapshot",
+                "example_value": "my_collection",
+            },
+            "location": {
+                "type": StringType,
+                "display_name": "Location",
+                "short_desc": "Snapshot file path or URL",
+                "desc": "The path to the snapshot file on the filesystem or a URL to download the snapshot from",
+                "example_value": "/snapshots/my_collection-snapshot.snapshot",
+            },
+            "priority": {
+                "type": StringOrNothingType,
+                "display_name": "Priority",
+                "short_desc": "Recovery priority",
+                "desc": "The priority of the recovery operation; one of: `snapshot`, `replica`, `no_sync`",
+                "example_value": "snapshot",
+            },
+            "checksum": {
+                "type": StringOrNothingType,
+                "display_name": "Checksum",
+                "short_desc": "Snapshot checksum",
+                "desc": "Optional SHA-256 checksum to verify the snapshot integrity",
+            },
+            "api_key": {
+                "type": StringOrNothingType,
+                "display_name": "API Key",
+                "short_desc": "API key for remote snapshot",
+                "desc": "Optional API key for downloading the snapshot from a remote Qdrant server",
+            },
+            "wait": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Wait",
+                "short_desc": "Wait for operation to complete",
+                "desc": "If `true`, the request will wait for the recovery to complete before returning",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Qdrant recover collection from snapshot response data type
+public class QdrantSnapshotsRecoverResponseDataType inherits DataProvider::HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "result": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Result",
+                "short_desc": "Operation result",
+                "desc": "Returns `true` if the collection was recovered successfully from the snapshot",
+                "example_value": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/QdrantDataProvider/QdrantSnapshotsRecoverDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantSnapshotsRecoverDataProvider.qc
@@ -98,7 +98,7 @@ public class QdrantSnapshotsRecoverDataProvider inherits QdrantDataProviderBase 
             }
             uri_path += sprintf("%s=%s", arg, QdrantDataProviderBase::formatQueryValue(remove req{arg}));
         }
-        return doQdrantPut(uri_path, req);
+        return {"result": doQdrantPut(uri_path, req)};
     }
 
     #! Returns the description of a successful request message, if any

--- a/qlib/QdrantDataProvider/QdrantTablesDataProvider.qc
+++ b/qlib/QdrantDataProvider/QdrantTablesDataProvider.qc
@@ -1,0 +1,123 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QdrantTablesDataProvider class definition
+
+/** QdrantTablesDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the QdrantDataProvider module
+public namespace QdrantDataProvider {
+#! Parent data provider listing Qdrant collections as record-based child providers
+/** Each child is a @ref QdrantCollectionTableDataProvider providing DPAT_FIND-based vector search
+*/
+public class QdrantTablesDataProvider inherits QdrantDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "tables",
+            "desc": "Qdrant tables data provider; provides record-based access to Qdrant collections for "
+                "vector similarity search with record streaming",
+            "type": "QdrantTablesDataProvider",
+            "constructor_options": QdrantDataProvider::ConstructorOptions,
+            "supports_children": True,
+            "children_can_support_records": True,
+            "children_identical": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        checkOptions("CONSTRUCTOR-ERROR", QdrantDataProvider::ConstructorOptions, options);
+        rest = QdrantDataProvider::getRestConnection(options);
+    }
+
+    #! Creates the object from a REST connection
+    constructor(RestClient::RestClient rest) : QdrantDataProviderBase(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Qdrant tables data provider for `%s`", rest.getSafeURL());
+    }
+
+    #! Return data provider summary info
+    *list<hash<DataProvider::DataProviderSummaryInfo>> getChildProviderSummaryInfo() {
+        return map <DataProviderSummaryInfo>{
+            "name": $1,
+            "desc": sprintf("Qdrant collection %y", $1),
+            "type": "QdrantCollectionTableDataProvider",
+            "supports_read": QdrantCollectionTableDataProvider::ProviderInfo.supports_read,
+            "supports_create": QdrantCollectionTableDataProvider::ProviderInfo.supports_create,
+            "supports_update": QdrantCollectionTableDataProvider::ProviderInfo.supports_update,
+            "supports_upsert": QdrantCollectionTableDataProvider::ProviderInfo.supports_upsert,
+            "supports_delete": QdrantCollectionTableDataProvider::ProviderInfo.supports_delete,
+            "supports_native_search":
+                QdrantCollectionTableDataProvider::ProviderInfo.supports_native_search,
+            "supports_bulk_create": QdrantCollectionTableDataProvider::ProviderInfo.supports_bulk_create,
+            "supports_bulk_upsert": QdrantCollectionTableDataProvider::ProviderInfo.supports_bulk_upsert,
+            "supports_children": False,
+            "has_record": QdrantCollectionTableDataProvider::ProviderInfo.has_record,
+            "children_can_support_records": False,
+        }, getChildProviderNames();
+    }
+
+    #! Returns a list of child data provider names, if any
+    /** @return a list of child data provider names, if any
+    */
+    private *list<string> getChildProviderNamesImpl() {
+        *list<auto> collections = doQdrantGet("/collections").collections;
+        return map $1.name, collections;
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    /** @return the given child provider or @ref nothing if the given child is unknown
+
+        @see getChildProviderEx()
+    */
+    private *DataProvider::AbstractDataProvider getChildProviderImpl(string name) {
+        # verify the collection exists
+        hash<auto> info;
+        try {
+            rest.get(collectionPath(name), NOTHING, \info);
+        } catch (hash<ExceptionInfo> ex) {
+            if (info."response-code" == 404) {
+                return;
+            }
+            rethrow;
+        }
+        return new QdrantCollectionTableDataProvider(rest, name);
+    }
+
+    #! Returns data provider static info
+    hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/QdrantDataProvider/qdrant-logo.svg
+++ b/qlib/QdrantDataProvider/qdrant-logo.svg
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="Capa_2"
+   data-name="Capa 2"
+   viewBox="0 0 399.99998 400"
+   version="1.1"
+   sodipodi:docname="qdrant-brandmark-red.svg"
+   width="400"
+   height="400"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview10"
+     pagecolor="#ffffff"
+     bordercolor="#999999"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="4.5225"
+     inkscape:cx="173.24489"
+     inkscape:cy="200"
+     inkscape:window-width="3736"
+     inkscape:window-height="2074"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Capa_2" />
+  <defs
+     id="defs1">
+    <style
+       id="style1">
+      .cls-1 {
+        fill: #9e0d38;
+      }
+
+      .cls-2 {
+        fill: #dc244c;
+      }
+
+      .cls-3 {
+        fill: #ff516b;
+      }
+    </style>
+  </defs>
+  <g
+     id="Vectors"
+     transform="translate(26.79)">
+    <g
+       id="g10">
+      <g
+         id="g2">
+        <polygon
+           class="cls-2"
+           points="238.16,362.5 238.16,287.5 173.21,325 64.96,262.5 64.96,137.5 173.21,75 281.46,137.5 281.46,387.5 346.42,350 346.42,100 173.21,0 0,100 0,300 173.21,400 "
+           id="polygon1" />
+        <polygon
+           class="cls-2"
+           points="238.16,162.5 173.21,125 108.26,162.5 108.26,237.5 173.21,275 238.16,237.5 "
+           id="polygon2" />
+      </g>
+      <g
+         id="g9">
+        <polygon
+           class="cls-1"
+           points="238.16,287.5 238.16,362.5 173.21,400 173.21,325 "
+           id="polygon3" />
+        <polygon
+           class="cls-1"
+           points="346.42,100 346.42,350 281.46,387.5 281.46,137.5 "
+           id="polygon4" />
+        <polygon
+           class="cls-3"
+           points="0,100 173.21,0 346.42,100 281.46,137.5 173.21,75 64.96,137.5 "
+           id="polygon5" />
+        <polygon
+           class="cls-2"
+           points="64.96,137.5 64.96,262.5 173.21,325 173.21,400 0,300 0,100 "
+           id="polygon6" />
+        <polygon
+           class="cls-3"
+           points="238.16,162.5 173.21,200 108.26,162.5 173.21,125 "
+           id="polygon7" />
+        <polygon
+           class="cls-2"
+           points="173.21,200 173.21,275 108.26,237.5 108.26,162.5 "
+           id="polygon8" />
+        <polygon
+           class="cls-1"
+           points="238.16,162.5 238.16,237.5 173.21,275 173.21,200 "
+           id="polygon9" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Adds new `QdrantDataProvider` module providing comprehensive data provider integration for the Qdrant vector database
- Implements full REST API coverage: collections, points, search, aliases, snapshots, cluster management, and service monitoring
- Includes a `tables` provider exposing collections as record-based data providers with CRUD operations (create, upsert, update, delete, bulk upsert) and DPAT_FIND-based vector similarity search with record streaming
- Adds `QdrantRestConnection` connection provider with `qdrantrest://` scheme
- Registers DPAT_API, DPAT_FIND, and DPAT_CREATE actions in the DataProviderActionCatalog

## Test plan
- [x] All 13 test cases pass (257 assertions, 0 warnings)
- [ ] Verify with `podman run -d --name qdrant-test -p 6333:6333 docker.io/qdrant/qdrant:v1.13.5`
- [ ] Run: `QORE_MODULE_DIR=qlib qore --enable-debug examples/test/qlib/QdrantDataProvider/QdrantDataProvider.qtest -u http://127.0.0.1:6333 -v`
- [ ] Verify collection CRUD (create, upsert, update payload/vector/both, delete, bulk upsert)
- [ ] Verify vector similarity search with filters, limit, offset
- [ ] Verify all API action providers (collections, points, search, aliases, snapshots, cluster, service)

🤖 Generated with [Claude Code](https://claude.com/claude-code)