### PR TITLE
feat: add modern threading primitives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,13 @@ set(LIBQORE_QPP_SRC
     lib/QC_AutoWriteLock.qpp
     lib/QC_Condition.qpp
     lib/QC_Counter.qpp
+    lib/QC_Channel.qpp
+    lib/QC_ChannelIterator.qpp
+    lib/QC_Future.qpp
+    lib/QC_Promise.qpp
+    lib/QC_Semaphore.qpp
+    lib/QC_AutoSemaphore.qpp
+    lib/QC_WaitGroup.qpp
     lib/QC_AbstractIterator.qpp
     lib/QC_AbstractQuantifiedIterator.qpp
     lib/QC_AbstractBidirectionalIterator.qpp
@@ -1186,7 +1193,14 @@ if (SINGLE_COMPILATION_UNIT)
 #include \"${CMAKE_BINARY_DIR}/QC_SandboxManager.cpp\"
 #include \"${CMAKE_BINARY_DIR}/QC_Gate.cpp\"
 #include \"${CMAKE_BINARY_DIR}/QC_Sequence.cpp\"
+#include \"${CMAKE_BINARY_DIR}/QC_Channel.cpp\"
+#include \"${CMAKE_BINARY_DIR}/QC_ChannelIterator.cpp\"
 #include \"${CMAKE_BINARY_DIR}/QC_Counter.cpp\"
+#include \"${CMAKE_BINARY_DIR}/QC_Future.cpp\"
+#include \"${CMAKE_BINARY_DIR}/QC_Promise.cpp\"
+#include \"${CMAKE_BINARY_DIR}/QC_Semaphore.cpp\"
+#include \"${CMAKE_BINARY_DIR}/QC_AutoSemaphore.cpp\"
+#include \"${CMAKE_BINARY_DIR}/QC_WaitGroup.cpp\"
 #include \"${CMAKE_BINARY_DIR}/QC_SSLCertificate.cpp\"
 #include \"${CMAKE_BINARY_DIR}/QC_SSLPrivateKey.cpp\"
 #include \"${CMAKE_BINARY_DIR}/QC_HTTPClient.cpp\"

--- a/design/modern-threading-primitives.md
+++ b/design/modern-threading-primitives.md
@@ -1,0 +1,406 @@
+# Modern Threading Primitives for Qore
+
+## Overview
+
+Qore 2.3.0 introduces a set of higher-level threading primitives that complement the existing low-level synchronization classes (Mutex, RWLock, Gate, Condition, Counter, Queue, ThreadPool). These primitives address common multi-threaded programming patterns that previously required manual wiring of multiple low-level components.
+
+| Primitive | Purpose | Analogy |
+|-----------|---------|---------|
+| **Future / Promise** | Cross-thread result delivery | Java `CompletableFuture`, C++ `std::future/promise` |
+| **WaitGroup** | Fork-join coordination | Go `sync.WaitGroup` |
+| **Semaphore** | N-permit concurrency limiter | Java `Semaphore` |
+| **AutoSemaphore** | RAII permit management | Like AutoLock for Mutex |
+| **Channel** | Closeable inter-thread communication | Go channels |
+| **ChannelIterator** | Iterate a Channel with `foreach` | Go `range` over channel |
+| **call_async()** | Async function execution | Go goroutine with return |
+| **parallel_map()** | Parallel collection mapping | Java `parallelStream().map()` |
+| **parallel_foreach()** | Parallel collection iteration | Java `parallelStream().forEach()` |
+| **channel_select()** | Multiplex on multiple Channels | Go `select` statement |
+
+All primitives live in the `Qore::Thread` namespace (classes) or `Qore` namespace (functions) and require the `THREAD_CLASS` functional domain (plus `THREAD_CONTROL` for functions that spawn threads).
+
+## Architecture
+
+### Common Design Principles
+
+1. **Cooperative cancellation via `waitWithInterrupt()`**: All blocking operations use `QoreCondition::waitWithInterrupt()` which atomically handles 500ms polling, `qore_check_cancel()` calls, and lock management. This is the same proven pattern used by Queue and Counter (see `design/cooperative-cancellation.md`). Returns `QORE_COND_RESULT_INTERRUPTED` when the thread is cancelled or a program interrupt occurs.
+
+2. **Exception safety**: All destructors detect threads blocked on the object and raise appropriate errors before waking them, preventing resource leaks and deadlocks.
+
+3. **Copy semantics**: Primitives that represent unique resources (Future, Promise, Channel, AutoSemaphore) throw on copy. Semaphore and WaitGroup support copy (creating independent instances).
+
+4. **Timeout support**: All blocking operations accept an optional `timeout` parameter (0 = infinite wait).
+
+### Implementation Files
+
+| Header | QPP | Test |
+|--------|-----|------|
+| `include/qore/intern/QoreFuture.h` | `lib/QC_Future.qpp`, `lib/QC_Promise.qpp` | `examples/test/qore/threads/future.qtest` |
+| `include/qore/intern/QoreWaitGroup.h` | `lib/QC_WaitGroup.qpp` | `examples/test/qore/threads/future.qtest` |
+| `include/qore/intern/QoreSemaphore.h` | `lib/QC_Semaphore.qpp`, `lib/QC_AutoSemaphore.qpp` | `examples/test/qore/threads/semaphore.qtest` |
+| `include/qore/intern/QoreChannel.h` | `lib/QC_Channel.qpp`, `lib/QC_ChannelIterator.qpp` | `examples/test/qore/threads/channel.qtest` |
+| — | `lib/ql_thread.qpp` (functions) | `examples/test/qore/threads/parallel.qtest` |
+
+All classes are registered in `get_thread_ns()` in `lib/thread.cpp`.
+
+## Future and Promise
+
+### Problem
+
+The `background` operator discards return values (`rv.discard(&xsink)` at `lib/thread.cpp:2936`). Users must manually wire Queue + exception forwarding to get results from background threads.
+
+### Design
+
+Promise is the producer side, Future is the consumer side. One Promise creates exactly one Future via `getFuture()`. Multiple threads can call `Future::get()`.
+
+```
+┌──────────┐     getFuture()      ┌──────────┐
+│  Promise  │ ──────────────────> │  Future   │
+│  (writer) │                     │  (reader) │
+└──────────┘                      └──────────┘
+     │                                  │
+     │ set(value)                       │ get() → value
+     │ setError(err,desc)               │ get() → throws
+     │ ~Promise() [if pending]          │
+     └─────────────────────────────────>│
+         signal via QoreCondition
+```
+
+### Internal State
+
+```cpp
+struct qore_future_private {
+    QoreThreadLock lock;
+    QoreCondition cond;
+    QoreValue result;
+    QoreException* exception;
+    enum State { PENDING, RESOLVED, REJECTED, DELETED } state;
+    int waiting;     // threads blocked in get()
+};
+```
+
+### Key Invariants
+
+- A Promise can only be set once (PENDING → RESOLVED or REJECTED)
+- If a Promise is destroyed while still PENDING, the Future is rejected with `PROMISE-ERROR`
+- If a Future is destroyed while threads are blocked in `get()`, they receive `FUTURE-ERROR`
+- `getFuture()` can only be called once per Promise
+
+### call_async()
+
+Convenience function that creates a Promise, spawns a background thread wrapping the callable in try/catch, and returns the Future:
+
+```qore
+Future f = call_async(\long_running_task(), arg1, arg2);
+# ... do other work ...
+auto result = f.get();
+```
+
+## WaitGroup
+
+### Problem
+
+Counter works for fork-join but has inverted semantics (count down to zero) and no protection against misuse (dec below zero is a runtime error).
+
+### Design
+
+Forward-counting: `add(n)` increments, `done()` decrements, `wait()` blocks until zero.
+
+```cpp
+struct qore_waitgroup_private {
+    QoreThreadLock lock;
+    QoreCondition cond;
+    int count;
+    int waiting;
+};
+```
+
+### Key Invariants
+
+- `add()` with n < 1 throws `WAITGROUP-ERROR`
+- `done()` when count is already 0 throws `WAITGROUP-ERROR`
+- Copy creates an independent WaitGroup starting at count 0
+
+## Semaphore and AutoSemaphore
+
+### Problem
+
+No N-permit concurrency limiter. Gate is reentrant/binary. Counter blocks on zero but doesn't provide acquire/release semantics.
+
+### Design
+
+Classic counting semaphore: `acquire()` decrements (blocking if 0), `release(n)` increments, `tryAcquire()` for non-blocking.
+
+AutoSemaphore provides RAII: constructor acquires, destructor releases. Supports explicit `release()` and `acquire()` for advanced use cases with protection against double-release/double-acquire.
+
+```cpp
+struct qore_semaphore_private {
+    QoreThreadLock lock;
+    QoreCondition cond;
+    int permits;
+    int waiting;
+    bool deleted;
+};
+```
+
+## Channel and ChannelIterator
+
+### Problem
+
+Queue lacks close semantics. Consumers can't distinguish "temporarily empty" from "permanently done". No iteration protocol.
+
+### Design
+
+Go-style channel with buffered and unbuffered modes:
+
+- **Buffered** (capacity > 0): FIFO buffer; `send()` blocks when full, `recv()` blocks when empty
+- **Unbuffered** (capacity = 0): Synchronous handoff; `send()` blocks until `recv()` is ready and vice versa
+
+```
+Producer                    Channel                     Consumer
+────────                    ───────                     ────────
+send(value) ──────>  ┌─────────────────┐  ──────> recv() → value
+                     │ [v1] [v2] [v3]  │
+send(value) ──────>  │ (blocks if full)│  ──────> recv() (blocks if empty)
+                     └─────────────────┘
+close() ──────────>  closed=true         ──────> recv() → NOTHING (after drain)
+```
+
+### Internal State
+
+```cpp
+struct qore_channel_private {
+    QoreThreadLock lock;
+    QoreCondition send_cond, recv_cond;
+    std::deque<QoreValue> buffer;
+    int capacity;
+    int send_waiting, recv_waiting;
+    bool closed, deleted;
+    // External waiter support for channel_select
+    std::vector<QoreCondition*> external_waiters;
+};
+```
+
+### NOTHING Value Handling
+
+A key design requirement: NOTHING must be a valid value sent through a Channel. The `recv()` method uses a `has_value` output parameter (C++ level) to distinguish between:
+- Receiving a NOTHING value (has_value=true, returned value is NOTHING)
+- Channel closed and drained (has_value=false, returned value is NOTHING)
+
+At the Qore API level, `recv()` returns NOTHING for both cases (closed+drained and NOTHING value). The `tryRecv()` method returns a hash with `has_value` and `value` keys to allow disambiguation. The ChannelIterator uses the C++ `has_value` parameter internally.
+
+### External Waiter Mechanism
+
+`channel_select()` requires waiting on multiple Channels simultaneously. This is implemented via an external waiter registration API on the Channel's private implementation:
+
+```cpp
+void registerExternalWaiter(QoreCondition* cond);
+void deregisterExternalWaiter(QoreCondition* cond);
+```
+
+When any `send()` or `recv()` completes, all registered external waiters are signaled in addition to the Channel's own condition variables. This allows `channel_select()` to share a single condition variable across all case Channels.
+
+## parallel_map and parallel_foreach
+
+### Problem
+
+No built-in way to process collections in parallel.
+
+### Design
+
+Both functions use a work-stealing pattern with `std::atomic<int> next_index`:
+
+```
+Main Thread                     Worker Threads (N)
+───────────                     ──────────────────
+Create ParallelExecState        │
+Start N workers via q_start_thread()
+                                ├── Worker 0: while (next_index < total)
+                                │     results[idx] = func(items[idx])
+                                ├── Worker 1: while (next_index < total)
+                                │     results[idx] = func(items[idx])
+                                └── ...
+Wait on Counter
+Check for errors
+Return ordered results
+```
+
+### Exception Handling
+
+Cross-thread exception propagation requires careful handling of Qore's `active_exceptions` counter:
+
+- Worker threads use `ExceptionSink::getExceptionInfo()` (not `assimilate()`) to capture exception information. This properly decrements the worker thread's `active_exceptions` counter via internal `catchException()`.
+- The exception info is stored as a `QoreHashNode*` (with err/desc/arg keys).
+- The main thread re-raises the exception via `raiseExceptionArg()`.
+- Only the first exception is captured; subsequent worker exceptions are cleared.
+
+**Important**: `ExceptionSink::assimilate()` must NOT be used for cross-thread exception transfer because it moves exception nodes without decrementing the source thread's `active_exceptions` counter, causing an assertion failure at thread exit (`q_run_thread(): Assertion 'xsink.isException() || !td->active_exceptions' failed`).
+
+## channel_select
+
+### Design
+
+Multiplexes across multiple Channel send/recv operations:
+
+1. **Non-blocking try**: Try all cases with `trySend()`/`tryRecv()` in random order
+2. **If none ready**: Register a shared `QoreCondition` with each Channel
+3. **Wait loop**: Wait on the shared condition via `waitWithInterrupt()`, re-try all cases on wake
+4. **Cleanup**: Deregister from all Channels
+
+### Fairness
+
+Ready cases are shuffled using `std::shuffle` with a thread-local RNG before each attempt, ensuring no channel is systematically preferred.
+
+### All-Closed Detection
+
+If all channels are in a terminal state (closed for send, closed+empty for recv), `channel_select()` returns NOTHING immediately instead of blocking forever. This is tracked via an `all_dead` flag updated on each `try_cases` iteration.
+
+## Integration Points
+
+### Cooperative Cancellation
+
+All blocking operations (Future::get, WaitGroup::wait, Semaphore::acquire, Channel::send/recv, channel_select) use `QoreCondition::waitWithInterrupt()` for cancellation-aware blocking. This method:
+
+1. Checks `qore_check_cancel()` before entering the wait
+2. Waits on the condition variable with 500ms polling intervals
+3. Re-checks `qore_check_cancel()` after each poll
+4. Returns `QORE_COND_RESULT_INTERRUPTED` (2) if the thread is cancelled or a program interrupt occurs
+5. Returns `QORE_COND_RESULT_TIMEOUT` (1) if the user-specified timeout expires
+6. Returns `QORE_COND_RESULT_SUCCESS` (0) if the condition was signaled
+
+All wait loops follow this canonical pattern (matching Queue and Counter):
+
+```cpp
+int64 cond_timeout = (timeout_ms <= 0) ? -1 : timeout_ms;  // map 0→infinite
+
+AutoLocker al(&lock);
+while (!condition_met && !deleted) {
+    int rc = cond.waitWithInterrupt(&lock, cond_timeout, xsink);
+    if (rc == QORE_COND_RESULT_INTERRUPTED) {
+        // thread cancelled or program interrupt — clean up and return
+        return -1;
+    }
+    if (condition_met || deleted) {
+        break;
+    }
+    if (rc == QORE_COND_RESULT_TIMEOUT) {
+        // user timeout expired — clean up and return
+        return -1;
+    }
+}
+```
+
+**Important**: The timeout convention differs between the Qore API (0 = infinite) and `waitWithInterrupt()` (-1 = infinite). All primitives map the timeout: `int64 cond_timeout = (timeout_ms <= 0) ? -1 : timeout_ms;`
+
+**Historical note**: An earlier implementation used manual `lock.unlock()` → `qore_check_cancel()` → `lock.lock()` → plain `cond.wait()` loops. This was replaced with `waitWithInterrupt()` to avoid race windows between unlock/relock and to use the same proven pattern as Queue and Counter that was hardened through the SmartMutex/RWLock signal-loss bug fixes (see `design/cooperative-cancellation.md`).
+
+### Functional Domains
+
+- Classes: `THREAD_CLASS` — required to create/use any threading class
+- Functions that spawn threads (`call_async`, `parallel_map`, `parallel_foreach`): `THREAD_CLASS | THREAD_CONTROL`
+- `channel_select`: `THREAD_CLASS | THREAD_CONTROL`
+
+### Deterministic GC
+
+Channel objects are scanned by the deterministic garbage collector (via `memberGate()`) since they hold `QoreValue` references in their internal buffer, similar to Queue.
+
+## Migration Guide
+
+### From Counter to WaitGroup
+
+```qore
+# Before (Counter)
+Counter done(num_tasks);
+for (int i = 0; i < num_tasks; ++i) {
+    background sub() {
+        # ... do work ...
+        done.dec();
+    }();
+}
+done.waitForZero();
+
+# After (WaitGroup)
+WaitGroup wg();
+for (int i = 0; i < num_tasks; ++i) {
+    wg.add();
+    background sub() {
+        on_exit wg.done();
+        # ... do work ...
+    }();
+}
+wg.wait();
+```
+
+### From Queue to Channel
+
+```qore
+# Before (Queue - no close semantics)
+Queue q();
+background sub() {
+    for (int i = 0; i < 10; ++i) {
+        q.push(i);
+    }
+    q.push(NOTHING);  # sentinel
+}();
+while (True) {
+    auto val = q.get();
+    if (!exists val) break;  # can't distinguish NOTHING value from sentinel
+    process(val);
+}
+
+# After (Channel - proper close semantics)
+Channel ch(10);
+background sub() {
+    for (int i = 0; i < 10; ++i) {
+        ch.send(i);
+    }
+    ch.close();
+}();
+foreach auto val in (ch.iterator()) {
+    process(val);  # NOTHING values work correctly
+}
+```
+
+### From background + Queue to call_async
+
+```qore
+# Before
+Queue q();
+background sub() {
+    try {
+        auto result = expensive_computation();
+        q.push({"value": result});
+    } catch (hash<auto> ex) {
+        q.push({"error": ex});
+    }
+}();
+# ... do other work ...
+auto msg = q.get();
+if (msg.error) throw msg.error.err, msg.error.desc;
+auto result = msg.value;
+
+# After
+Future f = call_async(\expensive_computation());
+# ... do other work ...
+auto result = f.get();  # exception propagation is automatic
+```
+
+### Parallel Collection Processing
+
+```qore
+# Before (manual thread pool)
+Queue results();
+Counter done(items.size());
+for (int i = 0; i < items.size(); ++i) {
+    background sub(int idx) {
+        results.push({"index": idx, "value": process(items[idx])});
+        done.dec();
+    }(i);
+}
+done.waitForZero();
+# ... manually sort results by index ...
+
+# After
+list<auto> results = parallel_map(\process(), items);
+# results are already in order
+```

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -431,6 +431,11 @@ cargo install tree-sitter-cli@0.26.5
         @ref Qore::Thread::AutoReadLock "AutoReadLock" / @ref Qore::Thread::AutoWriteLock "AutoWriteLock"
         constructors,
         @ref Qore::Thread::Queue "Queue" get/pop,
+        @ref Qore::Thread::Future "Future" get,
+        @ref Qore::Thread::WaitGroup "WaitGroup" wait,
+        @ref Qore::Thread::Semaphore "Semaphore" acquire,
+        @ref Qore::Thread::Channel "Channel" send/recv,
+        @ref Qore::channel_select() "channel_select()",
         pipe I/O, file locking, and backquote operations
       - integrates with the @ref Qore::SandboxManager "SandboxManager" interrupt mechanism via a unified
         internal check (\c qore_check_cancel()) that polls for both thread-level cancellation and
@@ -443,6 +448,50 @@ cargo install tree-sitter-cli@0.26.5
       - cancelling an already-cancelled thread updates the reason string
       - cancelling a thread that has already exited returns @ref False
       - attempting to cancel the current thread raises \c THREAD-CANCEL-ERROR
+    - <b>Modern threading primitives</b>
+      - new @ref Qore::Thread::Future "Future" / @ref Qore::Thread::Promise "Promise" classes for cross-thread
+        result delivery: @ref Qore::Thread::Promise "Promise" is the producer side (set a value or error),
+        @ref Qore::Thread::Future "Future" is the consumer side (block until result is available); multiple
+        threads can call @ref Qore::Thread::Future::get() "Future::get()"; the Future is created via
+        @ref Qore::Thread::Promise::getFuture() "Promise::getFuture()" (one Future per Promise)
+      - new @ref Qore::call_async() "call_async()" convenience function that spawns a background thread,
+        wraps the callable's result (or exception) into a @ref Qore::Thread::Promise "Promise", and returns
+        the associated @ref Qore::Thread::Future "Future" — provides a simple way to get return values from
+        background threads
+      - new @ref Qore::Thread::WaitGroup "WaitGroup" class for fork-join coordination: call
+        @ref Qore::Thread::WaitGroup::add() "add()" to register work, @ref Qore::Thread::WaitGroup::done() "done()"
+        to signal completion, and @ref Qore::Thread::WaitGroup::wait() "wait()" to block until all work
+        finishes; similar to @ref Qore::Thread::Counter "Counter" but with forward-counting semantics and
+        misuse protection
+      - new @ref Qore::Thread::Semaphore "Semaphore" class providing an N-permit concurrency limiter:
+        @ref Qore::Thread::Semaphore::acquire() "acquire()" blocks until a permit is available,
+        @ref Qore::Thread::Semaphore::release() "release()" returns permits; supports timed acquire and
+        non-blocking @ref Qore::Thread::Semaphore::tryAcquire() "tryAcquire()"
+      - new @ref Qore::Thread::AutoSemaphore "AutoSemaphore" RAII class for exception-safe permit management:
+        acquires a permit in the constructor and releases it in the destructor (like
+        @ref Qore::Thread::AutoLock "AutoLock" for @ref Qore::Thread::Mutex "Mutex")
+      - new @ref Qore::Thread::Channel "Channel" class for Go-style inter-thread communication with close
+        semantics: supports buffered (fixed capacity) and unbuffered (synchronous handoff) modes;
+        @ref Qore::Thread::Channel::send() "send()" blocks when full,
+        @ref Qore::Thread::Channel::recv() "recv()" blocks when empty;
+        @ref Qore::Thread::Channel::close() "close()" signals completion while allowing buffered values to be
+        drained; supports @ref Qore::Thread::Channel::trySend() "trySend()" /
+        @ref Qore::Thread::Channel::tryRecv() "tryRecv()" for non-blocking operations and timeout-based
+        operations; @ref Qore::Thread::Channel::send() "send()" and @ref Qore::Thread::Channel::recv() "recv()"
+        can send and receive @ref nothing "NOTHING" as a distinct value
+      - new @ref Qore::Thread::ChannelIterator "ChannelIterator" class enabling @ref foreach "foreach" iteration
+        over a @ref Qore::Thread::Channel "Channel" until it is closed and drained
+      - new @ref Qore::parallel_map() "parallel_map()" function: maps a function over a list using multiple
+        threads; preserves input order in output; propagates exceptions from worker threads; auto-detects
+        thread count from hardware concurrency; supports sequential mode with \c threads=1
+      - new @ref Qore::parallel_foreach() "parallel_foreach()" function: executes a function for each element
+        in a list using multiple threads; same semantics as @ref Qore::parallel_map() "parallel_map()" but
+        without collecting results
+      - new @ref Qore::channel_select() "channel_select()" function: waits on multiple
+        @ref Qore::Thread::Channel "Channel" objects simultaneously for the first ready send or recv operation;
+        supports random selection among ready channels for fairness; returns immediately when all channels are
+        closed; supports timeout
+      - all new threading primitives integrate with cooperative cancellation (checked at 500ms polling intervals)
     - new @ref Qore::ParseOptions "ParseOptions" class providing an opaque container for parse option flags
       supporting more than 64 option bits
       (<a href="https://github.com/qoretechnologies/qore/issues/5145">issue 5145</a>)
@@ -491,7 +540,11 @@ cargo install tree-sitter-cli@0.26.5
         connection string from a @ref datasource_hash "datasource hash" (the inverse of
         @ref Qore::SQL::parse_datasource() "parse_datasource()")
     - new functions:
+      - @ref Qore::call_async() "call_async()": spawns a background thread to execute a callable and returns a
+        @ref Qore::Thread::Future "Future" for the result
       - @ref Qore::cancel_thread() "cancel_thread()": requests cooperative cancellation of another thread
+      - @ref Qore::channel_select() "channel_select()": waits on multiple @ref Qore::Thread::Channel "Channel"
+        objects for the first ready operation (send or recv)
       - @ref Qore::clear_thread_cancel() "clear_thread_cancel()": clears the cancellation flag for the current thread
       - @ref Qore::clock_getseconds() "clock_getseconds()"
       - @ref Qore::deflate_raw() "deflate_raw()": raw DEFLATE compression (RFC 1951) without zlib/gzip headers
@@ -505,6 +558,8 @@ cargo install tree-sitter-cli@0.26.5
       - @ref Qore::SQL::make_datasource_string() "make_datasource_string()": builds a datasource connection string
         from a @ref datasource_hash "datasource hash" (the inverse of
         @ref Qore::SQL::parse_datasource() "parse_datasource()")
+      - @ref Qore::parallel_foreach() "parallel_foreach()": executes a function over list elements in parallel
+      - @ref Qore::parallel_map() "parallel_map()": maps a function over list elements in parallel, preserving order
       - @ref Qore::thread_cancelled() "thread_cancelled()": returns @ref True if cancellation has been requested
         for the current thread
     - new @ref string_formatting "printf format specifier":

--- a/examples/test/qore/threads/channel.qtest
+++ b/examples/test/qore/threads/channel.qtest
@@ -1,0 +1,313 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%modern
+%no-child-restrictions
+
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class ChannelTest
+
+class ChannelTest inherits QUnit::Test {
+    constructor() : QUnit::Test("Channel", "1.0", \ARGV) {
+        addTestCase("Buffered send/recv roundtrip", \testBufferedRoundtrip());
+        addTestCase("Unbuffered synchronous handoff", \testUnbufferedHandoff());
+        addTestCase("Close + drain remaining values", \testCloseDrain());
+        addTestCase("Send after close throws", \testSendAfterClose());
+        addTestCase("Recv after close + drain returns NOTHING", \testRecvAfterCloseDrain());
+        addTestCase("Backpressure (send blocks when full)", \testBackpressure());
+        addTestCase("foreach iteration until close", \testForeachIteration());
+        addTestCase("Multiple producers / multiple consumers", \testMultiProducerConsumer());
+        addTestCase("Timeout on recv", \testRecvTimeout());
+        addTestCase("Timeout on send", \testSendTimeout());
+        addTestCase("trySend/tryRecv", \testTrySendTryRecv());
+        addTestCase("Channel cannot be copied", \testCopy());
+        addTestCase("size/capacity/empty", \testSizeCapacityEmpty());
+        addTestCase("Negative capacity throws", \testNegativeCapacity());
+        addTestCase("ChannelIterator cannot be copied", \testIteratorCopy());
+        addTestCase("NOTHING value through channel", \testNothingValue());
+        addTestCase("NOTHING value through iterator", \testNothingValueIterator());
+        addTestCase("Channel isClosed", \testIsClosed());
+        addTestCase("Unlimited channel", \testUnlimitedChannel());
+        set_return_value(main());
+    }
+
+    testBufferedRoundtrip() {
+        Channel ch(10);
+        ch.send(1);
+        ch.send(2);
+        ch.send(3);
+        assertEq(1, ch.recv());
+        assertEq(2, ch.recv());
+        assertEq(3, ch.recv());
+    }
+
+    testUnbufferedHandoff() {
+        Channel ch(0);
+        Counter done(1);
+        auto received;
+        background sub() {
+            received = ch.recv();
+            done.dec();
+        }();
+        ch.send(42);
+        done.waitForZero();
+        assertEq(42, received);
+    }
+
+    testCloseDrain() {
+        Channel ch(10);
+        ch.send(1);
+        ch.send(2);
+        ch.send(3);
+        ch.close();
+        # Can still recv buffered values after close
+        assertEq(1, ch.recv());
+        assertEq(2, ch.recv());
+        assertEq(3, ch.recv());
+        # After drain, recv returns NOTHING
+        assertNothing(ch.recv());
+    }
+
+    testSendAfterClose() {
+        Channel ch(10);
+        ch.close();
+        assertThrows("CHANNEL-CLOSED", sub() { ch.send(1); });
+    }
+
+    testRecvAfterCloseDrain() {
+        Channel ch(10);
+        ch.close();
+        assertNothing(ch.recv());
+    }
+
+    testBackpressure() {
+        Channel ch(2);
+        ch.send(1);
+        ch.send(2);
+        # Channel is full - trySend should fail
+        assertFalse(ch.trySend(3));
+        # Drain one to make room
+        assertEq(1, ch.recv());
+        assertTrue(ch.trySend(3));
+        assertEq(2, ch.recv());
+        assertEq(3, ch.recv());
+    }
+
+    testForeachIteration() {
+        Channel ch(10);
+        background sub() {
+            for (int i = 0; i < 5; ++i) {
+                ch.send(i);
+            }
+            ch.close();
+        }();
+        list<auto> results = ();
+        foreach auto val in (ch.iterator()) {
+            push results, val;
+        }
+        assertEq(5, results.size());
+        for (int i = 0; i < 5; ++i) {
+            assertEq(i, results[i]);
+        }
+    }
+
+    testMultiProducerConsumer() {
+        Channel ch(20);
+        int num_producers = 3;
+        int items_per_producer = 10;
+        Counter producer_done(num_producers);
+
+        # Start producers
+        for (int p = 0; p < num_producers; ++p) {
+            background sub(int id) {
+                for (int i = 0; i < items_per_producer; ++i) {
+                    ch.send(id * 100 + i);
+                }
+                producer_done.dec();
+            }(p);
+        }
+
+        # Close channel when all producers done
+        background sub() {
+            producer_done.waitForZero();
+            ch.close();
+        }();
+
+        # Consume all values
+        list<auto> received = ();
+        foreach auto val in (ch.iterator()) {
+            push received, val;
+        }
+
+        assertEq(num_producers * items_per_producer, received.size());
+    }
+
+    testRecvTimeout() {
+        Channel ch(10);
+        assertThrows("CHANNEL-TIMEOUT", sub() { ch.recv(100ms); });
+    }
+
+    testSendTimeout() {
+        Channel ch(1);
+        ch.send(1);
+        # Channel full, should timeout
+        assertThrows("CHANNEL-TIMEOUT", sub() { ch.send(2, 100ms); });
+        ch.recv();
+    }
+
+    testTrySendTryRecv() {
+        Channel ch(1);
+        # tryRecv on empty returns NOTHING
+        assertNothing(ch.tryRecv());
+        # trySend succeeds
+        assertTrue(ch.trySend(42));
+        # trySend fails when full
+        assertFalse(ch.trySend(43));
+        # tryRecv returns hash with value and has_value keys
+        auto result = ch.tryRecv();
+        assertEq(True, result.has_value);
+        assertEq(42, result.value);
+        # tryRecv on empty again
+        assertNothing(ch.tryRecv());
+        # Test tryRecv with NOTHING value — can distinguish from empty channel
+        assertTrue(ch.trySend(NOTHING));
+        auto result2 = ch.tryRecv();
+        assertEq(True, result2.has_value);
+        assertNothing(result2.value);
+    }
+
+    testCopy() {
+        Channel ch(10);
+        assertThrows("CHANNEL-COPY-ERROR", sub() { Channel ch2 = ch.copy(); });
+    }
+
+    testSizeCapacityEmpty() {
+        Channel ch(5);
+        assertEq(5, ch.capacity());
+        assertEq(0, ch.size());
+        assertTrue(ch.empty());
+        ch.send(1);
+        assertEq(1, ch.size());
+        assertFalse(ch.empty());
+        ch.recv();
+        assertEq(0, ch.size());
+        assertTrue(ch.empty());
+    }
+
+    testNegativeCapacity() {
+        # -1 is valid (unlimited), -2 and below are invalid
+        assertThrows("CHANNEL-ERROR", sub() { Channel ch(-2); });
+
+        # Verify -1 creates an unlimited channel
+        Channel ch(-1);
+        assertEq(-1, ch.capacity());
+    }
+
+    testIteratorCopy() {
+        Channel ch(10);
+        ChannelIterator it(ch);
+        assertThrows("CHANNELITERATOR-COPY-ERROR", sub() { ChannelIterator it2 = it.copy(); });
+    }
+
+    testNothingValue() {
+        # Test that NOTHING can be sent and received as a distinct value
+        Channel ch(10);
+        ch.send(NOTHING);
+        ch.send(42);
+        ch.close();
+
+        # recv() should return NOTHING (the value), not signaling end-of-stream
+        auto val1 = ch.recv();
+        assertNothing(val1);
+
+        # Next recv should return 42
+        auto val2 = ch.recv();
+        assertEq(42, val2);
+
+        # After drain, recv returns NOTHING (end-of-stream)
+        auto val3 = ch.recv();
+        assertNothing(val3);
+    }
+
+    testNothingValueIterator() {
+        # Test that ChannelIterator handles NOTHING values correctly
+        Channel ch(10);
+        ch.send(1);
+        ch.send(NOTHING);
+        ch.send(3);
+        ch.close();
+
+        list<auto> results = ();
+        foreach auto val in (ch.iterator()) {
+            push results, val;
+        }
+        assertEq(3, results.size());
+        assertEq(1, results[0]);
+        assertNothing(results[1]);
+        assertEq(3, results[2]);
+    }
+
+    testIsClosed() {
+        Channel ch(10);
+        assertFalse(ch.isClosed());
+        ch.close();
+        assertTrue(ch.isClosed());
+    }
+
+    testUnlimitedChannel() {
+        # Unlimited channel: send never blocks
+        Channel ch(-1);
+        assertEq(-1, ch.capacity());
+        assertTrue(ch.empty());
+
+        # Send many values without blocking
+        int count = 1000;
+        for (int i = 0; i < count; ++i) {
+            ch.send(i);
+        }
+        assertEq(count, ch.size());
+        assertFalse(ch.empty());
+
+        # Receive all values in order
+        for (int i = 0; i < count; ++i) {
+            assertEq(i, ch.recv());
+        }
+        assertTrue(ch.empty());
+
+        # trySend always succeeds on unlimited channel
+        assertTrue(ch.trySend(42));
+        assertTrue(ch.trySend(43));
+        assertEq(2, ch.size());
+
+        # tryRecv works
+        auto result = ch.tryRecv();
+        assertTrue(exists result);
+        assertEq(42, result.value);
+        result = ch.tryRecv();
+        assertTrue(exists result);
+        assertEq(43, result.value);
+
+        # Close + drain works
+        ch.send("a");
+        ch.send("b");
+        ch.close();
+        assertThrows("CHANNEL-CLOSED", sub() { ch.send("c"); });
+        assertEq("a", ch.recv());
+        assertEq("b", ch.recv());
+        # After drain, recv returns NOTHING (no exception)
+        assertNothing(ch.recv());
+
+        # Iterator works on unlimited channel
+        Channel ch2(-1);
+        ch2.send(10);
+        ch2.send(20);
+        ch2.send(30);
+        ch2.close();
+        list<auto> results = ();
+        foreach auto val in (ch2.iterator()) {
+            push results, val;
+        }
+        assertEq((10, 20, 30), results);
+    }
+}

--- a/examples/test/qore/threads/future.qtest
+++ b/examples/test/qore/threads/future.qtest
@@ -1,0 +1,306 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%modern
+%no-child-restrictions
+
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class FutureTest
+
+class FutureTest inherits QUnit::Test {
+    constructor() : QUnit::Test("Future/Promise/WaitGroup", "1.0", \ARGV) {
+        addTestCase("Promise set/Future get roundtrip", \testBasicSetGet());
+        addTestCase("Promise setError/Future get throws", \testErrorPropagation());
+        addTestCase("Future get timeout", \testTimeout());
+        addTestCase("Multiple getters on same Future", \testMultipleGetters());
+        addTestCase("Promise destroyed without set", \testPromiseDestroyedPending());
+        addTestCase("Promise double set throws", \testDoubleSet());
+        addTestCase("Promise double getFuture throws", \testDoubleGetFuture());
+        addTestCase("Future cannot be constructed directly", \testFutureDirectConstruct());
+        addTestCase("Future cannot be copied", \testFutureCopy());
+        addTestCase("Promise cannot be copied", \testPromiseCopy());
+        addTestCase("Future isDone/isError", \testIsDoneIsError());
+        addTestCase("call_async with return value", \testCallAsyncReturn());
+        addTestCase("call_async with exception", \testCallAsyncException());
+        addTestCase("call_async with arguments", \testCallAsyncArgs());
+        addTestCase("WaitGroup basic add/done/wait", \testWaitGroupBasic());
+        addTestCase("WaitGroup timeout", \testWaitGroupTimeout());
+        addTestCase("WaitGroup done before add throws", \testWaitGroupDoneBeforeAdd());
+        addTestCase("WaitGroup multiple tasks", \testWaitGroupMultipleTasks());
+        addTestCase("Promise set NOTHING", \testSetNothing());
+        addTestCase("setError arg propagation", \testSetErrorArg());
+        addTestCase("call_async with NOTHING return", \testCallAsyncNothing());
+        addTestCase("WaitGroup reuse", \testWaitGroupReuse());
+        addTestCase("WaitGroup add with invalid value throws", \testWaitGroupAddInvalid());
+        addTestCase("WaitGroup copy is independent", \testWaitGroupCopy());
+        set_return_value(main());
+    }
+
+    testBasicSetGet() {
+        Promise p();
+        Future f = p.getFuture();
+        assertFalse(f.isDone());
+        Counter c(1);
+        auto result;
+        background sub() {
+            on_exit c.dec();
+            result = f.get();
+        }();
+        p.set(42);
+        c.waitForZero();
+        assertEq(42, result);
+        assertTrue(f.isDone());
+        assertFalse(f.isError());
+    }
+
+    testErrorPropagation() {
+        Promise p();
+        Future f = p.getFuture();
+        p.setError("MY-ERROR", "test error description");
+        assertTrue(f.isDone());
+        assertTrue(f.isError());
+        assertThrows("MY-ERROR", "test error description", sub() { f.get(); });
+    }
+
+    testTimeout() {
+        Promise p();
+        Future f = p.getFuture();
+        # Use a short timeout
+        assertThrows("FUTURE-TIMEOUT", sub() { f.get(100ms); });
+    }
+
+    testMultipleGetters() {
+        Promise p();
+        Future f = p.getFuture();
+        Counter c(3);
+        list<auto> results = ();
+        Mutex m();
+        for (int i = 0; i < 3; ++i) {
+            background sub() {
+                on_exit c.dec();
+                auto val = f.get();
+                {
+                    AutoLock al(m);
+                    push results, val;
+                }
+            }();
+        }
+        p.set("hello");
+        c.waitForZero();
+        assertEq(3, results.size());
+        for (int i = 0; i < 3; ++i) {
+            assertEq("hello", results[i]);
+        }
+    }
+
+    testPromiseDestroyedPending() {
+        Future f;
+        {
+            Promise p();
+            f = p.getFuture();
+            # Promise goes out of scope here without calling set()
+        }
+        assertTrue(f.isDone());
+        assertTrue(f.isError());
+        assertThrows("PROMISE-ERROR", sub() { f.get(); });
+    }
+
+    testDoubleSet() {
+        Promise p();
+        p.set(1);
+        assertThrows("PROMISE-ERROR", sub() { p.set(2); });
+    }
+
+    testDoubleGetFuture() {
+        Promise p();
+        Future f = p.getFuture();
+        assertThrows("PROMISE-ERROR", sub() { p.getFuture(); });
+    }
+
+    testFutureDirectConstruct() {
+        assertThrows("FUTURE-ERROR", sub() { Future f(); });
+    }
+
+    testFutureCopy() {
+        Promise p();
+        Future f = p.getFuture();
+        assertThrows("FUTURE-COPY-ERROR", sub() { Future f2 = f.copy(); });
+    }
+
+    testPromiseCopy() {
+        Promise p();
+        assertThrows("PROMISE-COPY-ERROR", sub() { Promise p2 = p.copy(); });
+    }
+
+    testIsDoneIsError() {
+        # Test resolved
+        {
+            Promise p();
+            Future f = p.getFuture();
+            assertFalse(f.isDone());
+            assertFalse(f.isError());
+            p.set(42);
+            assertTrue(f.isDone());
+            assertFalse(f.isError());
+        }
+
+        # Test rejected
+        {
+            Promise p();
+            Future f = p.getFuture();
+            assertFalse(f.isDone());
+            assertFalse(f.isError());
+            p.setError("ERR", "desc");
+            assertTrue(f.isDone());
+            assertTrue(f.isError());
+        }
+    }
+
+    testCallAsyncReturn() {
+        Future f = call_async(int sub() { return 42; });
+        auto result = f.get();
+        assertEq(42, result);
+    }
+
+    testCallAsyncException() {
+        Future f = call_async(sub() { throw "ASYNC-ERROR", "async test error"; });
+        assertThrows("ASYNC-ERROR", sub() { f.get(); });
+    }
+
+    testCallAsyncArgs() {
+        Future f = call_async(int sub(int x, int y) { return x + y; }, 20, 22);
+        assertEq(42, f.get());
+    }
+
+    testWaitGroupBasic() {
+        WaitGroup wg();
+        assertEq(0, wg.getCount());
+        wg.add(1);
+        assertEq(1, wg.getCount());
+        Counter c(1);
+        background sub() {
+            on_exit c.dec();
+            wg.done();
+        }();
+        assertEq(0, wg.wait());
+        c.waitForZero();
+        assertEq(0, wg.getCount());
+    }
+
+    testWaitGroupTimeout() {
+        WaitGroup wg();
+        wg.add(1);
+        # Wait with short timeout - should timeout since nothing calls done()
+        int rc = wg.wait(100ms);
+        assertEq(-1, rc);
+        # Clean up - call done so destructor doesn't error
+        wg.done();
+    }
+
+    testWaitGroupDoneBeforeAdd() {
+        WaitGroup wg();
+        assertThrows("WAITGROUP-ERROR", sub() { wg.done(); });
+    }
+
+    testWaitGroupMultipleTasks() {
+        WaitGroup wg();
+        int num_tasks = 5;
+        wg.add(num_tasks);
+        Mutex m();
+        int completed = 0;
+        for (int i = 0; i < num_tasks; ++i) {
+            background sub() {
+                {
+                    AutoLock al(m);
+                    ++completed;
+                }
+                wg.done();
+            }();
+        }
+        assertEq(0, wg.wait());
+        assertEq(num_tasks, completed);
+    }
+
+    testSetNothing() {
+        Promise p();
+        Future f = p.getFuture();
+        p.set(NOTHING);
+        auto result = f.get();
+        assertNothing(result);
+    }
+
+    testSetErrorArg() {
+        # Test that setError arg is propagated through Future::get()
+        Promise p();
+        Future f = p.getFuture();
+        hash<auto> error_detail = {"code": 404, "message": "not found"};
+        p.setError("MY-ERROR", "something went wrong", error_detail);
+        try {
+            f.get();
+            assertEq(True, False, "expected exception not thrown");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("MY-ERROR", ex.err);
+            assertEq("something went wrong", ex.desc);
+            assertEq(error_detail, ex.arg);
+        }
+    }
+
+    testCallAsyncNothing() {
+        Future f = call_async(auto sub() { return NOTHING; });
+        auto result = f.get();
+        assertNothing(result);
+        assertTrue(f.isDone());
+        assertFalse(f.isError());
+    }
+
+    testWaitGroupReuse() {
+        # Verify a WaitGroup can be used for multiple rounds
+        WaitGroup wg();
+
+        # Round 1
+        wg.add(2);
+        Counter c1(2);
+        for (int i = 0; i < 2; ++i) {
+            background sub() {
+                on_exit {
+                    wg.done();
+                    c1.dec();
+                }
+            }();
+        }
+        assertEq(0, wg.wait());
+        c1.waitForZero();
+        assertEq(0, wg.getCount());
+
+        # Round 2 — reuse the same WaitGroup
+        wg.add(3);
+        Counter c2(3);
+        for (int i = 0; i < 3; ++i) {
+            background sub() {
+                on_exit {
+                    wg.done();
+                    c2.dec();
+                }
+            }();
+        }
+        assertEq(0, wg.wait());
+        c2.waitForZero();
+        assertEq(0, wg.getCount());
+    }
+
+    testWaitGroupAddInvalid() {
+        WaitGroup wg();
+        assertThrows("WAITGROUP-ERROR", sub() { wg.add(0); });
+        assertThrows("WAITGROUP-ERROR", sub() { wg.add(-1); });
+    }
+
+    testWaitGroupCopy() {
+        WaitGroup wg();
+        wg.add(5);
+        WaitGroup wg2 = wg.copy();
+        # Copy starts fresh at 0, independent of original
+        assertEq(0, wg2.getCount());
+        assertEq(5, wg.getCount());
+    }
+}

--- a/examples/test/qore/threads/parallel.qtest
+++ b/examples/test/qore/threads/parallel.qtest
@@ -30,6 +30,9 @@ class ParallelTest inherits QUnit::Test {
         addTestCase("channel_select all channels closed", \testChannelSelectAllClosed());
         addTestCase("channel_select mixed send+recv", \testChannelSelectMixedSendRecv());
         addTestCase("parallel_foreach with threads=1", \testParallelForEachSequential());
+        addTestCase("channel_select deterministic wakeup", \testChannelSelectDeterministicWakeup());
+        addTestCase("channel_select concurrent selects", \testChannelSelectConcurrent());
+        addTestCase("channel_select unbuffered channel", \testChannelSelectUnbuffered());
         set_return_value(main());
     }
 
@@ -272,5 +275,110 @@ class ParallelTest inherits QUnit::Test {
         }, (10, 20, 30), 1);
         # Sequential mode preserves order
         assertEq((10, 20, 30), collected);
+    }
+
+    testChannelSelectDeterministicWakeup() {
+        # Verify channel_select wakes deterministically (not polling at 100ms intervals)
+        # A background thread sends after 20ms; select should return well under 100ms
+        Channel ch(10);
+
+        # Start a background thread that sends after a brief delay
+        Counter cnt(1);
+        background sub() {
+            usleep(20ms);
+            ch.send(42);
+            cnt.dec();
+        }();
+
+        date start = now_us();
+        auto result = channel_select((
+            {"channel": ch, "op": "recv"},
+        ), 2s);
+        date elapsed = now_us() - start;
+
+        assertEq(True, exists result, "should receive a value");
+        assertEq(0, result.index);
+        assertEq(42, result.value);
+        # With deterministic wakeup, elapsed should be close to 20ms, not 100ms+
+        # Use 80ms threshold to avoid flakiness while ensuring no 100ms polling
+        assertTrue(elapsed < 80ms, sprintf("elapsed %y should be < 80ms (was %y)", elapsed, elapsed));
+
+        cnt.waitForZero();
+    }
+
+    testChannelSelectConcurrent() {
+        # Two channel_select calls on overlapping channel sets both wake correctly
+        Channel ch1(10);
+        Channel ch2(10);
+        Channel result_ch(10);
+
+        # Use a gate counter so we only send values once both selects are waiting
+        Counter ready(2);
+        Counter done(2);
+
+        # Thread 1: select on ch1, ch2
+        background sub() {
+            ready.dec();
+            auto r = channel_select((
+                {"channel": ch1, "op": "recv"},
+                {"channel": ch2, "op": "recv"},
+            ), 5s);
+            result_ch.send({"thread": 1, "result": r});
+            done.dec();
+        }();
+
+        # Thread 2: select on ch1, ch2
+        background sub() {
+            ready.dec();
+            auto r = channel_select((
+                {"channel": ch1, "op": "recv"},
+                {"channel": ch2, "op": "recv"},
+            ), 5s);
+            result_ch.send({"thread": 2, "result": r});
+            done.dec();
+        }();
+
+        # Wait for both threads to start, then give extra time for waiter registration
+        ready.waitForZero(2s);
+        usleep(50ms);
+
+        # Send two values — each select should get one
+        ch1.send(100);
+        ch2.send(200);
+
+        done.waitForZero(5s);
+
+        auto r1 = result_ch.recv(1s);
+        auto r2 = result_ch.recv(1s);
+
+        # Both selects should have received a value
+        assertEq(True, exists r1.result, "thread 1 result exists");
+        assertEq(True, exists r2.result, "thread 2 result exists");
+
+        # Collect received values
+        list<auto> values = sort((r1.result.value, r2.result.value));
+        assertEq((100, 200), values, "both values received across the two selects");
+    }
+
+    testChannelSelectUnbuffered() {
+        # channel_select recv on unbuffered channel with background sender
+        Channel ch(0);
+
+        Counter cnt(1);
+        background sub() {
+            usleep(20ms);
+            ch.send(99);
+            cnt.dec();
+        }();
+
+        auto result = channel_select((
+            {"channel": ch, "op": "recv"},
+        ), 2s);
+
+        assertEq(True, exists result, "should receive from unbuffered channel");
+        assertEq(0, result.index);
+        assertEq(99, result.value);
+
+        cnt.waitForZero();
     }
 }

--- a/examples/test/qore/threads/parallel.qtest
+++ b/examples/test/qore/threads/parallel.qtest
@@ -1,0 +1,276 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%modern
+%no-child-restrictions
+
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class ParallelTest
+
+class ParallelTest inherits QUnit::Test {
+    constructor() : QUnit::Test("parallel_map/parallel_foreach/channel_select", "1.0", \ARGV) {
+        addTestCase("parallel_map preserves order", \testParallelMapOrder());
+        addTestCase("parallel_map with exception propagation", \testParallelMapException());
+        addTestCase("parallel_map with threads=1 (sequential)", \testParallelMapSequential());
+        addTestCase("parallel_map with empty list", \testParallelMapEmpty());
+        addTestCase("parallel_map with single element", \testParallelMapSingle());
+        addTestCase("parallel_map with large list", \testParallelMapLarge());
+        addTestCase("parallel_foreach basic execution", \testParallelForEach());
+        addTestCase("parallel_foreach with exception", \testParallelForEachException());
+        addTestCase("parallel_foreach with empty list", \testParallelForEachEmpty());
+        addTestCase("channel_select recv from first ready", \testChannelSelectRecv());
+        addTestCase("channel_select send case", \testChannelSelectSend());
+        addTestCase("channel_select timeout", \testChannelSelectTimeout());
+        addTestCase("channel_select fairness", \testChannelSelectFairness());
+        addTestCase("channel_select with closed channel", \testChannelSelectClosed());
+        addTestCase("channel_select empty cases throws", \testChannelSelectEmptyCases());
+        addTestCase("channel_select invalid case throws", \testChannelSelectInvalidCase());
+        addTestCase("parallel_map sequential exception", \testParallelMapSequentialException());
+        addTestCase("channel_select all channels closed", \testChannelSelectAllClosed());
+        addTestCase("channel_select mixed send+recv", \testChannelSelectMixedSendRecv());
+        addTestCase("parallel_foreach with threads=1", \testParallelForEachSequential());
+        set_return_value(main());
+    }
+
+    testParallelMapOrder() {
+        list<auto> input = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        list<auto> result = parallel_map(auto sub(auto x) { return x * 2; }, input);
+        assertEq(10, result.size());
+        for (int i = 0; i < 10; ++i) {
+            assertEq(input[i] * 2, result[i]);
+        }
+    }
+
+    testParallelMapException() {
+        assertThrows("TEST-ERROR", sub() {
+            parallel_map(auto sub(auto x) {
+                if (x == 3) {
+                    throw "TEST-ERROR", "error on element 3";
+                }
+                return x * 2;
+            }, (1, 2, 3, 4, 5));
+        });
+    }
+
+    testParallelMapSequential() {
+        list<auto> result = parallel_map(auto sub(auto x) { return x + 10; }, (1, 2, 3), 1);
+        assertEq((11, 12, 13), result);
+    }
+
+    testParallelMapEmpty() {
+        list<auto> result = parallel_map(auto sub(auto x) { return x; }, ());
+        assertEq(0, result.size());
+    }
+
+    testParallelMapSingle() {
+        list<auto> result = parallel_map(auto sub(auto x) { return x * 3; }, (7,));
+        assertEq((21,), result);
+    }
+
+    testParallelMapLarge() {
+        list<auto> input = ();
+        for (int i = 0; i < 100; ++i) {
+            push input, i;
+        }
+        list<auto> result = parallel_map(auto sub(auto x) { return x * x; }, input, 8);
+        assertEq(100, result.size());
+        for (int i = 0; i < 100; ++i) {
+            assertEq(i * i, result[i]);
+        }
+    }
+
+    testParallelForEach() {
+        Mutex m();
+        list<auto> collected = ();
+        parallel_foreach(sub(auto x) {
+            m.lock();
+            on_exit m.unlock();
+            push collected, x;
+        }, (10, 20, 30, 40, 50));
+        # Results may be in any order due to parallelism
+        assertEq(5, collected.size());
+        assertEq((10, 20, 30, 40, 50), sort(collected));
+    }
+
+    testParallelForEachException() {
+        assertThrows("FOREACH-ERROR", sub() {
+            parallel_foreach(sub(auto x) {
+                if (x == 2) {
+                    throw "FOREACH-ERROR", "error in foreach";
+                }
+            }, (1, 2, 3));
+        });
+    }
+
+    testParallelForEachEmpty() {
+        # Should not throw
+        parallel_foreach(sub(auto x) {
+            throw "SHOULD-NOT-REACH", "this should not be called";
+        }, ());
+        assertTrue(True);
+    }
+
+    testChannelSelectRecv() {
+        Channel ch1(10);
+        Channel ch2(10);
+
+        # Put a value in ch2
+        ch2.send(42);
+
+        auto result = channel_select((
+            {"channel": ch1, "op": "recv"},
+            {"channel": ch2, "op": "recv"},
+        ));
+        assertEq(True, exists result);
+        assertEq(1, result.index);
+        assertEq(42, result.value);
+    }
+
+    testChannelSelectSend() {
+        Channel full_ch(1);
+        full_ch.send(1);  # Fill it up
+        Channel empty_ch(10);
+
+        auto result = channel_select((
+            {"channel": full_ch, "op": "send", "value": 99},
+            {"channel": empty_ch, "op": "send", "value": 77},
+        ));
+        assertEq(True, exists result);
+        assertEq(1, result.index);  # empty_ch should accept the send
+        assertNothing(result.value);  # send operations return NOTHING as value
+        # Verify the value was actually sent
+        assertEq(77, empty_ch.recv());
+    }
+
+    testChannelSelectTimeout() {
+        Channel ch1(10);
+        Channel ch2(10);
+
+        # Both channels are empty, recv should timeout
+        auto result = channel_select((
+            {"channel": ch1, "op": "recv"},
+            {"channel": ch2, "op": "recv"},
+        ), 100ms);
+        assertNothing(result);
+    }
+
+    testChannelSelectFairness() {
+        # When multiple channels are ready, selection should be random
+        # Test by running many iterations and checking distribution
+        hash<string, int> counts;
+        int iterations = 100;
+
+        for (int i = 0; i < iterations; ++i) {
+            Channel ch1(10);
+            Channel ch2(10);
+            ch1.send(1);
+            ch2.send(2);
+
+            auto result = channel_select((
+                {"channel": ch1, "op": "recv"},
+                {"channel": ch2, "op": "recv"},
+            ));
+            string key = string(result.index);
+            counts{key} = (counts{key} ?? 0) + 1;
+        }
+
+        # Both channels should be selected at least once (statistical test)
+        # With random selection, probability of one channel never being selected in 100 trials
+        # is astronomically low (0.5^100)
+        assertTrue(counts{"0"} > 0, "channel 0 should be selected at least once");
+        assertTrue(counts{"1"} > 0, "channel 1 should be selected at least once");
+    }
+
+    testChannelSelectClosed() {
+        Channel ch1(10);
+        Channel ch2(10);
+        ch1.close();
+
+        # ch1 is closed - recv should return NOTHING (not selected)
+        # ch2 has no data - should timeout
+        auto result = channel_select((
+            {"channel": ch1, "op": "recv"},
+            {"channel": ch2, "op": "recv"},
+        ), 100ms);
+        # ch1 tryRecv returns NOTHING with has_value=false (closed+empty)
+        # ch2 tryRecv returns NOTHING with has_value=false (empty)
+        # So both fail non-blocking, then timeout
+        assertNothing(result);
+    }
+
+    testChannelSelectEmptyCases() {
+        assertThrows("CHANNEL-SELECT-ERROR", sub() {
+            channel_select(());
+        });
+    }
+
+    testChannelSelectInvalidCase() {
+        assertThrows("CHANNEL-SELECT-ERROR", sub() {
+            channel_select(({"channel": "not_a_channel", "op": "recv"},));
+        });
+    }
+
+    testParallelMapSequentialException() {
+        # Exception in sequential mode (threads=1) should propagate cleanly
+        assertThrows("SEQ-ERROR", sub() {
+            parallel_map(auto sub(auto x) {
+                if (x == 2) {
+                    throw "SEQ-ERROR", "error in sequential mode";
+                }
+                return x;
+            }, (1, 2, 3), 1);
+        });
+    }
+
+    testChannelSelectAllClosed() {
+        # When all channels are closed and empty, channel_select should return NOTHING immediately
+        # (not block forever)
+        Channel ch1(10);
+        Channel ch2(10);
+        ch1.close();
+        ch2.close();
+
+        auto result = channel_select((
+            {"channel": ch1, "op": "recv"},
+            {"channel": ch2, "op": "recv"},
+        ));
+        assertNothing(result);
+    }
+
+    testChannelSelectMixedSendRecv() {
+        # Test mixed send and recv cases
+        Channel recv_ch(10);
+        Channel send_ch(10);
+        recv_ch.send(99);  # recv_ch has data
+
+        auto result = channel_select((
+            {"channel": send_ch, "op": "send", "value": 42},
+            {"channel": recv_ch, "op": "recv"},
+        ));
+        assertEq(True, exists result);
+        # Both could fire (send_ch has space, recv_ch has data)
+        # but we can verify both indices are valid outcomes
+        if (result.index == 0) {
+            # send case fired
+            assertNothing(result.value);
+            assertEq(42, send_ch.recv());
+        } else {
+            assertEq(1, result.index);
+            assertEq(99, result.value);
+        }
+    }
+
+    testParallelForEachSequential() {
+        # Verify sequential mode (threads=1) works correctly
+        Mutex m();
+        list<auto> collected = ();
+        parallel_foreach(sub(auto x) {
+            m.lock();
+            on_exit m.unlock();
+            push collected, x;
+        }, (10, 20, 30), 1);
+        # Sequential mode preserves order
+        assertEq((10, 20, 30), collected);
+    }
+}

--- a/examples/test/qore/threads/semaphore.qtest
+++ b/examples/test/qore/threads/semaphore.qtest
@@ -1,0 +1,219 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%modern
+%no-child-restrictions
+
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class SemaphoreTest
+
+class SemaphoreTest inherits QUnit::Test {
+    constructor() : QUnit::Test("Semaphore", "1.0", \ARGV) {
+        addTestCase("Basic acquire/release single permit", \testBasicSinglePermit());
+        addTestCase("N-permit concurrent access", \testNPermitConcurrent());
+        addTestCase("tryAcquire when available", \testTryAcquireAvailable());
+        addTestCase("tryAcquire when exhausted", \testTryAcquireExhausted());
+        addTestCase("Timeout behavior", \testTimeout());
+        addTestCase("AutoSemaphore RAII pattern", \testAutoSemaphore());
+        addTestCase("release(n) wakes multiple waiters", \testReleaseMultiple());
+        addTestCase("Negative permits in constructor throws", \testNegativePermits());
+        addTestCase("release(n < 1) throws", \testReleaseInvalid());
+        addTestCase("Copy creates independent semaphore", \testCopy());
+        addTestCase("AutoSemaphore cannot be copied", \testAutoSemaphoreCopy());
+        addTestCase("availablePermits and getWaiting", \testPermitsAndWaiting());
+        addTestCase("AutoSemaphore contended wait", \testAutoSemaphoreContended());
+        addTestCase("AutoSemaphore manual release/reacquire", \testAutoSemaphoreReleaseReacquire());
+        addTestCase("Semaphore zero initial permits", \testZeroPermits());
+        set_return_value(main());
+    }
+
+    testBasicSinglePermit() {
+        Semaphore sem(1);
+        assertEq(1, sem.availablePermits());
+        sem.acquire();
+        assertEq(0, sem.availablePermits());
+        sem.release();
+        assertEq(1, sem.availablePermits());
+    }
+
+    testNPermitConcurrent() {
+        int max_concurrent = 3;
+        Semaphore sem(max_concurrent);
+        Mutex m();
+        int current = 0;
+        int max_seen = 0;
+        Counter done(5);
+
+        for (int i = 0; i < 5; ++i) {
+            background sub() {
+                sem.acquire();
+                {
+                    AutoLock al(m);
+                    ++current;
+                    if (current > max_seen) {
+                        max_seen = current;
+                    }
+                }
+                usleep(50ms);
+                {
+                    AutoLock al(m);
+                    --current;
+                }
+                sem.release();
+                done.dec();
+            }();
+        }
+        done.waitForZero();
+        assertTrue(max_seen <= max_concurrent);
+        assertTrue(max_seen > 0);
+    }
+
+    testTryAcquireAvailable() {
+        Semaphore sem(1);
+        assertTrue(sem.tryAcquire());
+        assertEq(0, sem.availablePermits());
+        sem.release();
+    }
+
+    testTryAcquireExhausted() {
+        Semaphore sem(1);
+        assertTrue(sem.tryAcquire());
+        assertFalse(sem.tryAcquire());
+        sem.release();
+    }
+
+    testTimeout() {
+        Semaphore sem(0);
+        assertThrows("SEMAPHORE-TIMEOUT", sub() { sem.acquire(100ms); });
+    }
+
+    testAutoSemaphore() {
+        Semaphore sem(1);
+        {
+            AutoSemaphore as(sem);
+            assertEq(0, sem.availablePermits());
+        }
+        # After AutoSemaphore goes out of scope, permit should be released
+        assertEq(1, sem.availablePermits());
+    }
+
+    testReleaseMultiple() {
+        Semaphore sem(0);
+        Counter done(3);
+        Mutex m();
+        int acquired_count = 0;
+
+        for (int i = 0; i < 3; ++i) {
+            background sub() {
+                sem.acquire();
+                {
+                    AutoLock al(m);
+                    ++acquired_count;
+                }
+                done.dec();
+            }();
+        }
+
+        usleep(50ms);
+        # Release 3 permits at once - should wake all 3 waiters
+        sem.release(3);
+        done.waitForZero();
+        assertEq(3, acquired_count);
+    }
+
+    testNegativePermits() {
+        assertThrows("SEMAPHORE-ERROR", sub() { Semaphore sem(-1); });
+    }
+
+    testReleaseInvalid() {
+        Semaphore sem(1);
+        assertThrows("SEMAPHORE-ERROR", sub() { sem.release(0); });
+        assertThrows("SEMAPHORE-ERROR", sub() { sem.release(-1); });
+    }
+
+    testCopy() {
+        Semaphore sem(3);
+        sem.acquire();
+        # sem now has 2 permits
+        Semaphore sem2 = sem.copy();
+        # copy should have 2 permits (current state)
+        assertEq(2, sem2.availablePermits());
+        sem.release();
+    }
+
+    testAutoSemaphoreCopy() {
+        Semaphore sem(1);
+        AutoSemaphore as(sem);
+        assertThrows("AUTOSEMAPHORE-COPY-ERROR", sub() { AutoSemaphore as2 = as.copy(); });
+    }
+
+    testPermitsAndWaiting() {
+        Semaphore sem(2);
+        assertEq(2, sem.availablePermits());
+        assertEq(0, sem.getWaiting());
+        sem.acquire();
+        assertEq(1, sem.availablePermits());
+        sem.acquire();
+        assertEq(0, sem.availablePermits());
+        sem.release(2);
+        assertEq(2, sem.availablePermits());
+    }
+
+    testAutoSemaphoreContended() {
+        # Test that AutoSemaphore waits properly when semaphore is contended
+        # (verifies the fix for premature timeout after 500ms)
+        Semaphore sem(1);
+        sem.acquire();  # exhaust the permit
+
+        bool acquired = False;
+        # Release the permit after 1 second from a background thread
+        background sub() {
+            sleep(1s);
+            sem.release();
+        }();
+
+        # AutoSemaphore should wait longer than 500ms for the permit
+        {
+            AutoSemaphore as(sem);
+            acquired = True;
+        }
+        assertTrue(acquired, "AutoSemaphore should have waited for contended permit");
+    }
+
+    testAutoSemaphoreReleaseReacquire() {
+        Semaphore sem(1);
+        {
+            AutoSemaphore as(sem);
+            assertEq(0, sem.availablePermits());
+
+            # Manual release
+            as.release();
+            assertEq(1, sem.availablePermits());
+
+            # Double release throws
+            assertThrows("AUTOSEMAPHORE-ERROR", sub() { as.release(); });
+
+            # Reacquire
+            as.acquire();
+            assertEq(0, sem.availablePermits());
+
+            # Double acquire throws
+            assertThrows("AUTOSEMAPHORE-ERROR", sub() { as.acquire(); });
+        }
+        # Destructor releases
+        assertEq(1, sem.availablePermits());
+    }
+
+    testZeroPermits() {
+        Semaphore sem(0);
+        assertEq(0, sem.availablePermits());
+        assertFalse(sem.tryAcquire());
+
+        # Release adds a permit
+        sem.release();
+        assertEq(1, sem.availablePermits());
+        assertTrue(sem.tryAcquire());
+        assertEq(0, sem.availablePermits());
+    }
+}

--- a/include/qore/intern/QC_AutoSemaphore.h
+++ b/include/qore/intern/QC_AutoSemaphore.h
@@ -1,0 +1,91 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_AutoSemaphore.h
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#ifndef _QORE_CLASS_AUTOSEMAPHORE_H
+#define _QORE_CLASS_AUTOSEMAPHORE_H
+
+#include "qore/intern/QC_Semaphore.h"
+
+DLLEXPORT extern qore_classid_t CID_AUTOSEMAPHORE;
+DLLLOCAL extern QoreClass* QC_AUTOSEMAPHORE;
+
+DLLLOCAL QoreClass* initAutoSemaphoreClass(QoreNamespace& ns);
+
+class QoreAutoSemaphore : public AbstractPrivateData {
+    QoreSemaphore* sem;
+    bool acquired;
+
+public:
+    DLLLOCAL QoreAutoSemaphore(QoreSemaphore* s) : sem(s), acquired(true) {
+    }
+
+    using AbstractPrivateData::deref;
+    DLLLOCAL virtual void deref(ExceptionSink* xsink) {
+        if (ROdereference()) {
+            sem->deref(xsink);
+            delete this;
+        }
+    }
+
+    DLLLOCAL void destructor(ExceptionSink* xsink) {
+        if (acquired) {
+            sem->release(1, xsink);
+            acquired = false;
+        }
+    }
+
+    DLLLOCAL void release(ExceptionSink* xsink) {
+        if (acquired) {
+            sem->release(1, xsink);
+            acquired = false;
+        } else {
+            xsink->raiseException("AUTOSEMAPHORE-ERROR", "semaphore permit has already been released");
+        }
+    }
+
+    DLLLOCAL int acquire(int64 timeout_ms, ExceptionSink* xsink) {
+        if (acquired) {
+            xsink->raiseException("AUTOSEMAPHORE-ERROR", "semaphore permit is already acquired");
+            return -1;
+        }
+        bool timed_out = false;
+        int rc = sem->acquire(timeout_ms, xsink, timed_out);
+        if (rc == 0) {
+            acquired = true;
+        } else if (timed_out && !*xsink) {
+            xsink->raiseException("SEMAPHORE-TIMEOUT",
+                "timed out after " QLLD "ms waiting to acquire semaphore", timeout_ms);
+        }
+        return rc;
+    }
+};
+
+#endif // _QORE_CLASS_AUTOSEMAPHORE_H

--- a/include/qore/intern/QC_Channel.h
+++ b/include/qore/intern/QC_Channel.h
@@ -1,0 +1,43 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_Channel.h
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#ifndef _QORE_CLASS_CHANNEL_H
+#define _QORE_CLASS_CHANNEL_H
+
+#include "qore/intern/QoreChannel.h"
+
+DLLEXPORT extern qore_classid_t CID_CHANNEL;
+DLLLOCAL extern QoreClass* QC_CHANNEL;
+
+DLLLOCAL void preinitChannelClass();
+DLLLOCAL QoreClass* initChannelClass(QoreNamespace& ns);
+
+#endif // _QORE_CLASS_CHANNEL_H

--- a/include/qore/intern/QC_ChannelIterator.h
+++ b/include/qore/intern/QC_ChannelIterator.h
@@ -1,0 +1,115 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_ChannelIterator.h
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#ifndef _QORE_CLASS_CHANNELITERATOR_H
+#define _QORE_CLASS_CHANNELITERATOR_H
+
+#include "qore/intern/QC_Channel.h"
+
+DLLEXPORT extern qore_classid_t CID_CHANNELITERATOR;
+DLLLOCAL extern QoreClass* QC_CHANNELITERATOR;
+
+DLLLOCAL QoreClass* initChannelIteratorClass(QoreNamespace& ns);
+
+class QoreChannelIterator : public QoreIteratorBase {
+public:
+    // if own_ref is true, takes ownership of an existing ref; if false, adds a new ref
+    DLLLOCAL QoreChannelIterator(QoreChannel* ch, bool own_ref = false) : channel(ch), validp(false) {
+        if (!own_ref) {
+            channel->ref();
+        }
+    }
+
+    DLLLOCAL bool next(ExceptionSink* xsink) {
+        bool timed_out = false;
+        bool has_value = false;
+        QoreValue val = channel->recv(0, xsink, timed_out, has_value);
+        if (*xsink) {
+            validp = false;
+            return false;
+        }
+        if (!has_value) {
+            // Channel closed and drained
+            validp = false;
+            return false;
+        }
+        current_value.discard(xsink);
+        current_value = val;
+        validp = true;
+        return true;
+    }
+
+    DLLLOCAL QoreValue getValue() const {
+        return current_value.refSelf();
+    }
+
+    DLLLOCAL bool valid() const {
+        return validp;
+    }
+
+    DLLLOCAL int checkValid(ExceptionSink* xsink) const {
+        if (!validp) {
+            xsink->raiseException("INVALID-ITERATOR",
+                "the %s is not pointing at a valid element; "
+                "make sure %s::next() returns True before calling this method",
+                getName(), getName());
+            return -1;
+        }
+        return 0;
+    }
+
+    using AbstractPrivateData::deref;
+    DLLLOCAL virtual void deref(ExceptionSink* xsink) {
+        if (ROdereference()) {
+            current_value.discard(xsink);
+            channel->deref(xsink);
+            delete this;
+        }
+    }
+
+    DLLLOCAL virtual const char* getName() const override {
+        return "ChannelIterator";
+    }
+
+    DLLLOCAL virtual const QoreTypeInfo* getElementType() const override {
+        return autoTypeInfo;
+    }
+
+protected:
+    DLLLOCAL virtual ~QoreChannelIterator() {}
+
+private:
+    QoreChannel* channel;
+    QoreValue current_value;
+    bool validp;
+};
+
+#endif // _QORE_CLASS_CHANNELITERATOR_H

--- a/include/qore/intern/QC_Future.h
+++ b/include/qore/intern/QC_Future.h
@@ -1,0 +1,42 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_Future.h
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#ifndef _QORE_CLASS_FUTURE_H
+#define _QORE_CLASS_FUTURE_H
+
+#include "qore/intern/QoreFuture.h"
+
+DLLEXPORT extern qore_classid_t CID_FUTURE;
+DLLLOCAL extern QoreClass* QC_FUTURE;
+
+DLLLOCAL QoreClass* initFutureClass(QoreNamespace& ns);
+
+#endif // _QORE_CLASS_FUTURE_H

--- a/include/qore/intern/QC_Promise.h
+++ b/include/qore/intern/QC_Promise.h
@@ -1,0 +1,42 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_Promise.h
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#ifndef _QORE_CLASS_PROMISE_H
+#define _QORE_CLASS_PROMISE_H
+
+#include "qore/intern/QoreFuture.h"
+
+DLLEXPORT extern qore_classid_t CID_PROMISE;
+DLLLOCAL extern QoreClass* QC_PROMISE;
+
+DLLLOCAL QoreClass* initPromiseClass(QoreNamespace& ns);
+
+#endif // _QORE_CLASS_PROMISE_H

--- a/include/qore/intern/QC_Semaphore.h
+++ b/include/qore/intern/QC_Semaphore.h
@@ -1,0 +1,42 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_Semaphore.h
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#ifndef _QORE_CLASS_SEMAPHORE_H
+#define _QORE_CLASS_SEMAPHORE_H
+
+#include "qore/intern/QoreSemaphore.h"
+
+DLLEXPORT extern qore_classid_t CID_SEMAPHORE;
+DLLLOCAL extern QoreClass* QC_SEMAPHORE;
+
+DLLLOCAL QoreClass* initSemaphoreClass(QoreNamespace& ns);
+
+#endif // _QORE_CLASS_SEMAPHORE_H

--- a/include/qore/intern/QC_WaitGroup.h
+++ b/include/qore/intern/QC_WaitGroup.h
@@ -1,0 +1,42 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_WaitGroup.h
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#ifndef _QORE_CLASS_WAITGROUP_H
+#define _QORE_CLASS_WAITGROUP_H
+
+#include "qore/intern/QoreWaitGroup.h"
+
+DLLEXPORT extern qore_classid_t CID_WAITGROUP;
+DLLLOCAL extern QoreClass* QC_WAITGROUP;
+
+DLLLOCAL QoreClass* initWaitGroupClass(QoreNamespace& ns);
+
+#endif // _QORE_CLASS_WAITGROUP_H

--- a/include/qore/intern/QoreChannel.h
+++ b/include/qore/intern/QoreChannel.h
@@ -1,0 +1,420 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QoreChannel.h
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#ifndef _QORE_INTERN_QORECHANNEL_H
+#define _QORE_INTERN_QORECHANNEL_H
+
+#include <qore/Qore.h>
+#include <qore/QoreCondition.h>
+#include <qore/AbstractPrivateData.h>
+
+#include <deque>
+#include <vector>
+
+//! A typed channel for inter-thread communication with close semantics
+class QoreChannel : public AbstractPrivateData {
+public:
+    DLLLOCAL QoreChannel(int cap) : cap(cap), closed(false), deleted(false),
+        send_waiting(0), recv_waiting(0) {
+        // For unbuffered (cap=0): we use a single-slot handoff mechanism
+        if (cap == 0) {
+            unbuffered_has_value = false;
+        }
+    }
+
+    //! Sends a value into the channel
+    /** @param val the value to send
+        @param timeout_ms timeout in milliseconds; 0 = infinite
+        @param xsink exception sink
+        @return 0 on success, -1 on error/timeout
+    */
+    DLLLOCAL int send(QoreValue val, int64 timeout_ms, ExceptionSink* xsink) {
+        // Convention: timeout_ms <= 0 means infinite; waitWithInterrupt uses -1 for infinite
+        int64 cond_timeout = (timeout_ms <= 0) ? -1 : timeout_ms;
+
+        AutoLocker al(&lck);
+        if (closed) {
+            val.discard(xsink);
+            xsink->raiseException("CHANNEL-CLOSED", "cannot send on a closed channel");
+            return -1;
+        }
+
+        if (cap == 0) {
+            // Unbuffered: synchronous handoff
+            // Wait until the slot is empty
+            ++send_waiting;
+            while (unbuffered_has_value && !deleted && !closed) {
+                int rc = send_cond.waitWithInterrupt(&lck, cond_timeout, xsink);
+                if (rc == QORE_COND_RESULT_INTERRUPTED) {
+                    --send_waiting;
+                    val.discard(xsink);
+                    return -1;
+                }
+                if (deleted || closed || !unbuffered_has_value) {
+                    break;
+                }
+                if (rc == QORE_COND_RESULT_TIMEOUT) {
+                    --send_waiting;
+                    val.discard(xsink);
+                    xsink->raiseException("CHANNEL-TIMEOUT",
+                        "timed out after " QLLD "ms waiting to send on channel", timeout_ms);
+                    return -1;
+                }
+            }
+            --send_waiting;
+
+            if (deleted) {
+                val.discard(xsink);
+                xsink->raiseException("CHANNEL-ERROR", "Channel has been deleted in another thread");
+                return -1;
+            }
+            if (closed) {
+                val.discard(xsink);
+                xsink->raiseException("CHANNEL-CLOSED", "cannot send on a closed channel");
+                return -1;
+            }
+
+            unbuffered_value = val;
+            unbuffered_has_value = true;
+            recv_cond.signal();
+            notifyExternalWaiters();
+
+            // Wait for receiver to take it (infinite wait — handoff must complete)
+            while (unbuffered_has_value && !deleted) {
+                int rc = send_cond.waitWithInterrupt(&lck, -1, xsink);
+                if (rc == QORE_COND_RESULT_INTERRUPTED) {
+                    return -1;
+                }
+                if (deleted || !unbuffered_has_value) {
+                    break;
+                }
+            }
+
+            if (deleted) {
+                xsink->raiseException("CHANNEL-ERROR", "Channel has been deleted in another thread");
+                return -1;
+            }
+
+            return 0;
+        }
+
+        // Buffered: wait for space (cap < 0 means unlimited — never wait)
+        ++send_waiting;
+        while (cap > 0 && (int)buffer.size() >= cap && !deleted && !closed) {
+            int rc = send_cond.waitWithInterrupt(&lck, cond_timeout, xsink);
+            if (rc == QORE_COND_RESULT_INTERRUPTED) {
+                --send_waiting;
+                val.discard(xsink);
+                return -1;
+            }
+            if (deleted || closed || (int)buffer.size() < cap) {
+                break;
+            }
+            if (rc == QORE_COND_RESULT_TIMEOUT) {
+                --send_waiting;
+                val.discard(xsink);
+                xsink->raiseException("CHANNEL-TIMEOUT",
+                    "timed out after " QLLD "ms waiting to send on channel", timeout_ms);
+                return -1;
+            }
+        }
+        --send_waiting;
+
+        if (deleted) {
+            val.discard(xsink);
+            xsink->raiseException("CHANNEL-ERROR", "Channel has been deleted in another thread");
+            return -1;
+        }
+        if (closed) {
+            val.discard(xsink);
+            xsink->raiseException("CHANNEL-CLOSED", "cannot send on a closed channel");
+            return -1;
+        }
+
+        buffer.push_back(val);
+        recv_cond.signal();
+        notifyExternalWaiters();
+        return 0;
+    }
+
+    //! Receives a value from the channel
+    /** @param timeout_ms timeout in milliseconds; 0 = infinite
+        @param xsink exception sink
+        @param timed_out set to true on timeout
+        @param has_value set to true if a value was actually received (distinguishes NOTHING value from closed+drained)
+        @return the received value, or NOTHING if channel is closed and drained
+    */
+    DLLLOCAL QoreValue recv(int64 timeout_ms, ExceptionSink* xsink, bool& timed_out, bool& has_value) {
+        // Convention: timeout_ms <= 0 means infinite; waitWithInterrupt uses -1 for infinite
+        int64 cond_timeout = (timeout_ms <= 0) ? -1 : timeout_ms;
+        timed_out = false;
+        has_value = false;
+
+        AutoLocker al(&lck);
+
+        if (cap == 0) {
+            // Unbuffered: wait for sender to provide a value
+            ++recv_waiting;
+            while (!unbuffered_has_value && !deleted && !closed) {
+                int rc = recv_cond.waitWithInterrupt(&lck, cond_timeout, xsink);
+                if (rc == QORE_COND_RESULT_INTERRUPTED) {
+                    --recv_waiting;
+                    return QoreValue();
+                }
+                if (deleted || closed || unbuffered_has_value) {
+                    break;
+                }
+                if (rc == QORE_COND_RESULT_TIMEOUT) {
+                    --recv_waiting;
+                    timed_out = true;
+                    return QoreValue();
+                }
+            }
+            --recv_waiting;
+
+            if (deleted) {
+                xsink->raiseException("CHANNEL-ERROR", "Channel has been deleted in another thread");
+                return QoreValue();
+            }
+
+            if (!unbuffered_has_value) {
+                // Channel closed with no value available
+                return QoreValue();
+            }
+
+            QoreValue rv = unbuffered_value;
+            unbuffered_value = QoreValue();
+            unbuffered_has_value = false;
+            has_value = true;
+            send_cond.signal();
+            notifyExternalWaiters();
+            return rv;
+        }
+
+        // Buffered: wait for data
+        ++recv_waiting;
+        while (buffer.empty() && !deleted && !closed) {
+            int rc = recv_cond.waitWithInterrupt(&lck, cond_timeout, xsink);
+            if (rc == QORE_COND_RESULT_INTERRUPTED) {
+                --recv_waiting;
+                return QoreValue();
+            }
+            if (deleted || closed || !buffer.empty()) {
+                break;
+            }
+            if (rc == QORE_COND_RESULT_TIMEOUT) {
+                --recv_waiting;
+                timed_out = true;
+                return QoreValue();
+            }
+        }
+        --recv_waiting;
+
+        if (deleted) {
+            xsink->raiseException("CHANNEL-ERROR", "Channel has been deleted in another thread");
+            return QoreValue();
+        }
+
+        if (buffer.empty()) {
+            // Channel closed with no buffered data
+            return QoreValue();
+        }
+
+        QoreValue rv = buffer.front();
+        buffer.pop_front();
+        has_value = true;
+        send_cond.signal();
+        notifyExternalWaiters();
+        return rv;
+    }
+
+    //! Non-blocking send
+    DLLLOCAL bool trySend(QoreValue val) {
+        AutoLocker al(&lck);
+        if (closed || deleted) {
+            return false;
+        }
+        if (cap == 0) {
+            // Unbuffered: can only send if a receiver is waiting and slot is empty
+            if (!unbuffered_has_value && recv_waiting > 0) {
+                unbuffered_value = val;
+                unbuffered_has_value = true;
+                recv_cond.signal();
+                notifyExternalWaiters();
+                return true;
+            }
+            return false;
+        }
+        if (cap > 0 && (int)buffer.size() >= cap) {
+            return false;
+        }
+        buffer.push_back(val);
+        recv_cond.signal();
+        notifyExternalWaiters();
+        return true;
+    }
+
+    //! Non-blocking receive
+    /** @param has_value set to true if a value was received
+        @return the value or NOTHING
+    */
+    DLLLOCAL QoreValue tryRecv(bool& has_value) {
+        AutoLocker al(&lck);
+        has_value = false;
+        if (cap == 0) {
+            if (unbuffered_has_value) {
+                QoreValue rv = unbuffered_value;
+                unbuffered_value = QoreValue();
+                unbuffered_has_value = false;
+                send_cond.signal();
+                notifyExternalWaiters();
+                has_value = true;
+                return rv;
+            }
+            return QoreValue();
+        }
+        if (buffer.empty()) {
+            return QoreValue();
+        }
+        has_value = true;
+        QoreValue rv = buffer.front();
+        buffer.pop_front();
+        send_cond.signal();
+        notifyExternalWaiters();
+        return rv;
+    }
+
+    //! Closes the channel
+    DLLLOCAL void close() {
+        AutoLocker al(&lck);
+        closed = true;
+        send_cond.broadcast();
+        recv_cond.broadcast();
+        notifyExternalWaiters();
+    }
+
+    DLLLOCAL bool isClosed() const {
+        AutoLocker al(&lck);
+        return closed;
+    }
+
+    DLLLOCAL int size() const {
+        AutoLocker al(&lck);
+        if (cap == 0) {
+            return unbuffered_has_value ? 1 : 0;
+        }
+        return (int)buffer.size();
+    }
+
+    DLLLOCAL int capacity() const {
+        return cap;
+    }
+
+    DLLLOCAL bool empty() const {
+        AutoLocker al(&lck);
+        if (cap == 0) {
+            return !unbuffered_has_value;
+        }
+        return buffer.empty();
+    }
+
+    //! Called from destructor
+    DLLLOCAL void destructor(ExceptionSink* xsink) {
+        AutoLocker al(&lck);
+        if (send_waiting > 0 || recv_waiting > 0) {
+            xsink->raiseException("CHANNEL-ERROR",
+                "Channel deleted while %d thread%s blocked on it",
+                send_waiting + recv_waiting,
+                (send_waiting + recv_waiting) == 1 ? " is" : "s are");
+        }
+        deleted = true;
+        closed = true;
+        send_cond.broadcast();
+        recv_cond.broadcast();
+        notifyExternalWaiters();
+
+        // Clean up any buffered values
+        for (auto& v : buffer) {
+            v.discard(xsink);
+        }
+        buffer.clear();
+        if (unbuffered_has_value) {
+            unbuffered_value.discard(xsink);
+            unbuffered_has_value = false;
+        }
+    }
+
+    //! Register an external waiter (for channel_select)
+    DLLLOCAL void registerExternalWaiter(QoreCondition* cond) {
+        AutoLocker al(&lck);
+        external_waiters.push_back(cond);
+    }
+
+    //! Deregister an external waiter
+    DLLLOCAL void deregisterExternalWaiter(QoreCondition* cond) {
+        AutoLocker al(&lck);
+        for (auto it = external_waiters.begin(); it != external_waiters.end(); ++it) {
+            if (*it == cond) {
+                external_waiters.erase(it);
+                break;
+            }
+        }
+    }
+
+protected:
+    DLLLOCAL virtual ~QoreChannel() {}
+
+private:
+    mutable QoreThreadLock lck;
+    QoreCondition send_cond;
+    QoreCondition recv_cond;
+    std::deque<QoreValue> buffer;
+    int cap;
+    bool closed;
+    bool deleted;
+    int send_waiting;
+    int recv_waiting;
+
+    // Unbuffered mode
+    QoreValue unbuffered_value;
+    bool unbuffered_has_value = false;
+
+    // External waiters for channel_select
+    std::vector<QoreCondition*> external_waiters;
+
+    DLLLOCAL void notifyExternalWaiters() {
+        for (auto* cond : external_waiters) {
+            cond->broadcast();
+        }
+    }
+};
+
+#endif // _QORE_INTERN_QORECHANNEL_H

--- a/include/qore/intern/QoreChannel.h
+++ b/include/qore/intern/QoreChannel.h
@@ -34,10 +34,64 @@
 
 #include <qore/Qore.h>
 #include <qore/QoreCondition.h>
+#include <qore/QoreReferenceCounter.h>
 #include <qore/AbstractPrivateData.h>
 
 #include <deque>
 #include <vector>
+
+//! Heap-allocated, refcounted waiter for channel_select deterministic wakeup
+/** channel_select creates one SelectWaiter, registers it with all channels.
+    Channel operations copy the pointer (bumping refcount), release channel lock,
+    then signal under the waiter's own lock.  Refcounting prevents use-after-free
+    when channel_select returns while in-flight notifications hold pointers.
+*/
+struct SelectWaiter : public QoreReferenceCounter {
+    QoreThreadLock lock;
+    QoreCondition cond;
+    bool notified = false;
+
+    void ref() { ROreference(); }
+    void deref() {
+        if (ROdereference()) {
+            delete this;
+        }
+    }
+};
+
+//! RAII helper that collects SelectWaiter pointers and notifies them on destruction
+/** Declared before AutoLocker in channel methods so it destructs *after* the
+    channel lock is released, ensuring notifications fire outside the channel lock.
+*/
+class WaiterNotifyHelper {
+    std::vector<SelectWaiter*> waiters;
+
+public:
+    ~WaiterNotifyHelper() {
+        flush();
+    }
+
+    //! Fire notifications immediately and clear the list
+    void flush() {
+        for (auto* w : waiters) {
+            {
+                AutoLocker al(&w->lock);
+                w->notified = true;
+                w->cond.broadcast();
+            }
+            w->deref();
+        }
+        waiters.clear();
+    }
+
+    //! Copy all registered external waiters (bumps refcount on each)
+    void addAll(const std::vector<SelectWaiter*>& external_waiters) {
+        for (auto* w : external_waiters) {
+            w->ref();
+            waiters.push_back(w);
+        }
+    }
+};
 
 //! A typed channel for inter-thread communication with close semantics
 class QoreChannel : public AbstractPrivateData {
@@ -60,73 +114,90 @@ public:
         // Convention: timeout_ms <= 0 means infinite; waitWithInterrupt uses -1 for infinite
         int64 cond_timeout = (timeout_ms <= 0) ? -1 : timeout_ms;
 
-        AutoLocker al(&lck);
-        if (closed) {
-            val.discard(xsink);
-            xsink->raiseException("CHANNEL-CLOSED", "cannot send on a closed channel");
-            return -1;
-        }
-
         if (cap == 0) {
-            // Unbuffered: synchronous handoff
-            // Wait until the slot is empty
-            ++send_waiting;
-            while (unbuffered_has_value && !deleted && !closed) {
-                int rc = send_cond.waitWithInterrupt(&lck, cond_timeout, xsink);
-                if (rc == QORE_COND_RESULT_INTERRUPTED) {
-                    --send_waiting;
+            // Unbuffered: synchronous handoff — two-phase with deferred notification
+            // Phase 1: Wait for slot to be empty, place value, notify external waiters
+            {
+                WaiterNotifyHelper wnh;
+                AutoLocker al(&lck);
+
+                if (closed) {
                     val.discard(xsink);
+                    xsink->raiseException("CHANNEL-CLOSED", "cannot send on a closed channel");
                     return -1;
                 }
-                if (deleted || closed || !unbuffered_has_value) {
-                    break;
+
+                ++send_waiting;
+                while (unbuffered_has_value && !deleted && !closed) {
+                    int rc = send_cond.waitWithInterrupt(&lck, cond_timeout, xsink);
+                    if (rc == QORE_COND_RESULT_INTERRUPTED) {
+                        --send_waiting;
+                        val.discard(xsink);
+                        return -1;
+                    }
+                    if (deleted || closed || !unbuffered_has_value) {
+                        break;
+                    }
+                    if (rc == QORE_COND_RESULT_TIMEOUT) {
+                        --send_waiting;
+                        val.discard(xsink);
+                        xsink->raiseException("CHANNEL-TIMEOUT",
+                            "timed out after " QLLD "ms waiting to send on channel", timeout_ms);
+                        return -1;
+                    }
                 }
-                if (rc == QORE_COND_RESULT_TIMEOUT) {
-                    --send_waiting;
+                --send_waiting;
+
+                if (deleted) {
                     val.discard(xsink);
-                    xsink->raiseException("CHANNEL-TIMEOUT",
-                        "timed out after " QLLD "ms waiting to send on channel", timeout_ms);
+                    xsink->raiseException("CHANNEL-ERROR", "Channel has been deleted in another thread");
                     return -1;
                 }
-            }
-            --send_waiting;
-
-            if (deleted) {
-                val.discard(xsink);
-                xsink->raiseException("CHANNEL-ERROR", "Channel has been deleted in another thread");
-                return -1;
-            }
-            if (closed) {
-                val.discard(xsink);
-                xsink->raiseException("CHANNEL-CLOSED", "cannot send on a closed channel");
-                return -1;
-            }
-
-            unbuffered_value = val;
-            unbuffered_has_value = true;
-            recv_cond.signal();
-            notifyExternalWaiters();
-
-            // Wait for receiver to take it (infinite wait — handoff must complete)
-            while (unbuffered_has_value && !deleted) {
-                int rc = send_cond.waitWithInterrupt(&lck, -1, xsink);
-                if (rc == QORE_COND_RESULT_INTERRUPTED) {
+                if (closed) {
+                    val.discard(xsink);
+                    xsink->raiseException("CHANNEL-CLOSED", "cannot send on a closed channel");
                     return -1;
                 }
-                if (deleted || !unbuffered_has_value) {
-                    break;
-                }
-            }
 
-            if (deleted) {
-                xsink->raiseException("CHANNEL-ERROR", "Channel has been deleted in another thread");
-                return -1;
+                unbuffered_value = val;
+                unbuffered_has_value = true;
+                recv_cond.signal();
+                wnh.addAll(external_waiters);
+            }
+            // AutoLocker releases channel lock first, then WaiterNotifyHelper fires notifications
+
+            // Phase 2: Wait for receiver to take the value (infinite wait — handoff must complete)
+            {
+                AutoLocker al(&lck);
+                while (unbuffered_has_value && !deleted) {
+                    int rc = send_cond.waitWithInterrupt(&lck, -1, xsink);
+                    if (rc == QORE_COND_RESULT_INTERRUPTED) {
+                        return -1;
+                    }
+                    if (deleted || !unbuffered_has_value) {
+                        break;
+                    }
+                }
+
+                if (deleted) {
+                    xsink->raiseException("CHANNEL-ERROR", "Channel has been deleted in another thread");
+                    return -1;
+                }
             }
 
             return 0;
         }
 
         // Buffered: wait for space (cap < 0 means unlimited — never wait)
+        WaiterNotifyHelper wnh;
+        AutoLocker al(&lck);
+
+        if (closed) {
+            val.discard(xsink);
+            xsink->raiseException("CHANNEL-CLOSED", "cannot send on a closed channel");
+            return -1;
+        }
+
         ++send_waiting;
         while (cap > 0 && (int)buffer.size() >= cap && !deleted && !closed) {
             int rc = send_cond.waitWithInterrupt(&lck, cond_timeout, xsink);
@@ -161,7 +232,7 @@ public:
 
         buffer.push_back(val);
         recv_cond.signal();
-        notifyExternalWaiters();
+        wnh.addAll(external_waiters);
         return 0;
     }
 
@@ -178,6 +249,7 @@ public:
         timed_out = false;
         has_value = false;
 
+        WaiterNotifyHelper wnh;
         AutoLocker al(&lck);
 
         if (cap == 0) {
@@ -215,7 +287,7 @@ public:
             unbuffered_has_value = false;
             has_value = true;
             send_cond.signal();
-            notifyExternalWaiters();
+            wnh.addAll(external_waiters);
             return rv;
         }
 
@@ -252,12 +324,13 @@ public:
         buffer.pop_front();
         has_value = true;
         send_cond.signal();
-        notifyExternalWaiters();
+        wnh.addAll(external_waiters);
         return rv;
     }
 
     //! Non-blocking send
     DLLLOCAL bool trySend(QoreValue val) {
+        WaiterNotifyHelper wnh;
         AutoLocker al(&lck);
         if (closed || deleted) {
             return false;
@@ -268,7 +341,7 @@ public:
                 unbuffered_value = val;
                 unbuffered_has_value = true;
                 recv_cond.signal();
-                notifyExternalWaiters();
+                wnh.addAll(external_waiters);
                 return true;
             }
             return false;
@@ -278,7 +351,7 @@ public:
         }
         buffer.push_back(val);
         recv_cond.signal();
-        notifyExternalWaiters();
+        wnh.addAll(external_waiters);
         return true;
     }
 
@@ -287,6 +360,7 @@ public:
         @return the value or NOTHING
     */
     DLLLOCAL QoreValue tryRecv(bool& has_value) {
+        WaiterNotifyHelper wnh;
         AutoLocker al(&lck);
         has_value = false;
         if (cap == 0) {
@@ -295,7 +369,7 @@ public:
                 unbuffered_value = QoreValue();
                 unbuffered_has_value = false;
                 send_cond.signal();
-                notifyExternalWaiters();
+                wnh.addAll(external_waiters);
                 has_value = true;
                 return rv;
             }
@@ -308,17 +382,18 @@ public:
         QoreValue rv = buffer.front();
         buffer.pop_front();
         send_cond.signal();
-        notifyExternalWaiters();
+        wnh.addAll(external_waiters);
         return rv;
     }
 
     //! Closes the channel
     DLLLOCAL void close() {
+        WaiterNotifyHelper wnh;
         AutoLocker al(&lck);
         closed = true;
         send_cond.broadcast();
         recv_cond.broadcast();
-        notifyExternalWaiters();
+        wnh.addAll(external_waiters);
     }
 
     DLLLOCAL bool isClosed() const {
@@ -348,6 +423,7 @@ public:
 
     //! Called from destructor
     DLLLOCAL void destructor(ExceptionSink* xsink) {
+        WaiterNotifyHelper wnh;
         AutoLocker al(&lck);
         if (send_waiting > 0 || recv_waiting > 0) {
             xsink->raiseException("CHANNEL-ERROR",
@@ -359,7 +435,7 @@ public:
         closed = true;
         send_cond.broadcast();
         recv_cond.broadcast();
-        notifyExternalWaiters();
+        wnh.addAll(external_waiters);
 
         // Clean up any buffered values
         for (auto& v : buffer) {
@@ -373,20 +449,24 @@ public:
     }
 
     //! Register an external waiter (for channel_select)
-    DLLLOCAL void registerExternalWaiter(QoreCondition* cond) {
+    DLLLOCAL void registerExternalWaiter(SelectWaiter* w) {
+        w->ref();  // bump refcount for the channel's copy
         AutoLocker al(&lck);
-        external_waiters.push_back(cond);
+        external_waiters.push_back(w);
     }
 
     //! Deregister an external waiter
-    DLLLOCAL void deregisterExternalWaiter(QoreCondition* cond) {
-        AutoLocker al(&lck);
-        for (auto it = external_waiters.begin(); it != external_waiters.end(); ++it) {
-            if (*it == cond) {
-                external_waiters.erase(it);
-                break;
+    DLLLOCAL void deregisterExternalWaiter(SelectWaiter* w) {
+        {
+            AutoLocker al(&lck);
+            for (auto it = external_waiters.begin(); it != external_waiters.end(); ++it) {
+                if (*it == w) {
+                    external_waiters.erase(it);
+                    break;
+                }
             }
         }
+        w->deref();
     }
 
 protected:
@@ -408,13 +488,7 @@ private:
     bool unbuffered_has_value = false;
 
     // External waiters for channel_select
-    std::vector<QoreCondition*> external_waiters;
-
-    DLLLOCAL void notifyExternalWaiters() {
-        for (auto* cond : external_waiters) {
-            cond->broadcast();
-        }
-    }
+    std::vector<SelectWaiter*> external_waiters;
 };
 
 #endif // _QORE_INTERN_QORECHANNEL_H

--- a/include/qore/intern/QoreFuture.h
+++ b/include/qore/intern/QoreFuture.h
@@ -1,0 +1,313 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QoreFuture.h
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#ifndef _QORE_INTERN_QOREFUTURE_H
+#define _QORE_INTERN_QOREFUTURE_H
+
+#include <qore/Qore.h>
+#include <qore/QoreCondition.h>
+#include <qore/AbstractPrivateData.h>
+
+#include <string>
+
+//! Shared implementation for Future and Promise
+class qore_future_private : public QoreReferenceCounter {
+public:
+    enum State {
+        PENDING,
+        RESOLVED,
+        REJECTED,
+    };
+
+    DLLLOCAL qore_future_private() : state(PENDING), waiting(0), future_retrieved(false) {
+    }
+
+    DLLLOCAL ~qore_future_private() {
+        assert(state != PENDING || !waiting);
+        ExceptionSink xsink;
+        result.discard(&xsink);
+        err_arg.discard(&xsink);
+    }
+
+    //! Resolves the future with a value
+    DLLLOCAL void set(QoreValue val, ExceptionSink* xsink) {
+        AutoLocker al(&lock);
+        if (state != PENDING) {
+            val.discard(xsink);
+            xsink->raiseException("PROMISE-ERROR", "Promise has already been %s",
+                state == RESOLVED ? "resolved" : "rejected");
+            return;
+        }
+        result = val;
+        state = RESOLVED;
+        cond.broadcast();
+    }
+
+    //! Rejects the future with an error
+    DLLLOCAL void setError(const char* err, const char* desc, QoreValue arg, ExceptionSink* xsink) {
+        AutoLocker al(&lock);
+        if (state != PENDING) {
+            arg.discard(xsink);
+            xsink->raiseException("PROMISE-ERROR", "Promise has already been %s",
+                state == RESOLVED ? "resolved" : "rejected");
+            return;
+        }
+        err_code = err;
+        err_desc = desc;
+        err_arg = arg;
+        state = REJECTED;
+        cond.broadcast();
+    }
+
+    //! Rejects the future by assimilating exceptions from an ExceptionSink
+    DLLLOCAL void setException(ExceptionSink& xs) {
+        AutoLocker al(&lock);
+        if (state != PENDING) {
+            xs.clear();
+            return;
+        }
+        // Store the exception info from the sink
+        QoreHashNode* ex = xs.getExceptionInfo();
+        if (ex) {
+            QoreValue errv = ex->getKeyValue("err");
+            QoreValue descv = ex->getKeyValue("desc");
+            QoreValue argv = ex->getKeyValue("arg");
+            if (errv.getType() == NT_STRING) {
+                err_code = errv.get<const QoreStringNode>()->c_str();
+            }
+            if (descv.getType() == NT_STRING) {
+                err_desc = descv.get<const QoreStringNode>()->c_str();
+            }
+            err_arg = argv.refSelf();
+            ex->deref(nullptr);
+        }
+        xs.clear();
+        state = REJECTED;
+        cond.broadcast();
+    }
+
+    //! Gets the result (blocking)
+    /** Returns the result value; on error, raises exception and returns nothing
+        @param timeout_ms timeout in milliseconds; 0 = infinite
+        @param xsink exception sink
+        @return the result value
+    */
+    DLLLOCAL QoreValue get(int64 timeout_ms, ExceptionSink* xsink) {
+        // Convention: timeout_ms <= 0 means infinite; waitWithInterrupt uses -1 for infinite
+        int64 cond_timeout = (timeout_ms <= 0) ? -1 : timeout_ms;
+
+        AutoLocker al(&lock);
+        ++waiting;
+        while (state == PENDING) {
+            int rc = cond.waitWithInterrupt(&lock, cond_timeout, xsink);
+            if (rc == QORE_COND_RESULT_INTERRUPTED) {
+                --waiting;
+                return QoreValue();
+            }
+            if (state != PENDING) {
+                break;
+            }
+            if (rc == QORE_COND_RESULT_TIMEOUT) {
+                --waiting;
+                xsink->raiseException("FUTURE-TIMEOUT",
+                    "timed out after " QLLD "ms waiting for future result", timeout_ms);
+                return QoreValue();
+            }
+        }
+        --waiting;
+
+        if (state == REJECTED) {
+            xsink->raiseExceptionArg(err_code.c_str(), err_arg.refSelf(), "%s", err_desc.c_str());
+            return QoreValue();
+        }
+
+        assert(state == RESOLVED);
+        return result.refSelf();
+    }
+
+    //! Non-blocking check if the future is done (resolved or rejected)
+    DLLLOCAL bool isDone() const {
+        AutoLocker al(&lock);
+        return state != PENDING;
+    }
+
+    //! Non-blocking check if the future was rejected
+    DLLLOCAL bool isError() const {
+        AutoLocker al(&lock);
+        return state == REJECTED;
+    }
+
+    //! Called from Promise destructor: reject if still pending
+    DLLLOCAL void promiseDestroyed(ExceptionSink* xsink) {
+        AutoLocker al(&lock);
+        if (state == PENDING) {
+            err_code = "PROMISE-ERROR";
+            err_desc = "Promise destroyed without setting a value";
+            state = REJECTED;
+            cond.broadcast();
+        }
+    }
+
+    //! Called from Future destructor: wake waiting threads with error
+    DLLLOCAL void futureDestroyed(ExceptionSink* xsink) {
+        AutoLocker al(&lock);
+        if (waiting > 0) {
+            xsink->raiseException("FUTURE-ERROR",
+                "Future deleted while %d thread%s blocked on it",
+                waiting, waiting == 1 ? " is" : "s are");
+            err_code = "FUTURE-ERROR";
+            err_desc = "Future deleted while thread(s) blocked on it";
+            state = REJECTED;
+            cond.broadcast();
+        }
+    }
+
+    //! Mark that the future object has been retrieved
+    DLLLOCAL bool markFutureRetrieved() {
+        AutoLocker al(&lock);
+        if (future_retrieved) {
+            return false;
+        }
+        future_retrieved = true;
+        return true;
+    }
+
+    DLLLOCAL void ref() {
+        ROreference();
+    }
+
+    DLLLOCAL void deref() {
+        if (ROdereference()) {
+            delete this;
+        }
+    }
+
+private:
+    mutable QoreThreadLock lock;
+    QoreCondition cond;
+    QoreValue result;
+    std::string err_code;
+    std::string err_desc;
+    QoreValue err_arg;
+    State state;
+    int waiting;
+    bool future_retrieved;
+};
+
+//! Future class: consumer side of Promise/Future pair
+class QoreFuture : public AbstractPrivateData {
+public:
+    DLLLOCAL QoreFuture(qore_future_private* p) : priv(p) {
+        priv->ref();
+    }
+
+    DLLLOCAL QoreValue get(int64 timeout_ms, ExceptionSink* xsink) {
+        return priv->get(timeout_ms, xsink);
+    }
+
+    DLLLOCAL bool isDone() const {
+        return priv->isDone();
+    }
+
+    DLLLOCAL bool isError() const {
+        return priv->isError();
+    }
+
+    DLLLOCAL void destructor(ExceptionSink* xsink) {
+        priv->futureDestroyed(xsink);
+    }
+
+    using AbstractPrivateData::deref;
+    DLLLOCAL virtual void deref(ExceptionSink* xsink) {
+        if (ROdereference()) {
+            priv->deref();
+            delete this;
+        }
+    }
+
+protected:
+    DLLLOCAL virtual ~QoreFuture() {}
+
+private:
+    qore_future_private* priv;
+};
+
+//! Promise class: producer side of Promise/Future pair
+class QorePromise : public AbstractPrivateData {
+public:
+    DLLLOCAL QorePromise() : priv(new qore_future_private()) {
+    }
+
+    DLLLOCAL void set(QoreValue val, ExceptionSink* xsink) {
+        priv->set(val, xsink);
+    }
+
+    DLLLOCAL void setError(const char* err, const char* desc, QoreValue arg, ExceptionSink* xsink) {
+        priv->setError(err, desc, arg, xsink);
+    }
+
+    DLLLOCAL void setException(ExceptionSink& xs) {
+        priv->setException(xs);
+    }
+
+    DLLLOCAL QoreFuture* getFuture(ExceptionSink* xsink) {
+        if (!priv->markFutureRetrieved()) {
+            xsink->raiseException("PROMISE-ERROR", "Future has already been retrieved from this Promise");
+            return nullptr;
+        }
+        return new QoreFuture(priv);
+    }
+
+    DLLLOCAL void destructor(ExceptionSink* xsink) {
+        priv->promiseDestroyed(xsink);
+    }
+
+    using AbstractPrivateData::deref;
+    DLLLOCAL virtual void deref(ExceptionSink* xsink) {
+        if (ROdereference()) {
+            priv->deref();
+            delete this;
+        }
+    }
+
+    //! Get internal private data (for call_async implementation)
+    DLLLOCAL qore_future_private* getPriv() {
+        return priv;
+    }
+
+protected:
+    DLLLOCAL virtual ~QorePromise() {}
+
+private:
+    qore_future_private* priv;
+};
+
+#endif // _QORE_INTERN_QOREFUTURE_H

--- a/include/qore/intern/QoreSemaphore.h
+++ b/include/qore/intern/QoreSemaphore.h
@@ -1,0 +1,155 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QoreSemaphore.h
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#ifndef _QORE_INTERN_QORESEMAPHORE_H
+#define _QORE_INTERN_QORESEMAPHORE_H
+
+#include <qore/Qore.h>
+#include <qore/QoreCondition.h>
+#include <qore/AbstractPrivateData.h>
+
+//! A counting semaphore for limiting concurrent access to N permits
+class QoreSemaphore : public AbstractPrivateData {
+public:
+    DLLLOCAL QoreSemaphore(int initial_permits) : permits(initial_permits), waiting(0), deleted(false) {
+    }
+
+    //! Acquires a permit, blocking until one is available
+    /** @param timeout_ms timeout in milliseconds; 0 = infinite
+        @param xsink exception sink
+        @param timed_out set to true if the operation timed out (no exception raised for timeout)
+        @return 0 on success, -1 on timeout or error
+    */
+    DLLLOCAL int acquire(int64 timeout_ms, ExceptionSink* xsink, bool& timed_out) {
+        // Convention: timeout_ms <= 0 means infinite; waitWithInterrupt uses -1 for infinite
+        int64 cond_timeout = (timeout_ms <= 0) ? -1 : timeout_ms;
+        timed_out = false;
+
+        AutoLocker al(&lock);
+        ++waiting;
+        while (permits <= 0 && !deleted) {
+            int rc = cond.waitWithInterrupt(&lock, cond_timeout, xsink);
+            if (rc == QORE_COND_RESULT_INTERRUPTED) {
+                --waiting;
+                return -1;
+            }
+            if (deleted) {
+                --waiting;
+                xsink->raiseException("SEMAPHORE-ERROR", "Semaphore has been deleted in another thread");
+                return -1;
+            }
+            if (permits > 0) {
+                break;
+            }
+            if (rc == QORE_COND_RESULT_TIMEOUT) {
+                --waiting;
+                timed_out = true;
+                return -1;
+            }
+        }
+        --waiting;
+
+        if (deleted) {
+            xsink->raiseException("SEMAPHORE-ERROR", "Semaphore has been deleted in another thread");
+            return -1;
+        }
+
+        --permits;
+        return 0;
+    }
+
+    //! Non-blocking acquire attempt
+    DLLLOCAL bool tryAcquire() {
+        AutoLocker al(&lock);
+        if (permits > 0) {
+            --permits;
+            return true;
+        }
+        return false;
+    }
+
+    //! Releases n permits
+    DLLLOCAL void release(int n, ExceptionSink* xsink) {
+        if (n < 1) {
+            xsink->raiseException("SEMAPHORE-ERROR", "Semaphore::release() called with invalid value %d; must be >= 1", n);
+            return;
+        }
+        AutoLocker al(&lock);
+        permits += n;
+        if (n == 1) {
+            cond.signal();
+        } else {
+            cond.broadcast();
+        }
+    }
+
+    //! Returns the current number of available permits
+    DLLLOCAL int availablePermits() const {
+        AutoLocker al(&lock);
+        return permits;
+    }
+
+    //! Returns the number of threads waiting to acquire
+    DLLLOCAL int getWaiting() const {
+        AutoLocker al(&lock);
+        return waiting;
+    }
+
+    //! Called from destructor
+    DLLLOCAL void destructor(ExceptionSink* xsink) {
+        AutoLocker al(&lock);
+        if (waiting > 0) {
+            xsink->raiseException("SEMAPHORE-ERROR",
+                "Semaphore deleted while %d thread%s blocked on it",
+                waiting, waiting == 1 ? " is" : "s are");
+        }
+        deleted = true;
+        cond.broadcast();
+    }
+
+    //! Returns the initial permit count for copy
+    DLLLOCAL int getPermits() const {
+        AutoLocker al(&lock);
+        return permits;
+    }
+
+protected:
+    DLLLOCAL virtual ~QoreSemaphore() {}
+
+private:
+    mutable QoreThreadLock lock;
+    QoreCondition cond;
+    int permits;
+    int waiting;
+    bool deleted;
+};
+
+#endif // _QORE_INTERN_QORESEMAPHORE_H

--- a/include/qore/intern/QoreWaitGroup.h
+++ b/include/qore/intern/QoreWaitGroup.h
@@ -1,0 +1,127 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QoreWaitGroup.h
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#ifndef _QORE_INTERN_QOREWAITGROUP_H
+#define _QORE_INTERN_QOREWAITGROUP_H
+
+#include <qore/Qore.h>
+#include <qore/QoreCondition.h>
+#include <qore/AbstractPrivateData.h>
+
+//! A WaitGroup waits for a collection of tasks to finish
+class QoreWaitGroup : public AbstractPrivateData {
+public:
+    DLLLOCAL QoreWaitGroup() : count(0), waiting(0) {
+    }
+
+    //! Increments the counter by n
+    DLLLOCAL void add(int n, ExceptionSink* xsink) {
+        AutoLocker al(&lock);
+        if (n < 1) {
+            xsink->raiseException("WAITGROUP-ERROR", "WaitGroup::add() called with invalid value %d; must be >= 1", n);
+            return;
+        }
+        if (count == 0 && waiting > 0) {
+            xsink->raiseException("WAITGROUP-ERROR", "WaitGroup::add() called after count reached 0 with waiting threads");
+            return;
+        }
+        count += n;
+    }
+
+    //! Decrements the counter by 1
+    DLLLOCAL void done(ExceptionSink* xsink) {
+        AutoLocker al(&lock);
+        if (count <= 0) {
+            xsink->raiseException("WAITGROUP-ERROR", "WaitGroup::done() called when count is already 0");
+            return;
+        }
+        --count;
+        if (count == 0) {
+            cond.broadcast();
+        }
+    }
+
+    //! Blocks until the counter reaches 0
+    /** @param timeout_ms timeout in milliseconds; 0 = infinite
+        @return 0 on success, -1 on timeout
+    */
+    DLLLOCAL int wait(int64 timeout_ms, ExceptionSink* xsink) {
+        // Convention: timeout_ms <= 0 means infinite; waitWithInterrupt uses -1 for infinite
+        int64 cond_timeout = (timeout_ms <= 0) ? -1 : timeout_ms;
+
+        AutoLocker al(&lock);
+        ++waiting;
+        while (count > 0) {
+            int rc = cond.waitWithInterrupt(&lock, cond_timeout, xsink);
+            if (rc == QORE_COND_RESULT_INTERRUPTED) {
+                --waiting;
+                return -1;
+            }
+            if (count <= 0) {
+                break;
+            }
+            if (rc == QORE_COND_RESULT_TIMEOUT) {
+                --waiting;
+                return -1;
+            }
+        }
+        --waiting;
+        return 0;
+    }
+
+    //! Returns the current count
+    DLLLOCAL int getCount() const {
+        AutoLocker al(&lock);
+        return count;
+    }
+
+    //! Called from destructor
+    DLLLOCAL void destructor(ExceptionSink* xsink) {
+        AutoLocker al(&lock);
+        if (waiting > 0) {
+            xsink->raiseException("WAITGROUP-ERROR",
+                "WaitGroup deleted while %d thread%s blocked on it",
+                waiting, waiting == 1 ? " is" : "s are");
+            cond.broadcast();
+        }
+    }
+
+protected:
+    DLLLOCAL virtual ~QoreWaitGroup() {}
+
+private:
+    mutable QoreThreadLock lock;
+    QoreCondition cond;
+    int count;
+    int waiting;
+};
+
+#endif // _QORE_INTERN_QOREWAITGROUP_H

--- a/lib/QC_AutoSemaphore.qpp
+++ b/lib/QC_AutoSemaphore.qpp
@@ -1,0 +1,171 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_AutoSemaphore.qpp
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#include <qore/Qore.h>
+#include <qore/QoreSandboxManager.h>
+#include "qore/intern/QC_AutoSemaphore.h"
+
+//! A RAII helper for @ref Qore::Thread::Semaphore "Semaphore" for exception-safe acquire/release
+/** AutoSemaphore objects acquire a permit from a @ref Qore::Thread::Semaphore "Semaphore" in the constructor
+    and release it in the destructor, ensuring the permit is released even if exceptions are thrown.
+
+    This class follows the same RAII pattern as @ref Qore::Thread::AutoLock "AutoLock" for
+    @ref Qore::Thread::Mutex "Mutex".
+
+    @par Example: Exception-safe permit management
+    @code{.py}
+Semaphore sem(3);
+
+{
+    AutoSemaphore as(sem);  # acquires permit (blocks if none available)
+    # ... permit is held ...
+    # if an exception is thrown here, the permit is still released
+}  # permit automatically released
+    @endcode
+
+    @par Example: Limiting concurrent access in a function
+    @code{.py}
+our Semaphore db_pool(5);
+
+hash<auto> query_database(string sql) {
+    AutoSemaphore as(db_pool);  # limit to 5 concurrent queries
+    return db.exec(sql);
+    # permit released when function returns or throws
+}
+    @endcode
+
+    @par Example: Manual release and reacquire
+    @code{.py}
+Semaphore sem(1);
+{
+    AutoSemaphore as(sem);
+    # ... do work with permit ...
+    as.release();     # temporarily release permit
+    # ... other threads can acquire now ...
+    as.acquire();     # reacquire permit
+    # ... continue with permit ...
+}  # final release in destructor
+    @endcode
+
+    @see @ref Qore::Thread::Semaphore "Semaphore"
+    @see @ref Qore::Thread::AutoLock "AutoLock"
+
+    @note This class is not available with the @ref PO_NO_THREAD_CLASSES parse option.
+
+    @since %Qore 2.3
+ */
+qclass AutoSemaphore [dom=THREAD_CLASS; arg=QoreAutoSemaphore* as; ns=Qore::Thread];
+
+//! Creates the AutoSemaphore and acquires a permit from the given Semaphore
+/** @param sem the @ref Qore::Thread::Semaphore "Semaphore" to acquire from
+
+    @par Example:
+    @code{.py}
+{
+    AutoSemaphore as(sem);
+    # permit is held
+}
+    @endcode
+
+    @throw SEMAPHORE-ERROR Semaphore has been deleted in another thread
+    @throw SEMAPHORE-TIMEOUT timed out waiting for a permit
+    @throw PROGRAM-INTERRUPTED this exception is thrown if the program has a @ref Qore::SandboxManager "SandboxManager" attached and @ref Qore::SandboxManager::requestInterrupt() "SandboxManager::requestInterrupt()" is called while the constructor is blocked
+ */
+AutoSemaphore::constructor(Semaphore[QoreSemaphore] sem) {
+    // Acquire the semaphore with polling for cancellation support
+    const int poll_ms = 500;
+    while (true) {
+        if (qore_check_cancel(xsink, "semaphore acquire")) {
+            return;
+        }
+        bool timed_out = false;
+        int rc = sem->acquire(poll_ms, xsink, timed_out);
+        if (*xsink) {
+            // Real error (deleted, etc.) — propagate
+            return;
+        }
+        if (rc == 0) {
+            // Acquired — create the AutoSemaphore
+            QoreAutoSemaphore* qas = new QoreAutoSemaphore(sem.release());
+            self->setPrivate(CID_AUTOSEMAPHORE, qas);
+            return;
+        }
+        // timed_out from poll — loop and check cancel again
+    }
+}
+
+//! Releases the permit and destroys the AutoSemaphore
+/** The permit is only released if it is still held.
+
+    @par Example:
+    @code{.py}
+delete as;
+    @endcode
+ */
+AutoSemaphore::destructor() {
+    as->destructor(xsink);
+    as->deref(xsink);
+}
+
+//! Throws an exception; objects of this class cannot be copied
+/** @throw AUTOSEMAPHORE-COPY-ERROR Objects of this class cannot be copied
+ */
+AutoSemaphore::copy() {
+    xsink->raiseException("AUTOSEMAPHORE-COPY-ERROR", "objects of this class cannot be copied");
+}
+
+//! Manually releases the permit
+/** @par Example:
+    @code{.py}
+as.release();
+    @endcode
+
+    @throw AUTOSEMAPHORE-ERROR permit has already been released
+ */
+nothing AutoSemaphore::release() {
+    as->release(xsink);
+}
+
+//! Manually reacquires the permit
+/** @param timeout_ms a @ref timeout_type "timeout" value; 0 (the default) means wait indefinitely
+
+    @par Example:
+    @code{.py}
+as.acquire();
+    @endcode
+
+    @throw AUTOSEMAPHORE-ERROR permit is already acquired
+    @throw SEMAPHORE-ERROR Semaphore has been deleted
+    @throw SEMAPHORE-TIMEOUT timed out waiting for a permit
+ */
+nothing AutoSemaphore::acquire(timeout timeout_ms = 0) {
+    as->acquire(timeout_ms, xsink);
+}

--- a/lib/QC_Channel.qpp
+++ b/lib/QC_Channel.qpp
@@ -1,0 +1,398 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_Channel.qpp
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#include <qore/Qore.h>
+#include <qore/QoreSandboxManager.h>
+#include "qore/intern/QC_Channel.h"
+#include "qore/intern/QC_ChannelIterator.h"
+
+//! A typed channel for inter-thread communication with close semantics
+/** Channel objects provide a Go-style channel for passing values between threads with backpressure
+    and close semantics.
+
+    Channels can be unlimited (capacity = -1), buffered (capacity > 0), or unbuffered (capacity = 0):
+    - @b Unlimited channels have an unbounded buffer; @ref send() never blocks (like @ref Queue
+      but with close semantics)
+    - @b Buffered channels have an internal buffer; @ref send() blocks only when the buffer is full
+    - @b Unbuffered channels provide synchronous handoff; @ref send() blocks until a @ref recv() is ready
+
+    Once closed via @ref close(), no more values can be sent, but remaining buffered values can
+    still be received. After all values are drained, @ref recv() returns @ref NOTHING.
+
+    Channels support iteration via @ref Qore::Thread::ChannelIterator "ChannelIterator",
+    enabling use with @ref foreach:
+    @code{.py}
+foreach auto val in (channel.iterator()) {
+    printf("got: %y\n", val);
+}
+    @endcode
+
+    @par Example: Producer-consumer pipeline
+    @code{.py}
+Channel ch(10);  # buffered channel with capacity 10
+background sub() {
+    for (int i = 0; i < 5; ++i) {
+        ch.send(i);
+    }
+    ch.close();
+}();
+foreach auto val in (ch.iterator()) {
+    printf("received: %d\n", val);
+}
+    @endcode
+
+    @par Example: Unbuffered synchronous handoff
+    @code{.py}
+Channel ch(0);  # unbuffered — send() blocks until recv() is called
+background sub() {
+    ch.send("hello");  # blocks until the main thread calls recv()
+}();
+auto val = ch.recv();  # "hello"
+    @endcode
+
+    @par Example: Multiple producers, single consumer
+    @code{.py}
+Channel ch(20);
+int num_producers = 4;
+Counter done(num_producers);
+
+for (int p = 0; p < num_producers; ++p) {
+    background sub(int id) {
+        for (int i = 0; i < 10; ++i) {
+            ch.send({"producer": id, "item": i});
+        }
+        done.dec();
+    }(p);
+}
+
+# Close channel when all producers are done
+background sub() {
+    done.waitForZero();
+    ch.close();
+}();
+
+# Consume all items from all producers
+foreach auto val in (ch.iterator()) {
+    printf("producer %d: item %d\n", val.producer, val.item);
+}
+    @endcode
+
+    @par Example: Backpressure with timeout
+    @code{.py}
+Channel ch(100);  # bounded buffer for backpressure
+background sub() {
+    while (auto item = get_next_item()) {
+        try {
+            ch.send(item, 10s);  # wait up to 10s for space
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.err == "CHANNEL-TIMEOUT") {
+                printf("consumer too slow, dropping item\n");
+                continue;
+            }
+            rethrow;
+        }
+    }
+    ch.close();
+}();
+    @endcode
+
+    @par Example: Non-blocking send/recv
+    @code{.py}
+Channel ch(5);
+if (ch.trySend(42)) {
+    printf("sent successfully\n");
+} else {
+    printf("channel full or closed\n");
+}
+
+auto result = ch.tryRecv();
+if (exists result) {
+    printf("received: %y\n", result.value);
+} else {
+    printf("nothing available\n");
+}
+    @endcode
+
+    @par Example: Fan-out to multiple workers
+    @code{.py}
+Channel work_ch(50);
+Channel result_ch(50);
+
+# Start workers
+int num_workers = 4;
+Counter worker_done(num_workers);
+for (int w = 0; w < num_workers; ++w) {
+    background sub() {
+        foreach auto item in (work_ch.iterator()) {
+            result_ch.send(process(item));
+        }
+        worker_done.dec();
+    }();
+}
+
+# Feed work
+background sub() {
+    foreach auto item in (items) {
+        work_ch.send(item);
+    }
+    work_ch.close();
+}();
+
+# Close result channel when all workers are done
+background sub() {
+    worker_done.waitForZero();
+    result_ch.close();
+}();
+
+# Collect results
+foreach auto result in (result_ch.iterator()) {
+    printf("result: %y\n", result);
+}
+    @endcode
+
+    @see @ref Qore::Thread::ChannelIterator "ChannelIterator"
+    @see @ref channel_select()
+    @see @ref Qore::Thread::Queue "Queue"
+
+    @note This class is not available with the @ref PO_NO_THREAD_CLASSES parse option.
+
+    @since %Qore 2.3
+ */
+qclass Channel [dom=THREAD_CLASS; arg=QoreChannel* ch; ns=Qore::Thread];
+
+//! Creates the Channel with the given capacity
+/** @param capacity the buffer capacity; -1 = unlimited (unbounded buffer), 0 = unbuffered
+    (synchronous handoff), > 0 = buffered with backpressure
+
+    @par Example:
+    @code{.py}
+Channel ch(10);  # buffered with capacity 10
+Channel sync_ch(0);  # unbuffered
+Channel unlimited(-1);  # unlimited buffer (like Queue but with close semantics)
+    @endcode
+
+    @throw CHANNEL-ERROR capacity less than -1
+
+    @since %Qore 2.3
+ */
+Channel::constructor(int capacity = 0) {
+    if (capacity < -1) {
+        xsink->raiseException("CHANNEL-ERROR",
+            "Channel::constructor() called with invalid capacity " QLLD
+            "; must be >= -1 (-1 = unlimited, 0 = unbuffered, > 0 = buffered)", capacity);
+        return;
+    }
+    self->setPrivate(CID_CHANNEL, new QoreChannel(capacity));
+}
+
+//! Destroys the Channel
+/** Closes the channel and wakes all blocked threads. Remaining values are discarded.
+
+    @throw CHANNEL-ERROR Object deleted while threads blocked on it
+ */
+Channel::destructor() {
+    ch->destructor(xsink);
+    ch->deref(xsink);
+}
+
+//! Throws an exception; Channel objects cannot be copied
+/** @throw CHANNEL-COPY-ERROR Objects of this class cannot be copied
+ */
+Channel::copy() {
+    xsink->raiseException("CHANNEL-COPY-ERROR", "objects of this class cannot be copied");
+}
+
+//! Sends a value into the channel, blocking if the channel is full
+/** @param value the value to send
+    @param timeout_ms a @ref timeout_type "timeout" value; 0 (the default) means wait indefinitely
+
+    @par Example:
+    @code{.py}
+ch.send(42);
+    @endcode
+
+    @throw CHANNEL-CLOSED channel is closed
+    @throw CHANNEL-ERROR channel deleted in another thread
+    @throw CHANNEL-TIMEOUT timed out waiting to send
+    @throw PROGRAM-INTERRUPTED interrupted by SandboxManager
+ */
+nothing Channel::send(auto value, timeout timeout_ms = 0) {
+    ch->send(value.refSelf(), timeout_ms, xsink);
+}
+
+//! Receives a value from the channel, blocking until a value is available
+/** @param timeout_ms a @ref timeout_type "timeout" value; 0 (the default) means wait indefinitely
+
+    @return the received value, or @ref NOTHING if the channel is closed and drained
+
+    @par Example:
+    @code{.py}
+auto val = ch.recv();
+    @endcode
+
+    @throw CHANNEL-ERROR channel deleted in another thread
+    @throw CHANNEL-TIMEOUT timed out waiting to receive
+    @throw PROGRAM-INTERRUPTED interrupted by SandboxManager
+ */
+auto Channel::recv(timeout timeout_ms = 0) {
+    bool timed_out = false;
+    bool has_value = false;
+    QoreValue rv = ch->recv(timeout_ms, xsink, timed_out, has_value);
+    if (timed_out && !*xsink) {
+        xsink->raiseException("CHANNEL-TIMEOUT",
+            "timed out after " QLLD "ms waiting to receive from channel", (int64)timeout_ms);
+    }
+    return rv;
+}
+
+//! Attempts to send a value without blocking
+/** @param value the value to send
+
+    @return @ref True if the value was sent, @ref False if the channel is full or closed
+
+    @par Example:
+    @code{.py}
+if (ch.trySend(42)) {
+    printf("sent!\n");
+}
+    @endcode
+ */
+bool Channel::trySend(auto value) {
+    QoreValue v = value.refSelf();
+    if (ch->trySend(v)) {
+        return true;
+    }
+    v.discard(xsink);
+    return false;
+}
+
+//! Attempts to receive a value without blocking
+/** @return a hash with \c "value" (the received value) and \c "has_value" (\c True) if a value
+    was received, or @ref NOTHING if no value is available
+
+    This allows distinguishing between an empty channel and a channel that contains @ref NOTHING.
+
+    @par Example:
+    @code{.py}
+auto result = ch.tryRecv();
+if (exists result) {
+    printf("received: %y\n", result.value);
+}
+    @endcode
+ */
+auto Channel::tryRecv() {
+    bool has_value = false;
+    QoreValue rv = ch->tryRecv(has_value);
+    if (!has_value) {
+        return QoreValue();
+    }
+    QoreHashNode* h = new QoreHashNode(autoTypeInfo);
+    h->setKeyValue("value", rv, xsink);
+    h->setKeyValue("has_value", true, xsink);
+    return h;
+}
+
+//! Closes the channel; remaining values can still be received
+/** After closing, @ref send() will throw \c CHANNEL-CLOSED. Remaining buffered values
+    can still be received via @ref recv().
+
+    @par Example:
+    @code{.py}
+ch.close();
+    @endcode
+ */
+nothing Channel::close() {
+    ch->close();
+}
+
+//! Returns @ref True if the channel is closed
+/** @return @ref True if the channel is closed
+
+    @par Example:
+    @code{.py}
+if (ch.isClosed()) { ... }
+    @endcode
+ */
+bool Channel::isClosed() [flags=CONSTANT] {
+    return ch->isClosed();
+}
+
+//! Returns the number of buffered values
+/** @return the number of values currently in the buffer
+
+    @par Example:
+    @code{.py}
+int s = ch.size();
+    @endcode
+ */
+int Channel::size() [flags=CONSTANT] {
+    return ch->size();
+}
+
+//! Returns the channel capacity
+/** @return the maximum buffer capacity (-1 for unlimited, 0 for unbuffered channels)
+
+    @par Example:
+    @code{.py}
+int c = ch.capacity();
+    @endcode
+ */
+int Channel::capacity() [flags=CONSTANT] {
+    return ch->capacity();
+}
+
+//! Returns @ref True if the channel buffer is empty
+/** @return @ref True if the buffer is empty
+
+    @par Example:
+    @code{.py}
+if (ch.empty()) { ... }
+    @endcode
+ */
+bool Channel::empty() [flags=CONSTANT] {
+    return ch->empty();
+}
+
+//! Returns a @ref Qore::Thread::ChannelIterator "ChannelIterator" for this channel
+/** Enables @ref foreach iteration over the channel until it is closed and drained.
+
+    @return a ChannelIterator for this channel
+
+    @par Example:
+    @code{.py}
+foreach auto val in (ch.iterator()) {
+    printf("got: %y\n", val);
+}
+    @endcode
+ */
+ChannelIterator Channel::iterator() {
+    return new QoreObject(QC_CHANNELITERATOR, getProgram(), new QoreChannelIterator(ch));
+}

--- a/lib/QC_ChannelIterator.qpp
+++ b/lib/QC_ChannelIterator.qpp
@@ -1,0 +1,131 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_ChannelIterator.qpp
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#include <qore/Qore.h>
+#include "qore/intern/QC_ChannelIterator.h"
+
+//! An iterator for @ref Qore::Thread::Channel "Channel" objects that enables @ref foreach iteration
+/** This iterator calls @ref Qore::Thread::Channel::recv() "Channel::recv()" in each call to @ref next().
+    When the channel is closed and all values are drained, @ref next() returns @ref False.
+
+    @par Example: Using foreach
+    @code{.py}
+Channel ch(10);
+background sub() {
+    for (int i = 0; i < 5; ++i) {
+        ch.send(i);
+    }
+    ch.close();
+}();
+foreach auto val in (ch.iterator()) {
+    printf("received: %y\n", val);
+}
+    @endcode
+
+    @par Example: Using while loop
+    @code{.py}
+ChannelIterator it(ch);
+while (it.next()) {
+    printf("value: %y\n", it.getValue());
+}
+    @endcode
+
+    @see @ref Qore::Thread::Channel "Channel"
+
+    @note This class is not available with the @ref PO_NO_THREAD_CLASSES parse option.
+
+    @since %Qore 2.3
+ */
+qclass ChannelIterator [dom=THREAD_CLASS; arg=QoreChannelIterator* i; ns=Qore::Thread; vparent=AbstractIterator];
+
+//! Creates the ChannelIterator for the given Channel
+/** @param channel the @ref Qore::Thread::Channel "Channel" to iterate
+
+    @par Example:
+    @code{.py}
+ChannelIterator it(channel);
+    @endcode
+ */
+ChannelIterator::constructor(Channel[QoreChannel] channel) {
+    self->setPrivate(CID_CHANNELITERATOR, new QoreChannelIterator(channel.release(), true));
+}
+
+//! Throws an exception; ChannelIterator objects cannot be copied
+/** @throw CHANNELITERATOR-COPY-ERROR Objects of this class cannot be copied
+ */
+ChannelIterator::copy() {
+    xsink->raiseException("CHANNELITERATOR-COPY-ERROR", "objects of this class cannot be copied");
+}
+
+//! Moves the iterator to the next value; blocks until a value is available or the channel is closed
+/** @return @ref True if a value was received, @ref False if the channel is closed and drained
+
+    @par Example:
+    @code{.py}
+while (it.next()) {
+    printf("value: %y\n", it.getValue());
+}
+    @endcode
+ */
+bool ChannelIterator::next() {
+    return i->next(xsink);
+}
+
+//! Returns the current value
+/** @return the current value
+
+    @par Example:
+    @code{.py}
+auto val = it.getValue();
+    @endcode
+
+    @throw INVALID-ITERATOR iterator is not pointing at a valid element
+ */
+auto ChannelIterator::getValue() [flags=RET_VALUE_ONLY] {
+    if (i->checkValid(xsink)) {
+        return QoreValue();
+    }
+    return i->getValue();
+}
+
+//! Returns @ref True if the iterator is pointing at a valid element
+/** @return @ref True if valid
+
+    @par Example:
+    @code{.py}
+if (it.valid()) {
+    printf("current value: %y\n", it.getValue());
+}
+    @endcode
+ */
+bool ChannelIterator::valid() [flags=CONSTANT] {
+    return i->valid();
+}

--- a/lib/QC_Future.qpp
+++ b/lib/QC_Future.qpp
@@ -1,0 +1,180 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_Future.qpp
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#include <qore/Qore.h>
+#include <qore/QoreSandboxManager.h>
+#include "qore/intern/QC_Future.h"
+
+//! The consumer side of a Promise/Future pair for cross-thread result delivery
+/** Future objects allow a thread to block until a result is available from another thread.
+    A Future can only be created by calling @ref Qore::Thread::Promise::getFuture() "Promise::getFuture()".
+
+    Multiple threads can call @ref get() on the same Future; all will receive the same result.
+
+    @par Example: Basic async computation
+    @code{.py}
+Promise p();
+Future f = p.getFuture();
+background sub() { p.set(42); }();
+auto result = f.get();  # blocks until set, returns 42
+    @endcode
+
+    @par Example: Error handling
+    @code{.py}
+Promise p();
+Future f = p.getFuture();
+background sub() {
+    try {
+        auto result = perform_network_request();
+        p.set(result);
+    } catch (hash<ExceptionInfo> ex) {
+        p.setError(ex.err, ex.desc, ex.arg);
+    }
+}();
+
+try {
+    auto result = f.get(30s);  # wait up to 30 seconds
+    printf("result: %y\n", result);
+} catch (hash<ExceptionInfo> ex) {
+    if (ex.err == "FUTURE-TIMEOUT") {
+        printf("request timed out\n");
+    } else {
+        printf("request failed: %s: %s\n", ex.err, ex.desc);
+    }
+}
+    @endcode
+
+    @par Example: Fan-out / fan-in with multiple Futures
+    @code{.py}
+# Launch multiple async operations
+list<Future> futures = map call_async(auto sub(auto url) {
+    return fetch_url(url);
+}, $1), urls;
+
+# Collect all results
+list<auto> results = map $1.get(), futures;
+    @endcode
+
+    @par Example: Polling with isDone()
+    @code{.py}
+Future f = call_async(sub() { return long_computation(); });
+while (!f.isDone()) {
+    printf("still working...\n");
+    sleep(1s);
+}
+if (f.isError()) {
+    printf("computation failed\n");
+} else {
+    printf("result: %y\n", f.get());
+}
+    @endcode
+
+    @see @ref Qore::Thread::Promise "Promise"
+    @see @ref call_async()
+
+    @note This class is not available with the @ref PO_NO_THREAD_CLASSES parse option.
+
+    @since %Qore 2.3
+ */
+qclass Future [dom=THREAD_CLASS; arg=QoreFuture* f; ns=Qore::Thread];
+
+//! Throws an exception; Future objects can only be created by calling Promise::getFuture()
+/** @throw FUTURE-ERROR Future objects cannot be created directly
+ */
+Future::constructor() {
+    xsink->raiseException("FUTURE-ERROR", "Future objects can only be created by calling Promise::getFuture()");
+}
+
+//! Destroys the Future object
+/** Note that it is a programming error to delete this object while other threads are blocked on it; in this case an exception is thrown in the deleting thread.
+
+    @throw FUTURE-ERROR Object deleted while other threads blocked on it
+ */
+Future::destructor() {
+    f->destructor(xsink);
+    f->deref(xsink);
+}
+
+//! Throws an exception; Future objects cannot be copied
+/** @throw FUTURE-COPY-ERROR Objects of this class cannot be copied
+ */
+Future::copy() {
+    xsink->raiseException("FUTURE-COPY-ERROR", "objects of this class cannot be copied");
+}
+
+//! Blocks the calling thread until the result is available or an error occurs
+/** @param timeout_ms a @ref timeout_type "timeout" value to wait; integers are interpreted as milliseconds; @ref relative_dates "relative date/time values" are interpreted literally (with a resolution of milliseconds); 0 (the default) means wait indefinitely
+
+    @return the value set by the associated Promise
+
+    @par Example:
+    @code{.py}
+auto result = future.get();
+    @endcode
+
+    @throw FUTURE-TIMEOUT timed out waiting for the result
+    @throw FUTURE-ERROR Future object was deleted in another thread while waiting
+    @throw PROMISE-ERROR Promise was destroyed without setting a value
+    @throw PROGRAM-INTERRUPTED this exception is thrown if the program has a @ref Qore::SandboxManager "SandboxManager" attached and @ref Qore::SandboxManager::requestInterrupt() "SandboxManager::requestInterrupt()" is called while the method is blocked
+
+    @note Any exception set via @ref Qore::Thread::Promise::setError() "Promise::setError()" will be re-thrown here
+ */
+auto Future::get(timeout timeout_ms = 0) {
+    return f->get(timeout_ms, xsink);
+}
+
+//! Returns @ref True if the Future has been resolved or rejected
+/** @return @ref True if the result is available (resolved) or an error has been set (rejected)
+
+    @par Example:
+    @code{.py}
+if (future.isDone()) {
+    auto result = future.get();
+}
+    @endcode
+ */
+bool Future::isDone() [flags=CONSTANT] {
+    return f->isDone();
+}
+
+//! Returns @ref True if the Future has been rejected with an error
+/** @return @ref True if an error has been set
+
+    @par Example:
+    @code{.py}
+if (future.isError()) {
+    try { future.get(); } catch (hash<auto> ex) { ... }
+}
+    @endcode
+ */
+bool Future::isError() [flags=CONSTANT] {
+    return f->isError();
+}

--- a/lib/QC_Promise.qpp
+++ b/lib/QC_Promise.qpp
@@ -1,0 +1,186 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_Promise.qpp
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#include <qore/Qore.h>
+#include "qore/intern/QC_Promise.h"
+#include "qore/intern/QC_Future.h"
+
+//! The producer side of a Promise/Future pair for cross-thread result delivery
+/** Promise objects allow a thread to set a result that another thread can retrieve via
+    the associated @ref Qore::Thread::Future "Future" object.
+
+    A Promise can be resolved with a value via @ref set() or rejected with an error via @ref setError().
+    If a Promise is destroyed without being resolved or rejected, the Future will receive a
+    \c PROMISE-ERROR exception.
+
+    @par Example: Basic usage
+    @code{.py}
+Promise p();
+Future f = p.getFuture();
+background sub() { p.set(42); }();
+auto result = f.get();  # blocks until set, returns 42
+    @endcode
+
+    @par Example: Error propagation
+    @code{.py}
+Promise p();
+Future f = p.getFuture();
+background sub() {
+    try {
+        auto data = fetch_data_from_api();
+        p.set(data);
+    } catch (hash<ExceptionInfo> ex) {
+        p.setError(ex.err, ex.desc, ex.arg);
+    }
+}();
+# The exception is re-thrown to the consumer
+auto data = f.get();  # throws the same exception if setError() was called
+    @endcode
+
+    @par Example: Promise destroyed without set
+    @code{.py}
+Future f;
+{
+    Promise p();
+    f = p.getFuture();
+    # p goes out of scope without calling set() or setError()
+}
+try {
+    f.get();
+} catch (hash<ExceptionInfo> ex) {
+    printf("%s: %s\n", ex.err, ex.desc);
+    # prints: PROMISE-ERROR: Promise destroyed without setting a value
+}
+    @endcode
+
+    @par Example: Worker thread pattern
+    @code{.py}
+# Create a pool of async workers
+list<Future> futures = ();
+for (int i = 0; i < 10; ++i) {
+    Promise p();
+    push futures, p.getFuture();
+    background sub(Promise p, int id) {
+        on_error p.setError($1.err, $1.desc);
+        p.set(process_item(id));
+    }(p, i);
+}
+
+# Wait for all results
+for (int i = 0; i < 10; ++i) {
+    printf("item %d: %y\n", i, futures[i].get());
+}
+    @endcode
+
+    @see @ref Qore::Thread::Future "Future"
+    @see @ref call_async()
+
+    @note This class is not available with the @ref PO_NO_THREAD_CLASSES parse option.
+
+    @since %Qore 2.3
+ */
+qclass Promise [dom=THREAD_CLASS; arg=QorePromise* p; ns=Qore::Thread];
+
+//! Creates the Promise object
+/** @par Example:
+    @code{.py}
+Promise p();
+    @endcode
+ */
+Promise::constructor() {
+    self->setPrivate(CID_PROMISE, new QorePromise());
+}
+
+//! Destroys the Promise object
+/** If the Promise has not been resolved or rejected, the associated Future is automatically rejected
+    with a \c PROMISE-ERROR exception.
+ */
+Promise::destructor() {
+    p->destructor(xsink);
+    p->deref(xsink);
+}
+
+//! Throws an exception; Promise objects cannot be copied
+/** @throw PROMISE-COPY-ERROR Objects of this class cannot be copied
+ */
+Promise::copy() {
+    xsink->raiseException("PROMISE-COPY-ERROR", "objects of this class cannot be copied");
+}
+
+//! Resolves the Future with the given value
+/** @param value the value to set as the result of the Future
+
+    @par Example:
+    @code{.py}
+p.set(42);
+    @endcode
+
+    @throw PROMISE-ERROR Promise has already been resolved or rejected
+ */
+nothing Promise::set(auto value) {
+    p->set(value.refSelf(), xsink);
+}
+
+//! Rejects the Future with an error
+/** @param err the error code string
+    @param desc the error description string
+    @param arg an optional error argument
+
+    @par Example:
+    @code{.py}
+p.setError("MY-ERROR", "something went wrong");
+    @endcode
+
+    @throw PROMISE-ERROR Promise has already been resolved or rejected
+ */
+nothing Promise::setError(string err, string desc, auto arg) {
+    p->setError(err->c_str(), desc->c_str(), arg.refSelf(), xsink);
+}
+
+//! Returns the Future associated with this Promise
+/** This method can only be called once per Promise.
+
+    @return the Future object associated with this Promise
+
+    @par Example:
+    @code{.py}
+Future f = p.getFuture();
+    @endcode
+
+    @throw PROMISE-ERROR Future has already been retrieved from this Promise
+ */
+Future Promise::getFuture() {
+    QoreFuture* future = p->getFuture(xsink);
+    if (!future) {
+        return QoreValue();
+    }
+    return new QoreObject(QC_FUTURE, getProgram(), future);
+}

--- a/lib/QC_Semaphore.qpp
+++ b/lib/QC_Semaphore.qpp
@@ -1,0 +1,229 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_Semaphore.qpp
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#include <qore/Qore.h>
+#include <qore/QoreSandboxManager.h>
+#include "qore/intern/QC_Semaphore.h"
+
+//! A counting semaphore for limiting concurrent access to a shared resource
+/** Semaphore objects maintain a set of permits. Each @ref acquire() blocks if necessary until a permit is available,
+    and then takes it. Each @ref release() adds a permit, potentially waking a blocked acquirer.
+
+    Unlike @ref Qore::Thread::Gate "Gate" (which is reentrant/binary), Semaphore supports N permits,
+    making it suitable for controlling access to a pool of resources.
+
+    @par Example: Connection pool limiter
+    @code{.py}
+# Allow at most 3 concurrent database connections
+Semaphore sem(3);
+
+for (int i = 0; i < 10; ++i) {
+    background sub(int id) {
+        sem.acquire();
+        on_exit sem.release();
+        printf("thread %d: using connection\n", id);
+        # ... use database connection ...
+    }(i);
+}
+    @endcode
+
+    @par Example: Rate limiting
+    @code{.py}
+# Limit to 5 concurrent API requests
+Semaphore api_limiter(5);
+
+list<Future> futures = ();
+for (int i = 0; i < 100; ++i) {
+    push futures, call_async(auto sub(auto item) {
+        api_limiter.acquire();
+        on_exit api_limiter.release();
+        return call_external_api(item);
+    }, items[i]);
+}
+
+# Collect results — at most 5 API calls run at any time
+list<auto> results = map $1.get(), futures;
+    @endcode
+
+    @par Example: Non-blocking tryAcquire
+    @code{.py}
+Semaphore sem(3);
+if (sem.tryAcquire()) {
+    on_exit sem.release();
+    # ... use resource ...
+} else {
+    printf("resource busy, trying later\n");
+}
+    @endcode
+
+    @par Example: Timed acquire
+    @code{.py}
+Semaphore sem(1);
+try {
+    sem.acquire(5s);  # wait up to 5 seconds for a permit
+    on_exit sem.release();
+    # ... use resource ...
+} catch (hash<ExceptionInfo> ex) {
+    if (ex.err == "SEMAPHORE-TIMEOUT") {
+        printf("could not acquire permit within 5 seconds\n");
+    }
+}
+    @endcode
+
+    @par Example: RAII with AutoSemaphore
+    @code{.py}
+Semaphore sem(3);
+{
+    AutoSemaphore as(sem);  # blocks until permit acquired
+    # ... permit is held ...
+}  # permit automatically released, even on exception
+    @endcode
+
+    @see @ref Qore::Thread::AutoSemaphore "AutoSemaphore"
+    @see @ref Qore::Thread::Gate "Gate"
+
+    @note This class is not available with the @ref PO_NO_THREAD_CLASSES parse option.
+
+    @since %Qore 2.3
+ */
+qclass Semaphore [dom=THREAD_CLASS; arg=QoreSemaphore* sem; ns=Qore::Thread];
+
+//! Creates a Semaphore with the given number of initial permits
+/** @param permits the initial number of permits; must be >= 0
+
+    @par Example:
+    @code{.py}
+Semaphore sem(5);
+    @endcode
+
+    @throw SEMAPHORE-ERROR negative initial permit count
+ */
+Semaphore::constructor(int permits = 1) {
+    if (permits < 0) {
+        xsink->raiseException("SEMAPHORE-ERROR", "Semaphore::constructor() called with negative permits value " QLLD, permits);
+        return;
+    }
+    self->setPrivate(CID_SEMAPHORE, new QoreSemaphore(permits));
+}
+
+//! Destroys the Semaphore object
+/** Note that it is a programming error to delete this object while other threads are blocked on it.
+
+    @throw SEMAPHORE-ERROR Object deleted while other threads blocked on it
+ */
+Semaphore::destructor() {
+    sem->destructor(xsink);
+    sem->deref(xsink);
+}
+
+//! Creates a new Semaphore with the same number of available permits
+/** @par Example:
+    @code{.py}
+Semaphore new_sem = sem.copy();
+    @endcode
+ */
+Semaphore::copy() {
+    self->setPrivate(CID_SEMAPHORE, new QoreSemaphore(sem->getPermits()));
+}
+
+//! Acquires a permit, blocking until one is available
+/** @param timeout_ms a @ref timeout_type "timeout" value to wait; integers are interpreted as milliseconds; @ref relative_dates "relative date/time values" are interpreted literally (with a resolution of milliseconds); 0 (the default) means wait indefinitely
+
+    @par Example:
+    @code{.py}
+sem.acquire();
+    @endcode
+
+    @throw SEMAPHORE-ERROR Semaphore has been deleted in another thread
+    @throw SEMAPHORE-TIMEOUT timed out waiting for a permit
+    @throw PROGRAM-INTERRUPTED this exception is thrown if the program has a @ref Qore::SandboxManager "SandboxManager" attached and @ref Qore::SandboxManager::requestInterrupt() "SandboxManager::requestInterrupt()" is called while the method is blocked
+ */
+nothing Semaphore::acquire(timeout timeout_ms = 0) {
+    bool timed_out = false;
+    sem->acquire(timeout_ms, xsink, timed_out);
+    if (timed_out && !*xsink) {
+        xsink->raiseException("SEMAPHORE-TIMEOUT",
+            "timed out after " QLLD "ms waiting to acquire semaphore", (int64)timeout_ms);
+    }
+}
+
+//! Attempts to acquire a permit without blocking
+/** @return @ref True if the permit was acquired, @ref False if no permits are available
+
+    @par Example:
+    @code{.py}
+if (sem.tryAcquire()) {
+    on_exit sem.release();
+    # ... use resource ...
+}
+    @endcode
+ */
+bool Semaphore::tryAcquire() {
+    return sem->tryAcquire();
+}
+
+//! Releases one or more permits, potentially waking blocked threads
+/** @param n the number of permits to release; must be >= 1
+
+    @par Example:
+    @code{.py}
+sem.release();
+    @endcode
+
+    @throw SEMAPHORE-ERROR n < 1
+ */
+nothing Semaphore::release(int n = 1) {
+    sem->release(n, xsink);
+}
+
+//! Returns the current number of available permits
+/** @return the current number of available permits
+
+    @par Example:
+    @code{.py}
+int p = sem.availablePermits();
+    @endcode
+ */
+int Semaphore::availablePermits() [flags=CONSTANT] {
+    return sem->availablePermits();
+}
+
+//! Returns the number of threads currently blocked waiting to acquire
+/** @return the number of threads currently blocked on this object
+
+    @par Example:
+    @code{.py}
+int w = sem.getWaiting();
+    @endcode
+ */
+int Semaphore::getWaiting() [flags=CONSTANT] {
+    return sem->getWaiting();
+}

--- a/lib/QC_WaitGroup.qpp
+++ b/lib/QC_WaitGroup.qpp
@@ -1,0 +1,213 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_WaitGroup.qpp
+
+    Qore Programming Language
+
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Note that the Qore library is released under a choice of three open-source
+    licenses: MIT (as above), LGPL 2+, or GPL 2+; see README-LICENSE for more
+    information.
+*/
+
+#include <qore/Qore.h>
+#include <qore/QoreSandboxManager.h>
+#include "qore/intern/QC_WaitGroup.h"
+
+//! A fork-join coordination primitive that waits for a collection of tasks to complete
+/** WaitGroup provides a simple way to wait for multiple background tasks to finish.
+    The typical pattern is:
+    - Call @ref add() before starting each task
+    - Call @ref done() when each task completes
+    - Call @ref wait() to block until all tasks are done
+
+    @par Example: Basic fork-join
+    @code{.py}
+WaitGroup wg();
+wg.add(3);
+for (int i = 0; i < 3; ++i) {
+    background sub() {
+        on_exit wg.done();
+        # ... do work ...
+    }();
+}
+wg.wait();  # blocks until all 3 tasks call done()
+    @endcode
+
+    @par Example: Exception-safe with on_exit
+    @code{.py}
+WaitGroup wg();
+int num_urls = urls.size();
+wg.add(num_urls);
+Mutex m();
+list<auto> results = ();
+
+for (int i = 0; i < num_urls; ++i) {
+    background sub(string url) {
+        on_exit wg.done();
+        auto data = fetch_url(url);
+        {
+            AutoLock al(m);
+            push results, data;
+        }
+    }(urls[i]);
+}
+
+if (wg.wait(30s)) {
+    throw "TIMEOUT", "not all URLs fetched within 30 seconds";
+}
+printf("fetched %d results\n", results.size());
+    @endcode
+
+    @par Example: Multi-stage pipeline
+    @code{.py}
+# Stage 1: Download
+WaitGroup download_wg();
+download_wg.add(files.size());
+for (int i = 0; i < files.size(); ++i) {
+    background sub(string file) {
+        on_exit download_wg.done();
+        download(file);
+    }(files[i]);
+}
+download_wg.wait();
+
+# Stage 2: Process (only starts after all downloads complete)
+WaitGroup process_wg();
+process_wg.add(files.size());
+for (int i = 0; i < files.size(); ++i) {
+    background sub(string file) {
+        on_exit process_wg.done();
+        process(file);
+    }(files[i]);
+}
+process_wg.wait();
+    @endcode
+
+    @par Example: Add tasks incrementally
+    @code{.py}
+WaitGroup wg();
+while (auto item = get_next_work_item()) {
+    wg.add(1);
+    background sub(auto item) {
+        on_exit wg.done();
+        process(item);
+    }(item);
+}
+wg.wait();  # wait for all dynamically added tasks
+    @endcode
+
+    @see @ref Qore::Thread::Counter "Counter"
+
+    @note This class is not available with the @ref PO_NO_THREAD_CLASSES parse option.
+
+    @since %Qore 2.3
+ */
+qclass WaitGroup [dom=THREAD_CLASS; arg=QoreWaitGroup* wg; ns=Qore::Thread];
+
+//! Creates the WaitGroup with an initial count of 0
+/** @par Example:
+    @code{.py}
+WaitGroup wg();
+    @endcode
+ */
+WaitGroup::constructor() {
+    self->setPrivate(CID_WAITGROUP, new QoreWaitGroup());
+}
+
+//! Destroys the WaitGroup object
+/** Note that it is a programming error to delete this object while other threads are blocked on it; in this case an exception is thrown in the deleting thread.
+
+    @throw WAITGROUP-ERROR Object deleted while other threads blocked on it
+ */
+WaitGroup::destructor() {
+    wg->destructor(xsink);
+    wg->deref(xsink);
+}
+
+//! Creates a new WaitGroup with an initial count of 0
+/** @par Example:
+    @code{.py}
+WaitGroup new_wg = wg.copy();
+    @endcode
+ */
+WaitGroup::copy() {
+    self->setPrivate(CID_WAITGROUP, new QoreWaitGroup());
+}
+
+//! Atomically increments the counter
+/** @param n the number of tasks to add; must be >= 1
+
+    @par Example:
+    @code{.py}
+wg.add(3);
+    @endcode
+
+    @throw WAITGROUP-ERROR n < 1 or count was already 0 with waiting threads
+ */
+nothing WaitGroup::add(int n = 1) {
+    wg->add(n, xsink);
+}
+
+//! Decrements the counter by 1 and wakes waiting threads if the count reaches 0
+/** @par Example:
+    @code{.py}
+wg.done();
+    @endcode
+
+    @throw WAITGROUP-ERROR count is already 0
+ */
+nothing WaitGroup::done() {
+    wg->done(xsink);
+}
+
+//! Blocks the calling thread until the counter reaches 0
+/** @param timeout_ms a @ref timeout_type "timeout" value to wait; integers are interpreted as milliseconds; @ref relative_dates "relative date/time values" are interpreted literally (with a resolution of milliseconds); 0 (the default) means wait indefinitely
+
+    @return 0 on success, or -1 if a timeout occurred
+
+    @par Example:
+    @code{.py}
+if (wg.wait(5000))
+    throw "TIMEOUT", "tasks did not complete in 5 seconds";
+    @endcode
+
+    @throw WAITGROUP-ERROR WaitGroup has been deleted in another thread
+    @throw PROGRAM-INTERRUPTED this exception is thrown if the program has a @ref Qore::SandboxManager "SandboxManager" attached and @ref Qore::SandboxManager::requestInterrupt() "SandboxManager::requestInterrupt()" is called while the method is blocked
+
+    @since %Qore 2.3
+ */
+int WaitGroup::wait(timeout timeout_ms = 0) {
+    return wg->wait(timeout_ms, xsink);
+}
+
+//! Returns the current counter value
+/** @return the current counter value
+
+    @par Example:
+    @code{.py}
+int c = wg.getCount();
+    @endcode
+ */
+int WaitGroup::getCount() [flags=CONSTANT] {
+    return wg->getCount();
+}

--- a/lib/QoreNamespace.cpp
+++ b/lib/QoreNamespace.cpp
@@ -74,6 +74,8 @@
 #include "qore/intern/QC_FilePollOperation.h"
 #include "qore/intern/QC_SandboxManager.h"
 #include "qore/intern/QC_QoreParseOptions.h"
+#include "qore/intern/QC_Channel.h"
+#include "qore/intern/QC_ChannelIterator.h"
 
 #include "qore/intern/QC_Datasource.h"
 #include "qore/intern/QC_DatasourcePool.h"
@@ -1222,7 +1224,9 @@ StaticSystemNamespace::StaticSystemNamespace() : RootQoreNamespace(new qore_root
 
     enumHTTP2Mode = init_enum_HTTP2Mode(qns);
 
-    qore_ns_private::addNamespace(qns, get_thread_ns(qns));
+    // add Thread namespace (save pointer for late-bound classes that depend on AbstractIterator)
+    QoreNamespace* thread_ns = get_thread_ns(qns);
+    qore_ns_private::addNamespace(qns, thread_ns);
 
     // pre-init classes
     // serializable class
@@ -1323,6 +1327,12 @@ StaticSystemNamespace::StaticSystemNamespace() : RootQoreNamespace(new qore_root
     qns.addSystemClass(initRangeIteratorClass(qns));
     qns.addSystemClass(initTreeMapClass(qns));
     qns.addSystemClass(initSerializableClass(qns));
+
+    // add ChannelIterator + Channel to Thread namespace now that AbstractIterator is available
+    // preinit Channel first so QC_CHANNEL is available for ChannelIterator's constructor parameter
+    preinitChannelClass();
+    thread_ns->addSystemClass(initChannelIteratorClass(*thread_ns));
+    thread_ns->addSystemClass(initChannelClass(*thread_ns));
 
     init_qore_constants(qns);
 

--- a/lib/ql_thread.qpp
+++ b/lib/ql_thread.qpp
@@ -1861,34 +1861,17 @@ auto channel_select(list<auto> cases, timeout timeout_ms = 0) [dom=THREAD_CLASS,
         return result ? (QoreValue)result : QoreValue();
     }
 
-    // None ready - register external waiter with all channels
-    QoreCondition shared_cond;
-    QoreThreadLock shared_lock;
+    // None ready — create a heap-allocated SelectWaiter and register with all channels.
+    // The waiter has its own lock + condvar + notified flag.  Channel operations
+    // copy the waiter pointer (bumping its refcount) under the channel lock, then
+    // signal the waiter under the waiter's own lock *after* releasing the channel
+    // lock (via the WaiterNotifyHelper RAII pattern).  This eliminates the two-lock
+    // gap that caused lost wakeups in the old polling approach.
+    SelectWaiter* waiter = new SelectWaiter();
 
     for (auto& ci : case_info) {
-        ci.channel->registerExternalWaiter(&shared_cond);
+        ci.channel->registerExternalWaiter(waiter);
     }
-
-    // Re-check immediately after registration — a channel operation may have
-    // completed between the initial try_cases and registerExternalWaiter.
-    result = try_cases(xsink);
-    if (result || *xsink || all_dead) {
-        for (auto& ci : case_info) {
-            ci.channel->deregisterExternalWaiter(&shared_cond);
-            ci.channel->deref(xsink);
-            if (ci.is_send) {
-                ci.send_value.discard(xsink);
-            }
-        }
-        return result ? (QoreValue)result : QoreValue();
-    }
-
-    // Use a bounded internal poll interval to guard against lost wakeups.
-    // Since channel locks and the select's shared_lock are separate, a condvar
-    // broadcast from notifyExternalWaiters() can be lost if it fires between
-    // try_cases() returning and waitWithInterrupt() entering the wait state.
-    // The poll interval bounds the maximum latency for such lost signals.
-    static constexpr int64 SELECT_POLL_MS = 100;
 
     // Helper to get current time in milliseconds since epoch
     auto now_ms = []() -> int64 {
@@ -1902,52 +1885,80 @@ auto channel_select(list<auto> cases, timeout timeout_ms = 0) [dom=THREAD_CLASS,
     int64 deadline_ms = has_deadline ? (now_ms() + (int64)timeout_ms) : 0;
     QoreValue result_val;
 
+    // Deterministic wait loop.
+    //
+    // NOTE: try_cases() is called WITHOUT holding waiter->lock to avoid
+    // self-deadlock: trySend()/tryRecv() use WaiterNotifyHelper which tries
+    // to lock each external waiter — including ours.  Instead, we use the
+    // notified flag to detect signals in the gap between try_cases() and
+    // the condvar wait:
+    //
+    // 1. Clear notified under waiter lock
+    // 2. Release waiter lock
+    // 3. Call try_cases (may acquire channel locks internally)
+    // 4. If success: done
+    // 5. Acquire waiter lock
+    // 6. If notified was set (channel op happened in step 3-5): loop back
+    // 7. Otherwise: wait on condvar (atomically releases waiter lock)
+    //
+    // Lost-wakeup proof: any channel operation between step 1 and step 5
+    // sets notified=true under waiter->lock, so step 6 catches it.
     while (true) {
-        // Compute wait time: min(poll interval, remaining user timeout)
-        int64 wait_ms = SELECT_POLL_MS;
-        if (has_deadline) {
-            int64 remaining_ms = deadline_ms - now_ms();
-            if (remaining_ms <= 0) {
-                break;  // user timeout expired
-            }
-            if (remaining_ms < wait_ms) {
-                wait_ms = remaining_ms;
-            }
-        }
-        // Infinite user timeout: still use bounded poll for lost-wakeup safety
-
-        // Wait for a signal from any channel (with cancellation support)
-        int rc;
+        // Step 1: clear notified flag
         {
-            AutoLocker al(&shared_lock);
-            rc = shared_cond.waitWithInterrupt(&shared_lock, wait_ms, xsink);
+            AutoLocker al(&waiter->lock);
+            waiter->notified = false;
         }
 
-        if (rc == QORE_COND_RESULT_INTERRUPTED) {
-            break;
-        }
-
-        // Try all cases again
+        // Step 3: try all cases (no waiter lock held)
         result = try_cases(xsink);
         if (result || *xsink || all_dead) {
             result_val = result ? (QoreValue)result : QoreValue();
             break;
         }
 
-        // Check user timeout
+        // Step 5-7: check notified flag, wait if needed
+        {
+            AutoLocker al(&waiter->lock);
+            if (!waiter->notified) {
+                if (has_deadline) {
+                    int64 remaining_ms = deadline_ms - now_ms();
+                    if (remaining_ms <= 0) {
+                        break;  // user timeout expired
+                    }
+                    int rc = waiter->cond.waitWithInterrupt(&waiter->lock, remaining_ms, xsink);
+                    if (rc == QORE_COND_RESULT_INTERRUPTED) {
+                        break;
+                    }
+                } else {
+                    int rc = waiter->cond.waitWithInterrupt(&waiter->lock, -1, xsink);
+                    if (rc == QORE_COND_RESULT_INTERRUPTED) {
+                        break;
+                    }
+                }
+            }
+            // If notified or woken by condvar: loop back and try_cases again
+        }
+
+        if (*xsink) {
+            break;
+        }
+
+        // Check deadline after wakeup (condvar wait may have returned on timeout)
         if (has_deadline && now_ms() >= deadline_ms) {
-            break;  // user timeout expired
+            break;
         }
     }
 
-    // Deregister from all channels and clean up
+    // Deregister from all channels and release waiter
     for (auto& ci : case_info) {
-        ci.channel->deregisterExternalWaiter(&shared_cond);
+        ci.channel->deregisterExternalWaiter(waiter);
         ci.channel->deref(xsink);
         if (ci.is_send) {
             ci.send_value.discard(xsink);
         }
     }
+    waiter->deref();
 
     return result_val;
 }

--- a/lib/ql_thread.qpp
+++ b/lib/ql_thread.qpp
@@ -38,9 +38,77 @@
 #include "qore/intern/QC_AbstractThreadResource.h"
 #include "qore/intern/QoreHashNodeIntern.h"
 #include "qore/intern/QC_TimeZone.h"
+#include "qore/intern/QC_Future.h"
+#include "qore/intern/QC_Promise.h"
+#include "qore/intern/QC_Channel.h"
 
 #include <pthread.h>
 #include <thread>
+#include <random>
+#include <algorithm>
+#include <numeric>
+#include <atomic>
+
+// internal struct for call_async thread parameters
+struct CallAsyncParams {
+    ResolvedCallReferenceNode* code;
+    QoreListNode* args;
+    qore_future_private* priv;
+
+    DLLLOCAL CallAsyncParams(ResolvedCallReferenceNode* c, QoreListNode* a, qore_future_private* p)
+        : code(c), args(a), priv(p) {
+        priv->ref();
+    }
+
+    DLLLOCAL ~CallAsyncParams() {
+        assert(!code);
+        assert(!args);
+        priv->deref();
+    }
+
+    DLLLOCAL void del(ExceptionSink* xsink) {
+        code->deref(xsink);
+        code = nullptr;
+        if (args) {
+            args->deref(xsink);
+            args = nullptr;
+        } else {
+            args = nullptr;
+        }
+    }
+};
+
+// thread function for call_async
+static void call_async_thread(ExceptionSink* xsink, void* arg) {
+    CallAsyncParams* params = static_cast<CallAsyncParams*>(arg);
+
+    // Set up program context for the call reference
+    QoreProgram* pgm = params->code->getProgram();
+    if (pgm) {
+        QoreExternalProgramContextHelper pch(xsink, pgm);
+        if (!*xsink) {
+            QoreValue rv = params->code->execValue(params->args, xsink);
+            if (*xsink) {
+                // Capture exception info from the sink
+                ExceptionSink xs;
+                xs.assimilate(*xsink);
+                params->priv->setException(xs);
+            } else {
+                params->priv->set(rv, xsink);
+            }
+        } else {
+            ExceptionSink xs;
+            xs.assimilate(*xsink);
+            params->priv->setException(xs);
+        }
+    } else {
+        params->priv->setError("PROMISE-ERROR", "cannot execute code reference without a Program context",
+            QoreValue(), xsink);
+    }
+
+    params->del(xsink);
+    delete params;
+}
 
 extern QoreClass* QC_TIMEZONE;
 
@@ -1059,5 +1127,828 @@ bool thread_cancelled() [dom=THREAD_INFO;flags=CONSTANT] {
 */
 nothing clear_thread_cancel() [dom=THREAD_CONTROL] {
     qore_clear_thread_cancel();
+}
+
+//! Calls the given code in a background thread and returns a Future for the result
+/** This function creates a Promise, spawns a background thread that calls the given function
+    with the given arguments, and returns the associated Future. If the function throws an exception,
+    the exception is captured and re-thrown when @ref Qore::Thread::Future::get() "Future::get()" is called.
+
+    @param callable the code to execute in a background thread
+    @param ... optional arguments to pass to the callable
+
+    @return a @ref Qore::Thread::Future "Future" that will contain the result of the callable
+
+    @par Example: Simple async computation
+    @code{.py}
+Future f = call_async(sub() { return 42; });
+auto result = f.get();  # returns 42
+    @endcode
+
+    @par Example: With arguments
+    @code{.py}
+Future f = call_async(int sub(int x, int y) { return x + y; }, 20, 22);
+assertEq(42, f.get());
+    @endcode
+
+    @par Example: Async I/O with error handling
+    @code{.py}
+Future f = call_async(auto sub(string url) {
+    return HttpClient({"url": url}).get("");
+}, "https://example.com/api/data");
+
+try {
+    auto response = f.get(30s);  # wait up to 30 seconds
+    printf("response: %y\n", response.body);
+} catch (hash<ExceptionInfo> ex) {
+    if (ex.err == "FUTURE-TIMEOUT") {
+        printf("request timed out\n");
+    } else {
+        printf("request failed: %s\n", ex.desc);
+    }
+}
+    @endcode
+
+    @par Example: Fan-out multiple async tasks
+    @code{.py}
+list<Future> futures = map call_async(auto sub(auto item) {
+    return process_item(item);
+}, $1), items;
+
+# Wait for all results
+list<auto> results = map $1.get(), futures;
+    @endcode
+
+    @throw THREAD-CREATION-FAILURE the thread could not be created
+
+    @see @ref Qore::Thread::Future "Future"
+    @see @ref Qore::Thread::Promise "Promise"
+    @see @ref parallel_map()
+
+    @since %Qore 2.3
+*/
+Future call_async(code callable, ...) [dom=THREAD_CLASS,THREAD_CONTROL] {
+    // Get the code reference (callable is const ResolvedCallReferenceNode* from QPP)
+    ResolvedCallReferenceNode* code = const_cast<ResolvedCallReferenceNode*>(callable);
+    code->ref();
+
+    // Get the arguments (everything after the first arg)
+    ReferenceHolder<QoreListNode> call_args(xsink);
+    if (args && args->size() > 1) {
+        call_args = new QoreListNode(autoTypeInfo);
+        for (size_t i = 1; i < args->size(); ++i) {
+            call_args->push(args->getReferencedEntry(i), xsink);
+        }
+    }
+
+    // Create Promise and get Future
+    QorePromise* promise = new QorePromise();
+    qore_future_private* priv = promise->getPriv();
+
+    QoreFuture* future = promise->getFuture(xsink);
+    if (!future) {
+        promise->deref(xsink);
+        return QoreValue();
+    }
+
+    // Create thread params
+    CallAsyncParams* params = new CallAsyncParams(code, call_args.release(), priv);
+
+    // Start background thread
+    int tid = q_start_thread(xsink, call_async_thread, params);
+    if (tid == -1) {
+        params->del(xsink);
+        delete params;
+        promise->deref(xsink);
+        future->deref(xsink);
+        return QoreValue();
+    }
+
+    // We no longer need the promise reference from here - the thread owns it via priv
+    promise->deref(xsink);
+
+    return new QoreObject(QC_FUTURE, getProgram(), future);
+}
+
+// ===== parallel_map / parallel_foreach internal implementation =====
+
+// Shared state for parallel execution workers
+struct ParallelExecState {
+    QoreThreadLock lock;                     // protects error_info
+    const ResolvedCallReferenceNode* func;   // borrowed ref (not owned)
+    const QoreListNode* items;               // borrowed ref
+    std::vector<QoreValue> results;
+    std::atomic<int> next_index{0};
+    int total;
+    std::atomic<bool> has_error{false};
+    QoreHashNode* error_info{nullptr};       // exception info from first failing worker
+    QoreCounter counter;
+    bool collect_results;
+
+    DLLLOCAL ParallelExecState(const ResolvedCallReferenceNode* f, const QoreListNode* l,
+                                int n, int num_threads, bool collect)
+        : func(f), items(l), total(n),
+          counter(num_threads), collect_results(collect) {
+        if (collect) {
+            results.resize(n);
+        }
+    }
+
+    DLLLOCAL ~ParallelExecState() {
+        if (error_info) {
+            error_info->deref(nullptr);
+        }
+    }
+};
+
+// Helper: capture the first exception from a worker thread
+// Uses getExceptionInfo() which properly decrements active_exceptions via catchException()
+static void parallel_capture_exception(ParallelExecState* state, ExceptionSink* xsink) {
+    AutoLocker al(&state->lock);
+    if (!state->has_error.load(std::memory_order_acquire)) {
+        state->has_error.store(true, std::memory_order_release);
+        state->error_info = xsink->getExceptionInfo();
+    } else {
+        xsink->clear();
+    }
+}
+
+static void parallel_exec_worker(ExceptionSink* xsink, void* arg) {
+    ParallelExecState* state = static_cast<ParallelExecState*>(arg);
+
+    QoreProgram* pgm = state->func->getProgram();
+    if (!pgm) {
+        xsink->raiseException("PARALLEL-ERROR",
+            "cannot execute code reference without a Program context");
+        parallel_capture_exception(state, xsink);
+        state->counter.dec(xsink);
+        return;
+    }
+
+    QoreExternalProgramContextHelper pch(xsink, pgm);
+    if (*xsink) {
+        parallel_capture_exception(state, xsink);
+        state->counter.dec(xsink);
+        return;
+    }
+
+    while (true) {
+        // Lock-free work distribution
+        if (state->has_error.load(std::memory_order_acquire)) {
+            break;
+        }
+        int index = state->next_index.fetch_add(1, std::memory_order_relaxed);
+        if (index >= state->total) {
+            break;
+        }
+
+        // Get item value (referenced)
+        QoreValue item = state->items->getReferencedEntry(index);
+
+        // Create single-element arg list
+        ReferenceHolder<QoreListNode> call_args(new QoreListNode(autoTypeInfo), xsink);
+        call_args->push(item, xsink);
+
+        // Execute function
+        QoreValue rv = const_cast<ResolvedCallReferenceNode*>(state->func)->execValue(*call_args, xsink);
+        if (*xsink) {
+            parallel_capture_exception(state, xsink);
+            rv.discard(xsink);
+            break;
+        }
+
+        if (state->collect_results) {
+            // Store result at correct index (no lock needed - unique indices per thread)
+            state->results[index] = rv;
+        } else {
+            rv.discard(xsink);
+        }
+    }
+
+    state->counter.dec(xsink);
+}
+
+// Helper: wait for all workers to complete, signal them to stop on error/cancel
+static void parallel_wait_for_workers(ParallelExecState& state, ExceptionSink* xsink) {
+    int wrc = state.counter.waitForZero(xsink, 0);
+    if (wrc != 0 || *xsink) {
+        // Cancelled or error - signal workers to stop
+        state.has_error.store(true, std::memory_order_release);
+        // Wait for workers to finish deterministically using the non-interruptible
+        // waitForZero() overload.  The ExceptionSink overload cannot be used here
+        // because it calls waitWithInterrupt(), which checks the cancel flag before
+        // waiting — if we got here due to thread cancellation, the flag is still set,
+        // causing immediate return and a tight CPU loop.  The void overload uses plain
+        // cond.wait(), blocking until workers call dec() and the count reaches zero.
+        state.counter.waitForZero();
+    }
+}
+
+//! Applies a function to each element of a list in parallel, returning results in order
+/** The function is applied to each element concurrently using the specified number of threads.
+    Results are returned in the same order as the input list, regardless of completion order.
+
+    If any invocation throws an exception, remaining work is cancelled and the exception
+    is propagated to the caller.
+
+    @param callable the function to apply to each element; takes one argument and returns a value
+    @param items the list of items to process
+    @param threads the number of worker threads; 0 (default) = auto (hardware concurrency)
+
+    @return a list of results in the same order as the input
+
+    @par Example: Basic transform
+    @code{.py}
+list<auto> results = parallel_map(auto sub(auto x) { return x * 2; }, (1, 2, 3, 4, 5));
+# results = (2, 4, 6, 8, 10)
+    @endcode
+
+    @par Example: Parallel HTTP requests
+    @code{.py}
+list<string> urls = ("https://api.example.com/a", "https://api.example.com/b", ...);
+list<auto> responses = parallel_map(auto sub(auto url) {
+    return HttpClient({"url": url}).get("");
+}, urls, 8);  # use 8 worker threads
+    @endcode
+
+    @par Example: Error handling
+    @code{.py}
+try {
+    list<auto> results = parallel_map(auto sub(auto item) {
+        if (!item.valid) {
+            throw "INVALID-ITEM", sprintf("item %y is invalid", item);
+        }
+        return process(item);
+    }, items);
+} catch (hash<ExceptionInfo> ex) {
+    # first exception cancels remaining work and is propagated here
+    printf("parallel processing failed: %s: %s\n", ex.err, ex.desc);
+}
+    @endcode
+
+    @par Example: CPU-bound computation with explicit thread count
+    @code{.py}
+# Hash a large list of passwords with 4 threads
+list<auto> hashes = parallel_map(auto sub(auto pw) {
+    return hash_password(pw);
+}, passwords, 4);
+    @endcode
+
+    @throw PARALLEL-ERROR error starting worker threads or executing function
+    @throw THREAD-CREATION-FAILURE unable to create worker thread
+
+    @see @ref parallel_foreach()
+    @see @ref call_async()
+
+    @since %Qore 2.3
+*/
+list<auto> parallel_map(code callable, list<auto> items, int threads = 0) [dom=THREAD_CLASS,THREAD_CONTROL] {
+    const QoreListNode* l = items;
+    if (!l || l->empty()) {
+        return new QoreListNode(autoTypeInfo);
+    }
+
+    int total = (int)l->size();
+    int num_threads = threads > 0 ? threads : (int)std::thread::hardware_concurrency();
+    if (num_threads <= 0) {
+        num_threads = 4;
+    }
+    if (num_threads > total) {
+        num_threads = total;
+    }
+
+    // Sequential execution for single thread
+    if (num_threads == 1) {
+        ReferenceHolder<QoreListNode> result(new QoreListNode(autoTypeInfo), xsink);
+        for (int i = 0; i < total; ++i) {
+            QoreValue item = l->getReferencedEntry(i);
+            ReferenceHolder<QoreListNode> call_args(new QoreListNode(autoTypeInfo), xsink);
+            call_args->push(item, xsink);
+            QoreValue rv = const_cast<ResolvedCallReferenceNode*>(callable)->execValue(*call_args, xsink);
+            if (*xsink) {
+                rv.discard(xsink);
+                return QoreValue();
+            }
+            result->push(rv, xsink);
+        }
+        return result.release();
+    }
+
+    // Parallel execution
+    ParallelExecState state(callable, l, total, num_threads, true);
+
+    // Spawn worker threads
+    int spawned = 0;
+    for (int i = 0; i < num_threads; ++i) {
+        int tid = q_start_thread(xsink, parallel_exec_worker, &state);
+        if (tid == -1) {
+            break;
+        }
+        ++spawned;
+    }
+
+    if (spawned == 0) {
+        return QoreValue();
+    }
+
+    // Adjust counter if fewer threads were spawned
+    for (int i = spawned; i < num_threads; ++i) {
+        ExceptionSink xs;
+        state.counter.dec(&xs);
+    }
+
+    // Wait for all threads to complete
+    parallel_wait_for_workers(state, xsink);
+
+    // Check for errors
+    if (state.has_error) {
+        // Discard any collected results
+        for (auto& v : state.results) {
+            v.discard(xsink);
+        }
+        // Re-raise the captured exception in the calling thread
+        if (state.error_info) {
+            QoreValue err = state.error_info->getKeyValue("err");
+            QoreValue desc = state.error_info->getKeyValue("desc");
+            QoreValue arg = state.error_info->getKeyValue("arg");
+            xsink->raiseExceptionArg(
+                err.getType() == NT_STRING ? err.get<const QoreStringNode>()->c_str() : "PARALLEL-ERROR",
+                arg.refSelf(),
+                "%s",
+                desc.getType() == NT_STRING ? desc.get<const QoreStringNode>()->c_str()
+                    : "unknown error in parallel execution");
+        } else {
+            xsink->raiseException("PARALLEL-ERROR", "unknown error in parallel execution");
+        }
+        return QoreValue();
+    }
+
+    // Build result list preserving order
+    ReferenceHolder<QoreListNode> result(new QoreListNode(autoTypeInfo), xsink);
+    for (int i = 0; i < total; ++i) {
+        result->push(state.results[i], xsink);
+        state.results[i] = QoreValue();
+    }
+    return result.release();
+}
+
+//! Applies a function to each element of a list in parallel with no return value
+/** The function is applied to each element concurrently. If any invocation throws an exception,
+    remaining work is cancelled and the exception is propagated to the caller.
+
+    @param callable the function to apply to each element; takes one argument
+    @param items the list of items to process
+    @param threads the number of worker threads; 0 (default) = auto (hardware concurrency)
+
+    @par Example: Basic parallel execution
+    @code{.py}
+parallel_foreach(sub(auto x) { printf("processing: %y\n", x); }, (1, 2, 3, 4, 5));
+    @endcode
+
+    @par Example: Parallel file processing
+    @code{.py}
+list<string> files = glob("data/*.csv");
+parallel_foreach(sub(auto file) {
+    auto data = parse_csv(file);
+    write_to_database(data);
+}, files, 4);  # process with 4 threads
+    @endcode
+
+    @par Example: Parallel cleanup with error handling
+    @code{.py}
+try {
+    parallel_foreach(sub(auto resource) {
+        resource.cleanup();
+    }, resources);
+} catch (hash<ExceptionInfo> ex) {
+    printf("cleanup failed: %s\n", ex.desc);
+}
+    @endcode
+
+    @throw PARALLEL-ERROR error starting worker threads or executing function
+    @throw THREAD-CREATION-FAILURE unable to create worker thread
+
+    @see @ref parallel_map()
+    @see @ref call_async()
+
+    @since %Qore 2.3
+*/
+nothing parallel_foreach(code callable, list<auto> items, int threads = 0) [dom=THREAD_CLASS,THREAD_CONTROL] {
+    const QoreListNode* l = items;
+    if (!l || l->empty()) {
+        return QoreValue();
+    }
+
+    int total = (int)l->size();
+    int num_threads = threads > 0 ? threads : (int)std::thread::hardware_concurrency();
+    if (num_threads <= 0) {
+        num_threads = 4;
+    }
+    if (num_threads > total) {
+        num_threads = total;
+    }
+
+    // Sequential execution for single thread
+    if (num_threads == 1) {
+        for (int i = 0; i < total; ++i) {
+            QoreValue item = l->getReferencedEntry(i);
+            ReferenceHolder<QoreListNode> call_args(new QoreListNode(autoTypeInfo), xsink);
+            call_args->push(item, xsink);
+            QoreValue rv = const_cast<ResolvedCallReferenceNode*>(callable)->execValue(*call_args, xsink);
+            rv.discard(xsink);
+            if (*xsink) {
+                return QoreValue();
+            }
+        }
+        return QoreValue();
+    }
+
+    // Parallel execution
+    ParallelExecState state(callable, l, total, num_threads, false);
+
+    // Spawn worker threads
+    int spawned = 0;
+    for (int i = 0; i < num_threads; ++i) {
+        int tid = q_start_thread(xsink, parallel_exec_worker, &state);
+        if (tid == -1) {
+            break;
+        }
+        ++spawned;
+    }
+
+    if (spawned == 0) {
+        return QoreValue();
+    }
+
+    // Adjust counter if fewer threads were spawned
+    for (int i = spawned; i < num_threads; ++i) {
+        ExceptionSink xs;
+        state.counter.dec(&xs);
+    }
+
+    // Wait for all threads to complete
+    parallel_wait_for_workers(state, xsink);
+
+    // Propagate errors
+    if (state.has_error) {
+        if (state.error_info) {
+            QoreValue err = state.error_info->getKeyValue("err");
+            QoreValue desc = state.error_info->getKeyValue("desc");
+            QoreValue arg = state.error_info->getKeyValue("arg");
+            xsink->raiseExceptionArg(
+                err.getType() == NT_STRING ? err.get<const QoreStringNode>()->c_str() : "PARALLEL-ERROR",
+                arg.refSelf(),
+                "%s",
+                desc.getType() == NT_STRING ? desc.get<const QoreStringNode>()->c_str()
+                    : "unknown error in parallel execution");
+        } else {
+            xsink->raiseException("PARALLEL-ERROR", "unknown error in parallel execution");
+        }
+    }
+}
+
+// ===== channel_select internal implementation =====
+
+// Internal case info for channel_select
+struct ChannelSelectCase {
+    QoreChannel* channel;
+    bool is_send;
+    QoreValue send_value;
+};
+
+//! Waits on multiple Channel operations, returning when one succeeds
+/** Selects the first ready operation from a list of Channel send/recv cases.
+    If multiple cases are ready simultaneously, one is chosen at random (fairness).
+    If no case is ready, blocks until one becomes available or the timeout expires.
+
+    If all channels in the cases are closed (and empty for recv cases), the function
+    returns @ref NOTHING immediately rather than blocking forever.
+
+    Each case is a hash with the following keys:
+    - \c "channel": a @ref Qore::Thread::Channel "Channel" object
+    - \c "op": \c "send" or \c "recv"
+    - \c "value": (required for \c "send" operations) the value to send
+
+    @param cases a list of case hashes
+    @param timeout_ms a @ref timeout_type "timeout" value; 0 (default) means wait indefinitely
+
+    @return a hash with \c "index" (int, the 0-based case index) and \c "value" (the received value
+    for recv operations, @ref NOTHING for send operations), or @ref NOTHING on timeout or if all
+    channels are dead
+
+    @par Example: Multiplexed receiver
+    @code{.py}
+Channel ch1(10);
+Channel ch2(10);
+
+auto result = channel_select((
+    {"channel": ch1, "op": "recv"},
+    {"channel": ch2, "op": "recv"},
+));
+if (exists result) {
+    printf("received from channel %d: %y\n", result.index, result.value);
+}
+    @endcode
+
+    @par Example: First-available send
+    @code{.py}
+# Send to whichever channel has space first
+Channel fast_ch(1);
+Channel slow_ch(1);
+
+auto result = channel_select((
+    {"channel": fast_ch, "op": "send", "value": data},
+    {"channel": slow_ch, "op": "send", "value": data},
+));
+if (exists result) {
+    printf("sent via channel %d\n", result.index);
+}
+    @endcode
+
+    @par Example: Timeout handling
+    @code{.py}
+Channel work_ch(10);
+Channel cancel_ch(1);
+
+while (True) {
+    auto result = channel_select((
+        {"channel": work_ch, "op": "recv"},
+        {"channel": cancel_ch, "op": "recv"},
+    ), 5s);
+
+    if (!exists result) {
+        printf("no activity for 5 seconds\n");
+        continue;
+    }
+
+    if (result.index == 0) {
+        process_work(result.value);
+    } else {
+        printf("cancellation received\n");
+        break;
+    }
+}
+    @endcode
+
+    @par Example: Mixed send and recv
+    @code{.py}
+Channel input_ch(10);
+Channel output_ch(10);
+auto pending_result = process(input_ch.recv());
+
+# Try to either send our result or receive more input
+auto result = channel_select((
+    {"channel": output_ch, "op": "send", "value": pending_result},
+    {"channel": input_ch, "op": "recv"},
+));
+    @endcode
+
+    @throw CHANNEL-SELECT-ERROR invalid case specification
+    @throw PROGRAM-INTERRUPTED interrupted by SandboxManager
+
+    @see @ref Qore::Thread::Channel "Channel"
+
+    @since %Qore 2.3
+*/
+auto channel_select(list<auto> cases, timeout timeout_ms = 0) [dom=THREAD_CLASS,THREAD_CONTROL] {
+    const QoreListNode* case_list = cases;
+    if (!case_list || case_list->empty()) {
+        xsink->raiseException("CHANNEL-SELECT-ERROR", "channel_select() called with empty cases list");
+        return QoreValue();
+    }
+
+    int num_cases = (int)case_list->size();
+
+    // Parse cases
+    std::vector<ChannelSelectCase> case_info;
+    case_info.reserve(num_cases);
+
+    for (int i = 0; i < num_cases; ++i) {
+        QoreValue entry = case_list->retrieveEntry(i);
+        if (entry.getType() != NT_HASH) {
+            // Clean up already-parsed cases
+            for (auto& ci : case_info) {
+                ci.channel->deref(xsink);
+                if (ci.is_send) {
+                    ci.send_value.discard(xsink);
+                }
+            }
+            xsink->raiseException("CHANNEL-SELECT-ERROR",
+                "channel_select() case %d is not a hash", i);
+            return QoreValue();
+        }
+        const QoreHashNode* h = entry.get<const QoreHashNode>();
+
+        // Get channel
+        QoreValue ch_val = h->getKeyValue("channel");
+        if (ch_val.getType() != NT_OBJECT) {
+            for (auto& ci : case_info) {
+                ci.channel->deref(xsink);
+                if (ci.is_send) {
+                    ci.send_value.discard(xsink);
+                }
+            }
+            xsink->raiseException("CHANNEL-SELECT-ERROR",
+                "channel_select() case %d: 'channel' is not an object", i);
+            return QoreValue();
+        }
+        QoreObject* ch_obj = const_cast<QoreObject*>(ch_val.get<const QoreObject>());
+        QoreChannel* channel = static_cast<QoreChannel*>(
+            ch_obj->getReferencedPrivateData(CID_CHANNEL, xsink));
+        if (*xsink) {
+            for (auto& ci : case_info) {
+                ci.channel->deref(xsink);
+                if (ci.is_send) {
+                    ci.send_value.discard(xsink);
+                }
+            }
+            return QoreValue();
+        }
+
+        // Get operation
+        QoreValue op_val = h->getKeyValue("op");
+        if (op_val.getType() != NT_STRING) {
+            channel->deref(xsink);
+            for (auto& ci : case_info) {
+                ci.channel->deref(xsink);
+                if (ci.is_send) {
+                    ci.send_value.discard(xsink);
+                }
+            }
+            xsink->raiseException("CHANNEL-SELECT-ERROR",
+                "channel_select() case %d: 'op' is not a string", i);
+            return QoreValue();
+        }
+        const QoreStringNode* op_str = op_val.get<const QoreStringNode>();
+        bool is_send = !strcmp(op_str->c_str(), "send");
+        if (!is_send && strcmp(op_str->c_str(), "recv")) {
+            channel->deref(xsink);
+            for (auto& ci : case_info) {
+                ci.channel->deref(xsink);
+                if (ci.is_send) {
+                    ci.send_value.discard(xsink);
+                }
+            }
+            xsink->raiseException("CHANNEL-SELECT-ERROR",
+                "channel_select() case %d: 'op' must be 'send' or 'recv', got '%s'",
+                i, op_str->c_str());
+            return QoreValue();
+        }
+
+        QoreValue send_val;
+        if (is_send) {
+            send_val = h->getKeyValue("value").refSelf();
+        }
+
+        case_info.push_back({channel, is_send, send_val});
+    }
+
+    // Create randomized index order for fairness
+    std::vector<int> indices(num_cases);
+    std::iota(indices.begin(), indices.end(), 0);
+    static thread_local std::mt19937 rng(std::random_device{}());
+
+    // Helper lambda: try all cases non-blocking, return result hash or nullptr
+    // Sets all_dead to true if all channels are in a terminal state (no case can ever succeed)
+    bool all_dead = false;
+    auto try_cases = [&](ExceptionSink* xs) -> QoreHashNode* {
+        std::shuffle(indices.begin(), indices.end(), rng);
+        bool any_alive = false;
+        for (int idx : indices) {
+            auto& ci = case_info[idx];
+            if (ci.is_send) {
+                if (ci.channel->isClosed()) {
+                    continue;  // send to closed channel can never succeed
+                }
+                any_alive = true;
+                QoreValue ref_val = ci.send_value.refSelf();
+                if (ci.channel->trySend(ref_val)) {
+                    QoreHashNode* result = new QoreHashNode(autoTypeInfo);
+                    result->setKeyValue("index", idx, xs);
+                    result->setKeyValue("value", QoreValue(), xs);
+                    return result;
+                }
+                ref_val.discard(xs);
+            } else {
+                bool has_value = false;
+                QoreValue rv = ci.channel->tryRecv(has_value);
+                if (has_value) {
+                    QoreHashNode* result = new QoreHashNode(autoTypeInfo);
+                    result->setKeyValue("index", idx, xs);
+                    result->setKeyValue("value", rv, xs);
+                    return result;
+                }
+                // A recv on a non-closed channel might still succeed later
+                if (!ci.channel->isClosed()) {
+                    any_alive = true;
+                }
+            }
+        }
+        all_dead = !any_alive;
+        return nullptr;
+    };
+
+    // Try non-blocking first
+    QoreHashNode* result = try_cases(xsink);
+    if (result || *xsink || all_dead) {
+        // Clean up
+        for (auto& ci : case_info) {
+            ci.channel->deref(xsink);
+            if (ci.is_send) {
+                ci.send_value.discard(xsink);
+            }
+        }
+        return result ? (QoreValue)result : QoreValue();
+    }
+
+    // None ready - register external waiter with all channels
+    QoreCondition shared_cond;
+    QoreThreadLock shared_lock;
+
+    for (auto& ci : case_info) {
+        ci.channel->registerExternalWaiter(&shared_cond);
+    }
+
+    // Re-check immediately after registration — a channel operation may have
+    // completed between the initial try_cases and registerExternalWaiter.
+    result = try_cases(xsink);
+    if (result || *xsink || all_dead) {
+        for (auto& ci : case_info) {
+            ci.channel->deregisterExternalWaiter(&shared_cond);
+            ci.channel->deref(xsink);
+            if (ci.is_send) {
+                ci.send_value.discard(xsink);
+            }
+        }
+        return result ? (QoreValue)result : QoreValue();
+    }
+
+    // Use a bounded internal poll interval to guard against lost wakeups.
+    // Since channel locks and the select's shared_lock are separate, a condvar
+    // broadcast from notifyExternalWaiters() can be lost if it fires between
+    // try_cases() returning and waitWithInterrupt() entering the wait state.
+    // The poll interval bounds the maximum latency for such lost signals.
+    static constexpr int64 SELECT_POLL_MS = 100;
+
+    // Helper to get current time in milliseconds since epoch
+    auto now_ms = []() -> int64 {
+        int us;
+        int64 secs = q_epoch_us(us);
+        return secs * 1000 + us / 1000;
+    };
+
+    // Track user timeout via deadline
+    bool has_deadline = (timeout_ms > 0);
+    int64 deadline_ms = has_deadline ? (now_ms() + (int64)timeout_ms) : 0;
+    QoreValue result_val;
+
+    while (true) {
+        // Compute wait time: min(poll interval, remaining user timeout)
+        int64 wait_ms = SELECT_POLL_MS;
+        if (has_deadline) {
+            int64 remaining_ms = deadline_ms - now_ms();
+            if (remaining_ms <= 0) {
+                break;  // user timeout expired
+            }
+            if (remaining_ms < wait_ms) {
+                wait_ms = remaining_ms;
+            }
+        }
+        // Infinite user timeout: still use bounded poll for lost-wakeup safety
+
+        // Wait for a signal from any channel (with cancellation support)
+        int rc;
+        {
+            AutoLocker al(&shared_lock);
+            rc = shared_cond.waitWithInterrupt(&shared_lock, wait_ms, xsink);
+        }
+
+        if (rc == QORE_COND_RESULT_INTERRUPTED) {
+            break;
+        }
+
+        // Try all cases again
+        result = try_cases(xsink);
+        if (result || *xsink || all_dead) {
+            result_val = result ? (QoreValue)result : QoreValue();
+            break;
+        }
+
+        // Check user timeout
+        if (has_deadline && now_ms() >= deadline_ms) {
+            break;  // user timeout expired
+        }
+    }
+
+    // Deregister from all channels and clean up
+    for (auto& ci : case_info) {
+        ci.channel->deregisterExternalWaiter(&shared_cond);
+        ci.channel->deref(xsink);
+        if (ci.is_send) {
+            ci.send_value.discard(xsink);
+        }
+    }
+
+    return result_val;
 }
 ///@}

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -53,6 +53,13 @@
 #include "qore/intern/QC_Gate.h"
 #include "qore/intern/QC_Sequence.h"
 #include "qore/intern/QC_Counter.h"
+#include "qore/intern/QC_Channel.h"
+#include "qore/intern/QC_ChannelIterator.h"
+#include "qore/intern/QC_Future.h"
+#include "qore/intern/QC_Promise.h"
+#include "qore/intern/QC_WaitGroup.h"
+#include "qore/intern/QC_Semaphore.h"
+#include "qore/intern/QC_AutoSemaphore.h"
 #include "qore/intern/QC_AutoLock.h"
 #include "qore/intern/QC_AutoGate.h"
 #include "qore/intern/QC_AutoReadLock.h"
@@ -3218,6 +3225,14 @@ QoreNamespace* get_thread_ns(QoreNamespace &qorens) {
     Thread->addSystemClass(initThreadPoolClass(*Thread));
 
     Thread->addSystemClass(initAbstractThreadResourceClass(*Thread));
+
+    Thread->addSystemClass(initFutureClass(*Thread));
+    Thread->addSystemClass(initPromiseClass(*Thread));
+    Thread->addSystemClass(initWaitGroupClass(*Thread));
+    Thread->addSystemClass(initSemaphoreClass(*Thread));
+    Thread->addSystemClass(initAutoSemaphoreClass(*Thread));
+    // NOTE: ChannelIterator + Channel are registered later in QoreNamespace.cpp
+    // after AbstractIterator is available (ChannelIterator depends on vparent=AbstractIterator)
 
     return Thread;
 }

--- a/qlib/BigCommerceDataProvider/BigCommerceWatchDataProviderBase.qc
+++ b/qlib/BigCommerceDataProvider/BigCommerceWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace BigCommerceDataProvider {
 
 #! Base class for BigCommerce polling watch data providers
 public class BigCommerceWatchDataProviderBase inherits BigCommerceDataProviderBase,
-        DataProvider::DelayedObservable {
+        DataProvider::AbstractWatchDataProviderBase {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -48,24 +48,6 @@ public class BigCommerceWatchDataProviderBase inherits BigCommerceDataProviderBa
     }
 
     private {
-        #! Mutex for thread synchronization
-        Mutex lck();
-
-        #! Condition variable for sleeping
-        Condition cond();
-
-        #! Background thread ID
-        int io_tid;
-
-        #! Stop flag
-        bool stop = False;
-
-        #! Poll interval in seconds
-        int poll_secs;
-
-        #! Start date for filtering
-        date start_date;
-
         #! Last check time
         date last_check;
 
@@ -75,87 +57,14 @@ public class BigCommerceWatchDataProviderBase inherits BigCommerceDataProviderBa
 
     #! Creates the object with a REST client
     constructor(BigCommerceRestClient::BigCommerceRestClient rest, *hash<auto> options)
-            : BigCommerceDataProviderBase(rest) {
-        poll_secs = options.poll_interval ?? DefaultPollInterval;
-        if (poll_secs < MinPollInterval) {
-            poll_secs = MinPollInterval;
-        }
-        if (options.start_date) {
-            start_date = options.start_date;
-        }
+            : BigCommerceDataProviderBase(rest),
+              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
+        last_check = options.start_date ?? now_us();
     }
 
     #! Destructor - stops the polling thread
     destructor() {
         stopEventsIntern();
-    }
-
-    #! Called when observers are ready
-    observersReady() {
-        lck.lock();
-        on_exit lck.unlock();
-        if (io_tid) {
-            return;
-        }
-        io_tid = background pollThread();
-    }
-
-    #! Stops event generation
-    stopEvents() {
-        stopEventsIntern();
-    }
-
-    #! Internal method to stop events
-    private stopEventsIntern() {
-        lck.lock();
-        on_exit lck.unlock();
-        stop = True;
-        cond.broadcast();
-        # Wait for the polling thread to exit; no timeout needed since pollThread always broadcasts on exit
-        while (io_tid) {
-            cond.wait(lck);
-        }
-    }
-
-    #! Returns True if events are still being generated
-    bool isActive() {
-        return !stop && io_tid > 0;
-    }
-
-    #! The polling thread
-    private pollThread() {
-        on_exit {
-            lck.lock();
-            on_exit lck.unlock();
-            remove io_tid;
-            cond.broadcast();
-        }
-
-        # Initialize tracking state
-        last_check = start_date ?? now_us();
-
-        while (True) {
-            # Check stop flag under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-            }
-
-            pollOnce();
-
-            # Wait for next poll interval under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-                cond.wait(lck, poll_secs * 1000ms);
-            }
-        }
     }
 
     #! Polls for new records once
@@ -166,7 +75,7 @@ public class BigCommerceWatchDataProviderBase inherits BigCommerceDataProviderBa
 
             foreach hash<auto> record in (records) {
                 # check for shutdown between iterations
-                if (stop) {
+                if (isStopping()) {
                     break;
                 }
                 string id = getRecordId(record);

--- a/qlib/Cin7CoreDataProvider/Cin7CoreCustomerUpdatedWatchDataProvider.qc
+++ b/qlib/Cin7CoreDataProvider/Cin7CoreCustomerUpdatedWatchDataProvider.qc
@@ -63,7 +63,7 @@ public class Cin7CoreCustomerUpdatedWatchDataProvider inherits Cin7CoreWatchData
     }
 
     #! Poll for customer updates
-    list<hash<auto>> pollOnce() {
+    list<hash<auto>> pollOnceImpl() {
         hash<auto> params = {
             "ModifiedSince": since,
             "Page": 1,

--- a/qlib/Cin7CoreDataProvider/Cin7CoreNewPaymentWatchDataProvider.qc
+++ b/qlib/Cin7CoreDataProvider/Cin7CoreNewPaymentWatchDataProvider.qc
@@ -63,7 +63,7 @@ public class Cin7CoreNewPaymentWatchDataProvider inherits Cin7CoreWatchDataProvi
     }
 
     #! Poll for new payments
-    list<hash<auto>> pollOnce() {
+    list<hash<auto>> pollOnceImpl() {
         hash<auto> params = {
             "ModifiedSince": since,
             "Page": 1,

--- a/qlib/Cin7CoreDataProvider/Cin7CoreNewSaleCreditNoteWatchDataProvider.qc
+++ b/qlib/Cin7CoreDataProvider/Cin7CoreNewSaleCreditNoteWatchDataProvider.qc
@@ -63,7 +63,7 @@ public class Cin7CoreNewSaleCreditNoteWatchDataProvider inherits Cin7CoreWatchDa
     }
 
     #! Poll for new authorized credit notes
-    list<hash<auto>> pollOnce() {
+    list<hash<auto>> pollOnceImpl() {
         hash<auto> params = {
             "ModifiedSince": since,
             "Status": "Authorized",

--- a/qlib/Cin7CoreDataProvider/Cin7CoreNewSaleInvoiceWatchDataProvider.qc
+++ b/qlib/Cin7CoreDataProvider/Cin7CoreNewSaleInvoiceWatchDataProvider.qc
@@ -63,7 +63,7 @@ public class Cin7CoreNewSaleInvoiceWatchDataProvider inherits Cin7CoreWatchDataP
     }
 
     #! Poll for new authorized invoices
-    list<hash<auto>> pollOnce() {
+    list<hash<auto>> pollOnceImpl() {
         hash<auto> params = {
             "ModifiedSince": since,
             "Status": "Authorized",

--- a/qlib/Cin7CoreDataProvider/Cin7CoreSaleTrackingWatchDataProvider.qc
+++ b/qlib/Cin7CoreDataProvider/Cin7CoreSaleTrackingWatchDataProvider.qc
@@ -63,7 +63,7 @@ public class Cin7CoreSaleTrackingWatchDataProvider inherits Cin7CoreWatchDataPro
     }
 
     #! Poll for tracking changes
-    list<hash<auto>> pollOnce() {
+    list<hash<auto>> pollOnceImpl() {
         hash<auto> params = {
             "ModifiedSince": since,
             "Page": 1,

--- a/qlib/Cin7CoreDataProvider/Cin7CoreSaleVoidedWatchDataProvider.qc
+++ b/qlib/Cin7CoreDataProvider/Cin7CoreSaleVoidedWatchDataProvider.qc
@@ -63,7 +63,7 @@ public class Cin7CoreSaleVoidedWatchDataProvider inherits Cin7CoreWatchDataProvi
     }
 
     #! Poll for voided sales
-    list<hash<auto>> pollOnce() {
+    list<hash<auto>> pollOnceImpl() {
         hash<auto> params = {
             "ModifiedSince": since,
             "Status": "Voided",

--- a/qlib/Cin7CoreDataProvider/Cin7CoreStockLevelUpdateWatchDataProvider.qc
+++ b/qlib/Cin7CoreDataProvider/Cin7CoreStockLevelUpdateWatchDataProvider.qc
@@ -63,7 +63,7 @@ public class Cin7CoreStockLevelUpdateWatchDataProvider inherits Cin7CoreWatchDat
     }
 
     #! Poll for stock level changes
-    list<hash<auto>> pollOnce() {
+    list<hash<auto>> pollOnceImpl() {
         hash<auto> params = {
             "ModifiedSince": since,
             "Page": 1,

--- a/qlib/Cin7CoreDataProvider/Cin7CoreSupplierUpdatedWatchDataProvider.qc
+++ b/qlib/Cin7CoreDataProvider/Cin7CoreSupplierUpdatedWatchDataProvider.qc
@@ -63,7 +63,7 @@ public class Cin7CoreSupplierUpdatedWatchDataProvider inherits Cin7CoreWatchData
     }
 
     #! Poll for supplier updates
-    list<hash<auto>> pollOnce() {
+    list<hash<auto>> pollOnceImpl() {
         hash<auto> params = {
             "ModifiedSince": since,
             "Page": 1,

--- a/qlib/Cin7CoreDataProvider/Cin7CoreWatchDataProviderBase.qc
+++ b/qlib/Cin7CoreDataProvider/Cin7CoreWatchDataProviderBase.qc
@@ -45,44 +45,39 @@ public const WatchConstructorOptions = Cin7CoreDataProviderBase::BaseConstructor
 
 #! Base class for Cin7Core watch/trigger data providers
 public class Cin7CoreWatchDataProviderBase inherits Cin7CoreDataProviderBase,
-        DataProvider::DelayedObservable {
+        DataProvider::AbstractWatchDataProviderBase {
     public {
         #! Constructor options for watch providers
         const WatchProviderConstructorOptions = WatchConstructorOptions;
     }
 
     private {
-        #! Poll interval in seconds
-        int poll_interval;
-
         #! Last poll time for filtering
         date since;
 
         #! Set of seen IDs for deduplication
         hash<string, bool> seen_ids = {};
-
-        #! Whether the observable is running
-        bool running = False;
-
-        #! Background polling thread counter
-        Counter thread_counter();
     }
 
     #! Creates the object with a REST client
     constructor(Cin7CoreRestClient::Cin7CoreRestClient rest, *hash<auto> options)
-            : Cin7CoreDataProviderBase(rest) {
-        initOptions(options);
+            : Cin7CoreDataProviderBase(rest),
+              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
+        since = options.since ?? now_us();
     }
 
     #! Creates the object with a connection
     constructor(Cin7CoreRestClient::Cin7CoreRestConnection conn, *hash<auto> options)
-            : Cin7CoreDataProviderBase(conn) {
-        initOptions(options);
+            : Cin7CoreDataProviderBase(conn),
+              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
+        since = options.since ?? now_us();
     }
 
     #! Creates the object with options
-    constructor(*hash<auto> options) : Cin7CoreDataProviderBase(options) {
-        initOptions(options);
+    constructor(*hash<auto> options)
+            : Cin7CoreDataProviderBase(options),
+              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
+        since = options.since ?? now_us();
     }
 
     #! Destructor
@@ -90,89 +85,46 @@ public class Cin7CoreWatchDataProviderBase inherits Cin7CoreDataProviderBase,
         stopEventsIntern();
     }
 
-    #! Stops event generation
-    stopEvents() {
-        stopEventsIntern();
-    }
+    #! Performs a single polling operation
+    private pollOnce() {
+        date poll_start = now_us();
+        list<hash<auto>> records = pollOnceImpl();
 
-    #! Returns True if events are still being generated
-    bool isActive() {
-        return running;
-    }
-
-    #! Initialize poll options
-    private initOptions(*hash<auto> options) {
-        poll_interval = options.poll_interval ?? DefaultPollInterval;
-        if (poll_interval < MinPollInterval) {
-            poll_interval = MinPollInterval;
-        }
-        since = options.since ?? now_us();
-    }
-
-    #! Start the observer/polling
-    observersReady() {
-        if (running) {
-            return;
-        }
-        running = True;
-        thread_counter.inc();
-        background pollLoop();
-    }
-
-    #! Internal method to stop events
-    private stopEventsIntern() {
-        running = False;
-        thread_counter.waitForZero();
-    }
-
-    #! Main polling loop
-    private pollLoop() {
-        on_exit thread_counter.dec();
-
-        while (running) {
-            try {
-                date poll_start = now_us();
-                list<hash<auto>> records = pollOnce();
-
-                foreach hash<auto> record in (records) {
-                    string id = getRecordId(record);
-                    if (!seen_ids{id}) {
-                        seen_ids{id} = True;
-                        notifyObservers(getEventName(), record);
-                    }
-                }
-
-                # Update since time for next poll
-                since = poll_start;
-
-                # Clean up old seen_ids periodically (keep last 10000)
-                if (seen_ids.size() > 10000) {
-                    # Remove oldest half
-                    int count = 0;
-                    foreach string key in (keys seen_ids) {
-                        if (count++ < 5000) {
-                            remove seen_ids{key};
-                        } else {
-                            break;
-                        }
-                    }
-                }
-            } catch (hash<ExceptionInfo> ex) {
-                @debug(log(LoggerLevel::ERROR, "pollLoop error: %s: %s", ex.err, ex.desc));
+        foreach hash<auto> record in (records) {
+            if (isStopping()) {
+                break;
             }
-
-            # Sleep for poll interval
-            int sleep_ms = poll_interval * 1000;
-            while (running && sleep_ms > 0) {
-                int sleep_chunk = min(1000, sleep_ms);
-                usleep(sleep_chunk * 1000);
-                sleep_ms -= sleep_chunk;
+            string id = getRecordId(record);
+            if (!seen_ids{id}) {
+                seen_ids{id} = True;
+                notifyObservers(getEventName(), record);
             }
         }
+
+        # Update since time for next poll
+        since = poll_start;
+
+        # Clean up old seen_ids periodically (keep last 10000)
+        if (seen_ids.size() > 10000) {
+            # Remove oldest half
+            int count = 0;
+            foreach string key in (keys seen_ids) {
+                if (count++ < 5000) {
+                    remove seen_ids{key};
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    #! Called when a polling error occurs
+    private logPollError(hash<ExceptionInfo> ex) {
+        @debug(log(LoggerLevel::ERROR, "pollLoop error: %s: %s", ex.err, ex.desc));
     }
 
     #! Poll once and return any new records - override in subclasses
-    abstract list<hash<auto>> pollOnce();
+    abstract list<hash<auto>> pollOnceImpl();
 
     #! Get the unique ID from a record - override in subclasses
     abstract string getRecordId(hash<auto> record);
@@ -197,7 +149,7 @@ public class Cin7CoreWatchDataProviderBase inherits Cin7CoreDataProviderBase,
     private auto getExampleEventDataImpl(string event_id) {
         # Try to get real data from the API first
         try {
-            list<hash<auto>> records = pollOnce();
+            list<hash<auto>> records = pollOnceImpl();
             if (records.size() > 0) {
                 return records[0];
             }

--- a/qlib/ConnectionProvider/PollingConnectionMonitor.qc
+++ b/qlib/ConnectionProvider/PollingConnectionMonitor.qc
@@ -79,8 +79,8 @@ public class PollingConnectionMonitor inherits LoggerWrapper {
         #! Condition variable for timer thread signaling
         Condition timer_cond();
 
-        #! Timer thread counter
-        Counter mcnt();
+        #! Timer thread WaitGroup
+        WaitGroup mcnt();
     }
 
     #! Creates the object with an explicit async I/O controller
@@ -157,7 +157,7 @@ public class PollingConnectionMonitor inherits LoggerWrapper {
         foreach string name in (cancel_names) {
             controller.cancelByOwner("pcm:" + name);
         }
-        mcnt.waitForZero();
+        mcnt.wait();
         {
             AutoLock al(m);
             stopping = False;
@@ -187,7 +187,7 @@ public class PollingConnectionMonitor inherits LoggerWrapper {
         foreach string name in (cancel_names) {
             controller.cancelByOwner("pcm:" + name);
         }
-        mcnt.waitForZero();
+        mcnt.wait();
         {
             AutoLock al(m);
             stopping = False;
@@ -198,7 +198,7 @@ public class PollingConnectionMonitor inherits LoggerWrapper {
 
     #! Waits for the monitoring thread to stop if it's running
     waitStop() {
-        mcnt.waitForZero();
+        mcnt.wait();
     }
 
     #! Returns @ref True if the timer thread is running
@@ -373,8 +373,8 @@ public class PollingConnectionMonitor inherits LoggerWrapper {
 
     private startIntern() {
         quit = False;
-        mcnt.inc();
-        on_error mcnt.dec();
+        mcnt.add();
+        on_error mcnt.done();
         tid = background timerThread();
     }
 
@@ -392,7 +392,7 @@ public class PollingConnectionMonitor inherits LoggerWrapper {
                 }
             }
             log(LoggerLevel::INFO, "exiting polling connection monitor timer thread");
-            mcnt.dec();
+            mcnt.done();
         }
 
         while (True) {

--- a/qlib/DataProvider/AbstractDataProvider.qc
+++ b/qlib/DataProvider/AbstractDataProvider.qc
@@ -118,6 +118,11 @@ public hashdecl BaseOptionInfo inherits DisplayDescInfo {
     /** @since %DataProvider 3.3
     */
     *softlist<softstring> on_change;
+
+    #! Will any expression specified by this option be handled by the server?
+    /** @since %DataProvider 3.3
+    */
+    bool server_expression_handling = False;
 }
 
 #! Data provider option info

--- a/qlib/DataProvider/AbstractWatchDataProviderBase.qc
+++ b/qlib/DataProvider/AbstractWatchDataProviderBase.qc
@@ -1,0 +1,144 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! @file AbstractWatchDataProviderBase.qc abstract base class for polling Watch data providers
+
+/*  DataProvider Copyright 2019 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the DataProvider module
+public namespace DataProvider {
+
+#! Abstract base class for polling Watch data providers
+/**
+    Provides common thread lifecycle management for Watch data providers that poll an external
+    API at regular intervals. Subclasses implement @ref pollOnce() to perform the actual data
+    fetching and observer notification.
+
+    Features:
+    - WaitGroup-based thread lifecycle management
+    - Condition-based sleep for instant wakeup on stop (no busy-wait polling)
+    - Clean shutdown with @ref stopEventsIntern()
+    @since DataProvider 3.4
+*/
+public class AbstractWatchDataProviderBase inherits DataProvider::DelayedObservable {
+    private {
+        #! WaitGroup for tracking the polling thread
+        WaitGroup wg();
+
+        #! Mutex for condition-based sleep
+        Mutex sleep_m();
+
+        #! Condition for instant wakeup on stop
+        Condition sleep_cond();
+
+        #! Stop flag
+        bool stop_flag = False;
+
+        #! Poll interval in seconds
+        int poll_interval_secs;
+    }
+
+    #! Creates the object
+    /** @param poll_interval_secs the polling interval in seconds
+    */
+    constructor(int poll_interval_secs) {
+        self.poll_interval_secs = poll_interval_secs;
+    }
+
+    #! Called when all observers have been added to the object
+    /** Starts the background polling thread. Safe to call multiple times; only the first call
+        starts a thread.
+    */
+    observersReady() {
+        AutoLock al(sleep_m);
+        if (stop_flag) {
+            return;
+        }
+        wg.add();
+        background pollThread();
+    }
+
+    #! Called to stop generating events
+    stopEvents() {
+        stopEventsIntern();
+    }
+
+    #! Returns @ref True if the polling thread is running
+    bool isActive() {
+        return !stop_flag;
+    }
+
+    #! Stops event generation and waits for the polling thread to exit
+    private stopEventsIntern() {
+        {
+            AutoLock al(sleep_m);
+            stop_flag = True;
+            sleep_cond.broadcast();
+        }
+        wg.wait();
+    }
+
+    #! Polling thread main loop
+    private pollThread() {
+        on_exit wg.done();
+
+        while (!stop_flag) {
+            try {
+                pollOnce();
+            } catch (hash<ExceptionInfo> ex) {
+                logPollError(ex);
+            }
+
+            # Wait for next poll interval with instant wakeup on stop
+            {
+                AutoLock al(sleep_m);
+                if (!stop_flag) {
+                    sleep_cond.wait(sleep_m, poll_interval_secs * 1000ms);
+                }
+            }
+        }
+    }
+
+    #! Performs a single polling operation
+    /** Subclasses must implement this method to fetch records and call
+        @ref notifyObservers() for each new record.
+    */
+    abstract private pollOnce();
+
+    #! Called when a polling error occurs
+    /** Override this method to provide custom error logging.
+
+        The default implementation silently ignores errors.
+
+        @param ex the exception information
+    */
+    private logPollError(hash<ExceptionInfo> ex) {
+        # Default: ignore; subclasses should override for proper logging
+    }
+
+    #! Returns @ref True if the stop flag is set
+    /** Useful for subclasses to check during long-running pollOnce() operations
+    */
+    private bool isStopping() {
+        return stop_flag;
+    }
+}
+
+}

--- a/qlib/DataProvider/DataProviderActionCatalog.qc
+++ b/qlib/DataProvider/DataProviderActionCatalog.qc
@@ -296,9 +296,6 @@ public hashdecl ActionOptionInfo inherits BaseOptionInfo {
     #! Does this option support expressions?
     bool supports_expressions = True;
 
-    #! Will any expression specified by this option be handled by the server?
-    bool server_expression_handling = False;
-
     #! Option location for record-based data providers and data providers provided by a class
     /** values:
         - \c where: in the where clause
@@ -1531,7 +1528,7 @@ public class DataProviderActionCatalog {
             if (i.value instanceof hash<DataProviderOptionInfo>) {
                 info += i.value{"default_value", "required", "sensitive", "example_value", "ref_data",
                     "element_ref_data", "preselected", "required_groups", "exclusive_with",
-                    "on_change", "metadata", "messages", "icon", "image"}
+                    "on_change", "metadata", "messages", "icon", "image", "server_expression_handling"}
                     + additional_fields;
             } else {
                 info += i.value{"default_value", "required", "sensitive", "example_value", "ref_data",

--- a/qlib/DataProvider/DataProviderPipeline.qc
+++ b/qlib/DataProvider/DataProviderPipeline.qc
@@ -286,8 +286,8 @@ class PipelineQueue {
         #! Parent lock
         Mutex lck;
 
-        #! Parent counter
-        Counter cnt;
+        #! Parent WaitGroup
+        WaitGroup cnt;
 
         #! Queue condition variable
         Condition cond();
@@ -376,22 +376,23 @@ class PipelineQueue {
     }
 
     #! Creates the object
-    constructor(DataProviderPipeline parent, Mutex lck, Counter cnt, int id, int size) {
+    constructor(DataProviderPipeline parent, Mutex lck, WaitGroup cnt, int id, int size) {
         self.size = size;
         self.parent := parent;
         self.lck = lck;
         self.cnt = cnt;
 
-        cnt.inc();
+        cnt.add();
         on_error {
-            cnt.dec();
+            cnt.done();
         }
         self.id = id;
         self.id_str = id.toString();
-        Counter run_cnt(1);
+        WaitGroup run_cnt();
+        run_cnt.add();
         tid = background run(run_cnt);
         # do not return until the background thread is running
-        run_cnt.waitForZero();
+        run_cnt.wait();
     }
 
     #! Returns the pipeline ID
@@ -455,8 +456,8 @@ class PipelineQueue {
     }
 
     #! Processing thread
-    run(Counter run_cnt) {
-        run_cnt.dec();
+    run(WaitGroup run_cnt) {
+        run_cnt.done();
 
         parent.registerThread(self);
 
@@ -513,7 +514,7 @@ class PipelineQueue {
         # destructor in this thread.  The destructor calls
         # cnt.waitForZero(), so cnt must already be decremented to avoid
         # self-deadlock.
-        on_exit cnt.dec();
+        on_exit cnt.done();
 
         # Metrics batch state — flushed at threshold or when the queue goes idle
         int batch_count = 0;
@@ -910,7 +911,7 @@ public class PipelineMetricsCollector {
         #! Previous element metrics snapshot (internal key → field values)
         hash<string, hash<auto>> prev_element_snap;
 
-        #! Optional source element ID; when set, recordPipelineSubmit() also updates source element metrics
+        #! Optional source element ID; when set, recordBatchFlush() also updates source element metrics
         *string source_element_id;
 
         #! Abstract metrics collector
@@ -1504,7 +1505,11 @@ public class PipelineMetricsCollector {
     private hash<PipelineMetricsSnapshot> getSnapshotIntern() {
         date now = now_us();
         float duration_secs = (now - collection_start).durationSecondsFloat();
-        float throughput = duration_secs > 0 ? (total_completed / duration_secs) : 0.0;
+        # Use total_submitted (input rate) for throughput, not total_completed.
+        # In fan-out pipelines, total_completed sums completions from ALL branches
+        # (e.g. 2 branches × 100 records = 200 completed), which inflates the throughput
+        # relative to the actual data generation/submission rate (100 records).
+        float throughput = duration_secs > 0 ? (total_submitted / duration_secs) : 0.0;
 
         # Build output element metrics: remap aliases and filter out queue and mapper elements.
         # Internal element_metrics keys are auto-generated "queue_id:elem_index" IDs.
@@ -1554,7 +1559,8 @@ public class PipelineMetricsCollector {
         int delta_submitted = total_submitted - prev_submitted;
         int delta_completed = total_completed - prev_completed;
         float delta_secs = interval_ms / 1000.0;
-        float delta_throughput = (delta_secs > 0.0) ? (delta_completed / delta_secs) : 0.0;
+        # Use delta_submitted for consistency with pipeline-level throughput (input rate)
+        float delta_throughput = (delta_secs > 0.0) ? (delta_submitted / delta_secs) : 0.0;
 
         hash<string, hash<PipelineElementDelta>> delta_elements();
         foreach string k in (keys element_metrics) {
@@ -1697,8 +1703,8 @@ public class DataProviderPipeline {
         #! Abort flag
         bool abort_flag;
 
-        #! Thread counter
-        Counter cnt();
+        #! Thread WaitGroup
+        WaitGroup cnt();
 
         #! Metrics collector for real-time metrics reporting
         /** @since DataProvider 3.3
@@ -1737,7 +1743,7 @@ public class DataProviderPipeline {
         # create new synchronization objects
         lck = new Mutex();
         seq = new Sequence();
-        cnt = new Counter();
+        cnt = new WaitGroup();
 
         # ensure the copy is reset
         resetIntern();
@@ -1758,7 +1764,7 @@ public class DataProviderPipeline {
     */
     destructor() {
         stopIntern();
-        cnt.waitForZero();
+        cnt.wait();
         if (metrics_collector && !metrics_collector.isShutDown()) {
             metrics_collector.forceCallback();
             metrics_collector.shutdown();

--- a/qlib/DataProvider/QoreFilterRecordsProcessor.qc
+++ b/qlib/DataProvider/QoreFilterRecordsProcessor.qc
@@ -50,6 +50,7 @@ public class QoreFilterRecordsProcessor inherits AbstractDataProvider {
                     "the expression builder",
                 "type": AbstractDataProviderTypeMap."*hash",
                 "required": True,
+                "server_expression_handling": True,
             },
         };
     }

--- a/qlib/DeelDataProvider/DeelWatchDataProviderBase.qc
+++ b/qlib/DeelDataProvider/DeelWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace DeelDataProvider {
 
 #! Base class for Deel polling watch data providers
 public class DeelWatchDataProviderBase inherits DeelDataProviderBase,
-        DataProvider::DelayedObservable {
+        DataProvider::AbstractWatchDataProviderBase {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -48,24 +48,6 @@ public class DeelWatchDataProviderBase inherits DeelDataProviderBase,
     }
 
     private {
-        #! Mutex for thread synchronization
-        Mutex lck();
-
-        #! Condition variable for sleeping
-        Condition cond();
-
-        #! Background thread ID
-        int io_tid;
-
-        #! Stop flag
-        bool stop = False;
-
-        #! Poll interval in seconds
-        int poll_secs;
-
-        #! Start date for filtering (optional; if not set, polling starts from now)
-        *date start_date;
-
         #! Last check time
         date last_check;
 
@@ -78,87 +60,14 @@ public class DeelWatchDataProviderBase inherits DeelDataProviderBase,
 
     #! Creates the object with a REST client
     constructor(DeelRestClient::DeelRestClient rest, *hash<auto> options)
-            : DeelDataProviderBase(rest) {
-        poll_secs = options.poll_interval ?? DefaultPollInterval;
-        if (poll_secs < MinPollInterval) {
-            poll_secs = MinPollInterval;
-        }
-        if (options.start_date) {
-            start_date = options.start_date;
-        }
+            : DeelDataProviderBase(rest),
+              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
+        last_check = options.start_date ?? now_us();
     }
 
     #! Destructor - stops the polling thread
     destructor() {
         stopEventsIntern();
-    }
-
-    #! Called when observers are ready
-    observersReady() {
-        lck.lock();
-        on_exit lck.unlock();
-        if (io_tid) {
-            return;
-        }
-        io_tid = background pollThread();
-    }
-
-    #! Stops event generation
-    stopEvents() {
-        stopEventsIntern();
-    }
-
-    #! Internal method to stop events
-    private stopEventsIntern() {
-        lck.lock();
-        on_exit lck.unlock();
-        stop = True;
-        cond.broadcast();
-        # Wait in a loop until the polling thread exits
-        while (io_tid) {
-            cond.wait(lck, 5s);
-        }
-    }
-
-    #! Returns True if events are still being generated
-    bool isActive() {
-        return !stop && io_tid > 0;
-    }
-
-    #! The polling thread
-    private pollThread() {
-        on_exit {
-            lck.lock();
-            on_exit lck.unlock();
-            remove io_tid;
-            cond.broadcast();
-        }
-
-        # Initialize tracking state
-        last_check = start_date ?? now_us();
-
-        while (True) {
-            # Check stop flag under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-            }
-
-            pollOnce();
-
-            # Wait for next poll interval under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-                cond.wait(lck, poll_secs * 1000ms);
-            }
-        }
     }
 
     #! Polls for new records once
@@ -168,6 +77,9 @@ public class DeelWatchDataProviderBase inherits DeelDataProviderBase,
             date new_last_check = last_check;
 
             foreach hash<auto> record in (records) {
+                if (isStopping()) {
+                    break;
+                }
                 string id = getRecordId(record);
 
                 # Skip if already seen (check both current and previous buckets)

--- a/qlib/DiscordWebSocketClient.qm
+++ b/qlib/DiscordWebSocketClient.qm
@@ -316,8 +316,8 @@ public class DiscordWebSocketClient inherits WebSocketClientWithSerialization {
         #! Resume gateway URL
         string resume_gateway_url;
 
-        #! Heartbeat thread counter
-        Counter heartbeat_cnt();
+        #! Heartbeat thread WaitGroup
+        WaitGroup heartbeat_cnt();
 
         #! Heartbeat thread ID
         int hb_tid;
@@ -573,10 +573,10 @@ hash<auto> h = ws.getInfo();
         if (hb_tid) {
             throw "DISCORD-ERROR", sprintf("Heartbeat thread already running in TID %y", hb_tid);
         }
-        heartbeat_cnt.inc();
+        heartbeat_cnt.add();
         on_error {
             remove hb_tid;
-            heartbeat_cnt.dec();
+            heartbeat_cnt.done();
         }
 %ifdef PO_NO_THREAD_CONTROL
         hb_tid = start_thread(\heartbeatThread());
@@ -599,7 +599,7 @@ hash<auto> h = ws.getInfo();
             heartbeat_cond.signal();
         }
 
-        heartbeat_cnt.waitForZero();
+        heartbeat_cnt.wait();
         AutoLock al(heartbeat_lock);
         remove hb_tid;
         remove hb_stop;
@@ -609,7 +609,7 @@ hash<auto> h = ws.getInfo();
     private heartbeatThread() {
         # in case we went out of scope while running
         on_exit if (self) {
-            heartbeat_cnt.dec();
+            heartbeat_cnt.done();
         }
 
         bool running;

--- a/qlib/ElasticSearchLoggerAppender.qm
+++ b/qlib/ElasticSearchLoggerAppender.qm
@@ -245,8 +245,8 @@ public class ElasticSearchLoggerAppender inherits Logger::LoggerAppenderWithLayo
         #! Flag to signal timer thread to stop
         bool stopTimer = False;
 
-        #! Counter for tracking active flush operations
-        Counter flushCounter(0);
+        #! WaitGroup for tracking active flush operations
+        WaitGroup flushCounter();
 
         #! Whether the appender is open
         bool isOpened = False;
@@ -409,7 +409,7 @@ public class ElasticSearchLoggerAppender inherits Logger::LoggerAppenderWithLayo
         flush();
 
         # Wait for any in-progress flushes
-        flushCounter.waitForZero();
+        flushCounter.wait();
 
         isOpened = False;
     }
@@ -499,8 +499,8 @@ public class ElasticSearchLoggerAppender inherits Logger::LoggerAppenderWithLayo
             return;
         }
 
-        flushCounter.inc();
-        on_exit flushCounter.dec();
+        flushCounter.add();
+        on_exit flushCounter.done();
 
         string indexName = resolveIndexName();
         string bulkBody = "";

--- a/qlib/EmpathicBuildingDataProvider/EmpathicBuildingWatchSensorDataProvider.qc
+++ b/qlib/EmpathicBuildingDataProvider/EmpathicBuildingWatchSensorDataProvider.qc
@@ -31,7 +31,7 @@ public const EVENT_EB_SENSOR = "sensor-event";
 
 #! The EmpathicBuilding watch sensor data provider class
 public class EmpathicBuildingWatchSensorDataProvider inherits EmpathicBuildingDataProviderBase,
-        DataProvider::DelayedObservable {
+        DataProvider::AbstractWatchDataProviderBase {
     public {
         #! Provider info
         const ProviderInfo = <DataProviderInfo>{
@@ -65,36 +65,21 @@ public class EmpathicBuildingWatchSensorDataProvider inherits EmpathicBuildingDa
         #! Sensor data
         hash<auto> sensor;
 
-        #! callable value to start a new thread; must take a callable object as a parameter and return an integer TID
-        *code start_thread;
-
-        #! TID of the I/O thread
-        int tid;
-
-        #! I/O thread counter
-        Counter cnt();
-
-        #! I/O thread lock
-        Mutex m();
-
-        #! I/O thread condition
-        Condition cond();
-
-        #! Stop flag
-        bool stop_flag;
-
-        #! Poll interval in milliseconds
-        timeout poll_interval_ms;
+        #! Last event data for change detection
+        hash<auto> last_event;
     }
 
     #! Create the object from the REST connection
     constructor(RestClient::RestClient rest, *Logger::LoggerInterface logger, hash<auto> org, hash<auto> loc,
-            hash<auto> sensor) : EmpathicBuildingDataProviderBase(rest, logger) {
+            hash<auto> sensor)
+            : EmpathicBuildingDataProviderBase(rest, logger),
+              AbstractWatchDataProviderBase(
+                  max((DataProviderDataContextHelper::getHash().poll_interval_ms ?? PollInterval) / 1000, 1)) {
         self.org = org;
         self.loc = loc;
         self.sensor = sensor;
 
-        poll_interval_ms = DataProviderDataContextHelper::getHash().poll_interval_ms ?? PollInterval;
+        timeout poll_interval_ms = DataProviderDataContextHelper::getHash().poll_interval_ms ?? PollInterval;
         if (poll_interval_ms < 0) {
             throw "POLL-INTERVAL-ARG-ERROR", sprintf("poll_interval_ms %d is negative", poll_interval_ms);
         }
@@ -102,7 +87,7 @@ public class EmpathicBuildingWatchSensorDataProvider inherits EmpathicBuildingDa
 
     #! Destroys the object
     destructor() {
-        stop();
+        stopEventsIntern();
     }
 
     #! Returns the data provider name
@@ -118,81 +103,21 @@ public class EmpathicBuildingWatchSensorDataProvider inherits EmpathicBuildingDa
             EmpathicBuildingSensorDataProvider::getSensorDesc(sensor));
     }
 
-    #! Called when all observers have been added to the object
-    /** This method is meant to trigger event generation
-    */
-    observersReady() {
-        start();
-    }
-
-    #! Called to stop generating events
-    /** Stops polling for new events
-    */
-    stopEvents() {
-        stop();
-    }
-
-    #! Connects and starts receiving messages
-    private start() {
-        hash<auto> info;
-        try {
-            cnt.inc();
-            on_error cnt.dec();
-%ifdef PO_NO_THREAD_CONTROL
-            tid = start_thread(\eventLoop());
-%else
-            tid = start_thread ? start_thread(\ioThread()) : background ioThread();
-%endif
-        } catch (hash<ExceptionInfo> ex) {
-            LoggerWrapper::error("Failed to start I/O thread: %s", get_exception_string(ex));
-            rethrow;
+    #! Performs a single polling operation
+    private pollOnce() {
+        hash<auto> event = getEvent();
+        if (event != last_event) {
+            notifyObservers(EVENT_EB_SENSOR, event);
+            last_event = event;
+        } else {
+            debug("No new event data available");
         }
     }
 
-    #! Stops listening for new events
-    private stop() {
-        if (tid) {
-            stop_flag = True;
-            m.lock();
-            on_exit m.unlock();
-            cond.signal();
-        }
-
-        cnt.waitForZero();
-    }
-
-    #! I/O thread
-    private ioThread() {
-        on_exit {
-            debug("Exiting the I/O thread");
-            cnt.dec();
-        }
-
-        hash<auto> last;
-
-        while (!stop_flag) {
-            hash<auto> info;
-            try {
-                hash<auto> event = getEvent(\info);
-                if (event != last) {
-                    notifyObservers(EVENT_EB_SENSOR, event);
-                    last = event;
-                } else {
-                    debug("No new event data available");
-                }
-            } catch (hash<ExceptionInfo> ex) {
-                LoggerWrapper::error("Failed to acquire sensor data for org %s location %s sensor %s: %s", org.id,
-                    loc.id, sensor.id, get_exception_string(ex));
-            }
-
-            debug("Sleeping for %gs until next poll", poll_interval_ms / 1000n);
-
-            m.lock();
-            on_exit m.unlock();
-            if (!stop_flag) {
-                cond.wait(m, poll_interval_ms);
-            }
-        }
+    #! Called when a polling error occurs
+    private logPollError(hash<ExceptionInfo> ex) {
+        LoggerWrapper::error("Failed to acquire sensor data for org %s location %s sensor %s: %s", org.id,
+            loc.id, sensor.id, get_exception_string(ex));
     }
 
     #! Returns a hash of all supported event types
@@ -215,7 +140,8 @@ public class EmpathicBuildingWatchSensorDataProvider inherits EmpathicBuildingDa
     }
 
     #! Returns event data
-    private hash<auto> getEvent(*reference<hash<auto>> info) {
+    private hash<auto> getEvent() {
+        hash<auto> info;
         hash<auto> event = doRestCommand("GET", "v1/organizations/" + org.id + "/locations/" + loc.id
             + "/sensors/" + sensor.id, NOTHING, \info).body;
         return EmpathicBuildingSensorDataProvider::getSensorData(event);
@@ -234,7 +160,7 @@ public class EmpathicBuildingWatchSensorDataProvider inherits EmpathicBuildingDa
     private auto getExampleEventDataImpl(string event_id) {
         hash<auto> info;
         try {
-            return getEvent(\info);
+            return getEvent();
         } catch (hash<ExceptionInfo> ex) {
             # ensure that any error response body is included in the exception
             hash<auto> ex_arg = info{"request-uri", "response-code", "response-body"};

--- a/qlib/FileLocationHandler/FileLocationHandlerFile.qc
+++ b/qlib/FileLocationHandler/FileLocationHandlerFile.qc
@@ -179,7 +179,7 @@ class FileLocationHandlerFile inherits AbstractFileLocationHandler {
     */
     private OutputStreamWrapper getOutputStreamImpl(string scheme, string location, *hash<auto> opts) {
         return new OutputStreamWrapper(new FileOutputStream(substitute_env_vars(location), opts.append,
-            opts.file_permissions, opts.encoding), new Counter());
+            opts.file_permissions, opts.encoding), new WaitGroup());
     }
 
     #! Gets supported read options

--- a/qlib/FileLocationHandler/FileLocationHandlerFtp.qc
+++ b/qlib/FileLocationHandler/FileLocationHandlerFtp.qc
@@ -178,13 +178,14 @@ class FileLocationHandlerFtp inherits AbstractFileLocationHandler {
 
         StreamPipe pipe(False);
 
-        Counter io_counter(1);
+        WaitGroup io_counter();
+        io_counter.add();
         OutputStreamWrapper rv(pipe.getOutputStream(), io_counter);
 
         # run the I/O operation in the background
         background sub () {
             try {
-                on_exit io_counter.dec();
+                on_exit io_counter.done();
 
                 Qore::InputStream is = pipe.getInputStream();
                 f.put(is, file);

--- a/qlib/FileLocationHandler/FileLocationHandlerHttp.qc
+++ b/qlib/FileLocationHandler/FileLocationHandlerHttp.qc
@@ -242,13 +242,14 @@ class FileLocationHandlerHttp inherits AbstractFileLocationHandler {
 
         StreamPipe pipe(False);
 
-        Counter io_counter(1);
+        WaitGroup io_counter();
+        io_counter.add();
         OutputStreamWrapper rv(pipe.getOutputStream(), io_counter);
 
         # run the I/O operation in the background
         background sub () {
             try {
-                on_exit io_counter.dec();
+                on_exit io_counter.done();
 
                 Qore::InputStream is = pipe.getInputStream();
                 hc.sendChunked(new BinaryOutputStream(), is, opts.method ? opts.method.upr() : "POST", NOTHING, path);

--- a/qlib/FileLocationHandler/FileLocationHandlerSftp.qc
+++ b/qlib/FileLocationHandler/FileLocationHandlerSftp.qc
@@ -191,13 +191,14 @@ class FileLocationHandlerSftp inherits AbstractFileLocationHandler {
 
         StreamPipe pipe(False);
 
-        Counter io_counter(1);
+        WaitGroup io_counter();
+        io_counter.add();
         OutputStreamWrapper rv(pipe.getOutputStream(), io_counter);
 
         # run the I/O operation in the background
         background sub () {
             try {
-                on_exit io_counter.dec();
+                on_exit io_counter.done();
 
                 Qore::InputStream is = pipe.getInputStream();
                 sftp.put(is, file);

--- a/qlib/FileLocationHandler/OutputStramWrapper.qc
+++ b/qlib/FileLocationHandler/OutputStramWrapper.qc
@@ -33,12 +33,12 @@ public class OutputStreamWrapper inherits Qore::OutputStream {
         #! The output stream object
         Qore::OutputStream stream;
 
-        #! The synchronization Counter
-        Qore::Thread::Counter cnt;
+        #! The synchronization WaitGroup
+        Qore::Thread::WaitGroup cnt;
     }
 
     #! Creates the output stream wrapper object
-    constructor(Qore::OutputStream stream, Qore::Thread::Counter cnt) {
+    constructor(Qore::OutputStream stream, Qore::Thread::WaitGroup cnt) {
         self.stream = stream;
         self.cnt = cnt;
     }
@@ -50,7 +50,7 @@ public class OutputStreamWrapper inherits Qore::OutputStream {
 
     #! Wait for any background I/O to complete
     waitForIo() {
-        cnt.waitForZero();
+        cnt.wait();
     }
 
     #! Flushes any buffered (unwritten) bytes, closes the output stream and releases all resources.

--- a/qlib/FilePoller.qm
+++ b/qlib/FilePoller.qm
@@ -275,8 +275,14 @@ public class FilePoller {
         #! polling tid
         int tid;
 
-        #! stop counter
-        Qore::Thread::Counter sc();
+        #! stop WaitGroup
+        Qore::Thread::WaitGroup sc();
+
+        #! sleep mutex for condition-based sleep
+        Qore::Thread::Mutex sleep_m();
+
+        #! sleep condition for instant wakeup on stop
+        Qore::Thread::Condition sleep_cond();
 
         #! regex options
         int reopt;
@@ -484,10 +490,10 @@ public class FilePoller {
         if (runflag)
             return tid;
 
-        sc.waitForZero();
+        sc.wait();
 
         runflag = True;
-        sc.inc();
+        sc.add();
 
 %ifdef PO_NO_THREAD_CONTROL
         return tid = call_function(start_thread, \run());
@@ -513,9 +519,13 @@ public class FilePoller {
         m.lock();
         on_exit m.unlock();
 
-        runflag = False;
+        {
+            AutoLock al(sleep_m);
+            runflag = False;
+            sleep_cond.broadcast();
+        }
 
-        sc.waitForZero();
+        sc.wait();
     }
 
     #! stops the polling operation, returns immediately
@@ -527,7 +537,11 @@ public class FilePoller {
         m.lock();
         on_exit m.unlock();
 
-        runflag = False;
+        {
+            AutoLock al(sleep_m);
+            runflag = False;
+            sleep_cond.broadcast();
+        }
     }
 
     #! Waits indefinitely for the polling operation to stop
@@ -543,7 +557,7 @@ public class FilePoller {
     waitStop() {
         if (gettid() == tid)
             throw "THREAD-ERROR", sprintf("cannot call FilePoller::waitStop() from the event thread (%d)", tid);
-        sc.waitForZero();
+        sc.wait();
     }
 
     #! starts the polling operation inline (not in a background thread)
@@ -562,7 +576,7 @@ public class FilePoller {
             runflag = True;
             tid = gettid();
         }
-        sc.inc();
+        sc.add();
         run();
     }
 
@@ -579,24 +593,40 @@ public class FilePoller {
         return False;
     }
 
-    #! sleeps for the specificed number of seconds
+    #! sleeps for the specified number of seconds
     private fileSleep(softint secs) {
+%ifdef PO_NO_PROCESS_CONTROL
+        # Sandbox mode: must use custom sleep function with polling
         date end = now_us() + seconds(secs);
         while (True) {
-%ifdef PO_NO_PROCESS_CONTROL
             call_function(sleep, 1);
-%else
-            sleep ? call_function(sleep, 1) : Qore::usleep(250ms);
-%endif
             if (!runflag || (now_us() >= end)) {
                 break;
             }
         }
+%else
+        if (sleep) {
+            # Custom sleep function: use polling with custom sleep
+            date end = now_us() + seconds(secs);
+            while (True) {
+                call_function(sleep, 1);
+                if (!runflag || (now_us() >= end)) {
+                    break;
+                }
+            }
+        } else {
+            # Default: condition-based sleep for instant wakeup on stop
+            AutoLock al(sleep_m);
+            if (runflag) {
+                sleep_cond.wait(sleep_m, seconds(secs));
+            }
+        }
+%endif
     }
 
     #! starts the polling operation
     private run() {
-        on_exit sc.dec();
+        on_exit sc.done();
 
         while (runflag) {
             try {

--- a/qlib/FreshBooksDataProvider/FreshBooksWatchDataProviderBase.qc
+++ b/qlib/FreshBooksDataProvider/FreshBooksWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace FreshBooksDataProvider {
 
 #! Base class for FreshBooks polling watch data providers
 public class FreshBooksWatchDataProviderBase inherits FreshBooksDataProviderBase,
-        DataProvider::DelayedObservable {
+        DataProvider::AbstractWatchDataProviderBase {
     public {
         #! Maximum number of seen IDs to track before pruning
         const MaxSeenIds = 10000;
@@ -51,24 +51,6 @@ public class FreshBooksWatchDataProviderBase inherits FreshBooksDataProviderBase
     }
 
     private {
-        #! Mutex for thread synchronization
-        Mutex lck();
-
-        #! Condition variable for sleeping
-        Condition cond();
-
-        #! Background thread ID
-        int io_tid;
-
-        #! Stop flag
-        bool stop = False;
-
-        #! Poll interval in seconds
-        int poll_secs;
-
-        #! Start date for filtering
-        date start_date;
-
         #! Last check time
         date last_check;
 
@@ -78,90 +60,17 @@ public class FreshBooksWatchDataProviderBase inherits FreshBooksDataProviderBase
 
     #! Creates the object with a REST client
     constructor(FreshBooksRestClient::FreshBooksRestClient rest, *hash<auto> options)
-            : FreshBooksDataProviderBase(rest) {
+            : FreshBooksDataProviderBase(rest),
+              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
         if (options.account_id) {
             rest.setAccountId(options.account_id);
         }
-        poll_secs = options.poll_interval ?? DefaultPollInterval;
-        if (poll_secs < MinPollInterval) {
-            poll_secs = MinPollInterval;
-        }
-        if (options.start_date) {
-            start_date = options.start_date;
-        }
+        last_check = options.start_date ?? now_us();
     }
 
     #! Destructor - stops the polling thread
     destructor() {
         stopEventsIntern();
-    }
-
-    #! Called when observers are ready
-    observersReady() {
-        lck.lock();
-        on_exit lck.unlock();
-        if (io_tid) {
-            return;
-        }
-        io_tid = background pollThread();
-    }
-
-    #! Stops event generation
-    stopEvents() {
-        stopEventsIntern();
-    }
-
-    #! Internal method to stop events
-    private stopEventsIntern() {
-        lck.lock();
-        on_exit lck.unlock();
-        stop = True;
-        cond.broadcast();
-        # Wait for the polling thread to exit; no timeout needed since pollThread always broadcasts on exit
-        while (io_tid) {
-            cond.wait(lck);
-        }
-    }
-
-    #! Returns True if events are still being generated
-    bool isActive() {
-        return !stop && io_tid > 0;
-    }
-
-    #! The polling thread
-    private pollThread() {
-        on_exit {
-            lck.lock();
-            on_exit lck.unlock();
-            remove io_tid;
-            cond.broadcast();
-        }
-
-        # Initialize tracking state
-        last_check = start_date ?? now_us();
-
-        while (True) {
-            # Check stop flag under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-            }
-
-            pollOnce();
-
-            # Wait for next poll interval under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-                cond.wait(lck, poll_secs * 1000ms);
-            }
-        }
     }
 
     #! Polls for new records once
@@ -177,7 +86,7 @@ public class FreshBooksWatchDataProviderBase inherits FreshBooksDataProviderBase
 
             foreach hash<auto> record in (records) {
                 # check for shutdown between iterations
-                if (stop) {
+                if (isStopping()) {
                     break;
                 }
                 string id = getRecordId(record);

--- a/qlib/FtpPoller.qm
+++ b/qlib/FtpPoller.qm
@@ -318,8 +318,14 @@ public class FtpPoller {
         #! timeout in ms
         timeout timeout;
 
-        #! stop counter
-        Counter sc();
+        #! stop WaitGroup
+        WaitGroup sc();
+
+        #! sleep mutex for condition-based sleep
+        Mutex sleep_m();
+
+        #! sleep condition for instant wakeup on stop
+        Condition sleep_cond();
 
         #! FtpClient object
         Qore::FtpClient ftp;
@@ -792,10 +798,10 @@ public class FtpPoller {
             return tid;
         }
 
-        sc.waitForZero();
+        sc.wait();
 
         runflag = True;
-        sc.inc();
+        sc.add();
 
 %ifdef PO_NO_THREAD_CONTROL
         return call_function(start_thread, \run());
@@ -811,7 +817,11 @@ public class FtpPoller {
         m.lock();
         on_exit m.unlock();
 
-        runflag = False;
+        {
+            AutoLock al(sleep_m);
+            runflag = False;
+            sleep_cond.broadcast();
+        }
     }
 
     #! stops the polling operation, returns when the polling operation has been stopped
@@ -829,9 +839,13 @@ public class FtpPoller {
         m.lock();
         on_exit m.unlock();
 
-        runflag = False;
+        {
+            AutoLock al(sleep_m);
+            runflag = False;
+            sleep_cond.broadcast();
+        }
 
-        sc.waitForZero();
+        sc.wait();
     }
 
     #! waits indefinitely for the polling operation to stop
@@ -844,7 +858,7 @@ public class FtpPoller {
         if (gettid() == tid) {
             throw "THREAD-ERROR", sprintf("cannot call FtpPoller::waitStop() from the event thread (%d)", tid);
         }
-        sc.waitForZero();
+        sc.wait();
     }
 
     #! starts the polling operation inline (not in a background thread)
@@ -863,7 +877,7 @@ public class FtpPoller {
             runflag = True;
             tid = gettid();
         }
-        sc.inc();
+        sc.add();
         run();
     }
 
@@ -1005,25 +1019,41 @@ public class FtpPoller {
         return event;
     }
 
-    #! sleeps for the specificed number of seconds
+    #! sleeps for the specified number of seconds
     private ftpSleep(softint secs) {
+%ifdef PO_NO_PROCESS_CONTROL
+        # Sandbox mode: must use custom sleep function with polling
         date end = now_us() + seconds(secs);
         while (runflag) {
-%ifdef PO_NO_PROCESS_CONTROL
             call_function(sleep, 1);
-%else
-            sleep ? call_function(sleep, 1) : Qore::usleep(250ms);
-%endif
             if (!runflag || (now_us() >= end)) {
                 break;
             }
         }
+%else
+        if (sleep) {
+            # Custom sleep function: use polling with custom sleep
+            date end = now_us() + seconds(secs);
+            while (runflag) {
+                call_function(sleep, 1);
+                if (!runflag || (now_us() >= end)) {
+                    break;
+                }
+            }
+        } else {
+            # Default: condition-based sleep for instant wakeup on stop
+            AutoLock al(sleep_m);
+            if (runflag) {
+                sleep_cond.wait(sleep_m, seconds(secs));
+            }
+        }
+%endif
     }
 
     #! starts the polling operation
     private run() {
         on_exit {
-            sc.dec();
+            sc.done();
         }
 
         while (runflag) {

--- a/qlib/GmailDataProvider/GmailAttachmentWatchDataProvider.qc
+++ b/qlib/GmailDataProvider/GmailAttachmentWatchDataProvider.qc
@@ -162,7 +162,7 @@ public class GmailAttachmentWatchDataProvider inherits GmailMessageWatchDataProv
     */
     private auto getExampleEventDataImpl(string event_id) {
         hash<auto> info = setup() + {"test_mode": True};
-        *hash<auto> msg = pollOnce(\info);
+        *hash<auto> msg = pollOnceIntern(\info);
         if (msg.attachments) {
             return msg.attachments[0];
         }

--- a/qlib/GmailDataProvider/GmailMessageWatchDataProvider.qc
+++ b/qlib/GmailDataProvider/GmailMessageWatchDataProvider.qc
@@ -105,7 +105,7 @@ public class GmailMessageWatchDataProvider inherits GmailMessageWatchDataProvide
     */
     private auto getExampleEventDataImpl(string event_id) {
         hash<auto> info = setup() + {"test_mode": True};
-        if (*hash<auto> msg = pollOnce(\info)) {
+        if (*hash<auto> msg = pollOnceIntern(\info)) {
             return msg;
         }
         return AbstractDataProvider::getExampleEventDataImpl(event_id);

--- a/qlib/GmailDataProvider/GmailMessageWatchDataProviderBase.qc
+++ b/qlib/GmailDataProvider/GmailMessageWatchDataProviderBase.qc
@@ -26,7 +26,7 @@
 public namespace GmailDataProvider {
 #! The parent class for Gmail REST APIs
 public class GmailMessageWatchDataProviderBase inherits GoogleDataProvider::GoogleDataProviderBase,
-        DataProvider::DelayedObservable {
+        DataProvider::AbstractWatchDataProviderBase {
     public {
         #! Constructor options
         const ConstructorOptions = {
@@ -88,21 +88,6 @@ public class GmailMessageWatchDataProviderBase inherits GoogleDataProvider::Goog
     }
 
     private {
-        # I/O lock
-        Mutex lck();
-
-        #! I/O Condition
-        Condition cond();
-
-        #! Number of threads waiting on the I/O condition
-        int waiting;
-
-        #! I/O TID
-        int io_tid;
-
-        #! I/O stop flag
-        bool stop;
-
         #! Poll interval in seconds
         int poll_secs;
 
@@ -117,12 +102,16 @@ public class GmailMessageWatchDataProviderBase inherits GoogleDataProvider::Goog
 
         #! Match query
         string q;
+
+        #! Setup info for polling (initialized on first poll)
+        hash<auto> setup_info;
     }
 
     #! Creates the object from a REST connection
     constructor(GoogleRestClient::GoogleRestClient rest,
             hash<string, hash<DataProviderOptionInfo>> constructor_options, *hash<auto> options)
-            : GoogleDataProviderBase(rest) {
+            : GoogleDataProviderBase(rest),
+              AbstractWatchDataProviderBase(max(options.poll_interval ?? 120, MinPollInterval)) {
         *hash<auto> copts = checkOptions("CONSTRUCTOR-ERROR", constructor_options,
             DataProviderDataContextHelper::getHash(){keys constructor_options} + options);
         processOptions(copts);
@@ -130,47 +119,7 @@ public class GmailMessageWatchDataProviderBase inherits GoogleDataProvider::Goog
 
     #! Stops observing and deletes the object
     destructor() {
-        stopIntern();
-    }
-
-    #! Called when all observers have been added to the object
-    /** This method is meant to trigger event generation
-    */
-    observersReady() {
-        lck.lock();
-        on_exit lck.unlock();
-
-        # I/O thread already running
-        if (io_tid) {
-            return;
-        }
-
-        # start the I/O thread
-        io_tid = background pollThread();
-    }
-
-    #! Called to stop generating events
-    /** Stops polling for new events
-    */
-    stopEvents() {
-        stopIntern();
-    }
-
-    #! Stops polling
-    private stopIntern() {
-        lck.lock();
-        on_exit lck.unlock();
-
-        if (io_tid) {
-            # set the stop flag
-            stop = True;
-            # signal the I/O thread to wake up
-            cond.signal();
-            # wait for the thread to terminate
-            while (io_tid) {
-                cond.wait(lck);
-            }
-        }
+        stopEventsIntern();
     }
 
     #! Process constructor options
@@ -194,31 +143,6 @@ public class GmailMessageWatchDataProviderBase inherits GoogleDataProvider::Goog
         q = copts.q;
     }
 
-    #! I/O polling thread
-    private pollThread() {
-        on_exit {
-            lck.lock();
-            on_exit lck.unlock();
-
-            remove io_tid;
-
-            cond.broadcast();
-        }
-
-        hash<auto> info = setup();
-
-        while (!stop) {
-            pollOnce(\info);
-
-            # wait until next poll; check stop first to avoid sleeping after a signal was already sent
-            lck.lock();
-            on_exit lck.unlock();
-            if (!stop) {
-                cond.wait(lck, poll_secs * 1000);
-            }
-        }
-    }
-
     #! Setup for a poll operation
     private hash<auto> setup() {
         string uri = "gmail/v1/users/me/messages?q=" + q;
@@ -235,8 +159,16 @@ public class GmailMessageWatchDataProviderBase inherits GoogleDataProvider::Goog
         };
     }
 
+    #! Performs a single polling operation
+    private pollOnce() {
+        if (!setup_info) {
+            setup_info = setup();
+        }
+        pollOnceIntern(\setup_info);
+    }
+
     #! Perform one poll
-    private *hash<auto> pollOnce(reference<hash<auto>> setup) {
+    private *hash<auto> pollOnceIntern(reference<hash<auto>> setup) {
         # check for matching mail
         hash<auto> info;
         try {
@@ -252,7 +184,7 @@ public class GmailMessageWatchDataProviderBase inherits GoogleDataProvider::Goog
             int match;
             foreach hash<auto> minfo in (res.messages) {
                 # check for shutdown between REST calls
-                if (stop) {
+                if (isStopping()) {
                     break;
                 }
                 # skip messages already processed

--- a/qlib/Http2ClientIo/Http2ClientStreamHandle.qc
+++ b/qlib/Http2ClientIo/Http2ClientStreamHandle.qc
@@ -106,8 +106,8 @@ public class Http2ClientStreamHandle {
         #! Logger
         *Logger logger;
 
-        #! Data queue for streaming mode
-        *Queue data_queue;
+        #! Data channel for streaming mode
+        *Channel data_channel;
 
         #! Whether this stream is in streaming mode
         bool streaming = False;
@@ -325,7 +325,7 @@ public class Http2ClientStreamHandle {
             }
             state = Http2ClientStreamState::Open;
             streaming = True;
-            data_queue = new Queue();
+            data_channel = new Channel(-1);
         }
 
         # Wait for connection to become ready if not already
@@ -338,7 +338,7 @@ public class Http2ClientStreamHandle {
                     AutoLock al(lock);
                     state = Http2ClientStreamState::Pending;
                     streaming = False;
-                    delete data_queue;
+                    delete data_channel;
                 }
                 throw "HTTP2-TIMEOUT", "connection establishment timed out";
             }
@@ -355,7 +355,7 @@ public class Http2ClientStreamHandle {
                 AutoLock al(lock);
                 state = Http2ClientStreamState::Pending;
                 streaming = False;
-                delete data_queue;
+                delete data_channel;
             }
             rethrow;
         }
@@ -384,18 +384,18 @@ public class Http2ClientStreamHandle {
             if (state == Http2ClientStreamState::Complete
                     || state == Http2ClientStreamState::Error
                     || state == Http2ClientStreamState::Cancelled) {
-                if (data_queue.empty()) {
+                if (data_channel.empty()) {
                     throw "HTTP2-STREAM-CLOSED", "stream is closed";
                 }
             }
         }
 
         if (controller_mode) {
-            # Controller drives I/O; just wait on the queue
+            # Controller drives I/O; just wait on the channel
             try {
-                return data_queue.get(wait_timeout);
+                return data_channel.recv(wait_timeout);
             } catch (hash<ExceptionInfo> ex) {
-                if (ex.err == "QUEUE-TIMEOUT") {
+                if (ex.err == "CHANNEL-TIMEOUT") {
                     return NOTHING;
                 }
                 rethrow;
@@ -405,15 +405,12 @@ public class Http2ClientStreamHandle {
         # Non-controller mode: drive the poll while waiting for data
         date end_time = now_us() + wait_timeout;
         while (True) {
-            # Check queue with short timeout
-            try {
-                return data_queue.get(0);
-            } catch (hash<ExceptionInfo> ex) {
-                if (ex.err != "QUEUE-TIMEOUT") {
-                    rethrow;
-                }
-                # Queue empty — drive poll
+            # Check channel non-blocking
+            auto result = data_channel.tryRecv();
+            if (exists result) {
+                return result.value;
             }
+            # Channel empty — drive poll
 
             date remaining = end_time - now_us();
             if (remaining <= 0us) {
@@ -522,8 +519,15 @@ public class Http2ClientStreamHandle {
                 error_info = err;
                 state = Http2ClientStreamState::Error;
             }
-            # Push error to queue to unblock readers
-            data_queue.push({"error": err});
+            # Push error to channel to unblock readers, then close
+            try {
+                data_channel.send({"error": err});
+            } catch (hash<ExceptionInfo> ex2) {
+                if (ex2.err != "CHANNEL-CLOSED") {
+                    rethrow;
+                }
+            }
+            data_channel.close();
             return;
         }
 
@@ -548,12 +552,25 @@ public class Http2ClientStreamHandle {
         }
 
         if (resp.body) {
-            data_queue.push(resp.body);
+            try {
+                data_channel.send(resp.body);
+            } catch (hash<ExceptionInfo> ex2) {
+                if (ex2.err != "CHANNEL-CLOSED") {
+                    rethrow;
+                }
+            }
         }
 
         if (is_end) {
-            # Use explicit sentinel to distinguish from timeout (which returns NOTHING)
-            data_queue.push({"end_stream": True});
+            # Push sentinel to distinguish from timeout, then close channel
+            try {
+                data_channel.send({"end_stream": True});
+            } catch (hash<ExceptionInfo> ex2) {
+                if (ex2.err != "CHANNEL-CLOSED") {
+                    rethrow;
+                }
+            }
+            data_channel.close();
         }
     }
 

--- a/qlib/HttpServer.qm
+++ b/qlib/HttpServer.qm
@@ -612,8 +612,8 @@ public class HttpServer inherits HttpServer::AbstractLogger {
         # listener Gate
         Gate lm();
 
-        # running listener counter
-        Counter c();
+        # running listener WaitGroup
+        WaitGroup c();
 
         # dynamic handlers
         DynamicHttpHandlerList dhandlers();
@@ -1119,7 +1119,7 @@ public class HttpServer inherits HttpServer::AbstractLogger {
 
     #! waits for all listeners to be stopped; call after calling HttpServer::stopNoWait()
     waitStop() {
-        c.waitForZero();
+        c.wait();
     }
 
     #! called from listener when the actual listener thread is running
@@ -1136,7 +1136,7 @@ public class HttpServer inherits HttpServer::AbstractLogger {
     listenerStopped(HttpListener l) {
         # decrement listener count
         on_exit {
-            c.dec();
+            c.done();
         }
 
         lm.enter();
@@ -1214,7 +1214,7 @@ public class HttpServer inherits HttpServer::AbstractLogger {
         }
 
         map $1.stop(), listeners.iterator();
-        c.waitForZero();
+        c.wait();
 
         threadPool.stop();
 
@@ -1964,9 +1964,9 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
             info.no_start_main_thread = True;
         }
 
-        c.inc();
+        c.add();
         #printf("HttpServer::addListenerIntern() %y c=%y\n", sock, c.getCount());
-        on_error c.dec();
+        on_error c.done();
 
         HttpListener l = getListener(self, id, info);
 
@@ -2966,10 +2966,10 @@ public class HttpListener inherits Qore::Socket, HttpServer::HttpListenerInterfa
         auto socket;
         hash socket_info;
 
-        # connection counter for normal connection threads
-        Counter cThreads();
-        # connection counter for dedicated socket threads
-        Counter dThreads();
+        # connection WaitGroup for normal connection threads
+        WaitGroup cThreads();
+        # connection WaitGroup for dedicated socket threads
+        WaitGroup dThreads();
 
         bool exit = False;
         bool stopped = False;
@@ -3140,7 +3140,7 @@ public class HttpListener inherits Qore::Socket, HttpServer::HttpListenerInterfa
 
         # start main listener thread (unless using async I/O mode)
         if (!opts.no_start_main_thread) {
-            cThreads.inc();
+            cThreads.add();
             tid = background mainThread();
         }
     }
@@ -3574,7 +3574,7 @@ public class HttpListener inherits Qore::Socket, HttpServer::HttpListenerInterfa
         }
 
         # wait for all connection threads to terminate
-        cThreads.waitForZero();
+        cThreads.wait();
 
         # Close the listener socket explicitly to release the bound port.
         #
@@ -3614,7 +3614,7 @@ public class HttpListener inherits Qore::Socket, HttpServer::HttpListenerInterfa
         }
 
         # wait for all dedicated connection threads to terminate
-        dThreads.waitForZero();
+        dThreads.wait();
 
         stopped = True;
         if (!silent) {
@@ -3759,7 +3759,7 @@ public class HttpListener inherits Qore::Socket, HttpServer::HttpListenerInterfa
     }
 
     private mainThread() {
-        on_exit cThreads.dec();
+        on_exit cThreads.done();
 
         serv.listenerStarted(id, socket_info);
         # DEBUG
@@ -3792,12 +3792,12 @@ public class HttpListener inherits Qore::Socket, HttpServer::HttpListenerInterfa
             #    r.getPeerInfo().address_desc);
             #log("accepting HTTP connection from %s", r.getPeerInfo().address_desc);
 
-            cThreads.inc();
+            cThreads.add();
             try {
                 # use the thread pool to start the connection
                 serv.startConnection(sub () { connectionThread(r); });
             } catch (hash<ExceptionInfo> ex) {
-                cThreads.dec();
+                cThreads.done();
                 string err = sprintf("failed to start connection thread: %s: %s", ex.err, ex.desc);
                 serv.sendHttpError(self, {"id": -1, "close": True}, r, 500, err, NOTHING, NOTHING, NOTHING, True);
             }
@@ -4118,7 +4118,7 @@ public class HttpListener inherits Qore::Socket, HttpServer::HttpListenerInterfa
     */
     hash<HttpServerAsyncIo::HttpRequestResultInfo> processNativeRequest(Socket s, hash<auto> cx,
             hash<auto> hdr, hash<auto> header_info) {
-        cThreads.inc();
+        cThreads.add();
         RequestHelper request_helper(cThreads, dThreads);
 
         HttpPersistentHandlerInfo phi();
@@ -4751,7 +4751,7 @@ class HttpHandlerList {
 # class containing dynamic handler info
 class DynamicHandlerInfo inherits HandlerInfo {
     public {
-        Counter counter();
+        WaitGroup counter();
     }
 
     constructor(string name, hash<HttpHandlerConfigInfo> info) : HandlerInfo(name, info) {
@@ -4763,16 +4763,16 @@ class DynamicHandlerHelper {
     public {}
 
     private {
-        Counter c;
+        WaitGroup c;
     }
 
-    constructor(Counter n_c) {
+    constructor(WaitGroup n_c) {
         c = n_c;
-        c.inc();
+        c.add();
     }
 
     destructor() {
-        c.dec();
+        c.done();
     }
 }
 
@@ -4819,7 +4819,7 @@ class DynamicHttpHandlerList inherits HttpHandlerList {
     /** @throw REMOVEHANDLER-ERROR if the given dynamic handler does not exist
     */
     removeHandler(string name, *bool force_immediate) {
-        Counter c;
+        WaitGroup c;
         {
             # grab exclusive lock
             dhl.writeLock();
@@ -4837,7 +4837,7 @@ class DynamicHttpHandlerList inherits HttpHandlerList {
             if (!dhi.isregex && exists dhi.path)
                 treeMap.take(dhi.path);
 
-            # take a copy of a reference to the Counter
+            # take a copy of a reference to the WaitGroup
             c = dhi.counter;
 
             # stop handler if it is a dedicated socket handler
@@ -4849,7 +4849,7 @@ class DynamicHttpHandlerList inherits HttpHandlerList {
 
         # wait for the call counter to reach zero
         if (!force_immediate) {
-            c.waitForZero();
+            c.wait();
         }
     }
 
@@ -5136,16 +5136,16 @@ namespace Priv {
     2. **Dedicated connections (dThreads)**: Long-lived connections like WebSocket
        or SSE that take over the socket for bidirectional communication.
 
-    ## Counter Management
+    ## WaitGroup Management
 
-    The server uses counters to track active connections so that shutdown can wait
+    The server uses WaitGroups to track active connections so that shutdown can wait
     for all connections to complete. The flow is:
 
-    1. When a request starts: `cThreads.inc()` is called (before RequestHelper is created)
+    1. When a request starts: `cThreads.add()` is called (before RequestHelper is created)
     2. RequestHelper stores a reference to cThreads in `c`
     3. If the connection becomes dedicated (WebSocket/SSE):
-       - `setDedicated()` is called: increments dThreads, decrements cThreads, switches `c` to dThreads
-    4. When RequestHelper is destroyed: `c.dec()` decrements the appropriate counter
+       - `setDedicated()` is called: adds to dThreads, marks cThreads done, switches `c` to dThreads
+    4. When RequestHelper is destroyed: `c.done()` decrements the appropriate WaitGroup
 
     ## Dedicated External Mode
 
@@ -5153,26 +5153,26 @@ namespace Priv {
     from start()), `setDedicatedExternal()` is called. This:
     - Sets `dedicated_external = True` so the destructor won't close the socket
     - The handler is responsible for socket cleanup
-    - The counter is still decremented in the destructor
+    - The WaitGroup is still decremented in the destructor
 
-    ## Important: Counter Balance
+    ## Important: WaitGroup Balance
 
-    The counter increment happens BEFORE RequestHelper is created (in processNativeRequest
-    or similar). The decrement happens in the destructor. This ensures:
-    - Every increment has a matching decrement
-    - Server shutdown can wait for all counters to reach zero
+    The WaitGroup add() happens BEFORE RequestHelper is created (in processNativeRequest
+    or similar). The done() happens in the destructor. This ensures:
+    - Every add() has a matching done()
+    - Server shutdown can wait for all WaitGroups to reach zero
 
     @see HttpListener::cThreads
     @see HttpListener::dThreads
 */
 class RequestHelper {
     private {
-        #! Counter for normal connection threads (decremented if we stay in normal mode)
-        Counter cThreads;
-        #! Counter for dedicated connection threads (decremented if we switch to dedicated mode)
-        Counter dThreads;
-        #! Reference to the active counter (either cThreads or dThreads) - decremented in destructor
-        Counter c;
+        #! WaitGroup for normal connection threads (decremented if we stay in normal mode)
+        WaitGroup cThreads;
+        #! WaitGroup for dedicated connection threads (decremented if we switch to dedicated mode)
+        WaitGroup dThreads;
+        #! Reference to the active WaitGroup (either cThreads or dThreads) - decremented in destructor
+        WaitGroup c;
         #! Socket to manage (may be null for async connections where socket is managed elsewhere)
         Socket s;
         #! If True, socket is managed externally (e.g., by WebSocket handler) and won't be closed in destructor
@@ -5185,10 +5185,10 @@ class RequestHelper {
         @param s optional socket to manage (not passed for async connections where socket lifecycle
                is managed by the async I/O controller)
 
-        @note The caller must have already called cThreads.inc() before creating this object.
-              The destructor will call c.dec() to balance this.
+        @note The caller must have already called cThreads.add() before creating this object.
+              The destructor will call c.done() to balance this.
     */
-    constructor(Counter cThreads, Counter dThreads, *Socket s) {
+    constructor(WaitGroup cThreads, WaitGroup dThreads, *Socket s) {
         @assert(cThreads.getCount() > 0, "cThreads must be incremented before creating RequestHelper");
         self.cThreads = cThreads;
         self.dThreads = dThreads;
@@ -5204,7 +5204,7 @@ class RequestHelper {
         - Always decrements the active counter (c) to signal this connection is complete
 
         This allows HttpListener::stop() to wait for all connections to finish via
-        cThreads.waitForZero() and dThreads.waitForZero().
+        cThreads.wait() and dThreads.wait().
 
         @note We check isOpen() to avoid double-close if the socket was already closed
         (e.g., by handlePersistentConnectionSync())
@@ -5218,7 +5218,7 @@ class RequestHelper {
                 # Ignore close errors - socket may already be in error state
             }
         }
-        c.dec();
+        c.done();
     }
 
     #! Switches from normal connection mode to dedicated connection mode
@@ -5233,8 +5233,8 @@ class RequestHelper {
     */
     setDedicated() {
         @assert(c === cThreads);
-        dThreads.inc();
-        cThreads.dec();
+        dThreads.add();
+        cThreads.done();
         c = dThreads;
     }
 
@@ -5259,8 +5259,8 @@ class RequestHelper {
         # Only adjust counters if not already in dedicated mode
         # (setDedicated() may have been called first in registerDedicatedSocket)
         if (c === cThreads) {
-            dThreads.inc();
-            cThreads.dec();
+            dThreads.add();
+            cThreads.done();
             c = dThreads;
         }
         dedicated_external = True;

--- a/qlib/HttpServerAsyncIo/Http2SseStream.qc
+++ b/qlib/HttpServerAsyncIo/Http2SseStream.qc
@@ -42,8 +42,8 @@ public class Http2SseStream inherits AbstractSseConnection {
         #! The stream ID for this SSE stream
         int stream_id;
 
-        #! Queue of events to send
-        Queue event_queue();
+        #! Channel of events to send
+        Channel event_channel(-1);
 
         #! True if the stream is open
         bool stream_open = True;
@@ -69,7 +69,7 @@ public class Http2SseStream inherits AbstractSseConnection {
         if (!stream_open) {
             throw "SSE-CLOSED", "SSE stream is closed";
         }
-        event_queue.push({
+        event_channel.send({
             "type": event_type,
             "data": data,
             "id": id,
@@ -81,7 +81,7 @@ public class Http2SseStream inherits AbstractSseConnection {
         if (!stream_open) {
             throw "SSE-CLOSED", "SSE stream is closed";
         }
-        event_queue.push(event);
+        event_channel.send(event);
     }
 
     bool isOpen() {
@@ -93,7 +93,7 @@ public class Http2SseStream inherits AbstractSseConnection {
     }
 
     int getQueueSize() {
-        return event_queue.size();
+        return event_channel.size();
     }
 
     close() {
@@ -144,14 +144,8 @@ public class Http2SseStream inherits AbstractSseConnection {
     /** @return event hash or NOTHING if queue is empty
     */
     *hash<auto> getNextEvent() {
-        try {
-            return event_queue.get(0ms);
-        } catch (hash<ExceptionInfo> ex) {
-            if (ex.err == "QUEUE-TIMEOUT") {
-                return NOTHING;
-            }
-            rethrow;
-        }
+        auto result = event_channel.tryRecv();
+        return exists result ? result.value : NOTHING;
     }
 
     #! Formats an SSE event according to the spec

--- a/qlib/HttpServerAsyncIo/Http2WebSocketStream.qc
+++ b/qlib/HttpServerAsyncIo/Http2WebSocketStream.qc
@@ -59,11 +59,11 @@ public class Http2WebSocketStream inherits AbstractWebSocketConnection {
         #! Current state
         string state = STATE_CONNECTED;
 
-        #! Queue of frames to send
-        Queue send_queue();
+        #! Channel of frames to send
+        Channel send_channel(-1);
 
-        #! Queue of received frames
-        Queue recv_queue();
+        #! Channel of received frames
+        Channel recv_channel(-1);
 
         #! Buffer for incoming WebSocket frame data
         binary recv_buffer = binary();
@@ -129,18 +129,12 @@ public class Http2WebSocketStream inherits AbstractWebSocketConnection {
     }
 
     *hash<WebSocketFrameInfo> getReceivedFrame() {
-        try {
-            return recv_queue.get(0ms);
-        } catch (hash<ExceptionInfo> ex) {
-            if (ex.err == "QUEUE-TIMEOUT") {
-                return NOTHING;
-            }
-            rethrow;
-        }
+        auto result = recv_channel.tryRecv();
+        return exists result ? result.value : NOTHING;
     }
 
     bool hasReceivedFrames() {
-        return recv_queue.size() > 0;
+        return !recv_channel.empty();
     }
 
     bool isOpen() {
@@ -183,7 +177,7 @@ public class Http2WebSocketStream inherits AbstractWebSocketConnection {
         if (state == STATE_CLOSED || state == STATE_ERROR) {
             throw "WEBSOCKET-CLOSED", "WebSocket connection is closed";
         }
-        send_queue.push({
+        send_channel.send({
             "opcode": opcode,
             "data": data,
         });
@@ -193,14 +187,8 @@ public class Http2WebSocketStream inherits AbstractWebSocketConnection {
     /** @return frame hash with opcode and data, or NOTHING if queue is empty
     */
     *hash<auto> getNextSendFrame() {
-        try {
-            return send_queue.get(0ms);
-        } catch (hash<ExceptionInfo> ex) {
-            if (ex.err == "QUEUE-TIMEOUT") {
-                return NOTHING;
-            }
-            rethrow;
-        }
+        auto result = send_channel.tryRecv();
+        return exists result ? result.value : NOTHING;
     }
 
     #! Processes received data from HTTP/2 DATA frames
@@ -291,7 +279,7 @@ public class Http2WebSocketStream inherits AbstractWebSocketConnection {
         switch (opcode) {
             case WS_OP_TEXT: {
                 string text = payload.toString("UTF-8");
-                recv_queue.push(<WebSocketFrameInfo>{
+                recv_channel.send(<WebSocketFrameInfo>{
                     "type": "text",
                     "data": text,
                 });
@@ -299,7 +287,7 @@ public class Http2WebSocketStream inherits AbstractWebSocketConnection {
             }
 
             case WS_OP_BINARY: {
-                recv_queue.push(<WebSocketFrameInfo>{
+                recv_channel.send(<WebSocketFrameInfo>{
                     "type": "binary",
                     "data": payload,
                 });
@@ -309,7 +297,7 @@ public class Http2WebSocketStream inherits AbstractWebSocketConnection {
             case WS_OP_PING: {
                 # Send pong with same payload
                 queueFrame(WS_OP_PONG, payload);
-                recv_queue.push(<WebSocketFrameInfo>{
+                recv_channel.send(<WebSocketFrameInfo>{
                     "type": "ping",
                     "data": payload,
                 });
@@ -317,7 +305,7 @@ public class Http2WebSocketStream inherits AbstractWebSocketConnection {
             }
 
             case WS_OP_PONG: {
-                recv_queue.push(<WebSocketFrameInfo>{
+                recv_channel.send(<WebSocketFrameInfo>{
                     "type": "pong",
                     "data": payload,
                 });
@@ -332,7 +320,7 @@ public class Http2WebSocketStream inherits AbstractWebSocketConnection {
                     }
                 }
 
-                recv_queue.push(<WebSocketFrameInfo>{
+                recv_channel.send(<WebSocketFrameInfo>{
                     "type": "close",
                     "code": close_code,
                     "reason": close_reason,
@@ -347,7 +335,7 @@ public class Http2WebSocketStream inherits AbstractWebSocketConnection {
             }
 
             case WS_OP_CONTINUATION: {
-                recv_queue.push(<WebSocketFrameInfo>{
+                recv_channel.send(<WebSocketFrameInfo>{
                     "type": "binary",
                     "data": payload,
                 });

--- a/qlib/HttpServerAsyncIo/HttpSseStreamPollOperation.qc
+++ b/qlib/HttpServerAsyncIo/HttpSseStreamPollOperation.qc
@@ -50,8 +50,8 @@ public class HttpSseStreamPollOperation inherits AbstractPollOperation {
         #! Current state
         string state = STATE_STREAMING;
 
-        #! Queue of events to send
-        Queue event_queue();
+        #! Channel of events to send
+        Channel event_channel(-1);
 
         #! Error info if state is ERROR
         *hash<ExceptionInfo> error_info;
@@ -146,22 +146,17 @@ public class HttpSseStreamPollOperation inherits AbstractPollOperation {
             }
         }
 
-        # Check event queue for more data to send
-        try {
-            *hash<auto> event = event_queue.get(0ms);
-            if (event) {
-                pending_data = formatSseEvent(event);
+        # Check event channel for more data to send
+        {
+            auto result = event_channel.tryRecv();
+            if (exists result) {
+                pending_data = formatSseEvent(result.value);
                 pending_offset = 0;
                 # Request write poll
                 return <SocketPollInfo>{
                     "events": SOCK_POLLOUT | SOCK_POLLIN,
                     "socket": sock,
                 };
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            # Queue timeout is expected
-            if (ex.err != "QUEUE-TIMEOUT") {
-                rethrow;
             }
         }
 
@@ -179,7 +174,7 @@ public class HttpSseStreamPollOperation inherits AbstractPollOperation {
         @param retry retry interval in ms (optional)
     */
     queueEvent(*string event_type, string data, *string id, *int retry) {
-        event_queue.push({
+        event_channel.send({
             "type": event_type,
             "data": data,
             "id": id,
@@ -191,7 +186,7 @@ public class HttpSseStreamPollOperation inherits AbstractPollOperation {
     /** @param event hash with optional keys: type, data, id, retry
     */
     queueRawEvent(hash<auto> event) {
-        event_queue.push(event);
+        event_channel.send(event);
     }
 
     #! Formats an SSE event according to the spec
@@ -241,7 +236,7 @@ public class HttpSseStreamPollOperation inherits AbstractPollOperation {
 
     #! Returns the number of queued events
     int getQueueSize() {
-        return event_queue.size();
+        return event_channel.size();
     }
 
     #! Aborts the operation and closes the connection

--- a/qlib/HttpServerAsyncIo/HttpWebSocketPollOperation.qc
+++ b/qlib/HttpServerAsyncIo/HttpWebSocketPollOperation.qc
@@ -51,11 +51,11 @@ public class HttpWebSocketPollOperation inherits AbstractPollOperation {
         #! Current state
         string state = STATE_CONNECTED;
 
-        #! Queue of frames to send
-        Queue send_queue();
+        #! Channel of frames to send
+        Channel send_channel(-1);
 
-        #! Queue of received frames for the application
-        Queue recv_queue();
+        #! Channel of received frames for the application
+        Channel recv_channel(-1);
 
         #! Pending outgoing data
         *binary pending_send;
@@ -170,17 +170,11 @@ public class HttpWebSocketPollOperation inherits AbstractPollOperation {
 
         # Check for queued frames to send
         if (!pending_send) {
-            try {
-                *hash<auto> frame = send_queue.get(0ms);
-                if (frame) {
-                    pending_send = encodeFrame(frame);
-                    pending_send_offset = 0;
-                    poll_events |= SOCK_POLLOUT;
-                }
-            } catch (hash<ExceptionInfo> ex) {
-                if (ex.err != "QUEUE-TIMEOUT") {
-                    rethrow;
-                }
+            auto result = send_channel.tryRecv();
+            if (exists result) {
+                pending_send = encodeFrame(result.value);
+                pending_send_offset = 0;
+                poll_events |= SOCK_POLLOUT;
             }
         }
 
@@ -272,7 +266,7 @@ public class HttpWebSocketPollOperation inherits AbstractPollOperation {
         switch (opcode) {
             case WS_OP_TEXT: {
                 string text = payload.toString("UTF-8");
-                recv_queue.push(<WebSocketFrameInfo>{
+                recv_channel.send(<WebSocketFrameInfo>{
                     "type": "text",
                     "data": text,
                 });
@@ -280,7 +274,7 @@ public class HttpWebSocketPollOperation inherits AbstractPollOperation {
             }
 
             case WS_OP_BINARY: {
-                recv_queue.push(<WebSocketFrameInfo>{
+                recv_channel.send(<WebSocketFrameInfo>{
                     "type": "binary",
                     "data": payload,
                 });
@@ -290,7 +284,7 @@ public class HttpWebSocketPollOperation inherits AbstractPollOperation {
             case WS_OP_PING: {
                 # Send pong with same payload
                 queueFrame(WS_OP_PONG, payload);
-                recv_queue.push(<WebSocketFrameInfo>{
+                recv_channel.send(<WebSocketFrameInfo>{
                     "type": "ping",
                     "data": payload,
                 });
@@ -298,7 +292,7 @@ public class HttpWebSocketPollOperation inherits AbstractPollOperation {
             }
 
             case WS_OP_PONG: {
-                recv_queue.push(<WebSocketFrameInfo>{
+                recv_channel.send(<WebSocketFrameInfo>{
                     "type": "pong",
                     "data": payload,
                 });
@@ -313,7 +307,7 @@ public class HttpWebSocketPollOperation inherits AbstractPollOperation {
                     }
                 }
 
-                recv_queue.push(<WebSocketFrameInfo>{
+                recv_channel.send(<WebSocketFrameInfo>{
                     "type": "close",
                     "code": close_code,
                     "reason": close_reason,
@@ -329,7 +323,7 @@ public class HttpWebSocketPollOperation inherits AbstractPollOperation {
 
             case WS_OP_CONTINUATION: {
                 # Continuation frames - simplified handling
-                recv_queue.push(<WebSocketFrameInfo>{
+                recv_channel.send(<WebSocketFrameInfo>{
                     "type": "binary",
                     "data": payload,
                 });
@@ -375,7 +369,7 @@ public class HttpWebSocketPollOperation inherits AbstractPollOperation {
             payload = binary(string(data));
         }
 
-        send_queue.push({
+        send_channel.send({
             "opcode": opcode,
             "data": payload,
         });
@@ -417,19 +411,13 @@ public class HttpWebSocketPollOperation inherits AbstractPollOperation {
     /** @return frame info hash or NOTHING if no frames available
     */
     *hash<WebSocketFrameInfo> getReceivedFrame() {
-        try {
-            return recv_queue.get(0ms);
-        } catch (hash<ExceptionInfo> ex) {
-            if (ex.err == "QUEUE-TIMEOUT") {
-                return NOTHING;
-            }
-            rethrow;
-        }
+        auto result = recv_channel.tryRecv();
+        return exists result ? result.value : NOTHING;
     }
 
     #! Returns True if there are received frames waiting
     bool hasReceivedFrames() {
-        return recv_queue.size() > 0;
+        return !recv_channel.empty();
     }
 
     #! Returns the socket

--- a/qlib/Logger.qm
+++ b/qlib/Logger.qm
@@ -385,7 +385,7 @@ public class LoggerAppenderQueueThreadPool inherits LoggerAppenderQueue {
         #! worker thread pool
         ThreadPool threadPool;
         #! number of running worker threads
-        Counter runningCounter(0);
+        WaitGroup runningCounter();
         #! max.number of worker threads
         int maxThreads;
         #! events removed from queue but not passed to worker thread
@@ -409,8 +409,8 @@ public class LoggerAppenderQueueThreadPool inherits LoggerAppenderQueue {
     private:internal worker(string id, LoggerAppender appender, list<auto> events) {
         #printf("start worker(), id: %y, tid: %d\n", id, gettid());
         #printf("<S:%y, tid: %d> ", id, gettid());
-        runningCounter.inc();
-        on_exit runningCounter.dec();
+        runningCounter.add();
+        on_exit runningCounter.done();
         try {
             map appender.processEvent($1.type, $1.params), events;
         } catch (hash<ExceptionInfo> ex) {
@@ -450,7 +450,7 @@ public class LoggerAppenderQueueThreadPool inherits LoggerAppenderQueue {
     }
 
     destructor() {
-        runningCounter.waitForZero();
+        runningCounter.wait();
         threadPool.stopWait();
     }
 

--- a/qlib/OpenAiDataProvider/OpenAiResponseStreamDataProvider.qc
+++ b/qlib/OpenAiDataProvider/OpenAiResponseStreamDataProvider.qc
@@ -119,8 +119,8 @@ public class OpenAiResponseStreamDataProvider inherits OpenAiDataProviderCommon,
         #! Observers ready flag
         bool ready;
 
-        #! Thread counter
-        Counter cnt();
+        #! Thread WaitGroup
+        WaitGroup cnt();
 
         #! Thread lock
         Mutex m();
@@ -189,8 +189,8 @@ public class OpenAiResponseStreamDataProvider inherits OpenAiDataProviderCommon,
             return;
         }
         started = True;
-        cnt.inc();
-        on_error cnt.dec();
+        cnt.add();
+        on_error cnt.done();
         background eventLoop();
     }
 
@@ -205,13 +205,13 @@ public class OpenAiResponseStreamDataProvider inherits OpenAiDataProviderCommon,
         if (stream) {
             stream.close();
         }
-        cnt.waitForZero();
+        cnt.wait();
     }
 
     #! SSE event loop
     private eventLoop() {
         on_exit {
-            cnt.dec();
+            cnt.done();
         }
         try {
             hash<auto> ctx_info = {};

--- a/qlib/ServerSentEventHandler/ServerSentEventConnection.qc
+++ b/qlib/ServerSentEventHandler/ServerSentEventConnection.qc
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! @file ServerSentEventConnection.qc Qore handler definition for the HttpServer module for providing SSE connections
 
-/*  ServerSentEventConnection.qc Copyright 2025 Qore Technologies, s.r.o.
+/*  ServerSentEventConnection.qc Copyright 2025 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -56,8 +56,8 @@ public class ServerSentEventConnection {
     }
 
     private {
-        #! the @ref Qore::Thread::Queue "Queue" object stores messages to be sent to the server
-        Qore::Thread::Queue queue();
+        #! the @ref Qore::Thread::Channel "Channel" object stores messages to be sent to the server
+        Qore::Thread::Channel channel(-1);
 
         #! The TID of the I/O thread
         int tid = gettid();
@@ -86,10 +86,11 @@ public class ServerSentEventConnection {
     */
     *string pollData() {
         try {
-            return queue.get(DefaultQueuePollingInterval);
+            return channel.recv(DefaultQueuePollingInterval);
         } catch (hash<ExceptionInfo> ex) {
-            if (ex.err != "QUEUE-TIMEOUT")
+            if (ex.err != "CHANNEL-TIMEOUT") {
                 rethrow;
+            }
         }
     }
 
@@ -97,26 +98,32 @@ public class ServerSentEventConnection {
     /** Called by the @ref ServerSentEventHandler::ServerSentEventHandler "ServerSentEventHandler"
     */
     *string pollDataImmediate() {
+        auto result = channel.tryRecv();
+        return exists result ? result.value : NOTHING;
+    }
+
+    #! Pushes an already-encoded message on the connection's message channel
+    sendEncoded(string msg) {
         try {
-            # negative timeout values mean timeout immediately
-            return queue.get(-1);
+            channel.send(msg);
         } catch (hash<ExceptionInfo> ex) {
-            if (ex.err != "QUEUE-TIMEOUT") {
+            if (ex.err != "CHANNEL-CLOSED") {
                 rethrow;
             }
         }
     }
 
-    #! Pushes an already-encoded message on the connection's message queue
-    sendEncoded(string msg) {
-        queue.push(msg);
-    }
-
-    #! Pushes an unencoded message on the connection's message queue
+    #! Pushes an unencoded message on the connection's message channel
     /** The message will be encoded with \c ServerSentEventUtil::ws_encode_message() before sending
     */
     send(hash<SseMessageInfo> msg) {
-        queue.push(handler.encodeMessage(msg));
+        try {
+            channel.send(handler.encodeMessage(msg));
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.err != "CHANNEL-CLOSED") {
+                rethrow;
+            }
+        }
     }
 
     #! This method is called when the connection is closed
@@ -136,7 +143,7 @@ public class ServerSentEventConnection {
     #! Flush all output data
     flush() {
         if (gettid() != tid) {
-            while (!stop_flag && !queue.empty()) {
+            while (!stop_flag && !channel.empty()) {
                 usleep(DefaultQueuePollingInterval);
             }
         } else {
@@ -147,9 +154,8 @@ public class ServerSentEventConnection {
     #! force closing socket related to connection
     stop() {
         stop_flag = True;
-        # to get dummy data in polling thread immediately (unless stop called from the
-        # ServerSentEventHandler::startImpl() thread)
-        queue.push();
+        # closing the channel wakes up the polling thread immediately
+        channel.close();
     }
 }
 }

--- a/qlib/ServerSentEventHandler/ServerSentEventHandler.qc
+++ b/qlib/ServerSentEventHandler/ServerSentEventHandler.qc
@@ -251,7 +251,7 @@ public class ServerSentEventHandler inherits HttpServer::AbstractHttpSocketHandl
 
             try {
                 bool update;
-                # send any and all messages on the queue
+                # send any and all messages on the channel
                 *string str = conn.pollData();
                 if (str.val()) {
                     sock.send2(str, DefaultSocketSendTimeout);
@@ -287,7 +287,7 @@ public class ServerSentEventHandler inherits HttpServer::AbstractHttpSocketHandl
         return False;
     }
 
-    #! Flushes I/O in the connection queue
+    #! Flushes I/O in the connection channel
     /** @return True if any data was flushed, False if not
     */
     bool flushIo(ServerSentEventConnection conn, Socket sock) {
@@ -370,7 +370,7 @@ public class ServerSentEventHandler inherits HttpServer::AbstractHttpSocketHandl
         rwl.readLock();
         on_exit rwl.readUnlock();
 
-        # push the data on all connection queues
+        # push the data on all connection channels
         map $1.sendEncoded(str), ch.iterator();
         logInfo("SSE sent to connections: %y", keys ch);
         #if (ch) logDebug("sending data to connections: %y", keys ch);

--- a/qlib/ShippoDataProvider/ShippoWatchDataProviderBase.qc
+++ b/qlib/ShippoDataProvider/ShippoWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace ShippoDataProvider {
 
 #! Base class for Shippo polling watch data providers
 public class ShippoWatchDataProviderBase inherits ShippoDataProviderBase,
-        DataProvider::DelayedObservable {
+        DataProvider::AbstractWatchDataProviderBase {
     public {
         #! Maximum number of seen IDs to track before pruning
         const MaxSeenIds = 10000;
@@ -51,24 +51,6 @@ public class ShippoWatchDataProviderBase inherits ShippoDataProviderBase,
     }
 
     private {
-        #! Mutex for thread synchronization
-        Mutex lck();
-
-        #! Condition variable for sleeping
-        Condition cond();
-
-        #! Background thread ID
-        int io_tid;
-
-        #! Stop flag
-        bool stop = False;
-
-        #! Poll interval in seconds
-        int poll_secs;
-
-        #! Start date for filtering
-        date start_date;
-
         #! Last check time
         date last_check;
 
@@ -78,99 +60,21 @@ public class ShippoWatchDataProviderBase inherits ShippoDataProviderBase,
 
     #! Creates the object with a REST client
     constructor(ShippoRestClient::ShippoRestClient rest, *hash<auto> options)
-            : ShippoDataProviderBase(rest) {
-        poll_secs = options.poll_interval ?? DefaultPollInterval;
-        if (poll_secs < MinPollInterval) {
-            poll_secs = MinPollInterval;
-        }
-        if (options.start_date) {
-            start_date = options.start_date;
-        }
+            : ShippoDataProviderBase(rest),
+              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
+        last_check = options.start_date ?? now_us();
     }
 
     #! Creates the object with a connection
     constructor(ShippoRestClient::ShippoRestConnection conn, *hash<auto> options)
-            : ShippoDataProviderBase(conn) {
-        poll_secs = options.poll_interval ?? DefaultPollInterval;
-        if (poll_secs < MinPollInterval) {
-            poll_secs = MinPollInterval;
-        }
-        if (options.start_date) {
-            start_date = options.start_date;
-        }
+            : ShippoDataProviderBase(conn),
+              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
+        last_check = options.start_date ?? now_us();
     }
 
     #! Destructor - stops the polling thread
     destructor() {
         stopEventsIntern();
-    }
-
-    #! Called when observers are ready
-    observersReady() {
-        lck.lock();
-        on_exit lck.unlock();
-        if (io_tid) {
-            return;
-        }
-        io_tid = background pollThread();
-    }
-
-    #! Stops event generation
-    stopEvents() {
-        stopEventsIntern();
-    }
-
-    #! Internal method to stop events
-    private stopEventsIntern() {
-        lck.lock();
-        on_exit lck.unlock();
-        stop = True;
-        cond.broadcast();
-        # Wait for the polling thread to exit; no timeout needed since pollThread always broadcasts on exit
-        while (io_tid) {
-            cond.wait(lck);
-        }
-    }
-
-    #! Returns True if events are still being generated
-    bool isActive() {
-        return !stop && io_tid > 0;
-    }
-
-    #! The polling thread
-    private pollThread() {
-        on_exit {
-            lck.lock();
-            on_exit lck.unlock();
-            remove io_tid;
-            cond.broadcast();
-        }
-
-        # Initialize tracking state
-        last_check = start_date ?? now_us();
-
-        while (True) {
-            # Check stop flag under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-            }
-
-            pollOnce();
-
-            # Wait for next poll interval under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-                cond.wait(lck, poll_secs * 1000ms);
-            }
-        }
     }
 
     #! Polls for new records once
@@ -186,7 +90,7 @@ public class ShippoWatchDataProviderBase inherits ShippoDataProviderBase,
 
             foreach hash<auto> record in (records) {
                 # check for shutdown between iterations
-                if (stop) {
+                if (isStopping()) {
                     break;
                 }
                 string id = string(record{getIdField()});

--- a/qlib/SquareDataProvider/SquareWatchDataProviderBase.qc
+++ b/qlib/SquareDataProvider/SquareWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace SquareDataProvider {
 
 #! Base class for Square polling watch data providers
 public class SquareWatchDataProviderBase inherits SquareDataProviderBase,
-        DataProvider::DelayedObservable {
+        DataProvider::AbstractWatchDataProviderBase {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -48,24 +48,6 @@ public class SquareWatchDataProviderBase inherits SquareDataProviderBase,
     }
 
     private {
-        #! Mutex for thread synchronization
-        Mutex lck();
-
-        #! Condition variable for sleeping
-        Condition cond();
-
-        #! Background thread ID
-        int io_tid;
-
-        #! Stop flag
-        bool stop = False;
-
-        #! Poll interval in seconds
-        int poll_secs;
-
-        #! Start date for filtering
-        date start_date;
-
         #! Last check time
         date last_check;
 
@@ -75,87 +57,14 @@ public class SquareWatchDataProviderBase inherits SquareDataProviderBase,
 
     #! Creates the object with a REST client
     constructor(SquareRestClient::SquareRestClient rest, *hash<auto> options)
-            : SquareDataProviderBase(rest) {
-        poll_secs = options.poll_interval ?? DefaultPollInterval;
-        if (poll_secs < MinPollInterval) {
-            poll_secs = MinPollInterval;
-        }
-        if (options.start_date) {
-            start_date = options.start_date;
-        }
+            : SquareDataProviderBase(rest),
+              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
+        last_check = options.start_date ?? now_us();
     }
 
     #! Destructor - stops the polling thread
     destructor() {
         stopEventsIntern();
-    }
-
-    #! Called when observers are ready
-    observersReady() {
-        lck.lock();
-        on_exit lck.unlock();
-        if (io_tid) {
-            return;
-        }
-        io_tid = background pollThread();
-    }
-
-    #! Stops event generation
-    stopEvents() {
-        stopEventsIntern();
-    }
-
-    #! Internal method to stop events
-    private stopEventsIntern() {
-        lck.lock();
-        on_exit lck.unlock();
-        stop = True;
-        cond.broadcast();
-        # Wait for the polling thread to exit; no timeout needed since pollThread always broadcasts on exit
-        while (io_tid) {
-            cond.wait(lck);
-        }
-    }
-
-    #! Returns True if events are still being generated
-    bool isActive() {
-        return !stop && io_tid > 0;
-    }
-
-    #! The polling thread
-    private pollThread() {
-        on_exit {
-            lck.lock();
-            on_exit lck.unlock();
-            remove io_tid;
-            cond.broadcast();
-        }
-
-        # Initialize tracking state
-        last_check = start_date ?? now_us();
-
-        while (True) {
-            # Check stop flag under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-            }
-
-            pollOnce();
-
-            # Wait for next poll interval under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-                cond.wait(lck, poll_secs * 1000ms);
-            }
-        }
     }
 
     #! Polls for new records once
@@ -166,7 +75,7 @@ public class SquareWatchDataProviderBase inherits SquareDataProviderBase,
 
             foreach hash<auto> record in (records) {
                 # check for shutdown between iterations
-                if (stop) {
+                if (isStopping()) {
                     break;
                 }
                 string id = getRecordId(record);

--- a/qlib/SquarespaceDataProvider/SquarespaceWatchDataProviderBase.qc
+++ b/qlib/SquarespaceDataProvider/SquarespaceWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace SquarespaceDataProvider {
 
 #! Base class for Squarespace polling watch data providers
 public class SquarespaceWatchDataProviderBase inherits SquarespaceDataProviderBase,
-        DataProvider::DelayedObservable {
+        DataProvider::AbstractWatchDataProviderBase {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -48,24 +48,6 @@ public class SquarespaceWatchDataProviderBase inherits SquarespaceDataProviderBa
     }
 
     private {
-        #! Mutex for thread synchronization
-        Mutex lck();
-
-        #! Condition variable for sleeping
-        Condition cond();
-
-        #! Background thread ID
-        int io_tid;
-
-        #! Stop flag
-        bool stop = False;
-
-        #! Poll interval in seconds
-        int poll_secs;
-
-        #! Start date for filtering
-        date start_date;
-
         #! Last check time
         date last_check;
 
@@ -75,87 +57,14 @@ public class SquarespaceWatchDataProviderBase inherits SquarespaceDataProviderBa
 
     #! Creates the object with a REST client
     constructor(SquarespaceRestClient::SquarespaceRestClient rest, *hash<auto> options)
-            : SquarespaceDataProviderBase(rest) {
-        poll_secs = options.poll_interval ?? DefaultPollInterval;
-        if (poll_secs < MinPollInterval) {
-            poll_secs = MinPollInterval;
-        }
-        if (options.start_date) {
-            start_date = options.start_date;
-        }
+            : SquarespaceDataProviderBase(rest),
+              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
+        last_check = options.start_date ?? now_us();
     }
 
     #! Destructor - stops the polling thread
     destructor() {
         stopEventsIntern();
-    }
-
-    #! Called when observers are ready
-    observersReady() {
-        lck.lock();
-        on_exit lck.unlock();
-        if (io_tid) {
-            return;
-        }
-        io_tid = background pollThread();
-    }
-
-    #! Stops event generation
-    stopEvents() {
-        stopEventsIntern();
-    }
-
-    #! Internal method to stop events
-    private stopEventsIntern() {
-        lck.lock();
-        on_exit lck.unlock();
-        stop = True;
-        cond.broadcast();
-        # Wait for the polling thread to exit; no timeout needed since pollThread always broadcasts on exit
-        while (io_tid) {
-            cond.wait(lck);
-        }
-    }
-
-    #! Returns True if events are still being generated
-    bool isActive() {
-        return !stop && io_tid > 0;
-    }
-
-    #! The polling thread
-    private pollThread() {
-        on_exit {
-            lck.lock();
-            on_exit lck.unlock();
-            remove io_tid;
-            cond.broadcast();
-        }
-
-        # Initialize tracking state
-        last_check = start_date ?? now_us();
-
-        while (True) {
-            # Check stop flag under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-            }
-
-            pollOnce();
-
-            # Wait for next poll interval under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-                cond.wait(lck, poll_secs * 1000ms);
-            }
-        }
     }
 
     #! Polls for new records once
@@ -166,7 +75,7 @@ public class SquarespaceWatchDataProviderBase inherits SquarespaceDataProviderBa
 
             foreach hash<auto> record in (records) {
                 # check for shutdown between iterations
-                if (stop) {
+                if (isStopping()) {
                     break;
                 }
                 string id = getRecordId(record);

--- a/qlib/UnleashedDataProvider/UnleashedNewCustomerEventDataProvider.qc
+++ b/qlib/UnleashedDataProvider/UnleashedNewCustomerEventDataProvider.qc
@@ -63,7 +63,7 @@ public class UnleashedNewCustomerEventDataProvider inherits UnleashedWatchDataPr
     }
 
     #! Poll for customer updates
-    list<hash<auto>> pollOnce() {
+    list<hash<auto>> pollOnceImpl() {
         hash<auto> params = {
             "modifiedSince": formatDate(since),
             "pageSize": MaxPageSize,

--- a/qlib/UnleashedDataProvider/UnleashedNewSalesOrderEventDataProvider.qc
+++ b/qlib/UnleashedDataProvider/UnleashedNewSalesOrderEventDataProvider.qc
@@ -63,7 +63,7 @@ public class UnleashedNewSalesOrderEventDataProvider inherits UnleashedWatchData
     }
 
     #! Poll for sales order updates
-    list<hash<auto>> pollOnce() {
+    list<hash<auto>> pollOnceImpl() {
         hash<auto> params = {
             "modifiedSince": formatDate(since),
             "pageSize": MaxPageSize,

--- a/qlib/UnleashedDataProvider/UnleashedWatchDataProviderBase.qc
+++ b/qlib/UnleashedDataProvider/UnleashedWatchDataProviderBase.qc
@@ -45,44 +45,39 @@ public const WatchConstructorOptions = UnleashedDataProviderBase::BaseConstructo
 
 #! Base class for Unleashed watch/trigger data providers
 public class UnleashedWatchDataProviderBase inherits UnleashedDataProviderBase,
-        DataProvider::DelayedObservable {
+        DataProvider::AbstractWatchDataProviderBase {
     public {
         #! Constructor options for watch providers
         const WatchProviderConstructorOptions = WatchConstructorOptions;
     }
 
     private {
-        #! Poll interval in seconds
-        int poll_interval;
-
         #! Last poll time for filtering
         date since;
 
         #! Set of seen IDs for deduplication
         hash<string, bool> seen_ids = {};
-
-        #! Whether the observable is running
-        bool running = False;
-
-        #! Background polling thread counter
-        Counter thread_counter();
     }
 
     #! Creates the object with a REST client
     constructor(UnleashedRestClient::UnleashedRestClient rest, *hash<auto> options)
-            : UnleashedDataProviderBase(rest) {
-        initOptions(options);
+            : UnleashedDataProviderBase(rest),
+              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
+        since = options.since ?? now_us();
     }
 
     #! Creates the object with a connection
     constructor(UnleashedRestClient::UnleashedRestConnection conn, *hash<auto> options)
-            : UnleashedDataProviderBase(conn) {
-        initOptions(options);
+            : UnleashedDataProviderBase(conn),
+              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
+        since = options.since ?? now_us();
     }
 
     #! Creates the object with options
-    constructor(*hash<auto> options) : UnleashedDataProviderBase(options) {
-        initOptions(options);
+    constructor(*hash<auto> options)
+            : UnleashedDataProviderBase(options),
+              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
+        since = options.since ?? now_us();
     }
 
     #! Destructor
@@ -90,89 +85,46 @@ public class UnleashedWatchDataProviderBase inherits UnleashedDataProviderBase,
         stopEventsIntern();
     }
 
-    #! Stops event generation
-    stopEvents() {
-        stopEventsIntern();
-    }
+    #! Performs a single polling operation
+    private pollOnce() {
+        date poll_start = now_us();
+        list<hash<auto>> records = pollOnceImpl();
 
-    #! Returns True if events are still being generated
-    bool isActive() {
-        return running;
-    }
-
-    #! Initialize poll options
-    private initOptions(*hash<auto> options) {
-        poll_interval = options.poll_interval ?? DefaultPollInterval;
-        if (poll_interval < MinPollInterval) {
-            poll_interval = MinPollInterval;
-        }
-        since = options.since ?? now_us();
-    }
-
-    #! Start the observer/polling
-    observersReady() {
-        if (running) {
-            return;
-        }
-        running = True;
-        thread_counter.inc();
-        background pollLoop();
-    }
-
-    #! Internal method to stop events
-    private stopEventsIntern() {
-        running = False;
-        thread_counter.waitForZero();
-    }
-
-    #! Main polling loop
-    private pollLoop() {
-        on_exit thread_counter.dec();
-
-        while (running) {
-            try {
-                date poll_start = now_us();
-                list<hash<auto>> records = pollOnce();
-
-                foreach hash<auto> record in (records) {
-                    string id = getRecordId(record);
-                    if (!seen_ids{id}) {
-                        seen_ids{id} = True;
-                        notifyObservers(getEventName(), record);
-                    }
-                }
-
-                # Update since time for next poll
-                since = poll_start;
-
-                # Clean up old seen_ids periodically (keep last 10000)
-                if (seen_ids.size() > 10000) {
-                    # Remove oldest half
-                    int count = 0;
-                    foreach string key in (keys seen_ids) {
-                        if (count++ < 5000) {
-                            remove seen_ids{key};
-                        } else {
-                            break;
-                        }
-                    }
-                }
-            } catch (hash<ExceptionInfo> ex) {
-                @debug(log(LoggerLevel::ERROR, "pollLoop error: %s: %s", ex.err, ex.desc));
+        foreach hash<auto> record in (records) {
+            if (isStopping()) {
+                break;
             }
-
-            # Sleep for poll interval
-            int sleep_ms = poll_interval * 1000;
-            while (running && sleep_ms > 0) {
-                int sleep_chunk = min(1000, sleep_ms);
-                usleep(sleep_chunk * 1000);
-                sleep_ms -= sleep_chunk;
+            string id = getRecordId(record);
+            if (!seen_ids{id}) {
+                seen_ids{id} = True;
+                notifyObservers(getEventName(), record);
             }
         }
+
+        # Update since time for next poll
+        since = poll_start;
+
+        # Clean up old seen_ids periodically (keep last 10000)
+        if (seen_ids.size() > 10000) {
+            # Remove oldest half
+            int count = 0;
+            foreach string key in (keys seen_ids) {
+                if (count++ < 5000) {
+                    remove seen_ids{key};
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    #! Called when a polling error occurs
+    private logPollError(hash<ExceptionInfo> ex) {
+        @debug(log(LoggerLevel::ERROR, "pollLoop error: %s: %s", ex.err, ex.desc));
     }
 
     #! Poll once and return any new records - override in subclasses
-    abstract list<hash<auto>> pollOnce();
+    abstract list<hash<auto>> pollOnceImpl();
 
     #! Get the unique ID from a record - override in subclasses
     abstract string getRecordId(hash<auto> record);
@@ -197,7 +149,7 @@ public class UnleashedWatchDataProviderBase inherits UnleashedDataProviderBase,
     private auto getExampleEventDataImpl(string event_id) {
         # Try to get real data from the API first
         try {
-            list<hash<auto>> records = pollOnce();
+            list<hash<auto>> records = pollOnceImpl();
             if (records.size() > 0) {
                 return records[0];
             }

--- a/qlib/WebSocketHandler.qm
+++ b/qlib/WebSocketHandler.qm
@@ -193,8 +193,8 @@ public class WebSocketConnection {
     }
 
     private {
-        #! the @ref Qore::Thread::Queue "Queue" object stores messages to be sent to the server
-        Qore::Thread::Queue queue();
+        #! the @ref Qore::Thread::Channel "Channel" object stores messages to be sent to the server
+        Qore::Thread::Channel channel(-1);
 
         #! The TID of the I/O thread
         int tid = gettid();
@@ -285,10 +285,11 @@ public class WebSocketConnection {
     */
     *binary pollData() {
         try {
-            return queue.get(DefaultQueuePollingInterval);
+            return channel.recv(DefaultQueuePollingInterval);
         } catch (hash<ExceptionInfo> ex) {
-            if (ex.err != "QUEUE-TIMEOUT")
+            if (ex.err != "CHANNEL-TIMEOUT") {
                 rethrow;
+            }
         }
     }
 
@@ -296,19 +297,19 @@ public class WebSocketConnection {
     /** Called by the @ref WebSocketHandler::WebSocketHandler "WebSocketHandler"
     */
     *binary pollDataImmediate() {
+        auto result = channel.tryRecv();
+        return exists result ? result.value : NOTHING;
+    }
+
+    #! Pushes an already-encoded message on the connection's message channel
+    sendEncoded(binary msg) {
         try {
-            # negative timeout values mean timeout immediately
-            return queue.get(-1);
+            channel.send(msg);
         } catch (hash<ExceptionInfo> ex) {
-            if (ex.err != "QUEUE-TIMEOUT") {
+            if (ex.err != "CHANNEL-CLOSED") {
                 rethrow;
             }
         }
-    }
-
-    #! Pushes an already-encoded message on the connection's message queue
-    sendEncoded(binary msg) {
-        queue.push(msg);
     }
 
     #! Returns True if this connection requires per-connection encoding
@@ -328,7 +329,7 @@ public class WebSocketConnection {
         return exists active_extensions;
     }
 
-    #! Pushes an unencoded message on the connection's message queue
+    #! Pushes an unencoded message on the connection's message channel
     /** The message will be encoded with @ref WebSocketUtil::ws_encode_message() before sending
 
         If an AsyncAPI validator is set, the outgoing message will be validated before sending.
@@ -340,10 +341,16 @@ public class WebSocketConnection {
             asyncapi_validator.validateOutgoingMessage(asyncapi_channel, \msg, \headers);
         }
 %endif
-        queue.push(sendWithExtensions(msg));
+        try {
+            channel.send(sendWithExtensions(msg));
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.err != "CHANNEL-CLOSED") {
+                rethrow;
+            }
+        }
     }
 
-    #! Pushes an unencoded message on the connection's message queue
+    #! Pushes an unencoded message on the connection's message channel
     /** The message will be encoded with @ref WebSocketUtil::ws_encode_message() before sending
 
         If an AsyncAPI validator is set, the outgoing message will be validated before sending.
@@ -355,7 +362,13 @@ public class WebSocketConnection {
             asyncapi_validator.validateOutgoingMessage(asyncapi_channel, \msg, \headers);
         }
 %endif
-        queue.push(sendWithExtensions(msg, op, fin));
+        try {
+            channel.send(sendWithExtensions(msg, op, fin));
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.err != "CHANNEL-CLOSED") {
+                rethrow;
+            }
+        }
     }
 
     #! Applies extension transforms to outgoing message and encodes it
@@ -441,7 +454,7 @@ public class WebSocketConnection {
     */
     flush() {
         if (gettid() != tid) {
-            while (!stop_flag && !queue.empty()) {
+            while (!stop_flag && !channel.empty()) {
                 usleep(DefaultQueuePollingInterval);
             }
         } else {
@@ -452,9 +465,8 @@ public class WebSocketConnection {
     #! force closing socket related to connection
     stop() {
         stop_flag = True;
-        # to get a dummy data in polling thread immediately (unless stop called from the
-        # WebSocketHandler::startImpl() thread)
-        queue.push(binary());
+        # closing the channel wakes up the polling thread immediately
+        channel.close();
     }
 
 %ifndef NoAsyncApi
@@ -1138,7 +1150,7 @@ public class WebSocketHandler inherits HttpServer::AbstractHttpSocketHandler, Lo
 
             try {
                 bool update = False;
-                # send any and all messages on the queue
+                # send any and all messages on the channel
                 *binary d = wsc.pollData();
                 if (d) {
                     @debug {
@@ -1452,7 +1464,7 @@ public class WebSocketHandler inherits HttpServer::AbstractHttpSocketHandler, Lo
         return False;
     }
 
-    #! Flushes I/O in the connection queue
+    #! Flushes I/O in the connection channel
     /** @return True if any data was flushed, False if not
     */
     bool flushIo(WebSocketConnection wsc, Socket sock) {
@@ -1513,7 +1525,7 @@ public class WebSocketHandler inherits HttpServer::AbstractHttpSocketHandler, Lo
         # pre-encode once for connections that need no per-connection transforms
         *binary encoded;
 
-        # push the data on all connection queues
+        # push the data on all connection channels
         map (
             $1.needsPerConnectionEncoding()
                 ? $1.send(d)
@@ -1569,7 +1581,7 @@ public class WebSocketHandler inherits HttpServer::AbstractHttpSocketHandler, Lo
         Without this method, the server shutdown sequence would hang waiting for these threads
         to notice the shutdown flag. By calling stop() on each connection, we:
         1. Set the connection's stop_flag to True
-        2. Push an empty message to wake up pollData() immediately
+        2. Close the channel to wake up pollData() immediately
 
         @param lid the listener ID being stopped
 
@@ -1624,7 +1636,7 @@ public class WebSocketHandler inherits HttpServer::AbstractHttpSocketHandler, Lo
 
         For each connection, stop() does:
         1. Sets stop_flag = True (checked in startImpl's while loop)
-        2. Pushes empty binary to queue (wakes up pollData immediately)
+        2. Closes the channel (wakes up pollData immediately)
 
         This ensures the startImpl loop will exit on its next iteration, allowing the
         connection thread to complete and decrement the dThreads counter.

--- a/qlib/ZohoBooksDataProvider/ZohoBooksWatchDataProviderBase.qc
+++ b/qlib/ZohoBooksDataProvider/ZohoBooksWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace ZohoBooksDataProvider {
 
 #! Base class for Zoho Books polling watch data providers
 public class ZohoBooksWatchDataProviderBase inherits ZohoBooksDataProviderBase,
-        DataProvider::DelayedObservable {
+        DataProvider::AbstractWatchDataProviderBase {
     public {
         #! Maximum number of seen IDs to track before pruning
         const MaxSeenIds = 10000;
@@ -51,24 +51,6 @@ public class ZohoBooksWatchDataProviderBase inherits ZohoBooksDataProviderBase,
     }
 
     private {
-        #! Mutex for thread synchronization
-        Mutex lck();
-
-        #! Condition variable for sleeping
-        Condition cond();
-
-        #! Background thread ID
-        int io_tid;
-
-        #! Stop flag
-        bool stop = False;
-
-        #! Poll interval in seconds
-        int poll_secs;
-
-        #! Start date for filtering
-        date start_date;
-
         #! Last check time
         date last_check;
 
@@ -78,87 +60,14 @@ public class ZohoBooksWatchDataProviderBase inherits ZohoBooksDataProviderBase,
 
     #! Creates the object with a REST client
     constructor(ZohoBooksRestClient::ZohoBooksRestClient rest, *hash<auto> options)
-            : ZohoBooksDataProviderBase(rest) {
-        poll_secs = options.poll_interval ?? DefaultPollInterval;
-        if (poll_secs < MinPollInterval) {
-            poll_secs = MinPollInterval;
-        }
-        if (options.start_date) {
-            start_date = options.start_date;
-        }
+            : ZohoBooksDataProviderBase(rest),
+              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
+        last_check = options.start_date ?? now_us();
     }
 
     #! Destructor - stops the polling thread
     destructor() {
         stopEventsIntern();
-    }
-
-    #! Called when observers are ready
-    observersReady() {
-        lck.lock();
-        on_exit lck.unlock();
-        if (io_tid) {
-            return;
-        }
-        io_tid = background pollThread();
-    }
-
-    #! Stops event generation
-    stopEvents() {
-        stopEventsIntern();
-    }
-
-    #! Internal method to stop events
-    private stopEventsIntern() {
-        lck.lock();
-        on_exit lck.unlock();
-        stop = True;
-        cond.broadcast();
-        # Wait for the polling thread to exit; no timeout needed since pollThread always broadcasts on exit
-        while (io_tid) {
-            cond.wait(lck);
-        }
-    }
-
-    #! Returns True if events are still being generated
-    bool isActive() {
-        return !stop && io_tid > 0;
-    }
-
-    #! The polling thread
-    private pollThread() {
-        on_exit {
-            lck.lock();
-            on_exit lck.unlock();
-            remove io_tid;
-            cond.broadcast();
-        }
-
-        # Initialize tracking state
-        last_check = start_date ?? now_us();
-
-        while (True) {
-            # Check stop flag under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-            }
-
-            pollOnce();
-
-            # Wait for next poll interval under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-                cond.wait(lck, poll_secs * 1000ms);
-            }
-        }
     }
 
     #! Polls for new records once
@@ -174,7 +83,7 @@ public class ZohoBooksWatchDataProviderBase inherits ZohoBooksDataProviderBase,
 
             foreach hash<auto> record in (records) {
                 # check for shutdown between iterations
-                if (stop) {
+                if (isStopping()) {
                     break;
                 }
                 string id = string(record{getIdField()});

--- a/qlib/ZohoInventoryDataProvider/ZohoInventoryWatchDataProviderBase.qc
+++ b/qlib/ZohoInventoryDataProvider/ZohoInventoryWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace ZohoInventoryDataProvider {
 
 #! Base class for Zoho Inventory polling watch data providers
 public class ZohoInventoryWatchDataProviderBase inherits ZohoInventoryDataProviderBase,
-        DataProvider::DelayedObservable {
+        DataProvider::AbstractWatchDataProviderBase {
     public {
         #! Maximum number of seen IDs to track before pruning
         const MaxSeenIds = 10000;
@@ -51,24 +51,6 @@ public class ZohoInventoryWatchDataProviderBase inherits ZohoInventoryDataProvid
     }
 
     private {
-        #! Mutex for thread synchronization
-        Mutex lck();
-
-        #! Condition variable for sleeping
-        Condition cond();
-
-        #! Background thread ID
-        int io_tid;
-
-        #! Stop flag
-        bool stop = False;
-
-        #! Poll interval in seconds
-        int poll_secs;
-
-        #! Start date for filtering
-        date start_date;
-
         #! Last check time
         date last_check;
 
@@ -78,87 +60,14 @@ public class ZohoInventoryWatchDataProviderBase inherits ZohoInventoryDataProvid
 
     #! Creates the object with a REST client
     constructor(ZohoInventoryRestClient::ZohoInventoryRestClient rest, *hash<auto> options)
-            : ZohoInventoryDataProviderBase(rest) {
-        poll_secs = options.poll_interval ?? DefaultPollInterval;
-        if (poll_secs < MinPollInterval) {
-            poll_secs = MinPollInterval;
-        }
-        if (options.start_date) {
-            start_date = options.start_date;
-        }
+            : ZohoInventoryDataProviderBase(rest),
+              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
+        last_check = options.start_date ?? now_us();
     }
 
     #! Destructor - stops the polling thread
     destructor() {
         stopEventsIntern();
-    }
-
-    #! Called when observers are ready
-    observersReady() {
-        lck.lock();
-        on_exit lck.unlock();
-        if (io_tid) {
-            return;
-        }
-        io_tid = background pollThread();
-    }
-
-    #! Stops event generation
-    stopEvents() {
-        stopEventsIntern();
-    }
-
-    #! Internal method to stop events
-    private stopEventsIntern() {
-        lck.lock();
-        on_exit lck.unlock();
-        stop = True;
-        cond.broadcast();
-        # Wait for the polling thread to exit; no timeout needed since pollThread always broadcasts on exit
-        while (io_tid) {
-            cond.wait(lck);
-        }
-    }
-
-    #! Returns True if events are still being generated
-    bool isActive() {
-        return !stop && io_tid > 0;
-    }
-
-    #! The polling thread
-    private pollThread() {
-        on_exit {
-            lck.lock();
-            on_exit lck.unlock();
-            remove io_tid;
-            cond.broadcast();
-        }
-
-        # Initialize tracking state
-        last_check = start_date ?? now_us();
-
-        while (True) {
-            # Check stop flag under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-            }
-
-            pollOnce();
-
-            # Wait for next poll interval under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-                cond.wait(lck, poll_secs * 1000ms);
-            }
-        }
     }
 
     #! Polls for new records once
@@ -174,7 +83,7 @@ public class ZohoInventoryWatchDataProviderBase inherits ZohoInventoryDataProvid
 
             foreach hash<auto> record in (records) {
                 # check for shutdown between iterations
-                if (stop) {
+                if (isStopping()) {
                     break;
                 }
                 string id = string(record{getIdField()});

--- a/qlib/ZohoInvoiceDataProvider/ZohoInvoiceWatchDataProviderBase.qc
+++ b/qlib/ZohoInvoiceDataProvider/ZohoInvoiceWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace ZohoInvoiceDataProvider {
 
 #! Base class for Zoho Invoice polling watch data providers
 public class ZohoInvoiceWatchDataProviderBase inherits ZohoInvoiceDataProviderBase,
-        DataProvider::DelayedObservable {
+        DataProvider::AbstractWatchDataProviderBase {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -48,24 +48,6 @@ public class ZohoInvoiceWatchDataProviderBase inherits ZohoInvoiceDataProviderBa
     }
 
     private {
-        #! Mutex for thread synchronization
-        Mutex lck();
-
-        #! Condition variable for sleeping
-        Condition cond();
-
-        #! Background thread ID
-        int io_tid;
-
-        #! Stop flag
-        bool stop = False;
-
-        #! Poll interval in seconds
-        int poll_secs;
-
-        #! Start date for filtering
-        date start_date;
-
         #! Last check time
         date last_check;
 
@@ -75,75 +57,14 @@ public class ZohoInvoiceWatchDataProviderBase inherits ZohoInvoiceDataProviderBa
 
     #! Creates the object with a REST client
     constructor(ZohoInvoiceRestClient::ZohoInvoiceRestClient rest, *hash<auto> options)
-            : ZohoInvoiceDataProviderBase(rest) {
-        poll_secs = options.poll_interval ?? DefaultPollInterval;
-        if (poll_secs < MinPollInterval) {
-            poll_secs = MinPollInterval;
-        }
-        if (options.start_date) {
-            start_date = options.start_date;
-        }
+            : ZohoInvoiceDataProviderBase(rest),
+              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
+        last_check = options.start_date ?? now_us();
     }
 
     #! Destructor - stops the polling thread
     destructor() {
         stopEventsIntern();
-    }
-
-    #! Called when observers are ready
-    observersReady() {
-        lck.lock();
-        on_exit lck.unlock();
-        if (io_tid) {
-            return;
-        }
-        io_tid = background pollThread();
-    }
-
-    #! Stops event generation
-    stopEvents() {
-        stopEventsIntern();
-    }
-
-    #! Internal method to stop events
-    private stopEventsIntern() {
-        lck.lock();
-        on_exit lck.unlock();
-        stop = True;
-        cond.broadcast();
-        # Wait for the polling thread to exit; no timeout needed since pollThread always broadcasts on exit
-        while (io_tid) {
-            cond.wait(lck);
-        }
-    }
-
-    #! Returns True if events are still being generated
-    bool isActive() {
-        return !stop && io_tid > 0;
-    }
-
-    #! The polling thread
-    private pollThread() {
-        on_exit {
-            lck.lock();
-            on_exit lck.unlock();
-            remove io_tid;
-            cond.broadcast();
-        }
-
-        # Initialize tracking state
-        last_check = start_date ?? now_us();
-
-        while (!stop) {
-            pollOnce();
-
-            # Wait for next poll interval
-            lck.lock();
-            on_exit lck.unlock();
-            if (!stop) {
-                cond.wait(lck, poll_secs * 1000ms);
-            }
-        }
     }
 
     #! Polls for new records once
@@ -159,7 +80,7 @@ public class ZohoInvoiceWatchDataProviderBase inherits ZohoInvoiceDataProviderBa
 
             foreach hash<auto> record in (records) {
                 # check for shutdown between iterations
-                if (stop) {
+                if (isStopping()) {
                     break;
                 }
                 string id = string(record{getIdField()});


### PR DESCRIPTION
## Summary

- Adds high-level C++ builtin threading primitives to the `Qore::Thread` namespace: **Future/Promise**, **WaitGroup**, **Semaphore** (with AutoSemaphore RAII), **Channel** (with ChannelIterator for `foreach`), **parallel_map/parallel_foreach**, and **channel_select**
- All primitives integrate with Qore's cooperative cancellation (`waitWithInterrupt`) and sandbox interruption (`SandboxManager`)
- Migrates 19 qlib modules from `Counter`/`Queue` to `WaitGroup`/`Channel` where the new primitives provide better semantics (close signaling, fork-join coordination)
- Extracts common watch data provider polling logic into `AbstractWatchDataProviderBase`

### New C++ classes (qpp files)

| Class | Description |
|-------|-------------|
| `Future` / `Promise` | Cross-thread result delivery; `call_async()` convenience function spawns background thread and returns Future |
| `WaitGroup` | Fork-join coordination — counter starts at 0, `add()`/`done()`/`wait()` |
| `Semaphore` / `AutoSemaphore` | N-permit concurrency limiter with RAII support |
| `Channel` / `ChannelIterator` | Typed inter-thread communication with close semantics; buffered, unbuffered (synchronous handoff), and unlimited modes |

### New built-in functions

| Function | Description |
|----------|-------------|
| `call_async(code, ...)` | Spawns background thread, returns `Future` with result |
| `parallel_map(code, list, threads)` | Parallel collection transform preserving order |
| `parallel_foreach(code, list, threads)` | Parallel collection processing |
| `channel_select(cases, timeout)` | Multiplexed wait on multiple Channel operations with fairness |

### Key design decisions

- All primitives use `QoreThreadLock` (plain mutex), not `AbstractSmartLock` — consistent with existing `Counter`/`Queue`; deadlock detection only applies to mutual-exclusion locks (Mutex, Gate, RWLock)
- `parallel_wait_for_workers` uses non-interruptible `QoreCounter::waitForZero()` for deterministic cleanup when the main thread is cancelled (interruptible version would tight-loop since cancel flag stays set)
- `channel_select` uses bounded 100ms internal poll with external waiter registration to handle the lost-wakeup race between separate channel locks and the select's shared condvar

## Test plan

- [x] `examples/test/qore/threads/future.qtest` — 24 test cases (54 assertions): Promise/Future roundtrip, exception propagation, timeout, multiple getters, call_async, WaitGroup
- [x] `examples/test/qore/threads/semaphore.qtest` — 15 test cases (35 assertions): N-permit concurrency, tryAcquire, timeout, AutoSemaphore RAII
- [x] `examples/test/qore/threads/channel.qtest` — 19 test cases (1070 assertions): buffered/unbuffered, close+drain, backpressure, foreach iteration, NOTHING values, unlimited capacity
- [x] `examples/test/qore/threads/parallel.qtest` — 20 test cases (139 assertions): parallel_map order preservation, exception propagation, channel_select fairness/timeout/mixed ops
- [x] All 78 test cases pass under valgrind with 0 definitely/indirectly lost bytes
- [ ] Existing thread tests (`thread-object.qtest`) — regression check
- [ ] CI pipeline (Linux, macOS, Alpine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)