### PR TITLE
feat: DPQL template support, integration guide, and serializer fixes

### DIFF
--- a/design/action-session-services.md
+++ b/design/action-session-services.md
@@ -32,6 +32,9 @@ All sessions should expose a minimal common surface:
 
 ## DPQL Session
 
+For detailed callback setup, field metadata construction, and expression evaluation,
+see [DPQL Integration Guide](dpql-integration.md).
+
 ### New Session Class (Qore)
 
 Suggested name: `DpqlActionSession`.

--- a/design/dpql-integration.md
+++ b/design/dpql-integration.md
@@ -41,7 +41,7 @@ application startup via `AbstractDataProvider::setTemplateCallbacks()`:
 
 ```qore
 static bool setTemplateCallbacks(
-    code<auto(string, string, *string, *hash<auto>)> expand,
+    code<auto(string, string, *hash<auto>)> expand,
     *code<*AbstractDataProviderType(string, string, *hash<auto>)> resolve_type,
     *code<auto(*hash<auto>)> list_contexts,
     *code<auto(string, string, *hash<auto>)> list_values,
@@ -50,7 +50,7 @@ static bool setTemplateCallbacks(
 
 | Parameter | Signature | Purpose |
 |-----------|-----------|---------|
-| `expand` | `auto(string tmpl_context, string tmpl_value, *string type_assertion, *hash<auto> template_context)` | Resolve a template reference to a concrete value |
+| `expand` | `auto(string tmpl_context, string tmpl_value, *hash<auto> template_context)` | Resolve a template reference to a concrete value |
 | `resolve_type` | `*AbstractDataProviderType(string tmpl_context, string tmpl_value, *hash<auto> template_context)` | Return the type of a template reference (for validation) |
 | `list_contexts` | `auto(*hash<auto> template_context)` | List available template contexts (for completions) |
 | `list_values` | `auto(string context, string prefix, *hash<auto> template_context)` | List values within a context matching a prefix |
@@ -74,7 +74,7 @@ call at process startup before any concurrent access.
 # Example: register template callbacks at startup
 DataProvider::setTemplateCallbacks(
     # expand: resolve a template reference to a value
-    auto sub (string ctx, string val, *string type_assertion, *hash<auto> tctx) {
+    auto sub (string ctx, string val, *hash<auto> tctx) {
         switch (ctx) {
             case "static":  return static_ctx{val};
             case "config":  return config.get(val);
@@ -130,14 +130,13 @@ When `evalGenericExpressionValue()` encounters a `hash<DataProviderTemplateRefer
 it calls the registered `expand` callback:
 
 ```
-expand(tmpl_context, tmpl_value, type_assertion, template_context)
+expand(tmpl_context, tmpl_value, template_context)
 ```
 
 | Parameter | Source |
 |-----------|--------|
 | `tmpl_context` | The context identifier (e.g., `"static"`, `"config"`) |
 | `tmpl_value` | The value path (e.g., `"account.id"`, `"threshold"`) |
-| `type_assertion` | Optional type from `::type` suffix (e.g., `"int"`) |
 | `template_context` | Opaque per-query hash threaded from `DefaultRecordIterator` |
 
 The `template_context` parameter allows per-request state to flow from the iterator
@@ -148,28 +147,16 @@ If no `expand` callback is registered and a template reference is evaluated, a
 `TEMPLATE-RESOLUTION-ERROR` exception is thrown with the raw template text.
 
 ```qore
-# Example: expand callback with type assertion handling
-auto sub (string ctx, string val, *string type_assertion, *hash<auto> tctx) {
-    auto result;
+# Example: expand callback
+auto sub (string ctx, string val, *hash<auto> tctx) {
     switch (ctx) {
         case "static":
-            result = tctx.static_values{val};
-            break;
+            return tctx.static_values{val};
         case "config":
-            result = config_store.get(val);
-            break;
+            return config_store.get(val);
         default:
             throw "TEMPLATE-RESOLUTION-ERROR", sprintf("unknown context %y", ctx);
     }
-    if (type_assertion) {
-        switch (type_assertion) {
-            case "int":    return int(result);
-            case "float":  return float(result);
-            case "string": return string(result);
-            case "bool":   return boolean(result);
-        }
-    }
-    return result;
 }
 ```
 
@@ -526,7 +513,7 @@ unchanged to each registered template callback.
 |----------|------------|-------------|
 | `DataProviderExpression` | `exp` (string), `args` (list) | Parsed expression node |
 | `DataProviderFieldReference` | `field` (string) | Field reference (`@name`) |
-| `DataProviderTemplateReference` | `tmpl_context`, `tmpl_value`, `*type_assertion`, `raw` | Template reference (`$ctx:val`) |
+| `DataProviderTemplateReference` | `tmpl_context`, `tmpl_value`, `raw` | Template reference (`$ctx:val`) |
 | `DpqlParseResult` | `*expression`, `diagnostics`, `success`, `tokens` | Full parse result |
 | `DpqlDiagnostic` | `severity`, `message`, `code`, `line`, `column`, `end_line`, `end_column` | Parse/validation diagnostic (1-based positions) |
 | `DpqlTokenInfo` | `type` (int), `value`, `line`, `column`, `end_line`, `end_column` | Token info (1-based positions) |

--- a/design/dpql-integration.md
+++ b/design/dpql-integration.md
@@ -1,0 +1,584 @@
+# DPQL Integration Guide
+
+This guide is for host applications (such as Qorus) that embed DPQL — the Data Provider
+Query Language. It covers callback registration, session lifecycle, field metadata
+construction, WebSocket exposure, and expression evaluation at runtime.
+
+For the end-user syntax reference (fields, operators, values, template references), see
+[DPQL Syntax Reference](dpql-syntax.md). For the high-level session architecture and action
+patterns, see [Action-Based Session Services](action-session-services.md).
+
+## Overview
+
+DPQL integration is organized into three tiers of increasing complexity:
+
+| Tier | Classes | Use Case |
+|------|---------|----------|
+| Static API | `DataProvider::` static methods | Stateless parse / tokenize / validate / complete / serialize |
+| Session API | `DpqlActionSession` | Stateful sessions with provider context and field metadata |
+| WebSocket API | `DpqlWebSocketHandler` + `DpqlWebSocketConnection` | Browser and remote clients |
+
+**Static API** — parse a DPQL string into an expression tree, tokenize it for syntax
+highlighting, validate it against a field schema, get completions for an editor, or
+round-trip an expression back to text. No provider context required; field metadata is
+passed explicitly.
+
+**Session API** — wraps the static API with persistent state (provider, field schema,
+expressions). A single `handleAction()` entry point dispatches named actions
+(`dpql-parse`, `dpql-get-completions`, etc.) and returns structured response hashes.
+Ideal for server-side integration where the transport is already handled.
+
+**WebSocket API** — a ready-made `WebSocketHandler` subclass that creates
+`DpqlActionSession` instances per connection, translates JSON messages into actions, and
+sends JSON responses back over the socket. Suitable for browser-based DPQL editors.
+
+## Callback Registration
+
+### Template Callbacks
+
+Template callbacks resolve `$context:value` references at runtime. Register them once at
+application startup via `AbstractDataProvider::setTemplateCallbacks()`:
+
+```qore
+static bool setTemplateCallbacks(
+    code<auto(string, string, *string, *hash<auto>)> expand,
+    *code<*AbstractDataProviderType(string, string)> resolve_type,
+    *code<auto()> list_contexts,
+    *code<auto(string, string)> list_values,
+);
+```
+
+| Parameter | Signature | Purpose |
+|-----------|-----------|---------|
+| `expand` | `auto(string tmpl_context, string tmpl_value, *string type_assertion, *hash<auto> template_context)` | Resolve a template reference to a concrete value |
+| `resolve_type` | `*AbstractDataProviderType(string tmpl_context, string tmpl_value)` | Return the type of a template reference (for validation) |
+| `list_contexts` | `auto()` | List available template contexts (for completions) |
+| `list_values` | `auto(string context, string prefix)` | List values within a context matching a prefix |
+
+**Locking semantics**: The first call locks the callbacks. Subsequent calls succeed only
+if the passed closures are identity-equal to the already-registered ones (returns `True`),
+otherwise they return `False`. This prevents accidental re-registration from a different
+component. Use `clearTemplateCallbacks()` to unlock and remove all callbacks (intended for
+testing).
+
+**Thread safety**: The lock is a simple boolean flag with no mutex. Designed for a single
+call at process startup before any concurrent access.
+
+**Convenience delegate**: `DataProvider::setTemplateCallbacks()` forwards to the
+`AbstractDataProvider` static method and has the same signature.
+
+```qore
+# Example: register template callbacks at startup
+DataProvider::setTemplateCallbacks(
+    # expand: resolve a template reference to a value
+    auto sub (string ctx, string val, *string type_assertion, *hash<auto> tctx) {
+        switch (ctx) {
+            case "static":  return static_ctx{val};
+            case "config":  return config.get(val);
+            case "env":     return ENV{val};
+        }
+        throw "TEMPLATE-RESOLUTION-ERROR", sprintf("unknown context %y", ctx);
+    },
+    # resolve_type: return the type for validation (optional)
+    *AbstractDataProviderType sub (string ctx, string val) {
+        if (ctx == "config") {
+            return config.getType(val);
+        }
+    },
+    # list_contexts: for completions (optional)
+    auto sub () {
+        return (
+            {"name": "static",  "description": "Static values",  "sort_priority": 1},
+            {"name": "config",  "description": "Configuration",  "sort_priority": 2},
+            {"name": "env",     "description": "Environment",    "sort_priority": 3},
+        );
+    },
+    # list_values: for completions within a context (optional)
+    auto sub (string ctx, string prefix) {
+        if (ctx == "env") {
+            return map {"name": $1, "description": "env var"}, keys ENV,
+                $1.lwr().find(prefix.lwr()) == 0;
+        }
+    },
+);
+```
+
+### Dynamic Value Callbacks
+
+Dynamic value callbacks provide a legacy mechanism for resolving URI-style dynamic values
+(separate from DPQL template references). Register via
+`AbstractDataProvider::setDynamicValueCallbacks()`:
+
+```qore
+# Two-arg form: register callbacks
+static bool setDynamicValueCallbacks(code value_needs_resolution, code resolve_value);
+
+# Zero-arg form: lock without registering (prevents others from registering)
+static bool setDynamicValueCallbacks();
+```
+
+The same locking semantics apply: the first call locks, subsequent calls succeed only on
+identity match. These callbacks are independent of template callbacks and serve different
+resolution paths in the DataProvider framework.
+
+## Template Resolution
+
+When `evalGenericExpressionValue()` encounters a `hash<DataProviderTemplateReference>`,
+it calls the registered `expand` callback:
+
+```
+expand(tmpl_context, tmpl_value, type_assertion, template_context)
+```
+
+| Parameter | Source |
+|-----------|--------|
+| `tmpl_context` | The context identifier (e.g., `"static"`, `"config"`) |
+| `tmpl_value` | The value path (e.g., `"account.id"`, `"threshold"`) |
+| `type_assertion` | Optional type from `::type` suffix (e.g., `"int"`) |
+| `template_context` | Opaque per-query hash threaded from `DefaultRecordIterator` |
+
+The `template_context` parameter allows per-request state to flow from the iterator
+constructor through to the callback. For example, a Qorus workflow step might pass the
+current order ID so that `$static:order_id` resolves to the correct value.
+
+If no `expand` callback is registered and a template reference is evaluated, a
+`TEMPLATE-RESOLUTION-ERROR` exception is thrown with the raw template text.
+
+```qore
+# Example: expand callback with type assertion handling
+auto sub (string ctx, string val, *string type_assertion, *hash<auto> tctx) {
+    auto result;
+    switch (ctx) {
+        case "static":
+            result = tctx.static_values{val};
+            break;
+        case "config":
+            result = config_store.get(val);
+            break;
+        default:
+            throw "TEMPLATE-RESOLUTION-ERROR", sprintf("unknown context %y", ctx);
+    }
+    if (type_assertion) {
+        switch (type_assertion) {
+            case "int":    return int(result);
+            case "float":  return float(result);
+            case "string": return string(result);
+            case "bool":   return boolean(result);
+        }
+    }
+    return result;
+}
+```
+
+## Completion Callbacks
+
+### Listing Template Contexts
+
+The `list_contexts` callback returns available contexts for the `$` completion trigger.
+Each entry should be a hash with:
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `name` | `string` | yes | Context identifier (e.g., `"static"`) |
+| `description` | `string` | yes | Human-readable label |
+| `sort_priority` | `int` | no | Lower values sort first |
+
+If no `list_contexts` callback is registered, `DpqlCompletionProvider` falls back to
+9 well-known `DefaultTemplateContexts`: `static`, `dynamic`, `config`, `var`,
+`transient`, `env`, `timestamp`, `qore-expr`, `rest`.
+
+```qore
+auto sub () {
+    return (
+        {"name": "static",    "description": "Static context values",    "sort_priority": 1},
+        {"name": "dynamic",   "description": "Dynamic runtime values",   "sort_priority": 2},
+        {"name": "config",    "description": "Configuration values",     "sort_priority": 3},
+        {"name": "env",       "description": "Environment variables",    "sort_priority": 6},
+    );
+}
+```
+
+### Listing Template Values
+
+The `list_values` callback is called with the context name and a prefix string for
+filtering. Return a list of hashes with the same shape as context entries:
+
+```qore
+auto sub (string ctx, string prefix) {
+    if (ctx == "config") {
+        return map {"name": $1, "description": "config value"},
+            config_store.keys(), $1.find(prefix) == 0;
+    }
+    if (ctx == "env") {
+        return map {"name": $1, "description": ENV{$1}},
+            keys ENV, $1.lwr().find(prefix.lwr()) == 0;
+    }
+}
+```
+
+If no `list_values` callback is registered, template value completions return an empty
+list.
+
+## Type Resolution
+
+The `resolve_type` callback returns an `*AbstractDataProviderType` for a template
+reference, enabling type compatibility checking during `validateDpqlExpression()`:
+
+```qore
+*AbstractDataProviderType sub (string ctx, string val) {
+    if (ctx == "config") {
+        *string type_name = config_store.getTypeName(val);
+        switch (type_name) {
+            case "int":    return AbstractDataProviderType::get(IntType);
+            case "string": return AbstractDataProviderType::get(StringType);
+            case "float":  return AbstractDataProviderType::get(FloatType);
+        }
+    }
+    # Return NOTHING to skip type validation for unknown references
+}
+```
+
+When `resolve_type` returns `NOTHING` (or is not registered), type validation is skipped
+for that reference — the expression is accepted without type-checking the template value.
+
+## Session Lifecycle
+
+### Constructor Options
+
+Create a `DpqlActionSession` with optional configuration:
+
+```qore
+DpqlActionSession session({"token_format": "token-span", "field_format": "map"});
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `token_format` | `string` | `"token-span"` | `"token-span"`: 0-based row/col spans; `"dpql"`: 1-based, includes expression tree |
+| `field_format` | `string` | `"map"` | `"map"`: hash keyed by field name; `"list"`: list of field hashes |
+| `logger` | `*LoggerInterface` | `NOTHING` | Optional logger for debug output |
+
+### Action Dispatch
+
+All interaction goes through `handleAction()`:
+
+```qore
+hash<auto> handleAction(string action, *hash<auto> args);
+```
+
+### Action Reference
+
+| Action | Required Args | Optional Args | Response Keys |
+|--------|--------------|---------------|---------------|
+| `dpql-set-context` | `provider` (string) | `subtype`, `options`, `recordOptions`, `recordType` | `provider`, `recordType`, `recordRequiresSearchOptions`, `fields`, `expressions` |
+| `dpql-parse` | `text` (string) | `fields` | `success`, `diagnostics`, `tokens` (+ `expression` if format=`"dpql"`) |
+| `dpql-get-completions` | `text` (string), `position` (int) | `fields` | `completions` |
+| `dpql-get-tokens` | `text` (string) | | `tokens` |
+| `dpql-format` | `text` (string) | | `formatted`, `success` |
+| `dpql-validate` | `text` (string) | `fields` | `diagnostics` |
+| `dpql-serialize` | `expression` (hash) | | `dpql` |
+
+The `dpql-set-context` action must be called first to establish the provider and field
+schema. Subsequent parse/complete/validate actions use the cached context. The `fields`
+arg on `dpql-parse`, `dpql-get-completions`, and `dpql-validate` allows overriding the
+cached fields for a single call.
+
+```qore
+# Example: session lifecycle
+DpqlActionSession session({"token_format": "token-span", "field_format": "map"});
+
+# 1. Set context — establishes provider and field schema
+hash<auto> ctx = session.handleAction("dpql-set-context", {
+    "provider": "datasource/omq/table/orders",
+    "recordType": "record",
+});
+
+# 2. Parse — returns tokens and diagnostics
+hash<auto> parsed = session.handleAction("dpql-parse", {
+    "text": "@status == \"active\" && @amount > 100",
+});
+if (parsed.success) {
+    # expression parsed cleanly
+}
+
+# 3. Get completions at cursor position
+hash<auto> comps = session.handleAction("dpql-get-completions", {
+    "text": "@st",
+    "position": 3,
+});
+
+# 4. Validate against field schema
+hash<auto> diags = session.handleAction("dpql-validate", {
+    "text": "@status == \"active\"",
+});
+```
+
+## Field Metadata
+
+### Automatic Field Discovery
+
+When `dpql-set-context` is called with a `provider`, the session resolves the provider and
+calls `provider.getRecordType()` to obtain field metadata automatically. The result is a
+`hash<string, AbstractDataField>` mapping field names to their type descriptors.
+
+### Manual Field Construction
+
+For scenarios where the provider is not available or fields need augmentation, construct
+fields manually using `QoreDataField`:
+
+```qore
+hash<string, AbstractDataField> fields;
+
+# Simple typed fields
+fields.name = new QoreDataField("name", "User name", StringType);
+fields.age = new QoreDataField("age", "User age", IntType);
+fields.active = new QoreDataField("active", "Active flag", BoolType);
+
+# Nested hash field — enables @record{key} completions
+HashDataType address_type();
+address_type.addField(new QoreDataField("street", "Street", StringType));
+address_type.addField(new QoreDataField("city", "City", StringType));
+address_type.addField(new QoreDataField("zip", "ZIP code", StringType));
+fields.address = new QoreDataField("address", "Mailing address", address_type);
+```
+
+### Schema-Aware Key Completions
+
+When a field has a hash type with known sub-fields, the completion provider can suggest
+keys inside `{...}` accessors. For example, with the `address` field above, typing
+`@address{` will suggest `street`, `city`, and `zip`.
+
+This requires provider-backed context from `dpql-set-context` or manually constructed
+`HashDataType` fields with sub-fields.
+
+### Field Override Pattern
+
+The `dpql-parse`, `dpql-get-completions`, and `dpql-validate` actions accept an optional
+`fields` argument that overrides the cached field schema for that single call:
+
+```qore
+hash<auto> result = session.handleAction("dpql-get-completions", {
+    "text": "@",
+    "position": 1,
+    "fields": custom_field_map,
+});
+```
+
+## WebSocket Exposure
+
+### Handler Setup
+
+`DpqlWebSocketHandler` extends `WebSocketHandler` and creates per-connection
+`DpqlActionSession` instances:
+
+```qore
+constructor(*HttpServer::AbstractAuthenticator auth, *hash<auto> opts);
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `auth_callback` | `code(hash cx, hash hdr) returns bool` | `NOTHING` | Custom authentication callback |
+| `max_connections` | `int` | `0` | Maximum concurrent connections (0 = unlimited) |
+
+All additional options in `opts` are passed through to the base `WebSocketHandler`
+constructor (e.g., `heartbeat`, `heartbeat_msg`, `logger`, `send_timeout`).
+
+```qore
+# Example: handler with authentication and connection limit
+DpqlWebSocketHandler handler(authenticator, {
+    "auth_callback": bool sub (hash<auto> cx, hash<auto> hdr) {
+        return validate_token(hdr."Authorization");
+    },
+    "max_connections": 50,
+    "heartbeat": 30,
+});
+```
+
+### Connection Lifecycle
+
+When a client connects, `DpqlWebSocketConnection` is created with:
+- A new `DpqlActionSession` (token_format=`"dpql"`, field_format=`"list"`)
+- A random 16-character session ID
+
+The server immediately sends a `session` message:
+
+```json
+{"type": "session", "sessionId": "...", "version": "1.0", "qoreVersion": "..."}
+```
+
+Client messages are JSON objects with a `type` field that maps to session actions:
+
+| Client `type` | Session Action | Response `type` |
+|----------------|---------------|-----------------|
+| `context` | `dpql-set-context` | `context` |
+| `tokenize` | `dpql-get-tokens` | `tokens` |
+| `parse` | `dpql-parse` | `parse` |
+| `validate` | `dpql-validate` | `validate` |
+| `complete` | `dpql-get-completions` | `completions` |
+| `serialize` | `dpql-serialize` | `serialize` |
+| `ping` | (handled directly) | `pong` |
+
+For the full wire protocol schema, see
+[DpqlApi.asyncapi.yaml](../qlib/DpqlWebSocket/DpqlApi.asyncapi.yaml).
+
+## Expression Evaluation
+
+### Parse-Then-Evaluate Pipeline
+
+DPQL expressions are first parsed into a `hash<DataProviderExpression>` tree, then
+evaluated against record hashes at query time.
+
+**`evalGenericExpression()`** evaluates a parsed expression tree:
+
+```qore
+static auto evalGenericExpression(
+    hash<auto> rec,
+    hash<DataProviderExpression> exp,
+    *hash<auto> template_context,
+);
+```
+
+It looks up the operator implementation from `GenericExpressionImplementations`, calls it,
+and validates the return value against the operator's declared return type.
+
+**`evalGenericExpressionValue()`** resolves leaf values in the expression tree:
+
+```qore
+static auto evalGenericExpressionValue(
+    hash<auto> rec,
+    auto val,
+    *hash<auto> template_context,
+);
+```
+
+It handles three value types:
+- `hash<DataProviderFieldReference>` — resolves dotted field paths against the record
+- `hash<DataProviderTemplateReference>` — calls the registered `expand` callback
+- `hash<DataProviderExpression>` — recursively evaluates nested expressions
+- All other values are returned as-is (literals)
+
+### Old-Style Hash Matching
+
+`AbstractDataProviderRecordIterator::matchGeneric()` provides backward-compatible matching
+using operator hashes (the pre-DPQL query format). It also resolves template references
+via `resolveTemplateValue()`, which delegates to `evalGenericExpressionValue()` for
+`hash<DataProviderTemplateReference>` values.
+
+### DefaultRecordIterator Threading
+
+`DefaultRecordIterator` accepts a `template_context` hash in its constructor and threads
+it through to `matchGeneric()` on each iteration:
+
+```qore
+constructor(
+    AbstractIterator i,
+    *hash<auto> where_cond,
+    *hash<auto> search_options,
+    *hash<string, AbstractDataField> record_type,
+    *string subrecord,
+    *hash<auto> template_context,
+);
+```
+
+The `template_context` flows: constructor → stored as member → passed to
+`matchGeneric()` → passed to `evalGenericExpression()` → passed to `expand` callback.
+
+```qore
+# Example: parse-then-evaluate with template context
+string dpql_text = "@status == $static:required_status && @amount > $config:min_amount::int";
+
+# Parse
+hash<DataProviderExpression> expr = DataProvider::parseDpqlExpression(dpql_text);
+
+# Evaluate against a record with per-request context
+hash<auto> record = {"status": "active", "amount": 500};
+hash<auto> tctx = {"static_values": {"required_status": "active"}};
+
+bool match = AbstractDataProvider::evalGenericExpression(record, expr, tctx);
+```
+
+## Static API Reference
+
+### Method Summary
+
+All methods are static on the `DataProvider` class:
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `parseDpqlExpression` | `hash<DataProviderExpression>(string text, *hash<string, hash<DataProviderExpressionInfo>> expressions)` | Parse DPQL text into an expression tree; throws `DPQL-PARSE-ERROR` on syntax error |
+| `parseDpqlExpressionWithInfo` | `hash<DpqlParseResult>(string text, *hash<string, hash<DataProviderExpressionInfo>> expressions)` | Parse with full result (expression, diagnostics, tokens, success flag) |
+| `serializeDpqlExpression` | `string(hash<DataProviderExpression> exp, *hash<string, hash<DataProviderExpressionInfo>> expressions)` | Serialize an expression tree back to DPQL text |
+| `getDpqlTokens` | `list<hash<DpqlTokenInfo>>(string text)` | Tokenize DPQL text for syntax highlighting |
+| `getDpqlCompletions` | `list<hash<DpqlCompletionItem>>(string text, int position, hash<string, AbstractDataField> fields, *hash<string, hash<DataProviderExpressionInfo>> expressions)` | Get completions at a cursor position |
+| `validateDpqlExpression` | `list<hash<DpqlDiagnostic>>(string text, hash<string, AbstractDataField> fields, *hash<string, hash<DataProviderExpressionInfo>> expressions)` | Validate expression against field schema; returns diagnostics |
+| `setTemplateCallbacks` | `bool(code expand, *code resolve_type, *code list_contexts, *code list_values)` | Register template resolution callbacks |
+| `clearTemplateCallbacks` | `(none)` | Clear and unlock template callbacks |
+
+The optional `expressions` parameter defaults to `DataProviderGenericExpressions` (the
+built-in operator set) when not provided.
+
+### Hashdecl Summary
+
+| Hashdecl | Key Fields | Description |
+|----------|------------|-------------|
+| `DataProviderExpression` | `exp` (string), `args` (list) | Parsed expression node |
+| `DataProviderFieldReference` | `field` (string) | Field reference (`@name`) |
+| `DataProviderTemplateReference` | `tmpl_context`, `tmpl_value`, `*type_assertion`, `raw` | Template reference (`$ctx:val`) |
+| `DpqlParseResult` | `*expression`, `diagnostics`, `success`, `tokens` | Full parse result |
+| `DpqlDiagnostic` | `severity`, `message`, `code`, `line`, `column`, `end_line`, `end_column` | Parse/validation diagnostic (1-based positions) |
+| `DpqlTokenInfo` | `type` (int), `value`, `line`, `column`, `end_line`, `end_column` | Token info (1-based positions) |
+| `DpqlCompletionItem` | `label`, `kind`, `insert_text`, `*documentation`, `sort_priority` | Completion suggestion |
+| `DataProviderExpressionInfo` | `type`, `name`, `display_name`, `symbol`, `args`, `return_type` | Operator/function metadata |
+
+### Complete Pipeline Example
+
+```qore
+%modern
+
+hash<string, AbstractDataField> fields;
+fields.status = new QoreDataField("status", "Order status", StringType);
+fields.amount = new QoreDataField("amount", "Order amount", FloatType);
+fields.created = new QoreDataField("created", "Created date", DateType);
+
+string dpql = "@status == \"active\" && @amount > 100";
+
+# 1. Validate
+list<hash<DpqlDiagnostic>> diags = DataProvider::validateDpqlExpression(dpql, fields);
+if (diags) {
+    map printf("  %s:%d:%d: %s\n", $1.severity, $1.line, $1.column, $1.message), diags;
+}
+
+# 2. Parse
+hash<DataProviderExpression> expr = DataProvider::parseDpqlExpression(dpql);
+
+# 3. Evaluate
+hash<auto> record = {"status": "active", "amount": 250.0, "created": now()};
+bool match = AbstractDataProvider::evalGenericExpression(record, expr);
+# match == True
+
+# 4. Round-trip
+string serialized = DataProvider::serializeDpqlExpression(expr);
+# serialized == "@status == \"active\" && @amount > 100"
+```
+
+## Error Reference
+
+| Error | Thrown By | Condition |
+|-------|----------|-----------|
+| `DPQL-PARSE-ERROR` | `DpqlParser::parse()` | Syntax error in DPQL expression |
+| `TEMPLATE-RESOLUTION-ERROR` | `evalGenericExpressionValue()` | Template reference encountered but no `expand` callback registered |
+| `INVALID-OPERATION` | `evalGenericExpressionValue()`, `evalGenericExpression()` | Unknown operator or invalid field path in record |
+| `INVALID-ACTION` | `DpqlActionSession::handleAction()` | Unsupported action name |
+| `MISSING-PARAMETER` | `DpqlActionSession` action handlers | Required arg missing from action args |
+| `INVALID-PARAMETER` | `DpqlActionSession` action handlers | Arg has wrong type |
+| `NO-CONTEXT` | `DpqlActionSession::handleCompletions()` | Completions requested but no provider context set |
+| `CONTEXT-ERROR` | `DpqlActionSession::handleSetContext()` | Provider could not be resolved |
+| `WEBSOCKETHANDLER-OPTION-ERROR` | `DpqlWebSocketHandler::constructor()` | Invalid handler option |
+
+## Cross-References
+
+- [DPQL Syntax Reference](dpql-syntax.md) — end-user syntax for fields, operators, values,
+  and template references
+- [Action-Based Session Services](action-session-services.md) — high-level architecture for
+  DPQL, REPL, and OpenAI action-based sessions
+- [DpqlApi.asyncapi.yaml](../qlib/DpqlWebSocket/DpqlApi.asyncapi.yaml) — WebSocket wire
+  protocol schema

--- a/design/dpql-integration.md
+++ b/design/dpql-integration.md
@@ -42,18 +42,21 @@ application startup via `AbstractDataProvider::setTemplateCallbacks()`:
 ```qore
 static bool setTemplateCallbacks(
     code<auto(string, string, *string, *hash<auto>)> expand,
-    *code<*AbstractDataProviderType(string, string)> resolve_type,
-    *code<auto()> list_contexts,
-    *code<auto(string, string)> list_values,
+    *code<*AbstractDataProviderType(string, string, *hash<auto>)> resolve_type,
+    *code<auto(*hash<auto>)> list_contexts,
+    *code<auto(string, string, *hash<auto>)> list_values,
 );
 ```
 
 | Parameter | Signature | Purpose |
 |-----------|-----------|---------|
 | `expand` | `auto(string tmpl_context, string tmpl_value, *string type_assertion, *hash<auto> template_context)` | Resolve a template reference to a concrete value |
-| `resolve_type` | `*AbstractDataProviderType(string tmpl_context, string tmpl_value)` | Return the type of a template reference (for validation) |
-| `list_contexts` | `auto()` | List available template contexts (for completions) |
-| `list_values` | `auto(string context, string prefix)` | List values within a context matching a prefix |
+| `resolve_type` | `*AbstractDataProviderType(string tmpl_context, string tmpl_value, *hash<auto> template_context)` | Return the type of a template reference (for validation) |
+| `list_contexts` | `auto(*hash<auto> template_context)` | List available template contexts (for completions) |
+| `list_values` | `auto(string context, string prefix, *hash<auto> template_context)` | List values within a context matching a prefix |
+
+All callbacks receive an optional `template_context` hash that is threaded through from
+the query context (see [Expression Evaluation](#expression-evaluation)).
 
 **Locking semantics**: The first call locks the callbacks. Subsequent calls succeed only
 if the passed closures are identity-equal to the already-registered ones (returns `True`),
@@ -80,13 +83,13 @@ DataProvider::setTemplateCallbacks(
         throw "TEMPLATE-RESOLUTION-ERROR", sprintf("unknown context %y", ctx);
     },
     # resolve_type: return the type for validation (optional)
-    *AbstractDataProviderType sub (string ctx, string val) {
+    *AbstractDataProviderType sub (string ctx, string val, *hash<auto> tctx) {
         if (ctx == "config") {
             return config.getType(val);
         }
     },
     # list_contexts: for completions (optional)
-    auto sub () {
+    auto sub (*hash<auto> tctx) {
         return (
             {"name": "static",  "description": "Static values",  "sort_priority": 1},
             {"name": "config",  "description": "Configuration",  "sort_priority": 2},
@@ -94,7 +97,7 @@ DataProvider::setTemplateCallbacks(
         );
     },
     # list_values: for completions within a context (optional)
-    auto sub (string ctx, string prefix) {
+    auto sub (string ctx, string prefix, *hash<auto> tctx) {
         if (ctx == "env") {
             return map {"name": $1, "description": "env var"}, keys ENV,
                 $1.lwr().find(prefix.lwr()) == 0;
@@ -225,7 +228,7 @@ The `resolve_type` callback returns an `*AbstractDataProviderType` for a templat
 reference, enabling type compatibility checking during `validateDpqlExpression()`:
 
 ```qore
-*AbstractDataProviderType sub (string ctx, string val) {
+*AbstractDataProviderType sub (string ctx, string val, *hash<auto> tctx) {
     if (ctx == "config") {
         *string type_name = config_store.getTypeName(val);
         switch (type_name) {
@@ -508,13 +511,14 @@ All methods are static on the `DataProvider` class:
 | `parseDpqlExpressionWithInfo` | `hash<DpqlParseResult>(string text, *hash<string, hash<DataProviderExpressionInfo>> expressions)` | Parse with full result (expression, diagnostics, tokens, success flag) |
 | `serializeDpqlExpression` | `string(hash<DataProviderExpression> exp, *hash<string, hash<DataProviderExpressionInfo>> expressions)` | Serialize an expression tree back to DPQL text |
 | `getDpqlTokens` | `list<hash<DpqlTokenInfo>>(string text)` | Tokenize DPQL text for syntax highlighting |
-| `getDpqlCompletions` | `list<hash<DpqlCompletionItem>>(string text, int position, hash<string, AbstractDataField> fields, *hash<string, hash<DataProviderExpressionInfo>> expressions)` | Get completions at a cursor position |
+| `getDpqlCompletions` | `list<hash<DpqlCompletionItem>>(string text, int position, hash<string, AbstractDataField> fields, *hash<string, hash<DataProviderExpressionInfo>> expressions, *hash<auto> template_context)` | Get completions at a cursor position |
 | `validateDpqlExpression` | `list<hash<DpqlDiagnostic>>(string text, hash<string, AbstractDataField> fields, *hash<string, hash<DataProviderExpressionInfo>> expressions)` | Validate expression against field schema; returns diagnostics |
-| `setTemplateCallbacks` | `bool(code expand, *code resolve_type, *code list_contexts, *code list_values)` | Register template resolution callbacks |
+| `setTemplateCallbacks` | `bool(code expand, *code resolve_type, *code list_contexts, *code list_values)` | Register template resolution callbacks; all callbacks receive a trailing `*hash<auto> template_context` argument |
 | `clearTemplateCallbacks` | `(none)` | Clear and unlock template callbacks |
 
 The optional `expressions` parameter defaults to `DataProviderGenericExpressions` (the
-built-in operator set) when not provided.
+built-in operator set) when not provided. The `template_context` hash is passed through
+unchanged to each registered template callback.
 
 ### Hashdecl Summary
 

--- a/design/dpql-syntax.md
+++ b/design/dpql-syntax.md
@@ -3,6 +3,9 @@
 This document describes the syntax of DPQL (Data Provider Query Language), a domain-specific
 language for filtering and querying data in the Qore DataProvider framework.
 
+For integration guidance (callback registration, session lifecycle, expression evaluation),
+see [DPQL Integration Guide](dpql-integration.md).
+
 ## Field References
 
 Field references are prefixed with `@`:
@@ -247,6 +250,66 @@ Expressions can be grouped with parentheses:
 (@status == "active" || @status == "pending") && @age >= 18
 !(@deleted == true)
 ```
+
+## Template References
+
+Template references allow DPQL expressions to reference contextual values that are resolved
+at runtime via registered callbacks. This enables expressions like configuration values,
+environment variables, and dynamic context without hardcoding values.
+
+### Syntax
+
+| Form | Example | Description |
+|------|---------|-------------|
+| Simple | `$static:account.id` | Context `static`, value `account.id` |
+| Bracketed | `$qore-expr:{1 + 2}` | Bracketed value (allows special characters) |
+| Type-asserted | `$config:threshold::int` | With type assertion `int` |
+| Fallback | `$static:A??{$static:B}` | Fallback syntax (raw passthrough) |
+
+### Template Contexts
+
+Template contexts identify the source of the value. Well-known contexts include:
+
+| Context | Description |
+|---------|-------------|
+| `static` | Static context values |
+| `dynamic` | Dynamic runtime values |
+| `config` | Configuration values |
+| `var` | Variable values |
+| `transient` | Transient context values |
+| `env` | Environment variables |
+| `timestamp` | Timestamp values |
+| `qore-expr` | Qore expression evaluation |
+| `rest` | REST context values |
+
+### Usage in Expressions
+
+Template references can appear anywhere a value is expected:
+
+```dpql
+# As a comparison operand
+@name == $static:expected_name
+
+# In logical expressions
+@age > $config:min_age::int && @status == $static:required_status
+
+# As a standalone expression
+$static:name
+
+# Mixed with field references
+@price > $config:threshold && @category in ($static:allowed_categories)
+```
+
+### Resolution
+
+Template references are resolved at runtime via callbacks registered with
+`DataProvider::setTemplateCallbacks()`. If no callback is registered and a template
+reference is evaluated, a `TEMPLATE-RESOLUTION-ERROR` is thrown. See
+[DPQL Integration Guide — Template Resolution](dpql-integration.md#template-resolution)
+for callback implementation details.
+
+Array indexing, fallback syntax (`??{}`), and dot navigation within template values
+are passed as raw strings to the callback for handling.
 
 ## Examples
 

--- a/design/dpql-syntax.md
+++ b/design/dpql-syntax.md
@@ -263,7 +263,6 @@ environment variables, and dynamic context without hardcoding values.
 |------|---------|-------------|
 | Simple | `$static:account.id` | Context `static`, value `account.id` |
 | Bracketed | `$qore-expr:{1 + 2}` | Bracketed value (allows special characters) |
-| Type-asserted | `$config:threshold::int` | With type assertion `int` |
 | Fallback | `$static:A??{$static:B}` | Fallback syntax (raw passthrough) |
 
 ### Template Contexts

--- a/examples/test/qlib/DataProvider/Dpql.qtest
+++ b/examples/test/qlib/DataProvider/Dpql.qtest
@@ -103,6 +103,12 @@ public class DpqlTest inherits QUnit::Test {
         addTestCase("field dot edge case tests", \fieldDotEdgeCaseTests());
         addTestCase("DPQL string search API tests", \dpqlStringSearchTests());
         addTestCase("stress tests", \stressTests());
+        addTestCase("template tokenizer tests", \templateTokenizerTests());
+        addTestCase("template parser tests", \templateParserTests());
+        addTestCase("template serializer tests", \templateSerializerTests());
+        addTestCase("template evaluation tests", \templateEvaluationTests());
+        addTestCase("template completion tests", \templateCompletionTests());
+        addTestCase("template validation tests", \templateValidationTests());
 
         # Return for compatibility with test harnesses that check the return value.
         set_return_value(main());
@@ -3126,6 +3132,906 @@ public class DpqlTest inherits QUnit::Test {
         {
             hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('@name == "John"');
             assertEq(DP_SEARCH_OP_EQ, exp.exp);  # Not DP_EXPR_VALUE
+        }
+    }
+
+    templateTokenizerTests() {
+        # Simple template reference
+        {
+            DpqlTokenizer tok('$static:value');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(1, tokens.size());
+            assertEq(DPQL_TOK_TEMPLATE, tokens[0].type);
+            assertEq("$static:value", tokens[0].value);
+        }
+
+        # Template with dotted value
+        {
+            DpqlTokenizer tok('$static:account.id');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_TEMPLATE, tokens[0].type);
+            assertEq("$static:account.id", tokens[0].value);
+        }
+
+        # Template with hyphenated context (qore-expr)
+        {
+            DpqlTokenizer tok('$qore-expr:{1 + 2}');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_TEMPLATE, tokens[0].type);
+            assertEq("$qore-expr:{1 + 2}", tokens[0].value);
+        }
+
+        # Template with type assertion
+        {
+            DpqlTokenizer tok('$config:threshold::int');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_TEMPLATE, tokens[0].type);
+            assertEq("$config:threshold::int", tokens[0].value);
+        }
+
+        # Template with wildcard
+        {
+            DpqlTokenizer tok('$static:*');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_TEMPLATE, tokens[0].type);
+            assertEq("$static:*", tokens[0].value);
+        }
+
+        # Template with fallback syntax
+        {
+            DpqlTokenizer tok('$static:A??{$static:B}');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_TEMPLATE, tokens[0].type);
+            assertEq("$static:A??{$static:B}", tokens[0].value);
+        }
+
+        # Template in string is NOT a template token
+        {
+            DpqlTokenizer tok('"$static:value"');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_STRING, tokens[0].type);
+        }
+
+        # Template as part of comparison expression
+        {
+            DpqlTokenizer tok('@name == $static:expected');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            # @name, whitespace, ==, whitespace, $static:expected, EOF
+            int template_count = 0;
+            int field_count = 0;
+            foreach hash<DpqlTokenInfo> t in (tokens) {
+                if (t.type == DPQL_TOK_TEMPLATE) {
+                    ++template_count;
+                } else if (t.type == DPQL_TOK_FIELD) {
+                    ++field_count;
+                }
+            }
+            assertEq(1, template_count, "one template token");
+            assertEq(1, field_count, "one field token");
+        }
+
+        # Error: bare $ at end
+        {
+            DpqlTokenizer tok('$');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_ERROR, tokens[0].type);
+            list<hash<DpqlDiagnostic>> errors = tok.getErrors();
+            assertEq(1, errors.size());
+            assertEq("DPQL-E030", errors[0].code);
+        }
+
+        # Error: $ followed by non-identifier
+        {
+            DpqlTokenizer tok('$:value');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_ERROR, tokens[0].type);
+            list<hash<DpqlDiagnostic>> errors = tok.getErrors();
+            assertEq("DPQL-E031", errors[0].code);
+        }
+
+        # Error: $ctx without colon
+        {
+            DpqlTokenizer tok('$ctx ');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_ERROR, tokens[0].type);
+            list<hash<DpqlDiagnostic>> errors = tok.getErrors();
+            assertEq("DPQL-E032", errors[0].code);
+        }
+
+        # Error: $ctx: with no value
+        {
+            DpqlTokenizer tok('$ctx:');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_ERROR, tokens[0].type);
+            list<hash<DpqlDiagnostic>> errors = tok.getErrors();
+            assertEq("DPQL-E033", errors[0].code);
+        }
+
+        # Error: unterminated bracketed value
+        {
+            DpqlTokenizer tok('$ctx:{unterminated');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_ERROR, tokens[0].type);
+            list<hash<DpqlDiagnostic>> errors = tok.getErrors();
+            assertEq("DPQL-E034", errors[0].code);
+        }
+
+        # Nested bracketed value
+        {
+            DpqlTokenizer tok('$qore-expr:{hash{key}}');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_TEMPLATE, tokens[0].type);
+            assertEq("$qore-expr:{hash{key}}", tokens[0].value);
+        }
+
+        # Multiple templates in expression
+        {
+            DpqlTokenizer tok('$static:a == $config:b');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            int tmpl_count = 0;
+            foreach hash<DpqlTokenInfo> t in (tokens) {
+                if (t.type == DPQL_TOK_TEMPLATE) {
+                    ++tmpl_count;
+                }
+            }
+            assertEq(2, tmpl_count, "two template tokens");
+        }
+
+        # Complex type assertion
+        {
+            DpqlTokenizer tok('$config:limit::*softint');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_TEMPLATE, tokens[0].type);
+            assertEq("$config:limit::*softint", tokens[0].value);
+        }
+
+        # Bracketed value with string containing braces (Issue 5)
+        {
+            DpqlTokenizer tok('$qore-expr:{"hello}world"}');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_TEMPLATE, tokens[0].type);
+            assertEq('$qore-expr:{"hello}world"}', tokens[0].value);
+        }
+
+        # Bracketed value with single-quoted string containing braces
+        {
+            DpqlTokenizer tok("$qore-expr:{'hello}world'}");
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_TEMPLATE, tokens[0].type);
+            assertEq("$qore-expr:{'hello}world'}", tokens[0].value);
+        }
+
+        # Bracketed value with escaped brace
+        {
+            DpqlTokenizer tok('$qore-expr:{a\}b}');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_TEMPLATE, tokens[0].type);
+            assertEq('$qore-expr:{a\}b}', tokens[0].value);
+        }
+
+        # Empty bracketed value
+        {
+            DpqlTokenizer tok('$ctx:{}');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_TEMPLATE, tokens[0].type);
+            assertEq("$ctx:{}", tokens[0].value);
+        }
+
+        # Value followed by [ — tokenizer stops at [
+        {
+            DpqlTokenizer tok('$static:value[0]');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_TEMPLATE, tokens[0].type);
+            assertEq("$static:value", tokens[0].value, "tokenizer stops at '['");
+            # [0] follows as separate tokens
+            bool has_bracket = False;
+            for (int i = 1; i < tokens.size(); ++i) {
+                if (tokens[i].type == DPQL_TOK_LBRACKET) {
+                    has_bracket = True;
+                    break;
+                }
+            }
+            assertEq(True, has_bracket, "'[' is a separate token after template");
+        }
+
+        # :: in value path — parsed as type assertion (last ::)
+        {
+            DpqlTokenizer tok('$static:ns::class');
+            list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
+            assertEq(DPQL_TOK_TEMPLATE, tokens[0].type);
+            assertEq("$static:ns::class", tokens[0].value);
+        }
+    }
+
+    templateParserTests() {
+        # Simple template as comparison operand
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$static:id == "123"');
+            assertEq(DP_SEARCH_OP_EQ, exp.exp);
+            assertEq(True, exp.args[0] instanceof hash<DataProviderTemplateReference>);
+            hash<DataProviderTemplateReference> ref = cast<hash<DataProviderTemplateReference>>(exp.args[0]);
+            assertEq("static", ref.tmpl_context);
+            assertEq("id", ref.tmpl_value);
+            assertEq(NOTHING, ref.type_assertion);
+            assertEq("$static:id", ref.raw);
+            assertEq("123", exp.args[1]);
+        }
+
+        # Standalone template wraps in DP_EXPR_TEMPLATE
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$config:threshold');
+            assertEq(DP_EXPR_TEMPLATE, exp.exp);
+            assertEq(True, exp.args[0] instanceof hash<DataProviderTemplateReference>);
+            hash<DataProviderTemplateReference> ref = cast<hash<DataProviderTemplateReference>>(exp.args[0]);
+            assertEq("config", ref.tmpl_context);
+            assertEq("threshold", ref.tmpl_value);
+        }
+
+        # Template on right side of comparison
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('@age > $config:min_age');
+            assertEq(DP_SEARCH_OP_GT, exp.exp);
+            assertEq(True, exp.args[0] instanceof hash<DataProviderFieldReference>);
+            assertEq(True, exp.args[1] instanceof hash<DataProviderTemplateReference>);
+            hash<DataProviderTemplateReference> ref = cast<hash<DataProviderTemplateReference>>(exp.args[1]);
+            assertEq("config", ref.tmpl_context);
+            assertEq("min_age", ref.tmpl_value);
+        }
+
+        # Mixed template + field with logical operators
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '$static:active == true && @age > $config:min_age');
+            assertEq(DP_OP_AND, exp.exp);
+            assertEq(2, exp.args.size());
+        }
+
+        # Type assertion
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$config:limit::int');
+            assertEq(DP_EXPR_TEMPLATE, exp.exp);
+            hash<DataProviderTemplateReference> ref = cast<hash<DataProviderTemplateReference>>(exp.args[0]);
+            assertEq("config", ref.tmpl_context);
+            assertEq("limit", ref.tmpl_value);
+            assertEq("int", ref.type_assertion);
+        }
+
+        # Bracketed value
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$qore-expr:{$static:price * $static:qty}');
+            assertEq(DP_EXPR_TEMPLATE, exp.exp);
+            hash<DataProviderTemplateReference> ref = cast<hash<DataProviderTemplateReference>>(exp.args[0]);
+            assertEq("qore-expr", ref.tmpl_context);
+            assertEq("$static:price * $static:qty", ref.tmpl_value);
+        }
+
+        # Template with dotted value path
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$static:account.id');
+            assertEq(DP_EXPR_TEMPLATE, exp.exp);
+            hash<DataProviderTemplateReference> ref = cast<hash<DataProviderTemplateReference>>(exp.args[0]);
+            assertEq("static", ref.tmpl_context);
+            assertEq("account.id", ref.tmpl_value);
+        }
+
+        # Two templates in comparison
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '$static:left == $config:right');
+            assertEq(DP_SEARCH_OP_EQ, exp.exp);
+            assertEq(True, exp.args[0] instanceof hash<DataProviderTemplateReference>);
+            assertEq(True, exp.args[1] instanceof hash<DataProviderTemplateReference>);
+        }
+
+        # Template in parenthesized sub-expression
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '(@name == $static:n) && @age > 18');
+            assertEq(DP_OP_AND, exp.exp);
+        }
+
+        # :: in value path — last :: is type assertion
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$static:ns::class');
+            assertEq(DP_EXPR_TEMPLATE, exp.exp);
+            hash<DataProviderTemplateReference> ref = cast<hash<DataProviderTemplateReference>>(exp.args[0]);
+            assertEq("static", ref.tmpl_context);
+            assertEq("ns", ref.tmpl_value);
+            assertEq("class", ref.type_assertion, "last :: interpreted as type assertion");
+        }
+
+        # To get :: in value, use brackets
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$static:{ns::class}');
+            assertEq(DP_EXPR_TEMPLATE, exp.exp);
+            hash<DataProviderTemplateReference> ref = cast<hash<DataProviderTemplateReference>>(exp.args[0]);
+            assertEq("ns::class", ref.tmpl_value, "bracketed form preserves :: in value");
+            assertEq(NOTHING, ref.type_assertion);
+        }
+
+        # Empty brackets parse to empty value
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$ctx:{}');
+            assertEq(DP_EXPR_TEMPLATE, exp.exp);
+            hash<DataProviderTemplateReference> ref = cast<hash<DataProviderTemplateReference>>(exp.args[0]);
+            assertEq("ctx", ref.tmpl_context);
+            assertEq("", ref.tmpl_value, "empty brackets yield empty value");
+        }
+    }
+
+    templateSerializerTests() {
+        # Round-trip: simple template
+        {
+            string input = '$static:account.id';
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(input);
+            string serialized = DataProvider::serializeDpqlExpression(exp);
+            assertEq(input, serialized, "simple template round-trip");
+        }
+
+        # Round-trip: bracketed template with type assertion
+        {
+            string input = '$qore-expr:{1 + 2}';
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(input);
+            string serialized = DataProvider::serializeDpqlExpression(exp);
+            assertEq(input, serialized, "bracketed template round-trip");
+        }
+
+        # Round-trip: template with type assertion
+        {
+            string input = '$config:threshold::int';
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(input);
+            string serialized = DataProvider::serializeDpqlExpression(exp);
+            assertEq(input, serialized, "type-asserted template round-trip");
+        }
+
+        # Round-trip: comparison with template
+        {
+            string input = '@name == $static:name';
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(input);
+            string serialized = DataProvider::serializeDpqlExpression(exp);
+            assertEq(input, serialized, "comparison with template round-trip");
+        }
+
+        # Round-trip: mixed expression
+        {
+            string input = '@name == $static:name && @age > $config:min_age::int';
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(input);
+            string serialized = DataProvider::serializeDpqlExpression(exp);
+            assertEq(input, serialized, "mixed expression round-trip");
+        }
+
+        # Round-trip: template with fallback
+        {
+            string input = '$static:A??{$static:B}';
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(input);
+            string serialized = DataProvider::serializeDpqlExpression(exp);
+            assertEq(input, serialized, "fallback template round-trip");
+        }
+
+        # Round-trip: template with wildcard
+        {
+            string input = '$static:*';
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(input);
+            string serialized = DataProvider::serializeDpqlExpression(exp);
+            assertEq(input, serialized, "wildcard template round-trip");
+        }
+
+        # Serializer handles template ref constructed from parts (no raw)
+        {
+            hash<DataProviderExpression> exp = <DataProviderExpression>{
+                "exp": DP_EXPR_TEMPLATE,
+                "args": (<DataProviderTemplateReference>{
+                    "tmpl_context": "static",
+                    "tmpl_value": "test",
+                    "raw": "",
+                },),
+            };
+            string serialized = DataProvider::serializeDpqlExpression(exp);
+            assertEq("$static:test", serialized, "template serialized from parts");
+        }
+
+        # Serializer reconstructs bracketed form for special chars
+        {
+            hash<DataProviderExpression> exp = <DataProviderExpression>{
+                "exp": DP_EXPR_TEMPLATE,
+                "args": (<DataProviderTemplateReference>{
+                    "tmpl_context": "qore-expr",
+                    "tmpl_value": "1 + 2",
+                    "raw": "",
+                },),
+            };
+            string serialized = DataProvider::serializeDpqlExpression(exp);
+            assertEq("$qore-expr:{1 + 2}", serialized, "template bracketed from parts");
+        }
+    }
+
+    templateEvaluationTests() {
+        # Ensure clean state
+        AbstractDataProvider::clearTemplateCallbacks();
+
+        # Register a simple callback
+        hash<auto> callback_log();
+        code expand_cb = auto sub (string ctx, string val, *string type_assertion,
+                *hash<auto> template_context) {
+            callback_log = {
+                "ctx": ctx,
+                "val": val,
+                "type_assertion": type_assertion,
+                "template_context": template_context,
+            };
+            if (ctx == "static") {
+                if (template_context && template_context.hasKey(val)) {
+                    return template_context{val};
+                }
+                return "resolved_" + val;
+            }
+            if (ctx == "config") {
+                if (val == "min_age") {
+                    return 25;
+                }
+                if (val == "max_age") {
+                    return 65;
+                }
+                if (val == "threshold") {
+                    if (type_assertion == "int") {
+                        return 100;
+                    }
+                    return "100";
+                }
+                if (val == "status_active") {
+                    return "active";
+                }
+                if (val == "status_pending") {
+                    return "pending";
+                }
+                if (val == "valid_statuses") {
+                    return ("active", "pending");
+                }
+                return NOTHING;
+            }
+            return NOTHING;
+        };
+
+        assertEq(True, AbstractDataProvider::setTemplateCallbacks(expand_cb));
+
+        # Evaluate simple template
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$static:name');
+            auto result = AbstractDataProvider::evalGenericExpression({"dummy": 1}, exp);
+            assertEq("resolved_name", result, "simple template evaluation");
+            assertEq("static", callback_log.ctx);
+            assertEq("name", callback_log.val);
+        }
+
+        # Template with type assertion passes type_assertion to callback
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$config:threshold::int');
+            auto result = AbstractDataProvider::evalGenericExpression({"dummy": 1}, exp);
+            assertEq(100, result, "type assertion passed to callback");
+            assertEq("int", callback_log.type_assertion);
+        }
+
+        # Mixed: field ref and template in comparison
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@age > $config:min_age');
+            # Test with record age=30, callback returns 25 for min_age
+            auto result = AbstractDataProvider::evalGenericExpression({"age": 30}, exp);
+            assertEq(True, result, "mixed field ref + template comparison (True)");
+
+            # Test with record age=20, callback returns 25 for min_age
+            result = AbstractDataProvider::evalGenericExpression({"age": 20}, exp);
+            assertEq(False, result, "mixed field ref + template comparison (False)");
+        }
+
+        # Template context passed through
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$static:key');
+            hash<auto> tmpl_ctx = {"key": "custom_value"};
+            auto result = AbstractDataProvider::evalGenericExpression({"dummy": 1}, exp, tmpl_ctx);
+            assertEq("custom_value", result, "template_context passed through");
+            assertEq(tmpl_ctx, callback_log.template_context);
+        }
+
+        # Clean up and test missing callback error
+        AbstractDataProvider::clearTemplateCallbacks();
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$static:value');
+            assertThrows("TEMPLATE-RESOLUTION-ERROR", sub () {
+                AbstractDataProvider::evalGenericExpression({"dummy": 1}, exp);
+            });
+        }
+
+        # Re-register for template in AND expression
+        assertEq(True, AbstractDataProvider::setTemplateCallbacks(expand_cb));
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@name == $static:expected && @age > $config:min_age');
+            hash<auto> rec = {"name": "resolved_expected", "age": 30};
+            auto result = AbstractDataProvider::evalGenericExpression(rec, exp);
+            assertEq(True, result, "template in AND expression");
+        }
+
+        # Template in OR expression
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@name == "wrong" || @age > $config:min_age');
+            hash<auto> rec = {"name": "John", "age": 30};
+            auto result = AbstractDataProvider::evalGenericExpression(rec, exp);
+            assertEq(True, result, "template in OR expression");
+        }
+
+        # Template in equality
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '$static:left == $static:right');
+            hash<auto> tmpl_ctx = {"left": "hello", "right": "hello"};
+            auto result = AbstractDataProvider::evalGenericExpression({"dummy": 1}, exp, tmpl_ctx);
+            assertEq(True, result, "two templates in equality");
+        }
+
+        # Template in between expression — parse structure
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@age between $config:min_age and $config:max_age');
+            assertEq(DP_SEARCH_OP_BETWEEN, exp.exp);
+            assertEq(True, exp.args[0] instanceof hash<DataProviderFieldReference>);
+            assertEq(True, exp.args[1] instanceof hash<DataProviderTemplateReference>);
+            assertEq(True, exp.args[2] instanceof hash<DataProviderTemplateReference>);
+        }
+
+        # Template in between expression — evaluation
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@age between $config:min_age and $config:max_age');
+            # Callback returns 25 for min_age, 65 for max_age
+            # age=30 is between 25 and 65
+            auto result = AbstractDataProvider::evalGenericExpression({"age": 30}, exp);
+            assertEq(True, result, "template in between: 30 between 25 and 65");
+
+            # age=20 is NOT between 25 and 65
+            result = AbstractDataProvider::evalGenericExpression({"age": 20}, exp);
+            assertEq(False, result, "template in between: 20 not between 25 and 65");
+
+            # age=70 is NOT between 25 and 65
+            result = AbstractDataProvider::evalGenericExpression({"age": 70}, exp);
+            assertEq(False, result, "template in between: 70 not between 25 and 65");
+        }
+
+        # Template in in expression — parse structure
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@status in ($config:status_active, $config:status_pending)');
+            assertEq(DP_SEARCH_OP_IN, exp.exp);
+            assertEq(True, exp.args[0] instanceof hash<DataProviderFieldReference>);
+            assertEq(True, exp.args[1] instanceof hash<DataProviderTemplateReference>);
+            assertEq(True, exp.args[2] instanceof hash<DataProviderTemplateReference>);
+        }
+
+        # Template in in expression — evaluation with list haystack
+        # The "in" operator expects args[1] to be a list (haystack); construct the expression directly
+        {
+            hash<DataProviderTemplateReference> haystack_ref = <DataProviderTemplateReference>{
+                "tmpl_context": "config",
+                "tmpl_value": "valid_statuses",
+                "raw": "$config:valid_statuses",
+            };
+            hash<DataProviderExpression> exp = <DataProviderExpression>{
+                "exp": DP_SEARCH_OP_IN,
+                "args": (
+                    <DataProviderFieldReference>{"field": "status"},
+                    haystack_ref,
+                ),
+            };
+
+            # Callback returns ("active", "pending") list for config:valid_statuses
+            auto result = AbstractDataProvider::evalGenericExpression({"status": "active"}, exp);
+            assertEq(True, result, "template in 'in': status active matches");
+
+            result = AbstractDataProvider::evalGenericExpression({"status": "pending"}, exp);
+            assertEq(True, result, "template in 'in': status pending matches");
+
+            result = AbstractDataProvider::evalGenericExpression({"status": "closed"}, exp);
+            assertEq(False, result, "template in 'in': status closed does not match");
+        }
+
+        # Old-style matching with template refs in operator args via DefaultRecordIterator (Issue 1)
+        {
+            hash<DataProviderTemplateReference> tmpl_ref = <DataProviderTemplateReference>{
+                "tmpl_context": "config",
+                "tmpl_value": "min_age",
+                "raw": "$config:min_age",
+            };
+            list<hash<auto>> data = ({"age": 30}, {"age": 20}, {"age": 40});
+            ListIterator li(data);
+            hash<auto> where_cond = {"age": dp_op_gt(tmpl_ref)};
+            DefaultRecordIterator di(li, where_cond);
+            list<hash<auto>> results = ();
+            while (di.next()) {
+                push results, di.getValue();
+            }
+            # Callback returns 25 for config:min_age, so age > 25 matches 30 and 40
+            assertEq(2, results.size(), "old-style matching with template ref in operator arg");
+            assertEq(30, results[0].age);
+            assertEq(40, results[1].age);
+        }
+
+        # Old-style matching with template ref as direct value via DefaultRecordIterator
+        {
+            hash<DataProviderTemplateReference> tmpl_ref = <DataProviderTemplateReference>{
+                "tmpl_context": "static",
+                "tmpl_value": "expected",
+                "raw": "$static:expected",
+            };
+            list<hash<auto>> data = ({"name": "resolved_expected"}, {"name": "other"});
+            ListIterator li(data);
+            hash<auto> where_cond = {"name": tmpl_ref};
+            DefaultRecordIterator di(li, where_cond);
+            list<hash<auto>> results = ();
+            while (di.next()) {
+                push results, di.getValue();
+            }
+            # Callback returns "resolved_expected" for static:expected
+            assertEq(1, results.size(), "old-style matching with template ref as direct value");
+            assertEq("resolved_expected", results[0].name);
+        }
+
+        # Old-style matching with template_context via DefaultRecordIterator
+        {
+            hash<DataProviderTemplateReference> tmpl_ref = <DataProviderTemplateReference>{
+                "tmpl_context": "static",
+                "tmpl_value": "key",
+                "raw": "$static:key",
+            };
+            list<hash<auto>> data = ({"name": "custom_value"}, {"name": "other"});
+            ListIterator li(data);
+            hash<auto> where_cond = {"name": tmpl_ref};
+            hash<auto> tmpl_ctx = {"key": "custom_value"};
+            DefaultRecordIterator di(li, where_cond, NOTHING, NOTHING, NOTHING, tmpl_ctx);
+            list<hash<auto>> results = ();
+            while (di.next()) {
+                push results, di.getValue();
+            }
+            # With template_context, callback returns "custom_value" for static:key
+            assertEq(1, results.size(), "old-style matching passes template_context");
+            assertEq("custom_value", results[0].name);
+        }
+
+        # renderExpressionArg fallback when raw is empty (Issue 9)
+        {
+            hash<DataProviderTemplateReference> ref = <DataProviderTemplateReference>{
+                "tmpl_context": "static",
+                "tmpl_value": "test",
+                "raw": "",
+            };
+            hash<DataProviderExpression> exp = <DataProviderExpression>{
+                "exp": DP_EXPR_TEMPLATE,
+                "args": (ref,),
+            };
+            string serialized = DataProvider::serializeDpqlExpression(exp);
+            assertEq("$static:test", serialized, "serializer reconstructs from parts when raw empty");
+        }
+
+        # renderExpressionArg fallback for special chars uses brackets
+        {
+            hash<DataProviderTemplateReference> ref = <DataProviderTemplateReference>{
+                "tmpl_context": "qore-expr",
+                "tmpl_value": "1 + 2",
+                "type_assertion": "int",
+                "raw": "",
+            };
+            hash<DataProviderExpression> exp = <DataProviderExpression>{
+                "exp": DP_EXPR_TEMPLATE,
+                "args": (ref,),
+            };
+            string serialized = DataProvider::serializeDpqlExpression(exp);
+            assertEq("$qore-expr:{1 + 2}::int", serialized, "serializer reconstructs bracketed with type assertion");
+        }
+
+        # Clean up
+        AbstractDataProvider::clearTemplateCallbacks();
+    }
+
+    templateCompletionTests() {
+        hash<string, AbstractDataField> fields = getTestFields();
+
+        # $ at start triggers template completions
+        {
+            list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('$', 1, fields);
+            bool has_template = False;
+            foreach hash<DpqlCompletionItem> item in (items) {
+                if (item.kind == "template") {
+                    has_template = True;
+                    break;
+                }
+            }
+            assertEq(True, has_template, "$ triggers template completions");
+        }
+
+        # $sta filters to matching contexts
+        {
+            list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('$sta', 4, fields);
+            bool has_static = False;
+            foreach hash<DpqlCompletionItem> item in (items) {
+                if (item.label == "$static:") {
+                    has_static = True;
+                    break;
+                }
+            }
+            assertEq(True, has_static, "$sta filters to $static:");
+        }
+
+        # Template completions in value position (after operator)
+        {
+            list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('@name == $', 10, fields);
+            bool has_template = False;
+            foreach hash<DpqlCompletionItem> item in (items) {
+                if (item.kind == "template") {
+                    has_template = True;
+                    break;
+                }
+            }
+            assertEq(True, has_template, "template completions after operator");
+        }
+
+        # No template completions inside string
+        {
+            list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('"$sta', 5, fields);
+            bool has_template = False;
+            foreach hash<DpqlCompletionItem> item in (items) {
+                if (item.kind == "template") {
+                    has_template = True;
+                    break;
+                }
+            }
+            assertEq(False, has_template, "no template completions inside string");
+        }
+
+        # Template context value completions with callback
+        {
+            code list_values = list<hash<auto>> sub (string ctx, string prefix) {
+                if (ctx == "static") {
+                    return (
+                        {"name": "account.id", "description": "Account ID"},
+                        {"name": "user.name", "description": "User name"},
+                    );
+                }
+                return ();
+            };
+            AbstractDataProvider::clearTemplateCallbacks();
+            assertEq(True, AbstractDataProvider::setTemplateCallbacks(
+                auto sub (string ctx, string val, *string ta, *hash<auto> tc) { return NOTHING; },
+                NOTHING,
+                NOTHING,
+                list_values,
+            ));
+
+            list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('$static:', 8, fields);
+            bool has_value = False;
+            foreach hash<DpqlCompletionItem> item in (items) {
+                if (item.label =~ /account/) {
+                    has_value = True;
+                    break;
+                }
+            }
+            assertEq(True, has_value, "template value completions from callback");
+
+            AbstractDataProvider::clearTemplateCallbacks();
+        }
+
+        # Empty position also offers templates (in start context)
+        {
+            list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('', 0, fields);
+            bool has_template = False;
+            foreach hash<DpqlCompletionItem> item in (items) {
+                if (item.kind == "template") {
+                    has_template = True;
+                    break;
+                }
+            }
+            assertEq(True, has_template, "templates offered at start position");
+        }
+    }
+
+    templateValidationTests() {
+        # Template ref accepted in general positions (ST_Any)
+        {
+            # This should parse without errors - template is valid as a comparison operand
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression(
+                '@name == $static:expected');
+            assertEq(DP_SEARCH_OP_EQ, exp.exp);
+            assertEq(True, exp.args[1] instanceof hash<DataProviderTemplateReference>);
+        }
+
+        # Template ref as standalone expression
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$static:value');
+            assertEq(DP_EXPR_TEMPLATE, exp.exp);
+        }
+
+        # Verify that existing non-template expressions still work
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('@name == "John"');
+            assertEq(DP_SEARCH_OP_EQ, exp.exp);
+            assertEq("John", exp.args[1]);
+        }
+
+        # Verify field reference still works standalone
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('@name');
+            assertEq(DP_EXPR_VALUE, exp.exp);
+        }
+
+        # verifyExpressionArgValue: template ref rejected in ST_Value position
+        {
+            hash<DataProviderTemplateReference> tmpl_ref = <DataProviderTemplateReference>{
+                "tmpl_context": "static",
+                "tmpl_value": "test",
+                "raw": "$static:test",
+            };
+            # Construct an expression with a template ref where a literal value is expected
+            # ST_Value positions require literal values
+            hash<DataProviderExpressionInfo> expinfo = <DataProviderExpressionInfo>{
+                "type": DET_Operator,
+                "name": "test_op",
+                "display_name": "test",
+                "short_desc": "test",
+                "desc": "test operator",
+                "args": (<DataProviderSignatureTypeInfo>{
+                    "type_code": ST_Value,
+                    "type": AbstractDataProviderTypeMap."string",
+                },),
+                "return_type": AbstractDataProviderTypeMap."bool",
+            };
+            assertThrows("DATA-PROVIDER-EXPRESSION-ERROR", "template reference", sub () {
+                AbstractDataProvider::verifyExpressionArgValue(ER_All, 0, expinfo, (tmpl_ref,), 0);
+            });
+        }
+
+        # verifyExpressionArgValue: template ref rejected in ST_Field position
+        {
+            hash<DataProviderTemplateReference> tmpl_ref = <DataProviderTemplateReference>{
+                "tmpl_context": "static",
+                "tmpl_value": "test",
+                "raw": "$static:test",
+            };
+            hash<DataProviderExpressionInfo> expinfo = <DataProviderExpressionInfo>{
+                "type": DET_Operator,
+                "name": "test_op",
+                "display_name": "test",
+                "short_desc": "test",
+                "desc": "test operator",
+                "args": (<DataProviderSignatureTypeInfo>{
+                    "type_code": ST_Field,
+                },),
+                "return_type": AbstractDataProviderTypeMap."bool",
+            };
+            assertThrows("DATA-PROVIDER-EXPRESSION-ERROR", "template reference", sub () {
+                AbstractDataProvider::verifyExpressionArgValue(ER_All, 0, expinfo, (tmpl_ref,), 0);
+            });
+        }
+
+        # verifyExpressionArgValue: template ref accepted in ST_Any position
+        {
+            hash<DataProviderTemplateReference> tmpl_ref = <DataProviderTemplateReference>{
+                "tmpl_context": "static",
+                "tmpl_value": "test",
+                "raw": "$static:test",
+            };
+            hash<DataProviderExpressionInfo> expinfo = <DataProviderExpressionInfo>{
+                "type": DET_Operator,
+                "name": "test_op",
+                "display_name": "test",
+                "short_desc": "test",
+                "desc": "test operator",
+                "args": (<DataProviderSignatureTypeInfo>{
+                    "type_code": ST_Any,
+                    "type": AbstractDataProviderTypeMap."string",
+                },),
+                "return_type": AbstractDataProviderTypeMap."bool",
+            };
+            # Should not throw — ST_Any accepts template references
+            AbstractDataProvider::verifyExpressionArgValue(ER_All, 0, expinfo, (tmpl_ref,), 0);
         }
     }
 }

--- a/examples/test/qlib/DataProvider/Dpql.qtest
+++ b/examples/test/qlib/DataProvider/Dpql.qtest
@@ -3405,6 +3405,16 @@ public class DpqlTest inherits QUnit::Test {
             assertEq("$static:price * $static:qty", ref.tmpl_value);
         }
 
+        # Bracketed value with type assertion
+        {
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$qore-expr:{1 + 2}::int');
+            assertEq(DP_EXPR_TEMPLATE, exp.exp);
+            hash<DataProviderTemplateReference> ref = cast<hash<DataProviderTemplateReference>>(exp.args[0]);
+            assertEq("qore-expr", ref.tmpl_context);
+            assertEq("1 + 2", ref.tmpl_value);
+            assertEq("int", ref.type_assertion);
+        }
+
         # Template with dotted value path
         {
             hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$static:account.id');

--- a/examples/test/qlib/DataProvider/Dpql.qtest
+++ b/examples/test/qlib/DataProvider/Dpql.qtest
@@ -109,6 +109,7 @@ public class DpqlTest inherits QUnit::Test {
         addTestCase("template evaluation tests", \templateEvaluationTests());
         addTestCase("template completion tests", \templateCompletionTests());
         addTestCase("template validation tests", \templateValidationTests());
+        addTestCase("JSON expression serialization tests", \jsonExpressionSerializationTests());
 
         # Return for compatibility with test harnesses that check the return value.
         set_return_value(main());
@@ -4121,6 +4122,298 @@ public class DpqlTest inherits QUnit::Test {
             };
             # Should not throw — ST_Any accepts template references
             AbstractDataProvider::verifyExpressionArgValue(ER_All, 0, expinfo, (tmpl_ref,), 0);
+        }
+    }
+
+    jsonExpressionSerializationTests() {
+        # ---- Deserialize tests ----
+
+        # Basic expression with field ref and value wrapper
+        {
+            hash<auto> json = {
+                "exp": "==",
+                "args": ({"field": "name"}, {"value": "John"}),
+            };
+            hash<DataProviderExpression> exp = DataProvider::deserializeExpressionFromJson(json);
+            assertEq("==", exp.exp);
+            assertEq(2, exp.args.size());
+            assertTrue(exp.args[0] instanceof hash<DataProviderFieldReference>);
+            assertEq("name", exp.args[0].field);
+            assertEq("John", exp.args[1]);
+        }
+
+        # Nested expression: AND(== , !=)
+        {
+            hash<auto> json = {
+                "exp": "and",
+                "args": (
+                    {
+                        "exp": "==",
+                        "args": ({"field": "name"}, {"value": "John"}),
+                    },
+                    {
+                        "exp": "!=",
+                        "args": ({"field": "age"}, {"value": 30}),
+                    },
+                ),
+            };
+            hash<DataProviderExpression> exp = DataProvider::deserializeExpressionFromJson(json);
+            assertEq("and", exp.exp);
+            assertEq(2, exp.args.size());
+            assertTrue(exp.args[0] instanceof hash<DataProviderExpression>);
+            assertTrue(exp.args[1] instanceof hash<DataProviderExpression>);
+            hash<DataProviderExpression> left = exp.args[0];
+            assertEq("==", left.exp);
+            assertTrue(left.args[0] instanceof hash<DataProviderFieldReference>);
+            assertEq("John", left.args[1]);
+        }
+
+        # Template reference with raw
+        {
+            hash<auto> json_arg = {
+                "tmpl_context": "static",
+                "tmpl_value": "id",
+                "raw": "$static:id",
+            };
+            auto result = DataProvider::deserializeExpressionArgFromJson(json_arg);
+            assertTrue(result instanceof hash<DataProviderTemplateReference>);
+            assertEq("static", result.tmpl_context);
+            assertEq("id", result.tmpl_value);
+            assertEq("$static:id", result.raw);
+        }
+
+        # Template reference without raw: raw reconstructed
+        {
+            hash<auto> json_arg = {
+                "tmpl_context": "dynamic",
+                "tmpl_value": "count",
+            };
+            auto result = DataProvider::deserializeExpressionArgFromJson(json_arg);
+            assertTrue(result instanceof hash<DataProviderTemplateReference>);
+            assertEq("dynamic", result.tmpl_context);
+            assertEq("count", result.tmpl_value);
+            assertEq("$dynamic:count", result.raw);
+        }
+
+        # Plain value unwrap
+        {
+            assertEq(42, DataProvider::deserializeExpressionArgFromJson({"value": 42}));
+            assertEq("hello", DataProvider::deserializeExpressionArgFromJson({"value": "hello"}));
+            assertEq(NOTHING, DataProvider::deserializeExpressionArgFromJson({"value": NOTHING}));
+        }
+
+        # Non-hash scalars pass through
+        {
+            assertEq(42, DataProvider::deserializeExpressionArgFromJson(42));
+            assertEq("str", DataProvider::deserializeExpressionArgFromJson("str"));
+            assertEq(True, DataProvider::deserializeExpressionArgFromJson(True));
+        }
+
+        # Range spec: {"start": ..., "end": ...}
+        {
+            hash<auto> json_arg = {"start": 0, "end": 5};
+            auto result = DataProvider::deserializeExpressionArgFromJson(json_arg);
+            assertTrue(result instanceof hash<DataProviderRangeSpec>);
+            assertEq(0, result.start);
+            assertEq(5, result.end);
+        }
+
+        # Range spec: already typed passes through
+        {
+            hash<DataProviderRangeSpec> range = <DataProviderRangeSpec>{"start": 1, "end": 3};
+            auto result = DataProvider::deserializeExpressionArgFromJson(range);
+            assertTrue(result instanceof hash<DataProviderRangeSpec>);
+            assertEq(1, result.start);
+            assertEq(3, result.end);
+        }
+
+        # Idempotent: already-typed expression passes through
+        {
+            hash<DataProviderExpression> typed = <DataProviderExpression>{
+                "exp": "==",
+                "args": (<DataProviderFieldReference>{"field": "name"}, "John"),
+            };
+            hash<DataProviderExpression> result = DataProvider::deserializeExpressionFromJson(typed);
+            assertEq("==", result.exp);
+            assertTrue(result.args[0] instanceof hash<DataProviderFieldReference>);
+            assertEq("John", result.args[1]);
+        }
+
+        # Error: missing exp key
+        {
+            assertThrows("EXPRESSION-DESERIALIZE-ERROR", sub () {
+                DataProvider::deserializeExpressionFromJson({"args": (1, 2)});
+            });
+        }
+
+        # Error: exp is not a string
+        {
+            assertThrows("EXPRESSION-DESERIALIZE-ERROR", sub () {
+                DataProvider::deserializeExpressionFromJson({"exp": 123});
+            });
+        }
+
+        # Error: unknown hash arg
+        {
+            assertThrows("EXPRESSION-ARG-ERROR", sub () {
+                DataProvider::deserializeExpressionArgFromJson({"unknown_key": "val", "other": 1});
+            });
+        }
+
+        # ---- Serialize tests ----
+
+        # Basic typed expression to JSON
+        {
+            hash<DataProviderExpression> exp = <DataProviderExpression>{
+                "exp": "==",
+                "args": (<DataProviderFieldReference>{"field": "name"}, "John"),
+            };
+            hash<auto> json = DataProvider::serializeExpressionToJson(exp);
+            assertEq("==", json.exp);
+            assertEq(2, json.args.size());
+            assertEq({"field": "name"}, json.args[0]);
+            assertEq({"value": "John"}, json.args[1]);
+        }
+
+        # Field ref serialization
+        {
+            auto result = DataProvider::serializeExpressionArgToJson(
+                <DataProviderFieldReference>{"field": "age"});
+            assertEq({"field": "age"}, result);
+        }
+
+        # Template ref serialization preserves all fields
+        {
+            hash<DataProviderTemplateReference> tmpl = <DataProviderTemplateReference>{
+                "tmpl_context": "static",
+                "tmpl_value": "id",
+                "raw": "$static:id",
+            };
+            auto result = DataProvider::serializeExpressionArgToJson(tmpl);
+            assertEq("static", result.tmpl_context);
+            assertEq("id", result.tmpl_value);
+            assertEq("$static:id", result.raw);
+        }
+
+        # Nested expression serialization
+        {
+            hash<DataProviderExpression> exp = <DataProviderExpression>{
+                "exp": "and",
+                "args": (
+                    <DataProviderExpression>{
+                        "exp": "==",
+                        "args": (<DataProviderFieldReference>{"field": "a"}, 1),
+                    },
+                    <DataProviderExpression>{
+                        "exp": ">",
+                        "args": (<DataProviderFieldReference>{"field": "b"}, 10),
+                    },
+                ),
+            };
+            hash<auto> json = DataProvider::serializeExpressionToJson(exp);
+            assertEq("and", json.exp);
+            assertEq("==", json.args[0].exp);
+            assertEq({"field": "a"}, json.args[0].args[0]);
+            assertEq({"value": 1}, json.args[0].args[1]);
+            assertEq(">", json.args[1].exp);
+        }
+
+        # Range spec serialization
+        {
+            hash<DataProviderRangeSpec> range = <DataProviderRangeSpec>{"start": 0, "end": 2};
+            auto result = DataProvider::serializeExpressionArgToJson(range);
+            assertEq(0, result.start);
+            assertEq(2, result.end);
+        }
+
+        # Plain value wrapping
+        {
+            assertEq({"value": 42}, DataProvider::serializeExpressionArgToJson(42));
+            assertEq({"value": "str"}, DataProvider::serializeExpressionArgToJson("str"));
+            assertEq({"value": True}, DataProvider::serializeExpressionArgToJson(True));
+        }
+
+        # ---- Round-trip tests ----
+
+        # deserialize(serialize(exp)) == exp
+        {
+            hash<DataProviderExpression> original = <DataProviderExpression>{
+                "exp": "and",
+                "args": (
+                    <DataProviderExpression>{
+                        "exp": "==",
+                        "args": (
+                            <DataProviderFieldReference>{"field": "name"},
+                            <DataProviderTemplateReference>{
+                                "tmpl_context": "static",
+                                "tmpl_value": "expected_name",
+                                "raw": "$static:expected_name",
+                            },
+                        ),
+                    },
+                    <DataProviderExpression>{
+                        "exp": ">",
+                        "args": (<DataProviderFieldReference>{"field": "age"}, 18),
+                    },
+                ),
+            };
+            hash<auto> json = DataProvider::serializeExpressionToJson(original);
+            hash<DataProviderExpression> restored = DataProvider::deserializeExpressionFromJson(json);
+            assertEq(original.exp, restored.exp);
+            assertEq(original.args.size(), restored.args.size());
+            # Verify nested expression typing preserved
+            assertTrue(restored.args[0] instanceof hash<DataProviderExpression>);
+            hash<DataProviderExpression> left = restored.args[0];
+            assertTrue(left.args[0] instanceof hash<DataProviderFieldReference>);
+            assertTrue(left.args[1] instanceof hash<DataProviderTemplateReference>);
+            assertEq("static", left.args[1].tmpl_context);
+            assertEq("expected_name", left.args[1].tmpl_value);
+            hash<DataProviderExpression> right = restored.args[1];
+            assertTrue(right.args[0] instanceof hash<DataProviderFieldReference>);
+            assertEq(18, right.args[1]);
+        }
+
+        # serialize(deserialize(json)) produces valid JSON format
+        {
+            hash<auto> original_json = {
+                "exp": "or",
+                "args": (
+                    {
+                        "exp": "==",
+                        "args": ({"field": "status"}, {"value": "active"}),
+                    },
+                    {
+                        "exp": "==",
+                        "args": (
+                            {"field": "role"},
+                            {"tmpl_context": "config", "tmpl_value": "admin_role", "raw": "$config:admin_role"},
+                        ),
+                    },
+                ),
+            };
+            hash<DataProviderExpression> typed = DataProvider::deserializeExpressionFromJson(original_json);
+            hash<auto> reserialized = DataProvider::serializeExpressionToJson(typed);
+            assertEq("or", reserialized.exp);
+            assertEq(2, reserialized.args.size());
+            # First sub-expression
+            assertEq("==", reserialized.args[0].exp);
+            assertEq({"field": "status"}, reserialized.args[0].args[0]);
+            assertEq({"value": "active"}, reserialized.args[0].args[1]);
+            # Second sub-expression with template ref
+            assertEq("==", reserialized.args[1].exp);
+            assertEq({"field": "role"}, reserialized.args[1].args[0]);
+            assertEq("config", reserialized.args[1].args[1].tmpl_context);
+            assertEq("admin_role", reserialized.args[1].args[1].tmpl_value);
+        }
+
+        # Expression with no args
+        {
+            hash<auto> json = {"exp": "true"};
+            hash<DataProviderExpression> exp = DataProvider::deserializeExpressionFromJson(json);
+            assertEq("true", exp.exp);
+            assertEq(0, exp.args.size());
+            hash<auto> reserialized = DataProvider::serializeExpressionToJson(exp);
+            assertEq("true", reserialized.exp);
         }
     }
 }

--- a/examples/test/qlib/DataProvider/Dpql.qtest
+++ b/examples/test/qlib/DataProvider/Dpql.qtest
@@ -3889,7 +3889,7 @@ public class DpqlTest inherits QUnit::Test {
 
         # Template context value completions with callback
         {
-            code list_values = list<hash<auto>> sub (string ctx, string prefix) {
+            code list_values = list<hash<auto>> sub (string ctx, string prefix, *hash<auto> template_context) {
                 if (ctx == "static") {
                     return (
                         {"name": "account.id", "description": "Account ID"},
@@ -3930,6 +3930,104 @@ public class DpqlTest inherits QUnit::Test {
                 }
             }
             assertEq(True, has_template, "templates offered at start position");
+        }
+
+        # template_context is passed through to list_contexts, list_values, and resolve_type callbacks
+        {
+            *hash<auto> received_ctx_context;
+            *hash<auto> received_val_context;
+            *hash<auto> received_type_context;
+
+            code list_contexts = list<hash<auto>> sub (*hash<auto> template_context) {
+                received_ctx_context = template_context;
+                if (template_context.sandboxed) {
+                    # Filter out "env" when sandboxed
+                    return (
+                        {"name": "static", "description": "Static data"},
+                        {"name": "config", "description": "Config data"},
+                    );
+                }
+                return (
+                    {"name": "static", "description": "Static data"},
+                    {"name": "config", "description": "Config data"},
+                    {"name": "env", "description": "Environment variables"},
+                );
+            };
+            code list_values = list<hash<auto>> sub (string ctx, string prefix,
+                    *hash<auto> template_context) {
+                received_val_context = template_context;
+                if (ctx == "static") {
+                    return (
+                        {"name": "account.id", "description": "Account ID"},
+                    );
+                }
+                return ();
+            };
+            code resolve_type = *AbstractDataProviderType sub (string ctx, string val,
+                    *hash<auto> template_context) {
+                received_type_context = template_context;
+                if (ctx == "env" && !template_context.sandboxed) {
+                    return AbstractDataProviderTypeMap."*string";
+                }
+                return NOTHING;
+            };
+            AbstractDataProvider::clearTemplateCallbacks();
+            assertEq(True, AbstractDataProvider::setTemplateCallbacks(
+                auto sub (string ctx, string val, *string ta, *hash<auto> tc) { return NOTHING; },
+                resolve_type,
+                list_contexts,
+                list_values,
+            ));
+
+            # Test without template_context - should get all contexts including env
+            hash<auto> tc = {"sandboxed": False};
+            list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('$', 1, fields,
+                NOTHING, tc);
+            assertEq(tc, received_ctx_context,
+                "template_context passed to list_contexts callback");
+            bool has_env = False;
+            foreach hash<DpqlCompletionItem> item in (items) {
+                if (item.label == "\$env:") {
+                    has_env = True;
+                    break;
+                }
+            }
+            assertEq(True, has_env, "env present when not sandboxed");
+
+            # Test with sandboxed template_context - should filter out env
+            tc = {"sandboxed": True};
+            items = DataProvider::getDpqlCompletions('$', 1, fields, NOTHING, tc);
+            assertEq(tc, received_ctx_context,
+                "sandboxed template_context passed to list_contexts");
+            has_env = False;
+            foreach hash<DpqlCompletionItem> item in (items) {
+                if (item.label == "\$env:") {
+                    has_env = True;
+                    break;
+                }
+            }
+            assertEq(False, has_env, "env filtered out when sandboxed");
+
+            # Test template_context passed to list_values
+            items = DataProvider::getDpqlCompletions('$static:', 8, fields, NOTHING, tc);
+            assertEq(tc, received_val_context,
+                "template_context passed to list_values callback");
+
+            # Test template_context passed to resolve_type
+            tc = {"sandboxed": False};
+            *AbstractDataProviderType env_type = AbstractDataProvider::resolveTemplateType("env", "HOME", tc);
+            assertEq(tc, received_type_context,
+                "template_context passed to resolve_type callback");
+            assertTrue(exists env_type, "resolve_type returns type when not sandboxed");
+            assertEq("*string", env_type.getName(), "resolve_type returns *string for env");
+
+            tc = {"sandboxed": True};
+            *AbstractDataProviderType env_type_sb = AbstractDataProvider::resolveTemplateType("env", "HOME", tc);
+            assertEq(tc, received_type_context,
+                "sandboxed template_context passed to resolve_type");
+            assertNothing(env_type_sb, "resolve_type returns NOTHING when sandboxed");
+
+            AbstractDataProvider::clearTemplateCallbacks();
         }
     }
 

--- a/examples/test/qlib/DataProvider/Dpql.qtest
+++ b/examples/test/qlib/DataProvider/Dpql.qtest
@@ -3334,7 +3334,7 @@ public class DpqlTest inherits QUnit::Test {
             assertEq(True, has_bracket, "'[' is a separate token after template");
         }
 
-        # :: in value path — parsed as type assertion (last ::)
+        # :: in value path
         {
             DpqlTokenizer tok('$static:ns::class');
             list<hash<DpqlTokenInfo>> tokens = tok.getAllTokens();
@@ -3352,7 +3352,6 @@ public class DpqlTest inherits QUnit::Test {
             hash<DataProviderTemplateReference> ref = cast<hash<DataProviderTemplateReference>>(exp.args[0]);
             assertEq("static", ref.tmpl_context);
             assertEq("id", ref.tmpl_value);
-            assertEq(NOTHING, ref.type_assertion);
             assertEq("$static:id", ref.raw);
             assertEq("123", exp.args[1]);
         }
@@ -3386,14 +3385,13 @@ public class DpqlTest inherits QUnit::Test {
             assertEq(2, exp.args.size());
         }
 
-        # Type assertion
+        # :: in value is preserved (no type assertion parsing)
         {
             hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$config:limit::int');
             assertEq(DP_EXPR_TEMPLATE, exp.exp);
             hash<DataProviderTemplateReference> ref = cast<hash<DataProviderTemplateReference>>(exp.args[0]);
             assertEq("config", ref.tmpl_context);
-            assertEq("limit", ref.tmpl_value);
-            assertEq("int", ref.type_assertion);
+            assertEq("limit::int", ref.tmpl_value);
         }
 
         # Bracketed value
@@ -3405,14 +3403,13 @@ public class DpqlTest inherits QUnit::Test {
             assertEq("$static:price * $static:qty", ref.tmpl_value);
         }
 
-        # Bracketed value with type assertion
+        # Bracketed value — content after closing brace is ignored
         {
-            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$qore-expr:{1 + 2}::int');
+            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$qore-expr:{1 + 2}');
             assertEq(DP_EXPR_TEMPLATE, exp.exp);
             hash<DataProviderTemplateReference> ref = cast<hash<DataProviderTemplateReference>>(exp.args[0]);
             assertEq("qore-expr", ref.tmpl_context);
             assertEq("1 + 2", ref.tmpl_value);
-            assertEq("int", ref.type_assertion);
         }
 
         # Template with dotted value path
@@ -3440,23 +3437,21 @@ public class DpqlTest inherits QUnit::Test {
             assertEq(DP_OP_AND, exp.exp);
         }
 
-        # :: in value path — last :: is type assertion
+        # :: in value path preserved without brackets
         {
             hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$static:ns::class');
             assertEq(DP_EXPR_TEMPLATE, exp.exp);
             hash<DataProviderTemplateReference> ref = cast<hash<DataProviderTemplateReference>>(exp.args[0]);
             assertEq("static", ref.tmpl_context);
-            assertEq("ns", ref.tmpl_value);
-            assertEq("class", ref.type_assertion, "last :: interpreted as type assertion");
+            assertEq("ns::class", ref.tmpl_value, ":: preserved in value");
         }
 
-        # To get :: in value, use brackets
+        # :: in value also works with brackets
         {
             hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$static:{ns::class}');
             assertEq(DP_EXPR_TEMPLATE, exp.exp);
             hash<DataProviderTemplateReference> ref = cast<hash<DataProviderTemplateReference>>(exp.args[0]);
             assertEq("ns::class", ref.tmpl_value, "bracketed form preserves :: in value");
-            assertEq(NOTHING, ref.type_assertion);
         }
 
         # Empty brackets parse to empty value
@@ -3561,12 +3556,10 @@ public class DpqlTest inherits QUnit::Test {
 
         # Register a simple callback
         hash<auto> callback_log();
-        code expand_cb = auto sub (string ctx, string val, *string type_assertion,
-                *hash<auto> template_context) {
+        code expand_cb = auto sub (string ctx, string val, *hash<auto> template_context) {
             callback_log = {
                 "ctx": ctx,
                 "val": val,
-                "type_assertion": type_assertion,
                 "template_context": template_context,
             };
             if (ctx == "static") {
@@ -3583,9 +3576,6 @@ public class DpqlTest inherits QUnit::Test {
                     return 65;
                 }
                 if (val == "threshold") {
-                    if (type_assertion == "int") {
-                        return 100;
-                    }
                     return "100";
                 }
                 if (val == "status_active") {
@@ -3611,14 +3601,6 @@ public class DpqlTest inherits QUnit::Test {
             assertEq("resolved_name", result, "simple template evaluation");
             assertEq("static", callback_log.ctx);
             assertEq("name", callback_log.val);
-        }
-
-        # Template with type assertion passes type_assertion to callback
-        {
-            hash<DataProviderExpression> exp = DataProvider::parseDpqlExpression('$config:threshold::int');
-            auto result = AbstractDataProvider::evalGenericExpression({"dummy": 1}, exp);
-            assertEq(100, result, "type assertion passed to callback");
-            assertEq("int", callback_log.type_assertion);
         }
 
         # Mixed: field ref and template in comparison
@@ -3827,7 +3809,6 @@ public class DpqlTest inherits QUnit::Test {
             hash<DataProviderTemplateReference> ref = <DataProviderTemplateReference>{
                 "tmpl_context": "qore-expr",
                 "tmpl_value": "1 + 2",
-                "type_assertion": "int",
                 "raw": "",
             };
             hash<DataProviderExpression> exp = <DataProviderExpression>{
@@ -3835,7 +3816,7 @@ public class DpqlTest inherits QUnit::Test {
                 "args": (ref,),
             };
             string serialized = DataProvider::serializeDpqlExpression(exp);
-            assertEq("$qore-expr:{1 + 2}::int", serialized, "serializer reconstructs bracketed with type assertion");
+            assertEq("$qore-expr:{1 + 2}", serialized, "serializer reconstructs bracketed template from parts");
         }
 
         # Clean up
@@ -3910,7 +3891,7 @@ public class DpqlTest inherits QUnit::Test {
             };
             AbstractDataProvider::clearTemplateCallbacks();
             assertEq(True, AbstractDataProvider::setTemplateCallbacks(
-                auto sub (string ctx, string val, *string ta, *hash<auto> tc) { return NOTHING; },
+                auto sub (string ctx, string val, *hash<auto> tc) { return NOTHING; },
                 NOTHING,
                 NOTHING,
                 list_values,
@@ -3983,7 +3964,7 @@ public class DpqlTest inherits QUnit::Test {
             };
             AbstractDataProvider::clearTemplateCallbacks();
             assertEq(True, AbstractDataProvider::setTemplateCallbacks(
-                auto sub (string ctx, string val, *string ta, *hash<auto> tc) { return NOTHING; },
+                auto sub (string ctx, string val, *hash<auto> tc) { return NOTHING; },
                 resolve_type,
                 list_contexts,
                 list_values,

--- a/examples/test/qlib/DataProvider/DpqlActionSession.qtest
+++ b/examples/test/qlib/DataProvider/DpqlActionSession.qtest
@@ -159,6 +159,15 @@ class DpqlActionSessionTest inherits QUnit::Test {
         assertTrue(tok.hasKey("type"), "Token should have type");
         assertTrue(tok.hasKey("start"), "Token should have start");
         assertTrue(tok.hasKey("end"), "Token should have end");
+
+        # Test template token mapping
+        result = session.handleAction("dpql-get-tokens", {
+            "text": "@name == $static:value",
+        });
+        # Find the template token
+        *hash<auto> tmpl_tok = (map $1, result.tokens, $1.type == "variable")[0];
+        assertTrue(exists tmpl_tok, "Should have a template token mapped to 'variable'");
+        assertEq("$static:value", tmpl_tok.text, "Template token text should match");
     }
 
     testFormatInvalid() {

--- a/qlib/DataProvider/AbstractDataProvider.qc
+++ b/qlib/DataProvider/AbstractDataProvider.qc
@@ -1839,17 +1839,17 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
         #! static callback for resolving template reference types
         /** @since DataProvider 3.3
         */
-        static *code<*AbstractDataProviderType(string, string)> cb_resolve_template_type;
+        static *code<*AbstractDataProviderType(string, string, *hash<auto>)> cb_resolve_template_type;
 
         #! static callback for listing available template contexts
         /** @since DataProvider 3.3
         */
-        static *code<auto()> cb_list_template_contexts;
+        static *code<auto(*hash<auto>)> cb_list_template_contexts;
 
         #! static callback for listing available template values for a context
         /** @since DataProvider 3.3
         */
-        static *code<auto(string, string)> cb_list_template_values;
+        static *code<auto(string, string, *hash<auto>)> cb_list_template_values;
 
         #! flag if template callbacks are locked
         static bool template_callbacks_locked = False;
@@ -4938,9 +4938,9 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
     */
     static bool setTemplateCallbacks(
             code<auto(string, string, *string, *hash<auto>)> expand,
-            *code<*AbstractDataProviderType(string, string)> resolve_type,
-            *code<auto()> list_contexts,
-            *code<auto(string, string)> list_values) {
+            *code<*AbstractDataProviderType(string, string, *hash<auto>)> resolve_type,
+            *code<auto(*hash<auto>)> list_contexts,
+            *code<auto(string, string, *hash<auto>)> list_values) {
         if (template_callbacks_locked) {
             return expand == cb_expand_template && resolve_type == cb_resolve_template_type
                 && list_contexts == cb_list_template_contexts && list_values == cb_list_template_values;
@@ -4967,43 +4967,48 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
     }
 
     #! Returns the list of available template contexts, if a callback is registered
-    /** @return a list of template context info hashes, or NOTHING if no callback is registered
+    /** @param template_context optional context data for filtering (e.g., sandboxed, interface_type)
+        @return a list of template context info hashes, or NOTHING if no callback is registered
 
         @since DataProvider 3.3
     */
-    static *list<hash<auto>> getTemplateContexts() {
+    static *list<hash<auto>> getTemplateContexts(*hash<auto> template_context) {
         if (!cb_list_template_contexts) {
             return NOTHING;
         }
-        return call_function(cb_list_template_contexts);
+        return call_function_args(cb_list_template_contexts, (template_context,));
     }
 
     #! Returns the list of available template values for a context, if a callback is registered
     /** @param ctx the template context name
         @param prefix the value prefix to filter by
+        @param template_context optional context data for filtering (e.g., sandboxed, interface_type)
         @return a list of template value info hashes, or NOTHING if no callback is registered
 
         @since DataProvider 3.3
     */
-    static *list<hash<auto>> getTemplateValues(string ctx, string prefix) {
+    static *list<hash<auto>> getTemplateValues(string ctx, string prefix,
+            *hash<auto> template_context) {
         if (!cb_list_template_values) {
             return NOTHING;
         }
-        return call_function_args(cb_list_template_values, (ctx, prefix));
+        return call_function_args(cb_list_template_values, (ctx, prefix, template_context));
     }
 
     #! Resolves the type of a template reference using the registered callback
     /** @param ctx the template context name (e.g., "env", "timestamp")
         @param value the template value path (e.g., "HOME", "timegm")
+        @param template_context optional context data for filtering (e.g., sandboxed, interface_type)
         @return the resolved type, or NOTHING if no callback is registered or the type cannot be determined
 
         @since DataProvider 3.3
     */
-    static *AbstractDataProviderType resolveTemplateType(string ctx, string value) {
+    static *AbstractDataProviderType resolveTemplateType(string ctx, string value,
+            *hash<auto> template_context) {
         if (!cb_resolve_template_type) {
             return NOTHING;
         }
-        return call_function_args(cb_resolve_template_type, (ctx, value));
+        return call_function_args(cb_resolve_template_type, (ctx, value, template_context));
     }
 
     #! processes an expression in a certain context

--- a/qlib/DataProvider/AbstractDataProvider.qc
+++ b/qlib/DataProvider/AbstractDataProvider.qc
@@ -736,7 +736,6 @@ public hashdecl DataProviderFieldReference {
     @par Syntax
     - Simple: \c $context:value (e.g., \c $static:account.id)
     - Bracketed: \c $context:{value with special chars}
-    - Type-asserted: \c $context:value::type (e.g., \c $config:threshold::int)
     @since DataProvider 3.3
 */
 public hashdecl DataProviderTemplateReference {
@@ -744,8 +743,6 @@ public hashdecl DataProviderTemplateReference {
     string tmpl_context;
     #! Template value path (e.g., "account.id", "threshold")
     string tmpl_value;
-    #! Optional type assertion (e.g., "int", "string")
-    *string type_assertion;
     #! Original raw text for round-trip serialization
     string raw;
 }
@@ -1834,7 +1831,7 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
         #! static callback for template reference expansion
         /** @since DataProvider 3.3
         */
-        static *code<auto(string, string, *string, *hash<auto>)> cb_expand_template;
+        static *code<auto(string, string, *hash<auto>)> cb_expand_template;
 
         #! static callback for resolving template reference types
         /** @since DataProvider 3.3
@@ -4832,7 +4829,7 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     sprintf("template reference %y cannot be resolved: no template callback registered", val.raw);
             }
             return call_function_args(cb_expand_template,
-                (val.tmpl_context, val.tmpl_value, val.type_assertion, template_context));
+                (val.tmpl_context, val.tmpl_value, template_context));
         }
         if (val instanceof hash<DataProviderExpression>) {
             return AbstractDataProvider::evalGenericExpression(rec, val, template_context);
@@ -4937,7 +4934,7 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
         @since DataProvider 3.3
     */
     static bool setTemplateCallbacks(
-            code<auto(string, string, *string, *hash<auto>)> expand,
+            code<auto(string, string, *hash<auto>)> expand,
             *code<*AbstractDataProviderType(string, string, *hash<auto>)> resolve_type,
             *code<auto(*hash<auto>)> list_contexts,
             *code<auto(string, string, *hash<auto>)> list_values) {

--- a/qlib/DataProvider/AbstractDataProvider.qc
+++ b/qlib/DataProvider/AbstractDataProvider.qc
@@ -731,6 +731,25 @@ public hashdecl DataProviderFieldReference {
     string field;
 }
 
+#! Data provider template reference
+/** Represents a contextual data reference resolved at runtime via callback.
+    @par Syntax
+    - Simple: \c $context:value (e.g., \c $static:account.id)
+    - Bracketed: \c $context:{value with special chars}
+    - Type-asserted: \c $context:value::type (e.g., \c $config:threshold::int)
+    @since DataProvider 3.3
+*/
+public hashdecl DataProviderTemplateReference {
+    #! Template context name (e.g., "static", "dynamic", "config")
+    string tmpl_context;
+    #! Template value path (e.g., "account.id", "threshold")
+    string tmpl_value;
+    #! Optional type assertion (e.g., "int", "string")
+    *string type_assertion;
+    #! Original raw text for round-trip serialization
+    string raw;
+}
+
 #! Data provider expression
 public hashdecl DataProviderExpression {
     #! Expression name
@@ -1242,9 +1261,9 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     "varargs": True,
                     "return_type": AbstractDataProviderTypeMap."bool",
                 },
-                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp) {
+                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp, *hash<auto> template_context) {
                     foreach auto arg in (exp.args) {
-                        if (!AbstractDataProvider::evalGenericExpressionValue(rec, arg)) {
+                        if (!AbstractDataProvider::evalGenericExpressionValue(rec, arg, template_context)) {
                             return False;
                         }
                     }
@@ -1273,9 +1292,9 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     "varargs": True,
                     "return_type": AbstractDataProviderTypeMap."bool",
                 },
-                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp) {
+                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp, *hash<auto> template_context) {
                     foreach auto arg in (exp.args) {
-                        if (AbstractDataProvider::evalGenericExpressionValue(rec, arg)) {
+                        if (AbstractDataProvider::evalGenericExpressionValue(rec, arg, template_context)) {
                             return True;
                         }
                     }
@@ -1302,8 +1321,8 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     ),
                     "return_type": AbstractDataProviderTypeMap."bool",
                 },
-                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp) {
-                    return (!AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0]));
+                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp, *hash<auto> template_context) {
+                    return (!AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0], template_context));
                 },
             },
             DP_SEARCH_OP_EQ: {
@@ -1335,9 +1354,9 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     ),
                     "return_type": AbstractDataProviderTypeMap."bool",
                 },
-                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp) {
-                    auto arg0 = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0]);
-                    auto arg1 = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1]);
+                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp, *hash<auto> template_context) {
+                    auto arg0 = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0], template_context);
+                    auto arg1 = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1], template_context);
                     # for backwards compatibility, if the first argument is a field reference, and the second is a
                     # hash
                     return arg0 == arg1;
@@ -1370,9 +1389,9 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     ),
                     "return_type": AbstractDataProviderTypeMap."bool",
                 },
-                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp) {
-                    return AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0])
-                        != AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1]);
+                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp, *hash<auto> template_context) {
+                    return AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0], template_context)
+                        != AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1], template_context);
                 },
             },
             DP_SEARCH_OP_LT: {
@@ -1403,9 +1422,9 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     ),
                     "return_type": AbstractDataProviderTypeMap."bool",
                 },
-                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp) {
-                    return AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0])
-                        < AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1]);
+                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp, *hash<auto> template_context) {
+                    return AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0], template_context)
+                        < AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1], template_context);
                 },
             },
             DP_SEARCH_OP_LE: {
@@ -1436,9 +1455,9 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     ),
                     "return_type": AbstractDataProviderTypeMap."bool",
                 },
-                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp) {
-                    return AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0])
-                        <= AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1]);
+                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp, *hash<auto> template_context) {
+                    return AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0], template_context)
+                        <= AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1], template_context);
                 },
             },
             DP_SEARCH_OP_GT: {
@@ -1469,9 +1488,9 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     ),
                     "return_type": AbstractDataProviderTypeMap."bool",
                 },
-                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp) {
-                    return AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0])
-                        > AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1]);
+                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp, *hash<auto> template_context) {
+                    return AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0], template_context)
+                        > AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1], template_context);
                 },
             },
             DP_SEARCH_OP_GE: {
@@ -1502,9 +1521,9 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     ),
                     "return_type": AbstractDataProviderTypeMap."bool",
                 },
-                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp) {
-                    return AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0])
-                        >= AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1]);
+                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp, *hash<auto> template_context) {
+                    return AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0], template_context)
+                        >= AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1], template_context);
                 },
             },
             DP_SEARCH_OP_BETWEEN: {
@@ -1545,10 +1564,10 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     ),
                     "return_type": AbstractDataProviderTypeMap."bool",
                 },
-                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp) {
-                    auto arg0 = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0]);
-                    return arg0 > AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1])
-                        && arg0 < AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[2]);
+                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp, *hash<auto> template_context) {
+                    auto arg0 = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0], template_context);
+                    return arg0 > AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1], template_context)
+                        && arg0 < AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[2], template_context);
                 },
             },
             DP_SEARCH_OP_IN: {
@@ -1578,9 +1597,9 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     ),
                     "return_type": AbstractDataProviderTypeMap."bool",
                 },
-                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp) {
-                    return inlist(AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0]),
-                        AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1]));
+                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp, *hash<auto> template_context) {
+                    return inlist(AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0], template_context),
+                        AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1], template_context));
                 },
             },
             DP_SEARCH_OP_REGEX: {
@@ -1601,11 +1620,11 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     "arg_info": RegularExpressionArgInfo,
                     "return_type": AbstractDataProviderTypeMap."bool",
                 },
-                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp) {
-                    string str = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0]);
-                    string pattern = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1]);
+                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp, *hash<auto> template_context) {
+                    string str = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0], template_context);
+                    string pattern = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1], template_context);
                     int opts;
-                    if (*list<auto> options = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[2])) {
+                    if (*list<auto> options = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[2], template_context)) {
                         opts = foldl $1 | $2, (map RegexOpts{$1}, options);
                     }
                     return regex(str, pattern, opts);
@@ -1623,8 +1642,24 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     "args": (DataProviderSignatureAnyType,),
                     "return_type": AbstractDataProviderTypeMap."any",
                 },
-                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp) {
-                    return AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0]);
+                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp, *hash<auto> template_context) {
+                    return AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0], template_context);
+                },
+            },
+            DP_EXPR_TEMPLATE: {
+                "exp": <DataProviderExpressionInfo>{
+                    "type": DET_Operator,
+                    "name": DP_EXPR_TEMPLATE,
+                    "display_name": "template",
+                    "short_desc": "Evaluates and returns a template reference value",
+                    "desc": "Evaluates the given template reference via the registered callback and returns "
+                        "its value. This allows template references to be used as standalone expressions.",
+                    "symbol": "",
+                    "args": (DataProviderSignatureAnyType,),
+                    "return_type": AbstractDataProviderTypeMap."any",
+                },
+                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp, *hash<auto> template_context) {
+                    return AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0], template_context);
                 },
             },
             DP_FUNC_INDEX: {
@@ -1638,9 +1673,9 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     "args": (DataProviderSignatureAnyType, DataProviderSignatureIntType),
                     "return_type": AbstractDataProviderTypeMap."any",
                 },
-                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp) {
-                    auto value = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0]);
-                    int index = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1]);
+                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp, *hash<auto> template_context) {
+                    auto value = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0], template_context);
+                    int index = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[1], template_context);
                     if (value.typeCode() != NT_LIST) {
                         throw "INVALID-OPERATION", sprintf("index accessor [%d] applied to non-list value of "
                             "type %y", index, value.fullType());
@@ -1666,8 +1701,8 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     "varargs": True,
                     "return_type": AbstractDataProviderTypeMap."any",
                 },
-                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp) {
-                    auto value = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0]);
+                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp, *hash<auto> template_context) {
+                    auto value = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0], template_context);
                     if (value.typeCode() != NT_LIST) {
                         throw "INVALID-OPERATION", sprintf("slice accessor applied to non-list value of "
                             "type %y", value.fullType());
@@ -1675,7 +1710,7 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     int len = value.size();
                     list<auto> result = ();
                     for (int i = 1; i < exp.args.size(); ++i) {
-                        auto item = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[i]);
+                        auto item = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[i], template_context);
                         if (item.typeCode() == NT_HASH) {
                             hash<auto> range = item;
                             int start = exists range.start
@@ -1710,11 +1745,11 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                     "varargs": True,
                     "return_type": AbstractDataProviderTypeMap."any",
                 },
-                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp) {
-                    auto value = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0]);
+                "impl": auto sub (hash<auto> rec, hash<DataProviderExpression> exp, *hash<auto> template_context) {
+                    auto value = AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[0], template_context);
                     list<string> key_list = ();
                     for (int i = 1; i < exp.args.size(); ++i) {
-                        key_list += AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[i]);
+                        key_list += AbstractDataProvider::evalGenericExpressionValue(rec, exp.args[i], template_context);
                     }
                     return AbstractDataProvider::applyKeyAccessorImpl(value, key_list);
                 },
@@ -1795,6 +1830,29 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
 
         #! static callback for dynamic value resolution
         static code cb_resolve_value;
+
+        #! static callback for template reference expansion
+        /** @since DataProvider 3.3
+        */
+        static *code<auto(string, string, *string, *hash<auto>)> cb_expand_template;
+
+        #! static callback for resolving template reference types
+        /** @since DataProvider 3.3
+        */
+        static *code<*AbstractDataProviderType(string, string)> cb_resolve_template_type;
+
+        #! static callback for listing available template contexts
+        /** @since DataProvider 3.3
+        */
+        static *code<auto()> cb_list_template_contexts;
+
+        #! static callback for listing available template values for a context
+        /** @since DataProvider 3.3
+        */
+        static *code<auto(string, string)> cb_list_template_values;
+
+        #! flag if template callbacks are locked
+        static bool template_callbacks_locked = False;
     }
 
     private:internal {
@@ -4737,10 +4795,13 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
     }
 
     #! Evaluates the given expression with the generic internal implementation and returns the result
-    /**
+    /** @param rec the record hash to evaluate against
+        @param val the value to evaluate (field reference, template reference, expression, or literal)
+        @param template_context optional context hash passed through to template callbacks
+
         @since DataProvider 2.3
     */
-    static auto evalGenericExpressionValue(hash<auto> rec, auto val) {
+    static auto evalGenericExpressionValue(hash<auto> rec, auto val, *hash<auto> template_context) {
         if (val instanceof hash<DataProviderFieldReference>) {
             # allow for dotted references to be respected; allow escaping of dots
             list<string> f = map regex_subst($1, "\\\\.", ".", RE_Global), val.field.splitRegex("(?<!\\\\)\\.");
@@ -4765,8 +4826,16 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
             }
             return rv;
         }
+        if (val instanceof hash<DataProviderTemplateReference>) {
+            if (!cb_expand_template) {
+                throw "TEMPLATE-RESOLUTION-ERROR",
+                    sprintf("template reference %y cannot be resolved: no template callback registered", val.raw);
+            }
+            return call_function_args(cb_expand_template,
+                (val.tmpl_context, val.tmpl_value, val.type_assertion, template_context));
+        }
         if (val instanceof hash<DataProviderExpression>) {
-            return AbstractDataProvider::evalGenericExpression(rec, val);
+            return AbstractDataProvider::evalGenericExpression(rec, val, template_context);
         }
         return val;
     }
@@ -4808,10 +4877,14 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
     }
 
     #! Evaluates the given expression with the generic internal implementation and returns the result
-    /**
+    /** @param rec the record hash to evaluate against
+        @param exp the expression to evaluate
+        @param template_context optional context hash passed through to template callbacks
+
         @since DataProvider 2.3
     */
-    static auto evalGenericExpression(hash<auto> rec, hash<DataProviderExpression> exp) {
+    static auto evalGenericExpression(hash<auto> rec, hash<DataProviderExpression> exp,
+            *hash<auto> template_context) {
         *hash<auto> expinfo = AbstractDataProvider::GenericExpressionImplementations{exp.exp}
             ?? AbstractDataProvider::GenericExpressionImplementations{OperatorAliasMap{exp.exp}};
         if (!expinfo) {
@@ -4820,7 +4893,7 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
         }
         on_error rethrow $1.err, sprintf("error in return value type %y for %y expression: %s",
             expinfo.exp.return_type.getName(), expinfo.exp.name, $1.desc);
-        return expinfo.exp.return_type.acceptsValue(expinfo.impl(rec, exp));
+        return expinfo.exp.return_type.acceptsValue(expinfo.impl(rec, exp, template_context));
     }
 
     #! Set callbacks for dynamic URI resolution to allow for variable URI path elements to be resolved at runtime
@@ -4841,6 +4914,96 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
         cb_value_needs_resolution = value_needs_resolution;
         cb_resolve_value = resolve_value;
         return True;
+    }
+
+    #! Sets callbacks for template reference resolution
+    /** @param expand resolves a template reference to its value
+        @param resolve_type optional; returns the expected type for a template reference
+        @param list_contexts optional; returns available template contexts for completion
+        @param list_values optional; returns available template values for a context for completion
+
+        @return @ref True if callbacks were successfully set (first call) or if the same callbacks are being
+        re-registered; @ref False if different callbacks are already locked
+
+        @note
+        - After this call, template callbacks are locked and cannot be changed (except via @ref clearTemplateCallbacks)
+        - When locked, re-registration with the same callbacks returns @ref True; with different callbacks returns
+          @ref False. The comparison uses Qore's \c == operator on closures, which performs identity comparison
+          (same closure reference), not semantic equality
+        - This method is designed to be called once at startup before any concurrent access; the static callback
+          variables are not protected by a lock, following the same pattern as @ref setDynamicValueCallbacks().
+          Concurrent modification after initialization is not supported
+
+        @since DataProvider 3.3
+    */
+    static bool setTemplateCallbacks(
+            code<auto(string, string, *string, *hash<auto>)> expand,
+            *code<*AbstractDataProviderType(string, string)> resolve_type,
+            *code<auto()> list_contexts,
+            *code<auto(string, string)> list_values) {
+        if (template_callbacks_locked) {
+            return expand == cb_expand_template && resolve_type == cb_resolve_template_type
+                && list_contexts == cb_list_template_contexts && list_values == cb_list_template_values;
+        }
+        template_callbacks_locked = True;
+        cb_expand_template = expand;
+        cb_resolve_template_type = resolve_type;
+        cb_list_template_contexts = list_contexts;
+        cb_list_template_values = list_values;
+        return True;
+    }
+
+    #! Clears all template callbacks and resets the lock
+    /** This method is primarily for testing purposes.
+
+        @since DataProvider 3.3
+    */
+    static clearTemplateCallbacks() {
+        template_callbacks_locked = False;
+        delete cb_expand_template;
+        delete cb_resolve_template_type;
+        delete cb_list_template_contexts;
+        delete cb_list_template_values;
+    }
+
+    #! Returns the list of available template contexts, if a callback is registered
+    /** @return a list of template context info hashes, or NOTHING if no callback is registered
+
+        @since DataProvider 3.3
+    */
+    static *list<hash<auto>> getTemplateContexts() {
+        if (!cb_list_template_contexts) {
+            return NOTHING;
+        }
+        return call_function(cb_list_template_contexts);
+    }
+
+    #! Returns the list of available template values for a context, if a callback is registered
+    /** @param ctx the template context name
+        @param prefix the value prefix to filter by
+        @return a list of template value info hashes, or NOTHING if no callback is registered
+
+        @since DataProvider 3.3
+    */
+    static *list<hash<auto>> getTemplateValues(string ctx, string prefix) {
+        if (!cb_list_template_values) {
+            return NOTHING;
+        }
+        return call_function_args(cb_list_template_values, (ctx, prefix));
+    }
+
+    #! Resolves the type of a template reference using the registered callback
+    /** @param ctx the template context name (e.g., "env", "timestamp")
+        @param value the template value path (e.g., "HOME", "timegm")
+        @return the resolved type, or NOTHING if no callback is registered or the type cannot be determined
+
+        @since DataProvider 3.3
+    */
+    static *AbstractDataProviderType resolveTemplateType(string ctx, string value) {
+        if (!cb_resolve_template_type) {
+            return NOTHING;
+        }
+        return call_function_args(cb_resolve_template_type, (ctx, value));
     }
 
     #! processes an expression in a certain context
@@ -4902,15 +5065,16 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
         auto val = values[pos];
         bool is_exp = val instanceof hash<DataProviderExpression>;
         bool is_ref = is_exp ? False : val instanceof hash<DataProviderFieldReference>;
+        bool is_tmpl = !is_exp && !is_ref && val instanceof hash<DataProviderTemplateReference>;
 
         switch (arginfo.type_code) {
             case ST_Any:
                 return;
             case ST_Value:
-                if (is_exp || is_ref) {
+                if (is_exp || is_ref || is_tmpl) {
                     throw "DATA-PROVIDER-EXPRESSION-ERROR", sprintf("expression %y argument %d/%d expects a value; "
                         "got %y instead", expinfo.name, pos + 1, values.size(),
-                        is_exp ? "nested expression" : "field reference");
+                        is_exp ? "nested expression" : (is_ref ? "field reference" : "template reference"));
                 }
                 if (!arginfo.type.isAssignableFrom(Type::getType(val))) {
                     throw "DATA-PROVIDER-EXPRESSION-ERROR", sprintf("argument %d expects type %y; got %y instead",
@@ -4921,7 +5085,7 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
                 if (!is_ref) {
                     throw "DATA-PROVIDER-EXPRESSION-ERROR", sprintf("expression %y argument %d/%d expects a field "
                         "reference; got %y instead", expinfo.name, pos + 1, values.size(),
-                        is_exp ? "nested expression" : "value");
+                        is_exp ? "nested expression" : (is_tmpl ? "template reference" : "value"));
                 }
                 return;
         }

--- a/qlib/DataProvider/AbstractDataProviderRecordIterator.qc
+++ b/qlib/DataProvider/AbstractDataProviderRecordIterator.qc
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! Qore AbstractDataProviderRecordIterator class definition
 
-/** AbstractDataProviderRecordIterator.qc Copyright 2019 - 2024 Qore Technologies, s.r.o.
+/** AbstractDataProviderRecordIterator.qc Copyright 2019 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -132,6 +132,22 @@ public const DP_FUNC_KEY = "key";
     @since DataProvider 3.3
 */
 public const DP_EXPR_VALUE = "value";
+
+#! Template expression operator
+/** Used to wrap a standalone template reference as an expression.
+
+    @par Example
+    @code{.py}
+    # "$static:name" parses to:
+    {
+        "exp": "template",
+        "args": (<DataProviderTemplateReference>{"tmpl_context": "static", "tmpl_value": "name", "raw": "$static:name"},),
+    }
+    @endcode
+
+    @since DataProvider 3.3
+*/
+public const DP_EXPR_TEMPLATE = "template";
 #/@}
 
 #! Operator alias map; maps from old operator names to canonical ones
@@ -546,8 +562,9 @@ public class AbstractDataProviderRecordIterator inherits AbstractIterator {
         the input, otherwise a recursive partial match with only the keys given in the value to be checked is
         performed
     */
-    private static bool matchGeneric(hash<auto> record, hash<DataProviderExpression> where_cond) {
-        return AbstractDataProvider::evalGenericExpression(record, where_cond);
+    private static bool matchGeneric(hash<auto> record, hash<DataProviderExpression> where_cond,
+            *hash<auto> template_context) {
+        return AbstractDataProvider::evalGenericExpression(record, where_cond, template_context);
     }
 
     #! Checks if the current record matches the search criteria
@@ -556,14 +573,19 @@ public class AbstractDataProviderRecordIterator inherits AbstractIterator {
         the input, otherwise a recursive partial match with only the keys given in the value to be checked is
         performed
     */
-    private static bool matchGeneric(hash<auto> record, *hash<auto> where_cond) {
+    private static bool matchGeneric(hash<auto> record, *hash<auto> where_cond,
+            *hash<auto> template_context) {
         foreach hash<auto> elem in (where_cond.pairIterator()) {
-            if (elem.value.op && (*hash<auto> op = (DefaultGenericSearchOpMap{elem.value.op}
-                ?? DefaultGenericSearchOpMap{OperatorAliasMap{elem.value.op}}))) {
-                if (!AbstractDataProviderRecordIterator::evalOperator(elem.key, elem.value, op, record)) {
+            # Template references and other typed hashdecls are matched directly as values
+            if (!(elem.value instanceof hash<DataProviderTemplateReference>)
+                && elem.value.op && (*hash<auto> op = (DefaultGenericSearchOpMap{elem.value.op}
+                    ?? DefaultGenericSearchOpMap{OperatorAliasMap{elem.value.op}}))) {
+                if (!AbstractDataProviderRecordIterator::evalOperator(elem.key, elem.value, op, record,
+                        template_context)) {
                     return False;
                 }
-            } else if (!AbstractDataProviderRecordIterator::matchGenericValue(record{elem.key}, elem.value)) {
+            } else if (!AbstractDataProviderRecordIterator::matchGenericValue(record{elem.key}, elem.value,
+                    template_context)) {
                 return False;
             }
         }
@@ -571,25 +593,56 @@ public class AbstractDataProviderRecordIterator inherits AbstractIterator {
     }
 
     #! Evaluates a generic search operator on the field value and record and returns the result
-    private static bool evalOperator(string field, hash<auto> cmd, hash<auto> op, hash<auto> record) {
+    private static bool evalOperator(string field, hash<auto> cmd, hash<auto> op, hash<auto> record,
+            *hash<auto> template_context) {
         auto field_value = record{field};
         if (op.recursive && cmd.arg.op
             && (*hash<auto> op0 = (DefaultGenericSearchOpMap{cmd.arg.op}
                 ?? DefaultGenericSearchOpMap{OperatorAliasMap{cmd.arg.op}}))) {
-            field_value = AbstractDataProviderRecordIterator::evalOperator(field, cmd.arg, op0, record);
+            field_value = AbstractDataProviderRecordIterator::evalOperator(field, cmd.arg, op0, record,
+                template_context);
         }
-        return op.code(cmd, field_value, field, record);
+        # Resolve template references in the operator argument
+        hash<auto> resolved_cmd = cmd;
+        resolved_cmd.arg = AbstractDataProviderRecordIterator::resolveTemplateValue(cmd.arg, template_context);
+        return op.code(resolved_cmd, field_value, field, record);
+    }
+
+    #! Resolves template references in a value
+    /** Recursively resolves any @ref DataProviderTemplateReference values found in the input.
+        For lists, each element is resolved individually.
+
+        @param val the value to resolve
+        @param template_context optional context hash passed through to template callbacks
+
+        @return the resolved value
+
+        @since DataProvider 3.3
+    */
+    private static auto resolveTemplateValue(auto val, *hash<auto> template_context) {
+        if (val instanceof hash<DataProviderTemplateReference>) {
+            return AbstractDataProvider::evalGenericExpressionValue({}, val, template_context);
+        }
+        if (val.typeCode() == NT_LIST) {
+            return map AbstractDataProviderRecordIterator::resolveTemplateValue($1, template_context), val;
+        }
+        return val;
     }
 
     #! Match a single value
     /** in case of a hash value, a recursive partial match with only the keys given in the value to be checked is
         performed
     */
-    private static bool matchGenericValue(auto expects, auto val) {
+    private static bool matchGenericValue(auto expects, auto val, *hash<auto> template_context) {
+        # Resolve template references in the value
+        if (val instanceof hash<DataProviderTemplateReference>) {
+            val = AbstractDataProvider::evalGenericExpressionValue({}, val, template_context);
+        }
         if (val.typeCode() == NT_HASH) {
             # in case of a hash, do a recursive partial match with only the given keys
             foreach hash<auto> i in (val.pairIterator()) {
-                if (!AbstractDataProviderRecordIterator::matchGenericValue(expects{i.key}, i.value)) {
+                if (!AbstractDataProviderRecordIterator::matchGenericValue(expects{i.key}, i.value,
+                        template_context)) {
                     return False;
                 }
             }

--- a/qlib/DataProvider/DataProvider.qc
+++ b/qlib/DataProvider/DataProvider.qc
@@ -770,9 +770,10 @@ list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('@na', 3
     */
     static list<hash<DpqlCompletionItem>> getDpqlCompletions(string text, int position,
             hash<string, AbstractDataField> fields,
-            *hash<string, hash<DataProviderExpressionInfo>> expressions) {
+            *hash<string, hash<DataProviderExpressionInfo>> expressions,
+            *hash<auto> template_context) {
         DpqlCompletionProvider provider(expressions ?? DataProviderGenericExpressions);
-        return provider.getCompletions(text, position, fields);
+        return provider.getCompletions(text, position, fields, template_context);
     }
 
     #! Sets callbacks for template reference resolution
@@ -784,9 +785,9 @@ list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('@na', 3
     */
     static bool setTemplateCallbacks(
             code<auto(string, string, *string, *hash<auto>)> expand,
-            *code<*AbstractDataProviderType(string, string)> resolve_type,
-            *code<auto()> list_contexts,
-            *code<auto(string, string)> list_values) {
+            *code<*AbstractDataProviderType(string, string, *hash<auto>)> resolve_type,
+            *code<auto(*hash<auto>)> list_contexts,
+            *code<auto(string, string, *hash<auto>)> list_values) {
         return AbstractDataProvider::setTemplateCallbacks(expand, resolve_type, list_contexts, list_values);
     }
 

--- a/qlib/DataProvider/DataProvider.qc
+++ b/qlib/DataProvider/DataProvider.qc
@@ -775,6 +775,32 @@ list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('@na', 3
         return provider.getCompletions(text, position, fields);
     }
 
+    #! Sets callbacks for template reference resolution
+    /** Delegates to @ref AbstractDataProvider::setTemplateCallbacks()
+
+        @see AbstractDataProvider::setTemplateCallbacks() for full documentation
+
+        @since DataProvider 3.3
+    */
+    static bool setTemplateCallbacks(
+            code<auto(string, string, *string, *hash<auto>)> expand,
+            *code<*AbstractDataProviderType(string, string)> resolve_type,
+            *code<auto()> list_contexts,
+            *code<auto(string, string)> list_values) {
+        return AbstractDataProvider::setTemplateCallbacks(expand, resolve_type, list_contexts, list_values);
+    }
+
+    #! Clears all template callbacks and resets the lock
+    /** Delegates to @ref AbstractDataProvider::clearTemplateCallbacks()
+
+        @see AbstractDataProvider::clearTemplateCallbacks() for full documentation
+
+        @since DataProvider 3.3
+    */
+    static clearTemplateCallbacks() {
+        AbstractDataProvider::clearTemplateCallbacks();
+    }
+
     #! Validates a DPQL expression against available fields
     /** @param text the DPQL expression to validate
         @param fields available fields
@@ -1187,6 +1213,28 @@ if (errors) {
     static private string renderExpressionArg(hash<DataProviderFieldReference> ref,
             hash<string, hash<DataProviderExpressionInfo>> emap, *hash<DataProviderArgInfo> arg_info) {
         return sprintf("{%s}", ref.field);
+    }
+
+    #! Returns a descriptive string for the given template reference argument
+    /**
+        @since DataProvider 3.3
+    */
+    static private string renderExpressionArg(hash<DataProviderTemplateReference> ref,
+            hash<string, hash<DataProviderExpressionInfo>> emap, *hash<DataProviderArgInfo> arg_info) {
+        if (ref.raw) {
+            return ref.raw;
+        }
+        # Reconstruct from parts
+        string result = "$" + ref.tmpl_context + ":";
+        if (ref.tmpl_value =~ /[^a-zA-Z0-9_.*]/) {
+            result += "{" + ref.tmpl_value + "}";
+        } else {
+            result += ref.tmpl_value;
+        }
+        if (ref.type_assertion) {
+            result += "::" + ref.type_assertion;
+        }
+        return result;
     }
 
     #! Returns a descriptive string for the given expression argument

--- a/qlib/DataProvider/DataProvider.qc
+++ b/qlib/DataProvider/DataProvider.qc
@@ -785,7 +785,7 @@ list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions('@na', 3
         @since DataProvider 3.3
     */
     static bool setTemplateCallbacks(
-            code<auto(string, string, *string, *hash<auto>)> expand,
+            code<auto(string, string, *hash<auto>)> expand,
             *code<*AbstractDataProviderType(string, string, *hash<auto>)> resolve_type,
             *code<auto(*hash<auto>)> list_contexts,
             *code<auto(string, string, *hash<auto>)> list_values) {
@@ -1232,9 +1232,6 @@ if (errors) {
             result += "{" + ref.tmpl_value + "}";
         } else {
             result += ref.tmpl_value;
-        }
-        if (ref.type_assertion) {
-            result += "::" + ref.type_assertion;
         }
         return result;
     }

--- a/qlib/DataProvider/DataProvider.qc
+++ b/qlib/DataProvider/DataProvider.qc
@@ -728,6 +728,174 @@ string dpql = DataProvider::serializeDpqlExpression(exp);
         return serializer.serialize(exp);
     }
 
+    #! Deserializes an expression from JSON/YAML transport format to typed DataProviderExpression
+    /** Converts an untyped hash (as received from JSON/YAML) to a properly typed
+        @ref DataProviderExpression with all nested nodes typed.
+
+        @param h the untyped expression hash; must contain an \c exp string key
+        @return the typed DataProviderExpression
+
+        @throw EXPRESSION-DESERIALIZE-ERROR if \c exp is missing or not a string
+        @throw EXPRESSION-ARG-ERROR if an argument hash has an unrecognized format
+
+        @par Example:
+        @code{.py}
+# From JSON: {"exp": "==", "args": [{"field": "name"}, {"value": "John"}]}
+hash<auto> json_exp = {
+    "exp": "==",
+    "args": ({"field": "name"}, {"value": "John"}),
+};
+hash<DataProviderExpression> exp = DataProvider::deserializeExpressionFromJson(json_exp);
+        @endcode
+
+        @since DataProvider 3.4
+    */
+    static hash<DataProviderExpression> deserializeExpressionFromJson(hash<auto> h) {
+        if (!h.hasKey("exp") || h.exp.typeCode() != NT_STRING) {
+            throw "EXPRESSION-DESERIALIZE-ERROR", sprintf("expression hash missing \"exp\" string key; got: %y",
+                h);
+        }
+        return <DataProviderExpression>{
+            "exp": h.exp,
+            "args": h.args
+                ? (map DataProvider::deserializeExpressionArgFromJson($1), h.args)
+                : NOTHING,
+        };
+    }
+
+    #! Deserializes an expression argument from JSON/YAML transport format
+    /** Handles all argument types:
+        - Non-hash scalars: returned as-is (plain values)
+        - Already-typed hashdecls: passed through (expressions are recursed)
+        - \c {"tmpl_context": ..., "tmpl_value": ...}: converted to @ref DataProviderTemplateReference
+        - \c {"field": ...} (single key): converted to @ref DataProviderFieldReference
+        - \c {"exp": ...}: recursively deserialized via @ref deserializeExpressionFromJson()
+        - \c {"value": val}: unwrapped to \c val
+        - \c {"start": ..., "end": ...}: converted to @ref DataProviderRangeSpec
+        - Unknown hash: throws \c EXPRESSION-ARG-ERROR
+
+        @param arg the argument to deserialize
+        @return the typed argument
+
+        @throw EXPRESSION-ARG-ERROR if a hash argument has an unrecognized format
+
+        @since DataProvider 3.4
+    */
+    static auto deserializeExpressionArgFromJson(auto arg) {
+        if (arg.typeCode() != NT_HASH) {
+            # Non-hash scalar or list: return as-is
+            return arg;
+        }
+
+        # Already-typed hashdecls pass through (recurse into expressions)
+        if (arg instanceof hash<DataProviderExpression>) {
+            return DataProvider::deserializeExpressionFromJson(arg);
+        }
+        if (arg instanceof hash<DataProviderFieldReference>) {
+            return arg;
+        }
+        if (arg instanceof hash<DataProviderTemplateReference>) {
+            return arg;
+        }
+        if (arg instanceof hash<DataProviderRangeSpec>) {
+            return arg;
+        }
+
+        # Untyped hash: determine format from keys
+        if (arg.hasKey("tmpl_context") && arg.hasKey("tmpl_value")) {
+            return <DataProviderTemplateReference>{
+                "tmpl_context": arg.tmpl_context,
+                "tmpl_value": arg.tmpl_value,
+                "raw": arg.raw ?? ("$" + arg.tmpl_context + ":" + arg.tmpl_value),
+            };
+        }
+        if (arg.hasKey("field") && arg.size() == 1) {
+            return <DataProviderFieldReference>{
+                "field": arg.field,
+            };
+        }
+        if (arg.hasKey("exp")) {
+            return DataProvider::deserializeExpressionFromJson(arg);
+        }
+        if (arg.hasKey("value")) {
+            return arg.value;
+        }
+        # Range spec: {"start": ..., "end": ...}
+        if (arg.size() <= 2 && (arg.hasKey("start") || arg.hasKey("end"))
+                && !arg.hasKey("field") && !arg.hasKey("exp") && !arg.hasKey("value")) {
+            return <DataProviderRangeSpec>{
+                "start": arg.start,
+                "end": arg.end,
+            };
+        }
+
+        throw "EXPRESSION-ARG-ERROR", sprintf("unrecognized expression argument hash format: %y", arg);
+    }
+
+    #! Serializes a typed DataProviderExpression to JSON/YAML transport format
+    /** Converts a typed expression to an untyped hash suitable for JSON/YAML serialization,
+        wrapping plain values in \c {"value": val} to preserve type information.
+
+        @param exp the typed expression to serialize
+        @return the untyped hash in transport format
+
+        @par Example:
+        @code{.py}
+hash<DataProviderExpression> exp = <DataProviderExpression>{
+    "exp": "==",
+    "args": (<DataProviderFieldReference>{"field": "name"}, "John"),
+};
+hash<auto> json = DataProvider::serializeExpressionToJson(exp);
+# Result: {"exp": "==", "args": ({"field": "name"}, {"value": "John"})}
+        @endcode
+
+        @since DataProvider 3.4
+    */
+    static hash<auto> serializeExpressionToJson(hash<DataProviderExpression> exp) {
+        return {
+            "exp": exp.exp,
+            "args": exp.args
+                ? (map DataProvider::serializeExpressionArgToJson($1), exp.args)
+                : NOTHING,
+        };
+    }
+
+    #! Serializes an expression argument to JSON/YAML transport format
+    /** Handles all argument types:
+        - @ref DataProviderFieldReference: \c {"field": name}
+        - @ref DataProviderTemplateReference: \c {"tmpl_context": ..., "tmpl_value": ..., "raw": ...}
+        - @ref DataProviderRangeSpec: \c {"start": ..., "end": ...}
+        - @ref DataProviderExpression: recursively serialized
+        - Plain value: wrapped in \c {"value": val}
+
+        @param arg the argument to serialize
+        @return the serialized argument
+
+        @since DataProvider 3.4
+    */
+    static auto serializeExpressionArgToJson(auto arg) {
+        if (arg instanceof hash<DataProviderFieldReference>) {
+            return {"field": arg.field};
+        }
+        if (arg instanceof hash<DataProviderTemplateReference>) {
+            return {
+                "tmpl_context": arg.tmpl_context,
+                "tmpl_value": arg.tmpl_value,
+                "raw": arg.raw,
+            };
+        }
+        if (arg instanceof hash<DataProviderRangeSpec>) {
+            return {
+                "start": arg.start,
+                "end": arg.end,
+            };
+        }
+        if (arg instanceof hash<DataProviderExpression>) {
+            return DataProvider::serializeExpressionToJson(arg);
+        }
+        return {"value": arg};
+    }
+
     #! Gets all tokens from a DPQL expression for syntax highlighting
     /** @param text the DPQL expression to tokenize
 

--- a/qlib/DataProvider/DataProvider.qc
+++ b/qlib/DataProvider/DataProvider.qc
@@ -753,6 +753,7 @@ foreach hash<DpqlTokenInfo> tok in (tokens) {
         @param position cursor position (0-based character offset)
         @param fields available fields for completion
         @param expressions optional map of expression names to their info
+        @param template_context optional context hash forwarded to template completion callbacks for filtering
 
         @return a list of completion items sorted by priority
 

--- a/qlib/DataProvider/DataProvider.qm
+++ b/qlib/DataProvider/DataProvider.qm
@@ -42,7 +42,7 @@
 %endtry
 
 module DataProvider {
-    version = "3.3.0";
+    version = "3.4.0";
     desc = "user module for data integration patterns and data and API introspection";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";

--- a/qlib/DataProvider/DefaultRecordIterator.qc
+++ b/qlib/DataProvider/DefaultRecordIterator.qc
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! Qore DefaultRecordIterator class definition
 
-/** DefaultRecordIterator.qc Copyright 2019 - 2024 Qore Technologies, s.r.o.
+/** DefaultRecordIterator.qc Copyright 2019 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -35,6 +35,10 @@ public class DefaultRecordIterator inherits AbstractDataProviderRecordIterator {
         *hash<string, AbstractDataField> record_type;
         int count = 0;
         *string subrecord;
+        #! Optional template context for template reference resolution
+        /** @since DataProvider 3.3
+        */
+        *hash<auto> template_context;
     }
 
     #! Returns an iterator for zero or more records matching the search options
@@ -43,13 +47,16 @@ public class DefaultRecordIterator inherits AbstractDataProviderRecordIterator {
         @param search_options the search options after processing by validateSearchOptions()
         @param record_type the record type
         @param subrecord the optional name of a key of the record hash storing record data
+        @param template_context optional context hash for template reference resolution
     */
     constructor(AbstractIterator i, *hash<auto> where_cond, *hash<auto> search_options,
-            *hash<string, AbstractDataField> record_type, *string subrecord)
+            *hash<string, AbstractDataField> record_type, *string subrecord,
+            *hash<auto> template_context)
             : AbstractDataProviderRecordIterator(search_options.requires_result,
                 search_options.max_records) {
         self.i = i;
         self.where_cond = where_cond;
+        self.template_context = template_context;
         if (exists search_options.columns && search_options.columns.typeCode() != NT_LIST) {
             search_options.columns = list(search_options.columns);
         }
@@ -105,7 +112,7 @@ public class DefaultRecordIterator inherits AbstractDataProviderRecordIterator {
     */
     private bool nextImpl() {
         while (i.next()) {
-            if (!where_cond || (where_cond && matchGeneric(i.getValue(), where_cond))) {
+            if (!where_cond || (where_cond && matchGeneric(i.getValue(), where_cond, template_context))) {
                 if (search_options.offset > 0) {
                     if (exists search_options.limit && search_options.limit >= 0
                         && (count - search_options.offset) == search_options.limit) {

--- a/qlib/DataProvider/DpqlActionSession.qc
+++ b/qlib/DataProvider/DpqlActionSession.qc
@@ -287,7 +287,7 @@ public class DpqlActionSession {
         }
         hash<DataProviderExpression> dp_exp;
         try {
-            dp_exp = cast<hash<DataProviderExpression>>(args.expression);
+            dp_exp = DataProvider::deserializeExpressionFromJson(args.expression);
         } catch (hash<ExceptionInfo> ex) {
             throw "INVALID-PARAMETER", sprintf("Invalid 'expression' value: %s", ex.desc);
         }

--- a/qlib/DataProvider/DpqlActionSession.qc
+++ b/qlib/DataProvider/DpqlActionSession.qc
@@ -256,7 +256,7 @@ public class DpqlActionSession {
             throw "NO-CONTEXT", "Context must be set before completion";
         }
         list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions(text, position, use_fields,
-            expressions);
+            expressions, args.template_context);
         return {
             "completions": items,
         };

--- a/qlib/DataProvider/DpqlActionSession.qc
+++ b/qlib/DataProvider/DpqlActionSession.qc
@@ -255,6 +255,10 @@ public class DpqlActionSession {
         if (!use_fields) {
             throw "NO-CONTEXT", "Context must be set before completion";
         }
+        if (exists args.template_context && args.template_context.typeCode() != NT_HASH) {
+            throw "INVALID-PARAMETER", sprintf("Parameter 'template_context' must be a hash, got %s",
+                args.template_context.type());
+        }
         list<hash<DpqlCompletionItem>> items = DataProvider::getDpqlCompletions(text, position, use_fields,
             expressions, args.template_context);
         return {

--- a/qlib/DataProvider/DpqlActionSession.qc
+++ b/qlib/DataProvider/DpqlActionSession.qc
@@ -368,6 +368,7 @@ public class DpqlActionSession {
             case DPQL_TOK_LPAREN: return "punctuation";
             case DPQL_TOK_RPAREN: return "punctuation";
             case DPQL_TOK_COMMA: return "punctuation";
+            case DPQL_TOK_TEMPLATE: return "variable";
             case DPQL_TOK_ERROR: return "error";
         }
         return "identifier";

--- a/qlib/DataProvider/DpqlCompletionProvider.qc
+++ b/qlib/DataProvider/DpqlCompletionProvider.qc
@@ -53,6 +53,8 @@ public hashdecl DpqlCompletionContext {
     hash<string, AbstractDataField> fields;
     #! Available expressions
     *hash<string, hash<DataProviderExpressionInfo>> expressions;
+    #! Optional template context data for filtering (e.g., sandboxed, interface_type)
+    *hash<auto> template_context;
 }
 
 #! Completion context types
@@ -186,15 +188,17 @@ public class DpqlCompletionProvider {
     /** @param text the DPQL expression text
         @param position cursor position (0-based character offset)
         @param fields available fields for completion
+        @param template_context optional template context data for filtering
         @return a list of completion items
     */
     list<hash<DpqlCompletionItem>> getCompletions(string text, int position,
-            hash<string, AbstractDataField> fields) {
+            hash<string, AbstractDataField> fields, *hash<auto> template_context) {
         return getCompletionsWithContext(<DpqlCompletionContext>{
             "text": text,
             "position": position,
             "fields": fields,
             "expressions": expressions,
+            "template_context": template_context,
         });
     }
 
@@ -216,7 +220,7 @@ public class DpqlCompletionProvider {
                 items += getFieldCompletions(ctx.fields, analysis.prefix);
                 items += getValueCompletions(analysis.prefix);
                 items += getFunctionCompletions(analysis.prefix);
-                items += getTemplateCompletions(analysis.prefix);
+                items += getTemplateCompletions(analysis.prefix, ctx.template_context);
                 if (!analysis.prefix || index("!", analysis.prefix) == 0) {
                     items += <DpqlCompletionItem>{
                         "label": "!",
@@ -230,7 +234,7 @@ public class DpqlCompletionProvider {
 
             case DPQL_CTX_IN_TEMPLATE:
                 # Completing template context or value after $
-                items += getTemplateCompletions(analysis.prefix);
+                items += getTemplateCompletions(analysis.prefix, ctx.template_context);
                 break;
 
             case DPQL_CTX_IN_FIELD:
@@ -653,14 +657,16 @@ public class DpqlCompletionProvider {
         contains a colon separator.
 
         @param prefix the current prefix (starting with \c $)
+        @param template_context optional template context data for filtering
         @return a list of template completion items
 
         @since DataProvider 3.3
     */
-    private list<hash<DpqlCompletionItem>> getTemplateCompletions(string prefix) {
+    private list<hash<DpqlCompletionItem>> getTemplateCompletions(string prefix,
+            *hash<auto> template_context) {
         if (!prefix || prefix == "$") {
             # Just $ typed — show template context completions
-            return getTemplateContextCompletions("");
+            return getTemplateContextCompletions("", template_context);
         }
         if (prefix =~ /^\$/) {
             # Check if we have a colon separator
@@ -670,23 +676,25 @@ public class DpqlCompletionProvider {
                 # After $ctx: — show template value completions
                 string ctx = substr(rest, 0, colon_pos);
                 string value_prefix = substr(rest, colon_pos + 1);
-                return getTemplateValueCompletions(ctx, value_prefix);
+                return getTemplateValueCompletions(ctx, value_prefix, template_context);
             }
             # Still typing context name — filter context completions
-            return getTemplateContextCompletions(rest);
+            return getTemplateContextCompletions(rest, template_context);
         }
         return ();
     }
 
     #! Gets template context completions
     /** @param prefix the context name prefix to filter by
+        @param template_context optional template context data for filtering
         @return a list of template context completion items
 
         @since DataProvider 3.3
     */
-    private list<hash<DpqlCompletionItem>> getTemplateContextCompletions(string prefix) {
+    private list<hash<DpqlCompletionItem>> getTemplateContextCompletions(string prefix,
+            *hash<auto> template_context) {
         # Use registered callback if available
-        if (*list<hash<auto>> contexts = AbstractDataProvider::getTemplateContexts()) {
+        if (*list<hash<auto>> contexts = AbstractDataProvider::getTemplateContexts(template_context)) {
             list<hash<DpqlCompletionItem>> items = ();
             string lwr_prefix = prefix.lwr();
             foreach hash<auto> ctx in (contexts) {
@@ -720,12 +728,14 @@ public class DpqlCompletionProvider {
     #! Gets template value completions for a given context
     /** @param ctx the template context name
         @param prefix the value prefix to filter by
+        @param template_context optional template context data for filtering
         @return a list of template value completion items
 
         @since DataProvider 3.3
     */
-    private list<hash<DpqlCompletionItem>> getTemplateValueCompletions(string ctx, string prefix) {
-        *list<hash<auto>> values = AbstractDataProvider::getTemplateValues(ctx, prefix);
+    private list<hash<DpqlCompletionItem>> getTemplateValueCompletions(string ctx, string prefix,
+            *hash<auto> template_context) {
+        *list<hash<auto>> values = AbstractDataProvider::getTemplateValues(ctx, prefix, template_context);
         if (!values) {
             return ();
         }

--- a/qlib/DataProvider/DpqlCompletionProvider.qc
+++ b/qlib/DataProvider/DpqlCompletionProvider.qc
@@ -66,6 +66,7 @@ const DPQL_CTX_IN_PAREN = "in_paren";        # Inside parentheses
 const DPQL_CTX_IN_INDEX = "in_index";        # Inside index accessor [...]
 const DPQL_CTX_IN_KEY = "in_key";            # Inside key accessor {...}
 const DPQL_CTX_AFTER_ACCESSOR = "after_acc"; # After ] or } - can add more accessors
+const DPQL_CTX_IN_TEMPLATE = "in_template"; # Inside a template reference (after $)
 
 #! Completion provider for DPQL expressions
 /** This class provides context-aware code completion for DPQL query expressions.
@@ -141,6 +142,28 @@ public class DpqlCompletionProvider {
                 "documentation": "Member access", "sort_priority": 7},
         );
 
+        #! Well-known template contexts with descriptions
+        const DefaultTemplateContexts = (
+            {"label": "$static:", "kind": "template", "insert_text": "$static:",
+                "documentation": "Static context values", "sort_priority": 1},
+            {"label": "$dynamic:", "kind": "template", "insert_text": "$dynamic:",
+                "documentation": "Dynamic runtime values", "sort_priority": 2},
+            {"label": "$config:", "kind": "template", "insert_text": "$config:",
+                "documentation": "Configuration values", "sort_priority": 3},
+            {"label": "$var:", "kind": "template", "insert_text": "$var:",
+                "documentation": "Variable values", "sort_priority": 4},
+            {"label": "$transient:", "kind": "template", "insert_text": "$transient:",
+                "documentation": "Transient context values", "sort_priority": 5},
+            {"label": "$env:", "kind": "template", "insert_text": "$env:",
+                "documentation": "Environment variables", "sort_priority": 6},
+            {"label": "$timestamp:", "kind": "template", "insert_text": "$timestamp:",
+                "documentation": "Timestamp values", "sort_priority": 7},
+            {"label": "$qore-expr:", "kind": "template", "insert_text": "$qore-expr:{",
+                "documentation": "Qore expression evaluation", "sort_priority": 8},
+            {"label": "$rest:", "kind": "template", "insert_text": "$rest:",
+                "documentation": "REST context values", "sort_priority": 9},
+        );
+
         #! Index accessor suggestions
         const IndexSuggestions = (
             {"label": "0", "kind": "value", "insert_text": "0",
@@ -189,10 +212,11 @@ public class DpqlCompletionProvider {
             case DPQL_CTX_START:
             case DPQL_CTX_AFTER_OP:
             case DPQL_CTX_IN_PAREN:
-                # Can start with field, literal, function, or NOT
+                # Can start with field, literal, function, template, or NOT
                 items += getFieldCompletions(ctx.fields, analysis.prefix);
                 items += getValueCompletions(analysis.prefix);
                 items += getFunctionCompletions(analysis.prefix);
+                items += getTemplateCompletions(analysis.prefix);
                 if (!analysis.prefix || index("!", analysis.prefix) == 0) {
                     items += <DpqlCompletionItem>{
                         "label": "!",
@@ -202,6 +226,11 @@ public class DpqlCompletionProvider {
                         "sort_priority": 5,
                     };
                 }
+                break;
+
+            case DPQL_CTX_IN_TEMPLATE:
+                # Completing template context or value after $
+                items += getTemplateCompletions(analysis.prefix);
                 break;
 
             case DPQL_CTX_IN_FIELD:
@@ -293,6 +322,14 @@ public class DpqlCompletionProvider {
             return {
                 "ctx": DPQL_CTX_IN_FIELD,
                 "prefix": prefix.size() > 1 ? substr(prefix, 1) : "",
+            };
+        }
+
+        # Check if we're in a template reference (after $)
+        if (prefix =~ /^\$/) {
+            return {
+                "ctx": DPQL_CTX_IN_TEMPLATE,
+                "prefix": prefix,
             };
         }
 
@@ -608,6 +645,100 @@ public class DpqlCompletionProvider {
             }
         }
 
+        return items;
+    }
+
+    #! Gets template completions based on prefix
+    /** Dispatches to context or value completions depending on whether the prefix
+        contains a colon separator.
+
+        @param prefix the current prefix (starting with \c $)
+        @return a list of template completion items
+
+        @since DataProvider 3.3
+    */
+    private list<hash<DpqlCompletionItem>> getTemplateCompletions(string prefix) {
+        if (!prefix || prefix == "$") {
+            # Just $ typed — show template context completions
+            return getTemplateContextCompletions("");
+        }
+        if (prefix =~ /^\$/) {
+            # Check if we have a colon separator
+            string rest = substr(prefix, 1);
+            int colon_pos = index(rest, ":");
+            if (colon_pos >= 0) {
+                # After $ctx: — show template value completions
+                string ctx = substr(rest, 0, colon_pos);
+                string value_prefix = substr(rest, colon_pos + 1);
+                return getTemplateValueCompletions(ctx, value_prefix);
+            }
+            # Still typing context name — filter context completions
+            return getTemplateContextCompletions(rest);
+        }
+        return ();
+    }
+
+    #! Gets template context completions
+    /** @param prefix the context name prefix to filter by
+        @return a list of template context completion items
+
+        @since DataProvider 3.3
+    */
+    private list<hash<DpqlCompletionItem>> getTemplateContextCompletions(string prefix) {
+        # Use registered callback if available
+        if (*list<hash<auto>> contexts = AbstractDataProvider::getTemplateContexts()) {
+            list<hash<DpqlCompletionItem>> items = ();
+            string lwr_prefix = prefix.lwr();
+            foreach hash<auto> ctx in (contexts) {
+                string label = "$" + ctx.name + ":";
+                if (!prefix || index(ctx.name.lwr(), lwr_prefix) == 0) {
+                    items += <DpqlCompletionItem>{
+                        "label": label,
+                        "kind": "template",
+                        "insert_text": label,
+                        "documentation": ctx.description ?? sprintf("Template context: %s", ctx.name),
+                        "sort_priority": ctx.sort_priority ?? 10,
+                    };
+                }
+            }
+            return items;
+        }
+
+        # Fall back to default well-known contexts
+        list<hash<DpqlCompletionItem>> items = ();
+        string lwr_prefix = prefix.lwr();
+        foreach hash<auto> tmpl in (DefaultTemplateContexts) {
+            # Match against context name (strip leading $ and trailing :)
+            string ctx_name = substr(tmpl.label, 1, tmpl.label.size() - 2);
+            if (!prefix || index(ctx_name.lwr(), lwr_prefix) == 0) {
+                items += cast<hash<DpqlCompletionItem>>(tmpl);
+            }
+        }
+        return items;
+    }
+
+    #! Gets template value completions for a given context
+    /** @param ctx the template context name
+        @param prefix the value prefix to filter by
+        @return a list of template value completion items
+
+        @since DataProvider 3.3
+    */
+    private list<hash<DpqlCompletionItem>> getTemplateValueCompletions(string ctx, string prefix) {
+        *list<hash<auto>> values = AbstractDataProvider::getTemplateValues(ctx, prefix);
+        if (!values) {
+            return ();
+        }
+        list<hash<DpqlCompletionItem>> items = ();
+        foreach hash<auto> val in (values) {
+            items += <DpqlCompletionItem>{
+                "label": "$" + ctx + ":" + val.name,
+                "kind": "template",
+                "insert_text": "$" + ctx + ":" + val.name,
+                "documentation": val.description ?? sprintf("Template value: %s", val.name),
+                "sort_priority": val.sort_priority ?? 10,
+            };
+        }
         return items;
     }
 

--- a/qlib/DataProvider/DpqlParser.qc
+++ b/qlib/DataProvider/DpqlParser.qc
@@ -713,12 +713,10 @@ public class DpqlParser {
         string ctx = substr(rest, 0, colon_pos);
         rest = substr(rest, colon_pos + 1);
 
-        # Check for type assertion (last :: in the string, outside brackets)
-        *string type_assertion;
         string val;
 
         if (rest[0] == "{") {
-            # Bracketed value: find matching closing '}' and then (optionally) a trailing ::type
+            # Bracketed value: find matching closing '}'
             int depth = 0;
             int close_pos = -1;
             for (int i = 0; i < rest.size(); ++i) {
@@ -737,14 +735,6 @@ public class DpqlParser {
             if (close_pos > 0) {
                 # Content between the outermost { and }
                 val = substr(rest, 1, close_pos - 1);
-
-                # Check for ::type suffix after the closing '}'
-                int suffix_start = close_pos + 1;
-                if (suffix_start + 1 < rest.size()
-                    && rest[suffix_start] == ":"
-                    && rest[suffix_start + 1] == ":") {
-                    type_assertion = substr(rest, suffix_start + 2);
-                }
             } else {
                 # Fallback: no matching '}' found; strip outer braces as best effort
                 if (rest.size() > 1 && rest[rest.size() - 1] == "}") {
@@ -754,20 +744,12 @@ public class DpqlParser {
                 }
             }
         } else {
-            # Check for ::type suffix — find the last occurrence of ::
-            int type_pos = rindex(rest, "::");
-            if (type_pos >= 0) {
-                type_assertion = substr(rest, type_pos + 2);
-                val = substr(rest, 0, type_pos);
-            } else {
-                val = rest;
-            }
+            val = rest;
         }
 
         return <DataProviderTemplateReference>{
             "tmpl_context": ctx,
             "tmpl_value": val,
-            "type_assertion": type_assertion,
             "raw": raw,
         };
     }

--- a/qlib/DataProvider/DpqlParser.qc
+++ b/qlib/DataProvider/DpqlParser.qc
@@ -718,8 +718,41 @@ public class DpqlParser {
         string val;
 
         if (rest[0] == "{") {
-            # Bracketed value: extract content between { and last }
-            val = substr(rest, 1, rest.size() - 2);
+            # Bracketed value: find matching closing '}' and then (optionally) a trailing ::type
+            int depth = 0;
+            int close_pos = -1;
+            for (int i = 0; i < rest.size(); ++i) {
+                string ch = rest[i];
+                if (ch == "{") {
+                    ++depth;
+                } else if (ch == "}") {
+                    --depth;
+                    if (depth == 0) {
+                        close_pos = i;
+                        break;
+                    }
+                }
+            }
+
+            if (close_pos > 0) {
+                # Content between the outermost { and }
+                val = substr(rest, 1, close_pos - 1);
+
+                # Check for ::type suffix after the closing '}'
+                int suffix_start = close_pos + 1;
+                if (suffix_start + 1 < rest.size()
+                    && rest[suffix_start] == ":"
+                    && rest[suffix_start + 1] == ":") {
+                    type_assertion = substr(rest, suffix_start + 2);
+                }
+            } else {
+                # Fallback: no matching '}' found; strip outer braces as best effort
+                if (rest.size() > 1 && rest[rest.size() - 1] == "}") {
+                    val = substr(rest, 1, rest.size() - 2);
+                } else {
+                    val = substr(rest, 1);
+                }
+            }
         } else {
             # Check for ::type suffix — find the last occurrence of ::
             int type_pos = rindex(rest, "::");

--- a/qlib/DataProvider/DpqlParser.qc
+++ b/qlib/DataProvider/DpqlParser.qc
@@ -142,6 +142,11 @@ public class DpqlParser {
                 # This only happens at the top level, not for nested expressions or function args
                 if (parsed instanceof hash<DataProviderExpression>) {
                     exp = parsed;
+                } else if (parsed instanceof hash<DataProviderTemplateReference>) {
+                    exp = <DataProviderExpression>{
+                        "exp": DP_EXPR_TEMPLATE,
+                        "args": (parsed,),
+                    };
                 } else {
                     exp = <DataProviderExpression>{
                         "exp": DP_EXPR_VALUE,
@@ -577,6 +582,9 @@ public class DpqlParser {
             case DPQL_TOK_FIELD:
                 return parseFieldRef();
 
+            case DPQL_TOK_TEMPLATE:
+                return parseTemplateRef();
+
             case DPQL_TOK_STRING:
                 return parseStringLiteral();
 
@@ -676,6 +684,59 @@ public class DpqlParser {
 
         # Parse optional accessor chain, wrapping in expression nodes
         return parseAccessorChain(result);
+    }
+
+    #! Parses a template reference token into a DataProviderTemplateReference hashdecl
+    /** Extracts context, value, and optional type assertion from the raw template token text.
+
+        @par Supported forms
+        - Simple: \c $context:value
+        - Bracketed: \c $context:{value}
+        - Type-asserted: \c $context:value::type
+        - Fallback: \c $context:A??{$ctx:B}
+
+        @return a DataProviderTemplateReference hashdecl
+
+        @since DataProvider 3.3
+    */
+    private hash<DataProviderTemplateReference> parseTemplateRef() {
+        hash<DpqlTokenInfo> tok = nextToken();
+        string raw = tok.value;
+
+        # Strip leading '$'
+        string rest = substr(raw, 1);
+
+        # Extract context (up to first ':')
+        int colon_pos = index(rest, ":");
+        # The tokenizer guarantees ':' exists in a DPQL_TOK_TEMPLATE token (validated by DPQL-E032)
+        @assert(colon_pos >= 0);
+        string ctx = substr(rest, 0, colon_pos);
+        rest = substr(rest, colon_pos + 1);
+
+        # Check for type assertion (last :: in the string, outside brackets)
+        *string type_assertion;
+        string val;
+
+        if (rest[0] == "{") {
+            # Bracketed value: extract content between { and last }
+            val = substr(rest, 1, rest.size() - 2);
+        } else {
+            # Check for ::type suffix — find the last occurrence of ::
+            int type_pos = rindex(rest, "::");
+            if (type_pos >= 0) {
+                type_assertion = substr(rest, type_pos + 2);
+                val = substr(rest, 0, type_pos);
+            } else {
+                val = rest;
+            }
+        }
+
+        return <DataProviderTemplateReference>{
+            "tmpl_context": ctx,
+            "tmpl_value": val,
+            "type_assertion": type_assertion,
+            "raw": raw,
+        };
     }
 
     #! Parses accessor chain and wraps the base expression in nested operator nodes

--- a/qlib/DataProvider/DpqlSerializer.qc
+++ b/qlib/DataProvider/DpqlSerializer.qc
@@ -310,13 +310,18 @@ public class DpqlSerializer {
 
         switch (arg.typeCode()) {
             case NT_HASH:
-                if (arg instanceof hash<DataProviderTemplateReference>) {
+                # Use instanceof for typed hashdecls (from parser), fall back to
+                # hasKey for plain hashes (from JSON deserialization via WebSocket)
+                if (arg instanceof hash<DataProviderTemplateReference>
+                    || (arg.hasKey("tmpl_context") && arg.hasKey("raw"))) {
                     return serializeTemplateRef(arg);
                 }
-                if (arg instanceof hash<DataProviderFieldReference>) {
+                if (arg instanceof hash<DataProviderFieldReference>
+                    || (arg.hasKey("field") && arg.size() == 1)) {
                     return serializeFieldRef(arg);
                 }
-                if (arg instanceof hash<DataProviderExpression>) {
+                if (arg instanceof hash<DataProviderExpression>
+                    || arg.hasKey("exp")) {
                     return serializeExpr(arg, context_prec);
                 }
                 # Structured hash literal

--- a/qlib/DataProvider/DpqlSerializer.qc
+++ b/qlib/DataProvider/DpqlSerializer.qc
@@ -348,9 +348,6 @@ public class DpqlSerializer {
         } else {
             result += ref.tmpl_value;
         }
-        if (ref.type_assertion) {
-            result += "::" + ref.type_assertion;
-        }
         return result;
     }
 

--- a/qlib/DataProvider/DpqlSerializer.qc
+++ b/qlib/DataProvider/DpqlSerializer.qc
@@ -310,18 +310,13 @@ public class DpqlSerializer {
 
         switch (arg.typeCode()) {
             case NT_HASH:
-                # Use instanceof for typed hashdecls (from parser), fall back to
-                # hasKey for plain hashes (from JSON deserialization via WebSocket)
-                if (arg instanceof hash<DataProviderTemplateReference>
-                    || (arg.hasKey("tmpl_context") && arg.hasKey("raw"))) {
+                if (arg instanceof hash<DataProviderTemplateReference>) {
                     return serializeTemplateRef(arg);
                 }
-                if (arg instanceof hash<DataProviderFieldReference>
-                    || (arg.hasKey("field") && arg.size() == 1)) {
+                if (arg instanceof hash<DataProviderFieldReference>) {
                     return serializeFieldRef(arg);
                 }
-                if (arg instanceof hash<DataProviderExpression>
-                    || arg.hasKey("exp")) {
+                if (arg instanceof hash<DataProviderExpression>) {
                     return serializeExpr(arg, context_prec);
                 }
                 # Structured hash literal

--- a/qlib/DataProvider/DpqlSerializer.qc
+++ b/qlib/DataProvider/DpqlSerializer.qc
@@ -159,6 +159,11 @@ public class DpqlSerializer {
                 result = serializeArg(exp.args[0], DPQL_PREC_PRIMARY);
                 break;
 
+            case DP_EXPR_TEMPLATE:
+                # Template expression - serialize the template reference
+                result = serializeArg(exp.args[0], DPQL_PREC_PRIMARY);
+                break;
+
             case DP_FUNC_INDEX:
                 # Render as sugar: base[n] only if index arg is a literal
                 if (isAccessorArgLiteral(exp.args[1])) {
@@ -305,10 +310,13 @@ public class DpqlSerializer {
 
         switch (arg.typeCode()) {
             case NT_HASH:
-                if (arg.hasKey("field")) {
+                if (arg instanceof hash<DataProviderTemplateReference>) {
+                    return serializeTemplateRef(arg);
+                }
+                if (arg instanceof hash<DataProviderFieldReference>) {
                     return serializeFieldRef(arg);
                 }
-                if (arg.hasKey("exp")) {
+                if (arg instanceof hash<DataProviderExpression>) {
                     return serializeExpr(arg, context_prec);
                 }
                 # Structured hash literal
@@ -321,6 +329,29 @@ public class DpqlSerializer {
             default:
                 return serializeLiteral(arg);
         }
+    }
+
+    #! Serializes a template reference
+    /** Uses the \c raw field for perfect round-trip fidelity. Falls back to reconstruction
+        from parts if \c raw is empty.
+
+        @since DataProvider 3.3
+    */
+    private string serializeTemplateRef(hash<auto> ref) {
+        if (ref.raw) {
+            return ref.raw;
+        }
+        # Reconstruct from parts
+        string result = "$" + ref.tmpl_context + ":";
+        if (ref.tmpl_value =~ /[^a-zA-Z0-9_.*]/) {
+            result += "{" + ref.tmpl_value + "}";
+        } else {
+            result += ref.tmpl_value;
+        }
+        if (ref.type_assertion) {
+            result += "::" + ref.type_assertion;
+        }
+        return result;
     }
 
     #! Serializes a field reference

--- a/qlib/DataProvider/DpqlTokenizer.qc
+++ b/qlib/DataProvider/DpqlTokenizer.qc
@@ -90,6 +90,8 @@ public const DPQL_TOK_RBRACE = 36;
 public const DPQL_TOK_RANGE = 37;
 #! Dot (for member access after accessor)
 public const DPQL_TOK_DOT = 38;
+#! Template reference ($context:value)
+public const DPQL_TOK_TEMPLATE = 39;
 #! Whitespace (spaces, tabs)
 public const DPQL_TOK_WHITESPACE = 40;
 #! Newline character
@@ -133,6 +135,7 @@ public const DpqlTokenTypeNames = {
     DPQL_TOK_RBRACE: "}",
     DPQL_TOK_RANGE: "..",
     DPQL_TOK_DOT: ".",
+    DPQL_TOK_TEMPLATE: "template",
     DPQL_TOK_WHITESPACE: "whitespace",
     DPQL_TOK_NEWLINE: "newline",
     DPQL_TOK_EOF: "eof",
@@ -569,6 +572,12 @@ public class DpqlTokenizer {
             return makeToken(DPQL_TOK_COMMA, ",", start_line, start_column);
         }
 
+        # Template reference ($context:value)
+        if (c == "$") {
+            in_field_ref_context = False;
+            return scanTemplateRef();
+        }
+
         # Identifier (function names, keywords)
         if (c =~ /[a-zA-Z_]/) {
             # Only reset field-ref context if NOT in an accessor chain (i.e., not after a dot)
@@ -664,6 +673,178 @@ public class DpqlTokenizer {
         addError(sprintf("Invalid field reference: expected identifier or quoted string after '@', got '%s'", c),
             "DPQL-E003", start_line, start_column, line, column);
         return makeToken(DPQL_TOK_ERROR, value, start_line, start_column);
+    }
+
+    #! Scans a template reference ($context:value, $context:{bracketed}, $context:value::type)
+    /** Template references follow the pattern:
+        - \c $context:value — simple template
+        - \c $context:{value} — bracketed value (allows special chars)
+        - \c $context:value::type — with type assertion
+        - \c $context:A??{$ctx:B} — fallback syntax (passed through raw)
+
+        @return a DPQL_TOK_TEMPLATE token with the raw template text as the value
+
+        @since DataProvider 3.3
+    */
+    private:internal hash<DpqlTokenInfo> scanTemplateRef() {
+        int start_line = line;
+        int start_column = column;
+        string value = "$";
+        advance();  # skip $
+
+        if (pos >= len) {
+            addError("Incomplete template reference: expected context identifier after '$'", "DPQL-E030",
+                start_line, start_column, line, column);
+            return makeToken(DPQL_TOK_ERROR, value, start_line, start_column);
+        }
+
+        *string c = currentChar();
+
+        # Context identifier: letters, digits, underscores, hyphens (for qore-expr etc.)
+        if (c !~ /[a-zA-Z_]/) {
+            addError(sprintf("Invalid template reference: expected context identifier after '$', got '%s'", c),
+                "DPQL-E031", start_line, start_column, line, column);
+            return makeToken(DPQL_TOK_ERROR, value, start_line, start_column);
+        }
+
+        # Scan context identifier
+        while (pos < len) {
+            c = currentChar();
+            if (c !~ /[a-zA-Z0-9_\-]/) {
+                break;
+            }
+            value += c;
+            advance();
+        }
+
+        # Expect ':' separator
+        if (pos >= len || currentChar() != ":") {
+            addError("Invalid template reference: expected ':' after context identifier", "DPQL-E032",
+                start_line, start_column, line, column);
+            return makeToken(DPQL_TOK_ERROR, value, start_line, start_column);
+        }
+        value += ":";
+        advance();  # skip ':'
+
+        if (pos >= len) {
+            addError("Incomplete template reference: expected value after ':'", "DPQL-E033",
+                start_line, start_column, line, column);
+            return makeToken(DPQL_TOK_ERROR, value, start_line, start_column);
+        }
+
+        c = currentChar();
+
+        # Bracketed value: $context:{...}
+        if (c == "{") {
+            value += c;
+            advance();
+            int depth = 1;
+            while (pos < len && depth > 0) {
+                c = currentChar();
+                value += c;
+                advance();
+                if (c == "\\") {
+                    # Escaped character — consume next char without interpreting it
+                    if (pos < len) {
+                        value += currentChar();
+                        advance();
+                    }
+                } else if (c == '"' || c == "'") {
+                    # String literal inside brackets — scan until matching unescaped quote
+                    string quote = c;
+                    while (pos < len) {
+                        c = currentChar();
+                        value += c;
+                        advance();
+                        if (c == "\\") {
+                            if (pos < len) {
+                                value += currentChar();
+                                advance();
+                            }
+                        } else if (c == quote) {
+                            break;
+                        }
+                    }
+                } else if (c == "{") {
+                    ++depth;
+                } else if (c == "}") {
+                    --depth;
+                }
+            }
+            if (depth > 0) {
+                addError("Unterminated bracketed template value", "DPQL-E034",
+                    start_line, start_column, line, column);
+                return makeToken(DPQL_TOK_ERROR, value, start_line, start_column);
+            }
+        } else {
+            # Unbracketed value: alphanumeric, dots, underscores, *, and ??{...} fallback
+            while (pos < len) {
+                c = currentChar();
+                if (c =~ /[a-zA-Z0-9_.*]/) {
+                    value += c;
+                    advance();
+                } else if (c == "?" && peekChar() == "?") {
+                    # Fallback syntax: ??{...}
+                    value += "??";
+                    advance(2);
+                    if (pos < len && currentChar() == "{") {
+                        value += "{";
+                        advance();
+                        int depth = 1;
+                        while (pos < len && depth > 0) {
+                            c = currentChar();
+                            value += c;
+                            advance();
+                            if (c == "\\") {
+                                if (pos < len) {
+                                    value += currentChar();
+                                    advance();
+                                }
+                            } else if (c == '"' || c == "'") {
+                                string quote = c;
+                                while (pos < len) {
+                                    c = currentChar();
+                                    value += c;
+                                    advance();
+                                    if (c == "\\") {
+                                        if (pos < len) {
+                                            value += currentChar();
+                                            advance();
+                                        }
+                                    } else if (c == quote) {
+                                        break;
+                                    }
+                                }
+                            } else if (c == "{") {
+                                ++depth;
+                            } else if (c == "}") {
+                                --depth;
+                            }
+                        }
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
+
+        # Check for optional ::type suffix
+        if (pos + 1 < len && currentChar() == ":" && peekChar() == ":") {
+            value += "::";
+            advance(2);
+            # Scan type identifier: alphanumeric, *, <, >
+            while (pos < len) {
+                c = currentChar();
+                if (c =~ /[a-zA-Z0-9_*<>]/) {
+                    value += c;
+                    advance();
+                } else {
+                    break;
+                }
+            }
+        }
+
+        return makeToken(DPQL_TOK_TEMPLATE, value, start_line, start_column);
     }
 
     #! Scans a string literal

--- a/qlib/DataProvider/QoreFilterRecordsProcessor.qc
+++ b/qlib/DataProvider/QoreFilterRecordsProcessor.qc
@@ -61,7 +61,7 @@ public class QoreFilterRecordsProcessor inherits AbstractDataProvider {
     constructor(hash<auto> options) {
         *hash<auto> copts = checkOptions("CONSTRUCTOR-ERROR", ConstructorOptions, options);
         if (copts.where_cond) {
-            where_expr = cast<hash<DataProviderExpression>>(copts.where_cond);
+            where_expr = DataProvider::deserializeExpressionFromJson(copts.where_cond);
         }
     }
 


### PR DESCRIPTION
## Summary

- **New `design/dpql-integration.md`**: comprehensive guide for host applications embedding DPQL — covers callback registration, session lifecycle, field metadata, WebSocket exposure, expression evaluation, static API reference, and error reference
- **Template reference support**: `template_context` threaded through old-style `matchGeneric`/`evalOperator`/`matchGenericValue` paths; tokenizer handles bracketed values with strings/escapes; completion provider lists template contexts and values via callbacks
- **Serializer fix**: replaced fragile `hasKey` duck-typing with `instanceof` checks for `DataProviderFieldReference`, `DataProviderExpression`, and `DataProviderTemplateReference`
- **Cross-references**: added links from `dpql-syntax.md` and `action-session-services.md` to the new integration guide

## Test plan

- [x] DPQL tests pass: 31/31 cases, 912 assertions (includes new ST_Any validation, template eval in between/in, old-style matching with template context, serializer round-trip)
- [x] DpqlActionSession tests pass: 11/11 cases, 32 assertions (includes template token mapping)
- [x] Integration guide method signatures, hashdecls, and examples verified against source code
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)