### PR TITLE
fix: OBJECT-INCOMPATIBLE exception and proxy datasource bulk upsert fallback

### DIFF
--- a/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
@@ -109,6 +109,47 @@ class Bug2963Schema inherits SqlUtilTestSchema {
     }
 } # class Bug2963Schema
 
+#! Proxy class for testing bulk upsert with non-DatasourcePool AbstractDatasource subclasses
+/** This simulates remote datasource proxies (e.g. QdspClient in Qorus) that inherit
+    AbstractDatasource but are not Datasource or DatasourcePool instances.
+*/
+class DatasourceProxy inherits AbstractDatasource {
+    private {
+        AbstractDatasource real_ds;
+    }
+
+    constructor(AbstractDatasource ds) {
+        real_ds = ds;
+    }
+
+    nothing commit() { real_ds.commit(); }
+    nothing rollback() { real_ds.rollback(); }
+    auto exec(string sql, ...) { return call_function_args(\real_ds.vexec(), (sql, argv)); }
+    auto vexec(string sql, *softlist<auto> vargs) { return real_ds.vexec(sql, vargs); }
+    auto execRaw(string sql) { return real_ds.execRaw(sql); }
+    auto select(string sql, ...) { return call_function_args(\real_ds.vselect(), (sql, argv)); }
+    auto selectRow(string sql, ...) { return call_function_args(\real_ds.vselectRow(), (sql, argv)); }
+    auto selectRows(string sql, ...) { return call_function_args(\real_ds.vselectRows(), (sql, argv)); }
+    auto vselect(string sql, *softlist<auto> vargs) { return real_ds.vselect(sql, vargs); }
+    auto vselectRow(string sql, *softlist<auto> vargs) { return real_ds.vselectRow(sql, vargs); }
+    auto vselectRows(string sql, *softlist<auto> vargs) { return real_ds.vselectRows(sql, vargs); }
+    nothing beginTransaction() { real_ds.beginTransaction(); }
+    *string getUserName() { return real_ds.getUserName(); }
+    *string getPassword() { return real_ds.getPassword(); }
+    *string getDBName() { return real_ds.getDBName(); }
+    *string getDBEncoding() { return real_ds.getDBEncoding(); }
+    *string getOSEncoding() { return real_ds.getOSEncoding(); }
+    *string getHostName() { return real_ds.getHostName(); }
+    *int getPort() { return real_ds.getPort(); }
+    string getDriverName() { return real_ds.getDriverName(); }
+    auto getServerVersion() { return real_ds.getServerVersion(); }
+    auto getClientVersion() { return real_ds.getClientVersion(); }
+    bool inTransaction() { return real_ds.inTransaction(); }
+    hash<auto> getConfigHash() { return real_ds.getConfigHash(); }
+    string getConfigString() { return real_ds.getConfigString(); }
+    int getCapabilities() { return real_ds.getCapabilities(); }
+}
+
 class PgsqlTest inherits SqlTestBase {
     public {
         hash<SchemaAlignmentInfo> schema_info;
@@ -229,6 +270,7 @@ class PgsqlTest inherits SqlTestBase {
             addTestCase("analytic/window functions", \testAnalyticFunctions());
             addTestCase("default value", \testDefaultValue());
             addTestCase("pgsqlutil: schema align with trigger drop #2963", \test2963());
+            addTestCase("proxy bulk upsert", \proxyBulkUpsertTest());
         }
 
         set_return_value(main());
@@ -294,6 +336,74 @@ class PgsqlTest inherits SqlTestBase {
         # 1 = drop trigger
         # 2 = drop function
         assertEq(2, res, "2 actions must be performed");
+    }
+
+    #! Tests that bulk upsert UNNEST works with non-DatasourcePool AbstractDatasource subclasses
+    /** When the datasource is not a Datasource or DatasourcePool, getBulkUpsertClosure() should
+        fall back to using ds.vexec() instead of SQLStatement for the UNNEST path.
+    */
+    private proxyBulkUpsertTest() {
+        if (!table) {
+            testSkip("no DB connection");
+        }
+
+        AbstractDatasource real_ds = getDatasource();
+        DatasourceProxy proxy(real_ds);
+
+        # verify proxy is NOT a Datasource or DatasourcePool
+        assertEq(False, proxy instanceof Datasource);
+        assertEq(False, proxy instanceof DatasourcePool);
+        # verify proxy reports array bind capability
+        assertEq(True, (proxy.getCapabilities() & DBI_CAP_HAS_ARRAY_BIND) != 0);
+
+        # create the table with the real datasource, then swap in the proxy for the upsert
+        AbstractTable proxy_table = (new Table(real_ds, "pgsql_test")).getTable();
+        proxy_table.setDatasource(proxy);
+
+        on_error real_ds.rollback();
+        on_success real_ds.commit();
+
+        # insert seed rows via real_ds so all NOT NULL columns are satisfied
+        proxy_table.setDatasource(real_ds);
+        proxy_table.del({"id": op_in((500, 501, 502))});
+        real_ds.commit();
+        map proxy_table.insert({"id": $1, "id_": $1 + 100, "blob_f": <cafe>, "clob_f": "test"}),
+            (500, 501, 502);
+        real_ds.commit();
+
+        # swap to proxy datasource for the bulk upsert test
+        proxy_table.setDatasource(proxy);
+
+        # test UpsertAuto: update existing rows with new id_ values via UNNEST through vexec()
+        code upsert = proxy_table.getBulkUpsertClosure(
+            {"id": 500, "id_": 900, "blob_f": <cafe>, "clob_f": "test"},
+            AbstractTable::UpsertAuto);
+
+        int result = upsert({
+            "id": (500, 501, 502),
+            "id_": (900, 901, 902),
+            "blob_f": (<cafe>, <cafe>, <cafe>),
+            "clob_f": ("test", "test", "test"),
+        });
+        assertEq(AbstractTable::UR_Verified, result);
+        proxy.commit();
+
+        # verify the upsert updated the rows through the proxy
+        proxy_table.setDatasource(real_ds);
+        assertEq(900, proxy_table.selectRow({"where": {"id": 500}}).id_);
+        assertEq(901, proxy_table.selectRow({"where": {"id": 501}}).id_);
+        assertEq(902, proxy_table.selectRow({"where": {"id": 502}}).id_);
+
+        # clean up
+        proxy_table.del({"id": op_in((500, 501, 502))});
+
+        # negative test: prove that SQLStatement cannot be used with a proxy datasource;
+        # this is the runtime failure that the vexec() fallback above is designed to prevent.
+        # we pass the proxy typed as AbstractDatasource (as in real Qorus usage) so the
+        # parse-time type checker accepts it; at runtime, overload resolution rejects the
+        # proxy because it is not a Datasource or DatasourcePool
+        AbstractDatasource ads = proxy;
+        assertThrows("RUNTIME-OVERLOAD-ERROR", sub () { new SQLStatement(ads); });
     }
 
     private string getResultSetSql() {

--- a/examples/test/qore/misc/object.qtest
+++ b/examples/test/qore/misc/object.qtest
@@ -115,6 +115,35 @@ class Issue3596_2 {
     }
 }
 
+#! AbstractDatasource subclass with no C++ private data (abstract C++ base, no setPrivate() call)
+class NullDatasource inherits AbstractDatasource {
+    nothing commit() {}
+    nothing rollback() {}
+    auto exec(string sql, ...) {}
+    auto vexec(string sql, *softlist<auto> vargs) {}
+    auto execRaw(string sql) {}
+    auto select(string sql, ...) {}
+    auto selectRow(string sql, ...) {}
+    auto selectRows(string sql, ...) {}
+    auto vselect(string sql, *softlist<auto> vargs) {}
+    auto vselectRow(string sql, *softlist<auto> vargs) {}
+    auto vselectRows(string sql, *softlist<auto> vargs) {}
+    nothing beginTransaction() {}
+    *string getUserName() {}
+    *string getPassword() {}
+    *string getDBName() {}
+    *string getDBEncoding() {}
+    *string getOSEncoding() {}
+    *string getHostName() {}
+    *int getPort() {}
+    string getDriverName() { return "null"; }
+    auto getServerVersion() { return "1.0"; }
+    auto getClientVersion() { return "1.0"; }
+    bool inTransaction() { return False; }
+    hash<auto> getConfigHash() { return {}; }
+    string getConfigString() { return ""; }
+}
+
 our auto issue_3596;
 
 const Methods = ('p2', 'getData', 'hello', 'destructor', 'getType', 'p1', 'constructor');
@@ -144,6 +173,7 @@ object sub test3() { return create_object_args(\"PrivTest\", 1);}
         addTestCase("create_object", \testCreateObject());
         addTestCase("inheritance", \inheritance());
         addTestCase("weak refs", \weakRefTest());
+        addTestCase("no private data", \noPrivateDataTest());
         set_return_value(main());
     }
 
@@ -294,5 +324,21 @@ object sub test3() { return create_object_args(\"PrivTest\", 1);}
         }
 
         assertThrows("OBJECT-ALREADY-DELETED", \m.get());
+    }
+
+    #! Tests that calling a C++ method on an object with no C++ private data throws
+    #! OBJECT-INCOMPATIBLE instead of the misleading OBJECT-ALREADY-DELETED
+    noPrivateDataTest() {
+        # NullDatasource inherits abstract C++ class AbstractDatasource but has no C++ private
+        # data (no constructor calls setPrivate()), so calling a non-abstract C++ method on it
+        # triggers getReferencedPrivateData() with privateData == nullptr
+        AbstractDatasource ds = new NullDatasource();
+        assertThrows("OBJECT-INCOMPATIBLE", \ds.currentThreadInTransaction());
+
+        # verify that genuinely deleted objects still throw OBJECT-ALREADY-DELETED;
+        # capture the method reference before delete so the closure holds a strong ref
+        code ref = \ds.currentThreadInTransaction();
+        delete ds;
+        assertThrows("OBJECT-ALREADY-DELETED", ref);
     }
 }

--- a/include/qore/ExceptionSink.h
+++ b/include/qore/ExceptionSink.h
@@ -361,6 +361,19 @@ static inline void makeAccessDeletedObjectException(ExceptionSink *xsink, const 
     xsink->raiseException("OBJECT-ALREADY-DELETED", "attempt to access an already-deleted object of class '%s'", cname);
 }
 
+static inline void makeObjectIncompatibleException(ExceptionSink* xsink, const char* cname) {
+    xsink->raiseException("OBJECT-INCOMPATIBLE",
+        "object of class '%s' is not compatible with the expected builtin class for this operation",
+        cname);
+}
+
+static inline void makeObjectIncompatibleException(ExceptionSink* xsink, const char* cname,
+        const char* expected_cname) {
+    xsink->raiseException("OBJECT-INCOMPATIBLE",
+        "object of class '%s' is not compatible with the expected builtin class '%s'",
+        cname, expected_cname);
+}
+
 //! returns a custom Qore program location for external modules to generate runtime exceptions with the source location
 class QoreExternalProgramLocationWrapper {
 public:

--- a/lib/QoreObject.cpp
+++ b/lib/QoreObject.cpp
@@ -876,14 +876,19 @@ QoreValue qore_object_private::evalBuiltinMethodWithPrivateData(const QoreMethod
 AbstractPrivateData* qore_object_private::getReferencedPrivateData(qore_classid_t key, ExceptionSink* xsink) const {
     QoreSafeVarRWReadLocker sl(rml);
 
-    if (status == OS_DELETED || !privateData) {
+    if (status == OS_DELETED) {
         makeAccessDeletedObjectException(xsink, theclass->getName());
+        return nullptr;
+    }
+
+    if (!privateData) {
+        makeObjectIncompatibleException(xsink, theclass->getName());
         return nullptr;
     }
 
     AbstractPrivateData* d = privateData->getReferencedPrivateData(key);
     if (!d) {
-        makeAccessDeletedObjectException(xsink, theclass->getName());
+        makeObjectIncompatibleException(xsink, theclass->getName());
     }
 
     return d;

--- a/qlib/PgsqlSqlUtilBase.qm
+++ b/qlib/PgsqlSqlUtilBase.qm
@@ -2410,8 +2410,11 @@ public class PgsqlTable inherits SqlUtil::AbstractTable {
                 (foldl $1 + "," + $2, getColumnSqlNames(cols.keys())));
         }
 
-        # use a prepared statement for efficiency
+        # use a prepared statement for efficiency when the datasource supports it;
+        # AbstractDatasource subclasses that are not Datasource or DatasourcePool (e.g. remote
+        # proxy classes) cannot be used with SQLStatement, so fall back to exec() for those
         *SQLStatement stmt;
+        bool use_direct_exec = !(ds instanceof Datasource || ds instanceof DatasourcePool);
 
         # ON CONFLICT DO UPDATE cannot handle duplicate PK values in the same batch;
         # capture PK column names for deduplication in the closure
@@ -2419,16 +2422,21 @@ public class PgsqlTable inherits SqlUtil::AbstractTable {
         list<string> pk_cols = cols.keys();
 
         return int sub (hash<auto> h) {
-            if (!stmt) {
-                stmt = new SQLStatement(ds);
-                stmt.prepare(sql);
-            }
             # deduplicate rows by PK columns if using DO UPDATE
             if (needs_dedup) {
                 h = deduplicateByPk(h, pk_cols);
             }
             # unwrap bind hashes and wrap lists as pgsql_bind_array for proper array binding
-            stmt.execArgs(transformBulkBindArgs(h));
+            list<auto> args = transformBulkBindArgs(h);
+            if (use_direct_exec) {
+                ds.vexec(sql, args);
+            } else {
+                if (!stmt) {
+                    stmt = new SQLStatement(ds);
+                    stmt.prepare(sql);
+                }
+                stmt.execArgs(args);
+            }
             return UR_Verified;
         };
     }


### PR DESCRIPTION
## Summary
- **OBJECT-INCOMPATIBLE exception**: When a Qore object inherits from an abstract C++ class (e.g. `AbstractDatasource`) but has no C++ private data, `getReferencedPrivateData()` now throws `OBJECT-INCOMPATIBLE` instead of the misleading `OBJECT-ALREADY-DELETED`. This makes it clear the object is valid but incompatible with the expected builtin class.
- **PgsqlSqlUtil bulk upsert fallback**: `getBulkUpsertClosure()` UNNEST path now falls back to `ds.vexec()` when the datasource is not a `Datasource` or `DatasourcePool` instance (e.g. remote proxy classes like QdspClient in Qorus), since `SQLStatement` cannot be used with such proxies.

## Test plan
- [x] `object.qtest`: new `noPrivateDataTest` verifies `OBJECT-INCOMPATIBLE` for objects with no private data and `OBJECT-ALREADY-DELETED` for genuinely deleted objects
- [x] `PgsqlSqlUtil.qtest`: new `proxyBulkUpsertTest` verifies bulk upsert UNNEST works through a `DatasourceProxy`, plus negative test proving `SQLStatement` rejects proxies with `RUNTIME-OVERLOAD-ERROR`
- [x] `classes.qtest`, `callref.qtest`: no regressions
- [x] Valgrind: zero leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)