### PR TITLE
feat: HTTP/3 bidirectional streaming with graceful shutdown and per-stream notification

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,6 +56,11 @@ test-ubuntu-amd64:
             -d "{\"state\": \"failure\", \"context\": \"${REPO_NAME}\", \"description\": \"Gitlab CI\", \"target_url\": \"${CI_JOB_URL}\"}"
           exit 1
         fi
+  artifacts:
+    when: on_failure
+    paths:
+      - crash-dumps/
+    expire_in: 7 days
 
 test-ubuntu-arm64:
   stage: test
@@ -78,6 +83,11 @@ test-ubuntu-arm64:
             -d "{\"state\": \"failure\", \"context\": \"${REPO_NAME}\", \"description\": \"Gitlab CI\", \"target_url\": \"${CI_JOB_URL}\"}"
           exit 1
         fi
+  artifacts:
+    when: on_failure
+    paths:
+      - crash-dumps/
+    expire_in: 7 days
 
 test-alpine-amd64:
   stage: test
@@ -100,6 +110,11 @@ test-alpine-amd64:
             -d "{\"state\": \"failure\", \"context\": \"${REPO_NAME}\", \"description\": \"Gitlab CI\", \"target_url\": \"${CI_JOB_URL}\"}"
           exit 1
         fi
+  artifacts:
+    when: on_failure
+    paths:
+      - crash-dumps/
+    expire_in: 7 days
 
 test-alpine-arm64:
   stage: test
@@ -122,6 +137,11 @@ test-alpine-arm64:
             -d "{\"state\": \"failure\", \"context\": \"${REPO_NAME}\", \"description\": \"Gitlab CI\", \"target_url\": \"${CI_JOB_URL}\"}"
           exit 1
         fi
+  artifacts:
+    when: on_failure
+    paths:
+      - crash-dumps/
+    expire_in: 7 days
 
 test-macos:
   stage: test
@@ -149,3 +169,8 @@ test-macos:
             -d "{\"state\": \"failure\", \"context\": \"${REPO_NAME}-macos\", \"description\": \"Gitlab CI macOS\", \"target_url\": \"${CI_JOB_URL}\"}"
           exit 1
         fi
+  artifacts:
+    when: on_failure
+    paths:
+      - crash-dumps/
+    expire_in: 7 days

--- a/examples/test/qlib/HttpClientIo/HttpClientIo.qtest
+++ b/examples/test/qlib/HttpClientIo/HttpClientIo.qtest
@@ -122,6 +122,53 @@ class StreamingHandler inherits AbstractHttpRequestHandler {
     }
 }
 
+#! Handler that supports HTTP/2 bidirectional streaming
+/** Overrides the 5-arg handleRequest to get direct socket access for
+    incremental body reading and response streaming.
+*/
+class BidiEchoHandler inherits AbstractHttpRequestHandler {
+    bool wantsBodyStreaming(hash<auto> cx, hash<auto> hdr) {
+        return hdr."content-type" == "application/x-bidi-test";
+    }
+
+    hash<HttpResponseInfo> handleRequest(HttpListenerInterface listener,
+            Socket s, hash<auto> cx, hash<auto> hdr, *data body) {
+        if (!cx."header-info".body_streaming) {
+            return makeResponse(200, body ?? "no body");
+        }
+        int stream_id = cx."header-info".stream_id;
+
+        # Send response headers (no END_STREAM yet)
+        s.submitHttp2StreamingResponseHeaders(stream_id, 200,
+            {"content-type": "application/octet-stream"});
+        # In body_streaming mode, the handler has exclusive socket access
+        # (h2op is not on the I/O thread). Use flushHttp2() to send queued data.
+        s.flushHttp2();
+
+        # Read body data and echo it back (bidirectional).
+        # Use readHttp2StreamDataBlock() return value as loop control (not isHttp2StreamComplete),
+        # because DATA+END_STREAM may arrive in the same batch as HEADERS, making
+        # isHttp2StreamComplete() True before data is consumed. readHttp2StreamDataBlock()
+        # returns data first, then NOTHING when stream is complete.
+        while (True) {
+            *binary chunk = s.readHttp2StreamDataBlock(stream_id, 5s);
+            if (!chunk) {
+                break;
+            }
+            s.sendHttp2StreamData(stream_id, chunk);
+            s.flushHttp2();
+        }
+        # Send END_STREAM on response
+        s.sendHttp2StreamData(stream_id, NOTHING, True);
+        s.flushHttp2();
+        s.cleanupHttp2Stream(stream_id);
+
+        # Mark response as sent — framework will call setDedicatedExternal()
+        cx."response-sent" = True;
+        return <HttpResponseInfo>{"code": 200, "body": ""};
+    }
+}
+
 class HttpClientIoTest inherits QUnit::Test {
     private {
         HttpServer mServer;
@@ -270,6 +317,15 @@ Do+Sl1gfqlpgpszQaOMjR4M=
         # Connection draining test
         addTestCase("connection draining", \testConnectionDraining());
 
+        # Bidi streaming: sendData after server END_STREAM must not throw HTTP2-STREAM-ERROR
+        addTestCase("H2 bidi streaming send after server close", \testH2BidiSendAfterServerClose());
+
+        # Bidi streaming: echo test with BidiEchoHandler
+        addTestCase("H2 bidi echo streaming", \testH2BidiEchoStreaming());
+
+        # HTTP/3 callback ordering (stream removal after callback)
+        addTestCase("H3 callback ordering", \testH3CallbackOrdering());
+
         set_return_value(main());
     }
 
@@ -293,6 +349,7 @@ Do+Sl1gfqlpgpszQaOMjR4M=
         mServer.setHandler("slow", "/slow", NOTHING, new SlowHandler());
         mServer.setHandler("error", "/error", NOTHING, new ErrorHandler());
         mServer.setHandler("streaming", "/streaming", NOTHING, new StreamingHandler());
+        mServer.setHandler("bidi", "/bidi", NOTHING, new BidiEchoHandler());
 
         # Add HTTPS listener
         mSslPort = mServer.addListener(<HttpListenerOptionInfo>{
@@ -1797,5 +1854,158 @@ Do+Sl1gfqlpgpszQaOMjR4M=
 
         stats = mgr.getStats();
         assertEq(2, stats.total_connections, "second connection created because first is draining");
+    }
+
+    # ---- Bidi Streaming Race Condition Tests ----
+
+    testH2BidiSendAfterServerClose() {
+        AsyncSocketIo::AsyncSocketIoController controller(False);
+        HttpClientIo::HttpClientConnectionManager mgr(
+                <HttpClientIo::HttpClientConnectionManagerOptions>{
+            "accept_all_certs": True,
+            "protocol": "h2",
+            "logger": mLogger,
+        });
+        mgr.setController(controller);
+        controller.start();
+        on_exit {
+            controller.stop();
+            mgr.closeAll();
+        }
+
+        # Run multiple iterations to exercise the race window between stream
+        # removal from callbacks and state transition to Complete
+        for (int i = 0; i < 20; ++i) {
+            HttpClientIo::HttpClientStreamHandle stream = mgr.acquireStream(mSslUrl);
+            HttpClientIo::Http2ClientStreamHandle h2stream =
+                cast<HttpClientIo::Http2ClientStreamHandle>(stream);
+
+            # Start bidirectional streaming (body_streaming=True keeps client send side open)
+            h2stream.startStreaming("POST", "/simple", NOTHING, True);
+
+            # Send END_STREAM immediately — the server's body buffering loop needs this
+            # before it can dispatch to the handler. This tests the race window between
+            # stream removal from callbacks and state transition to Complete.
+            try {
+                h2stream.sendData(binary(), True);
+            } catch (hash<ExceptionInfo> ex) {
+                if (ex.err == "HTTP2-STREAM-ERROR") {
+                    fail(sprintf("iteration %d: HTTP2-STREAM-ERROR on send: %s - "
+                        "race condition between stream removal and state update",
+                        i, ex.desc));
+                }
+                # HTTPCLIENT-STATE-ERROR is acceptable (state already Complete)
+            }
+
+            # Read the server's response and end_stream marker
+            date end_time = now_us() + 10s;
+            while (now_us() < end_time) {
+                auto data = h2stream.readData(5s);
+                if (!exists data) {
+                    continue;
+                }
+                if (data.typeCode() == NT_HASH && data.end_stream) {
+                    break;
+                }
+                if (data.typeCode() == NT_HASH && data.error) {
+                    break;
+                }
+            }
+
+            assertTrue(h2stream.isDone(), sprintf("iteration %d: stream should be done", i));
+        }
+    }
+
+    testH2BidiEchoStreaming() {
+        AsyncSocketIo::AsyncSocketIoController controller(False);
+        HttpClientIo::HttpClientConnectionManager mgr(
+                <HttpClientIo::HttpClientConnectionManagerOptions>{
+            "accept_all_certs": True,
+            "protocol": "h2",
+            "logger": mLogger,
+        });
+        mgr.setController(controller);
+        controller.start();
+        on_exit {
+            controller.stop();
+            mgr.closeAll();
+        }
+
+        HttpClientIo::HttpClientStreamHandle stream = mgr.acquireStream(mSslUrl);
+        HttpClientIo::Http2ClientStreamHandle h2stream =
+            cast<HttpClientIo::Http2ClientStreamHandle>(stream);
+
+        # Start bidirectional streaming with the bidi-test content type
+        h2stream.startStreaming("POST", "/bidi",
+            {"content-type": "application/x-bidi-test"}, True);
+
+        # Send 3 chunks and collect echoed data
+        list<binary> sent_chunks = ();
+        binary all_received = binary();
+
+        for (int i = 0; i < 3; ++i) {
+            binary chunk = binary(sprintf("chunk-%d", i));
+            sent_chunks += chunk;
+            h2stream.sendData(chunk);
+        }
+        # Send END_STREAM to signal end of request body
+        h2stream.sendData(binary(), True);
+
+        # Read all echoed data until end_stream
+        date end_time = now_us() + 10s;
+        bool got_end_stream = False;
+        while (now_us() < end_time) {
+            auto rdata = h2stream.readData(5s);
+            if (!exists rdata) {
+                continue;
+            }
+            if (rdata.typeCode() == NT_HASH) {
+                if (rdata.end_stream) {
+                    got_end_stream = True;
+                    break;
+                }
+                if (rdata.error) {
+                    fail(sprintf("unexpected error: %y", rdata));
+                    break;
+                }
+            } else if (rdata.typeCode() == NT_BINARY) {
+                all_received += rdata;
+            }
+        }
+
+        assertTrue(got_end_stream, "server should send END_STREAM");
+        assertTrue(h2stream.isDone(), "stream should be done");
+
+        # Verify all sent data was echoed back
+        binary all_sent = binary();
+        map all_sent += $1, sent_chunks;
+        assertEq(all_sent, all_received, "echoed data should match sent data");
+    }
+
+    testH3CallbackOrdering() {
+        if (!mQuicUrl) {
+            testSkip("QUIC not available");
+        }
+
+        HttpClientIo::HttpClientConnectionManager mgr(
+                <HttpClientIo::HttpClientConnectionManagerOptions>{
+            "accept_all_certs": True,
+            "protocol": "h3",
+            "connect_timeout": 10s,
+            "request_timeout": 10s,
+            "logger": mLogger,
+        });
+        on_exit mgr.closeAll();
+
+        # Run multiple requests to exercise the callback ordering fix.
+        # Before the fix, the stream was removed from callbacks before the
+        # callback was invoked, creating a window where the stream handle's
+        # state could be inconsistent. After the fix, removal happens after
+        # the callback completes.
+        for (int i = 0; i < 20; ++i) {
+            hash<auto> resp = mgr.request(mQuicUrl, "GET", "/simple");
+            assertEq(200, resp.status_code,
+                sprintf("iteration %d: H3 response should be 200", i));
+        }
     }
 }

--- a/examples/test/qlib/HttpServer/HttpServerH3Streaming.qtest
+++ b/examples/test/qlib/HttpServer/HttpServerH3Streaming.qtest
@@ -1,0 +1,899 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+/*
+    Copyright (C) 2026 Qore Technologies, s.r.o., all rights reserved
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    Tests for HTTP/3 bidirectional streaming support (headers-only dispatch).
+
+    Tests cover:
+    - Unary POST with body over HTTP/3 (baseline)
+    - Server-streaming GET → response via InputStream (baseline)
+    - Client-streaming POST with headers-only dispatch, handler reads body
+      incrementally via readQuicStreamDataBlock()
+    - Headers-end-stream: GET with no body (FIN on HEADERS frame)
+    - body_streaming flag correctly set in header_info
+    - Backward-compat: handler without wantsBodyStreaming() gets buffered body
+*/
+
+%modern
+
+%requires ../../../../qlib/Util.qm
+%requires ../../../../qlib/QUnit.qm
+%requires ../../../../qlib/Mime.qm
+%requires ../../../../qlib/Logger.qm
+%requires ../../../../qlib/HttpServerUtil.qm
+%requires ../../../../qlib/AsyncSocketIo
+%requires ../../../../qlib/HttpServerAsyncIo
+%requires ../../../../qlib/HttpServer.qm
+%requires ../../../../qlib/HttpClientIo
+
+%exec-class HttpServerH3StreamingTest
+
+#! Size of the test payload
+const TestPayloadSize = 64 * 1024;  # 64 KB
+
+#! Size of each chunk for streaming writes
+
+#! Generates a deterministic binary payload of the given size
+binary sub generatePayload(int size) {
+    return binary(strmul("D", size));
+}
+
+#! Handler that echoes the POST body back in the response
+class EchoHandler inherits AbstractHttpRequestHandler {
+    hash<HttpResponseInfo> handleRequest(hash<auto> cx, hash<auto> hdr, *data body) {
+        return makeResponse(200, body ?? "", {
+            "Content-Type": hdr."content-type" ?? "application/octet-stream",
+        });
+    }
+}
+
+#! Handler that returns a large InputStream response (server-streaming)
+class StreamResponseHandler inherits AbstractHttpRequestHandler {
+    private {
+        binary payload;
+    }
+
+    constructor(binary payload) {
+        self.payload = payload;
+    }
+
+    hash<HttpResponseInfo> handleRequest(hash<auto> cx, hash<auto> hdr, *data body) {
+        return <HttpResponseInfo>{
+            "code": 200,
+            "body": new BinaryInputStream(payload),
+            "hdr": {
+                "Content-Type": "application/octet-stream",
+                "Content-Length": string(payload.size()),
+            },
+        };
+    }
+}
+
+#! Handler that reads body incrementally via readQuicStreamDataBlock()
+/** Tests headers-only dispatch: the handler is invoked before the request body
+    arrives, then reads body data incrementally using the socket-level
+    readQuicStreamDataBlock() method.
+*/
+class StreamingBodyHandler inherits AbstractHttpRequestHandler {
+    private {
+        #! Received data stored for test verification
+        Mutex data_lock();
+        list<hash<auto>> received_requests();
+    }
+
+    #! Opt in to body streaming so the framework doesn't buffer the body
+    bool wantsBodyStreaming(hash<auto> cx, hash<auto> hdr) {
+        return True;
+    }
+
+    hash<HttpResponseInfo> handleRequest(hash<auto> cx, hash<auto> hdr, *data body) {
+        int session_id = cx."header-info".session_id;
+        int stream_id = cx."header-info".stream_id;
+        bool body_streaming = cx."header-info".body_streaming ?? False;
+        bool headers_end_stream = cx."header-info".headers_end_stream ?? False;
+        *Socket sock = cx."header-info".sock;
+
+        @debug {
+            printf("StreamingBodyHandler: session=%d stream=%d body_streaming=%y "
+                "headers_end_stream=%y sock=%y body_present=%y\n",
+                session_id, stream_id, body_streaming, headers_end_stream,
+                exists sock, exists body);
+        }
+
+        hash<auto> result = {
+            "method": hdr.method,
+            "path": hdr.path,
+            "body_streaming": body_streaming,
+            "headers_end_stream": headers_end_stream,
+            "session_id": session_id,
+            "stream_id": stream_id,
+        };
+
+        if (body_streaming && !headers_end_stream) {
+            # Read body incrementally
+            @debug { printf("StreamingBodyHandler: entering streaming read loop\n"); }
+            binary accumulated_body = binary();
+            while (True) {
+                *binary chunk = sock.readQuicStreamDataBlock(session_id, stream_id, 10s);
+                @debug { printf("StreamingBodyHandler: read chunk size=%y\n", chunk.size()); }
+                if (!exists chunk) {
+                    @debug { printf("StreamingBodyHandler: no more data, exiting loop\n"); }
+                    # Stream complete (END_STREAM received)
+                    break;
+                }
+                accumulated_body += chunk;
+            }
+            @debug { printf("StreamingBodyHandler: total accumulated=%d\n", accumulated_body.size()); }
+            result.body_size = accumulated_body.size();
+            result.body = accumulated_body;
+        } else if (body) {
+            # Non-streaming: body was provided directly
+            result.body_size = body.size();
+            result.body = body;
+        } else {
+            result.body_size = 0;
+        }
+
+        {
+            AutoLock al(data_lock);
+            received_requests += result;
+        }
+
+        # Return the body size in the response
+        return makeResponse(200, sprintf("%d", result.body_size), {
+            "Content-Type": "text/plain",
+            "X-Body-Streaming": body_streaming ? "true" : "false",
+            "X-Headers-End-Stream": headers_end_stream ? "true" : "false",
+        });
+    }
+
+    #! Returns received requests for test verification
+    list<hash<auto>> getReceivedRequests() {
+        AutoLock al(data_lock);
+        return received_requests;
+    }
+
+    #! Clears received requests
+    clearRequests() {
+        AutoLock al(data_lock);
+        received_requests = ();
+    }
+}
+
+#! Handler that reads one chunk and responds immediately (partial body read)
+class PartialReadHandler inherits AbstractHttpRequestHandler {
+    bool wantsBodyStreaming(hash<auto> cx, hash<auto> hdr) {
+        return True;
+    }
+
+    hash<HttpResponseInfo> handleRequest(hash<auto> cx, hash<auto> hdr, *data body) {
+        int session_id = cx."header-info".session_id;
+        int stream_id = cx."header-info".stream_id;
+        bool body_streaming = cx."header-info".body_streaming ?? False;
+        *Socket sock = cx."header-info".sock;
+
+        if (body_streaming && sock) {
+            # Read just one chunk and return immediately without reading the rest
+            try {
+                *binary chunk = sock.readQuicStreamDataBlock(session_id, stream_id, 5s);
+                int chunk_size = chunk ? chunk.size() : 0;
+                return makeResponse(200, sprintf("partial:%d", chunk_size), {
+                    "Content-Type": "text/plain",
+                });
+            } catch (hash<ExceptionInfo> ex) {
+                return makeResponse(500, sprintf("error:%s:%s", ex.err, ex.desc), {
+                    "Content-Type": "text/plain",
+                });
+            }
+        }
+        return makeResponse(200, "no-streaming", {"Content-Type": "text/plain"});
+    }
+}
+
+#! Handler for shutdown test — blocks in readQuicStreamDataBlock() until session is closed
+/** Uses a large payload (4MB) so the handler is still reading when server.stop() fires.
+    Signals a gate after receiving the first data chunk to synchronize with the test.
+*/
+class ShutdownTestHandler inherits AbstractHttpRequestHandler {
+    private {
+        Counter reading_gate(1);
+    }
+
+    bool wantsBodyStreaming(hash<auto> cx, hash<auto> hdr) {
+        return True;
+    }
+
+    hash<HttpResponseInfo> handleRequest(hash<auto> cx, hash<auto> hdr, *data body) {
+        int session_id = cx."header-info".session_id;
+        int stream_id = cx."header-info".stream_id;
+        bool body_streaming = cx."header-info".body_streaming ?? False;
+        *Socket sock = cx."header-info".sock;
+
+        if (body_streaming && sock) {
+            # Signal that we're in the handler and actively reading
+            reading_gate.dec();
+
+            # Read body data — with a 4MB payload and QUIC flow control, the handler
+            # will be blocked in readQuicStreamDataBlock() for many iterations.
+            # server.stop() calls markClosed() which signals the per-stream CV,
+            # causing readQuicStreamDataBlock() to raise QUIC-ERROR immediately.
+            while (True) {
+                try {
+                    *binary chunk = sock.readQuicStreamDataBlock(session_id, stream_id, 30s);
+                    if (!exists chunk) {
+                        break;
+                    }
+                } catch (hash<ExceptionInfo> ex) {
+                    # Expected: QUIC-ERROR from markClosed() during shutdown
+                    break;
+                }
+            }
+        }
+        return makeResponse(200, "ok", {"Content-Type": "text/plain"});
+    }
+
+    #! Waits until the handler has started reading
+    /** @return 0 on success, ETIMEDOUT on timeout
+    */
+    int waitForReading(timeout t = 10s) {
+        return reading_gate.waitForZero(t);
+    }
+}
+
+#! Handler that exercises timeout handling by reading with a tiny timeout after data
+class TimeoutHandler inherits AbstractHttpRequestHandler {
+    private {
+        Mutex lock();
+        bool timeout_hit = False;
+    }
+
+    bool wantsBodyStreaming(hash<auto> cx, hash<auto> hdr) {
+        return True;
+    }
+
+    hash<HttpResponseInfo> handleRequest(hash<auto> cx, hash<auto> hdr, *data body) {
+        int session_id = cx."header-info".session_id;
+        int stream_id = cx."header-info".stream_id;
+        bool body_streaming = cx."header-info".body_streaming ?? False;
+        *Socket sock = cx."header-info".sock;
+
+        if (body_streaming && sock) {
+            # Read all available data first
+            binary accumulated = binary();
+            while (True) {
+                try {
+                    # Use 1ms timeout — after reading all available data, this will timeout
+                    *binary chunk = sock.readQuicStreamDataBlock(session_id, stream_id, 1ms);
+                    if (!exists chunk) {
+                        # Stream complete
+                        break;
+                    }
+                    accumulated += chunk;
+                } catch (hash<ExceptionInfo> ex) {
+                    if (ex.err == "QUIC-STREAM-TIMEOUT") {
+                        {
+                            AutoLock al(lock);
+                            timeout_hit = True;
+                        }
+                        # Got timeout — this is the expected path when not all data arrived yet
+                        return makeResponse(408, sprintf("timeout:%d", accumulated.size()), {
+                            "Content-Type": "text/plain",
+                        });
+                    }
+                    rethrow;
+                }
+            }
+            # Got all data without timeout (happens when data arrives in one batch on loopback)
+            return makeResponse(200, sprintf("complete:%d", accumulated.size()), {
+                "Content-Type": "text/plain",
+            });
+        }
+        return makeResponse(200, "no-streaming", {"Content-Type": "text/plain"});
+    }
+
+    bool wasTimeoutHit() {
+        AutoLock al(lock);
+        return timeout_hit;
+    }
+}
+
+class HttpServerH3StreamingTest inherits Test {
+    private {
+        *Logger mLogger;
+        binary mPayload;
+
+        # Self-signed test certificate (localhost, RSA 2048)
+        const CertPem = "-----BEGIN CERTIFICATE-----
+MIIDCTCCAfGgAwIBAgIUahuuRGDlubXWYmiPhjVeT66vtNYwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDIyMjE5MjIwMVoXDTM2MDIy
+MDE5MjIwMVowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAjZNfLFUyyo02MjZjouaR11FybkZNwDWBG/bhkpTVyj/x
+QKlwKf20LbGSCmMIYHaFnODMg6u6E6sfRJVk+ofwVHBN/Ug+mvoL1zlNJanMdXLH
+7oUsUILY6bVUDPm1ACZmFJsAc9jfHfkluJ6vfYG+DOJbyB0nsMfO9/fvrwndQPUQ
+k9eMq2VfDohni4ijk5BWD/P9UmrciZUNOaNISay469Le5ZrtfGt9An1+Ye3TckJC
+tTF4q7+V+GC88w5QtLd1AMQGf/1ax5cwqQv9SSFvhnwj9o3V3Wkz1dq4XA/9rSA1
+ecPHh/tJeGuvbD11Hyr9LTYjQ+DIel0DV0ZDHdc5vwIDAQABo1MwUTAdBgNVHQ4E
+FgQUYBBsVylVinbbAzTbUt0jRM6mJvwwHwYDVR0jBBgwFoAUYBBsVylVinbbAzTb
+Ut0jRM6mJvwwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAfIAE
+EPvLO+gOnm366xJabLr2Sw3hfmvCq/zSTlPcrB9jdBlOLpMmKcdGiOOCNmzg9+BX
+YNX+I6+MNOGp0j3afWlVwEjiMD66ydSMPEQw0FTzvpIjFN3fHo/MJzFbingRLrk8
+LCo94GmjMBYG+50M8MCKE6EzqfmoYT9fiMJcyJwwdptOWf0URNYKKrG1wRlX4+o8
+uNjQ3VwynI95fAw9WcR/ZtP0pkmCor/hKaYgVRsSGjD78Fu0Uuhm/pCAOuObpEHj
+5eoTlaWC3pZzGA67piqlEDOWiRi9Mo2CzG0t5fmQ83KB51ImauKdYB21whxjkZ+5
+BjwMC4hqSD+bzO2B+A==
+-----END CERTIFICATE-----";
+
+        const KeyPem = "-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCNk18sVTLKjTYy
+NmOi5pHXUXJuRk3ANYEb9uGSlNXKP/FAqXAp/bQtsZIKYwhgdoWc4MyDq7oTqx9E
+lWT6h/BUcE39SD6a+gvXOU0lqcx1csfuhSxQgtjptVQM+bUAJmYUmwBz2N8d+SW4
+nq99gb4M4lvIHSewx8739++vCd1A9RCT14yrZV8OiGeLiKOTkFYP8/1SatyJlQ05
+o0hJrLjr0t7lmu18a30CfX5h7dNyQkK1MXirv5X4YLzzDlC0t3UAxAZ//VrHlzCp
+C/1JIW+GfCP2jdXdaTPV2rhcD/2tIDV5w8eH+0l4a69sPXUfKv0tNiND4Mh6XQNX
+RkMd1zm/AgMBAAECggEAATo1WYTgPK75DiS4PBR5UDS7DryvoN/LNOsGLUdQC9b+
+aEaacSrAvKKs9vJr2KuTtfahn0SbsjRKFZtL9aYRuHxZbhLfGWiF4MGflcOBQRq+
+eVFl6clwnaS+S/cq5rZD1/WODUhkisslqhI/cubvNwe2rvyduE510LgxYkLuIZ7a
++SCQz1XyPyhb8eVrWIZiprufjqXvDy01MC74l3ZYqaq1hr1oKi0ZDHI95Os7gtwQ
+4HQ3qdJsmYfbaf1223REp8gybnshsxkyjhKRU3nG7ZvgrRRMFkJvfHZ8VcS3cvsK
+ccKBJg7376+VDtc+RHUcBMyVZ881y4Rq2t6ssYVJVQKBgQDFq+N7ZGKOtQChSIXn
+ju/gP5WzSKJFaZhdkSggHi1K+PkuCZ1SXzKD3CPibreSUx9hzoZAAmTjzOfwhVZ7
+5HDqhrKfkWNeThAdXlglhNX5LVKhhmBsNGawANO8Pmq+pueWhK/76XgiGcOknyt6
+NH1ZE/QZpFeZB2binEhf6leYGwKBgQC3WgF2eaj2c4pugq13oZ9BHms5nsbYQgj8
+1H2C1wsgJNiz4tq6xFdvjiaw+r1OrCFrl9nz7npFc7uohtrRxXr7sq5nwMPO3QAP
+VxzyZ/TFP/FI70Avz6x+xX7HIlptpQ1mWacsdrvtoIG1c8veEJTyA4JgjoMhdDer
+JuPze+ZHLQKBgAzuLIhCzcul/W+Pberyx7A0mJdMtgiyWpwsRaKsNqxD0xD24gqk
+XYqQmOxT78Arnc7pEpEXVwArxDRQlJKwI87DluWnPgfKNXWmWT/DC7gsBc65Go+Z
+ceorc65JqvPjuRx4e4aQBCK+6rRXESICUvzDuGEBBhXljQ5fyMA1dRtnAoGAQSFH
+w74Ttvf0BK2G0SgoWglkLWOpXsiWSLlynDenTBPKppu+9vkn1gi41cU72eZrOL0I
+Pw5HgMRLtOGyeTGdLiuaqGBhLepzSv+22KT03dyI6U+TjWhH7gBZuIMLfEdVKzZN
+nA3RU+fgK4SmtotNXWrBtWrqScfuvm1iK+unMUECgYBrwc1rU/GI9tH4MWvBX99n
+pmFneeIUuXJajOsh7jUyTxcrHl+4kkgHDExuFMNPHfrIG8xCj43fjzxD/spz3xRS
++Ki3i3lYOFNhTUCREt5Xx23hkksK6j7SYlfY0IV2UruWt/UubpsfEqxC1Uk07NTo
+l50Xb2GWQesIt9k5jF5IOw==
+-----END PRIVATE KEY-----";
+    }
+
+    constructor() : Test("HttpServerH3StreamingTest", "1.0") {
+        @debug {
+            set_signal_handler(SIGUSR1, sub (int sig) {
+                printf("=== SIGUSR1 Thread Stacks ===\n%Y\n=== End Thread Stacks ===\n",
+                    get_all_thread_call_stacks());
+            });
+        }
+
+        mPayload = generatePayload(TestPayloadSize);
+
+        addTestCase("HTTP/3 unary POST (baseline)", \testH3UnaryPost());
+        addTestCase("HTTP/3 server-streaming GET (baseline)", \testH3ServerStreaming());
+        addTestCase("HTTP/3 client-streaming POST (headers-only)", \testH3ClientStreaming());
+        addTestCase("HTTP/3 headers-end-stream GET (no body)", \testH3HeadersEndStream());
+        addTestCase("HTTP/3 body_streaming flag detection", \testH3BodyStreamingFlag());
+        addTestCase("HTTP/3 backward-compat body buffering", \testH3BackwardCompatBuffering());
+        addTestCase("HTTP/3 timeout handling", \testH3Timeout());
+        addTestCase("HTTP/3 oversized body (413)", \testH3OversizedBody());
+        addTestCase("HTTP/3 concurrent streaming", \testH3ConcurrentStreaming());
+        addTestCase("HTTP/3 shutdown during streaming", \testH3ShutdownDuringStreaming());
+        addTestCase("HTTP/3 partial body read + early response", \testH3PartialBodyRead());
+        addTestCase("HTTP/3 headers-only GET (no body read)", \testH3HeadersOnlyGetNoBodyRead());
+
+        set_return_value(main());
+    }
+
+    globalSetUp() {
+        mLogger = new Logger("h3-streaming-test", LoggerLevel::getLevelInfo());
+        if (m_options.verbose > 2) {
+            mLogger.addAppender(new StdoutAppender());
+        }
+    }
+
+    #! Creates a new async HTTP server with TLS and HTTP/3 + headers-only
+    private hash<auto> createServer(*hash<auto> opts) {
+        HttpServer server(<HttpServerOptionInfo>{
+            "logger": mLogger,
+            "debug": True,
+            "async_mode": True,
+            "quic_headers_only": opts.headers_only ?? False,
+            "max_request_body_size": opts.max_request_body_size ?? 0,
+        });
+
+        StreamingBodyHandler streaming_handler();
+        server.setHandler("echo", "/echo", NOTHING, new EchoHandler());
+        server.setHandler("stream-response", "/stream-response", NOTHING,
+            new StreamResponseHandler(mPayload));
+        server.setHandler("streaming-body", "/streaming-body", NOTHING, streaming_handler);
+
+        # Add extra handlers if provided
+        if (opts.extra_handlers) {
+            HashIterator hi(opts.extra_handlers);
+            while (hi.next()) {
+                hash<auto> h = hi.getValue();
+                server.setHandler(hi.getKey(), h.path, NOTHING, h.handler);
+            }
+        }
+
+        server.waitForAsyncIo();
+
+        hash<auto> h2info = server.addListener(<HttpListenerOptionInfo>{
+            "service": 0,
+            "cert": new SSLCertificate(CertPem),
+            "key": new SSLPrivateKey(KeyPem),
+            "enable_h3": True,
+        });
+        server.waitForAsyncIo();
+
+        return {
+            "server": server,
+            "port": h2info.port,
+            "streaming_handler": streaming_handler,
+        };
+    }
+
+    #! Creates an HTTP/3 client connection manager
+    private HttpClientIo::HttpClientConnectionManager createH3Manager() {
+        return new HttpClientIo::HttpClientConnectionManager(
+            <HttpClientIo::HttpClientConnectionManagerOptions>{
+                "protocol": "h3",
+                "accept_all_certs": True,
+                "logger": mLogger,
+                "request_timeout": 30s,
+                "connect_timeout": 15s,
+            },
+        );
+    }
+
+    # ---- Baseline Tests ----
+
+    #! Unary POST: normal request/response (body buffered before dispatch)
+    testH3UnaryPost() {
+        hash<auto> setup = createServer();
+        HttpServer server = setup.server;
+        on_exit delete server;
+
+        HttpClientIo::HttpClientConnectionManager mgr = createH3Manager();
+        on_exit delete mgr;
+
+        string url = sprintf("https://127.0.0.1:%d", setup.port);
+        hash<auto> resp = mgr.request(url, "POST", "/echo",
+            {"Content-Type": "application/octet-stream"}, mPayload);
+        assertEq(200, resp.status_code, "H3 unary POST response status");
+        binary resp_body;
+        if (resp.body.typeCode() == NT_BINARY) {
+            resp_body = resp.body;
+        } else {
+            resp_body = binary(resp.body);
+        }
+        assertEq(mPayload.size(), resp_body.size(), "H3 unary POST response body size");
+        assertEq(mPayload, resp_body, "H3 unary POST response body content");
+    }
+
+    #! Server-streaming: GET → InputStream response
+    testH3ServerStreaming() {
+        hash<auto> setup = createServer();
+        HttpServer server = setup.server;
+        on_exit delete server;
+
+        HttpClientIo::HttpClientConnectionManager mgr = createH3Manager();
+        on_exit delete mgr;
+
+        string url = sprintf("https://127.0.0.1:%d", setup.port);
+        hash<auto> resp = mgr.request(url, "GET", "/stream-response");
+        assertEq(200, resp.status_code, "H3 server-streaming response status");
+        binary resp_body;
+        if (resp.body.typeCode() == NT_BINARY) {
+            resp_body = resp.body;
+        } else {
+            resp_body = binary(resp.body);
+        }
+        assertEq(TestPayloadSize, resp_body.size(), "H3 server-streaming response body size");
+        assertEq(mPayload, resp_body, "H3 server-streaming response body content");
+    }
+
+    # ---- Headers-Only Dispatch Tests ----
+
+    #! Client-streaming POST: handler reads body via readQuicStreamDataBlock()
+    testH3ClientStreaming() {
+        hash<auto> setup = createServer({"headers_only": True});
+        HttpServer server = setup.server;
+        StreamingBodyHandler handler = setup.streaming_handler;
+        on_exit delete server;
+
+        HttpClientIo::HttpClientConnectionManager mgr = createH3Manager();
+        on_exit delete mgr;
+
+        handler.clearRequests();
+
+        string url = sprintf("https://127.0.0.1:%d", setup.port);
+        hash<auto> resp = mgr.request(url, "POST", "/streaming-body",
+            {"Content-Type": "application/octet-stream"}, mPayload);
+        assertEq(200, resp.status_code, "H3 client-streaming response status");
+
+        # Response body contains the size read by the handler
+        string body_str = resp.body.typeCode() == NT_BINARY
+            ? resp.body.toString() : string(resp.body);
+        int body_size = int(body_str);
+        assertEq(TestPayloadSize, body_size, "H3 client-streaming: handler read correct body size");
+
+        # Verify the header indicates body_streaming was used
+        assertEq("true", resp.headers."x-body-streaming",
+            "H3 client-streaming: body_streaming header");
+        assertEq("false", resp.headers."x-headers-end-stream",
+            "H3 client-streaming: headers_end_stream header");
+
+        # Verify handler's recorded data
+        list<hash<auto>> requests = handler.getReceivedRequests();
+        assertEq(1, requests.size(), "H3 client-streaming: one request received");
+        assertTrue(requests[0].body_streaming, "H3 client-streaming: body_streaming flag set");
+        assertFalse(requests[0].headers_end_stream,
+            "H3 client-streaming: headers_end_stream flag not set");
+        assertEq(TestPayloadSize, requests[0].body_size,
+            "H3 client-streaming: handler accumulated correct body size");
+        assertEq(mPayload, requests[0].body,
+            "H3 client-streaming: handler accumulated correct body content");
+    }
+
+    #! Headers-end-stream: GET with no body (FIN on HEADERS frame)
+    testH3HeadersEndStream() {
+        hash<auto> setup = createServer({"headers_only": True});
+        HttpServer server = setup.server;
+        StreamingBodyHandler handler = setup.streaming_handler;
+        on_exit delete server;
+
+        HttpClientIo::HttpClientConnectionManager mgr = createH3Manager();
+        on_exit delete mgr;
+
+        handler.clearRequests();
+
+        string url = sprintf("https://127.0.0.1:%d", setup.port);
+        hash<auto> resp = mgr.request(url, "GET", "/streaming-body");
+        assertEq(200, resp.status_code, "H3 headers-end-stream response status");
+
+        # Verify headers_end_stream was detected
+        assertEq("true", resp.headers."x-headers-end-stream",
+            "H3 headers-end-stream: header flag set");
+
+        # Verify handler's recorded data
+        list<hash<auto>> requests = handler.getReceivedRequests();
+        assertEq(1, requests.size(), "H3 headers-end-stream: one request received");
+        assertTrue(requests[0].headers_end_stream,
+            "H3 headers-end-stream: flag set in handler");
+        assertEq(0, requests[0].body_size,
+            "H3 headers-end-stream: no body data");
+    }
+
+    #! Verify body_streaming flag is correctly set based on headers-only mode
+    testH3BodyStreamingFlag() {
+        # With headers_only=True and a POST with body, body_streaming should be True
+        hash<auto> setup = createServer({"headers_only": True});
+        HttpServer server = setup.server;
+        StreamingBodyHandler handler = setup.streaming_handler;
+        on_exit delete server;
+
+        HttpClientIo::HttpClientConnectionManager mgr = createH3Manager();
+        on_exit delete mgr;
+
+        handler.clearRequests();
+
+        # POST with body → body_streaming=True, headers_end_stream=False
+        string url = sprintf("https://127.0.0.1:%d", setup.port);
+        hash<auto> resp1 = mgr.request(url, "POST", "/streaming-body",
+            {"Content-Type": "text/plain"}, binary("hello"));
+        assertEq(200, resp1.status_code, "body_streaming flag: POST status");
+
+        list<hash<auto>> requests = handler.getReceivedRequests();
+        assertEq(1, requests.size(), "body_streaming flag: POST request received");
+        assertTrue(requests[0].body_streaming,
+            "body_streaming flag: POST with body → body_streaming=True");
+        assertFalse(requests[0].headers_end_stream,
+            "body_streaming flag: POST with body → headers_end_stream=False");
+    }
+
+    #! Backward-compat: handler without wantsBodyStreaming() gets fully buffered body
+    /** When headers_only=True is set on the server but the handler doesn't override
+        wantsBodyStreaming(), the framework should automatically buffer the body via
+        readQuicStreamDataBlock() before passing it to handleRequest().
+    */
+    testH3BackwardCompatBuffering() {
+        # Create server with headers_only=True — the EchoHandler doesn't override
+        # wantsBodyStreaming() so the framework will buffer the body automatically
+        hash<auto> setup = createServer({"headers_only": True});
+        HttpServer server = setup.server;
+        on_exit delete server;
+
+        HttpClientIo::HttpClientConnectionManager mgr = createH3Manager();
+        on_exit delete mgr;
+
+        string url = sprintf("https://127.0.0.1:%d", setup.port);
+        hash<auto> resp = mgr.request(url, "POST", "/echo",
+            {"Content-Type": "application/octet-stream"}, mPayload);
+        assertEq(200, resp.status_code, "backward-compat: response status");
+
+        # The EchoHandler echoes the body — verify the full body was buffered and passed
+        binary resp_body;
+        if (resp.body.typeCode() == NT_BINARY) {
+            resp_body = resp.body;
+        } else {
+            resp_body = binary(resp.body);
+        }
+        assertEq(mPayload.size(), resp_body.size(), "backward-compat: response body size");
+        assertEq(mPayload, resp_body, "backward-compat: response body content");
+    }
+
+    # ---- Negative/Edge-Case Tests ----
+
+    #! Test 3.1: Timeout handling — handler exercises QUIC-STREAM-TIMEOUT path
+    /** Tests timeout handling with a 1ms read timeout and a large payload.
+        Uses a 512KB payload to increase the likelihood of flow control delays
+        that cause the 1ms timeout to fire between data batches.
+
+        On loopback, all data may still arrive in one batch (no timeout), so
+        the test validates whichever path fires:
+        - 408 with timeout: validates QUIC-STREAM-TIMEOUT exception handling
+        - 200 with complete data: validates normal streaming read to completion
+
+        @note A fully deterministic timeout test would require client-side streaming
+        support (send headers, delay body) which HttpClientIo does not yet support.
+    */
+    testH3Timeout() {
+        TimeoutHandler timeout_handler();
+
+        # Use 512KB payload — larger payloads are more likely to trigger flow
+        # control delays that cause the 1ms read timeout to fire
+        binary large_payload = generatePayload(512 * 1024);
+
+        hash<auto> setup = createServer({
+            "headers_only": True,
+            "extra_handlers": {
+                "timeout": {
+                    "path": "/timeout",
+                    "handler": timeout_handler,
+                },
+            },
+        });
+        HttpServer server = setup.server;
+        on_exit delete server;
+
+        HttpClientIo::HttpClientConnectionManager mgr = createH3Manager();
+        on_exit delete mgr;
+
+        string url = sprintf("https://127.0.0.1:%d", setup.port);
+        hash<auto> resp = mgr.request(url, "POST", "/timeout",
+            {"Content-Type": "application/octet-stream"}, large_payload);
+
+        string body_str = resp.body.typeCode() == NT_BINARY
+            ? resp.body.toString() : string(resp.body);
+
+        if (resp.status_code == 408) {
+            # Timeout path: handler caught QUIC-STREAM-TIMEOUT and returned 408
+            assertTrue(timeout_handler.wasTimeoutHit(), "timeout: handler recorded timeout");
+            assertTrue(body_str =~ /^timeout:/, "timeout: response body format");
+        } else {
+            # Complete path: all data arrived before the 1ms timeout between chunks
+            assertEq(200, resp.status_code, "timeout: response status");
+            assertTrue(body_str =~ /^complete:/, "timeout: response body format");
+            assertEq("complete:" + string(large_payload.size()), body_str,
+                "timeout: all data received");
+        }
+    }
+
+    #! Test 3.2: Oversized body — framework returns 413 via backward-compat buffering
+    testH3OversizedBody() {
+        hash<auto> setup = createServer({
+            "headers_only": True,
+            "max_request_body_size": 1024,
+        });
+        HttpServer server = setup.server;
+        on_exit delete server;
+
+        HttpClientIo::HttpClientConnectionManager mgr = createH3Manager();
+        on_exit delete mgr;
+
+        # Send 2048-byte body to EchoHandler (no wantsBodyStreaming) with 1024-byte limit
+        binary oversized = binary(strmul("X", 2048));
+        string url = sprintf("https://127.0.0.1:%d", setup.port);
+        hash<auto> resp = mgr.request(url, "POST", "/echo",
+            {"Content-Type": "application/octet-stream"}, oversized);
+        assertEq(413, resp.status_code, "oversized body: response status 413");
+    }
+
+    #! Test 3.3: Concurrent streaming — multiple simultaneous POSTs
+    testH3ConcurrentStreaming() {
+        hash<auto> setup = createServer({"headers_only": True});
+        HttpServer server = setup.server;
+        StreamingBodyHandler handler = setup.streaming_handler;
+        on_exit delete server;
+
+        handler.clearRequests();
+
+        int num_concurrent = 4;
+        Counter cnt(num_concurrent);
+        list<hash<auto>> results();
+        Mutex results_lock();
+
+        for (int i = 0; i < num_concurrent; ++i) {
+            int idx = i;
+            background sub () {
+                try {
+                    HttpClientIo::HttpClientConnectionManager mgr = createH3Manager();
+                    on_exit delete mgr;
+
+                    string url = sprintf("https://127.0.0.1:%d", setup.port);
+                    hash<auto> resp = mgr.request(url, "POST", "/streaming-body",
+                        {"Content-Type": "application/octet-stream"}, mPayload);
+                    {
+                        AutoLock al(results_lock);
+                        results += {
+                            "idx": idx,
+                            "status_code": resp.status_code,
+                            "body": resp.body,
+                        };
+                    }
+                } catch (hash<ExceptionInfo> ex) {
+                    {
+                        AutoLock al(results_lock);
+                        results += {
+                            "idx": idx,
+                            "error": sprintf("%s: %s", ex.err, ex.desc),
+                        };
+                    }
+                }
+                cnt.dec();
+            }();
+        }
+
+        int rc = cnt.waitForZero(60s);
+        assertEq(0, rc, "concurrent: all threads completed");
+
+        # Check results
+        assertEq(num_concurrent, results.size(), "concurrent: all results received");
+        for (int i = 0; i < results.size(); ++i) {
+            assertFalse(exists results[i].error,
+                sprintf("concurrent[%d]: no error (got: %y)", results[i].idx, results[i].error));
+            assertEq(200, results[i].status_code,
+                sprintf("concurrent[%d]: status 200", results[i].idx));
+            string body_str = results[i].body.typeCode() == NT_BINARY
+                ? results[i].body.toString() : string(results[i].body);
+            assertEq(string(TestPayloadSize), body_str,
+                sprintf("concurrent[%d]: correct body size", results[i].idx));
+        }
+    }
+
+    #! Test 3.4: Server shutdown during streaming — handler exits quickly
+    /** Uses a ShutdownTestHandler with a Counter gate to deterministically wait
+        for the handler to start reading before shutting down.  Uses a 4MB payload
+        to ensure the handler is actively reading (not already finished) when
+        server.stop() fires.
+    */
+    testH3ShutdownDuringStreaming() {
+        ShutdownTestHandler shutdown_handler();
+        hash<auto> setup = createServer({
+            "headers_only": True,
+            "extra_handlers": {
+                "shutdown-test": {
+                    "path": "/shutdown-test",
+                    "handler": shutdown_handler,
+                },
+            },
+        });
+        HttpServer server = setup.server;
+        on_exit delete server;
+
+        # Use a 4MB payload — large enough that QUIC flow control ensures the handler
+        # is still actively reading when server.stop() fires
+        binary large_payload = generatePayload(4 * 1024 * 1024);
+
+        # Start streaming POST in background with short request timeout
+        Counter cnt(1);
+        background sub () {
+            try {
+                HttpClientIo::HttpClientConnectionManager mgr =
+                    new HttpClientIo::HttpClientConnectionManager(
+                        <HttpClientIo::HttpClientConnectionManagerOptions>{
+                            "protocol": "h3",
+                            "accept_all_certs": True,
+                            "logger": mLogger,
+                            "request_timeout": 10s,
+                            "connect_timeout": 10s,
+                        },
+                    );
+                on_exit delete mgr;
+                string url = sprintf("https://127.0.0.1:%d", setup.port);
+                mgr.request(url, "POST", "/shutdown-test",
+                    {"Content-Type": "application/octet-stream"}, large_payload);
+            } catch (hash<ExceptionInfo> ex) {
+                # Expected: connection error due to server shutdown
+            }
+            cnt.dec();
+        }();
+
+        # Wait for the handler to start reading (deterministic, no sleep)
+        int gate_rc = shutdown_handler.waitForReading(15s);
+        assertEq(0, gate_rc, "shutdown: handler entered read loop");
+
+        # Measure shutdown time
+        date start = now_us();
+        server.stop();
+        date elapsed = now_us() - start;
+        int elapsed_ms = int(elapsed) * 1000 / 1000000;
+
+        # Shutdown should be fast (< 5s), not 30s
+        assertTrue(elapsed_ms < 5000,
+            sprintf("shutdown: completed in %dms (expected < 5000ms)", elapsed_ms));
+
+        # Wait for background thread to finish (client has 10s request timeout)
+        int rc = cnt.waitForZero(15s);
+        assertEq(0, rc, "shutdown: background thread completed");
+    }
+
+    #! Test 3.5: Partial body read + early response — handler reads one chunk, returns
+    testH3PartialBodyRead() {
+        PartialReadHandler partial_handler();
+        hash<auto> setup = createServer({
+            "headers_only": True,
+            "extra_handlers": {
+                "partial": {
+                    "path": "/partial",
+                    "handler": partial_handler,
+                },
+            },
+        });
+        HttpServer server = setup.server;
+        on_exit delete server;
+
+        HttpClientIo::HttpClientConnectionManager mgr = createH3Manager();
+        on_exit delete mgr;
+
+        string url = sprintf("https://127.0.0.1:%d", setup.port);
+        hash<auto> resp = mgr.request(url, "POST", "/partial",
+            {"Content-Type": "application/octet-stream"}, mPayload);
+
+        assertEq(200, resp.status_code, "partial read: response status 200");
+        string body_str = resp.body.typeCode() == NT_BINARY
+            ? resp.body.toString() : string(resp.body);
+        # Response should start with "partial:" and have a non-zero chunk size
+        assertTrue(body_str =~ /^partial:/, "partial read: response format correct");
+    }
+
+    #! Test 3.6: Headers-only GET with no body — handler doesn't call readQuicStreamDataBlock
+    testH3HeadersOnlyGetNoBodyRead() {
+        hash<auto> setup = createServer({"headers_only": True});
+        HttpServer server = setup.server;
+        StreamingBodyHandler handler = setup.streaming_handler;
+        on_exit delete server;
+
+        HttpClientIo::HttpClientConnectionManager mgr = createH3Manager();
+        on_exit delete mgr;
+
+        handler.clearRequests();
+
+        string url = sprintf("https://127.0.0.1:%d", setup.port);
+        hash<auto> resp = mgr.request(url, "GET", "/streaming-body");
+        assertEq(200, resp.status_code, "headers-only GET: response status");
+
+        # Verify handler saw headers_end_stream=True and body_streaming=False (GET has no body)
+        list<hash<auto>> requests = handler.getReceivedRequests();
+        assertEq(1, requests.size(), "headers-only GET: one request received");
+        assertTrue(requests[0].headers_end_stream,
+            "headers-only GET: headers_end_stream=True");
+        assertEq(0, requests[0].body_size, "headers-only GET: no body data");
+    }
+}

--- a/include/qore/QoreSocketObject.h
+++ b/include/qore/QoreSocketObject.h
@@ -716,7 +716,8 @@ public:
         @param stream_id the HTTP/3 stream ID
         @param timeout_ms maximum wait time in milliseconds
         @param xsink exception sink
-        @return binary data if available, or NOTHING if stream complete or timeout
+        @return binary data if available, or NOTHING if the stream is complete (end-of-stream);
+            on timeout, the QUIC-STREAM-TIMEOUT exception is raised
         @since %Qore 2.3
     */
     DLLEXPORT BinaryNode* readQuicStreamDataBlock(int64_t session_id, int64_t stream_id,

--- a/include/qore/QoreSocketObject.h
+++ b/include/qore/QoreSocketObject.h
@@ -710,6 +710,34 @@ public:
     DLLEXPORT QoreValue readQuicConnectStreamData(int64_t session_id, int64_t stream_id,
         ExceptionSink* xsink);
 
+    //! Read body data from a dispatched HTTP/3 stream (headers-only mode)
+    /** Blocks until body data is available, the stream completes, or the timeout expires.
+        @param session_id the QUIC session ID
+        @param stream_id the HTTP/3 stream ID
+        @param timeout_ms maximum wait time in milliseconds
+        @param xsink exception sink
+        @return binary data if available, or NOTHING if stream complete or timeout
+        @since %Qore 2.3
+    */
+    DLLEXPORT BinaryNode* readQuicStreamDataBlock(int64_t session_id, int64_t stream_id,
+        int timeout_ms, ExceptionSink* xsink);
+
+    //! Check if an HTTP/3 stream has received END_STREAM
+    /** @param session_id the QUIC session ID
+        @param stream_id the HTTP/3 stream ID
+        @return true if body_complete or stream not found
+        @since %Qore 2.3
+    */
+    DLLEXPORT bool isQuicStreamComplete(int64_t session_id, int64_t stream_id) const;
+
+    //! Remove a dispatched HTTP/3 stream from the session map
+    /** @param session_id the QUIC session ID
+        @param stream_id the HTTP/3 stream ID
+        @param xsink exception sink
+        @since %Qore 2.3
+    */
+    DLLEXPORT void cleanupQuicStream(int64_t session_id, int64_t stream_id, ExceptionSink* xsink);
+
 private:
     DLLLOCAL QoreSocketObject(QoreSocket* s, QoreSSLCertificate* cert = nullptr, QoreSSLPrivateKey* pk = nullptr);
 

--- a/include/qore/intern/Http2Session.h
+++ b/include/qore/intern/Http2Session.h
@@ -116,6 +116,7 @@ struct Http2StreamInfo {
     bool reset = false;
     bool marked_complete = false;  //!< True if already added to completed_streams (prevents duplicates)
     bool dispatched = false;       //!< True after headers-only dispatch (stream stays in map for DATA accumulation)
+    bool headers_end_stream = false; //!< True if END_STREAM was on the initial HEADERS frame (no body expected)
     bool streaming = false;        //!< True for streaming requests (bidi/client-streaming) on client side
     uint32_t error_code = 0;
 

--- a/include/qore/intern/QC_SocketPollOperation.h
+++ b/include/qore/intern/QC_SocketPollOperation.h
@@ -1157,6 +1157,7 @@ enum class QCS : int {
     FLUSHING = 8,        //!< flushing pending QUIC packets
     SENT = 9,            //!< response sent
     CLOSED = 10,         //!< connection closed
+    HEADERS_READY = 11,  //!< HTTP/3 headers received (headers-only mode)
 };
 
 //! Poll operation for QUIC client: handshake + HTTP/3 request/response
@@ -1199,9 +1200,10 @@ public:
         // Hold socket lock for the entire abort to prevent races with
         // concurrent socket destruction (lock ordering: priv->m → quic_sessions_lock)
         AutoLocker al(sock->priv->m);
-        // Remove session from socket's session map and release our reference;
-        // QuicSession destructor handles ngtcp2/nghttp3 cleanup
+        // Wake handler threads blocked in waitForStreamData()/waitForStreamDrain()
+        // BEFORE removing the session from the socket map
         if (quic_session) {
+            quic_session->markClosed();
             sock->priv->socket->priv->removeQuicSession(quic_session->getSessionId());
             quic_session.reset();
         }
@@ -1297,7 +1299,7 @@ public:
     }
 
     DLLLOCAL virtual bool goalReached() const override {
-        return qcs_state == QCS::REQUEST_READY;
+        return qcs_state == QCS::REQUEST_READY || qcs_state == QCS::HEADERS_READY;
     }
 
     DLLLOCAL virtual const char* getStateImpl() const override;
@@ -1313,9 +1315,10 @@ public:
         // Hold socket lock for the entire abort to prevent races with
         // concurrent socket destruction (lock ordering: priv->m → quic_sessions_lock)
         AutoLocker al(sock->priv->m);
-        // Clean up local session map and remove sessions from the authoritative map;
-        // without a poll operation driving timers/ACKs, orphaned sessions would leak
+        // Wake handler threads blocked in waitForStreamData()/waitForStreamDrain()
+        // BEFORE removing sessions from the socket map
         for (auto& [id, session] : sessions_) {
+            session->markClosed();
             sock->priv->socket->priv->removeQuicSession(id);
         }
         sessions_.clear();
@@ -1336,12 +1339,20 @@ public:
     //! (clients will retry or time out).
     static constexpr size_t MAX_QUIC_SERVER_SESSIONS = 10000;
 
+    //! Set headers-only dispatch mode
+    /** When true, requests are dispatched as soon as headers are received,
+        before the full body arrives.  The handler reads body data incrementally
+        via readQuicStreamDataBlock().
+    */
+    DLLLOCAL void setHeadersOnly(bool v);
+
 private:
     //! Cached completed stream with session ID and session pointer (for peer address extraction)
     struct CachedStream {
         int64_t session_id;
         std::unique_ptr<QuicStreamInfo> stream;
         std::shared_ptr<QuicSession> session;
+        std::shared_ptr<StreamNotifier> notifier;  //!< per-stream notifier for targeted wakeup
     };
 
     //! Local session map — single-threaded working copy used only from the I/O
@@ -1351,6 +1362,9 @@ private:
     std::unordered_map<int64_t, std::shared_ptr<QuicSession>> sessions_;
 
     QCS qcs_state = QCS::NONE;
+
+    //! Headers-only mode flag
+    bool headers_only_ = false;
 
     //! Cached completed stream info; mutable so getOutput() (const) can consume it.
     //! Thread safety: the poll framework serializes continuePoll() and getOutput()
@@ -1365,6 +1379,12 @@ private:
     //! avoids per-datagram getsockname() syscall
     struct sockaddr_storage local_addr_{};
     socklen_t local_addrlen_ = 0;
+
+    //! Check for headers-only dispatch during READING state
+    /** @param handled set to true if a dispatch occurred
+        @return nullptr if goal reached, poll info hash if I/O needed
+    */
+    DLLLOCAL QoreHashNode* checkHeadersOnlyDispatch(bool& handled, ExceptionSink* xsink);
 
     //! Coalesced timer + write + send for all sessions in a single pass
     /** Replaces separate processTimers() + sendAllPendingPackets() + getMinExpiry()

--- a/include/qore/intern/QuicSession.h
+++ b/include/qore/intern/QuicSession.h
@@ -96,6 +96,11 @@ struct QuicStreamInfo {
     //! RFC 9220: True if this stream is a CONNECT tunnel that must stay in streams_
     //! after being dispatched (so h3RecvDataCallback can route tunnel data)
     bool connect_tunnel_active = false;
+
+    //! True after headers-only dispatch (stream stays in map for DATA accumulation)
+    bool dispatched = false;
+    //! True if FIN was set on the HEADERS frame (no body expected)
+    bool headers_end_stream = false;
 };
 
 //! Per-stream body data for sending via nghttp3 data reader callback
@@ -124,6 +129,54 @@ struct QuicStreamingBodyData {
 };
 
 class qore_socket_private;
+
+//! Per-stream notification object for targeted wakeup (avoids thundering herd)
+/** Heap-allocated and shared via shared_ptr between the I/O thread (signal side)
+    and the handler thread (wait side). Non-copyable (contains mutex/CV), but
+    QuicStreamInfo remains copyable because streams reference this indirectly.
+*/
+struct StreamNotifier {
+    std::mutex mtx;
+    std::condition_variable cv;
+    std::atomic<unsigned> gen{0};
+    std::atomic<bool> closed{false};
+
+    //! Signal that data is available (increments gen, notify_one)
+    void signal() {
+        gen.fetch_add(1, std::memory_order_release);
+        {
+            std::lock_guard<std::mutex> lg(mtx);
+        }
+        cv.notify_one();
+    }
+
+    //! Mark as closed and wake the waiter
+    void markClosed() {
+        closed.store(true, std::memory_order_release);
+        gen.fetch_add(1, std::memory_order_release);
+        {
+            std::lock_guard<std::mutex> lg(mtx);
+        }
+        cv.notify_one();
+    }
+
+    //! Wait for signal or timeout (uses generation-based wakeup)
+    /** @param timeout_ms max wait in ms; capped at 100ms per iteration
+    */
+    void wait(int timeout_ms) {
+        if (closed.load(std::memory_order_acquire)) {
+            return;
+        }
+        unsigned cur_gen = gen.load(std::memory_order_acquire);
+        std::unique_lock<std::mutex> lk(mtx);
+        int wait_ms = timeout_ms >= 0 ? std::min(timeout_ms, 100) : 100;
+        cv.wait_for(lk, std::chrono::milliseconds(wait_ms),
+            [this, cur_gen]() {
+                return closed.load(std::memory_order_acquire)
+                    || gen.load(std::memory_order_acquire) != cur_gen;
+            });
+    }
+};
 
 //! Result from processTimerAndWrite() — coalesces timer check + packet generation
 struct QuicTimerWriteResult {
@@ -375,11 +428,74 @@ public:
     */
     DLLLOCAL bool hasCompletedStreams() const;
 
+    //! Set headers-only dispatch mode
+    /** When true, headers-complete streams are kept in the map for
+        takeHeadersReadyStreamCopy() to find and dispatch them.
+    */
+    DLLLOCAL void setHeadersOnlyMode(bool v);
+
+    //! Atomically find first headers-ready stream, copy it, and mark as dispatched
+    /** Finds the first stream with headers_complete && !dispatched, creates a copy
+        (clears body on copy), marks original as dispatched = true.
+        @return copy of the stream info, or nullptr if none found
+    */
+    DLLLOCAL std::unique_ptr<QuicStreamInfo> takeHeadersReadyStreamCopy(
+        std::shared_ptr<StreamNotifier>* notifier_out = nullptr);
+
+    //! Check if a dispatched stream has received all body data (END_STREAM)
+    /** @param stream_id the HTTP/3 stream ID
+        @return true if body_complete or stream not found (treat as complete)
+    */
+    DLLLOCAL bool isStreamComplete(int64_t stream_id) const;
+
+    //! Remove a dispatched stream from the session map
+    /** Called after the handler has finished processing all body data.
+        @param stream_id the HTTP/3 stream ID
+    */
+    DLLLOCAL void cleanupStream(int64_t stream_id);
+
+    //! Get the per-stream notifier for a dispatched stream (if any)
+    /** @param stream_id the HTTP/3 stream ID
+        @return shared_ptr to the notifier, or nullptr if not found
+    */
+    DLLLOCAL std::shared_ptr<StreamNotifier> getStreamNotifier(int64_t stream_id) const;
+
+    //! Take accumulated body data from a dispatched stream (atomic with completion check)
+    /** Swaps out the body data from stream->body and returns it as BinaryNode*.
+        Also sets @a complete to indicate whether the stream has received END_STREAM.
+        Both data extraction and completion check happen under a single lock to avoid
+        TOCTOU races with the I/O thread.
+
+        When data is consumed, QUIC flow control windows are extended to allow the peer
+        to send more data (consumption-driven flow control).
+
+        Used by handler threads to incrementally read request body data.
+        @param stream_id the HTTP/3 stream ID
+        @param complete [out] set to true if body_complete (END_STREAM received) or stream not found
+        @return body data as BinaryNode*, or NOTHING if no data available
+    */
+    DLLLOCAL QoreValue takeStreamData(int64_t stream_id, bool& complete);
+
+    //! Wait for stream data or completion on a dispatched stream
+    /** Blocks until the stream_data_cv_ is signaled or the timeout expires.
+        @param timeout_ms maximum wait time in milliseconds
+    */
+    DLLLOCAL void waitForStreamData(int timeout_ms);
+
     //! Check if the QUIC handshake is complete
     DLLLOCAL bool isHandshakeComplete() const;
 
     //! Check if the connection is closed or closing
     DLLLOCAL bool isClosed() const;
+
+    //! Mark session as closed — wakes all handler threads blocked in waitForStreamData()/waitForStreamDrain()
+    /** Called by abort() before removing the session from the socket map.
+        Thread-safe: uses atomic store + signals all CVs.
+    */
+    DLLLOCAL void markClosed();
+
+    //! Check if session has been marked closed via markClosed()
+    DLLLOCAL bool isMarkedClosed() const { return closed_.load(std::memory_order_acquire); }
 
     //! Get the connection close error (if any)
     DLLLOCAL ngtcp2_ccerr getCloseError() const;
@@ -926,10 +1042,12 @@ private:
     std::atomic<bool> handshake_completed_{false};   //!< true when handshake completes
     std::atomic<bool> pending_write_{false};         //!< true when data queued for writing
     std::atomic<bool> has_completed_streams_{false};  //!< true when completed streams are queued (lock-free check)
+    bool headers_only_mode_{false};                  //!< when true, markStreamComplete() keeps undispatched headers-complete streams in map
     std::atomic<bool> attempting_0rtt_{false};          //!< true when attempting 0-RTT connection
     std::atomic<bool> early_data_rejected_{false};    //!< true when 0-RTT early data was rejected by server
     std::atomic<bool> early_data_ready_{false};       //!< true when 0-RTT TX key installed (can send early data)
     std::atomic<bool> goaway_sent_{false};           //!< true when final GOAWAY (submitShutdown) has been queued; false during notice-only phase
+    std::atomic<bool> closed_{false};                //!< true when session is being torn down (abort); wakes blocked handlers
     std::atomic<bool> goaway_received_{false};       //!< true when GOAWAY received from peer
     std::atomic<bool> path_migrated_{false};         //!< set by pathValidationCallback on SUCCESS; cleared by clearPathMigrated()
     //! Address change generation counter — incremented each time remote_addr_ is updated.
@@ -947,6 +1065,9 @@ private:
 
     //! Active streams (unordered_map for O(1) lookup vs O(log n) with std::map)
     std::unordered_map<int64_t, std::unique_ptr<QuicStreamInfo>> streams_;
+
+    //! Per-stream notifiers for targeted wakeup of handler threads (protected by mtx_)
+    std::unordered_map<int64_t, std::shared_ptr<StreamNotifier>> stream_notifiers_;
 
     //! Queue of completed stream IDs
     std::queue<int64_t> completed_streams_;
@@ -1024,6 +1145,18 @@ private:
     std::mutex drain_mtx_;
     std::condition_variable drain_cv_;
     std::atomic<unsigned> drain_gen_{0};
+
+    //! Condition variable for stream data notifications (headers-only body streaming)
+    /** Signaled by h3RecvDataCallback and h3EndStreamCallback when data arrives or
+        a dispatched stream completes.  Used by readQuicStreamDataBlock() to wait for
+        body data on dispatched streams without polling.
+
+        Uses a separate non-recursive stream_data_mtx_ + stream_data_cv_ pair with an
+        atomic generation counter (same pattern as drain_cv_).
+    */
+    std::mutex stream_data_mtx_;
+    std::condition_variable stream_data_cv_;
+    std::atomic<unsigned> stream_data_gen_{0};
 };
 
 #endif // _QORE_INTERN_QUICSESSION_H

--- a/lib/Http2Session.cpp
+++ b/lib/Http2Session.cpp
@@ -1408,6 +1408,7 @@ int Http2Session::onFrameRecvCallback(nghttp2_session* session,
                         stream->headers_complete = true;
                         // For requests without a body (like GET), END_STREAM is on the HEADERS frame
                         if (frame->hd.flags & NGHTTP2_FLAG_END_STREAM) {
+                            stream->headers_end_stream = true;
                             stream->body_complete = true;
                             // Mark as complete so the handler is called
                             // For CONNECT streams, markStreamComplete() keeps the stream in the map

--- a/lib/QC_Socket.qpp
+++ b/lib/QC_Socket.qpp
@@ -5341,15 +5341,59 @@ AbstractPollOperation Socket::startPollQuicConnect(string host, int port, int fa
     @throw QUIC-ERROR if QUIC/HTTP/3 support is not available
     @throw SOCKET-NOT-OPEN if the socket is not open
 
+    @param opts optional options hash:
+    - \c "headers_only": if @ref True, dispatches requests as soon as headers are received
+      (before the full body arrives); the handler reads body data incrementally via
+      @ref readQuicStreamDataBlock().  When enabled:
+      - The poll operation completes when HEADERS are received (not when the full body arrives)
+      - The output hash will have \c body set to @ref nothing
+      - The output hash includes \c hdr set to @ref True to indicate headers-only dispatch
+      - The output hash includes \c headers_end_stream: @ref True if END_STREAM was set
+        on the HEADERS frame (e.g., GET requests with no body)
+      - The handler must call @ref readQuicStreamDataBlock() to read body data and
+        @ref cleanupQuicStream() when done
+
+    @par Headers-Only Example
+    @code{.py}
+    Socket sock();
+    sock.bindINET("0.0.0.0", 8443, True, AF_INET);
+    AbstractPollOperation op = sock.startPollQuicAccept({"headers_only": True});
+    while (*hash<SocketPollInfo> info = op.continuePoll()) {
+        Socket::poll((info,), 10s);
+    }
+    hash<auto> request = op.getOutput();
+    # request.hdr is True — body must be read incrementally
+    if (!request.headers_end_stream) {
+        binary body = binary();
+        while (True) {
+            *binary chunk = sock.readQuicStreamDataBlock(request.session_id,
+                request.stream_id, 30s);
+            if (!exists chunk) {
+                break;
+            }
+            body += chunk;
+        }
+        sock.cleanupQuicStream(request.session_id, request.stream_id);
+    }
+    @endcode
+
     @note Requires a UDP socket bound with @ref bindINET() before calling this method
 
     @since %Qore 2.3
 */
-AbstractPollOperation Socket::startPollQuicAccept() {
+AbstractPollOperation Socket::startPollQuicAccept(*hash<auto> opts) {
     s->ref();
     ReferenceHolder<SocketPollOperationBase> poller(new SocketQuicServerPollOperation(xsink, s), xsink);
     if (*xsink) {
         return QoreValue();
+    }
+
+    // Apply options
+    if (opts) {
+        bool headers_only = opts->getKeyValue("headers_only").getAsBool();
+        if (headers_only) {
+            reinterpret_cast<SocketQuicServerPollOperation*>(*poller)->setHeadersOnly(true);
+        }
     }
 
     ReferenceHolder<QoreObject> rv(new QoreObject(QC_SOCKETPOLLOPERATION, getProgram(), *poller), xsink);
@@ -5987,4 +6031,213 @@ nothing Socket::submitQuicConnectResponse(int session_id, int stream_id, int sta
         return QoreValue();
     }
     return s->readQuicConnectStreamData(session_id, stream_id, xsink);
+}
+
+//! Reads body data from a dispatched HTTP/3 stream (headers-only mode)
+/** Blocks until body data is available, the stream completes (END_STREAM), or the
+    timeout expires.  Used by handler threads to incrementally read request body data
+    from streams that were dispatched via headers-only mode.
+
+    @par HTTP/3 vs HTTP/2 Threading Model
+    Unlike HTTP/2 where the handler thread drives the TCP socket directly,
+    HTTP/3 uses a shared UDP socket where a dedicated I/O thread processes
+    datagrams and buffers incoming data per stream.  This method uses a
+    per-stream condition variable to wait for data, so only the handler for
+    the specific stream that received data is woken (no thundering herd).
+
+    @par Thread Safety
+    This method intentionally does @b not acquire the Socket object's mutex, because
+    holding the mutex during a blocking wait would prevent other threads from performing
+    operations on the same socket.  Thread safety for the QUIC session internals is
+    provided by the session's own recursive mutex.
+
+    Multiple handler threads can safely call this method concurrently for different
+    streams on the same session — each handler waits on its own per-stream condition
+    variable.
+
+    @par Stream Lifecycle
+    When a stream is dispatched with the \c headers_only option via
+    @ref startPollQuicAccept(), the stream remains in the QuicSession so that body
+    data can be read incrementally with this method.  After all data has been consumed
+    (this method returns @ref nothing), call @ref cleanupQuicStream() to free the
+    stream state.  If the handler is invoked via the @ref HttpServer "HttpServer"
+    framework, cleanup is handled automatically by the framework's \c on_exit handler.
+
+    @par Typical Usage (Low-Level Socket API)
+    @code{.py}
+    # In a handler thread after receiving a headers-only dispatched request:
+    int session_id = request.session_id;
+    int stream_id = request.stream_id;
+    binary body = binary();
+    while (True) {
+        *binary chunk = sock.readQuicStreamDataBlock(session_id, stream_id, 30s);
+        if (!exists chunk) {
+            # Stream complete — END_STREAM received and no more buffered data
+            break;
+        }
+        body += chunk;
+    }
+    # Process the complete body
+    process_body(body);
+    # Clean up the stream state (required to prevent stream-state accumulation)
+    sock.cleanupQuicStream(session_id, stream_id);
+    @endcode
+
+    @par Typical Usage (HttpServer Framework)
+    @code{.py}
+    class MyStreamingHandler inherits AbstractHttpRequestHandler {
+        bool wantsBodyStreaming(hash<auto> cx, hash<auto> hdr) {
+            return True;
+        }
+
+        hash<HttpResponseInfo> handleRequest(hash<auto> cx, hash<auto> hdr, *data body) {
+            int session_id = cx."header-info".session_id;
+            int stream_id = cx."header-info".stream_id;
+            Socket sock = cx."header-info".sock;
+
+            # Read body incrementally — the framework handles cleanup automatically
+            binary accumulated = binary();
+            while (True) {
+                *binary chunk = sock.readQuicStreamDataBlock(session_id, stream_id, 30s);
+                if (!exists chunk) {
+                    break;
+                }
+                accumulated += chunk;
+            }
+            return makeResponse(200, process(accumulated));
+        }
+    }
+    @endcode
+
+    @par Timeout Handling
+    @code{.py}
+    # Use a short timeout and handle QUIC-STREAM-TIMEOUT for time-sensitive reads
+    try {
+        *binary chunk = sock.readQuicStreamDataBlock(session_id, stream_id, 5s);
+    } catch (hash<ExceptionInfo> ex) {
+        if (ex.err == "QUIC-STREAM-TIMEOUT") {
+            # Timeout — no data arrived within 5 seconds
+            return makeResponse(408, "Request Timeout");
+        }
+        rethrow;
+    }
+    @endcode
+
+    @par Session Closure
+    If the QUIC session is closed (e.g., server shutdown or peer disconnect) while
+    this method is waiting, it raises a \c QUIC-ERROR exception immediately rather
+    than waiting for the timeout to expire.
+
+    @param session_id the QUIC session ID (from \c cx."header-info".session_id)
+    @param stream_id the HTTP/3 stream ID (from \c cx."header-info".stream_id)
+    @param timeout the maximum time to wait for data; default 30s
+
+    @return binary data if available, or @ref nothing if the stream is complete
+    (END_STREAM received and no more buffered data)
+
+    @throw QUIC-ERROR if no QUIC session with the given ID is active, or if the session
+    is closed during the wait (e.g., server shutdown)
+    @throw QUIC-STREAM-TIMEOUT if the timeout expires before data arrives or the stream
+    completes
+
+    @see @ref cleanupQuicStream()
+    @see @ref isQuicStreamComplete()
+    @see @ref wantsBodyStreaming()
+
+    @since %Qore 2.3
+*/
+*binary Socket::readQuicStreamDataBlock(int session_id, int stream_id, timeout timeout = 30s) {
+    if (session_id <= 0) {
+        xsink->raiseException("QUIC-ERROR", "invalid session_id %lld: must be > 0", (long long)session_id);
+        return QoreValue();
+    }
+    if (stream_id < 0) {
+        xsink->raiseException("QUIC-ERROR", "invalid stream_id %lld: must be >= 0", (long long)stream_id);
+        return QoreValue();
+    }
+    return s->readQuicStreamDataBlock(session_id, stream_id, (int)timeout, xsink);
+}
+
+//! Check if an HTTP/3 stream has received END_STREAM
+/** Returns @ref True "True" if all body data has been received for the given stream
+    (i.e., END_STREAM has been received), or if the stream is not found in the session.
+
+    @note In most cases, you do not need to call this method directly.
+    @ref readQuicStreamDataBlock() returns @ref nothing when the stream is complete,
+    which is the recommended way to detect end-of-stream in a read loop.  This method
+    is useful for non-blocking status checks without attempting a read.
+
+    @par Example
+    @code{.py}
+    # Non-blocking check whether more data is expected
+    if (!sock.isQuicStreamComplete(session_id, stream_id)) {
+        # More data may arrive — continue reading
+        *binary chunk = sock.readQuicStreamDataBlock(session_id, stream_id, 30s);
+    }
+    @endcode
+
+    @param session_id the QUIC session ID
+    @param stream_id the HTTP/3 stream ID
+
+    @return @ref True if END_STREAM has been received (body_complete) or the stream is
+    not found (treat unknown streams as complete for safety)
+
+    @see @ref readQuicStreamDataBlock()
+
+    @since %Qore 2.3
+*/
+bool Socket::isQuicStreamComplete(int session_id, int stream_id) [flags=CONSTANT] {
+    if (session_id <= 0 || stream_id < 0) {
+        return true;
+    }
+    return s->isQuicStreamComplete(session_id, stream_id);
+}
+
+//! Remove a dispatched HTTP/3 stream from the session map
+/** Called after the handler has finished processing all body data from a
+    headers-only dispatched stream.  Releases the stream's state (buffered data,
+    per-stream notifier, completion flag) from the QuicSession and prevents
+    stream-state accumulation on long-lived connections.
+
+    @par When to Call
+    Call this method after @ref readQuicStreamDataBlock() returns @ref nothing
+    (stream complete) or when the handler decides to stop reading (early return).
+    If using the @ref HttpServer "HttpServer" framework with @ref wantsBodyStreaming(),
+    cleanup is handled automatically by the framework's \c on_exit handler — you do
+    @b not need to call this manually.
+
+    @par Typical Usage (Low-Level Socket API)
+    @code{.py}
+    # Read all data from a headers-only dispatched HTTP/3 stream
+    binary body = binary();
+    while (True) {
+        *binary chunk = sock.readQuicStreamDataBlock(session_id, stream_id, 30s);
+        if (!exists chunk) {
+            break;
+        }
+        body += chunk;
+    }
+    # Free the stream state from the session
+    sock.cleanupQuicStream(session_id, stream_id);
+    @endcode
+
+    @param session_id the QUIC session ID
+    @param stream_id the HTTP/3 stream ID
+
+    @throw QUIC-ERROR if no QUIC session with the given ID is active
+
+    @see @ref readQuicStreamDataBlock()
+
+    @since %Qore 2.3
+*/
+nothing Socket::cleanupQuicStream(int session_id, int stream_id) {
+    if (session_id <= 0) {
+        xsink->raiseException("QUIC-ERROR", "invalid session_id %lld: must be > 0", (long long)session_id);
+        return QoreValue();
+    }
+    if (stream_id < 0) {
+        xsink->raiseException("QUIC-ERROR", "invalid stream_id %lld: must be >= 0", (long long)stream_id);
+        return QoreValue();
+    }
+    s->cleanupQuicStream(session_id, stream_id, xsink);
 }

--- a/lib/QoreSocket.cpp
+++ b/lib/QoreSocket.cpp
@@ -6833,6 +6833,10 @@ QoreValue SocketHttp2ServerPollOperation::getOutput() const {
     // Indicate headers-only dispatch (stream still in map for incremental reading)
     if (h2_state == H2S_HEADERS_READY) {
         result->setKeyValue("hdr", true, nullptr);
+        // Indicate whether END_STREAM was on the HEADERS frame itself (no body expected)
+        if (cached_stream->headers_end_stream) {
+            result->setKeyValue("headers_end_stream", true, nullptr);
+        }
     }
 
     return result;

--- a/lib/QoreSocketObject.cpp
+++ b/lib/QoreSocketObject.cpp
@@ -1449,6 +1449,97 @@ QoreValue QoreSocketObject::readQuicConnectStreamData(int64_t session_id, int64_
     return session->readConnectStreamData(stream_id, xsink);
 }
 
+BinaryNode* QoreSocketObject::readQuicStreamDataBlock(int64_t session_id, int64_t stream_id,
+        int timeout_ms, ExceptionSink* xsink) {
+    // Get the session WITHOUT holding the socket lock — the session is reference-counted
+    // and we need to avoid holding the socket lock while blocking on the CV
+    std::shared_ptr<QuicSession> session;
+    {
+        AutoLocker al(priv->m);
+        qore_socket_private* sp = qore_socket_private::get(*priv->socket);
+        session = sp->getQuicSession(session_id);
+    }
+    if (!session) {
+        xsink->raiseException("QUIC-ERROR", "no QUIC session with id %lld on this socket",
+            (long long)session_id);
+        return nullptr;
+    }
+    // Use a deadline to avoid timeout reset when data arrives incrementally
+    int64 deadline_ms = timeout_ms >= 0
+        ? q_clock_getmillis() + timeout_ms
+        : -1;
+
+    // Get per-stream notifier for targeted wakeup (avoids thundering herd)
+    std::shared_ptr<StreamNotifier> notifier = session->getStreamNotifier(stream_id);
+
+    while (true) {
+        // Check if session has been torn down (abort)
+        if (session->isMarkedClosed()) {
+            xsink->raiseException("QUIC-ERROR",
+                "QUIC session closed during stream read (session %lld, stream %lld)",
+                (long long)session_id, (long long)stream_id);
+            return nullptr;
+        }
+
+        // 1. Atomically check stream buffer AND completion status under one lock
+        // This eliminates the TOCTOU race where data could arrive between separate
+        // takeStreamData() and isStreamComplete() calls
+        bool complete = false;
+        QoreValue data = session->takeStreamData(stream_id, complete);
+        if (data.getType() == NT_BINARY) {
+            return data.get<BinaryNode>();
+        }
+        if (complete) {
+            return nullptr;
+        }
+
+        // 3. Calculate remaining timeout from deadline
+        int remaining_ms;
+        if (deadline_ms >= 0) {
+            remaining_ms = (int)(deadline_ms - q_clock_getmillis());
+            if (remaining_ms <= 0) {
+                // Timeout — raise exception so callers can distinguish from stream completion
+                xsink->raiseException("QUIC-STREAM-TIMEOUT",
+                    "timeout reading QUIC stream data (session %lld, stream %lld)",
+                    (long long)session_id, (long long)stream_id);
+                return nullptr;
+            }
+        } else {
+            remaining_ms = -1;
+        }
+
+        // 4. Wait for stream data or completion — per-stream notifier avoids thundering herd
+        if (notifier) {
+            notifier->wait(remaining_ms);
+        } else {
+            session->waitForStreamData(remaining_ms);
+        }
+    }
+}
+
+bool QoreSocketObject::isQuicStreamComplete(int64_t session_id, int64_t stream_id) const {
+    AutoLocker al(priv->m);
+    qore_socket_private* sp = qore_socket_private::get(*priv->socket);
+    std::shared_ptr<QuicSession> session = sp->getQuicSession(session_id);
+    if (!session) {
+        return true;  // Session not found, treat as complete
+    }
+    return session->isStreamComplete(stream_id);
+}
+
+void QoreSocketObject::cleanupQuicStream(int64_t session_id, int64_t stream_id,
+        ExceptionSink* xsink) {
+    AutoLocker al(priv->m);
+    qore_socket_private* sp = qore_socket_private::get(*priv->socket);
+    std::shared_ptr<QuicSession> session = sp->getQuicSession(session_id);
+    if (!session) {
+        xsink->raiseException("QUIC-ERROR", "no QUIC session with id %lld on this socket",
+            (long long)session_id);
+        return;
+    }
+    session->cleanupStream(stream_id);
+}
+
 bool my_socket_priv::hasQuicSession() const {
     qore_socket_private* sp = qore_socket_private::get(*socket);
     AutoLocker al(sp->quic_sessions_lock);

--- a/lib/QuicPollOperations.cpp
+++ b/lib/QuicPollOperations.cpp
@@ -988,8 +988,44 @@ const char* SocketQuicServerPollOperation::getStateImpl() const {
         case QCS::HANDSHAKE_RECV: return "handshake-recv";
         case QCS::READING: return "reading";
         case QCS::REQUEST_READY: return "request-ready";
+        case QCS::HEADERS_READY: return "headers-ready";
         default: return "unknown";
     }
+}
+
+void SocketQuicServerPollOperation::setHeadersOnly(bool v) {
+    headers_only_ = v;
+    for (auto& [id, session] : sessions_) {
+        session->setHeadersOnlyMode(v);
+    }
+}
+
+QoreHashNode* SocketQuicServerPollOperation::checkHeadersOnlyDispatch(bool& handled,
+        ExceptionSink* xsink) {
+    handled = false;
+    if (!headers_only_) {
+        return nullptr;
+    }
+    // Iterate sessions to find one with a headers-ready stream
+    for (auto& [id, session] : sessions_) {
+        std::shared_ptr<StreamNotifier> notifier;
+        auto stream = session->takeHeadersReadyStreamCopy(&notifier);
+        if (stream) {
+            handled = true;
+            cached_stream_ = std::make_unique<CachedStream>();
+            cached_stream_->session_id = session->getSessionId();
+            cached_stream_->stream = std::move(stream);
+            cached_stream_->session = session;
+            cached_stream_->notifier = std::move(notifier);
+            qcs_state = QCS::HEADERS_READY;
+            // Restore OS-level blocking mode
+            sock->priv->socket->priv->set_non_blocking(false, xsink);
+            sock->priv->clearNonBlock();
+            set_non_block = false;
+            return nullptr;  // goal reached
+        }
+    }
+    return nullptr;
 }
 
 QoreValue SocketQuicServerPollOperation::getOutput() const {
@@ -1068,6 +1104,12 @@ QoreValue SocketQuicServerPollOperation::getOutput() const {
         SimpleRefHolder<BinaryNode> body(new BinaryNode());
         body->append(cached_stream_->stream->body.data(), cached_stream_->stream->body.size());
         h->setKeyValue("body", body.release(), nullptr);
+    }
+
+    // Indicate headers-only dispatch (stream still in map for incremental reading)
+    if (qcs_state == QCS::HEADERS_READY) {
+        h->setKeyValue("hdr", true, nullptr);
+        h->setKeyValue("headers_end_stream", cached_stream_->stream->headers_end_stream, nullptr);
     }
 
     // Consume the cached stream so subsequent calls return NOTHING
@@ -1252,6 +1294,10 @@ int SocketQuicServerPollOperation::recvAndProcessPacket(ExceptionSink* xsink, Qu
         // Store in both local and qore_socket_private session maps
         sessions_[new_session->getSessionId()] = new_session;
         sock->priv->socket->priv->addQuicSession(new_session);
+        // Propagate headers-only mode to new sessions
+        if (headers_only_) {
+            new_session->setHeadersOnlyMode(true);
+        }
 
         target_session = new_session.get();
     }
@@ -1379,6 +1425,18 @@ QoreHashNode* SocketQuicServerPollOperation::continuePoll(ExceptionSink* xsink) 
             }
 
             case QCS::READING: {
+                // Headers-only mode: check for streams with HEADERS complete but not yet dispatched
+                {
+                    bool handled = false;
+                    QoreHashNode* rv = checkHeadersOnlyDispatch(handled, xsink);
+                    if (*xsink) {
+                        return nullptr;
+                    }
+                    if (handled) {
+                        return rv;
+                    }
+                }
+
                 // Check ALL sessions for completed streams
                 for (auto& entry : sessions_) {
                     auto& session = entry.second;
@@ -1517,8 +1575,23 @@ QoreHashNode* SocketQuicServerPollOperation::continuePoll(ExceptionSink* xsink) 
                 }
             }
 
-            case QCS::REQUEST_READY: {
+            case QCS::REQUEST_READY:
+            case QCS::HEADERS_READY: {
                 // Already reached goal; if called again, go back to reading
+                // Check for headers-only dispatch first
+                if (headers_only_) {
+                    for (auto& entry : sessions_) {
+                        auto stream = entry.second->takeHeadersReadyStreamCopy();
+                        if (stream) {
+                            cached_stream_ = std::make_unique<CachedStream>();
+                            cached_stream_->session_id = entry.second->getSessionId();
+                            cached_stream_->stream = std::move(stream);
+                            cached_stream_->session = entry.second;
+                            qcs_state = QCS::HEADERS_READY;
+                            return nullptr;
+                        }
+                    }
+                }
                 // Check all sessions for more completed streams
                 for (auto& entry : sessions_) {
                     auto& session = entry.second;
@@ -1528,6 +1601,7 @@ QoreHashNode* SocketQuicServerPollOperation::continuePoll(ExceptionSink* xsink) 
                         cached_stream_->session_id = session->getSessionId();
                         cached_stream_->stream = std::move(stream);
                         cached_stream_->session = session;
+                        qcs_state = QCS::REQUEST_READY;
                         return nullptr;
                     }
                 }

--- a/lib/QuicSession.cpp
+++ b/lib/QuicSession.cpp
@@ -1925,6 +1925,10 @@ int QuicSession::waitForStreamDrain(int64_t stream_id, int timeout_ms) {
         }
     }
 
+    if (closed_.load(std::memory_order_acquire)) {
+        return -1;  // session closing
+    }
+
     if (timeout_ms == 0) {
         return 1;  // no wait requested, buffer is full
     }
@@ -1943,13 +1947,18 @@ int QuicSession::waitForStreamDrain(int64_t stream_id, int timeout_ms) {
         {
             std::unique_lock<std::mutex> dlock(drain_mtx_);
             auto gen_changed = [this, gen]() {
-                return drain_gen_.load(std::memory_order_acquire) != gen;
+                return closed_.load(std::memory_order_acquire)
+                    || drain_gen_.load(std::memory_order_acquire) != gen;
             };
             if (timeout_ms < 0) {
                 drain_cv_.wait(dlock, gen_changed);
             } else {
                 drain_cv_.wait_until(dlock, deadline, gen_changed);
             }
+        }
+
+        if (closed_.load(std::memory_order_acquire)) {
+            return -1;  // session closing
         }
 
         // Re-check actual predicate under mtx_
@@ -2103,10 +2112,41 @@ QuicStreamInfo* QuicSession::getOrCreateStream(int64_t stream_id) {
 void QuicSession::markStreamComplete(int64_t stream_id) {
     auto it = streams_.find(stream_id);
     if (it != streams_.end() && !it->second->body_complete) {
-        printd(5, "QuicSession::markStreamComplete() stream_id=" QLLD " body_size=%d status=%d\n",
-            stream_id, (int)it->second->body.size(), it->second->status_code);
+        printd(5, "QuicSession::markStreamComplete() stream_id=" QLLD " body_size=%d status=%d dispatched=%d\n",
+            stream_id, (int)it->second->body.size(), it->second->status_code,
+            it->second->dispatched ? 1 : 0);
         it->second->state = QuicStreamState::Closed;
         it->second->body_complete = true;
+
+        // If stream was dispatched via headers-only mode, the handler is reading DATA
+        // incrementally. Keep stream in map for continued DATA accumulation; don't push
+        // to completed_streams or erase. Notify the handler's condition variable.
+        if (it->second->dispatched) {
+            printd(5, "QuicSession::markStreamComplete() stream_id=" QLLD " dispatched, keeping in map\n",
+                stream_id);
+            // Signal per-stream notifier first (targeted wakeup), fallback to session-wide CV
+            auto nit = stream_notifiers_.find(stream_id);
+            if (nit != stream_notifiers_.end()) {
+                nit->second->signal();
+            } else {
+                {
+                    std::lock_guard<std::mutex> lg(stream_data_mtx_);
+                    stream_data_gen_.fetch_add(1, std::memory_order_release);
+                }
+                stream_data_cv_.notify_all();
+            }
+            return;
+        }
+
+        // In headers-only mode, if headers are complete but the stream hasn't been
+        // dispatched yet (e.g., HEADERS + DATA + END_STREAM arrived in one batch),
+        // keep the stream in the map so takeHeadersReadyStreamCopy() can find it.
+        if (headers_only_mode_ && it->second->headers_complete) {
+            printd(5, "QuicSession::markStreamComplete() stream_id=" QLLD " headers-only mode, keeping in map\n",
+                stream_id);
+            return;
+        }
+
         completed_streams_.push(stream_id);
         has_completed_streams_.store(true, std::memory_order_release);
     }
@@ -2155,6 +2195,119 @@ bool QuicSession::hasCompletedStreams() const {
     return has_completed_streams_.load(std::memory_order_acquire);
 }
 
+void QuicSession::setHeadersOnlyMode(bool v) {
+    std::lock_guard<std::recursive_mutex> lock(mtx_);
+    headers_only_mode_ = v;
+}
+
+std::unique_ptr<QuicStreamInfo> QuicSession::takeHeadersReadyStreamCopy(
+        std::shared_ptr<StreamNotifier>* notifier_out) {
+    std::lock_guard<std::recursive_mutex> lock(mtx_);
+    for (auto& [id, info] : streams_) {
+        if (info->headers_complete && !info->dispatched) {
+            // Copy stream info for the caller (headers, method, path, etc.)
+            auto copy = std::make_unique<QuicStreamInfo>(*info);
+            // Clear body on the COPY: any DATA that arrived with HEADERS stays
+            // in the original for takeStreamData()/readQuicStreamDataBlock() to return.
+            copy->body.clear();
+            info->dispatched = true;
+
+            // Create per-stream notifier for targeted wakeup
+            auto notifier = std::make_shared<StreamNotifier>();
+            stream_notifiers_[id] = notifier;
+            if (notifier_out) {
+                *notifier_out = notifier;
+            }
+
+            printd(5, "QuicSession::takeHeadersReadyStreamCopy() stream_id=" QLLD "\n", id);
+            return copy;
+        }
+    }
+    return nullptr;
+}
+
+bool QuicSession::isStreamComplete(int64_t stream_id) const {
+    std::lock_guard<std::recursive_mutex> lock(mtx_);
+    auto it = streams_.find(stream_id);
+    if (it == streams_.end()) {
+        return true;  // Stream not found, treat as complete
+    }
+    return it->second->body_complete;
+}
+
+void QuicSession::cleanupStream(int64_t stream_id) {
+    std::lock_guard<std::recursive_mutex> lock(mtx_);
+    auto it = streams_.find(stream_id);
+    if (it != streams_.end()) {
+        printd(5, "QuicSession::cleanupStream() stream_id=" QLLD " removing dispatched stream\n",
+            stream_id);
+        streams_.erase(it);
+    }
+    stream_notifiers_.erase(stream_id);
+}
+
+std::shared_ptr<StreamNotifier> QuicSession::getStreamNotifier(int64_t stream_id) const {
+    std::lock_guard<std::recursive_mutex> lock(mtx_);
+    auto it = stream_notifiers_.find(stream_id);
+    if (it != stream_notifiers_.end()) {
+        return it->second;
+    }
+    return nullptr;
+}
+
+QoreValue QuicSession::takeStreamData(int64_t stream_id, bool& complete) {
+    std::lock_guard<std::recursive_mutex> lock(mtx_);
+    auto it = streams_.find(stream_id);
+    if (it == streams_.end()) {
+        complete = true;  // Stream not found, treat as complete
+        return QoreValue();
+    }
+
+    // Atomic: extract data AND check completion under one lock
+    complete = it->second->body_complete;
+
+    if (it->second->body.empty()) {
+        return QoreValue();  // NOTHING — caller checks 'complete' to decide next step
+    }
+
+    // Extract data with swap — avoids copy and releases vector memory
+    std::vector<char> data;
+    data.swap(it->second->body);
+    size_t consumed = data.size();
+
+    // Consumption-driven flow control: extend QUIC windows only when the handler
+    // consumes data, not when it arrives. This naturally caps the buffer to the
+    // initial flow control window (QUIC_SERVER_INITIAL_MAX_STREAM_DATA = 256KB)
+    // and provides backpressure when the handler is slow.
+    if (conn_) {
+        ngtcp2_conn_extend_max_stream_offset(conn_, stream_id,
+                                              static_cast<uint64_t>(consumed));
+        ngtcp2_conn_extend_max_offset(conn_, static_cast<uint64_t>(consumed));
+        // Signal that MAX_STREAM_DATA/MAX_DATA frames need to be sent so the peer
+        // can continue sending. Without this, the window update is delayed until
+        // the next natural I/O cycle (timer or incoming packet).
+        pending_write_.store(true, std::memory_order_release);
+    }
+
+    SimpleRefHolder<BinaryNode> bin(new BinaryNode());
+    bin->append(data.data(), data.size());
+    return bin.release();
+}
+
+void QuicSession::waitForStreamData(int timeout_ms) {
+    if (closed_.load(std::memory_order_acquire)) {
+        return;
+    }
+    unsigned gen = stream_data_gen_.load(std::memory_order_acquire);
+    std::unique_lock<std::mutex> lk(stream_data_mtx_);
+    int wait_ms = timeout_ms >= 0 ? std::min(timeout_ms, 100) : 100;
+    stream_data_cv_.wait_for(lk, std::chrono::milliseconds(wait_ms),
+        [this, gen]() {
+            return closed_.load(std::memory_order_acquire)
+                || stream_data_gen_.load(std::memory_order_acquire) != gen;
+        });
+}
+
 bool QuicSession::isHandshakeComplete() const {
     // No lock needed: handshake_completed_ is std::atomic<bool>
     return handshake_completed_.load(std::memory_order_acquire);
@@ -2166,6 +2319,32 @@ bool QuicSession::isClosed() const {
         return true;
     }
     return ngtcp2_conn_in_closing_period(conn_) || ngtcp2_conn_in_draining_period(conn_);
+}
+
+void QuicSession::markClosed() {
+    closed_.store(true, std::memory_order_release);
+
+    // Wake all per-stream notifiers (targeted wakeup for dispatched stream handlers)
+    {
+        std::lock_guard<std::recursive_mutex> lock(mtx_);
+        for (auto& [id, notifier] : stream_notifiers_) {
+            notifier->markClosed();
+        }
+    }
+
+    // Wake all handler threads blocked in waitForStreamData() (session-wide fallback)
+    stream_data_gen_.fetch_add(1, std::memory_order_release);
+    {
+        std::lock_guard<std::mutex> lg(stream_data_mtx_);
+    }
+    stream_data_cv_.notify_all();
+
+    // Wake all handler threads blocked in waitForStreamDrain()
+    drain_gen_.fetch_add(1, std::memory_order_release);
+    {
+        std::lock_guard<std::mutex> lg(drain_mtx_);
+    }
+    drain_cv_.notify_all();
 }
 
 ssize_t QuicSession::writeConnectionClose(uint8_t* buf, size_t buflen) {
@@ -2933,6 +3112,7 @@ int QuicSession::h3EndHeadersCallback(nghttp3_conn* /* conn */, int64_t stream_i
         auto* session = static_cast<QuicSession*>(conn_user_data);
         auto* stream = session->getOrCreateStream(stream_id);
         stream->headers_complete = true;
+        stream->headers_end_stream = (fin != 0);
 
         // Pre-allocate body buffer using content-length hint to avoid repeated
         // reallocation in h3RecvDataCallback
@@ -2960,6 +3140,23 @@ int QuicSession::h3EndHeadersCallback(nghttp3_conn* /* conn */, int64_t stream_i
             return 0;
         }
 
+        // In headers-only mode, dispatch immediately on HEADERS
+        if (session->headers_only_mode_) {
+            if (fin) {
+                // FIN on HEADERS = no body; mark truly complete
+                printd(5, "QuicSession::h3EndHeadersCallback() stream_id=" QLLD " headers-only mode "
+                    "FIN on HEADERS - marking complete\n", stream_id);
+                session->markStreamComplete(stream_id);
+            } else {
+                // No FIN = body expected; stream stays in map with headers_complete=true
+                // (set above) so takeHeadersReadyStreamCopy() can find it.
+                // body_complete is NOT set — DATA frames are expected.
+                printd(5, "QuicSession::h3EndHeadersCallback() stream_id=" QLLD " headers-only mode "
+                    "no FIN - headers ready for dispatch\n", stream_id);
+            }
+            return 0;
+        }
+
         // If fin is set, the stream has no body — mark it complete now
         if (fin) {
             printd(5, "QuicSession::h3EndHeadersCallback() stream_id=" QLLD " FIN set - marking complete (body=%d)\n",
@@ -2980,7 +3177,20 @@ int QuicSession::h3RecvDataCallback(nghttp3_conn* /* conn */, int64_t stream_id,
                                      void* conn_user_data, void* /* stream_user_data */) {
     try {
         auto* session = static_cast<QuicSession*>(conn_user_data);
-        auto* stream = session->getOrCreateStream(stream_id);
+        // Use find() instead of getOrCreateStream() to avoid recreating zombie streams
+        // that were already cleaned up by the handler (via cleanupStream())
+        auto it = session->streams_.find(stream_id);
+        if (it == session->streams_.end()) {
+            // Stream was cleaned up — extend flow control so the connection continues,
+            // but discard the data
+            printd(5, "h3RecvDataCallback() stream_id=" QLLD " datalen=%d — stream already cleaned up\n",
+                stream_id, (int)datalen);
+            ngtcp2_conn_extend_max_stream_offset(session->conn_, stream_id,
+                                                  static_cast<uint64_t>(datalen));
+            ngtcp2_conn_extend_max_offset(session->conn_, static_cast<uint64_t>(datalen));
+            return 0;
+        }
+        auto* stream = it->second.get();
         printd(5, "h3RecvDataCallback() stream_id=" QLLD " datalen=%d body_total=%d\n",
             stream_id, (int)datalen, (int)(stream->body.size() + datalen));
 
@@ -2995,6 +3205,28 @@ int QuicSession::h3RecvDataCallback(nghttp3_conn* /* conn */, int64_t stream_id,
             ngtcp2_conn_extend_max_stream_offset(session->conn_, stream_id,
                                                   static_cast<uint64_t>(datalen));
             ngtcp2_conn_extend_max_offset(session->conn_, static_cast<uint64_t>(datalen));
+            return 0;
+        }
+
+        // For dispatched streams (headers-only mode), buffer data and notify handler.
+        // Flow control is NOT extended here — it's extended in takeStreamData() when
+        // the handler actually consumes data (consumption-driven flow control). This
+        // naturally caps the buffer to the initial flow control window
+        // (QUIC_SERVER_INITIAL_MAX_STREAM_DATA = 256KB) and provides backpressure
+        // when the handler is slow.
+        if (stream->dispatched) {
+            stream->body.insert(stream->body.end(), data, data + datalen);
+            // Signal per-stream notifier first (targeted wakeup), fallback to session-wide CV
+            auto nit = session->stream_notifiers_.find(stream_id);
+            if (nit != session->stream_notifiers_.end()) {
+                nit->second->signal();
+            } else {
+                {
+                    std::lock_guard<std::mutex> lg(session->stream_data_mtx_);
+                    session->stream_data_gen_.fetch_add(1, std::memory_order_release);
+                }
+                session->stream_data_cv_.notify_all();
+            }
             return 0;
         }
 

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -677,7 +677,8 @@ void ThreadEntry::cleanup() {
 
     assert(!thread_data);
 
-    if (status != QTS_NA && status != QTS_RESERVED && !joined && ptid) {
+    if (status != QTS_NA && status != QTS_RESERVED && !joined && ptid
+            && !pthread_equal(ptid, pthread_self())) {
         pthread_detach(ptid);
     }
 

--- a/qlib/HttpClientIo/Http2ClientPollOperationImpl.qc
+++ b/qlib/HttpClientIo/Http2ClientPollOperationImpl.qc
@@ -415,22 +415,13 @@ public class Http2ClientPollOperation inherits HttpClientPollOperation {
                 *hash<auto> stream_ctx;
                 {
                     AutoLock al(stream_lock);
-                    if (is_end) {
-                        cb = remove stream_callbacks{sid};
-                        stream_ctx = remove stream_ctxs{sid};
-                        if (cb) {
-                            --active_stream_count;
-                        }
-                    } else {
-                        cb = stream_callbacks{sid};
-                        stream_ctx = stream_ctxs{sid};
-                    }
+                    cb = stream_callbacks{sid};
+                    stream_ctx = stream_ctxs{sid};
                     if (cb) {
                         callback_dispatched = True;
                     }
                 }
                 if (cb) {
-
                     try {
                         cb(output + {"ctx": stream_ctx}, NOTHING);
                     } catch (hash<ExceptionInfo> ex) {
@@ -439,6 +430,16 @@ public class Http2ClientPollOperation inherits HttpClientPollOperation {
                     }
                 } else {
                     log(LoggerLevel::DEBUG, "discarding response for cancelled stream %d", stream_id);
+                }
+                # Remove stream AFTER callback completes so the stream handle's
+                # state is already Complete before the stream becomes unavailable
+                # for sends — eliminates the race where isDone() returns False
+                # but the stream is already gone from the map
+                if (is_end && cb) {
+                    AutoLock al(stream_lock);
+                    remove stream_callbacks{sid};
+                    remove stream_ctxs{sid};
+                    --active_stream_count;
                 }
             }
 

--- a/qlib/HttpClientIo/Http3ClientPollOperationImpl.qc
+++ b/qlib/HttpClientIo/Http3ClientPollOperationImpl.qc
@@ -455,11 +455,8 @@ public class Http3ClientPollOperation inherits HttpClientPollOperation {
                 *hash<auto> stream_ctx;
                 {
                     AutoLock al(stream_lock);
-                    cb = remove stream_callbacks{sid};
-                    stream_ctx = remove stream_ctxs{sid};
-                    if (cb) {
-                        --active_stream_count;
-                    }
+                    cb = stream_callbacks{sid};
+                    stream_ctx = stream_ctxs{sid};
                     if (cb) {
                         callback_dispatched = True;
                     }
@@ -474,6 +471,14 @@ public class Http3ClientPollOperation inherits HttpClientPollOperation {
                 } else {
                     log(LoggerLevel::DEBUG, "discarding response for cancelled stream %d",
                         stream_id);
+                }
+                # Remove stream AFTER callback completes so the stream handle's
+                # state is already updated before the stream becomes unavailable
+                if (cb) {
+                    AutoLock al(stream_lock);
+                    remove stream_callbacks{sid};
+                    remove stream_ctxs{sid};
+                    --active_stream_count;
                 }
             }
 

--- a/qlib/HttpServer.qm
+++ b/qlib/HttpServer.qm
@@ -517,6 +517,42 @@ public hashdecl HttpServerOptionInfo {
         @since HttpServer 1.6
     */
     timeout quic_drain_timeout = 5s;
+
+    #! Enable HTTP/3 headers-only dispatch mode
+    /** When @ref True "True", HTTP/3 (and HTTP/2) requests are dispatched to handlers as
+        soon as headers arrive, before the full body is received.  Handlers that override
+        @ref AbstractHttpRequestHandler::wantsBodyStreaming() "wantsBodyStreaming()" and
+        return @ref True "True" can read body data incrementally via
+        @ref Qore::Socket::readQuicStreamDataBlock() (HTTP/3) or
+        @ref Qore::Socket::readHttp2StreamDataBlock() (HTTP/2).
+
+        Handlers that do @b not override \c wantsBodyStreaming() are unaffected — the
+        framework automatically buffers the full body before calling \c handleRequest(),
+        maintaining backward compatibility.
+
+        This enables bidirectional streaming for gRPC-style, Connect protocol, and
+        chunked upload use cases where processing should begin before the full body arrives.
+
+        @par Example
+        @code{.py}
+        HttpServer server(<HttpServerOptionInfo>{
+            "async_mode": True,
+            "quic_headers_only": True,
+        });
+        server.setHandler("upload", "/upload", NOTHING, new MyStreamingHandler());
+        server.addListener(<HttpListenerOptionInfo>{
+            "service": 8443,
+            "cert": cert,
+            "key": key,
+            "enable_h3": True,
+        });
+        @endcode
+
+        @see @ref AbstractHttpRequestHandler::wantsBodyStreaming()
+
+        @since HttpServer 1.6
+    */
+    bool quic_headers_only = False;
 }
 
 #! The HttpServer class implements a multithreaded HTTP server
@@ -2064,6 +2100,7 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
                 "min_idle_handler_threads": opts.min_idle_handler_threads,
                 "max_idle_handler_threads": opts.max_idle_handler_threads,
                 "quic_drain_timeout": opts.quic_drain_timeout,
+                "quic_headers_only": opts.quic_headers_only,
             });
             asyncIo.start();
         }
@@ -2470,9 +2507,112 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
             s.setMaxChunkedBodySize(max_body);
             s.setHttp2MaxRequestBodySize(max_body);
 
+            # Check if handler wants body streaming (bidi) for HTTP/2 or HTTP/3
+            bool want_streaming = cx."header-info".body_streaming
+                && handler
+                && handler.wantsBodyStreaming(cx, hdr);
+
             *data body;
-            # For HTTP/2 and HTTP/3, body is already read by poll operation and stored in header-info
-            if ((cx."header-info".http2 || cx."header-info".http3) && cx."header-info".body) {
+            if (cx."header-info".body_streaming && !want_streaming) {
+                # Handler doesn't support streaming — buffer body on handler thread
+                # for backward compatibility (body was previously read by I/O thread)
+                int sid = cx."header-info".stream_id;
+                binary body_data = binary();
+                if (cx."header-info".http3) {
+                    # HTTP/3: use QUIC stream data methods (CV-based; I/O thread stays active)
+                    int session_id = cx."header-info".session_id;
+                    try {
+                        while (True) {
+                            *binary chunk = s.readQuicStreamDataBlock(session_id, sid, 30s);
+                            if (!chunk) {
+                                break;
+                            }
+                            body_data += chunk;
+                            # Incremental size check: reject early instead of buffering the full body
+                            if (max_body > 0 && body_data.size() > max_body) {
+                                break;
+                            }
+                        }
+                    } catch (hash<ExceptionInfo> ex) {
+                        if (ex.err == "QUIC-STREAM-TIMEOUT") {
+                            listener.logError("HTTP/3 request body read timeout from %s",
+                                cx."peer-info".address_desc);
+                            cx.close = True;
+                            if (async_response_out) {
+                                async_response_out = buildAsyncErrorResponse(408,
+                                    "Request Timeout", cx, listener, s, !is_multiplexed);
+                            } else {
+                                sendHttpError(listener, cx, s, 408, "Request Timeout",
+                                    NOTHING, NOTHING, cx."response-encoding",
+                                    hdr.method == "HEAD");
+                            }
+                            return;
+                        }
+                        rethrow;
+                    }
+                    # NOTE: cleanupQuicStream is called by the controller's on_exit handler
+                } else {
+                    # HTTP/2: use H2 stream data methods
+                    # Use readHttp2StreamDataBlock() return value as loop control:
+                    # it returns data if available (even if stream is already complete),
+                    # and NOTHING when no more data is available. This handles the case
+                    # where DATA+END_STREAM arrived in the same batch as HEADERS.
+                    while (True) {
+                        *binary chunk = s.readHttp2StreamDataBlock(sid, 30s);
+                        if (!chunk) {
+                            break;
+                        }
+                        body_data += chunk;
+                        # Incremental size check: reject early instead of buffering the full body
+                        if (max_body > 0 && body_data.size() > max_body) {
+                            break;
+                        }
+                    }
+                    # readHttp2StreamDataBlock() returns NOTHING on both timeout and stream
+                    # completion — check isHttp2StreamComplete() to distinguish.
+                    # Only treat as timeout if we didn't exit due to max_body.
+                    bool h2_complete = s.isHttp2StreamComplete(sid);
+                    s.cleanupHttp2Stream(sid);
+                    if (!h2_complete && !(max_body > 0 && body_data.size() > max_body)) {
+                        listener.logError("HTTP/2 request body read timeout from %s",
+                            cx."peer-info".address_desc);
+                        cx.close = True;
+                        if (async_response_out) {
+                            async_response_out = buildAsyncErrorResponse(408,
+                                "Request Timeout", cx, listener, s, !is_multiplexed);
+                        } else {
+                            sendHttpError(listener, cx, s, 408, "Request Timeout",
+                                NOTHING, NOTHING, cx."response-encoding",
+                                hdr.method == "HEAD");
+                        }
+                        return;
+                    }
+                }
+                # Apply max body size check
+                if (max_body > 0 && body_data.size() > max_body) {
+                    string etxt = sprintf("%s request body size %d exceeds maximum allowed body size %d",
+                        cx."header-info".http3 ? "HTTP/3" : "HTTP/2",
+                        body_data.size(), max_body);
+                    listener.logError("%s: from %s", etxt, cx."peer-info".address_desc);
+                    cx.close = True;
+                    if (async_response_out) {
+                        async_response_out = buildAsyncErrorResponse(413, etxt, cx,
+                            listener, s, !is_multiplexed);
+                    } else {
+                        sendHttpError(listener, cx, s, 413, etxt, NOTHING, NOTHING,
+                            cx."response-encoding", hdr.method == "HEAD");
+                    }
+                    return;
+                }
+                if (body_data.size()) {
+                    if (hdr."content-encoding" || hdr."content-type" == MimeTypeOctetStream) {
+                        body = body_data;
+                    } else {
+                        body = body_data.toString();
+                    }
+                }
+            } else if ((cx."header-info".http2 || cx."header-info".http3) && cx."header-info".body) {
+                # For HTTP/2 and HTTP/3, body is already read by poll operation and stored in header-info
                 # Check body size against limit (body was already read by the C++
                 # layer; this is a secondary check in case the C++ limit was not set)
                 if (max_body > 0 && cx."header-info".body.size() > max_body) {
@@ -2631,6 +2771,17 @@ http.setListenerLogOptionsID(0, LLO_RECV_HEADERS|LLO_SEND_HEADERS);
                         cx.persistent = True;
                     }
                 }
+            }
+
+            # Handle HTTP/2 bidirectional streaming: the handler managed the stream
+            # lifecycle directly (read body data, sent response).  Mark as dedicated
+            # so the controller leaves the stream alone.
+            if (want_streaming && cx."response-sent") {
+                request_helper.setDedicatedExternal();
+                if (async_response_out) {
+                    delete async_response_out;
+                }
+                return;
             }
 
             if (rv.reply_sent) {
@@ -4500,6 +4651,11 @@ public class HttpListener inherits Qore::Socket, HttpServer::HttpListenerInterfa
 
         # Set user context and header info
         cx.uctx = get_thread_data("uctx");
+        # For body_streaming, expose the socket so handlers can read body data
+        # incrementally via readQuicStreamDataBlock()
+        if (header_info.body_streaming) {
+            header_info.sock = s;
+        }
         cx."header-info" = header_info;
 
         # Add client certificate if requested and available

--- a/qlib/HttpServerAsyncIo/Http2PollOperation.qc
+++ b/qlib/HttpServerAsyncIo/Http2PollOperation.qc
@@ -73,17 +73,24 @@ public class Http2PollOperation inherits AbstractPollOperation {
 
         #! Counter for consecutive empty reads to prevent infinite poll loops
         int empty_read_count = 0;
+
+        #! Whether to use headers-only mode for request reading
+        bool headers_only = False;
     }
 
     #! Creates the poll operation
     /** @param sock the client socket with an established HTTP/2 connection
+        @param headers_only if True, dispatch requests as soon as headers arrive
+        (before END_STREAM), enabling bidirectional streaming; the handler must read
+        the body via Socket::readHttp2StreamDataBlock()
     */
-    constructor(Socket sock) {
+    constructor(Socket sock, bool headers_only = False) {
         @assert(sock, "socket cannot be null");
         @assert(sock.isOpen(), "socket must be open");
         self.sock = sock;
+        self.headers_only = headers_only;
         # Start reading HTTP/2 request
-        startReadRequest();
+        startReadRequest(headers_only);
     }
 
     #! Returns the goal of the operation
@@ -409,7 +416,7 @@ if (push) {
             throw "HTTP2-STATE-ERROR", sprintf("cannot read next request in state: %y", state);
         }
         remove request;
-        startReadRequest();
+        startReadRequest(headers_only);
     }
 
     #! Continues reading without creating a new C++ read operation
@@ -439,8 +446,8 @@ if (push) {
     }
 
     #! Internal: starts the read request operation
-    private startReadRequest() {
-        current_op = sock.startPollReadHttp2Request();
+    private startReadRequest(*bool headers_only) {
+        current_op = sock.startPollReadHttp2Request(headers_only ? {"headers_only": True} : NOTHING);
         state = STATE_READING;
     }
 }

--- a/qlib/HttpServerAsyncIo/Http3ServerPollOperation.qc
+++ b/qlib/HttpServerAsyncIo/Http3ServerPollOperation.qc
@@ -100,6 +100,9 @@ public class Http3ServerPollOperation inherits AbstractPollOperation {
         #! Effective drain timeout for this operation
         timeout drain_timeout;
 
+        #! Headers-only mode: dispatch on HEADERS before full body
+        bool headers_only = False;
+
         #! Mutex for thread safety between I/O thread (continuePoll) and handler
         #! thread (startSendResponse)
         Mutex op_lock();
@@ -109,8 +112,12 @@ public class Http3ServerPollOperation inherits AbstractPollOperation {
     /** @param sock the UDP socket bound and ready for QUIC connections
         @param drain_timeout duration to wait for in-flight requests to complete
         during GOAWAY graceful shutdown; defaults to @ref DefaultDrainTimeout (5s)
+        @param headers_only if @ref True, dispatches requests as soon as headers are
+        received (before the full body arrives); the handler reads body data
+        incrementally via @ref Qore::Socket::readQuicStreamDataBlock()
     */
-    constructor(Socket sock, timeout drain_timeout = DefaultDrainTimeout) {
+    constructor(Socket sock, timeout drain_timeout = DefaultDrainTimeout,
+            bool headers_only = False) {
         if (!sock) {
             throw "HTTP3-ERROR", "socket cannot be null";
         }
@@ -119,6 +126,7 @@ public class Http3ServerPollOperation inherits AbstractPollOperation {
         }
         self.sock = sock;
         self.drain_timeout = drain_timeout;
+        self.headers_only = headers_only;
         # Start accepting QUIC connection and reading HTTP/3 request
         startReadRequest();
     }
@@ -513,7 +521,7 @@ public class Http3ServerPollOperation inherits AbstractPollOperation {
         both initial accept and subsequent request reads.
     */
     private startReadRequest() {
-        current_op = sock.startPollQuicAccept();
+        current_op = sock.startPollQuicAccept(headers_only ? {"headers_only": True} : NOTHING);
         state = STATE_READING;
     }
 }

--- a/qlib/HttpServerAsyncIo/HttpAsyncSocketIoController.qc
+++ b/qlib/HttpServerAsyncIo/HttpAsyncSocketIoController.qc
@@ -803,7 +803,7 @@ public class HttpAsyncSocketIoController {
                 }
             }
 
-            Http2PollOperation h2op(sock);
+            Http2PollOperation h2op(sock, True);
 
             # Opt #5/#7: Merge round-robin + connection creation into single lock scope
             hash<HttpActiveConnectionInfo> new_cinfo = <HttpActiveConnectionInfo>{
@@ -879,7 +879,8 @@ public class HttpAsyncSocketIoController {
         string op_key = sprintf("quic-accept:%s:%d", owner, seq);
 
         Http3ServerPollOperation h3op(listener, pool_opts.quic_drain_timeout
-            ?? Http3ServerPollOperation::DefaultDrainTimeout);
+            ?? Http3ServerPollOperation::DefaultDrainTimeout,
+            pool_opts.quic_headers_only ?? False);
 
         log(LoggerLevel::DEBUG, "submitQuicAcceptOp: key=%s listener=%s", op_key, owner);
 
@@ -1062,6 +1063,9 @@ public class HttpAsyncSocketIoController {
                 hdr."accept-encoding".split(",");
         }
 
+        # Detect headers-only dispatch
+        bool body_streaming = request.hdr && !request.headers_end_stream;
+
         # Convert to HttpConnectionInfo (same dispatch chain as HTTP/2)
         hash<HttpConnectionInfo> conn_info = <HttpConnectionInfo>{
             "sock": listener,
@@ -1072,7 +1076,9 @@ public class HttpAsyncSocketIoController {
                 "stream_id": stream_id,
                 "is_websocket_connect": is_websocket_connect,
                 "accept-encoding": accept_encoding,
-                "body": request.body,
+                "body": body_streaming ? NOTHING : request.body,
+                "body_streaming": body_streaming,
+                "headers_end_stream": request.headers_end_stream ?? False,
             },
             "listener": linfo.http_listener,
             "cx": new_cinfo.cx,
@@ -1083,6 +1089,15 @@ public class HttpAsyncSocketIoController {
         # Dispatch to handler thread pool
         try {
             handler_pool.submit(sub () {
+                # Clean up dispatched stream state after handler completes
+                # (applies to all headers-only dispatched streams, not just body_streaming)
+                # NOTE: on_exit must be at closure scope (not inside if-block), otherwise
+                # the cleanup fires immediately when the if-block exits
+                on_exit if (request.hdr) {
+                    try {
+                        listener.cleanupQuicStream(session_id, stream_id);
+                    } catch () {}
+                }
                 try {
                     hash<HttpRequestResultInfo> result = target.onHttpRequest(conn_info);
                     handleHttp3MultiplexedResult(uh, new_cinfo, session_id, stream_id, result);
@@ -1112,6 +1127,12 @@ public class HttpAsyncSocketIoController {
                     "stream=%d: %s: %s", session_id, stream_id, ex2.err, ex2.desc);
             }
             controllers[new_cinfo.controller_idx].wake();
+            # Clean up dispatched stream state for headers-only dispatch
+            if (request.hdr) {
+                try {
+                    listener.cleanupQuicStream(session_id, stream_id);
+                } catch () {}
+            }
         }
     }
 
@@ -1345,7 +1366,7 @@ public class HttpAsyncSocketIoController {
         try {
             hash<HttpActiveConnectionInfo> cinfo;
             if (is_http2) {
-                Http2PollOperation h2op(sock);
+                Http2PollOperation h2op(sock, True);
                 {
                     AutoWriteLock al(m);
                     # Check if connection still exists (may have been removed during shutdown)
@@ -2213,24 +2234,6 @@ public class HttpAsyncSocketIoController {
         log(LoggerLevel::DEBUG, "HTTP/2 request ready: %y stream=%d %s %s",
             uh, stream_id, request.method, request.path);
 
-        # Continue reading on h2op immediately — do NOT hold it for the handler
-        h2op.continueReading();
-        hash<HttpActiveConnectionInfo> new_cinfo;
-        {
-            AutoWriteLock al(m);
-            # Check if connection still exists
-            if (!connections.hasKey(uh)) {
-                try { cinfo.sock.close(); } catch () {}
-                return;
-            }
-            # Cast to typed hash to update fields and assign back
-            hash<HttpActiveConnectionInfo> conn_info = cast<hash<HttpActiveConnectionInfo>>(connections{uh});
-            conn_info.stream_op = h2op;
-            conn_info.state = HttpConnectionState::Http2;
-            new_cinfo = connections{uh} = conn_info;
-        }
-        submitConnectionOp(uh, new_cinfo);
-
         # Build header hash
         hash<auto> hdr = request.headers;
         hdr.method = request.method;
@@ -2247,8 +2250,40 @@ public class HttpAsyncSocketIoController {
                 hdr."accept-encoding".split(",");
         }
 
+        # In headers-only mode, check if the HEADERS frame itself had END_STREAM.
+        # If not, body data is expected and the handler thread gets exclusive socket access.
+        # NOTE: We use headers_end_stream (set by C++) rather than isHttp2StreamComplete()
+        # because DATA+END_STREAM can arrive in the same receiveData() call as HEADERS,
+        # making isHttp2StreamComplete() return True even when body data exists.
+        bool body_streaming = request.hdr.toBool()
+            && !request.headers_end_stream.toBool();
+
+        # For requests with END_STREAM on HEADERS (no body), clean up the dispatch map entry
+        if (request.hdr.toBool() && !body_streaming) {
+            cinfo.sock.cleanupHttp2Stream(stream_id);
+        }
+
+        if (!body_streaming) {
+            # Normal path: resume h2op immediately for multiplexing.
+            # The handler thread sends responses via submitHttp2Response().
+            h2op.continueReading();
+            hash<HttpActiveConnectionInfo> new_cinfo;
+            {
+                AutoWriteLock al(m);
+                if (!connections.hasKey(uh)) {
+                    try { cinfo.sock.close(); } catch () {}
+                    return;
+                }
+                hash<HttpActiveConnectionInfo> conn_info_upd =
+                    cast<hash<HttpActiveConnectionInfo>>(connections{uh});
+                conn_info_upd.stream_op = h2op;
+                conn_info_upd.state = HttpConnectionState::Http2;
+                new_cinfo = connections{uh} = conn_info_upd;
+            }
+            submitConnectionOp(uh, new_cinfo);
+        }
+
         # Convert HTTP/2 request to HttpConnectionInfo format
-        # Note: h2op is NOT passed to the handler — it stays on the I/O thread
         hash<HttpConnectionInfo> conn_info = <HttpConnectionInfo>{
             "sock": cinfo.sock,
             "hdr": hdr,
@@ -2256,26 +2291,61 @@ public class HttpAsyncSocketIoController {
                 "http2": True,
                 "stream_id": stream_id,
                 "accept-encoding": accept_encoding,
-                "body": request.body,
+                "body": body_streaming ? NOTHING : request.body,
+                "body_streaming": body_streaming,
+                "headers_end_stream": request.headers_end_stream ?? False,
+                "io_wake": sub () { controllers[cinfo.controller_idx].wake(); },
             },
             "listener": cinfo.listener,
             "cx": cinfo.cx,
             "keep_alive": True,
             "ssl": cinfo.sock.isSecure(),
         };
-
         # Dispatch to handler thread pool
         try {
             handler_pool.submit(sub () {
                 try {
                     hash<HttpRequestResultInfo> result = cinfo.target.onHttpRequest(conn_info);
+                    if (body_streaming) {
+                        # Body streaming is complete; resume h2op for continued multiplexing.
+                        # The handler had exclusive socket access for body reading.
+                        h2op.continueReading();
+                        hash<HttpActiveConnectionInfo> resumed_cinfo;
+                        {
+                            AutoWriteLock al(m);
+                            if (connections.hasKey(uh)) {
+                                hash<HttpActiveConnectionInfo> conn_info_upd =
+                                    cast<hash<HttpActiveConnectionInfo>>(connections{uh});
+                                conn_info_upd.stream_op = h2op;
+                                conn_info_upd.state = HttpConnectionState::Http2;
+                                resumed_cinfo = connections{uh} = conn_info_upd;
+                            }
+                        }
+                        # Use freshly-updated cinfo (not the stale closure capture)
+                        submitConnectionOp(uh, resumed_cinfo);
+                    }
                     handleHttp2MultiplexedResult(uh, cinfo, stream_id, result);
                 } catch (hash<ExceptionInfo> ex) {
                     log(LoggerLevel::ERROR, "Error handling HTTP/2 request stream=%d: %s: %s",
                         stream_id, ex.err, ex.desc);
-                    # NOTE: do NOT call cinfo.target.onError() here — that closes the shared
-                    # connection socket which breaks all other streams.  In HTTP/2 multiplexed
-                    # mode, a handler error affects only this stream; send a 500 response.
+                    if (body_streaming) {
+                        # Resume h2op even on error
+                        try {
+                            h2op.continueReading();
+                            hash<HttpActiveConnectionInfo> resumed_cinfo;
+                            {
+                                AutoWriteLock al(m);
+                                if (connections.hasKey(uh)) {
+                                    hash<HttpActiveConnectionInfo> conn_info_upd =
+                                        cast<hash<HttpActiveConnectionInfo>>(connections{uh});
+                                    conn_info_upd.stream_op = h2op;
+                                    conn_info_upd.state = HttpConnectionState::Http2;
+                                    resumed_cinfo = connections{uh} = conn_info_upd;
+                                }
+                            }
+                            submitConnectionOp(uh, resumed_cinfo);
+                        } catch () {}
+                    }
                     try {
                         cinfo.sock.submitHttp2Response(stream_id, 500,
                             {"content-type": "text/plain"},
@@ -2287,7 +2357,25 @@ public class HttpAsyncSocketIoController {
         } catch (hash<ExceptionInfo> ex) {
             log(LoggerLevel::ERROR, "Failed to submit HTTP/2 multiplexed handler for stream=%d "
                 "on %y: %s: %s", stream_id, uh, ex.err, ex.desc);
-            # h2op is still on the I/O thread reading — send error response for this stream
+            if (body_streaming) {
+                # Resume h2op — it was not resumed before submit in body_streaming mode
+                try {
+                    h2op.continueReading();
+                    hash<HttpActiveConnectionInfo> resumed_cinfo;
+                    {
+                        AutoWriteLock al(m);
+                        if (connections.hasKey(uh)) {
+                            hash<HttpActiveConnectionInfo> conn_info_upd =
+                                cast<hash<HttpActiveConnectionInfo>>(connections{uh});
+                            conn_info_upd.stream_op = h2op;
+                            conn_info_upd.state = HttpConnectionState::Http2;
+                            resumed_cinfo = connections{uh} = conn_info_upd;
+                        }
+                    }
+                    submitConnectionOp(uh, resumed_cinfo);
+                } catch () {}
+            }
+            # Send error response for this stream
             try {
                 cinfo.sock.submitHttp2Response(stream_id, 503,
                     {"content-type": "text/plain"},

--- a/qlib/HttpServerAsyncIo/HttpAsyncSocketIoController.qc
+++ b/qlib/HttpServerAsyncIo/HttpAsyncSocketIoController.qc
@@ -2322,7 +2322,9 @@ public class HttpAsyncSocketIoController {
                             }
                         }
                         # Use freshly-updated cinfo (not the stale closure capture)
-                        submitConnectionOp(uh, resumed_cinfo);
+                        if (resumed_cinfo) {
+                            submitConnectionOp(uh, resumed_cinfo);
+                        }
                     }
                     handleHttp2MultiplexedResult(uh, cinfo, stream_id, result);
                 } catch (hash<ExceptionInfo> ex) {
@@ -2343,7 +2345,9 @@ public class HttpAsyncSocketIoController {
                                     resumed_cinfo = connections{uh} = conn_info_upd;
                                 }
                             }
-                            submitConnectionOp(uh, resumed_cinfo);
+                            if (resumed_cinfo) {
+                                submitConnectionOp(uh, resumed_cinfo);
+                            }
                         } catch () {}
                     }
                     try {
@@ -2372,7 +2376,9 @@ public class HttpAsyncSocketIoController {
                             resumed_cinfo = connections{uh} = conn_info_upd;
                         }
                     }
-                    submitConnectionOp(uh, resumed_cinfo);
+                    if (resumed_cinfo) {
+                        submitConnectionOp(uh, resumed_cinfo);
+                    }
                 } catch () {}
             }
             # Send error response for this stream

--- a/qlib/HttpServerAsyncIo/HttpServerAsyncIo.qm
+++ b/qlib/HttpServerAsyncIo/HttpServerAsyncIo.qm
@@ -175,13 +175,28 @@ public namespace HttpServerAsyncIo {
 
     #! Connection info passed to callbacks
     /** For HTTP/2 connections, \c header_info contains:
-        - \c http2: True for HTTP/2 requests
+        - \c http2: \c True for HTTP/2 requests
         - \c stream_id: The HTTP/2 stream ID (needed for sending response)
+        - \c body_streaming: \c True when the client sent HEADERS without END_STREAM (request body
+          not yet complete); the handler should use \c Socket::readHttp2StreamDataBlock() to read
+          body data incrementally and \c Socket::flushHttp2() to send outgoing data (the handler
+          has exclusive socket access in this mode)
+        - \c headers_end_stream: \c True if END_STREAM was on the HEADERS frame (e.g., GET with
+          no body); when \c True, \c body_streaming is \c False and there is no body to read
+        - \c io_wake: a code closure to call after queuing outgoing data to wake the I/O thread;
+          @note in \c body_streaming mode, \c io_wake has no effect because the I/O thread does not
+          manage the socket — use \c Socket::flushHttp2() instead
 
         For HTTP/3 connections, \c header_info contains:
-        - \c http3: True for HTTP/3 requests
+        - \c http3: \c True for HTTP/3 requests
         - \c session_id: The QUIC session ID
         - \c stream_id: The HTTP/3 stream ID (needed for sending response)
+        - \c body_streaming: \c True when the stream has not received END_STREAM on HEADERS
+        - \c headers_end_stream: \c True if END_STREAM was on the HEADERS frame
+
+        When \c body_streaming is \c True, the following additional key is available after
+        the request is dispatched through \c HttpServer:
+        - \c sock: The \c Socket object for calling stream data methods
 
         For HTTP/2, the \c hdr hash also includes:
         - \c method: The HTTP method

--- a/qlib/HttpServerUtil.qm
+++ b/qlib/HttpServerUtil.qm
@@ -1932,6 +1932,111 @@ public class AbstractHttpRequestHandler {
         stream = n_stream;
     }
 
+    #! Returns @ref True "True" if this handler wants to receive streaming requests without waiting for the full
+    #! request body
+    /** When @ref True "True" and the request has \c body_streaming set in \c header_info, the handler is called
+        immediately when headers arrive, before the request body has been fully received.  The handler reads
+        body data incrementally using protocol-specific methods:
+
+        - <b>HTTP/3</b>: use @ref Qore::Socket::readQuicStreamDataBlock() with \c session_id and \c stream_id
+          from \c cx."header-info".  The I/O thread drives the shared UDP socket; the handler waits on a
+          per-stream condition variable for data.
+        - <b>HTTP/2</b>: use @ref Qore::Socket::readHttp2StreamDataBlock() with \c stream_id from
+          \c cx."header-info".  The handler thread drives the TCP socket directly.
+
+        Check \c cx."header-info".http3 to determine which protocol is in use.
+
+        @par Context Keys Available to Streaming Handlers
+        When \c body_streaming is \c True, the following keys are available in \c cx."header-info":
+        - \c body_streaming (\c bool): \c True — body data must be read incrementally
+        - \c headers_end_stream (\c bool): \c True if END_STREAM was set on the HEADERS frame
+          (e.g., GET with no body) — the handler should not attempt to read body data
+        - \c session_id (\c int): QUIC session ID (HTTP/3 only)
+        - \c stream_id (\c int): HTTP/2 or HTTP/3 stream ID
+        - \c sock (\c Socket): the socket object for calling stream data methods
+        - \c http3 (\c bool): \c True for HTTP/3 requests
+        - \c http2 (\c bool): \c True for HTTP/2 requests
+
+        @par Complete HTTP/3 Streaming Handler Example
+        @code{.py}
+        class StreamingUploadHandler inherits AbstractHttpRequestHandler {
+            bool wantsBodyStreaming(hash<auto> cx, hash<auto> hdr) {
+                # Only opt in for POST/PUT requests
+                return hdr.method == "POST" || hdr.method == "PUT";
+            }
+
+            hash<HttpResponseInfo> handleRequest(hash<auto> cx, hash<auto> hdr, *data body) {
+                # Check if this is actually a streaming request
+                bool body_streaming = cx."header-info".body_streaming ?? False;
+                bool headers_end_stream = cx."header-info".headers_end_stream ?? False;
+
+                if (!body_streaming || headers_end_stream) {
+                    # Non-streaming path (GET, or body already buffered)
+                    return makeResponse(200, body ?? "no body");
+                }
+
+                int session_id = cx."header-info".session_id;
+                int stream_id = cx."header-info".stream_id;
+                Socket sock = cx."header-info".sock;
+
+                # Read body data incrementally
+                binary accumulated = binary();
+                while (True) {
+                    *binary chunk;
+                    if (cx."header-info".http3) {
+                        chunk = sock.readQuicStreamDataBlock(session_id, stream_id, 30s);
+                    } else {
+                        chunk = sock.readHttp2StreamDataBlock(stream_id, 30s);
+                    }
+                    if (!exists chunk) {
+                        break;  # END_STREAM — no more data
+                    }
+                    accumulated += chunk;
+                    # Optional: process chunks as they arrive for streaming use cases
+                }
+
+                return makeResponse(200, sprintf("received %d bytes", accumulated.size()));
+            }
+        }
+        @endcode
+
+        @par Backward Compatibility
+        If this method returns @ref False "False" (the default), the framework automatically buffers
+        the full request body using @ref Qore::Socket::readQuicStreamDataBlock() (HTTP/3) or
+        @ref Qore::Socket::readHttp2StreamDataBlock() (HTTP/2) before calling
+        @ref handleRequest() with the complete body in the \c body parameter.  This maintains
+        full backward compatibility — existing handlers work without modification when
+        \c quic_headers_only is enabled on the server.
+
+        @par Error Handling
+        If a streaming read times out, the handler can catch the \c QUIC-STREAM-TIMEOUT exception
+        (HTTP/3) and return an appropriate error response:
+        @code{.py}
+        try {
+            *binary chunk = sock.readQuicStreamDataBlock(session_id, stream_id, 10s);
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.err == "QUIC-STREAM-TIMEOUT") {
+                return makeResponse(408, "Request Timeout");
+            }
+            rethrow;
+        }
+        @endcode
+
+        @param cx the connection context
+        @param hdr the HTTP headers
+
+        @return @ref True "True" to receive the streaming request, @ref False "False" to buffer
+        the body first
+
+        @see @ref Qore::Socket::readQuicStreamDataBlock()
+        @see @ref Qore::Socket::readHttp2StreamDataBlock()
+
+        @since HttpServerUtil 2.1
+    */
+    bool wantsBodyStreaming(hash<auto> cx, hash<auto> hdr) {
+        return False;
+    }
+
     #! Returns @ref True "True" if the current connection is persistent, @ref False "False" if not
     /** Persistent mode means that subsequent requests on the same connection will be handled
         by the same thread, providing thread affinity for thread-local resources.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -176,10 +176,17 @@ LD_PRELOAD=$LIBQORE
 
 # Enable core dumps for crash diagnostics
 ulimit -c unlimited 2>/dev/null
-# Try to set core pattern to a writable location (may fail in containers)
+# Create a directory for core dumps (used as CI artifact)
+# Use a path relative to the project root so GitLab can collect it as an artifact
+CORE_DIR="${CORE_DIR:-./crash-dumps}"
+mkdir -p "$CORE_DIR" 2>/dev/null
+CORE_DIR_ABS=$(cd "$CORE_DIR" && pwd)
+# Try to set core pattern to write cores to our directory (may fail in containers)
 if [ -w /proc/sys/kernel/core_pattern ]; then
-    echo "/tmp/core.%p" > /proc/sys/kernel/core_pattern
+    echo "$CORE_DIR_ABS/core.%e.%p" > /proc/sys/kernel/core_pattern
 fi
+# Also try sysctl (works on some systems where /proc write fails)
+sysctl -w "kernel.core_pattern=$CORE_DIR_ABS/core.%e.%p" 2>/dev/null || true
 
 # Print info about used variables etc.
 echo "Using qore: $QORE"
@@ -238,22 +245,31 @@ for test in $TESTS; do
         if [ $TEST_EXIT -gt 128 ]; then
             SIG_NUM=`expr $TEST_EXIT - 128`
             echo "*** CRASH: test killed by signal $SIG_NUM (exit code $TEST_EXIT) ***"
-            # Check for core dump
+            # Check for core dump in known locations
             CORE_FILE=""
-            for cf in core core.* /tmp/core.*; do
+            for cf in "$CORE_DIR"/core.* "$CORE_DIR_ABS"/core.* core core.* /tmp/core.*; do
                 if [ -f "$cf" ] 2>/dev/null; then
                     CORE_FILE="$cf"
                     break
                 fi
             done
+            TEST_BASENAME=$(basename "$test" .qtest)
             if [ -n "$CORE_FILE" ] && command -v gdb > /dev/null 2>&1; then
                 echo "*** Core dump found: $CORE_FILE - extracting backtrace ***"
-                gdb -batch -ex "thread apply all bt" -ex "quit" "$QORE" "$CORE_FILE" 2>&1 | head -200
-                rm -f "$CORE_FILE"
+                BT_FILE="$CORE_DIR/backtrace-${TEST_BASENAME}.txt"
+                gdb -batch -ex "thread apply all bt full" -ex "quit" "$QORE" "$CORE_FILE" 2>&1 | tee "$BT_FILE" | head -500
+                # Move core to artifact directory for CI collection (don't delete)
+                case "$CORE_FILE" in
+                    "$CORE_DIR"/*|"$CORE_DIR_ABS"/*) ;;
+                    *) cp "$CORE_FILE" "$CORE_DIR/" 2>/dev/null && rm -f "$CORE_FILE" || true ;;
+                esac
             elif command -v gdb > /dev/null 2>&1; then
                 echo "*** No core dump found; re-running under gdb to try to capture backtrace ***"
-                gdb -batch -ex run -ex "thread apply all bt" -ex quit \
-                    --args $QORE $QORE_TEST_OPTS $test $TEST_OUTPUT_FORMAT 2>&1 | head -200
+                BT_FILE="$CORE_DIR/backtrace-${TEST_BASENAME}.txt"
+                # Filter out thread creation/exit noise, keep backtrace output
+                gdb -batch -ex run -ex "thread apply all bt full" -ex quit \
+                    --args $QORE $QORE_TEST_OPTS $test $TEST_OUTPUT_FORMAT 2>&1 \
+                    | grep -v '^\[New Thread\|^\[Thread.*exited\]' | tee "$BT_FILE" | head -500
             fi
         fi
     fi


### PR DESCRIPTION
## Summary

- **HTTP/3 bidirectional body streaming**: Handlers can now opt into incremental body reading via `wantsBodyStreaming()` + `readQuicStreamDataBlock()` for HTTP/3 requests, with backward-compatible auto-buffering for handlers that don't opt in
- **Graceful session shutdown**: `markClosed()` signals all blocked handler threads immediately when `abort()` is called, preventing 30s hangs during server shutdown
- **Per-stream condition variables**: `StreamNotifier` eliminates thundering herd — only the handler for the specific stream receiving data wakes up
- **Comprehensive tests**: 12 test cases covering streaming echo, timeout handling, oversized body rejection, concurrent multiplexing, server shutdown during streaming, partial reads, and headers-only dispatch

## Key Changes

### C++ Core (`include/qore/intern/QuicSession.h`, `lib/QuicSession.cpp`)
- `StreamNotifier` struct with per-stream mutex/CV/generation counter
- `markClosed()` / `isMarkedClosed()` for immediate session closure signaling
- Per-stream notification in `h3RecvDataCallback` and `markStreamComplete`

### QPP Bindings (`lib/QC_Socket.qpp`)
- Extensive documentation with code examples for `readQuicStreamDataBlock()`, `isQuicStreamComplete()`, `cleanupQuicStream()`, `startPollQuicAccept()`

### Qore Modules
- `HttpServer.qm`: `quic_headers_only` option, backward-compat body buffering for HTTP/2 and HTTP/3
- `HttpServerUtil.qm`: `wantsBodyStreaming()` documentation with complete handler examples
- `HttpServerAsyncIo`: Headers-only dispatch for both HTTP/2 and HTTP/3

### Tests
- `HttpServerH3Streaming.qtest`: 12 test cases, all passing including under valgrind

## Test plan

- [x] All 12 H3 streaming tests pass
- [x] Regression: HttpServerAsyncStreamingResponse, HttpServerAsyncHttp2, HttpClientIo tests pass
- [x] Valgrind clean (0 definitely/possibly lost)
- [x] Build clean after merge with develop

Fixes #5224

🤖 Generated with [Claude Code](https://claude.com/claude-code)