### PR TITLE
feat: ML preprocessing, evaluation, classification, persistence, and model registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1869,6 +1869,7 @@ qore_user_module("qlib/EdifactUtil" "Util;DataProvider;FileLocationHandler")
 # base 3 modules
 qore_user_module("qlib/DataProvider" "MapperUtil;Mime;Util" "DataProvider-Full.svg;Qore-Q-square.svg")
 qore_user_module("qlib/DataProviderML" "DataProvider;modules/ml/ml")
+qore_user_module("qlib/QoreModelRegistry" "DataProvider;modules/ml/ml;Mime;Util")
 qore_user_module("qlib/DpqlWebSocket" "DataProvider;HttpServerUtil;WebSocketHandler")
 qore_user_module("qlib/DebugProgramControl.qm" "DebugUtil")
 qore_user_module("qlib/HttpServerUtil.qm" "Mime;Util;FileLocationHandler;Logger;modules/logger_bin/logger_bin")

--- a/design/ml-enhancement-plan.md
+++ b/design/ml-enhancement-plan.md
@@ -1,0 +1,1135 @@
+# ML Enhancement Plan
+
+## Overview
+
+This document describes a 6-phase plan to significantly improve Qore's ML capabilities in
+the `ml` binary module (C++/Eigen3) and `DataProviderML` user module (Qore). Each phase
+builds incrementally on existing infrastructure and includes independent verification.
+
+## Current State
+
+- **ml module**: 10 native algorithms (IsolationForest, LOF, DBSCAN, KMeans, GMM,
+  LinearRegression, HoltWinters, SeasonalDecomposition, PCA) + optional OnnxModel
+- **DataProviderML module**: 9 pipeline processors with window-based accumulation
+- **Architecture**: C++ with Eigen3 (no Python), thread-safe, typed hashdecl results,
+  dual API (hash-based + matrix-based)
+
+## Architecture After Enhancement
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                Qorus / Applications                      │
+├──────────────────────────────────────────────────────────┤
+│               DataProviderML (Qore)                      │
+│  Existing processors + preprocessing + metric processors │
+├──────────────────────────────────────────────────────────┤
+│             QoreModelRegistry (Qore)                     │
+│  Model versioning, comparison, deployment management     │
+├──────────────────────────────────────────────────────────┤
+│                 ml (C++ binary)                           │
+│  Existing algorithms + LogisticRegression + KNN          │
+│  + StandardScaler + MinMaxScaler + Imputer + Pipeline    │
+│  + Metrics (accuracy, F1, silhouette, MSE, ...)          │
+│  + ModelSerializer (native, ONNX export, JSON)           │
+│  + Online learning (LinearRegression, GMM)               │
+├──────────────────────────────────────────────────────────┤
+│    Eigen3          ONNX Runtime (opt)    libprotobuf*    │
+└──────────────────────────────────────────────────────────┘
+* libprotobuf only needed for ONNX export; optional like ONNX Runtime
+```
+
+---
+
+## Phase 1: Data Preprocessing Pipeline
+
+### Motivation
+
+Users must normalize, scale, and clean data manually before calling `fit()`. This is
+error-prone and tedious, especially when the same preprocessing must be applied consistently
+at training and prediction time.
+
+### Components
+
+#### 1.1 StandardScaler (C++)
+
+Transforms features to zero mean and unit variance.
+
+```cpp
+class QoreStandardScaler : public AbstractPrivateData {
+public:
+    void fit(const MatrixXd& data, ExceptionSink* xsink);
+    MatrixXd transform(const MatrixXd& data, ExceptionSink* xsink) const;
+    MatrixXd inverseTransform(const MatrixXd& data, ExceptionSink* xsink) const;
+    MatrixXd fitTransform(const MatrixXd& data, ExceptionSink* xsink);
+    bool isFitted() const;
+
+private:
+    VectorXd mean_vec;
+    VectorXd std_vec;
+    int n_features = 0;
+    bool fitted = false;
+    mutable std::mutex mtx;
+    std::vector<std::string> field_names;
+};
+```
+
+**QPP bindings**: `fit(list<hash>)`, `fitMatrix(list<auto>)`, `transform(hash)` → `hash`,
+`transformMatrix(list<auto>)` → `list<list<float>>`, `inverseTransform()`, `fitTransform()`.
+
+**Hashdecl**: `StandardScalerInfo` — `mean` (list<float>), `std` (list<float>),
+`n_features` (int).
+
+#### 1.2 MinMaxScaler (C++)
+
+Scales features to a configurable range (default [0, 1]).
+
+```cpp
+class QoreMinMaxScaler : public AbstractPrivateData {
+    // Options: feature_min (default 0.0), feature_max (default 1.0)
+    VectorXd data_min;
+    VectorXd data_max;
+    double feature_min, feature_max;
+    // Same API pattern as StandardScaler
+};
+```
+
+**Hashdecl**: `MinMaxScalerInfo` — `data_min`, `data_max`, `feature_min`, `feature_max`.
+
+#### 1.3 Imputer (C++)
+
+Fills missing values using a configurable strategy.
+
+```cpp
+class QoreImputer : public AbstractPrivateData {
+    // Strategy: "mean", "median", "most_frequent", "constant"
+    // fit() computes fill values; transform() applies them
+    std::string strategy;
+    VectorXd fill_values;       // computed during fit
+    double constant_value;      // for "constant" strategy
+};
+```
+
+**Detection**: A field value of `NOTHING`/`NULL` or `NaN` is treated as missing.
+
+#### 1.4 MLPipeline (C++)
+
+Chains preprocessors and an estimator into a single fit/predict unit.
+
+```cpp
+class QoreMLPipeline : public AbstractPrivateData {
+public:
+    // steps: list of (name, transformer/estimator) pairs
+    // The last step may be an estimator (has predict); all others must be transformers
+    void fit(const MatrixXd& X, const VectorXd* y, ExceptionSink* xsink);
+    QoreValue predict(const RowVectorXd& point, ExceptionSink* xsink) const;
+
+private:
+    struct Step {
+        std::string name;
+        enum Type { SCALER, IMPUTER, ESTIMATOR } type;
+        AbstractPrivateData* obj;  // borrowed ref, caller owns
+    };
+    std::vector<Step> steps;
+};
+```
+
+**Qore API**:
+```qore
+MLPipeline p(("scaler", new StandardScaler(), "model", new LinearRegression()));
+p.fit(training_data, target_data);
+auto result = p.predict(new_record);
+```
+
+The pipeline ensures that `transform()` is called on each preprocessor before the data
+reaches the estimator, and the same transformation chain is applied at prediction time.
+
+#### 1.5 DataProvider Processors
+
+- `standard-scaler` processor: scales fields in streaming records
+- `min-max-scaler` processor: min-max normalization
+- `imputer` processor: fill missing values
+
+Each follows the existing window-accumulation pattern: fit on the first window, then
+transform all subsequent records.
+
+### Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `modules/ml/src/QC_StandardScaler.h` | New — class declaration |
+| `modules/ml/src/StandardScaler.cpp` | New — implementation |
+| `modules/ml/src/QC_StandardScaler.qpp` | New — QPP bindings |
+| `modules/ml/src/QC_MinMaxScaler.h` | New — class declaration |
+| `modules/ml/src/MinMaxScaler.cpp` | New — implementation |
+| `modules/ml/src/QC_MinMaxScaler.qpp` | New — QPP bindings |
+| `modules/ml/src/QC_Imputer.h` | New — class declaration |
+| `modules/ml/src/Imputer.cpp` | New — implementation |
+| `modules/ml/src/QC_Imputer.qpp` | New — QPP bindings |
+| `modules/ml/src/QC_MLPipeline.h` | New — class declaration |
+| `modules/ml/src/MLPipeline.cpp` | New — implementation |
+| `modules/ml/src/QC_MLPipeline.qpp` | New — QPP bindings |
+| `modules/ml/src/ql_ml.qpp` | Modify — add hashdecls |
+| `modules/ml/src/ml-module.cpp` | Modify — register new classes |
+| `modules/ml/CMakeLists.txt` | Modify — add source files |
+| `qlib/DataProviderML/QoreStandardScalerProcessor.qc` | New |
+| `qlib/DataProviderML/QoreMinMaxScalerProcessor.qc` | New |
+| `qlib/DataProviderML/QoreImputerProcessor.qc` | New |
+| `qlib/DataProviderML/DataProviderML.qm` | Modify — register processors |
+| `qlib/DataProviderML/MLProcessorsDataProvider.qc` | Modify — add to nav |
+
+### Independent Verification
+
+1. **Unit tests** (`modules/ml/test/ml.qtest`):
+   - StandardScaler: verify mean≈0, std≈1 after transform; inverse recovers original;
+     fit on one dataset, transform another
+   - MinMaxScaler: verify all values in [min, max] after transform; custom ranges;
+     inverse recovers original
+   - Imputer: verify NaN/NOTHING replaced; each strategy tested; new unseen NaN handled
+   - MLPipeline: verify pipeline(scaler + model) matches manual scaler.fit→transform→model.fit
+   - Edge cases: single feature, single sample, all-zero variance, all-missing column
+   - Thread safety: concurrent transform after fit
+
+2. **Numerical verification**: Compare StandardScaler output against hand-computed
+   values for a small dataset (e.g., 5 samples × 3 features with known mean/std).
+
+3. **DataProvider tests** (`examples/test/qlib/DataProviderML/DataProviderMLProcessors.qtest`):
+   - Each processor: window accumulation, field selection, event output format
+   - Pipeline consistency: same data through processor vs direct API gives identical output
+
+4. **Valgrind**: Run all ML tests under valgrind to verify no memory leaks.
+
+---
+
+## Phase 2: Model Evaluation Metrics
+
+### Motivation
+
+Without standardized metrics, users cannot objectively evaluate or compare models.
+LinearRegression reports R², but there are no general classification, regression, or
+clustering metrics.
+
+### Components
+
+#### 2.1 Classification Metrics (C++ namespace functions)
+
+```cpp
+// All functions take ground-truth labels and predicted labels as Eigen vectors
+double ml_accuracy(const VectorXd& y_true, const VectorXd& y_pred);
+QoreHashNode* ml_confusion_matrix(const VectorXd& y_true, const VectorXd& y_pred, ...);
+double ml_precision(const VectorXd& y_true, const VectorXd& y_pred, ...);
+double ml_recall(const VectorXd& y_true, const VectorXd& y_pred, ...);
+double ml_f1_score(const VectorXd& y_true, const VectorXd& y_pred, ...);
+```
+
+**Hashdecls**:
+```
+hashdecl ConfusionMatrixResult {
+    list<list<int>> matrix;     // n_classes × n_classes
+    list<string> labels;        // class labels
+}
+
+hashdecl ClassificationReport {
+    float accuracy;
+    list<hash<ClassMetrics>> per_class;   // precision, recall, f1 per class
+    float macro_precision;
+    float macro_recall;
+    float macro_f1;
+    float weighted_f1;
+}
+
+hashdecl ClassMetrics {
+    string label;
+    float precision;
+    float recall;
+    float f1;
+    int support;    // number of true instances
+}
+```
+
+#### 2.2 Regression Metrics
+
+```cpp
+double ml_mse(const VectorXd& y_true, const VectorXd& y_pred);
+double ml_rmse(const VectorXd& y_true, const VectorXd& y_pred);
+double ml_mae(const VectorXd& y_true, const VectorXd& y_pred);
+double ml_r2_score(const VectorXd& y_true, const VectorXd& y_pred);
+double ml_explained_variance(const VectorXd& y_true, const VectorXd& y_pred);
+```
+
+#### 2.3 Clustering Metrics
+
+```cpp
+double ml_silhouette_score(const MatrixXd& data, const VectorXi& labels);
+double ml_davies_bouldin_score(const MatrixXd& data, const VectorXi& labels);
+double ml_calinski_harabasz_score(const MatrixXd& data, const VectorXi& labels);
+```
+
+#### 2.4 Cross-Validation Utility
+
+```cpp
+// k-fold split utility: returns list of (train_indices, test_indices) pairs
+class QoreCrossValidator : public AbstractPrivateData {
+public:
+    QoreCrossValidator(int n_folds, bool shuffle, int64_t seed);
+    QoreListNode* split(int n_samples, ExceptionSink* xsink);
+};
+```
+
+**Qore API**:
+```qore
+auto cv = new ML::CrossValidator({"n_folds": 5, "shuffle": True, "seed": 42});
+list<hash<auto>> folds = cv.split(data.size());
+# Each fold: {"train_indices": (0, 1, 3, ...), "test_indices": (2, 7, ...)}
+```
+
+#### 2.5 DataProvider Metric Processors
+
+- `classification-metrics` processor: accumulates predictions + ground truth, emits
+  ClassificationReport on flush
+- `regression-metrics` processor: accumulates predictions + actuals, emits regression
+  metrics on flush
+- `clustering-metrics` processor: accumulates data + cluster assignments, emits
+  clustering metrics on flush
+
+### Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `modules/ml/src/ml_metrics.h` | New — metric function declarations |
+| `modules/ml/src/ml_metrics.cpp` | New — metric implementations |
+| `modules/ml/src/QC_CrossValidator.h` | New — class declaration |
+| `modules/ml/src/CrossValidator.cpp` | New — implementation |
+| `modules/ml/src/QC_CrossValidator.qpp` | New — QPP bindings |
+| `modules/ml/src/ql_ml.qpp` | Modify — add metric functions and hashdecls |
+| `modules/ml/src/ml-module.cpp` | Modify — register |
+| `modules/ml/CMakeLists.txt` | Modify — add source files |
+| `qlib/DataProviderML/QoreClassificationMetricsProcessor.qc` | New |
+| `qlib/DataProviderML/QoreRegressionMetricsProcessor.qc` | New |
+| `qlib/DataProviderML/QoreClusteringMetricsProcessor.qc` | New |
+| `qlib/DataProviderML/DataProviderML.qm` | Modify |
+| `qlib/DataProviderML/MLProcessorsDataProvider.qc` | Modify |
+
+### Independent Verification
+
+1. **Reference value tests**: Compute expected values by hand for small datasets:
+   - accuracy, precision, recall, F1 for a 3×3 confusion matrix
+   - MSE, RMSE, MAE, R² for 5 known (y_true, y_pred) pairs
+   - Silhouette score for 2 well-separated clusters of 3 points each
+
+2. **Cross-validation consistency**: Verify that all samples appear in exactly one
+   test fold, and each fold has approximately equal size.
+
+3. **Metric identity properties**:
+   - `accuracy(y, y) == 1.0` (perfect predictions)
+   - `mse(y, y) == 0.0`
+   - `r2_score(y, y) == 1.0`
+   - `silhouette_score` for perfectly separated clusters ≈ 1.0
+
+4. **Integration test**: Train LinearRegression → predict → `ml_r2_score()` matches
+   the model's internal R². Train KMeans → predict → `ml_silhouette_score()` returns
+   a reasonable value.
+
+5. **DataProvider tests**: metric processors accumulate correctly, emit proper events.
+
+6. **Valgrind**: Full memory check.
+
+---
+
+## Phase 3: New Algorithms — Logistic Regression and k-NN
+
+### Motivation
+
+Classification is the most common supervised ML task, and Qore currently has no
+classification algorithms. Logistic Regression and k-NN are the two most fundamental
+classifiers, covering different use cases (linear vs. instance-based).
+
+### Components
+
+#### 3.1 LogisticRegression (C++)
+
+Binary and multiclass classification via gradient descent.
+
+```cpp
+class QoreLogisticRegression : public AbstractPrivateData {
+public:
+    QoreLogisticRegression(double learning_rate, int max_iterations,
+        double tolerance, double regularization, const std::string& penalty,
+        bool fit_intercept);
+
+    void fit(const MatrixXd& X, const VectorXd& y, ExceptionSink* xsink);
+    QoreHashNode* predict(const RowVectorXd& point, ExceptionSink* xsink) const;
+    QoreListNode* predictMatrix(const MatrixXd& X, ExceptionSink* xsink) const;
+
+private:
+    // Binary: single weight vector
+    // Multiclass: one weight vector per class (one-vs-rest)
+    MatrixXd weights;       // n_classes × n_features (or 1 × n_features for binary)
+    VectorXd intercepts;
+    std::vector<double> classes;  // unique class labels
+    bool is_binary = false;
+    // Hyperparameters
+    double learning_rate;
+    int max_iterations;
+    double tolerance;
+    double regularization;  // L2 regularization strength
+    std::string penalty;    // "l2", "none"
+    bool fit_intercept;
+};
+```
+
+**Hashdecl**:
+```
+hashdecl LogisticRegressionResult {
+    float predicted_class;          // most likely class label
+    float max_probability;          // probability of predicted class
+    list<float> probabilities;      // probability for each class
+    list<float> classes;            // class labels (same order as probabilities)
+}
+```
+
+**Key implementation details**:
+- Sigmoid activation for binary; softmax for multiclass
+- L-BFGS or mini-batch gradient descent (Eigen provides efficient matrix ops)
+- One-vs-rest (OvR) decomposition for multiclass when using sigmoid
+- `predict_proba()` returns probabilities alongside class predictions
+
+#### 3.2 KNN (C++)
+
+k-Nearest Neighbors for classification and regression.
+
+```cpp
+class QoreKNN : public AbstractPrivateData {
+public:
+    QoreKNN(int k, const std::string& metric, const std::string& task,
+        const std::string& weight_func);
+
+    void fit(const MatrixXd& X, const VectorXd& y, ExceptionSink* xsink);
+    QoreHashNode* predict(const RowVectorXd& point, ExceptionSink* xsink) const;
+    QoreListNode* predictMatrix(const MatrixXd& X, ExceptionSink* xsink) const;
+
+private:
+    int k;
+    std::string metric;      // "euclidean", "manhattan", "cosine"
+    std::string task;         // "classification", "regression"
+    std::string weight_func;  // "uniform", "distance"
+    MatrixXd ref_data;        // stored training data
+    VectorXd ref_labels;      // stored training labels
+};
+```
+
+**Hashdecls**:
+```
+hashdecl KNNClassificationResult {
+    float predicted_class;
+    float confidence;               // proportion of k neighbors with this class
+    list<hash<KNNNeighborInfo>> neighbors;  // k nearest neighbors (optional detail)
+}
+
+hashdecl KNNRegressionResult {
+    float prediction;               // weighted average of neighbor values
+    list<hash<KNNNeighborInfo>> neighbors;
+}
+
+hashdecl KNNNeighborInfo {
+    int index;
+    float distance;
+    float label;
+}
+```
+
+**Key implementation details**:
+- Brute-force distance computation (efficient for moderate datasets with Eigen)
+- Weighted voting: "uniform" (majority) or "distance" (inverse-distance weighted)
+- Dual-purpose: classification (majority vote) or regression (weighted average)
+
+#### 3.3 DataProvider Processors
+
+- `logistic-regression` processor: window-based, binary/multiclass classification
+- `knn-classification` processor: stores training window, classifies new records
+- `knn-regression` processor: stores training window, predicts continuous values
+
+### Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `modules/ml/src/QC_LogisticRegression.h` | New |
+| `modules/ml/src/LogisticRegression.cpp` | New |
+| `modules/ml/src/QC_LogisticRegression.qpp` | New |
+| `modules/ml/src/QC_KNN.h` | New |
+| `modules/ml/src/KNN.cpp` | New |
+| `modules/ml/src/QC_KNN.qpp` | New |
+| `modules/ml/src/ql_ml.qpp` | Modify — hashdecls |
+| `modules/ml/src/ml-module.cpp` | Modify — register |
+| `modules/ml/CMakeLists.txt` | Modify |
+| `qlib/DataProviderML/QoreLogisticRegressionProcessor.qc` | New |
+| `qlib/DataProviderML/QoreKNNClassificationProcessor.qc` | New |
+| `qlib/DataProviderML/QoreKNNRegressionProcessor.qc` | New |
+| `qlib/DataProviderML/DataProviderML.qm` | Modify |
+| `qlib/DataProviderML/MLProcessorsDataProvider.qc` | Modify |
+
+### Independent Verification
+
+1. **Known-answer tests**:
+   - LogisticRegression on linearly separable 2D data → 100% accuracy
+   - LogisticRegression on XOR-like data → accuracy around 50% (expected failure for
+     linear model — verifies it doesn't overfit)
+   - KNN with k=1 on training data → 100% accuracy (memorization property)
+   - KNN regression on constant-value data → all predictions equal the constant
+
+2. **Reference comparison**: Train on the Iris-like dataset (3 classes, 4 features):
+   - LogisticRegression should achieve >90% accuracy
+   - KNN (k=5) should achieve >90% accuracy
+   - Compare against hand-computed softmax probabilities for 2-3 sample points
+
+3. **Metric integration**: Train → predict → `ml_accuracy()` → verify against
+   manual count of correct predictions.
+
+4. **Multiclass verification**: 3+ classes, verify probability vectors sum to 1.0
+   (within floating-point tolerance).
+
+5. **Edge cases**: single class (degenerate), k > n_samples, empty features, single
+   training sample.
+
+6. **Thread safety**: concurrent predictions after fit.
+
+7. **Valgrind**: Full memory check.
+
+---
+
+## Phase 4: Online Learning Extensions
+
+### Motivation
+
+Currently only KMeans supports online learning (`update()`). Extending this to
+LinearRegression and GMM enables continuous model refinement on streaming data without
+full retraining. HoltWinters already has `update()` for sequential observations.
+
+### Components
+
+#### 4.1 LinearRegression Online Learning
+
+Add Stochastic Gradient Descent (SGD) update to LinearRegression.
+
+```cpp
+// New methods on QoreLinearRegression
+void update(const MatrixXd& X, const VectorXd& y, double learning_rate,
+    ExceptionSink* xsink);
+void updateSingle(const RowVectorXd& x, double y, double learning_rate,
+    ExceptionSink* xsink);
+```
+
+**Implementation**: Standard SGD update rule:
+```
+w = w - lr * (predicted - actual) * x
+b = b - lr * (predicted - actual)
+```
+
+The learning rate can be constant or use a schedule (1/sqrt(t)).
+
+#### 4.2 GMM Online Learning
+
+Add incremental EM update to GMM.
+
+```cpp
+// New method on QoreGMM
+void update(const MatrixXd& data, ExceptionSink* xsink);
+```
+
+**Implementation**: Online EM with sufficient statistics:
+- Maintain running sums for responsibilities, means, covariances
+- Each `update()` call performs a partial E-step on the new data, then updates the
+  sufficient statistics and re-derives parameters
+- Learning rate η = 1/(batch_count + 1) for convergence
+
+#### 4.3 LogisticRegression Online Learning
+
+Include online learning from the start in the Phase 3 implementation.
+
+```cpp
+void update(const MatrixXd& X, const VectorXd& y, double learning_rate,
+    ExceptionSink* xsink);
+```
+
+**Implementation**: Mini-batch SGD on the cross-entropy loss.
+
+#### 4.4 DataProvider Integration
+
+Update existing processors to support online mode:
+- `linear-regression` processor: add `online` option (like KMeans already has)
+- `gmm` processor: add `online` option
+- `logistic-regression` processor: add `online` option
+
+### Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `modules/ml/src/QC_LinearRegression.h` | Modify — add update methods |
+| `modules/ml/src/LinearRegression.cpp` | Modify — implement SGD update |
+| `modules/ml/src/QC_LinearRegression.qpp` | Modify — add QPP bindings |
+| `modules/ml/src/QC_GMM.h` | Modify — add update method |
+| `modules/ml/src/GMM.cpp` | Modify — implement online EM |
+| `modules/ml/src/QC_GMM.qpp` | Modify — add QPP bindings |
+| `modules/ml/src/QC_LogisticRegression.h` | Modify (if Phase 3 didn't include it) |
+| `modules/ml/src/LogisticRegression.cpp` | Modify |
+| `modules/ml/src/QC_LogisticRegression.qpp` | Modify |
+| `qlib/DataProviderML/QoreLinearRegressionProcessor.qc` | Modify — add online option |
+| `qlib/DataProviderML/QoreGMMProcessor.qc` | Modify — add online option |
+| `qlib/DataProviderML/QoreLogisticRegressionProcessor.qc` | Modify — add online option |
+
+### Independent Verification
+
+1. **Convergence test**: Generate linear data (y = 2x + 3 + noise). Fit batch
+   LinearRegression, note coefficients. Then create a fresh model, call `update()` in
+   many mini-batches on the same data — verify coefficients converge to approximately
+   the same values as batch fit.
+
+2. **Monotonic improvement**: For each update batch, track the loss (MSE for regression,
+   cross-entropy for classification). With a small enough learning rate, the loss should
+   decrease monotonically (or at least trend downward).
+
+3. **Consistency**: `fit()` on data1 + `update()` on data2 should produce different
+   coefficients than `fit()` on data1 alone — verify the update actually changes the
+   model.
+
+4. **GMM online**: Fit GMM on data1 (2 clusters). Generate data2 from a shifted
+   distribution. After `update()`, means should move toward the new data.
+
+5. **DataProvider integration**: Pipeline with `online=True` processes multiple
+   windows; verify the model state changes between windows (examine output cluster
+   assignments or predictions).
+
+6. **Thread safety**: concurrent `update()` calls should not corrupt state (mutex
+   serializes them).
+
+7. **Valgrind**: Full memory check.
+
+---
+
+## Phase 5: Model Persistence and Export
+
+### Motivation
+
+This is the foundational capability for production ML: trained models must be saved,
+loaded, shared, and deployed. Without persistence, every restart retrains from scratch.
+A generic persistence layer with pluggable format backends enables both fast native
+save/load and cross-platform interoperability via ONNX and other formats.
+
+### Architecture
+
+```
+                      Qore API
+                         │
+              ┌──────────┴──────────┐
+              │   ModelSerializer    │  (C++ — abstract interface)
+              │   save() / load()   │
+              └──────────┬──────────┘
+                         │
+         ┌───────────────┼───────────────┐
+         │               │               │
+    ┌────┴────┐    ┌─────┴─────┐   ┌─────┴─────┐
+    │ Native  │    │   ONNX    │   │   JSON    │
+    │ (.qml)  │    │  (.onnx)  │   │  (.json)  │
+    └─────────┘    └───────────┘   └───────────┘
+```
+
+### Components
+
+#### 5.1 Generic Persistence Interface (C++)
+
+```cpp
+//! Abstract serialization interface — each algorithm implements this
+class MLSerializable {
+public:
+    virtual ~MLSerializable() = default;
+
+    //! Serialize model state to a byte buffer
+    virtual BinaryNode* serialize(ExceptionSink* xsink) const = 0;
+
+    //! Deserialize model state from a byte buffer (static factory pattern)
+    //! Each algorithm registers a deserializer function
+    // See ml_serialization.h for the registry
+
+    //! Return algorithm type name (e.g. "KMeans", "LinearRegression")
+    virtual const char* algorithmName() const = 0;
+
+    //! Return model metadata as a hash (hyperparams, feature count, etc.)
+    virtual QoreHashNode* getMetadata(ExceptionSink* xsink) const = 0;
+};
+```
+
+**Native format (.qml)**:
+
+A compact binary format with a header and algorithm-specific payload.
+
+```
+┌─────────────────────────────────────────────┐
+│  Magic: "QML\x01"            (4 bytes)      │
+│  Format version: uint16      (2 bytes)      │
+│  Algorithm name length: uint16              │
+│  Algorithm name: UTF-8 string               │
+│  Hyperparameter JSON length: uint32         │
+│  Hyperparameter JSON: UTF-8                 │
+│  Field names JSON length: uint32            │
+│  Field names JSON: UTF-8 (or 0 if none)    │
+│  Model data length: uint64                  │
+│  Model data: algorithm-specific binary      │
+│    (Eigen matrices stored row-major with    │
+│     rows, cols, then flat double[])         │
+│  CRC-32 checksum: uint32                    │
+└─────────────────────────────────────────────┘
+```
+
+Each algorithm's `serialize()` writes its Eigen matrices and scalar state into the
+"model data" section. The format is versioned so future changes are backward-compatible.
+
+**Serialization helper** (`ml_serialization.h`):
+
+```cpp
+namespace MLSerialization {
+    // Write an Eigen matrix to a buffer: rows(int32), cols(int32), data(double[])
+    void writeMatrix(std::vector<uint8_t>& buf, const MatrixXd& mat);
+    MatrixXd readMatrix(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink);
+
+    void writeVector(std::vector<uint8_t>& buf, const VectorXd& vec);
+    VectorXd readVector(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink);
+
+    void writeScalar(std::vector<uint8_t>& buf, double val);
+    double readScalar(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink);
+
+    void writeInt32(std::vector<uint8_t>& buf, int32_t val);
+    int32_t readInt32(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink);
+
+    void writeString(std::vector<uint8_t>& buf, const std::string& s);
+    std::string readString(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink);
+
+    void writeStringVector(std::vector<uint8_t>& buf, const std::vector<std::string>& v);
+    std::vector<std::string> readStringVector(const uint8_t*& ptr, size_t& remaining,
+        ExceptionSink* xsink);
+
+    uint32_t computeCRC32(const uint8_t* data, size_t len);
+}
+```
+
+**Qore-level API** (namespace functions):
+
+```qore
+# Save a model to file (format detected from extension)
+ML::ml_save_model(ML::KMeans model, string path, *hash<auto> options);
+
+# Load a model from file (returns the algorithm object, ready for predict)
+auto model = ML::ml_load_model(string path);
+
+# Serialize to binary (in-memory, no file)
+binary data = ML::ml_serialize(ML::KMeans model);
+auto model = ML::ml_deserialize(binary data);
+```
+
+The `ml_save_model()` function detects the format from the file extension:
+- `.qml` → native format
+- `.onnx` → ONNX export
+- `.json` → JSON format
+
+An explicit `format` option overrides extension-based detection.
+
+#### 5.2 Per-Algorithm Serialization
+
+Each algorithm implements `serialize()` / static `deserialize()`. The state to serialize
+for each algorithm:
+
+| Algorithm | Serialized State |
+|-----------|-----------------|
+| **KMeans** | k, centroids (MatrixXd), centroid_counts, n_features, inertia, field_names, init_method, max_iterations, tolerance |
+| **LinearRegression** | coefficients (VectorXd), intercept, r_squared, n_features, fit_intercept, do_normalize, feature_means, feature_stds, field_names, target_field |
+| **PCA** | components (MatrixXd), mean_vec, stddev_vec, explained_variance_ratio_vec, n_features, actual_n_components, center, scale, field_names |
+| **IsolationForest** | trees (vector<IsolationTree>: each tree's nodes with feature, split_value, left, right, size), n_features, actual_sample_size, threshold, n_trees, sample_size, max_depth, field_names |
+| **LOF** | ref_data (MatrixXd), ref_k_distances, ref_lrds, ref_knn_indices, k, threshold, n_features, field_names |
+| **GMM** | means (vector<VectorXd>), covariances (vector<MatrixXd>), weights (VectorXd), n_components, n_features, covariance_type, field_names |
+| **HoltWinters** | level, trend, seasonal (vector<double>), t, period, alpha, beta, gamma, seasonal_type, damped, phi |
+| **SeasonalDecomposition** | period, type (stateless algorithm — only hyperparams needed) |
+| **DBSCAN** | epsilon, min_points, metric (stateless — re-clusters each time; nothing to persist beyond hyperparams) |
+| **LogisticRegression** | weights (MatrixXd), intercepts (VectorXd), classes, n_features, is_binary, hyperparams, field_names |
+| **KNN** | ref_data (MatrixXd), ref_labels (VectorXd), k, metric, task, weight_func, n_features, field_names |
+| **StandardScaler** | mean_vec, std_vec, n_features, field_names |
+| **MinMaxScaler** | data_min, data_max, feature_min, feature_max, n_features, field_names |
+| **Imputer** | fill_values, strategy, constant_value, n_features, field_names |
+
+Note: DBSCAN and SeasonalDecomposition are stateless (they operate on input data directly
+without maintaining a trained model). Their persistence stores only hyperparameters
+so they can be reconstructed, but there is no trained state to save.
+
+#### 5.3 ONNX Export Backend
+
+Export trained native models to ONNX format for deployment in any ONNX Runtime-compatible
+environment (Python, C#, Java, JavaScript, edge devices).
+
+**Dependency**: ONNX uses Protocol Buffers (protobuf). The ONNX .proto files define the
+model schema. We use the ONNX protobuf definitions directly (header-only or via
+libprotobuf).
+
+**CMake integration**: `find_package(Protobuf)` — optional like ONNX Runtime. ONNX
+export is `#ifdef HAVE_PROTOBUF` guarded.
+
+**Algorithm-to-ONNX operator mapping**:
+
+| Algorithm | ONNX Operators | ONNX-ML Operators |
+|-----------|---------------|-------------------|
+| **LinearRegression** | MatMul + Add | ai.onnx.ml.LinearRegressor |
+| **LogisticRegression** | MatMul + Add + Sigmoid/Softmax | ai.onnx.ml.LinearClassifier |
+| **PCA** | Sub (center) + MatMul (project) | — (standard ops) |
+| **KMeans** | — | ai.onnx.ml.KMeansPredictor* |
+| **StandardScaler** | Sub + Div | ai.onnx.ml.Scaler |
+| **MinMaxScaler** | Sub + Div + Mul + Add | ai.onnx.ml.Scaler |
+| **KNN** | — | ai.onnx.ml.KNearestNeighbors* |
+| **IsolationForest** | — | ai.onnx.ml.TreeEnsembleRegressor (score) |
+| **GMM** | Complex subgraph | — (not natively supported) |
+| **HoltWinters** | — | — (stateful time-series, no ONNX mapping) |
+| **LOF** | — | — (requires reference data, no standard mapping) |
+
+*Note: KMeans and KNN do not have standard ONNX-ML operators but can be expressed as
+computation graphs. Alternatively, we can use custom operator domains.*
+
+**Algorithms that export cleanly to ONNX**: LinearRegression, LogisticRegression, PCA,
+StandardScaler, MinMaxScaler, IsolationForest (via TreeEnsembleRegressor), KMeans
+(via distance computation graph).
+
+**Algorithms that do NOT export to ONNX** (and throw ML-ONNX-EXPORT-ERROR): HoltWinters,
+SeasonalDecomposition, LOF, DBSCAN (stateless), GMM (complex covariance computations
+not worth the graph complexity). These models can still be saved in native and JSON formats.
+
+**Export API**:
+
+```cpp
+class OnnxExporter {
+public:
+    // Export a model to ONNX format
+    static BinaryNode* exportModel(const MLSerializable* model,
+        const std::string& producer_name, int64_t opset_version,
+        ExceptionSink* xsink);
+
+    // Export a pipeline (preprocessors + estimator) as a single ONNX graph
+    static BinaryNode* exportPipeline(const QoreMLPipeline* pipeline,
+        const std::string& producer_name, int64_t opset_version,
+        ExceptionSink* xsink);
+};
+```
+
+**Pipeline export**: The MLPipeline's chain of preprocessors + estimator is exported
+as a single ONNX graph where each step's operators are concatenated. This is the most
+natural ONNX representation and avoids the need for multiple model files.
+
+#### 5.4 JSON Export Backend
+
+Human-readable format for debugging, inspection, and web service integration.
+
+```json
+{
+    "format": "qore-ml-json",
+    "version": 1,
+    "algorithm": "KMeans",
+    "hyperparameters": {
+        "k": 3,
+        "max_iterations": 100,
+        "tolerance": 0.0001,
+        "init": "kmeans++"
+    },
+    "field_names": ["sepal_length", "sepal_width", "petal_length", "petal_width"],
+    "model_state": {
+        "n_features": 4,
+        "centroids": [[5.0, 3.4, 1.5, 0.2], [5.9, 2.8, 4.3, 1.3], [6.6, 3.0, 5.5, 2.0]],
+        "centroid_counts": [50, 50, 50],
+        "inertia": 78.94
+    },
+    "metadata": {
+        "created": "2026-03-20T10:30:00Z",
+        "ml_module_version": "1.2",
+        "eigen_version": "3.4.0"
+    }
+}
+```
+
+**Implementation**: Uses Qore's built-in JSON serialization. Each algorithm implements
+`toJSON()` / static `fromJSON()`. Eigen matrices are serialized as nested lists of
+numbers.
+
+The JSON backend does NOT require any external dependencies — it uses the
+json module already available in Qore.
+
+#### 5.5 ONNX Import Enhancement
+
+Currently `OnnxModel` loads any `.onnx` file for inference. Enhance it to recognize
+Qore-exported ONNX models (via producer metadata) and optionally reconstruct the
+native algorithm object for further training/updating:
+
+```qore
+# Load as OnnxModel (inference only — already works)
+auto onnx = new ML::OnnxModel("model.onnx");
+
+# Load as native algorithm (if exported by Qore)
+auto model = ML::ml_load_model("model.onnx");
+# Returns a KMeans/LinearRegression/etc. if the ONNX model was exported by Qore
+# Returns an OnnxModel otherwise
+```
+
+This is best-effort: ONNX models exported by other tools remain as `OnnxModel`.
+
+### Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `modules/ml/src/ml_serialization.h` | New — serialization primitives + registry |
+| `modules/ml/src/ml_serialization.cpp` | New — implementations |
+| `modules/ml/src/ml_onnx_export.h` | New — ONNX export (ifdef HAVE_PROTOBUF) |
+| `modules/ml/src/ml_onnx_export.cpp` | New — ONNX graph construction |
+| `modules/ml/src/ml_json_export.h` | New — JSON export/import |
+| `modules/ml/src/ml_json_export.cpp` | New — implementations |
+| `modules/ml/src/ql_ml.qpp` | Modify — add save/load/serialize functions |
+| `modules/ml/src/ml-module.cpp` | Modify — register deserializer factories |
+| `modules/ml/CMakeLists.txt` | Modify — add sources, optional protobuf dep |
+| Every `QC_*.h` | Modify — add MLSerializable base, serialize/deserialize |
+| Every `*.cpp` | Modify — implement serialize/deserialize |
+| `modules/ml/src/QC_MLPipeline.h` | Modify — pipeline serialize (delegates) |
+
+### Independent Verification
+
+1. **Round-trip tests (native format)**: For each algorithm:
+   - Train model → `ml_save_model("test.qml")` → `ml_load_model("test.qml")` →
+     predict on same input → assert identical results to original model
+   - Verify all hyperparameters preserved (k, threshold, etc.)
+   - Verify field_names preserved (hash-based API still works after load)
+
+2. **Round-trip tests (JSON format)**: Same as native, but with `.json` extension.
+   Additionally verify the JSON file is valid JSON and contains expected keys.
+
+3. **Binary integrity**: Corrupt one byte in a `.qml` file → `ml_load_model()` must
+   raise `ML-DESERIALIZE-ERROR` (CRC check fails).
+
+4. **Cross-version compatibility**: Save with format version 1, bump the reader to
+   expect version 1, verify it still loads. (Foundation for future version upgrades.)
+
+5. **ONNX export verification**: For each exportable algorithm:
+   - Export to `.onnx` → load with `OnnxModel` → run inference → compare results
+     against the native algorithm's predictions (within floating-point tolerance
+     of 1e-6)
+   - Verify the ONNX model's metadata (producer_name, description, inputs, outputs)
+
+6. **ONNX cross-platform verification** (if Python available on CI):
+   - Export `.onnx` from Qore → load in Python `onnxruntime` → run same test input →
+     compare predictions. This is the gold standard for interoperability.
+
+7. **Pipeline export**: Export a pipeline (StandardScaler + LinearRegression) to ONNX →
+   run inference → verify output matches the pipeline's `predict()`.
+
+8. **Large model stress test**: Train IsolationForest with 1000 trees on 10K points →
+   save → load → verify file size is reasonable and load time < 2 seconds.
+
+9. **Thread safety**: Concurrent `ml_save_model()` and `predict()` on the same model
+   (save acquires read lock, predict acquires read lock — both should succeed).
+
+10. **Valgrind**: Full memory check on save/load cycle.
+
+---
+
+## Phase 6: Model Registry and Deployment Management
+
+### Motivation
+
+Production ML requires tracking which models are in use, comparing versions, and
+managing the lifecycle from training to deployment. The QoreModelRegistry module provides
+this without external dependencies (filesystem or database-backed).
+
+### Components
+
+#### 6.1 QoreModelRegistry Module (Qore)
+
+A new Qore user module (`qlib/QoreModelRegistry/`) that builds on Phase 5's persistence.
+
+```
+qlib/QoreModelRegistry/
+├── QoreModelRegistry.qm                 # Main module
+├── ModelRegistry.qc                     # Core registry class
+├── ModelVersion.qc                      # Version tracking
+├── ModelComparison.qc                   # Side-by-side model comparison
+├── ModelRegistryDataProvider.qc         # DataProvider integration
+└── ModelRegistryDataProviderFactory.qc  # Factory
+```
+
+**Core API**:
+
+```qore
+# Registry backed by filesystem
+auto reg = new ModelRegistry({"path": "/var/models"});
+
+# Register a trained model
+string version_id = reg.register(model, {
+    "name": "fraud-detector",
+    "tags": ("production", "v2"),
+    "description": "Isolation forest for transaction anomaly detection",
+    "metrics": {"silhouette_score": 0.82, "f1": 0.91},
+    "training_data_hash": "sha256:abc...",
+});
+
+# List versions
+list<hash<ModelVersionInfo>> versions = reg.listVersions("fraud-detector");
+
+# Load a specific version
+auto model = reg.load("fraud-detector", version_id);
+# Or load the latest
+auto model = reg.load("fraud-detector", "latest");
+
+# Compare two versions
+hash<ModelComparisonResult> cmp = reg.compare("fraud-detector", v1_id, v2_id, test_data);
+
+# Promote a version (tag as "production")
+reg.tag(version_id, "production");
+
+# Delete old versions (keeps tagged versions)
+reg.prune("fraud-detector", {"keep_tagged": True, "keep_latest": 5});
+```
+
+**Hashdecls**:
+
+```
+hashdecl ModelVersionInfo {
+    string version_id;          # UUID
+    string name;                # model name
+    string algorithm;           # algorithm type
+    date created;               # registration timestamp
+    *string description;
+    *hash<auto> metrics;        # stored evaluation metrics
+    *hash<auto> hyperparameters;
+    list<string> tags;
+    int file_size;              # bytes
+    string format;              # "qml", "onnx", "json"
+    *string training_data_hash;
+}
+
+hashdecl ModelComparisonResult {
+    hash<ModelVersionInfo> version_a;
+    hash<ModelVersionInfo> version_b;
+    *hash<auto> metric_deltas;   # metric_name → (a_value, b_value, delta)
+    *hash<auto> prediction_comparison;  # summary of prediction differences
+}
+```
+
+**Storage layout** (filesystem backend):
+```
+/var/models/
+├── fraud-detector/
+│   ├── registry.json               # version index
+│   ├── v_20260320_abc123.qml       # model file
+│   ├── v_20260320_abc123.meta.json # metadata
+│   ├── v_20260321_def456.qml
+│   └── v_20260321_def456.meta.json
+└── sales-forecast/
+    └── ...
+```
+
+#### 6.2 Database Backend (optional)
+
+For production deployments with multiple instances, the registry can be backed by a
+database using Qore's SqlUtil/DatasourcePool:
+
+```qore
+auto reg = new ModelRegistry({"datasource": ds, "table_prefix": "ml_"});
+```
+
+Tables: `ml_models` (name, algorithm), `ml_versions` (version_id, model_id, created,
+metadata JSON), `ml_tags` (version_id, tag), `ml_blobs` (version_id, data BLOB).
+
+This is an optional add-on and depends on existing SqlUtil infrastructure.
+
+#### 6.3 DataProvider Integration
+
+- `model-registry` data provider: browse registered models, list versions
+- Supports DataProvider search/navigation for Qorus integration
+- Actions: register, load, compare, prune — accessible via DataProviderActionCatalog
+
+### Files to Create
+
+| File | Action |
+|------|--------|
+| `qlib/QoreModelRegistry/QoreModelRegistry.qm` | New — main module |
+| `qlib/QoreModelRegistry/ModelRegistry.qc` | New — core registry class |
+| `qlib/QoreModelRegistry/ModelVersion.qc` | New — version tracking |
+| `qlib/QoreModelRegistry/ModelComparison.qc` | New — comparison utilities |
+| `qlib/QoreModelRegistry/ModelRegistryDataProvider.qc` | New |
+| `qlib/QoreModelRegistry/ModelRegistryDataProviderFactory.qc` | New |
+| `CMakeLists.txt` | Modify — add module |
+| `Makefile.am` | Modify — add module |
+| `examples/test/qlib/QoreModelRegistry/QoreModelRegistry.qtest` | New |
+
+### Independent Verification
+
+1. **Registration round-trip**: Register a model → `listVersions()` → verify it
+   appears with correct metadata → `load()` → predict → same results as original.
+
+2. **Multi-version management**: Register 5 versions of the same model → verify
+   chronological ordering → load "latest" → verify it's the most recent.
+
+3. **Tagging**: Tag version as "production" → load by tag → verify correct version.
+
+4. **Pruning**: Register 10 versions, tag 2 → `prune(keep_tagged=True, keep_latest=3)`
+   → verify 5 versions remain (2 tagged + 3 latest).
+
+5. **Comparison**: Register two KMeans models with different k → `compare()` with
+   test data → verify metric_deltas computed correctly.
+
+6. **Concurrent access**: Multiple processes register models simultaneously (filesystem
+   locking via advisory locks or atomic rename).
+
+7. **Storage integrity**: Verify `.meta.json` files are valid JSON with expected schema.
+   Verify model files match stored file_size.
+
+8. **DataProvider navigation**: Browse registry via DataProvider API, verify model
+   listing matches direct registry listing.
+
+9. **Error handling**: Load non-existent model → `ML-REGISTRY-ERROR`. Load corrupted
+   file → `ML-DESERIALIZE-ERROR`. Register unfitted model → `ML-REGISTRY-ERROR`.
+
+---
+
+## Implementation Schedule and Dependencies
+
+```
+Phase 1 ──────────────> Phase 2 ──────────────> Phase 3
+(Preprocessing)         (Metrics)               (New Algorithms)
+                                                       │
+                            Phase 4 <──────────────────┘
+                            (Online Learning)
+                                  │
+                            Phase 5 <── depends on all trained models existing
+                            (Persistence & Export)
+                                  │
+                            Phase 6
+                            (Model Registry)
+```
+
+- **Phase 1** has no dependencies on other phases
+- **Phase 2** can proceed in parallel with Phase 1 (metrics don't depend on preprocessing)
+- **Phase 3** benefits from Phase 2 (can use metrics in tests) but is not blocked by it
+- **Phase 4** depends on Phase 3 (extends LogisticRegression)
+- **Phase 5** benefits from all prior phases (more algorithms to serialize) but can start
+  with existing algorithms first
+- **Phase 6** depends on Phase 5 (uses persistence layer)
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|------------|
+| Protobuf dependency for ONNX export | Make fully optional (ifdef); JSON and native formats work without it |
+| ONNX operator coverage | Not all algorithms map to ONNX; clearly document which export and which don't |
+| Large model serialization performance | Use binary format with Eigen's raw memory layout; avoid JSON for large models |
+| Backward-compatible format evolution | Version field in header; reader checks version and dispatches accordingly |
+| Thread safety in registry | Filesystem: atomic rename + advisory locks; Database: SQL transactions |
+
+## Conventions
+
+All new code follows the existing patterns documented in `design/ml-architecture.md`:
+- C++ classes extend `AbstractPrivateData` with `mutable std::mutex mtx`
+- QPP bindings follow `qclass Name [arg=QoreType* var; ns=Qore::ML; flags=final]`
+- Hashdecls in `ql_ml.qpp`, registered in `ml-module.cpp`
+- DataProvider processors in `qlib/DataProviderML/`, registered in `DataProviderML.qm`
+- Tests: binary module tests in `modules/ml/test/ml.qtest`, DataProvider tests in
+  `examples/test/qlib/DataProviderML/DataProviderMLProcessors.qtest`
+- Copyright 2026, MIT license
+- All hashdecls and functions marked with `@since ml 1.2` (or appropriate version)

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -793,6 +793,8 @@ cargo install tree-sitter-cli@0.26.5
       - Imputer for missing value replacement (mean, median, most_frequent, constant strategies)
       - LogisticRegression for binary and multiclass classification with L2 regularization
       - KNN (k-Nearest Neighbors) for classification and regression by similarity
+      - Model persistence: ml_serialize/ml_deserialize (in-memory), ml_save_model/ml_load_model
+        (file-based .qml native format) for all 12 algorithms
       - Online learning (incremental updates) for KMeans, LinearRegression, GMM, and LogisticRegression
       - MLPipeline for chaining preprocessing steps and estimators into a single fit/predict unit
       - Model evaluation: classification metrics (accuracy, precision, recall, F1, confusion matrix),

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -791,6 +791,8 @@ cargo install tree-sitter-cli@0.26.5
       - StandardScaler for zero-mean unit-variance feature normalization
       - MinMaxScaler for configurable-range feature scaling
       - Imputer for missing value replacement (mean, median, most_frequent, constant strategies)
+      - LogisticRegression for binary and multiclass classification with L2 regularization
+      - KNN (k-Nearest Neighbors) for classification and regression by similarity
       - MLPipeline for chaining preprocessing steps and estimators into a single fit/predict unit
       - Model evaluation: classification metrics (accuracy, precision, recall, F1, confusion matrix),
         regression metrics (MSE, RMSE, MAE, R², explained variance), clustering metrics (silhouette,
@@ -800,6 +802,7 @@ cargo install tree-sitter-cli@0.26.5
       - 9 core ML pipeline processors: isolation-forest, dbscan-clustering, kmeans-clustering, pca,
         holt-winters, seasonal-decomposition, linear-regression, lof, and gmm
       - 3 preprocessing pipeline processors: standard-scaler, min-max-scaler, imputer
+      - 3 classification/regression pipeline processors: logistic-regression, knn-classification, knn-regression
       - 3 evaluation pipeline processors: classification-metrics, regression-metrics, clustering-metrics
       - optional onnx-model pipeline processor for ONNX Runtime inference
       - action catalog integration with the "ML Analytics" app

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -788,10 +788,19 @@ cargo install tree-sitter-cli@0.26.5
       - Holt-Winters triple exponential smoothing for time series forecasting
       - Seasonal Decomposition for decomposing time series into trend, seasonal, and residual components
       - optional ONNX Runtime support for running pre-trained models (OnnxModel class)
+      - StandardScaler for zero-mean unit-variance feature normalization
+      - MinMaxScaler for configurable-range feature scaling
+      - Imputer for missing value replacement (mean, median, most_frequent, constant strategies)
+      - MLPipeline for chaining preprocessing steps and estimators into a single fit/predict unit
+      - Model evaluation: classification metrics (accuracy, precision, recall, F1, confusion matrix),
+        regression metrics (MSE, RMSE, MAE, R², explained variance), clustering metrics (silhouette,
+        Davies-Bouldin, Calinski-Harabasz), and CrossValidator for k-fold cross-validation
     - @ref dataprovidermlintro "DataProviderML" module
       - new module providing data pipeline processors wrapping the ml binary module
       - 9 core ML pipeline processors: isolation-forest, dbscan-clustering, kmeans-clustering, pca,
         holt-winters, seasonal-decomposition, linear-regression, lof, and gmm
+      - 3 preprocessing pipeline processors: standard-scaler, min-max-scaler, imputer
+      - 3 evaluation pipeline processors: classification-metrics, regression-metrics, clustering-metrics
       - optional onnx-model pipeline processor for ONNX Runtime inference
       - action catalog integration with the "ML Analytics" app
     - @ref mongodbintro "mongodb" module

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -793,6 +793,7 @@ cargo install tree-sitter-cli@0.26.5
       - Imputer for missing value replacement (mean, median, most_frequent, constant strategies)
       - LogisticRegression for binary and multiclass classification with L2 regularization
       - KNN (k-Nearest Neighbors) for classification and regression by similarity
+      - Online learning (incremental updates) for KMeans, LinearRegression, GMM, and LogisticRegression
       - MLPipeline for chaining preprocessing steps and estimators into a single fit/predict unit
       - Model evaluation: classification metrics (accuracy, precision, recall, F1, confusion matrix),
         regression metrics (MSE, RMSE, MAE, R², explained variance), clustering metrics (silhouette,

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -793,6 +793,9 @@ cargo install tree-sitter-cli@0.26.5
       - Imputer for missing value replacement (mean, median, most_frequent, constant strategies)
       - LogisticRegression for binary and multiclass classification with L2 regularization
       - KNN (k-Nearest Neighbors) for classification and regression by similarity
+      - @ref qoremodelregistryintro "QoreModelRegistry" module
+      - new module providing a filesystem-backed ML model registry for versioning,
+        tagging, comparison, and deployment management of trained models
       - Model persistence: ml_serialize/ml_deserialize (in-memory), ml_save_model/ml_load_model
         (file-based .qml native format) for all 12 algorithms
       - Online learning (incremental updates) for KMeans, LinearRegression, GMM, and LogisticRegression

--- a/examples/test/qlib/DataProviderML/DataProviderMLProcessors.qtest
+++ b/examples/test/qlib/DataProviderML/DataProviderMLProcessors.qtest
@@ -102,6 +102,26 @@ class DataProviderMLProcessorsTest inherits QUnit::Test {
         addTestCase("onnx-model - capabilities", \onnxModelCapabilities());
         addTestCase("onnx-model - constructor validation", \onnxModelConstructorValidation());
 
+        # StandardScaler tests
+        addTestCase("standard-scaler - basic window", \stdScalerBasicWindow());
+        addTestCase("standard-scaler - subsequent windows", \stdScalerSubsequentWindows());
+        addTestCase("standard-scaler - capabilities", \stdScalerCapabilities());
+
+        # MinMaxScaler tests
+        addTestCase("min-max-scaler - basic window", \mmScalerBasicWindow());
+        addTestCase("min-max-scaler - custom range", \mmScalerCustomRange());
+        addTestCase("min-max-scaler - capabilities", \mmScalerCapabilities());
+
+        # Imputer tests
+        addTestCase("imputer - mean strategy", \imputerMeanStrategy());
+        addTestCase("imputer - constant strategy", \imputerConstantStrategy());
+        addTestCase("imputer - capabilities", \imputerCapabilities());
+
+        # Metric processors
+        addTestCase("classification-metrics - basic", \classMetricsBasic());
+        addTestCase("regression-metrics - basic", \regMetricsBasic());
+        addTestCase("clustering-metrics - basic", \clusterMetricsBasic());
+
         # Integration tests
         addTestCase("integration - factory registration", \integrationFactory());
         addTestCase("integration - navigation children", \integrationNavigation());
@@ -1171,6 +1191,241 @@ class DataProviderMLProcessorsTest inherits QUnit::Test {
         });
     }
 
+    # ===================== StandardScaler Tests =====================
+
+    stdScalerBasicWindow() {
+        DataProviderML::QoreStandardScalerProcessor proc({
+            "fields": "x,y",
+            "window_size": 5,
+        });
+
+        list<auto> results;
+        # Feed 5 records to fill the window
+        list<hash<auto>> data = (
+            {"x": 1.0, "y": 10.0},
+            {"x": 2.0, "y": 20.0},
+            {"x": 3.0, "y": 30.0},
+            {"x": 4.0, "y": 40.0},
+            {"x": 5.0, "y": 50.0},
+        );
+        foreach hash<auto> rec in (data) {
+            collectResult(\results, proc.processRecord(rec));
+        }
+        # Should get 5 events when window is full
+        assertEq(5, results.lsize());
+        assertEq("standard-scaler", results[0].event_type);
+        assertTrue(exists results[0].scaled_values);
+        assertTrue(exists results[0].record_values);
+        # Middle point (mean) should have scaled values near 0
+        assertFloat(0.0, results[2].scaled_values.x, 0.01);
+        assertFloat(0.0, results[2].scaled_values.y, 0.01);
+    }
+
+    stdScalerSubsequentWindows() {
+        DataProviderML::QoreStandardScalerProcessor proc({
+            "fields": "x",
+            "window_size": 3,
+        });
+
+        # First window: fits the scaler
+        list<auto> results;
+        foreach hash<auto> rec in (({"x": 1.0}, {"x": 2.0}, {"x": 3.0})) {
+            collectResult(\results, proc.processRecord(rec));
+        }
+        assertEq(3, results.lsize());
+
+        # Second window: uses the already-fitted scaler
+        list<auto> results2;
+        foreach hash<auto> rec in (({"x": 1.0}, {"x": 2.0}, {"x": 3.0})) {
+            collectResult(\results2, proc.processRecord(rec));
+        }
+        assertEq(3, results2.lsize());
+        # Results should be same as first window (same data, same scaler)
+        assertFloat(results[0].scaled_values.x, results2[0].scaled_values.x, 1e-10);
+    }
+
+    stdScalerCapabilities() {
+        DataProviderML::QoreStandardScalerProcessor proc();
+        hash<DataProviderInfo> info = proc.getInfo();
+        assertEq("QoreStandardScalerProcessor", info.type);
+        assertTrue(info.supports_pipeline_processor);
+    }
+
+    # ===================== MinMaxScaler Tests =====================
+
+    mmScalerBasicWindow() {
+        DataProviderML::QoreMinMaxScalerProcessor proc({
+            "fields": "x",
+            "window_size": 3,
+        });
+
+        list<auto> results;
+        foreach hash<auto> rec in (({"x": 0.0}, {"x": 5.0}, {"x": 10.0})) {
+            collectResult(\results, proc.processRecord(rec));
+        }
+        assertEq(3, results.lsize());
+        assertEq("min-max-scaler", results[0].event_type);
+        # min → 0.0, mid → 0.5, max → 1.0
+        assertFloat(0.0, results[0].scaled_values.x, 1e-10);
+        assertFloat(0.5, results[1].scaled_values.x, 1e-10);
+        assertFloat(1.0, results[2].scaled_values.x, 1e-10);
+    }
+
+    mmScalerCustomRange() {
+        DataProviderML::QoreMinMaxScalerProcessor proc({
+            "fields": "x",
+            "window_size": 3,
+            "feature_min": -1.0,
+            "feature_max": 1.0,
+        });
+
+        list<auto> results;
+        foreach hash<auto> rec in (({"x": 0.0}, {"x": 5.0}, {"x": 10.0})) {
+            collectResult(\results, proc.processRecord(rec));
+        }
+        assertEq(3, results.lsize());
+        assertFloat(-1.0, results[0].scaled_values.x, 1e-10);
+        assertFloat(0.0, results[1].scaled_values.x, 1e-10);
+        assertFloat(1.0, results[2].scaled_values.x, 1e-10);
+    }
+
+    mmScalerCapabilities() {
+        DataProviderML::QoreMinMaxScalerProcessor proc();
+        hash<DataProviderInfo> info = proc.getInfo();
+        assertEq("QoreMinMaxScalerProcessor", info.type);
+        assertTrue(info.supports_pipeline_processor);
+    }
+
+    # ===================== Imputer Tests =====================
+
+    imputerMeanStrategy() {
+        DataProviderML::QoreImputerProcessor proc({
+            "fields": "x,y",
+            "window_size": 4,
+            "strategy": "mean",
+        });
+
+        list<auto> results;
+        # Feed data with missing values
+        list<hash<auto>> data = (
+            {"x": 1.0, "y": 10.0},
+            {"x": 2.0, "y": NOTHING},
+            {"x": NOTHING, "y": 30.0},
+            {"x": 4.0, "y": 40.0},
+        );
+        foreach hash<auto> rec in (data) {
+            collectResult(\results, proc.processRecord(rec));
+        }
+        assertEq(4, results.lsize());
+        assertEq("imputer", results[0].event_type);
+        assertTrue(exists results[0].imputed_values);
+        # Row 0: no missing values — imputed values same as original
+        assertFloat(1.0, results[0].imputed_values.x, 1e-10);
+        assertFloat(10.0, results[0].imputed_values.y, 1e-10);
+    }
+
+    imputerConstantStrategy() {
+        DataProviderML::QoreImputerProcessor proc({
+            "fields": "x",
+            "window_size": 3,
+            "strategy": "constant",
+            "constant_value": -999.0,
+        });
+
+        list<auto> results;
+        foreach hash<auto> rec in (({"x": 1.0}, {"x": NOTHING}, {"x": 3.0})) {
+            collectResult(\results, proc.processRecord(rec));
+        }
+        assertEq(3, results.lsize());
+        # Row 1 had missing x — should be filled with -999.0
+        assertFloat(-999.0, results[1].imputed_values.x, 1e-10);
+        # Row 0 and 2 should be unchanged
+        assertFloat(1.0, results[0].imputed_values.x, 1e-10);
+        assertFloat(3.0, results[2].imputed_values.x, 1e-10);
+    }
+
+    imputerCapabilities() {
+        DataProviderML::QoreImputerProcessor proc();
+        hash<DataProviderInfo> info = proc.getInfo();
+        assertEq("QoreImputerProcessor", info.type);
+        assertTrue(info.supports_pipeline_processor);
+    }
+
+    # ===================== Metric Processor Tests =====================
+
+    classMetricsBasic() {
+        DataProviderML::QoreClassificationMetricsProcessor proc({
+            "predicted_field": "pred",
+            "true_field": "actual",
+            "window_size": 5,
+        });
+
+        list<auto> results;
+        # 4 correct out of 5
+        list<hash<auto>> data = (
+            {"pred": 1, "actual": 1},
+            {"pred": 0, "actual": 0},
+            {"pred": 1, "actual": 0},
+            {"pred": 1, "actual": 1},
+            {"pred": 0, "actual": 0},
+        );
+        foreach hash<auto> rec in (data) {
+            collectResult(\results, proc.processRecord(rec));
+        }
+        assertEq(1, results.size());
+        assertEq("classification-metrics", results[0].event_type);
+        assertFloat(0.8, results[0].accuracy, 1e-10);
+        assertEq(5, results[0].sample_count);
+    }
+
+    regMetricsBasic() {
+        DataProviderML::QoreRegressionMetricsProcessor proc({
+            "predicted_field": "pred",
+            "true_field": "actual",
+            "window_size": 3,
+        });
+
+        list<auto> results;
+        list<hash<auto>> data = (
+            {"pred": 1.0, "actual": 1.0},
+            {"pred": 2.0, "actual": 2.0},
+            {"pred": 3.0, "actual": 3.0},
+        );
+        foreach hash<auto> rec in (data) {
+            collectResult(\results, proc.processRecord(rec));
+        }
+        assertEq(1, results.size());
+        assertEq("regression-metrics", results[0].event_type);
+        assertFloat(0.0, results[0].mse, 1e-10);
+        assertFloat(1.0, results[0].r2, 1e-10);
+    }
+
+    clusterMetricsBasic() {
+        DataProviderML::QoreClusteringMetricsProcessor proc({
+            "fields": "x,y",
+            "cluster_field": "cluster",
+            "window_size": 6,
+        });
+
+        list<auto> results;
+        list<hash<auto>> data = (
+            {"x": 0.0, "y": 0.0, "cluster": 0},
+            {"x": 0.1, "y": 0.0, "cluster": 0},
+            {"x": 0.0, "y": 0.1, "cluster": 0},
+            {"x": 10.0, "y": 10.0, "cluster": 1},
+            {"x": 10.1, "y": 10.0, "cluster": 1},
+            {"x": 10.0, "y": 10.1, "cluster": 1},
+        );
+        foreach hash<auto> rec in (data) {
+            collectResult(\results, proc.processRecord(rec));
+        }
+        assertEq(1, results.size());
+        assertEq("clustering-metrics", results[0].event_type);
+        assertTrue(results[0].silhouette_score > 0.9);
+        assertEq(2, results[0].n_clusters);
+        assertEq(6, results[0].sample_count);
+    }
+
     # ===================== Integration Tests =====================
 
     integrationFactory() {
@@ -1195,13 +1450,19 @@ class DataProviderMLProcessorsTest inherits QUnit::Test {
         assertTrue(children.contains("linear-regression"));
         assertTrue(children.contains("lof"));
         assertTrue(children.contains("gmm"));
+        assertTrue(children.contains("standard-scaler"));
+        assertTrue(children.contains("min-max-scaler"));
+        assertTrue(children.contains("imputer"));
+        assertTrue(children.contains("classification-metrics"));
+        assertTrue(children.contains("regression-metrics"));
+        assertTrue(children.contains("clustering-metrics"));
 
         hash<ML::MLCapabilities> caps = ML::ml_get_capabilities();
         if (caps.has_onnx) {
             assertTrue(children.contains("onnx-model"));
-            assertEq(10, children.lsize());
+            assertEq(16, children.lsize());
         } else {
-            assertEq(9, children.lsize());
+            assertEq(15, children.lsize());
         }
 
         # check that each child can be retrieved
@@ -1246,6 +1507,30 @@ class DataProviderMLProcessorsTest inherits QUnit::Test {
             {"fields": "x", "window_size": 10, "n_components": 2});
         assertTrue(exists gmm.getPipelineProcessorOutputType());
 
+        DataProviderML::QoreStandardScalerProcessor stdscaler(
+            {"fields": "x,y", "window_size": 10});
+        assertTrue(exists stdscaler.getPipelineProcessorOutputType());
+
+        DataProviderML::QoreMinMaxScalerProcessor mmscaler(
+            {"fields": "x,y", "window_size": 10});
+        assertTrue(exists mmscaler.getPipelineProcessorOutputType());
+
+        DataProviderML::QoreImputerProcessor imputer(
+            {"fields": "x,y", "window_size": 10});
+        assertTrue(exists imputer.getPipelineProcessorOutputType());
+
+        DataProviderML::QoreClassificationMetricsProcessor clsm(
+            {"predicted_field": "pred", "true_field": "actual", "window_size": 10});
+        assertTrue(exists clsm.getPipelineProcessorOutputType());
+
+        DataProviderML::QoreRegressionMetricsProcessor regm(
+            {"predicted_field": "pred", "true_field": "actual", "window_size": 10});
+        assertTrue(exists regm.getPipelineProcessorOutputType());
+
+        DataProviderML::QoreClusteringMetricsProcessor clusm(
+            {"fields": "x,y", "cluster_field": "c", "window_size": 10});
+        assertTrue(exists clusm.getPipelineProcessorOutputType());
+
         if (ML::ml_get_capabilities().has_onnx) {
             DataProviderML::QoreOnnxModelProcessor onnx({
                 "model_path": getTestModelPath(),
@@ -1254,5 +1539,12 @@ class DataProviderMLProcessorsTest inherits QUnit::Test {
             });
             assertTrue(exists onnx.getPipelineProcessorOutputType());
         }
+    }
+
+    private assertFloat(float expected, auto actual, float tolerance) {
+        float diff = abs(expected - actual.toFloat());
+        assertTrue(diff < tolerance,
+            sprintf("expected %f, got %f (diff=%f, tolerance=%f)", expected, actual, diff,
+                tolerance));
     }
 }

--- a/examples/test/qlib/DataProviderML/DataProviderMLProcessors.qtest
+++ b/examples/test/qlib/DataProviderML/DataProviderMLProcessors.qtest
@@ -1456,13 +1456,16 @@ class DataProviderMLProcessorsTest inherits QUnit::Test {
         assertTrue(children.contains("classification-metrics"));
         assertTrue(children.contains("regression-metrics"));
         assertTrue(children.contains("clustering-metrics"));
+        assertTrue(children.contains("logistic-regression"));
+        assertTrue(children.contains("knn-classification"));
+        assertTrue(children.contains("knn-regression"));
 
         hash<ML::MLCapabilities> caps = ML::ml_get_capabilities();
         if (caps.has_onnx) {
             assertTrue(children.contains("onnx-model"));
-            assertEq(16, children.lsize());
+            assertEq(19, children.lsize());
         } else {
-            assertEq(15, children.lsize());
+            assertEq(18, children.lsize());
         }
 
         # check that each child can be retrieved

--- a/examples/test/qlib/QoreModelRegistry/QoreModelRegistry.qtest
+++ b/examples/test/qlib/QoreModelRegistry/QoreModelRegistry.qtest
@@ -1,0 +1,386 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+/*  QoreModelRegistry.qtest Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%modern
+%strict-args
+%require-types
+%enable-all-warnings
+
+%requires ../../../../qlib/Util.qm
+%requires ../../../../qlib/QUnit.qm
+%requires ../../../../qlib/Mime.qm
+%requires ../../../../qlib/DataProvider
+%requires ../../../../qlib/QoreModelRegistry
+%requires ml
+
+%exec-class ModelRegistryTest
+
+class ModelRegistryTest inherits QUnit::Test {
+    constructor() : Test("ModelRegistryTest", "1.0") {
+        addTestCase("registrationRoundTrip", \registrationRoundTripTest());
+        addTestCase("multipleVersions", \multipleVersionsTest());
+        addTestCase("tagging", \taggingTest());
+        addTestCase("pruning", \pruningTest());
+        addTestCase("listModels", \listModelsTest());
+        addTestCase("deleteModel", \deleteModelTest());
+        addTestCase("errorCases", \errorCasesTest());
+        addTestCase("untagging", \untaggingTest());
+        addTestCase("getVersionMetadata", \getVersionMetadataTest());
+
+        set_return_value(main());
+    }
+
+    private string getTestDir() {
+        string dir = tmp_location() + DirSep + "qore_model_registry_test_"
+            + get_random_bytes(4).toHex();
+        mkdir_ex(dir, 0755, True);
+        return dir;
+    }
+
+    private nothing cleanupDir(string dir) {
+        # Recursively delete directory contents
+        if (!is_dir(dir)) {
+            return;
+        }
+        Dir d();
+        d.chdir(dir);
+        # Delete subdirectories first
+        foreach string subdir in (d.listDirs()) {
+            cleanupDir(dir + DirSep + subdir);
+        }
+        # Delete files
+        foreach string f in (d.listFiles()) {
+            unlink(dir + DirSep + f);
+        }
+        rmdir(dir);
+    }
+
+    private ML::KMeans createFittedKMeans() {
+        ML::KMeans km({"k": 2, "seed": 42});
+        km.fitMatrix(((1.0, 1.0), (1.1, 1.1), (5.0, 5.0), (5.1, 5.1)));
+        return km;
+    }
+
+    private ML::LinearRegression createFittedLR() {
+        ML::LinearRegression lr({"fit_intercept": True});
+        lr.fitMatrix(((1.0,), (2.0,), (3.0,), (4.0,), (5.0,)), (2.0, 4.0, 6.0, 8.0, 10.0));
+        return lr;
+    }
+
+    registrationRoundTripTest() {
+        string dir = getTestDir();
+        on_exit { cleanupDir(dir); }
+
+        QoreModelRegistry::ModelRegistry registry({"path": dir});
+
+        # Create and register a fitted KMeans model
+        ML::KMeans km = createFittedKMeans();
+        list<hash<ML::KMeansResult>> orig = km.predictMatrix(((1.05, 1.05),));
+
+        string version_id = registry.register(km, {
+            "name": "test_kmeans",
+            "description": "test model",
+            "metrics": {"silhouette": 0.95},
+        });
+        assertTrue(version_id.val(), "version_id should be non-empty");
+
+        # List versions
+        list<hash<auto>> versions = registry.listVersions("test_kmeans");
+        assertEq(1, versions.size(), "should have 1 version");
+        assertEq(version_id, versions[0].version_id, "version_id should match");
+        assertEq("test_kmeans", versions[0].name, "name should match");
+        assertEq("KMeans", versions[0].algorithm, "algorithm should be KMeans");
+        assertEq("test model", versions[0].description, "description should match");
+
+        # Load and predict
+        object loaded = registry.load("test_kmeans", version_id);
+        assertTrue(loaded instanceof ML::KMeans, "loaded model should be KMeans");
+        list<hash<ML::KMeansResult>> res = loaded.predictMatrix(((1.05, 1.05),));
+        assertEq(orig[0].cluster, res[0].cluster, "cluster prediction should match");
+    }
+
+    multipleVersionsTest() {
+        string dir = getTestDir();
+        on_exit { cleanupDir(dir); }
+
+        QoreModelRegistry::ModelRegistry registry({"path": dir});
+
+        # Register 3 versions
+        list<string> version_ids();
+        for (int i = 0; i < 3; ++i) {
+            ML::KMeans km({"k": 2, "seed": 42 + i});
+            km.fitMatrix(((1.0, 1.0), (1.1, 1.1), (5.0, 5.0), (5.1, 5.1)));
+            string vid = registry.register(km, {"name": "multi_model"});
+            push version_ids, vid;
+        }
+
+        # List versions
+        list<hash<auto>> versions = registry.listVersions("multi_model");
+        assertEq(3, versions.size(), "should have 3 versions");
+
+        # Verify order (oldest first)
+        for (int i = 0; i < 3; ++i) {
+            assertEq(version_ids[i], versions[i].version_id,
+                sprintf("version %d should match", i));
+        }
+
+        # Load latest (should be the last registered)
+        object latest = registry.load("multi_model");
+        assertTrue(latest instanceof ML::KMeans, "latest should be KMeans");
+
+        # Load latest explicitly
+        object latest2 = registry.load("multi_model", "latest");
+        assertTrue(latest2 instanceof ML::KMeans, "latest explicit should be KMeans");
+    }
+
+    taggingTest() {
+        string dir = getTestDir();
+        on_exit { cleanupDir(dir); }
+
+        QoreModelRegistry::ModelRegistry registry({"path": dir});
+
+        # Register two versions
+        ML::KMeans km1 = createFittedKMeans();
+        string v1 = registry.register(km1, {"name": "tag_model"});
+
+        ML::LinearRegression lr = createFittedLR();
+        string v2 = registry.register(lr, {"name": "tag_model"});
+
+        # Tag first version as "production"
+        registry.tag("tag_model", v1, "production");
+
+        # Verify tag is persisted
+        list<hash<auto>> versions = registry.listVersions("tag_model");
+        assertTrue(versions[0].tags.contains("production"),
+            "first version should have 'production' tag");
+        assertEq(0, versions[1].tags.size(), "second version should have no tags");
+
+        # Tag with duplicate (should not add twice)
+        registry.tag("tag_model", v1, "production");
+        versions = registry.listVersions("tag_model");
+        assertEq(1, versions[0].tags.size(), "duplicate tag should not be added");
+
+        # Load by tag
+        object tagged = registry.loadByTag("tag_model", "production");
+        assertTrue(tagged instanceof ML::KMeans, "production-tagged model should be KMeans");
+
+        # Tag second version as "staging"
+        registry.tag("tag_model", v2, "staging");
+        object staging = registry.loadByTag("tag_model", "staging");
+        assertTrue(staging instanceof ML::LinearRegression,
+            "staging-tagged model should be LinearRegression");
+
+        # Verify loadByTag gets latest tagged if multiple have same tag
+        registry.tag("tag_model", v2, "production");
+        object latest_prod = registry.loadByTag("tag_model", "production");
+        assertTrue(latest_prod instanceof ML::LinearRegression,
+            "latest production-tagged should be LinearRegression");
+    }
+
+    pruningTest() {
+        string dir = getTestDir();
+        on_exit { cleanupDir(dir); }
+
+        QoreModelRegistry::ModelRegistry registry({"path": dir});
+
+        # Register 5 versions
+        list<string> version_ids();
+        for (int i = 0; i < 5; ++i) {
+            ML::KMeans km({"k": 2, "seed": 42 + i});
+            km.fitMatrix(((1.0, 1.0), (1.1, 1.1), (5.0, 5.0), (5.1, 5.1)));
+            string vid = registry.register(km, {"name": "prune_model"});
+            push version_ids, vid;
+        }
+
+        # Tag version 1 (index 0) as "important"
+        registry.tag("prune_model", version_ids[0], "important");
+
+        # Prune keeping latest 2, with keep_tagged=True
+        int deleted = registry.prune("prune_model", {
+            "keep_latest": 2,
+            "keep_tagged": True,
+        });
+        assertEq(2, deleted, "should delete 2 (v2 and v3, keeping v1-tagged + v4,v5)");
+
+        # Verify remaining versions
+        list<hash<auto>> remaining = registry.listVersions("prune_model");
+        assertEq(3, remaining.size(), "should have 3 remaining (1 tagged + 2 latest)");
+
+        # The tagged version should be preserved
+        bool has_tagged = False;
+        foreach hash<auto> v in (remaining) {
+            if (v.version_id == version_ids[0]) {
+                has_tagged = True;
+            }
+        }
+        assertTrue(has_tagged, "tagged version should be preserved");
+
+        # The latest 2 should be preserved
+        assertEq(version_ids[3], remaining[1].version_id, "4th version should remain");
+        assertEq(version_ids[4], remaining[2].version_id, "5th version should remain");
+
+        # Prune with keep_tagged=False
+        deleted = registry.prune("prune_model", {
+            "keep_latest": 2,
+            "keep_tagged": False,
+        });
+        assertEq(1, deleted, "should delete 1 (the tagged version)");
+
+        remaining = registry.listVersions("prune_model");
+        assertEq(2, remaining.size(), "should have 2 remaining");
+
+        # Prune when fewer versions than keep_latest
+        deleted = registry.prune("prune_model", {"keep_latest": 5});
+        assertEq(0, deleted, "should delete 0 when fewer than keep_latest");
+    }
+
+    listModelsTest() {
+        string dir = getTestDir();
+        on_exit { cleanupDir(dir); }
+
+        QoreModelRegistry::ModelRegistry registry({"path": dir});
+
+        # Register models with different names
+        ML::KMeans km = createFittedKMeans();
+        registry.register(km, {"name": "alpha_model"});
+        registry.register(km, {"name": "beta_model"});
+        registry.register(km, {"name": "gamma_model"});
+
+        # List models
+        list<string> models = registry.listModels();
+        assertEq(3, models.size(), "should have 3 models");
+        # Should be sorted
+        assertEq("alpha_model", models[0], "first should be alpha");
+        assertEq("beta_model", models[1], "second should be beta");
+        assertEq("gamma_model", models[2], "third should be gamma");
+    }
+
+    deleteModelTest() {
+        string dir = getTestDir();
+        on_exit { cleanupDir(dir); }
+
+        QoreModelRegistry::ModelRegistry registry({"path": dir});
+
+        # Register a model
+        ML::KMeans km = createFittedKMeans();
+        registry.register(km, {"name": "delete_me"});
+
+        # Verify it exists
+        list<string> models = registry.listModels();
+        assertTrue(models.contains("delete_me"), "model should exist before deletion");
+
+        # Delete it
+        registry.deleteModel("delete_me");
+
+        # Verify it's gone
+        models = registry.listModels();
+        assertFalse(models.contains("delete_me"), "model should not exist after deletion");
+
+        # Deleting again should throw
+        assertThrows("ML-REGISTRY-ERROR", \registry.deleteModel(), "delete_me");
+    }
+
+    errorCasesTest() {
+        string dir = getTestDir();
+        on_exit { cleanupDir(dir); }
+
+        QoreModelRegistry::ModelRegistry registry({"path": dir});
+
+        # Load nonexistent model
+        assertThrows("ML-REGISTRY-ERROR", \registry.load(), ("nonexistent",));
+
+        # Register with missing name
+        ML::KMeans km = createFittedKMeans();
+        assertThrows("ML-REGISTRY-ERROR", \registry.register(), (km, {}));
+
+        # Constructor with missing path
+        assertThrows("ML-REGISTRY-ERROR", sub() {
+            new QoreModelRegistry::ModelRegistry({});
+        });
+
+        # loadByTag with nonexistent tag
+        registry.register(km, {"name": "error_model"});
+        assertThrows("ML-REGISTRY-ERROR", \registry.loadByTag(), ("error_model", "no_such_tag"));
+
+        # tag nonexistent version
+        assertThrows("ML-REGISTRY-ERROR", \registry.tag(),
+            ("error_model", "fake_version", "sometag"));
+
+        # Load nonexistent version
+        assertThrows("ML-REGISTRY-ERROR", \registry.load(),
+            ("error_model", "nonexistent_version"));
+    }
+
+    untaggingTest() {
+        string dir = getTestDir();
+        on_exit { cleanupDir(dir); }
+
+        QoreModelRegistry::ModelRegistry registry({"path": dir});
+
+        ML::KMeans km = createFittedKMeans();
+        string vid = registry.register(km, {"name": "untag_model"});
+
+        # Tag and verify
+        registry.tag("untag_model", vid, "production");
+        list<hash<auto>> versions = registry.listVersions("untag_model");
+        assertTrue(versions[0].tags.contains("production"), "tag should be present");
+
+        # Untag and verify
+        registry.untag("untag_model", vid, "production");
+        versions = registry.listVersions("untag_model");
+        assertFalse(versions[0].tags.contains("production"), "tag should be removed");
+
+        # Untag nonexistent version
+        assertThrows("ML-REGISTRY-ERROR", \registry.untag(),
+            ("untag_model", "fake_version", "sometag"));
+    }
+
+    getVersionMetadataTest() {
+        string dir = getTestDir();
+        on_exit { cleanupDir(dir); }
+
+        QoreModelRegistry::ModelRegistry registry({"path": dir});
+
+        ML::KMeans km = createFittedKMeans();
+        string vid = registry.register(km, {
+            "name": "meta_model",
+            "description": "metadata test",
+            "metrics": {"accuracy": 0.99},
+        });
+
+        hash<auto> meta = registry.getVersionMetadata("meta_model", vid);
+        assertEq(vid, meta.version_id, "version_id should match");
+        assertEq("meta_model", meta.name, "name should match");
+        assertEq("KMeans", meta.algorithm, "algorithm should match");
+        assertEq("metadata test", meta.description, "description should match");
+        assertEq(0.99, meta.metrics.accuracy, "metrics should match");
+        assertEq("qml", meta.format, "format should be qml");
+        assertTrue(meta.file_size > 0, "file_size should be positive");
+        assertTrue(meta.created.val(), "created should be non-empty");
+
+        # Nonexistent version
+        assertThrows("ML-REGISTRY-ERROR", \registry.getVersionMetadata(),
+            ("meta_model", "nonexistent"));
+    }
+}

--- a/modules/ml/CMakeLists.txt
+++ b/modules/ml/CMakeLists.txt
@@ -79,6 +79,11 @@ set(ML_QPP_SRC
     src/QC_LOF.qpp
     src/QC_GMM.qpp
     src/QC_OnnxModel.qpp
+    src/QC_StandardScaler.qpp
+    src/QC_MinMaxScaler.qpp
+    src/QC_Imputer.qpp
+    src/QC_MLPipeline.qpp
+    src/QC_CrossValidator.qpp
     src/ql_ml.qpp
 )
 
@@ -95,6 +100,12 @@ set(ML_CPP_SRC
     src/LinearRegression.cpp
     src/LOF.cpp
     src/GMM.cpp
+    src/StandardScaler.cpp
+    src/MinMaxScaler.cpp
+    src/Imputer.cpp
+    src/MLPipeline.cpp
+    src/ml_metrics.cpp
+    src/CrossValidator.cpp
 )
 
 # Conditional ONNX Runtime support

--- a/modules/ml/CMakeLists.txt
+++ b/modules/ml/CMakeLists.txt
@@ -93,6 +93,7 @@ set(ML_QPP_SRC
 set(ML_CPP_SRC
     src/ml-module.cpp
     src/ml_common.cpp
+    src/ml_serialization.cpp
     src/IsolationForest.cpp
     src/DBSCAN.cpp
     src/KMeans.cpp

--- a/modules/ml/CMakeLists.txt
+++ b/modules/ml/CMakeLists.txt
@@ -76,7 +76,9 @@ set(ML_QPP_SRC
     src/QC_PCA.qpp
     src/QC_SeasonalDecomposition.qpp
     src/QC_LinearRegression.qpp
+    src/QC_LogisticRegression.qpp
     src/QC_LOF.qpp
+    src/QC_KNN.qpp
     src/QC_GMM.qpp
     src/QC_OnnxModel.qpp
     src/QC_StandardScaler.qpp
@@ -98,7 +100,9 @@ set(ML_CPP_SRC
     src/PCA.cpp
     src/SeasonalDecomposition.cpp
     src/LinearRegression.cpp
+    src/LogisticRegression.cpp
     src/LOF.cpp
+    src/KNN.cpp
     src/GMM.cpp
     src/StandardScaler.cpp
     src/MinMaxScaler.cpp

--- a/modules/ml/docs/mainpage.dox.tmpl
+++ b/modules/ml/docs/mainpage.dox.tmpl
@@ -195,6 +195,40 @@ if (caps.has_onnx) {
 }
     @endcode
 
+    @section mlpersistence Model Persistence
+
+    Save trained models so they survive restarts and can be shared between systems.
+
+    @subsection mlpersist_inmemory In-Memory Serialization
+
+    Serialize a fitted model to binary and deserialize it back — useful for caching,
+    sending over the network, or storing in a database:
+
+    @code{.py}
+# Serialize a trained model to binary
+binary data = Qore::ML::ml_serialize(trained_model);
+
+# Later, reconstruct it (ready for prediction immediately)
+auto restored = Qore::ML::ml_deserialize(data);
+hash<auto> result = restored.predict(new_record);
+    @endcode
+
+    @subsection mlpersist_file File-Based Persistence
+
+    Save models to disk and load them back:
+
+    @code{.py}
+# Save a trained KMeans model
+Qore::ML::ml_save_model(km, "/models/customer_segments.qml");
+
+# Load it in another process or after restart
+auto km2 = Qore::ML::ml_load_model("/models/customer_segments.qml");
+hash<Qore::ML::KMeansResult> result = km2.predict(customer_data);
+    @endcode
+
+    The native \c .qml format is a compact binary format with CRC-32 integrity checking.
+    All 12 algorithm types are supported.
+
     @section mlchoosing Choosing the Right Algorithm
 
     <b>"I need to find bad or unusual records"</b>
@@ -493,6 +527,8 @@ if (!caps.has_onnx) {
       - Clustering metrics: \c ml_silhouette_score(), \c ml_davies_bouldin_score(), \c ml_calinski_harabasz_score()
       - @ref Qore::ML::CrossValidator "CrossValidator" — k-fold cross-validation split utility
     - Optional @ref Qore::ML::OnnxModel "OnnxModel" for ONNX Runtime inference (requires libonnxruntime)
+    - Model persistence: \c ml_serialize() / \c ml_deserialize() for in-memory round-trip,
+      \c ml_save_model() / \c ml_load_model() for file-based persistence (.qml native format)
     - Online learning (incremental updates) for KMeans, LinearRegression, GMM, and LogisticRegression
     - All algorithms use Eigen3 for efficient matrix operations
     - All algorithms support cooperative cancellation for responsive interrupt handling

--- a/modules/ml/docs/mainpage.dox.tmpl
+++ b/modules/ml/docs/mainpage.dox.tmpl
@@ -70,7 +70,7 @@
     - @ref Qore::ML::GMM "GMM" — Assigns each record a probability for each group rather than a hard
       label. A customer might be 70%% "budget shopper" and 30%% "impulse buyer," reflecting
       genuine overlap. Uses Gaussian mixtures (EM algorithm) and supports full, diagonal, and
-      spherical covariance types.
+      spherical covariance types. Supports online learning via incremental EM updates.
 
     @subsection mlalgo_classification Classification
 
@@ -82,7 +82,8 @@
       score, and debt ratio. Handles two categories (binary) or many categories (multiclass via
       one-vs-rest). Reports the probability of each category, not just the prediction — so you
       can flag borderline cases (e.g., 52%% approve) for manual review. Supports L2
-      regularization to prevent overfitting.
+      regularization to prevent overfitting. Supports online learning via mini-batch
+      SGD updates for continuous model refinement on streaming data.
     - @ref Qore::ML::KNN "KNN" — Classifies each record based on its most similar neighbors in
       the training data. For example, if 4 of the 5 most similar past customers churned, predict
       this customer will too. Also works for regression (predict a number as the average of
@@ -97,7 +98,8 @@
     - @ref Qore::ML::LinearRegression "LinearRegression" — Learns the best straight-line relationship
       between inputs and a target. For example, predict a property's price from square footage,
       number of bedrooms, and neighborhood — the model reports which features matter most
-      (coefficients), the baseline (intercept), and prediction accuracy (R-squared).
+      (coefficients), the baseline (intercept), and prediction accuracy (R-squared). Supports
+      online learning via SGD updates for continuous model refinement.
 
     @subsection mlalgo_timeseries Time Series
 
@@ -491,6 +493,7 @@ if (!caps.has_onnx) {
       - Clustering metrics: \c ml_silhouette_score(), \c ml_davies_bouldin_score(), \c ml_calinski_harabasz_score()
       - @ref Qore::ML::CrossValidator "CrossValidator" — k-fold cross-validation split utility
     - Optional @ref Qore::ML::OnnxModel "OnnxModel" for ONNX Runtime inference (requires libonnxruntime)
+    - Online learning (incremental updates) for KMeans, LinearRegression, GMM, and LogisticRegression
     - All algorithms use Eigen3 for efficient matrix operations
     - All algorithms support cooperative cancellation for responsive interrupt handling
     - \c NOTHING values in input data are treated as missing values for Imputer compatibility

--- a/modules/ml/docs/mainpage.dox.tmpl
+++ b/modules/ml/docs/mainpage.dox.tmpl
@@ -29,6 +29,14 @@
     |@ref Qore::ML::SeasonalDecomposition "SeasonalDecomposition"|Time Series|Separate sales into growth trend, holiday spikes, and noise|
     |@ref Qore::ML::PCA "PCA"|Dimensionality Reduction|Compress 50 sensor readings into 3 key values for analysis|
     |@ref Qore::ML::OnnxModel "OnnxModel"|Inference|Run neural networks or gradient-boosted models trained in Python|
+    |@ref Qore::ML::StandardScaler "StandardScaler"|Preprocessing|Normalize features to zero mean and unit variance|
+    |@ref Qore::ML::MinMaxScaler "MinMaxScaler"|Preprocessing|Scale features to a configurable range (e.g., 0 to 1)|
+    |@ref Qore::ML::Imputer "Imputer"|Preprocessing|Fill missing values using mean, median, mode, or constant|
+    |@ref Qore::ML::MLPipeline "MLPipeline"|Pipeline|Chain preprocessing steps and an estimator into one unit|
+    |@ref Qore::ML::CrossValidator "CrossValidator"|Evaluation|Split data into training/test folds for cross-validation|
+    |\c ml_accuracy(), \c ml_classification_report()|Evaluation|Measure classification accuracy, precision, recall, F1|
+    |\c ml_mse(), \c ml_rmse(), \c ml_mae(), \c ml_r2_score()|Evaluation|Measure regression prediction quality|
+    |\c ml_silhouette_score(), \c ml_davies_bouldin_score()|Evaluation|Measure clustering quality|
 
     @subsection mlalgo_anomaly Anomaly Detection
 
@@ -94,6 +102,58 @@
       explain 95%% of the variance, making it practical to visualize equipment health on a 3D
       plot. Supports fixed component count or automatic selection via variance threshold.
 
+    @subsection mlalgo_preprocess Data Preprocessing
+
+    Clean and prepare data before analysis. Most ML algorithms give poor results when fields
+    have very different ranges or when records have missing values — preprocessing fixes both.
+
+    - @ref Qore::ML::StandardScaler "StandardScaler" — Makes fields with different ranges
+      directly comparable by adjusting each one so it centers around zero with similar spread.
+      For example, if "age" ranges from 18–65 and "income" ranges from 20,000–200,000,
+      standardizing them prevents income from dominating the analysis. Use before clustering
+      (KMeans, DBSCAN), anomaly detection (IsolationForest, LOF), or dimensionality reduction
+      (PCA).
+    - @ref Qore::ML::MinMaxScaler "MinMaxScaler" — Converts field values to fit within a
+      specific range (default 0.0 to 1.0). For example, temperatures from -20°C to 45°C become
+      0.0 to 1.0, making them easy to compare with humidity or wind speed. Useful for heat maps,
+      scoring dashboards, or feeding data into pre-trained ONNX models that expect normalized
+      input. Supports inverse transformation to recover original values.
+    - @ref Qore::ML::Imputer "Imputer" — Automatically fills in missing values so downstream
+      analysis can process complete records. Strategies: \c "mean" (average — best for
+      temperatures, response times), \c "median" (middle value — better when outliers are present,
+      e.g., transaction amounts), \c "most_frequent" (most common value — best for status codes
+      or ratings), \c "constant" (a fixed number you choose, e.g., 0 or -1 as a sentinel).
+    - @ref Qore::ML::MLPipeline "MLPipeline" — Chains multiple preprocessing steps and an
+      analysis algorithm into one unit that you fit and predict with in a single call. For
+      example, chain a StandardScaler with KMeans so that new data is always scaled the same
+      way before being assigned to a cluster. Prevents inconsistencies between training and
+      production.
+
+    @subsection mlalgo_evaluation Model Evaluation
+
+    Measure how well your models perform — without objective metrics you can't know whether
+    a model is good enough for production or which of two models is better.
+
+    <b>Classification metrics</b> (for models that predict categories):
+    - \c ml_accuracy() — fraction of correct predictions (e.g., 0.95 = 95%% right)
+    - \c ml_classification_report() — detailed breakdown with precision, recall, and F1 per class
+    - \c ml_confusion_matrix() — shows where the model confuses one class for another
+
+    <b>Regression metrics</b> (for models that predict numbers):
+    - \c ml_mse() / \c ml_rmse() — average squared/root error (lower is better)
+    - \c ml_mae() — average absolute error, in the same units as your data
+    - \c ml_r2_score() — how much of the variation your model explains (1.0 = perfect)
+    - \c ml_explained_variance() — similar to R² but accounts for bias
+
+    <b>Clustering metrics</b> (for models that group data):
+    - \c ml_silhouette_score() — how well-separated the groups are (-1 to 1; above 0.5 is good)
+    - \c ml_davies_bouldin_score() — how compact and separated the groups are (lower is better)
+    - \c ml_calinski_harabasz_score() — ratio of between-group to within-group variance (higher is better)
+
+    <b>Cross-validation</b>:
+    - @ref Qore::ML::CrossValidator "CrossValidator" — splits your data into k folds for
+      train/test evaluation, so you can check whether a model generalizes to unseen data
+
     @subsection mlalgo_onnx ONNX Model Inference
 
     Run complex models (neural networks, gradient-boosted trees, etc.) trained in Python, R, or
@@ -140,6 +200,26 @@ if (caps.has_onnx) {
       → Use @ref Qore::ML::SeasonalDecomposition "SeasonalDecomposition"
     - Do you want to compress many fields into fewer meaningful values?
       → Use @ref Qore::ML::PCA "PCA"
+
+    <b>"I need to know how good my model is"</b>
+    - Predicting categories (fraud/not fraud, customer segment)?
+      → Use \c ml_classification_report() for accuracy, precision, recall, F1
+    - Predicting numbers (prices, delivery times)?
+      → Use \c ml_r2_score() and \c ml_rmse() to measure prediction quality
+    - Evaluating cluster quality?
+      → Use \c ml_silhouette_score() — above 0.5 means good separation
+    - Want to test on data the model hasn't seen?
+      → Use @ref Qore::ML::CrossValidator "CrossValidator" for k-fold cross-validation
+
+    <b>"My data has different scales or missing values"</b>
+    - Do your fields have very different ranges (e.g., age 18–65 vs income 20,000–200,000)?
+      → Use @ref Qore::ML::StandardScaler "StandardScaler" to put them on the same scale
+    - Do you need values in a fixed range like 0 to 1?
+      → Use @ref Qore::ML::MinMaxScaler "MinMaxScaler"
+    - Do you have gaps in your data (missing sensor readings, incomplete records)?
+      → Use @ref Qore::ML::Imputer "Imputer" to fill them in automatically
+    - Do you want to preprocess <i>and</i> analyze in one step?
+      → Use @ref Qore::ML::MLPipeline "MLPipeline" to chain preprocessing with analysis
 
     <b>"I have a pre-trained model from Python or R"</b>
     - Export it to ONNX format and use @ref Qore::ML::OnnxModel "OnnxModel"
@@ -230,6 +310,115 @@ if (result.is_anomaly) {
 }
     @endcode
 
+    @subsection mlexample_scaler Preparing Data with StandardScaler
+
+    @code{.py}
+%requires ml
+
+# Employee data: salary (20K-200K) and years_experience (0-40)
+# Without scaling, salary would dominate any clustering or anomaly detection
+list<hash<auto>> employees = (
+    {"salary": 45000, "years_experience": 2},
+    {"salary": 85000, "years_experience": 12},
+    {"salary": 150000, "years_experience": 25},
+);
+
+# Put both fields on the same scale
+Qore::ML::StandardScaler scaler();
+scaler.fit(employees);
+
+# Now transform new data using the same learned scale
+hash<auto> scaled = scaler.transform({"salary": 95000, "years_experience": 15});
+printf("Scaled: %y\n", scaled);
+# Both values now center around 0 — ready for clustering or anomaly detection
+    @endcode
+
+    @subsection mlexample_imputer Filling Missing Sensor Data with Imputer
+
+    @code{.py}
+%requires ml
+
+# IoT sensor readings — some are missing due to connectivity issues
+list<auto> readings = (
+    (22.5, 65.0, 1013.0),  # temp, humidity, pressure
+    (23.1, NOTHING, 1012.5),  # humidity reading missing
+    (NOTHING, 63.0, 1014.0),  # temperature reading missing
+    (22.8, 64.0, 1013.5),
+);
+
+# Fill gaps with the average of available readings
+Qore::ML::Imputer imp({"strategy": "mean"});
+imp.fitMatrix(readings);
+list<list<float>> complete = imp.transformMatrix(readings);
+# Missing values are now filled with column averages
+    @endcode
+
+    @subsection mlexample_pipeline End-to-End Pipeline: Scale + Cluster
+
+    @code{.py}
+%requires ml
+
+# Build a pipeline that scales data then clusters customers
+Qore::ML::MLPipeline pipeline();
+pipeline.addStandardScaler("scale", new Qore::ML::StandardScaler());
+pipeline.addKMeans("cluster", new Qore::ML::KMeans({"k": 3, "seed": 42}));
+
+# Fit on customer data (features have different scales)
+list<list<float>> customer_data = (
+    (25000, 2, 580),   # income, purchases_per_month, credit_score
+    (75000, 8, 720),
+    (150000, 15, 800),
+    # ... more customers
+);
+pipeline.fitMatrix(customer_data);
+
+# Predict segments for new customers — scaling is applied automatically
+list<hash<auto>> results = pipeline.predictMatrix(((55000, 5, 650),));
+printf("Customer segment: %d\n", results[0].cluster);
+    @endcode
+
+    @subsection mlexample_minmax Normalizing for a Dashboard with MinMaxScaler
+
+    @code{.py}
+%requires ml
+
+# Normalize KPIs to 0-100 for a performance dashboard
+Qore::ML::MinMaxScaler scaler({"feature_min": 0.0, "feature_max": 100.0});
+scaler.fit(historical_kpi_data);
+
+# Convert today's raw KPIs to dashboard percentages
+hash<auto> dashboard = scaler.transform(
+    {"response_time_ms": 45, "throughput_rps": 1200, "error_rate": 0.02}
+);
+printf("Response time score: %.0f/100\n", dashboard.response_time_ms);
+printf("Throughput score: %.0f/100\n", dashboard.throughput_rps);
+    @endcode
+
+    @subsection mlexample_evaluate Evaluating a Model with Cross-Validation
+
+    @code{.py}
+%requires ml
+
+# Split 200 samples into 5 folds for cross-validation
+Qore::ML::CrossValidator cv({"n_folds": 5, "shuffle": True, "seed": 42});
+list<hash<Qore::ML::CrossValidationFold>> folds = cv.split(200);
+
+foreach hash<Qore::ML::CrossValidationFold> fold in (folds) {
+    # Train on fold's training indices, predict on test indices
+    # ... (build X_train, y_train, X_test, y_test from indices) ...
+
+    # Measure regression quality
+    float r2 = Qore::ML::ml_r2_score(y_test, predictions);
+    float rmse = Qore::ML::ml_rmse(y_test, predictions);
+    printf("Fold %d: R²=%.3f, RMSE=%.2f\n", fold.fold, r2, rmse);
+}
+
+# For classification, use the full report
+hash<Qore::ML::ClassificationReport> report =
+    Qore::ML::ml_classification_report(all_true_labels, all_predictions);
+printf("Overall: accuracy=%.2f, macro F1=%.2f\n", report.accuracy, report.macro_f1);
+    @endcode
+
     @subsection mlexample_onnx Credit Scoring with an ONNX Model
 
     @code{.py}
@@ -254,7 +443,7 @@ if (!caps.has_onnx) {
     @section mlreleasenotes ml Module Release Notes
 
     @subsection ml_1_0 ml Module Version 1.0
-    - Initial release with 9 native ML algorithms:
+    - Initial release with 9 native ML algorithms and 4 preprocessing tools:
       - @ref Qore::ML::IsolationForest "IsolationForest" — anomaly detection using isolation trees
       - @ref Qore::ML::LOF "LOF" — Local Outlier Factor density-based anomaly detection
       - @ref Qore::ML::DBSCAN "DBSCAN" — density-based clustering
@@ -264,7 +453,19 @@ if (!caps.has_onnx) {
       - @ref Qore::ML::HoltWinters "HoltWinters" — triple exponential smoothing forecasting
       - @ref Qore::ML::SeasonalDecomposition "SeasonalDecomposition" — time series decomposition
       - @ref Qore::ML::PCA "PCA" — principal component analysis
+    - Data preprocessing:
+      - @ref Qore::ML::StandardScaler "StandardScaler" — put fields on the same scale (zero mean, unit variance)
+      - @ref Qore::ML::MinMaxScaler "MinMaxScaler" — normalize values to a configurable range (e.g., 0 to 1)
+      - @ref Qore::ML::Imputer "Imputer" — fill missing values using average, median, most common, or fixed value
+      - @ref Qore::ML::MLPipeline "MLPipeline" — chain preprocessing and analysis into a single fit/predict unit
+    - Model evaluation:
+      - Classification metrics: \c ml_accuracy(), \c ml_confusion_matrix(), \c ml_classification_report()
+      - Regression metrics: \c ml_mse(), \c ml_rmse(), \c ml_mae(), \c ml_r2_score(), \c ml_explained_variance()
+      - Clustering metrics: \c ml_silhouette_score(), \c ml_davies_bouldin_score(), \c ml_calinski_harabasz_score()
+      - @ref Qore::ML::CrossValidator "CrossValidator" — k-fold cross-validation split utility
     - Optional @ref Qore::ML::OnnxModel "OnnxModel" for ONNX Runtime inference (requires libonnxruntime)
     - All algorithms use Eigen3 for efficient matrix operations
+    - All algorithms support cooperative cancellation for responsive interrupt handling
+    - \c NOTHING values in input data are treated as missing values for Imputer compatibility
     - \c ml_get_capabilities() function for runtime capability and ONNX support discovery
 */

--- a/modules/ml/docs/mainpage.dox.tmpl
+++ b/modules/ml/docs/mainpage.dox.tmpl
@@ -24,6 +24,8 @@
     |@ref Qore::ML::DBSCAN "DBSCAN"|Clustering|Discover delivery zones, support ticket themes, or traffic hotspots|
     |@ref Qore::ML::KMeans "KMeans"|Clustering|Segment customers into tiers or classify products into categories|
     |@ref Qore::ML::GMM "GMM"|Clustering|Identify overlapping segments (e.g., 70%% budget / 30%% impulse buyer)|
+    |@ref Qore::ML::LogisticRegression "LogisticRegression"|Classification|Categorize emails as spam/not-spam, approve/deny loan applications|
+    |@ref Qore::ML::KNN "KNN"|Classification/Regression|Classify or predict based on the most similar historical records|
     |@ref Qore::ML::LinearRegression "LinearRegression"|Regression|Predict property prices, delivery times, or demand from features|
     |@ref Qore::ML::HoltWinters "HoltWinters"|Time Series|Forecast monthly revenue, daily server load, or weekly inventory|
     |@ref Qore::ML::SeasonalDecomposition "SeasonalDecomposition"|Time Series|Separate sales into growth trend, holiday spikes, and noise|
@@ -69,6 +71,23 @@
       label. A customer might be 70%% "budget shopper" and 30%% "impulse buyer," reflecting
       genuine overlap. Uses Gaussian mixtures (EM algorithm) and supports full, diagonal, and
       spherical covariance types.
+
+    @subsection mlalgo_classification Classification
+
+    Assign records to categories — approve or deny, spam or legitimate, which product
+    category, which risk tier. Classification is the most common supervised ML task.
+
+    - @ref Qore::ML::LogisticRegression "LogisticRegression" — Learns a decision boundary to
+      separate categories. For example, approve or deny loan applications based on income, credit
+      score, and debt ratio. Handles two categories (binary) or many categories (multiclass via
+      one-vs-rest). Reports the probability of each category, not just the prediction — so you
+      can flag borderline cases (e.g., 52%% approve) for manual review. Supports L2
+      regularization to prevent overfitting.
+    - @ref Qore::ML::KNN "KNN" — Classifies each record based on its most similar neighbors in
+      the training data. For example, if 4 of the 5 most similar past customers churned, predict
+      this customer will too. Also works for regression (predict a number as the average of
+      neighbors' values). Simple, interpretable, and no training phase — but slower on large
+      datasets since it compares against every training record.
 
     @subsection mlalgo_regression Regression
 
@@ -188,6 +207,12 @@ if (caps.has_onnx) {
       - No → Use @ref Qore::ML::DBSCAN "DBSCAN"
     - Do records need probability scores for multiple groups (soft assignment)?
       → Use @ref Qore::ML::GMM "GMM"
+
+    <b>"I need to assign records to categories"</b>
+    - Do your categories have a clear boundary (e.g., approve/deny based on rules)?
+      → Use @ref Qore::ML::LogisticRegression "LogisticRegression"
+    - Do you want to classify based on what similar past records looked like?
+      → Use @ref Qore::ML::KNN "KNN" (classification mode)
 
     <b>"I need to predict or forecast values"</b>
     - Is your data a time series with seasonal patterns (daily, weekly, monthly)?
@@ -443,7 +468,7 @@ if (!caps.has_onnx) {
     @section mlreleasenotes ml Module Release Notes
 
     @subsection ml_1_0 ml Module Version 1.0
-    - Initial release with 9 native ML algorithms and 4 preprocessing tools:
+    - Initial release with 11 native ML algorithms and 4 preprocessing tools:
       - @ref Qore::ML::IsolationForest "IsolationForest" — anomaly detection using isolation trees
       - @ref Qore::ML::LOF "LOF" — Local Outlier Factor density-based anomaly detection
       - @ref Qore::ML::DBSCAN "DBSCAN" — density-based clustering
@@ -453,6 +478,8 @@ if (!caps.has_onnx) {
       - @ref Qore::ML::HoltWinters "HoltWinters" — triple exponential smoothing forecasting
       - @ref Qore::ML::SeasonalDecomposition "SeasonalDecomposition" — time series decomposition
       - @ref Qore::ML::PCA "PCA" — principal component analysis
+      - @ref Qore::ML::LogisticRegression "LogisticRegression" — binary and multiclass classification
+      - @ref Qore::ML::KNN "KNN" — k-nearest neighbors for classification and regression
     - Data preprocessing:
       - @ref Qore::ML::StandardScaler "StandardScaler" — put fields on the same scale (zero mean, unit variance)
       - @ref Qore::ML::MinMaxScaler "MinMaxScaler" — normalize values to a configurable range (e.g., 0 to 1)

--- a/modules/ml/src/CrossValidator.cpp
+++ b/modules/ml/src/CrossValidator.cpp
@@ -1,0 +1,87 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    CrossValidator.cpp
+
+    Qore ml module - CrossValidator implementation
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "QC_CrossValidator.h"
+
+#include <algorithm>
+#include <numeric>
+
+extern const TypedHashDecl* hashdeclCrossValidationFold;
+
+QoreListNode* QoreCrossValidator::split(int n_samples, ExceptionSink* xsink) {
+    if (n_samples < n_folds) {
+        xsink->raiseException("ML-CROSS-VALIDATOR-ERROR",
+            "n_samples (%d) must be >= n_folds (%d)", n_samples, n_folds);
+        return nullptr;
+    }
+
+    // Create index array
+    std::vector<int> indices(n_samples);
+    std::iota(indices.begin(), indices.end(), 0);
+
+    if (do_shuffle) {
+        std::shuffle(indices.begin(), indices.end(), rng);
+    }
+
+    // Compute fold boundaries
+    int base_size = n_samples / n_folds;
+    int remainder = n_samples % n_folds;
+
+    ReferenceHolder<QoreListNode> rv(
+        new QoreListNode(hashdeclCrossValidationFold->getTypeInfo()), xsink);
+
+    int offset = 0;
+    for (int fold = 0; fold < n_folds; ++fold) {
+        int fold_size = base_size + (fold < remainder ? 1 : 0);
+
+        // Test indices for this fold
+        ReferenceHolder<QoreListNode> test_list(new QoreListNode(bigIntTypeInfo), xsink);
+        for (int j = offset; j < offset + fold_size; ++j) {
+            test_list->push(static_cast<int64>(indices[j]), xsink);
+        }
+
+        // Train indices = everything except this fold
+        ReferenceHolder<QoreListNode> train_list(new QoreListNode(bigIntTypeInfo), xsink);
+        for (int j = 0; j < n_samples; ++j) {
+            if (j < offset || j >= offset + fold_size) {
+                train_list->push(static_cast<int64>(indices[j]), xsink);
+            }
+        }
+
+        ReferenceHolder<QoreHashNode> fold_hash(
+            new QoreHashNode(hashdeclCrossValidationFold, xsink), xsink);
+        fold_hash->setKeyValue("train_indices", train_list.release(), xsink);
+        fold_hash->setKeyValue("test_indices", test_list.release(), xsink);
+        fold_hash->setKeyValue("fold", static_cast<int64>(fold), xsink);
+
+        rv->push(fold_hash.release(), xsink);
+
+        offset += fold_size;
+    }
+
+    return rv.release();
+}

--- a/modules/ml/src/DBSCAN.cpp
+++ b/modules/ml/src/DBSCAN.cpp
@@ -32,13 +32,16 @@ extern const TypedHashDecl* hashdeclDBSCANResult;
 
 // NOTE: Computes and stores the full n x n distance matrix, requiring O(n^2) memory.
 // This is suitable for small-to-medium datasets; for large n consider a spatial index approach.
-MatrixXd QoreDBSCAN::computeDistanceMatrix(const MatrixXd& data) const {
+MatrixXd QoreDBSCAN::computeDistanceMatrix(const MatrixXd& data, ExceptionSink* xsink) const {
     int n = static_cast<int>(data.rows());
     MatrixXd dist(n, n);
     dist.setZero();
 
     if (metric == "euclidean") {
         for (int i = 0; i < n; ++i) {
+            if (i % 100 == 0 && qore_check_cancel(xsink, "DBSCAN computeDistanceMatrix")) {
+                return MatrixXd();
+            }
             for (int j = i + 1; j < n; ++j) {
                 double d = (data.row(i) - data.row(j)).norm();
                 dist(i, j) = d;
@@ -47,6 +50,9 @@ MatrixXd QoreDBSCAN::computeDistanceMatrix(const MatrixXd& data) const {
         }
     } else if (metric == "manhattan") {
         for (int i = 0; i < n; ++i) {
+            if (i % 100 == 0 && qore_check_cancel(xsink, "DBSCAN computeDistanceMatrix")) {
+                return MatrixXd();
+            }
             for (int j = i + 1; j < n; ++j) {
                 double d = (data.row(i) - data.row(j)).cwiseAbs().sum();
                 dist(i, j) = d;
@@ -62,6 +68,9 @@ MatrixXd QoreDBSCAN::computeDistanceMatrix(const MatrixXd& data) const {
             norms(i) = data.row(i).norm();
         }
         for (int i = 0; i < n; ++i) {
+            if (i % 100 == 0 && qore_check_cancel(xsink, "DBSCAN computeDistanceMatrix")) {
+                return MatrixXd();
+            }
             for (int j = i + 1; j < n; ++j) {
                 double d;
                 if (norms(i) == 0.0 || norms(j) == 0.0) {
@@ -101,13 +110,19 @@ QoreListNode* QoreDBSCAN::cluster(const MatrixXd& data, ExceptionSink* xsink) {
     }
 
     // Compute distance matrix
-    MatrixXd dist_matrix = computeDistanceMatrix(data);
+    MatrixXd dist_matrix = computeDistanceMatrix(data, xsink);
+    if (*xsink) {
+        return nullptr;
+    }
 
     // Find neighbors and identify core points
     std::vector<std::vector<int>> all_neighbors(n);
     std::vector<bool> is_core(n, false);
 
     for (int i = 0; i < n; ++i) {
+        if (i % 100 == 0 && qore_check_cancel(xsink, "DBSCAN cluster")) {
+            return nullptr;
+        }
         all_neighbors[i] = findNeighbors(dist_matrix, i);
         // MinPts includes the point itself; findNeighbors() excludes it
         if (static_cast<int>(all_neighbors[i].size()) + 1 >= min_points) {

--- a/modules/ml/src/GMM.cpp
+++ b/modules/ml/src/GMM.cpp
@@ -26,6 +26,7 @@
 */
 
 #include "QC_GMM.h"
+#include "ml_serialization.h"
 
 #include <algorithm>
 #include <numeric>
@@ -496,4 +497,86 @@ double QoreGMM::getLogLikelihood(ExceptionSink* xsink) const {
         return 0.0;
     }
     return log_likelihood;
+}
+
+std::vector<uint8_t> QoreGMM::serializeState() const {
+    std::vector<uint8_t> buf;
+    // Hyperparameters
+    MLSerialization::writeInt32(buf, n_components);
+    MLSerialization::writeInt32(buf, max_iterations);
+    MLSerialization::writeScalar(buf, tolerance);
+    MLSerialization::writeString(buf, covariance_type);
+    // Model state
+    MLSerialization::writeInt32(buf, n_features);
+    MLSerialization::writeInt32(buf, batch_count);
+    MLSerialization::writeScalar(buf, log_likelihood);
+    // Means: n_components vectors
+    MLSerialization::writeInt32(buf, static_cast<int32_t>(means.size()));
+    for (const auto& m : means) {
+        MLSerialization::writeVector(buf, m);
+    }
+    // Covariances: n_components matrices
+    MLSerialization::writeInt32(buf, static_cast<int32_t>(covariances.size()));
+    for (const auto& cov : covariances) {
+        MLSerialization::writeMatrix(buf, cov);
+    }
+    // Weights
+    MLSerialization::writeVector(buf, weights);
+    MLSerialization::writeStringVector(buf, field_names);
+    return buf;
+}
+
+QoreGMM* QoreGMM::deserializeState(const uint8_t* data, size_t len, ExceptionSink* xsink) {
+    const uint8_t* ptr = data;
+    size_t remaining = len;
+
+    int32_t n_components = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t max_iterations = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double tolerance = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::string covariance_type = MLSerialization::readString(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t n_features = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t batch_count = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double log_likelihood = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    int32_t means_count = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::vector<VectorXd> means;
+    means.reserve(means_count);
+    for (int32_t i = 0; i < means_count; ++i) {
+        means.push_back(MLSerialization::readVector(ptr, remaining, xsink));
+        if (*xsink) { return nullptr; }
+    }
+
+    int32_t cov_count = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::vector<MatrixXd> covariances;
+    covariances.reserve(cov_count);
+    for (int32_t i = 0; i < cov_count; ++i) {
+        covariances.push_back(MLSerialization::readMatrix(ptr, remaining, xsink));
+        if (*xsink) { return nullptr; }
+    }
+
+    VectorXd weights = MLSerialization::readVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::vector<std::string> field_names = MLSerialization::readStringVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    std::unique_ptr<QoreGMM> obj(new QoreGMM(n_components, max_iterations, tolerance,
+        1, covariance_type));
+    obj->n_features = n_features;
+    obj->batch_count = batch_count;
+    obj->log_likelihood = log_likelihood;
+    obj->means = std::move(means);
+    obj->covariances = std::move(covariances);
+    obj->weights = std::move(weights);
+    obj->field_names = std::move(field_names);
+    obj->fitted = true;
+    return obj.release();
 }

--- a/modules/ml/src/GMM.cpp
+++ b/modules/ml/src/GMM.cpp
@@ -265,6 +265,10 @@ void QoreGMM::fit(const MatrixXd& data, ExceptionSink* xsink) {
     // EM iterations
     double prev_ll = -std::numeric_limits<double>::max();
     for (int iter = 0; iter < max_iterations; ++iter) {
+        if (qore_check_cancel(xsink, "GMM fit")) {
+            return;
+        }
+
         // E-step
         MatrixXd responsibilities = eStep(data);
 
@@ -360,6 +364,9 @@ QoreListNode* QoreGMM::predictMatrix(const MatrixXd& data, ExceptionSink* xsink)
 
     ReferenceHolder<QoreListNode> rv(new QoreListNode(hashdeclGMMResult->getTypeInfo()), xsink);
     for (Eigen::Index i = 0; i < data.rows(); ++i) {
+        if (i % 100 == 0 && qore_check_cancel(xsink, "GMM predictMatrix")) {
+            return nullptr;
+        }
         RowVectorXd row = data.row(i);
         QoreHashNode* result = predictInternal(row, xsink);
         if (*xsink) {

--- a/modules/ml/src/GMM.cpp
+++ b/modules/ml/src/GMM.cpp
@@ -286,6 +286,98 @@ void QoreGMM::fit(const MatrixXd& data, ExceptionSink* xsink) {
     }
 
     fitted = true;
+    batch_count = 1;
+}
+
+void QoreGMM::update(const MatrixXd& data, ExceptionSink* xsink) {
+    std::lock_guard<std::mutex> lk(mtx);
+    if (!fitted) {
+        xsink->raiseException("ML-GMM-ERROR",
+            "model has not been fitted: call fit() or fitMatrix() before update()");
+        return;
+    }
+    if (data.cols() != n_features) {
+        xsink->raiseException("ML-GMM-ERROR",
+            "input has %d features but model was trained with %d features",
+            static_cast<int>(data.cols()), n_features);
+        return;
+    }
+    if (data.rows() == 0) {
+        xsink->raiseException("ML-GMM-ERROR",
+            "cannot update on empty data");
+        return;
+    }
+
+    if (qore_check_cancel(xsink, "GMM update")) {
+        return;
+    }
+
+    ++batch_count;
+    double eta = 1.0 / (batch_count + 1);
+
+    // E-step: compute responsibilities on new data using current parameters
+    MatrixXd responsibilities = eStep(data);
+
+    // Compute new parameters from the new batch only
+    int n = static_cast<int>(data.rows());
+    int d = n_features;
+    double reg = 1e-6;
+
+    std::vector<VectorXd> new_means(n_components);
+    std::vector<MatrixXd> new_covariances(n_components);
+    VectorXd new_weights(n_components);
+
+    for (int c = 0; c < n_components; ++c) {
+        double resp_sum = responsibilities.col(c).sum();
+
+        // New weight from this batch
+        new_weights(c) = resp_sum / n;
+        if (new_weights(c) < 1e-10) {
+            new_weights(c) = 1e-10;
+        }
+
+        // New mean from this batch
+        VectorXd nm = VectorXd::Zero(d);
+        for (int i = 0; i < n; ++i) {
+            nm += responsibilities(i, c) * data.row(i).transpose();
+        }
+        new_means[c] = nm / resp_sum;
+
+        // New covariance from this batch
+        if (covariance_type == "diagonal") {
+            VectorXd diag = VectorXd::Zero(d);
+            for (int i = 0; i < n; ++i) {
+                VectorXd diff = data.row(i).transpose() - new_means[c];
+                diag += responsibilities(i, c) * diff.array().square().matrix();
+            }
+            diag /= resp_sum;
+            diag.array() += reg;
+            new_covariances[c] = diag.asDiagonal();
+        } else {
+            MatrixXd cov = MatrixXd::Zero(d, d);
+            for (int i = 0; i < n; ++i) {
+                VectorXd diff = data.row(i).transpose() - new_means[c];
+                cov += responsibilities(i, c) * (diff * diff.transpose());
+            }
+            cov /= resp_sum;
+            cov += MatrixXd::Identity(d, d) * reg;
+            new_covariances[c] = cov;
+        }
+    }
+
+    // Blend old and new parameters
+    for (int c = 0; c < n_components; ++c) {
+        means[c] = (1.0 - eta) * means[c] + eta * new_means[c];
+        covariances[c] = (1.0 - eta) * covariances[c] + eta * new_covariances[c];
+        weights(c) = (1.0 - eta) * weights(c) + eta * new_weights(c);
+    }
+
+    // Normalize weights to sum to 1
+    double weight_sum = weights.sum();
+    weights /= weight_sum;
+
+    // Recompute log-likelihood on this batch
+    log_likelihood = computeLogLikelihood(data);
 }
 
 QoreHashNode* QoreGMM::predictInternal(const RowVectorXd& point, ExceptionSink* xsink) const {

--- a/modules/ml/src/HoltWinters.cpp
+++ b/modules/ml/src/HoltWinters.cpp
@@ -26,6 +26,7 @@
 */
 
 #include "QC_HoltWinters.h"
+#include "ml_serialization.h"
 
 // Extern declaration for hashdecl (defined in ml-module.cpp)
 extern const TypedHashDecl* hashdeclHoltWintersResult;
@@ -289,4 +290,61 @@ QoreListNode* QoreHoltWinters::getSeasonal(ExceptionSink* xsink) {
         rv->push(seasonal[i], xsink);
     }
     return rv.release();
+}
+
+std::vector<uint8_t> QoreHoltWinters::serializeState() const {
+    std::vector<uint8_t> buf;
+    // Hyperparameters
+    MLSerialization::writeInt32(buf, period);
+    MLSerialization::writeScalar(buf, alpha);
+    MLSerialization::writeScalar(buf, beta);
+    MLSerialization::writeScalar(buf, gamma);
+    MLSerialization::writeString(buf, seasonal_type);
+    MLSerialization::writeBool(buf, damped);
+    MLSerialization::writeScalar(buf, phi);
+    // Model state
+    MLSerialization::writeScalar(buf, level);
+    MLSerialization::writeScalar(buf, trend);
+    MLSerialization::writeDoubleVector(buf, seasonal);
+    MLSerialization::writeInt32(buf, t);
+    return buf;
+}
+
+QoreHoltWinters* QoreHoltWinters::deserializeState(const uint8_t* data, size_t len,
+    ExceptionSink* xsink) {
+    const uint8_t* ptr = data;
+    size_t remaining = len;
+
+    int32_t period = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double alpha = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double beta = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double gamma = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::string seasonal_type = MLSerialization::readString(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    bool damped = MLSerialization::readBool(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double phi = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    double hw_level = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double hw_trend = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::vector<double> seasonal = MLSerialization::readDoubleVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t t = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    std::unique_ptr<QoreHoltWinters> obj(new QoreHoltWinters(
+        period, alpha, beta, gamma, seasonal_type.c_str(), damped, phi));
+    obj->level = hw_level;
+    obj->trend = hw_trend;
+    obj->seasonal = std::move(seasonal);
+    obj->t = t;
+    obj->fitted = true;
+    return obj.release();
 }

--- a/modules/ml/src/HoltWinters.cpp
+++ b/modules/ml/src/HoltWinters.cpp
@@ -120,6 +120,10 @@ void QoreHoltWinters::fit(const VectorXd& series, ExceptionSink* xsink) {
 
     // Run through the historical series to warm up the model
     for (int i = 0; i < n; ++i) {
+        if (i % 100 == 0 && qore_check_cancel(xsink, "HoltWinters fit")) {
+            return;
+        }
+
         double value = series(i);
         int season_idx = i % period;
         double prev_level = level;

--- a/modules/ml/src/Imputer.cpp
+++ b/modules/ml/src/Imputer.cpp
@@ -1,0 +1,222 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    Imputer.cpp
+
+    Qore ml module - Imputer implementation
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "QC_Imputer.h"
+
+#include <algorithm>
+#include <map>
+
+extern const TypedHashDecl* hashdeclImputerInfo;
+
+double QoreImputer::computeMedian(const MatrixXd& data, Eigen::Index col) {
+    std::vector<double> values;
+    for (Eigen::Index i = 0; i < data.rows(); ++i) {
+        if (!std::isnan(data(i, col))) {
+            values.push_back(data(i, col));
+        }
+    }
+    if (values.empty()) {
+        return 0.0;
+    }
+
+    size_t n = values.size();
+    std::sort(values.begin(), values.end());
+    if (n % 2 == 0) {
+        return (values[n / 2 - 1] + values[n / 2]) / 2.0;
+    } else {
+        return values[n / 2];
+    }
+}
+
+double QoreImputer::computeMostFrequent(const MatrixXd& data, Eigen::Index col) {
+    std::map<double, int> counts;
+    for (Eigen::Index i = 0; i < data.rows(); ++i) {
+        if (!std::isnan(data(i, col))) {
+            counts[data(i, col)]++;
+        }
+    }
+    if (counts.empty()) {
+        return 0.0;
+    }
+
+    double most_freq = counts.begin()->first;
+    int max_count = counts.begin()->second;
+    for (const auto& pair : counts) {
+        if (pair.second > max_count) {
+            max_count = pair.second;
+            most_freq = pair.first;
+        }
+    }
+    return most_freq;
+}
+
+void QoreImputer::fit(const MatrixXd& data, ExceptionSink* xsink) {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (data.rows() == 0 || data.cols() == 0) {
+        xsink->raiseException("ML-IMPUTER-ERROR",
+            "cannot fit on empty data: provide at least one sample with one feature");
+        return;
+    }
+
+    n_features = static_cast<int>(data.cols());
+    fill_values.resize(n_features);
+
+    for (int j = 0; j < n_features; ++j) {
+        if (strategy == "mean") {
+            // Compute mean of non-NaN values
+            double sum = 0.0;
+            int count = 0;
+            for (Eigen::Index i = 0; i < data.rows(); ++i) {
+                if (!std::isnan(data(i, j))) {
+                    sum += data(i, j);
+                    ++count;
+                }
+            }
+            fill_values(j) = (count > 0) ? sum / count : 0.0;
+        } else if (strategy == "median") {
+            fill_values(j) = computeMedian(data, j);
+        } else if (strategy == "most_frequent") {
+            fill_values(j) = computeMostFrequent(data, j);
+        } else if (strategy == "constant") {
+            fill_values(j) = constant_value;
+        }
+    }
+
+    fitted = true;
+}
+
+RowVectorXd QoreImputer::transformRow(const RowVectorXd& row, ExceptionSink* xsink) const {
+    if (row.size() != n_features) {
+        xsink->raiseException("ML-IMPUTER-ERROR",
+            "input has %d features but imputer was fitted with %d features",
+            static_cast<int>(row.size()), n_features);
+        return RowVectorXd();
+    }
+
+    RowVectorXd result = row;
+    for (int j = 0; j < n_features; ++j) {
+        if (std::isnan(result(j))) {
+            result(j) = fill_values(j);
+        }
+    }
+    return result;
+}
+
+MatrixXd QoreImputer::transform(const MatrixXd& data, ExceptionSink* xsink) const {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (!fitted) {
+        xsink->raiseException("ML-IMPUTER-ERROR",
+            "imputer has not been fitted: call fit() or fitMatrix() first");
+        return MatrixXd();
+    }
+    if (data.cols() != n_features) {
+        xsink->raiseException("ML-IMPUTER-ERROR",
+            "input has %d features but imputer was fitted with %d features",
+            static_cast<int>(data.cols()), n_features);
+        return MatrixXd();
+    }
+
+    MatrixXd result = data;
+    for (Eigen::Index i = 0; i < result.rows(); ++i) {
+        for (int j = 0; j < n_features; ++j) {
+            if (std::isnan(result(i, j))) {
+                result(i, j) = fill_values(j);
+            }
+        }
+    }
+    return result;
+}
+
+MatrixXd QoreImputer::fitTransform(const MatrixXd& data, ExceptionSink* xsink) {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (data.rows() == 0 || data.cols() == 0) {
+        xsink->raiseException("ML-IMPUTER-ERROR",
+            "cannot fit on empty data: provide at least one sample with one feature");
+        return MatrixXd();
+    }
+
+    n_features = static_cast<int>(data.cols());
+    fill_values.resize(n_features);
+
+    for (int j = 0; j < n_features; ++j) {
+        if (strategy == "mean") {
+            double sum = 0.0;
+            int count = 0;
+            for (Eigen::Index i = 0; i < data.rows(); ++i) {
+                if (!std::isnan(data(i, j))) {
+                    sum += data(i, j);
+                    ++count;
+                }
+            }
+            fill_values(j) = (count > 0) ? sum / count : 0.0;
+        } else if (strategy == "median") {
+            fill_values(j) = computeMedian(data, j);
+        } else if (strategy == "most_frequent") {
+            fill_values(j) = computeMostFrequent(data, j);
+        } else if (strategy == "constant") {
+            fill_values(j) = constant_value;
+        }
+    }
+
+    fitted = true;
+
+    // Transform in place
+    MatrixXd result = data;
+    for (Eigen::Index i = 0; i < result.rows(); ++i) {
+        for (int j = 0; j < n_features; ++j) {
+            if (std::isnan(result(i, j))) {
+                result(i, j) = fill_values(j);
+            }
+        }
+    }
+    return result;
+}
+
+QoreHashNode* QoreImputer::getInfo(ExceptionSink* xsink) const {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (!fitted) {
+        xsink->raiseException("ML-IMPUTER-ERROR",
+            "imputer has not been fitted: call fit() or fitMatrix() first");
+        return nullptr;
+    }
+
+    ReferenceHolder<QoreListNode> fv_list(new QoreListNode(floatTypeInfo), xsink);
+    for (int j = 0; j < n_features; ++j) {
+        fv_list->push(fill_values(j), xsink);
+    }
+
+    ReferenceHolder<QoreHashNode> rv(new QoreHashNode(hashdeclImputerInfo, xsink), xsink);
+    rv->setKeyValue("strategy", new QoreStringNode(strategy), xsink);
+    rv->setKeyValue("fill_values", fv_list.release(), xsink);
+    rv->setKeyValue("n_features", static_cast<int64>(n_features), xsink);
+
+    return rv.release();
+}

--- a/modules/ml/src/Imputer.cpp
+++ b/modules/ml/src/Imputer.cpp
@@ -26,6 +26,7 @@
 */
 
 #include "QC_Imputer.h"
+#include "ml_serialization.h"
 
 #include <algorithm>
 #include <map>
@@ -219,4 +220,40 @@ QoreHashNode* QoreImputer::getInfo(ExceptionSink* xsink) const {
     rv->setKeyValue("n_features", static_cast<int64>(n_features), xsink);
 
     return rv.release();
+}
+
+std::vector<uint8_t> QoreImputer::serializeState() const {
+    std::vector<uint8_t> buf;
+    // Hyperparameters
+    MLSerialization::writeString(buf, strategy);
+    MLSerialization::writeScalar(buf, constant_value);
+    // Model state
+    MLSerialization::writeInt32(buf, n_features);
+    MLSerialization::writeVector(buf, fill_values);
+    MLSerialization::writeStringVector(buf, field_names);
+    return buf;
+}
+
+QoreImputer* QoreImputer::deserializeState(const uint8_t* data, size_t len,
+    ExceptionSink* xsink) {
+    const uint8_t* ptr = data;
+    size_t remaining = len;
+
+    std::string strategy = MLSerialization::readString(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double constant_value = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t n_features = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    VectorXd fill_values = MLSerialization::readVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::vector<std::string> field_names = MLSerialization::readStringVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    std::unique_ptr<QoreImputer> obj(new QoreImputer(strategy, constant_value));
+    obj->n_features = n_features;
+    obj->fill_values = std::move(fill_values);
+    obj->field_names = std::move(field_names);
+    obj->fitted = true;
+    return obj.release();
 }

--- a/modules/ml/src/IsolationForest.cpp
+++ b/modules/ml/src/IsolationForest.cpp
@@ -26,6 +26,7 @@
 */
 
 #include "QC_IsolationForest.h"
+#include "ml_serialization.h"
 
 #include <numeric>
 
@@ -283,4 +284,86 @@ QoreListNode* QoreIsolationForest::scoreMatrix(const MatrixXd& data, ExceptionSi
         rv->push(result, xsink);
     }
     return rv.release();
+}
+
+std::vector<uint8_t> QoreIsolationForest::serializeState() const {
+    std::vector<uint8_t> buf;
+    // Hyperparameters
+    MLSerialization::writeInt32(buf, n_trees);
+    MLSerialization::writeInt32(buf, sample_size);
+    MLSerialization::writeInt32(buf, max_depth);
+    MLSerialization::writeScalar(buf, threshold);
+    // Model state
+    MLSerialization::writeInt32(buf, n_features);
+    MLSerialization::writeInt32(buf, actual_sample_size);
+    // Trees: count + per-tree flat nodes
+    MLSerialization::writeInt32(buf, static_cast<int32_t>(trees.size()));
+    for (const auto& tree : trees) {
+        MLSerialization::writeInt32(buf, static_cast<int32_t>(tree.nodes.size()));
+        for (const auto& node : tree.nodes) {
+            MLSerialization::writeInt32(buf, node.feature);
+            MLSerialization::writeScalar(buf, node.split_value);
+            MLSerialization::writeInt32(buf, node.left);
+            MLSerialization::writeInt32(buf, node.right);
+            MLSerialization::writeInt32(buf, node.size);
+        }
+    }
+    MLSerialization::writeStringVector(buf, field_names);
+    return buf;
+}
+
+QoreIsolationForest* QoreIsolationForest::deserializeState(const uint8_t* data, size_t len,
+    ExceptionSink* xsink) {
+    const uint8_t* ptr = data;
+    size_t remaining = len;
+
+    int32_t n_trees = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t sample_size = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t max_depth = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double threshold = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t n_features = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t actual_sample_size = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    int32_t tree_count = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    std::vector<IsolationTree> trees;
+    trees.reserve(tree_count);
+    for (int32_t t = 0; t < tree_count; ++t) {
+        int32_t node_count = MLSerialization::readInt32(ptr, remaining, xsink);
+        if (*xsink) { return nullptr; }
+        IsolationTree tree;
+        tree.nodes.resize(node_count);
+        for (int32_t n = 0; n < node_count; ++n) {
+            tree.nodes[n].feature = MLSerialization::readInt32(ptr, remaining, xsink);
+            if (*xsink) { return nullptr; }
+            tree.nodes[n].split_value = MLSerialization::readScalar(ptr, remaining, xsink);
+            if (*xsink) { return nullptr; }
+            tree.nodes[n].left = MLSerialization::readInt32(ptr, remaining, xsink);
+            if (*xsink) { return nullptr; }
+            tree.nodes[n].right = MLSerialization::readInt32(ptr, remaining, xsink);
+            if (*xsink) { return nullptr; }
+            tree.nodes[n].size = MLSerialization::readInt32(ptr, remaining, xsink);
+            if (*xsink) { return nullptr; }
+        }
+        trees.push_back(std::move(tree));
+    }
+
+    std::vector<std::string> field_names = MLSerialization::readStringVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    std::unique_ptr<QoreIsolationForest> obj(new QoreIsolationForest(
+        n_trees, sample_size, max_depth, threshold, 1));
+    obj->n_features = n_features;
+    obj->actual_sample_size = actual_sample_size;
+    obj->trees = std::move(trees);
+    obj->field_names = std::move(field_names);
+    obj->fitted = true;
+    return obj.release();
 }

--- a/modules/ml/src/IsolationForest.cpp
+++ b/modules/ml/src/IsolationForest.cpp
@@ -87,6 +87,10 @@ void QoreIsolationForest::fit(const MatrixXd& data, ExceptionSink* xsink) {
     std::iota(all_indices.begin(), all_indices.end(), 0);
 
     for (int t = 0; t < n_trees; ++t) {
+        if (qore_check_cancel(xsink, "IsolationForest fit")) {
+            return;
+        }
+
         // Random subsample without replacement
         std::vector<int> sample_indices(all_indices);
         for (int i = static_cast<int>(sample_indices.size()) - 1; i > 0; --i) {
@@ -268,6 +272,9 @@ QoreListNode* QoreIsolationForest::scoreMatrix(const MatrixXd& data, ExceptionSi
 
     ReferenceHolder<QoreListNode> rv(new QoreListNode(hashdeclIsolationForestResult->getTypeInfo()), xsink);
     for (Eigen::Index i = 0; i < data.rows(); ++i) {
+        if (i % 100 == 0 && qore_check_cancel(xsink, "IsolationForest scoreMatrix")) {
+            return nullptr;
+        }
         RowVectorXd row = data.row(i);
         QoreHashNode* result = scoreInternal(row, xsink);
         if (*xsink) {

--- a/modules/ml/src/KMeans.cpp
+++ b/modules/ml/src/KMeans.cpp
@@ -174,6 +174,10 @@ void QoreKMeans::fit(const MatrixXd& data, ExceptionSink* xsink) {
 
     // Lloyd's algorithm
     for (int iter = 0; iter < max_iterations; ++iter) {
+        if (qore_check_cancel(xsink, "KMeans fit")) {
+            return;
+        }
+
         MatrixXd old_centroids = centroids;
 
         std::vector<int> assignments = assignClusters(data);
@@ -220,6 +224,9 @@ void QoreKMeans::update(const MatrixXd& data, ExceptionSink* xsink) {
 
     // Mini-batch update (Sculley 2010)
     for (int i = 0; i < n; ++i) {
+        if (i % 100 == 0 && qore_check_cancel(xsink, "KMeans update")) {
+            return;
+        }
         // Find nearest centroid
         double min_dist = std::numeric_limits<double>::max();
         int best = 0;
@@ -307,6 +314,9 @@ QoreListNode* QoreKMeans::predictMatrix(const MatrixXd& data, ExceptionSink* xsi
 
     ReferenceHolder<QoreListNode> rv(new QoreListNode(hashdeclKMeansResult->getTypeInfo()), xsink);
     for (Eigen::Index i = 0; i < data.rows(); ++i) {
+        if (i % 100 == 0 && qore_check_cancel(xsink, "KMeans predict")) {
+            return nullptr;
+        }
         RowVectorXd row = data.row(i);
         QoreHashNode* result = predictInternal(row, xsink);
         if (*xsink) {

--- a/modules/ml/src/KMeans.cpp
+++ b/modules/ml/src/KMeans.cpp
@@ -26,6 +26,7 @@
 */
 
 #include "QC_KMeans.h"
+#include "ml_serialization.h"
 
 #include <numeric>
 
@@ -344,4 +345,56 @@ QoreListNode* QoreKMeans::getCentroids(ExceptionSink* xsink) {
         rv->push(row.release(), xsink);
     }
     return rv.release();
+}
+
+std::vector<uint8_t> QoreKMeans::serializeState() const {
+    std::vector<uint8_t> buf;
+    // Hyperparameters
+    MLSerialization::writeInt32(buf, k);
+    MLSerialization::writeInt32(buf, max_iterations);
+    MLSerialization::writeScalar(buf, tolerance);
+    MLSerialization::writeString(buf, init_method);
+    // Model state
+    MLSerialization::writeMatrix(buf, centroids);
+    MLSerialization::writeIntVector(buf, centroid_counts);
+    MLSerialization::writeInt32(buf, n_features);
+    MLSerialization::writeScalar(buf, inertia);
+    MLSerialization::writeStringVector(buf, field_names);
+    return buf;
+}
+
+QoreKMeans* QoreKMeans::deserializeState(const uint8_t* data, size_t len,
+    ExceptionSink* xsink) {
+    const uint8_t* ptr = data;
+    size_t remaining = len;
+
+    int32_t k = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t max_iterations = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double tolerance = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::string init_method = MLSerialization::readString(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    MatrixXd centroids = MLSerialization::readMatrix(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::vector<int> centroid_counts = MLSerialization::readIntVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t n_features = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double inertia = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::vector<std::string> field_names = MLSerialization::readStringVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    std::unique_ptr<QoreKMeans> obj(new QoreKMeans(k, max_iterations, tolerance, 1,
+        init_method.c_str()));
+    obj->centroids = std::move(centroids);
+    obj->centroid_counts = std::move(centroid_counts);
+    obj->n_features = n_features;
+    obj->inertia = inertia;
+    obj->field_names = std::move(field_names);
+    obj->fitted = true;
+    return obj.release();
 }

--- a/modules/ml/src/KNN.cpp
+++ b/modules/ml/src/KNN.cpp
@@ -26,6 +26,7 @@
 */
 
 #include "QC_KNN.h"
+#include "ml_serialization.h"
 
 #include <algorithm>
 #include <numeric>
@@ -218,4 +219,53 @@ QoreListNode* QoreKNN::predictMatrix(const MatrixXd& X, ExceptionSink* xsink) co
         rv->push(result, xsink);
     }
     return rv.release();
+}
+
+std::vector<uint8_t> QoreKNN::serializeState() const {
+    std::vector<uint8_t> buf;
+    // Hyperparameters
+    MLSerialization::writeInt32(buf, k);
+    MLSerialization::writeString(buf, metric);
+    MLSerialization::writeString(buf, task);
+    MLSerialization::writeString(buf, weight_func);
+    // Model state
+    MLSerialization::writeInt32(buf, n_features);
+    MLSerialization::writeMatrix(buf, ref_data);
+    MLSerialization::writeVector(buf, ref_labels);
+    MLSerialization::writeStringVector(buf, field_names);
+    MLSerialization::writeString(buf, target_field);
+    return buf;
+}
+
+QoreKNN* QoreKNN::deserializeState(const uint8_t* data, size_t len, ExceptionSink* xsink) {
+    const uint8_t* ptr = data;
+    size_t remaining = len;
+
+    int32_t k = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::string metric = MLSerialization::readString(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::string task = MLSerialization::readString(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::string weight_func = MLSerialization::readString(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t n_features = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    MatrixXd ref_data = MLSerialization::readMatrix(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    VectorXd ref_labels = MLSerialization::readVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::vector<std::string> field_names = MLSerialization::readStringVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::string target_field = MLSerialization::readString(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    std::unique_ptr<QoreKNN> obj(new QoreKNN(k, metric, task, weight_func));
+    obj->n_features = n_features;
+    obj->ref_data = std::move(ref_data);
+    obj->ref_labels = std::move(ref_labels);
+    obj->field_names = std::move(field_names);
+    obj->target_field = std::move(target_field);
+    obj->fitted = true;
+    return obj.release();
 }

--- a/modules/ml/src/KNN.cpp
+++ b/modules/ml/src/KNN.cpp
@@ -1,0 +1,221 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    KNN.cpp
+
+    Qore ml module - K-Nearest Neighbors implementation
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "QC_KNN.h"
+
+#include <algorithm>
+#include <numeric>
+#include <unordered_map>
+
+// Extern declarations for hashdecls (defined in ml-module.cpp)
+extern const TypedHashDecl* hashdeclKNNClassificationResult;
+extern const TypedHashDecl* hashdeclKNNRegressionResult;
+
+QoreKNN::QoreKNN(int k, const std::string& metric, const std::string& task,
+    const std::string& weight_func)
+    : k(k), metric(metric), task(task), weight_func(weight_func) {
+}
+
+double QoreKNN::computeDistance(const RowVectorXd& a, const RowVectorXd& b) const {
+    if (metric == "euclidean") {
+        return (a - b).norm();
+    }
+    if (metric == "manhattan") {
+        return (a - b).cwiseAbs().sum();
+    }
+    // cosine distance: 1 - cos(theta)
+    double norm_a = a.norm();
+    double norm_b = b.norm();
+    if (norm_a < 1e-10 || norm_b < 1e-10) {
+        return 1.0;
+    }
+    return 1.0 - a.dot(b) / (norm_a * norm_b);
+}
+
+void QoreKNN::fit(const MatrixXd& X, const VectorXd& y, ExceptionSink* xsink) {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (X.rows() == 0 || X.cols() == 0) {
+        xsink->raiseException("ML-KNN-ERROR",
+            "cannot fit on empty data: provide at least one sample with one feature");
+        return;
+    }
+    if (X.rows() != y.size()) {
+        xsink->raiseException("ML-KNN-ERROR",
+            "X has %d rows but y has %d elements; they must match",
+            static_cast<int>(X.rows()), static_cast<int>(y.size()));
+        return;
+    }
+
+    int n = static_cast<int>(X.rows());
+    if (k > n) {
+        xsink->raiseException("ML-KNN-ERROR",
+            "k (%d) must be <= the number of samples (%d); reduce k or provide more data",
+            k, n);
+        return;
+    }
+
+    n_features = static_cast<int>(X.cols());
+    ref_data = X;
+    ref_labels = y;
+    fitted = true;
+}
+
+QoreHashNode* QoreKNN::predictInternal(const RowVectorXd& point, ExceptionSink* xsink) const {
+    if (point.size() != n_features) {
+        xsink->raiseException("ML-KNN-ERROR",
+            "input has %d features but model was trained with %d features",
+            static_cast<int>(point.size()), n_features);
+        return nullptr;
+    }
+
+    int n = static_cast<int>(ref_data.rows());
+
+    // Compute distances to all reference points
+    std::vector<double> distances(n);
+    for (int i = 0; i < n; ++i) {
+        distances[i] = computeDistance(point, ref_data.row(i));
+    }
+
+    // Find k nearest neighbors using partial sort on indices
+    std::vector<int> indices(n);
+    std::iota(indices.begin(), indices.end(), 0);
+    int actual_k = std::min(k, n);
+    std::partial_sort(indices.begin(), indices.begin() + actual_k, indices.end(),
+        [&distances](int a, int b) { return distances[a] < distances[b]; });
+
+    // Build neighbors list
+    ReferenceHolder<QoreListNode> neighbors(new QoreListNode(autoTypeInfo), xsink);
+    for (int i = 0; i < actual_k; ++i) {
+        int idx = indices[i];
+        ReferenceHolder<QoreHashNode> neighbor(new QoreHashNode(autoTypeInfo), xsink);
+        neighbor->setKeyValue("index", static_cast<int64>(idx), xsink);
+        neighbor->setKeyValue("distance", distances[idx], xsink);
+        neighbor->setKeyValue("label", ref_labels(idx), xsink);
+        neighbors->push(neighbor.release(), xsink);
+    }
+
+    if (task == "classification") {
+        // Weighted vote for classification
+        std::unordered_map<int64, double> votes;
+        for (int i = 0; i < actual_k; ++i) {
+            int idx = indices[i];
+            int64 label = static_cast<int64>(std::round(ref_labels(idx)));
+            double w;
+            if (weight_func == "distance") {
+                double d = distances[idx];
+                w = (d < 1e-10) ? 1e10 : 1.0 / d;
+            } else {
+                w = 1.0;
+            }
+            votes[label] += w;
+        }
+
+        // Find class with highest vote weight
+        int64 predicted_class = 0;
+        double max_weight = -1.0;
+        double total_weight = 0.0;
+        for (const auto& p : votes) {
+            total_weight += p.second;
+            if (p.second > max_weight) {
+                max_weight = p.second;
+                predicted_class = p.first;
+            }
+        }
+
+        double confidence = (total_weight > 1e-10) ? max_weight / total_weight : 0.0;
+
+        ReferenceHolder<QoreHashNode> rv(new QoreHashNode(hashdeclKNNClassificationResult, xsink), xsink);
+        rv->setKeyValue("predicted_class", predicted_class, xsink);
+        rv->setKeyValue("confidence", confidence, xsink);
+        rv->setKeyValue("neighbors", neighbors.release(), xsink);
+        return rv.release();
+    }
+
+    // Regression: weighted average
+    double weighted_sum = 0.0;
+    double total_weight = 0.0;
+    for (int i = 0; i < actual_k; ++i) {
+        int idx = indices[i];
+        double w;
+        if (weight_func == "distance") {
+            double d = distances[idx];
+            w = (d < 1e-10) ? 1e10 : 1.0 / d;
+        } else {
+            w = 1.0;
+        }
+        weighted_sum += w * ref_labels(idx);
+        total_weight += w;
+    }
+
+    double prediction = (total_weight > 1e-10) ? weighted_sum / total_weight : 0.0;
+
+    ReferenceHolder<QoreHashNode> rv(new QoreHashNode(hashdeclKNNRegressionResult, xsink), xsink);
+    rv->setKeyValue("prediction", prediction, xsink);
+    rv->setKeyValue("neighbors", neighbors.release(), xsink);
+    return rv.release();
+}
+
+QoreHashNode* QoreKNN::predict(const RowVectorXd& point, ExceptionSink* xsink) const {
+    std::lock_guard<std::mutex> lk(mtx);
+    if (!fitted) {
+        xsink->raiseException("ML-KNN-ERROR",
+            "model has not been fitted: call fit() or fitMatrix() before predict()");
+        return nullptr;
+    }
+    return predictInternal(point, xsink);
+}
+
+QoreListNode* QoreKNN::predictMatrix(const MatrixXd& X, ExceptionSink* xsink) const {
+    std::lock_guard<std::mutex> lk(mtx);
+    if (!fitted) {
+        xsink->raiseException("ML-KNN-ERROR",
+            "model has not been fitted: call fit() or fitMatrix() before predictMatrix()");
+        return nullptr;
+    }
+
+    if (X.cols() != n_features) {
+        xsink->raiseException("ML-KNN-ERROR",
+            "input has %d features but model was trained with %d features",
+            static_cast<int>(X.cols()), n_features);
+        return nullptr;
+    }
+
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(autoTypeInfo), xsink);
+    for (Eigen::Index i = 0; i < X.rows(); ++i) {
+        if (i % 100 == 0 && qore_check_cancel(xsink, "KNN predictMatrix")) {
+            return nullptr;
+        }
+        RowVectorXd row = X.row(i);
+        QoreHashNode* result = predictInternal(row, xsink);
+        if (*xsink) {
+            return nullptr;
+        }
+        rv->push(result, xsink);
+    }
+    return rv.release();
+}

--- a/modules/ml/src/LOF.cpp
+++ b/modules/ml/src/LOF.cpp
@@ -101,6 +101,10 @@ void QoreLOF::fit(const MatrixXd& data, ExceptionSink* xsink) {
     ref_k_distances.resize(n);
 
     for (int i = 0; i < n; ++i) {
+        if (i % 100 == 0 && qore_check_cancel(xsink, "LOF fit")) {
+            return;
+        }
+
         // Compute distances from point i to all other points
         VectorXd distances(n);
         for (int j = 0; j < n; ++j) {
@@ -209,6 +213,9 @@ QoreListNode* QoreLOF::scoreMatrix(const MatrixXd& data, ExceptionSink* xsink) c
 
     ReferenceHolder<QoreListNode> rv(new QoreListNode(hashdeclLOFResult->getTypeInfo()), xsink);
     for (Eigen::Index i = 0; i < data.rows(); ++i) {
+        if (i % 100 == 0 && qore_check_cancel(xsink, "LOF scoreMatrix")) {
+            return nullptr;
+        }
         RowVectorXd row = data.row(i);
         QoreHashNode* result = scoreInternal(row, xsink);
         if (*xsink) {

--- a/modules/ml/src/LOF.cpp
+++ b/modules/ml/src/LOF.cpp
@@ -26,6 +26,7 @@
 */
 
 #include "QC_LOF.h"
+#include "ml_serialization.h"
 
 #include <algorithm>
 #include <numeric>
@@ -224,4 +225,63 @@ QoreListNode* QoreLOF::scoreMatrix(const MatrixXd& data, ExceptionSink* xsink) c
         rv->push(result, xsink);
     }
     return rv.release();
+}
+
+std::vector<uint8_t> QoreLOF::serializeState() const {
+    std::vector<uint8_t> buf;
+    // Hyperparameters
+    MLSerialization::writeInt32(buf, k);
+    MLSerialization::writeScalar(buf, threshold);
+    // Model state
+    MLSerialization::writeInt32(buf, n_features);
+    MLSerialization::writeMatrix(buf, ref_data);
+    MLSerialization::writeDoubleVector(buf, ref_k_distances);
+    MLSerialization::writeDoubleVector(buf, ref_lrds);
+    // ref_knn_indices: vector of vector of int
+    MLSerialization::writeUint32(buf, static_cast<uint32_t>(ref_knn_indices.size()));
+    for (const auto& knn : ref_knn_indices) {
+        MLSerialization::writeIntVector(buf, knn);
+    }
+    MLSerialization::writeStringVector(buf, field_names);
+    return buf;
+}
+
+QoreLOF* QoreLOF::deserializeState(const uint8_t* data, size_t len, ExceptionSink* xsink) {
+    const uint8_t* ptr = data;
+    size_t remaining = len;
+
+    int32_t k = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double threshold = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t n_features = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    MatrixXd ref_data = MLSerialization::readMatrix(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::vector<double> ref_k_distances = MLSerialization::readDoubleVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::vector<double> ref_lrds = MLSerialization::readDoubleVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    uint32_t knn_count = MLSerialization::readUint32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::vector<std::vector<int>> ref_knn_indices;
+    ref_knn_indices.reserve(knn_count);
+    for (uint32_t i = 0; i < knn_count; ++i) {
+        ref_knn_indices.push_back(MLSerialization::readIntVector(ptr, remaining, xsink));
+        if (*xsink) { return nullptr; }
+    }
+
+    std::vector<std::string> field_names = MLSerialization::readStringVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    std::unique_ptr<QoreLOF> obj(new QoreLOF(k, threshold));
+    obj->n_features = n_features;
+    obj->ref_data = std::move(ref_data);
+    obj->ref_k_distances = std::move(ref_k_distances);
+    obj->ref_lrds = std::move(ref_lrds);
+    obj->ref_knn_indices = std::move(ref_knn_indices);
+    obj->field_names = std::move(field_names);
+    obj->fitted = true;
+    return obj.release();
 }

--- a/modules/ml/src/LinearRegression.cpp
+++ b/modules/ml/src/LinearRegression.cpp
@@ -26,6 +26,7 @@
 */
 
 #include "QC_LinearRegression.h"
+#include "ml_serialization.h"
 
 // Extern declarations for hashdecls (defined in ml-module.cpp)
 extern const TypedHashDecl* hashdeclLinearRegressionResult;
@@ -281,4 +282,60 @@ double QoreLinearRegression::getRSquared(ExceptionSink* xsink) const {
         return 0.0;
     }
     return r_squared;
+}
+
+std::vector<uint8_t> QoreLinearRegression::serializeState() const {
+    std::vector<uint8_t> buf;
+    // Hyperparameters
+    MLSerialization::writeBool(buf, fit_intercept);
+    MLSerialization::writeBool(buf, do_normalize);
+    // Model state
+    MLSerialization::writeInt32(buf, n_features);
+    MLSerialization::writeVector(buf, coefficients);
+    MLSerialization::writeScalar(buf, intercept);
+    MLSerialization::writeScalar(buf, r_squared);
+    MLSerialization::writeVector(buf, feature_means);
+    MLSerialization::writeVector(buf, feature_stds);
+    MLSerialization::writeStringVector(buf, field_names);
+    MLSerialization::writeString(buf, target_field);
+    return buf;
+}
+
+QoreLinearRegression* QoreLinearRegression::deserializeState(const uint8_t* data, size_t len,
+    ExceptionSink* xsink) {
+    const uint8_t* ptr = data;
+    size_t remaining = len;
+
+    bool fit_intercept = MLSerialization::readBool(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    bool do_normalize = MLSerialization::readBool(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t n_features = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    VectorXd coefficients = MLSerialization::readVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double intercept = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double r_squared = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    VectorXd feature_means = MLSerialization::readVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    VectorXd feature_stds = MLSerialization::readVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::vector<std::string> field_names = MLSerialization::readStringVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::string target_field = MLSerialization::readString(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    std::unique_ptr<QoreLinearRegression> obj(new QoreLinearRegression(fit_intercept, do_normalize));
+    obj->n_features = n_features;
+    obj->coefficients = std::move(coefficients);
+    obj->intercept = intercept;
+    obj->r_squared = r_squared;
+    obj->feature_means = std::move(feature_means);
+    obj->feature_stds = std::move(feature_stds);
+    obj->field_names = std::move(field_names);
+    obj->target_field = std::move(target_field);
+    obj->fitted = true;
+    return obj.release();
 }

--- a/modules/ml/src/LinearRegression.cpp
+++ b/modules/ml/src/LinearRegression.cpp
@@ -158,6 +158,9 @@ QoreListNode* QoreLinearRegression::predictMatrix(const MatrixXd& X, ExceptionSi
 
     ReferenceHolder<QoreListNode> rv(new QoreListNode(hashdeclLinearRegressionResult->getTypeInfo()), xsink);
     for (Eigen::Index i = 0; i < X.rows(); ++i) {
+        if (i % 100 == 0 && qore_check_cancel(xsink, "LinearRegression predictMatrix")) {
+            return nullptr;
+        }
         RowVectorXd row = X.row(i);
         QoreHashNode* result = predictInternal(row, xsink);
         if (*xsink) {

--- a/modules/ml/src/LinearRegression.cpp
+++ b/modules/ml/src/LinearRegression.cpp
@@ -107,6 +107,62 @@ void QoreLinearRegression::fit(const MatrixXd& X, const VectorXd& y, ExceptionSi
     fitted = true;
 }
 
+void QoreLinearRegression::update(const MatrixXd& X, const VectorXd& y,
+    double lr, ExceptionSink* xsink) {
+    std::lock_guard<std::mutex> lk(mtx);
+    if (!fitted) {
+        xsink->raiseException("ML-LINEAR-REGRESSION-ERROR",
+            "model has not been fitted: call fit() or fitMatrix() before update()");
+        return;
+    }
+    if (X.cols() != n_features) {
+        xsink->raiseException("ML-LINEAR-REGRESSION-ERROR",
+            "input has %d features but model was trained with %d features",
+            static_cast<int>(X.cols()), n_features);
+        return;
+    }
+    if (X.rows() != y.size()) {
+        xsink->raiseException("ML-LINEAR-REGRESSION-ERROR",
+            "X has %d rows but y has %d elements; they must match",
+            static_cast<int>(X.rows()), static_cast<int>(y.size()));
+        return;
+    }
+    if (X.rows() == 0) {
+        xsink->raiseException("ML-LINEAR-REGRESSION-ERROR",
+            "cannot update on empty data");
+        return;
+    }
+
+    int n = static_cast<int>(X.rows());
+
+    // SGD update: for each row adjust coefficients and intercept
+    for (int i = 0; i < n; ++i) {
+        if (i % 100 == 0 && qore_check_cancel(xsink, "LinearRegression update")) {
+            return;
+        }
+        double predicted = X.row(i).dot(coefficients) + intercept;
+        double error = predicted - y(i);
+        coefficients -= lr * error * X.row(i).transpose();
+        if (fit_intercept) {
+            intercept -= lr * error;
+        }
+    }
+
+    // Recompute R-squared on the new batch
+    VectorXd y_pred = X * coefficients;
+    if (fit_intercept) {
+        y_pred.array() += intercept;
+    }
+    double ss_res = (y - y_pred).squaredNorm();
+    double y_mean = y.mean();
+    double ss_tot = (y.array() - y_mean).square().sum();
+    if (ss_tot > 1e-10) {
+        r_squared = 1.0 - ss_res / ss_tot;
+    } else {
+        r_squared = (ss_res < 1e-10) ? 1.0 : 0.0;
+    }
+}
+
 QoreHashNode* QoreLinearRegression::predictInternal(const RowVectorXd& point, ExceptionSink* xsink) const {
     if (point.size() != n_features) {
         xsink->raiseException("ML-LINEAR-REGRESSION-ERROR",

--- a/modules/ml/src/LogisticRegression.cpp
+++ b/modules/ml/src/LogisticRegression.cpp
@@ -1,0 +1,268 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    LogisticRegression.cpp
+
+    Qore ml module - LogisticRegression implementation
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "QC_LogisticRegression.h"
+
+#include <algorithm>
+#include <set>
+
+// Extern declaration for hashdecl (defined in ml-module.cpp)
+extern const TypedHashDecl* hashdeclLogisticRegressionResult;
+
+QoreLogisticRegression::QoreLogisticRegression(double learning_rate, int max_iterations,
+    double tolerance, double regularization, const std::string& penalty, bool fit_intercept)
+    : learning_rate(learning_rate), max_iterations(max_iterations), tolerance(tolerance),
+      regularization(regularization), penalty(penalty), fit_intercept(fit_intercept) {
+}
+
+double QoreLogisticRegression::sigmoid(double z) const {
+    // Clamp to avoid overflow in exp()
+    if (z > 500.0) {
+        z = 500.0;
+    } else if (z < -500.0) {
+        z = -500.0;
+    }
+    return 1.0 / (1.0 + std::exp(-z));
+}
+
+VectorXd QoreLogisticRegression::softmax(const VectorXd& z) const {
+    // Subtract max for numerical stability
+    double max_z = z.maxCoeff();
+    VectorXd exp_z = (z.array() - max_z).exp();
+    double sum = exp_z.sum();
+    if (sum <= 0.0) {
+        // Fallback: uniform probabilities
+        return VectorXd::Constant(z.size(), 1.0 / z.size());
+    }
+    return exp_z / sum;
+}
+
+void QoreLogisticRegression::fit(const MatrixXd& X, const VectorXd& y, ExceptionSink* xsink) {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (X.rows() == 0 || X.cols() == 0) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "cannot fit on empty data: provide at least one sample with one feature");
+        return;
+    }
+    if (X.rows() != y.size()) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "X has %d rows but y has %d elements; they must match",
+            static_cast<int>(X.rows()), static_cast<int>(y.size()));
+        return;
+    }
+
+    int n_samples = static_cast<int>(X.rows());
+    n_features = static_cast<int>(X.cols());
+
+    // Extract unique sorted classes from y
+    std::set<double> class_set;
+    for (int i = 0; i < n_samples; ++i) {
+        class_set.insert(y(i));
+    }
+    classes.assign(class_set.begin(), class_set.end());
+    int n_classes = static_cast<int>(classes.size());
+
+    if (n_classes < 2) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "need at least 2 distinct classes for classification; found %d", n_classes);
+        return;
+    }
+
+    is_binary = (n_classes == 2);
+
+    // Number of weight vectors: 1 for binary, n_classes for OvR multiclass
+    int n_models = is_binary ? 1 : n_classes;
+    weights = MatrixXd::Zero(n_models, n_features);
+    intercepts = VectorXd::Zero(n_models);
+
+    // For binary classification: map classes[0] -> 0, classes[1] -> 1
+    // For multiclass OvR: for each class c, create binary target (1 if class == c, 0 otherwise)
+
+    for (int m = 0; m < n_models; ++m) {
+        // Create binary target vector for this model
+        VectorXd y_binary(n_samples);
+        if (is_binary) {
+            for (int i = 0; i < n_samples; ++i) {
+                y_binary(i) = (y(i) == classes[1]) ? 1.0 : 0.0;
+            }
+        } else {
+            for (int i = 0; i < n_samples; ++i) {
+                y_binary(i) = (y(i) == classes[m]) ? 1.0 : 0.0;
+            }
+        }
+
+        // Gradient descent for this binary classifier
+        RowVectorXd w = RowVectorXd::Zero(n_features);
+        double b = 0.0;
+
+        for (int iter = 0; iter < max_iterations; ++iter) {
+            if (qore_check_cancel(xsink, "LogisticRegression fit")) {
+                return;
+            }
+
+            // Compute predictions: sigmoid(X * w^T + b)
+            VectorXd z = (X * w.transpose()).array() + b;
+            VectorXd predictions(n_samples);
+            for (int i = 0; i < n_samples; ++i) {
+                predictions(i) = sigmoid(z(i));
+            }
+
+            // Compute error
+            VectorXd error = predictions - y_binary;
+
+            // Compute gradients
+            // gradient_w = (1/n) * X^T * error + regularization * w (for L2)
+            RowVectorXd gradient_w = (X.transpose() * error).transpose() / n_samples;
+            if (penalty == "l2") {
+                gradient_w += regularization * w;
+            }
+
+            double gradient_b = 0.0;
+            if (fit_intercept) {
+                gradient_b = error.mean();
+            }
+
+            // Update weights
+            RowVectorXd old_w = w;
+            w -= learning_rate * gradient_w;
+            if (fit_intercept) {
+                b -= learning_rate * gradient_b;
+            }
+
+            // Check convergence: max absolute weight change
+            double max_change = (w - old_w).array().abs().maxCoeff();
+            if (max_change < tolerance) {
+                break;
+            }
+        }
+
+        weights.row(m) = w;
+        intercepts(m) = b;
+    }
+
+    fitted = true;
+}
+
+QoreHashNode* QoreLogisticRegression::predictInternal(const RowVectorXd& point,
+    ExceptionSink* xsink) const {
+    if (point.size() != n_features) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "input has %d features but model was trained with %d features",
+            static_cast<int>(point.size()), n_features);
+        return nullptr;
+    }
+
+    int n_classes = static_cast<int>(classes.size());
+    VectorXd probabilities(n_classes);
+
+    if (is_binary) {
+        double z = point.dot(weights.row(0).transpose()) + intercepts(0);
+        double p1 = sigmoid(z);
+        probabilities(0) = 1.0 - p1;
+        probabilities(1) = p1;
+    } else {
+        // Compute raw scores for each class
+        VectorXd scores(n_classes);
+        for (int c = 0; c < n_classes; ++c) {
+            scores(c) = point.dot(weights.row(c).transpose()) + intercepts(c);
+        }
+        // Apply softmax to get probabilities
+        probabilities = softmax(scores);
+    }
+
+    // Find class with highest probability
+    int best_class = 0;
+    double max_prob = probabilities(0);
+    for (int c = 1; c < n_classes; ++c) {
+        if (probabilities(c) > max_prob) {
+            max_prob = probabilities(c);
+            best_class = c;
+        }
+    }
+
+    // Build result hash
+    ReferenceHolder<QoreListNode> prob_list(new QoreListNode(floatTypeInfo), xsink);
+    for (int c = 0; c < n_classes; ++c) {
+        prob_list->push(probabilities(c), xsink);
+    }
+
+    ReferenceHolder<QoreListNode> class_list(new QoreListNode(floatTypeInfo), xsink);
+    for (int c = 0; c < n_classes; ++c) {
+        class_list->push(classes[c], xsink);
+    }
+
+    ReferenceHolder<QoreHashNode> rv(new QoreHashNode(hashdeclLogisticRegressionResult, xsink), xsink);
+    rv->setKeyValue("predicted_class", classes[best_class], xsink);
+    rv->setKeyValue("max_probability", max_prob, xsink);
+    rv->setKeyValue("probabilities", prob_list.release(), xsink);
+    rv->setKeyValue("classes", class_list.release(), xsink);
+
+    return rv.release();
+}
+
+QoreHashNode* QoreLogisticRegression::predict(const RowVectorXd& point,
+    ExceptionSink* xsink) const {
+    std::lock_guard<std::mutex> lk(mtx);
+    if (!fitted) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "model has not been fitted: call fit() or fitMatrix() before predict()");
+        return nullptr;
+    }
+    return predictInternal(point, xsink);
+}
+
+QoreListNode* QoreLogisticRegression::predictMatrix(const MatrixXd& X,
+    ExceptionSink* xsink) const {
+    std::lock_guard<std::mutex> lk(mtx);
+    if (!fitted) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "model has not been fitted: call fit() or fitMatrix() before predictMatrix()");
+        return nullptr;
+    }
+
+    if (X.cols() != n_features) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "input has %d features but model was trained with %d features",
+            static_cast<int>(X.cols()), n_features);
+        return nullptr;
+    }
+
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(hashdeclLogisticRegressionResult->getTypeInfo()), xsink);
+    for (Eigen::Index i = 0; i < X.rows(); ++i) {
+        if (i % 100 == 0 && qore_check_cancel(xsink, "LogisticRegression predictMatrix")) {
+            return nullptr;
+        }
+        RowVectorXd row = X.row(i);
+        QoreHashNode* result = predictInternal(row, xsink);
+        if (*xsink) {
+            return nullptr;
+        }
+        rv->push(result, xsink);
+    }
+    return rv.release();
+}

--- a/modules/ml/src/LogisticRegression.cpp
+++ b/modules/ml/src/LogisticRegression.cpp
@@ -26,6 +26,7 @@
 */
 
 #include "QC_LogisticRegression.h"
+#include "ml_serialization.h"
 
 #include <algorithm>
 #include <set>
@@ -358,4 +359,70 @@ QoreListNode* QoreLogisticRegression::predictMatrix(const MatrixXd& X,
         rv->push(result, xsink);
     }
     return rv.release();
+}
+
+std::vector<uint8_t> QoreLogisticRegression::serializeState() const {
+    std::vector<uint8_t> buf;
+    // Hyperparameters
+    MLSerialization::writeScalar(buf, learning_rate);
+    MLSerialization::writeInt32(buf, max_iterations);
+    MLSerialization::writeScalar(buf, tolerance);
+    MLSerialization::writeScalar(buf, regularization);
+    MLSerialization::writeString(buf, penalty);
+    MLSerialization::writeBool(buf, fit_intercept);
+    // Model state
+    MLSerialization::writeMatrix(buf, weights);
+    MLSerialization::writeVector(buf, intercepts);
+    MLSerialization::writeDoubleVector(buf, classes);
+    MLSerialization::writeBool(buf, is_binary);
+    MLSerialization::writeInt32(buf, n_features);
+    MLSerialization::writeStringVector(buf, field_names);
+    MLSerialization::writeString(buf, target_field);
+    return buf;
+}
+
+QoreLogisticRegression* QoreLogisticRegression::deserializeState(const uint8_t* data,
+    size_t len, ExceptionSink* xsink) {
+    const uint8_t* ptr = data;
+    size_t remaining = len;
+
+    double learning_rate = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t max_iterations = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double tolerance = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double regularization = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::string penalty = MLSerialization::readString(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    bool fit_intercept = MLSerialization::readBool(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    MatrixXd weights = MLSerialization::readMatrix(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    VectorXd intercepts = MLSerialization::readVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::vector<double> classes = MLSerialization::readDoubleVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    bool is_binary = MLSerialization::readBool(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t n_features = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::vector<std::string> field_names = MLSerialization::readStringVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::string target_field = MLSerialization::readString(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    std::unique_ptr<QoreLogisticRegression> obj(new QoreLogisticRegression(
+        learning_rate, max_iterations, tolerance, regularization, penalty, fit_intercept));
+    obj->weights = std::move(weights);
+    obj->intercepts = std::move(intercepts);
+    obj->classes = std::move(classes);
+    obj->is_binary = is_binary;
+    obj->n_features = n_features;
+    obj->field_names = std::move(field_names);
+    obj->target_field = std::move(target_field);
+    obj->fitted = true;
+    return obj.release();
 }

--- a/modules/ml/src/LogisticRegression.cpp
+++ b/modules/ml/src/LogisticRegression.cpp
@@ -168,6 +168,99 @@ void QoreLogisticRegression::fit(const MatrixXd& X, const VectorXd& y, Exception
     fitted = true;
 }
 
+void QoreLogisticRegression::update(const MatrixXd& X, const VectorXd& y,
+    double lr, ExceptionSink* xsink) {
+    std::lock_guard<std::mutex> lk(mtx);
+    if (!fitted) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "model has not been fitted: call fit() or fitMatrix() before update()");
+        return;
+    }
+    if (X.cols() != n_features) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "input has %d features but model was trained with %d features",
+            static_cast<int>(X.cols()), n_features);
+        return;
+    }
+    if (X.rows() != y.size()) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "X has %d rows but y has %d elements; they must match",
+            static_cast<int>(X.rows()), static_cast<int>(y.size()));
+        return;
+    }
+    if (X.rows() == 0) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "cannot update on empty data");
+        return;
+    }
+
+    // Verify y contains only known classes
+    for (Eigen::Index i = 0; i < y.size(); ++i) {
+        bool found = false;
+        for (size_t c = 0; c < classes.size(); ++c) {
+            if (y(i) == classes[c]) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+                "target value %f at index %d is not a known class from training",
+                y(i), static_cast<int>(i));
+            return;
+        }
+    }
+
+    if (qore_check_cancel(xsink, "LogisticRegression update")) {
+        return;
+    }
+
+    int n_samples = static_cast<int>(X.rows());
+    int n_models = is_binary ? 1 : static_cast<int>(classes.size());
+
+    for (int m = 0; m < n_models; ++m) {
+        // Create binary target vector for this model
+        VectorXd y_binary(n_samples);
+        if (is_binary) {
+            for (int i = 0; i < n_samples; ++i) {
+                y_binary(i) = (y(i) == classes[1]) ? 1.0 : 0.0;
+            }
+        } else {
+            for (int i = 0; i < n_samples; ++i) {
+                y_binary(i) = (y(i) == classes[m]) ? 1.0 : 0.0;
+            }
+        }
+
+        // Compute predictions: sigmoid(X * w^T + b)
+        RowVectorXd w = weights.row(m);
+        double b = intercepts(m);
+
+        VectorXd z = (X * w.transpose()).array() + b;
+        VectorXd predictions(n_samples);
+        for (int i = 0; i < n_samples; ++i) {
+            predictions(i) = sigmoid(z(i));
+        }
+
+        // Compute error and gradient
+        VectorXd error = predictions - y_binary;
+        RowVectorXd gradient_w = (X.transpose() * error).transpose() / n_samples;
+        if (penalty == "l2") {
+            gradient_w += regularization * w;
+        }
+
+        double gradient_b = 0.0;
+        if (fit_intercept) {
+            gradient_b = error.mean();
+        }
+
+        // Update weights
+        weights.row(m) -= lr * gradient_w;
+        if (fit_intercept) {
+            intercepts(m) -= lr * gradient_b;
+        }
+    }
+}
+
 QoreHashNode* QoreLogisticRegression::predictInternal(const RowVectorXd& point,
     ExceptionSink* xsink) const {
     if (point.size() != n_features) {

--- a/modules/ml/src/MLPipeline.cpp
+++ b/modules/ml/src/MLPipeline.cpp
@@ -1,0 +1,489 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    MLPipeline.cpp
+
+    Qore ml module - MLPipeline implementation
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "QC_MLPipeline.h"
+
+void QoreMLPipeline::addStep(const std::string& name, PipelineStepType type, QoreObject* obj) {
+    obj->ref();
+    steps.push_back({name, type, obj});
+}
+
+bool QoreMLPipeline::isTransformer(PipelineStepType type) {
+    switch (type) {
+        case PipelineStepType::STANDARD_SCALER:
+        case PipelineStepType::MINMAX_SCALER:
+        case PipelineStepType::IMPUTER:
+        case PipelineStepType::PCA:
+            return true;
+        default:
+            return false;
+    }
+}
+
+MatrixXd QoreMLPipeline::fitTransformer(const PipelineStep& step, const MatrixXd& data,
+        ExceptionSink* xsink) {
+    switch (step.type) {
+        case PipelineStepType::STANDARD_SCALER: {
+            QoreStandardScaler* s = static_cast<QoreStandardScaler*>(
+                step.obj->getReferencedPrivateData(CID_STANDARDSCALER, xsink));
+            if (*xsink) {
+                return MatrixXd();
+            }
+            MatrixXd result = s->fitTransform(data, xsink);
+            s->deref(xsink);
+            return result;
+        }
+        case PipelineStepType::MINMAX_SCALER: {
+            QoreMinMaxScaler* s = static_cast<QoreMinMaxScaler*>(
+                step.obj->getReferencedPrivateData(CID_MINMAXSCALER, xsink));
+            if (*xsink) {
+                return MatrixXd();
+            }
+            MatrixXd result = s->fitTransform(data, xsink);
+            s->deref(xsink);
+            return result;
+        }
+        case PipelineStepType::IMPUTER: {
+            QoreImputer* s = static_cast<QoreImputer*>(
+                step.obj->getReferencedPrivateData(CID_IMPUTER, xsink));
+            if (*xsink) {
+                return MatrixXd();
+            }
+            MatrixXd result = s->fitTransform(data, xsink);
+            s->deref(xsink);
+            return result;
+        }
+        case PipelineStepType::PCA: {
+            QorePCA* s = static_cast<QorePCA*>(
+                step.obj->getReferencedPrivateData(CID_PCA, xsink));
+            if (*xsink) {
+                return MatrixXd();
+            }
+            QoreListNode* list_result = s->fitTransformInternal(data, xsink);
+            s->deref(xsink);
+            if (*xsink) {
+                return MatrixXd();
+            }
+            // Convert back from list to matrix
+            ReferenceHolder<QoreListNode> holder(list_result, xsink);
+            if (!list_result || !list_result->size()) {
+                return MatrixXd();
+            }
+            // Each element is a PCAResult hash — extract "components" field
+            int n = static_cast<int>(list_result->size());
+            // Get n_components from first result
+            QoreHashNode* first = list_result->retrieveEntry(0).get<QoreHashNode>();
+            QoreListNode* comps = first->getKeyValue("components").get<QoreListNode>();
+            int nc = static_cast<int>(comps->size());
+
+            MatrixXd result(n, nc);
+            for (int i = 0; i < n; ++i) {
+                QoreHashNode* h = list_result->retrieveEntry(i).get<QoreHashNode>();
+                QoreListNode* c = h->getKeyValue("components").get<QoreListNode>();
+                for (int j = 0; j < nc; ++j) {
+                    result(i, j) = c->retrieveEntry(j).getAsFloat();
+                }
+            }
+            return result;
+        }
+        default:
+            xsink->raiseException("ML-PIPELINE-ERROR",
+                "step '%s' is not a transformer", step.name.c_str());
+            return MatrixXd();
+    }
+}
+
+MatrixXd QoreMLPipeline::applyTransformer(const PipelineStep& step, const MatrixXd& data,
+        ExceptionSink* xsink) const {
+    switch (step.type) {
+        case PipelineStepType::STANDARD_SCALER: {
+            QoreStandardScaler* s = static_cast<QoreStandardScaler*>(
+                step.obj->getReferencedPrivateData(CID_STANDARDSCALER, xsink));
+            if (*xsink) {
+                return MatrixXd();
+            }
+            MatrixXd result = s->transform(data, xsink);
+            s->deref(xsink);
+            return result;
+        }
+        case PipelineStepType::MINMAX_SCALER: {
+            QoreMinMaxScaler* s = static_cast<QoreMinMaxScaler*>(
+                step.obj->getReferencedPrivateData(CID_MINMAXSCALER, xsink));
+            if (*xsink) {
+                return MatrixXd();
+            }
+            MatrixXd result = s->transform(data, xsink);
+            s->deref(xsink);
+            return result;
+        }
+        case PipelineStepType::IMPUTER: {
+            QoreImputer* s = static_cast<QoreImputer*>(
+                step.obj->getReferencedPrivateData(CID_IMPUTER, xsink));
+            if (*xsink) {
+                return MatrixXd();
+            }
+            MatrixXd result = s->transform(data, xsink);
+            s->deref(xsink);
+            return result;
+        }
+        case PipelineStepType::PCA: {
+            QorePCA* s = static_cast<QorePCA*>(
+                step.obj->getReferencedPrivateData(CID_PCA, xsink));
+            if (*xsink) {
+                return MatrixXd();
+            }
+            QoreListNode* list_result = s->transformMatrix(data, xsink);
+            s->deref(xsink);
+            if (*xsink) {
+                return MatrixXd();
+            }
+            ReferenceHolder<QoreListNode> holder(list_result, xsink);
+            if (!list_result || !list_result->size()) {
+                return MatrixXd();
+            }
+            int n = static_cast<int>(list_result->size());
+            QoreHashNode* first = list_result->retrieveEntry(0).get<QoreHashNode>();
+            QoreListNode* comps = first->getKeyValue("components").get<QoreListNode>();
+            int nc = static_cast<int>(comps->size());
+
+            MatrixXd result(n, nc);
+            for (int i = 0; i < n; ++i) {
+                QoreHashNode* h = list_result->retrieveEntry(i).get<QoreHashNode>();
+                QoreListNode* c = h->getKeyValue("components").get<QoreListNode>();
+                for (int j = 0; j < nc; ++j) {
+                    result(i, j) = c->retrieveEntry(j).getAsFloat();
+                }
+            }
+            return result;
+        }
+        default:
+            xsink->raiseException("ML-PIPELINE-ERROR",
+                "step '%s' is not a transformer", step.name.c_str());
+            return MatrixXd();
+    }
+}
+
+void QoreMLPipeline::fitMatrix(const MatrixXd& X, const VectorXd* y, ExceptionSink* xsink) {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (steps.empty()) {
+        xsink->raiseException("ML-PIPELINE-ERROR", "pipeline has no steps");
+        return;
+    }
+
+    MatrixXd current = X;
+
+    // Process all steps except the last
+    for (size_t i = 0; i < steps.size() - 1; ++i) {
+        if (!isTransformer(steps[i].type)) {
+            xsink->raiseException("ML-PIPELINE-ERROR",
+                "step '%s' at position %d is an estimator but is not the last step; "
+                "only the last step may be an estimator",
+                steps[i].name.c_str(), static_cast<int>(i));
+            return;
+        }
+        current = fitTransformer(steps[i], current, xsink);
+        if (*xsink) {
+            return;
+        }
+    }
+
+    // Last step: can be transformer or estimator
+    const PipelineStep& last = steps.back();
+    if (isTransformer(last.type)) {
+        fitTransformer(last, current, xsink);
+    } else {
+        // Fit the estimator
+        switch (last.type) {
+            case PipelineStepType::LINEAR_REGRESSION: {
+                if (!y) {
+                    xsink->raiseException("ML-PIPELINE-ERROR",
+                        "LinearRegression estimator requires target vector y; "
+                        "use fitMatrix(X, y)");
+                    return;
+                }
+                QoreLinearRegression* lr = static_cast<QoreLinearRegression*>(
+                    last.obj->getReferencedPrivateData(CID_LINEARREGRESSION, xsink));
+                if (*xsink) {
+                    return;
+                }
+                lr->fit(current, *y, xsink);
+                lr->deref(xsink);
+                break;
+            }
+            case PipelineStepType::KMEANS: {
+                QoreKMeans* km = static_cast<QoreKMeans*>(
+                    last.obj->getReferencedPrivateData(CID_KMEANS, xsink));
+                if (*xsink) {
+                    return;
+                }
+                km->fit(current, xsink);
+                km->deref(xsink);
+                break;
+            }
+            case PipelineStepType::ISOLATION_FOREST: {
+                QoreIsolationForest* ifo = static_cast<QoreIsolationForest*>(
+                    last.obj->getReferencedPrivateData(CID_ISOLATIONFOREST, xsink));
+                if (*xsink) {
+                    return;
+                }
+                ifo->fit(current, xsink);
+                ifo->deref(xsink);
+                break;
+            }
+            case PipelineStepType::LOF: {
+                QoreLOF* lof = static_cast<QoreLOF*>(
+                    last.obj->getReferencedPrivateData(CID_LOF, xsink));
+                if (*xsink) {
+                    return;
+                }
+                lof->fit(current, xsink);
+                lof->deref(xsink);
+                break;
+            }
+            case PipelineStepType::GMM: {
+                QoreGMM* gmm = static_cast<QoreGMM*>(
+                    last.obj->getReferencedPrivateData(CID_GMM, xsink));
+                if (*xsink) {
+                    return;
+                }
+                gmm->fit(current, xsink);
+                gmm->deref(xsink);
+                break;
+            }
+            default:
+                xsink->raiseException("ML-PIPELINE-ERROR",
+                    "unknown estimator type for step '%s'", last.name.c_str());
+                return;
+        }
+    }
+
+    fitted = true;
+}
+
+MatrixXd QoreMLPipeline::transformMatrix(const MatrixXd& X, ExceptionSink* xsink) const {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (!fitted) {
+        xsink->raiseException("ML-PIPELINE-ERROR",
+            "pipeline has not been fitted: call fitMatrix() first");
+        return MatrixXd();
+    }
+
+    MatrixXd current = X;
+
+    // Apply all transformer steps (skip the estimator if last step is one)
+    size_t n = steps.size();
+    if (!isTransformer(steps.back().type)) {
+        --n;  // skip last estimator
+    }
+    for (size_t i = 0; i < n; ++i) {
+        current = applyTransformer(steps[i], current, xsink);
+        if (*xsink) {
+            return MatrixXd();
+        }
+    }
+
+    return current;
+}
+
+QoreHashNode* QoreMLPipeline::predict(const RowVectorXd& point, ExceptionSink* xsink) const {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (!fitted) {
+        xsink->raiseException("ML-PIPELINE-ERROR",
+            "pipeline has not been fitted: call fitMatrix() first");
+        return nullptr;
+    }
+    if (isTransformer(steps.back().type)) {
+        xsink->raiseException("ML-PIPELINE-ERROR",
+            "last step is a transformer, not an estimator; use transformMatrix() instead");
+        return nullptr;
+    }
+
+    // Transform through all transformer steps
+    MatrixXd current(1, point.size());
+    current.row(0) = point;
+    for (size_t i = 0; i < steps.size() - 1; ++i) {
+        current = applyTransformer(steps[i], current, xsink);
+        if (*xsink) {
+            return nullptr;
+        }
+    }
+
+    RowVectorXd transformed = current.row(0);
+
+    // Predict with the estimator
+    const PipelineStep& last = steps.back();
+    switch (last.type) {
+        case PipelineStepType::LINEAR_REGRESSION: {
+            QoreLinearRegression* lr = static_cast<QoreLinearRegression*>(
+                last.obj->getReferencedPrivateData(CID_LINEARREGRESSION, xsink));
+            if (*xsink) {
+                return nullptr;
+            }
+            QoreHashNode* result = lr->predict(transformed, xsink);
+            lr->deref(xsink);
+            return result;
+        }
+        case PipelineStepType::KMEANS: {
+            QoreKMeans* km = static_cast<QoreKMeans*>(
+                last.obj->getReferencedPrivateData(CID_KMEANS, xsink));
+            if (*xsink) {
+                return nullptr;
+            }
+            QoreHashNode* result = km->predict(transformed, xsink);
+            km->deref(xsink);
+            return result;
+        }
+        case PipelineStepType::ISOLATION_FOREST: {
+            QoreIsolationForest* ifo = static_cast<QoreIsolationForest*>(
+                last.obj->getReferencedPrivateData(CID_ISOLATIONFOREST, xsink));
+            if (*xsink) {
+                return nullptr;
+            }
+            QoreHashNode* result = ifo->score(transformed, xsink);
+            ifo->deref(xsink);
+            return result;
+        }
+        case PipelineStepType::LOF: {
+            QoreLOF* lof = static_cast<QoreLOF*>(
+                last.obj->getReferencedPrivateData(CID_LOF, xsink));
+            if (*xsink) {
+                return nullptr;
+            }
+            QoreHashNode* result = lof->score(transformed, xsink);
+            lof->deref(xsink);
+            return result;
+        }
+        case PipelineStepType::GMM: {
+            QoreGMM* gmm = static_cast<QoreGMM*>(
+                last.obj->getReferencedPrivateData(CID_GMM, xsink));
+            if (*xsink) {
+                return nullptr;
+            }
+            QoreHashNode* result = gmm->predict(transformed, xsink);
+            gmm->deref(xsink);
+            return result;
+        }
+        default:
+            xsink->raiseException("ML-PIPELINE-ERROR",
+                "unknown estimator type for step '%s'", last.name.c_str());
+            return nullptr;
+    }
+}
+
+QoreListNode* QoreMLPipeline::predictMatrix(const MatrixXd& X, ExceptionSink* xsink) const {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (!fitted) {
+        xsink->raiseException("ML-PIPELINE-ERROR",
+            "pipeline has not been fitted: call fitMatrix() first");
+        return nullptr;
+    }
+    if (isTransformer(steps.back().type)) {
+        xsink->raiseException("ML-PIPELINE-ERROR",
+            "last step is a transformer, not an estimator; use transformMatrix() instead");
+        return nullptr;
+    }
+
+    // Transform through all transformer steps
+    MatrixXd current = X;
+    for (size_t i = 0; i < steps.size() - 1; ++i) {
+        current = applyTransformer(steps[i], current, xsink);
+        if (*xsink) {
+            return nullptr;
+        }
+    }
+
+    // Predict with the estimator
+    const PipelineStep& last = steps.back();
+    switch (last.type) {
+        case PipelineStepType::LINEAR_REGRESSION: {
+            QoreLinearRegression* lr = static_cast<QoreLinearRegression*>(
+                last.obj->getReferencedPrivateData(CID_LINEARREGRESSION, xsink));
+            if (*xsink) {
+                return nullptr;
+            }
+            QoreListNode* result = lr->predictMatrix(current, xsink);
+            lr->deref(xsink);
+            return result;
+        }
+        case PipelineStepType::KMEANS: {
+            QoreKMeans* km = static_cast<QoreKMeans*>(
+                last.obj->getReferencedPrivateData(CID_KMEANS, xsink));
+            if (*xsink) {
+                return nullptr;
+            }
+            QoreListNode* result = km->predictMatrix(current, xsink);
+            km->deref(xsink);
+            return result;
+        }
+        case PipelineStepType::ISOLATION_FOREST: {
+            QoreIsolationForest* ifo = static_cast<QoreIsolationForest*>(
+                last.obj->getReferencedPrivateData(CID_ISOLATIONFOREST, xsink));
+            if (*xsink) {
+                return nullptr;
+            }
+            QoreListNode* result = ifo->scoreMatrix(current, xsink);
+            ifo->deref(xsink);
+            return result;
+        }
+        case PipelineStepType::LOF: {
+            QoreLOF* lof = static_cast<QoreLOF*>(
+                last.obj->getReferencedPrivateData(CID_LOF, xsink));
+            if (*xsink) {
+                return nullptr;
+            }
+            QoreListNode* result = lof->scoreMatrix(current, xsink);
+            lof->deref(xsink);
+            return result;
+        }
+        case PipelineStepType::GMM: {
+            QoreGMM* gmm = static_cast<QoreGMM*>(
+                last.obj->getReferencedPrivateData(CID_GMM, xsink));
+            if (*xsink) {
+                return nullptr;
+            }
+            QoreListNode* result = gmm->predictMatrix(current, xsink);
+            gmm->deref(xsink);
+            return result;
+        }
+        default:
+            xsink->raiseException("ML-PIPELINE-ERROR",
+                "unknown estimator type for step '%s'", last.name.c_str());
+            return nullptr;
+    }
+}
+
+QoreListNode* QoreMLPipeline::getStepNames(ExceptionSink* xsink) const {
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(stringTypeInfo), xsink);
+    for (const auto& step : steps) {
+        rv->push(new QoreStringNode(step.name), xsink);
+    }
+    return rv.release();
+}

--- a/modules/ml/src/MLPipeline.cpp
+++ b/modules/ml/src/MLPipeline.cpp
@@ -275,6 +275,38 @@ void QoreMLPipeline::fitMatrix(const MatrixXd& X, const VectorXd* y, ExceptionSi
                 gmm->deref(xsink);
                 break;
             }
+            case PipelineStepType::LOGISTIC_REGRESSION: {
+                if (!y) {
+                    xsink->raiseException("ML-PIPELINE-ERROR",
+                        "LogisticRegression estimator requires target vector y; "
+                        "use fitMatrix(X, y)");
+                    return;
+                }
+                QoreLogisticRegression* lr = static_cast<QoreLogisticRegression*>(
+                    last.obj->getReferencedPrivateData(CID_LOGISTICREGRESSION, xsink));
+                if (*xsink) {
+                    return;
+                }
+                lr->fit(current, *y, xsink);
+                lr->deref(xsink);
+                break;
+            }
+            case PipelineStepType::KNN_CLASSIFICATION: {
+                if (!y) {
+                    xsink->raiseException("ML-PIPELINE-ERROR",
+                        "KNN estimator requires target vector y; "
+                        "use fitMatrix(X, y)");
+                    return;
+                }
+                QoreKNN* knn = static_cast<QoreKNN*>(
+                    last.obj->getReferencedPrivateData(CID_KNN, xsink));
+                if (*xsink) {
+                    return;
+                }
+                knn->fit(current, *y, xsink);
+                knn->deref(xsink);
+                break;
+            }
             default:
                 xsink->raiseException("ML-PIPELINE-ERROR",
                     "unknown estimator type for step '%s'", last.name.c_str());
@@ -390,6 +422,26 @@ QoreHashNode* QoreMLPipeline::predict(const RowVectorXd& point, ExceptionSink* x
             gmm->deref(xsink);
             return result;
         }
+        case PipelineStepType::LOGISTIC_REGRESSION: {
+            QoreLogisticRegression* lr = static_cast<QoreLogisticRegression*>(
+                last.obj->getReferencedPrivateData(CID_LOGISTICREGRESSION, xsink));
+            if (*xsink) {
+                return nullptr;
+            }
+            QoreHashNode* result = lr->predict(transformed, xsink);
+            lr->deref(xsink);
+            return result;
+        }
+        case PipelineStepType::KNN_CLASSIFICATION: {
+            QoreKNN* knn = static_cast<QoreKNN*>(
+                last.obj->getReferencedPrivateData(CID_KNN, xsink));
+            if (*xsink) {
+                return nullptr;
+            }
+            QoreHashNode* result = knn->predict(transformed, xsink);
+            knn->deref(xsink);
+            return result;
+        }
         default:
             xsink->raiseException("ML-PIPELINE-ERROR",
                 "unknown estimator type for step '%s'", last.name.c_str());
@@ -471,6 +523,26 @@ QoreListNode* QoreMLPipeline::predictMatrix(const MatrixXd& X, ExceptionSink* xs
             }
             QoreListNode* result = gmm->predictMatrix(current, xsink);
             gmm->deref(xsink);
+            return result;
+        }
+        case PipelineStepType::LOGISTIC_REGRESSION: {
+            QoreLogisticRegression* lr = static_cast<QoreLogisticRegression*>(
+                last.obj->getReferencedPrivateData(CID_LOGISTICREGRESSION, xsink));
+            if (*xsink) {
+                return nullptr;
+            }
+            QoreListNode* result = lr->predictMatrix(current, xsink);
+            lr->deref(xsink);
+            return result;
+        }
+        case PipelineStepType::KNN_CLASSIFICATION: {
+            QoreKNN* knn = static_cast<QoreKNN*>(
+                last.obj->getReferencedPrivateData(CID_KNN, xsink));
+            if (*xsink) {
+                return nullptr;
+            }
+            QoreListNode* result = knn->predictMatrix(current, xsink);
+            knn->deref(xsink);
             return result;
         }
         default:

--- a/modules/ml/src/MinMaxScaler.cpp
+++ b/modules/ml/src/MinMaxScaler.cpp
@@ -26,6 +26,7 @@
 */
 
 #include "QC_MinMaxScaler.h"
+#include "ml_serialization.h"
 
 extern const TypedHashDecl* hashdeclMinMaxScalerInfo;
 
@@ -179,4 +180,52 @@ QoreHashNode* QoreMinMaxScaler::getInfo(ExceptionSink* xsink) const {
     rv->setKeyValue("n_features", static_cast<int64>(n_features), xsink);
 
     return rv.release();
+}
+
+std::vector<uint8_t> QoreMinMaxScaler::serializeState() const {
+    std::vector<uint8_t> buf;
+    // Hyperparameters
+    MLSerialization::writeScalar(buf, feature_min);
+    MLSerialization::writeScalar(buf, feature_max);
+    // Model state
+    MLSerialization::writeInt32(buf, n_features);
+    MLSerialization::writeVector(buf, data_min);
+    MLSerialization::writeVector(buf, data_max);
+    MLSerialization::writeVector(buf, scale);
+    MLSerialization::writeVector(buf, min_adj);
+    MLSerialization::writeStringVector(buf, field_names);
+    return buf;
+}
+
+QoreMinMaxScaler* QoreMinMaxScaler::deserializeState(const uint8_t* data, size_t len,
+    ExceptionSink* xsink) {
+    const uint8_t* ptr = data;
+    size_t remaining = len;
+
+    double feature_min = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double feature_max = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t n_features = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    VectorXd data_min_v = MLSerialization::readVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    VectorXd data_max_v = MLSerialization::readVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    VectorXd scale_v = MLSerialization::readVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    VectorXd min_adj_v = MLSerialization::readVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::vector<std::string> field_names = MLSerialization::readStringVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    std::unique_ptr<QoreMinMaxScaler> obj(new QoreMinMaxScaler(feature_min, feature_max));
+    obj->n_features = n_features;
+    obj->data_min = std::move(data_min_v);
+    obj->data_max = std::move(data_max_v);
+    obj->scale = std::move(scale_v);
+    obj->min_adj = std::move(min_adj_v);
+    obj->field_names = std::move(field_names);
+    obj->fitted = true;
+    return obj.release();
 }

--- a/modules/ml/src/MinMaxScaler.cpp
+++ b/modules/ml/src/MinMaxScaler.cpp
@@ -1,0 +1,182 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    MinMaxScaler.cpp
+
+    Qore ml module - MinMaxScaler implementation
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "QC_MinMaxScaler.h"
+
+extern const TypedHashDecl* hashdeclMinMaxScalerInfo;
+
+void QoreMinMaxScaler::computeScaleFactors() {
+    double range = feature_max - feature_min;
+    scale.resize(n_features);
+    min_adj.resize(n_features);
+    for (int j = 0; j < n_features; ++j) {
+        double data_range = data_max(j) - data_min(j);
+        if (data_range > 1e-10) {
+            scale(j) = range / data_range;
+        } else {
+            // Constant feature: map to feature_min
+            scale(j) = 0.0;
+        }
+        min_adj(j) = feature_min - data_min(j) * scale(j);
+    }
+}
+
+void QoreMinMaxScaler::fit(const MatrixXd& data, ExceptionSink* xsink) {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (data.rows() == 0 || data.cols() == 0) {
+        xsink->raiseException("ML-MIN-MAX-SCALER-ERROR",
+            "cannot fit on empty data: provide at least one sample with one feature");
+        return;
+    }
+
+    n_features = static_cast<int>(data.cols());
+    data_min = data.colwise().minCoeff();
+    data_max = data.colwise().maxCoeff();
+    computeScaleFactors();
+    fitted = true;
+}
+
+RowVectorXd QoreMinMaxScaler::transformRow(const RowVectorXd& row, ExceptionSink* xsink) const {
+    if (row.size() != n_features) {
+        xsink->raiseException("ML-MIN-MAX-SCALER-ERROR",
+            "input has %d features but scaler was fitted with %d features",
+            static_cast<int>(row.size()), n_features);
+        return RowVectorXd();
+    }
+    return row.array() * scale.transpose().array() + min_adj.transpose().array();
+}
+
+RowVectorXd QoreMinMaxScaler::inverseTransformRow(const RowVectorXd& row, ExceptionSink* xsink) const {
+    if (row.size() != n_features) {
+        xsink->raiseException("ML-MIN-MAX-SCALER-ERROR",
+            "input has %d features but scaler was fitted with %d features",
+            static_cast<int>(row.size()), n_features);
+        return RowVectorXd();
+    }
+
+    RowVectorXd result(n_features);
+    for (int j = 0; j < n_features; ++j) {
+        if (std::abs(scale(j)) > 1e-10) {
+            result(j) = (row(j) - min_adj(j)) / scale(j);
+        } else {
+            // Constant feature: return data_min
+            result(j) = data_min(j);
+        }
+    }
+    return result;
+}
+
+MatrixXd QoreMinMaxScaler::transform(const MatrixXd& data, ExceptionSink* xsink) const {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (!fitted) {
+        xsink->raiseException("ML-MIN-MAX-SCALER-ERROR",
+            "scaler has not been fitted: call fit() or fitMatrix() first");
+        return MatrixXd();
+    }
+    if (data.cols() != n_features) {
+        xsink->raiseException("ML-MIN-MAX-SCALER-ERROR",
+            "input has %d features but scaler was fitted with %d features",
+            static_cast<int>(data.cols()), n_features);
+        return MatrixXd();
+    }
+
+    return (data.array().rowwise() * scale.transpose().array()).rowwise() + min_adj.transpose().array();
+}
+
+MatrixXd QoreMinMaxScaler::inverseTransform(const MatrixXd& data, ExceptionSink* xsink) const {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (!fitted) {
+        xsink->raiseException("ML-MIN-MAX-SCALER-ERROR",
+            "scaler has not been fitted: call fit() or fitMatrix() first");
+        return MatrixXd();
+    }
+    if (data.cols() != n_features) {
+        xsink->raiseException("ML-MIN-MAX-SCALER-ERROR",
+            "input has %d features but scaler was fitted with %d features",
+            static_cast<int>(data.cols()), n_features);
+        return MatrixXd();
+    }
+
+    MatrixXd result(data.rows(), n_features);
+    for (Eigen::Index i = 0; i < data.rows(); ++i) {
+        for (int j = 0; j < n_features; ++j) {
+            if (std::abs(scale(j)) > 1e-10) {
+                result(i, j) = (data(i, j) - min_adj(j)) / scale(j);
+            } else {
+                result(i, j) = data_min(j);
+            }
+        }
+    }
+    return result;
+}
+
+MatrixXd QoreMinMaxScaler::fitTransform(const MatrixXd& data, ExceptionSink* xsink) {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (data.rows() == 0 || data.cols() == 0) {
+        xsink->raiseException("ML-MIN-MAX-SCALER-ERROR",
+            "cannot fit on empty data: provide at least one sample with one feature");
+        return MatrixXd();
+    }
+
+    n_features = static_cast<int>(data.cols());
+    data_min = data.colwise().minCoeff();
+    data_max = data.colwise().maxCoeff();
+    computeScaleFactors();
+    fitted = true;
+
+    return (data.array().rowwise() * scale.transpose().array()).rowwise() + min_adj.transpose().array();
+}
+
+QoreHashNode* QoreMinMaxScaler::getInfo(ExceptionSink* xsink) const {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (!fitted) {
+        xsink->raiseException("ML-MIN-MAX-SCALER-ERROR",
+            "scaler has not been fitted: call fit() or fitMatrix() first");
+        return nullptr;
+    }
+
+    ReferenceHolder<QoreListNode> dmin_list(new QoreListNode(floatTypeInfo), xsink);
+    ReferenceHolder<QoreListNode> dmax_list(new QoreListNode(floatTypeInfo), xsink);
+    for (int j = 0; j < n_features; ++j) {
+        dmin_list->push(data_min(j), xsink);
+        dmax_list->push(data_max(j), xsink);
+    }
+
+    ReferenceHolder<QoreHashNode> rv(new QoreHashNode(hashdeclMinMaxScalerInfo, xsink), xsink);
+    rv->setKeyValue("data_min", dmin_list.release(), xsink);
+    rv->setKeyValue("data_max", dmax_list.release(), xsink);
+    rv->setKeyValue("feature_min", feature_min, xsink);
+    rv->setKeyValue("feature_max", feature_max, xsink);
+    rv->setKeyValue("n_features", static_cast<int64>(n_features), xsink);
+
+    return rv.release();
+}

--- a/modules/ml/src/PCA.cpp
+++ b/modules/ml/src/PCA.cpp
@@ -237,6 +237,9 @@ QoreListNode* QorePCA::doTransformMatrix(const MatrixXd& data, ExceptionSink* xs
 
     ReferenceHolder<QoreListNode> rv(new QoreListNode(hashdeclPCAResult->getTypeInfo()), xsink);
     for (Eigen::Index r = 0; r < data.rows(); ++r) {
+        if (r % 100 == 0 && qore_check_cancel(xsink, "PCA transformMatrix")) {
+            return nullptr;
+        }
         ReferenceHolder<QoreListNode> comp_list(new QoreListNode(floatTypeInfo), xsink);
         for (int i = 0; i < actual_n_components; ++i) {
             comp_list->push(projected(r, i), xsink);

--- a/modules/ml/src/PCA.cpp
+++ b/modules/ml/src/PCA.cpp
@@ -26,6 +26,7 @@
 */
 
 #include "QC_PCA.h"
+#include "ml_serialization.h"
 
 #include <Eigen/Eigenvalues>
 
@@ -304,4 +305,62 @@ QoreListNode* QorePCA::getMean(ExceptionSink* xsink) {
     }
 
     return eigenVectorToQoreList(mean_vec);
+}
+
+std::vector<uint8_t> QorePCA::serializeState() const {
+    std::vector<uint8_t> buf;
+    // Hyperparameters
+    MLSerialization::writeInt32(buf, n_components);
+    MLSerialization::writeScalar(buf, variance_threshold);
+    MLSerialization::writeBool(buf, center);
+    MLSerialization::writeBool(buf, scale);
+    // Model state
+    MLSerialization::writeInt32(buf, actual_n_components);
+    MLSerialization::writeInt32(buf, n_features);
+    MLSerialization::writeMatrix(buf, components);
+    MLSerialization::writeVector(buf, mean_vec);
+    MLSerialization::writeVector(buf, stddev_vec);
+    MLSerialization::writeVector(buf, explained_variance_ratio_vec);
+    MLSerialization::writeStringVector(buf, field_names);
+    return buf;
+}
+
+QorePCA* QorePCA::deserializeState(const uint8_t* data, size_t len, ExceptionSink* xsink) {
+    const uint8_t* ptr = data;
+    size_t remaining = len;
+
+    int32_t n_components = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    double variance_threshold = MLSerialization::readScalar(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    bool center = MLSerialization::readBool(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    bool pca_scale = MLSerialization::readBool(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    int32_t actual_n_components = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t n_features = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    MatrixXd components = MLSerialization::readMatrix(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    VectorXd mean_vec = MLSerialization::readVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    VectorXd stddev_vec = MLSerialization::readVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    VectorXd explained_variance_ratio_vec = MLSerialization::readVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::vector<std::string> field_names = MLSerialization::readStringVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    std::unique_ptr<QorePCA> obj(new QorePCA(n_components, variance_threshold, center, pca_scale));
+    obj->actual_n_components = actual_n_components;
+    obj->n_features = n_features;
+    obj->components = std::move(components);
+    obj->mean_vec = std::move(mean_vec);
+    obj->stddev_vec = std::move(stddev_vec);
+    obj->explained_variance_ratio_vec = std::move(explained_variance_ratio_vec);
+    obj->field_names = std::move(field_names);
+    obj->fitted = true;
+    return obj.release();
 }

--- a/modules/ml/src/QC_CrossValidator.h
+++ b/modules/ml/src/QC_CrossValidator.h
@@ -1,0 +1,66 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_CrossValidator.h
+
+    Qore ml module - CrossValidator class
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _QORE_MODULE_ML_QC_CROSSVALIDATOR_H
+#define _QORE_MODULE_ML_QC_CROSSVALIDATOR_H
+
+#include "ml_common.h"
+
+#include <random>
+
+DLLEXPORT extern qore_classid_t CID_CROSSVALIDATOR;
+DLLLOCAL extern QoreClass* QC_CROSSVALIDATOR;
+
+DLLLOCAL void preinitCrossValidatorClass();
+DLLLOCAL QoreClass* initCrossValidatorClass(QoreNamespace& ns);
+
+//! CrossValidator — k-fold cross-validation split utility
+class QoreCrossValidator : public AbstractPrivateData {
+public:
+    DLLLOCAL QoreCrossValidator(int n_folds, bool shuffle, int64_t seed)
+        : n_folds(n_folds), do_shuffle(shuffle) {
+        if (seed == 0) {
+            std::random_device rd;
+            rng.seed(rd());
+        } else {
+            rng.seed(static_cast<unsigned>(seed));
+        }
+    }
+
+    //! Generate k-fold split indices
+    DLLLOCAL QoreListNode* split(int n_samples, ExceptionSink* xsink);
+
+    //! Getters
+    DLLLOCAL int getNumFolds() const { return n_folds; }
+
+private:
+    int n_folds;
+    bool do_shuffle;
+    std::mt19937 rng;
+};
+
+#endif // _QORE_MODULE_ML_QC_CROSSVALIDATOR_H

--- a/modules/ml/src/QC_CrossValidator.qpp
+++ b/modules/ml/src/QC_CrossValidator.qpp
@@ -1,0 +1,119 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_CrossValidator.qpp
+
+    Qore ml module - CrossValidator class definition
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "qore/Qore.h"
+#include "QC_CrossValidator.h"
+
+extern const TypedHashDecl* hashdeclCrossValidationFold;
+
+//! The CrossValidator class splits data indices into k folds for cross-validation
+/** Cross-validation helps evaluate how well a model generalizes to unseen data.
+    The data is split into k equally-sized folds; each fold takes a turn as the
+    test set while the remaining folds form the training set.
+
+    @par Example:
+    @code{.py}
+CrossValidator cv({"n_folds": 5, "shuffle": True, "seed": 42});
+list<hash<CrossValidationFold>> folds = cv.split(100);
+# folds[0]: {"train_indices": (20..99), "test_indices": (0..19), "fold": 0}
+# folds[1]: {"train_indices": (0..19,40..99), "test_indices": (20..39), "fold": 1}
+# ... 5 folds total, each sample appears in exactly one test set
+    @endcode
+*/
+qclass CrossValidator [arg=QoreCrossValidator* cv; ns=Qore::ML; flags=final];
+
+//! Creates a CrossValidator instance
+/** @param options a hash with the following keys:
+    - \c n_folds (int, default 5): number of folds (must be >= 2)
+    - \c shuffle (bool, default False): whether to shuffle indices before splitting
+    - \c seed (int, default 0 = random): random seed for reproducible shuffling
+
+    @throw ML-CROSS-VALIDATOR-ERROR invalid option values
+*/
+CrossValidator::constructor(*hash<auto> options) {
+    int64 n_folds = 5;
+    bool shuffle = false;
+    int64 seed = 0;
+
+    if (options) {
+        QoreValue v = options->getKeyValue("n_folds");
+        if (!v.isNullOrNothing()) {
+            n_folds = v.getAsBigInt();
+        }
+        v = options->getKeyValue("shuffle");
+        if (!v.isNullOrNothing()) {
+            shuffle = v.getAsBool();
+        }
+        v = options->getKeyValue("seed");
+        if (!v.isNullOrNothing()) {
+            seed = v.getAsBigInt();
+        }
+    }
+
+    if (n_folds < 2) {
+        xsink->raiseException("ML-CROSS-VALIDATOR-ERROR",
+            "n_folds must be >= 2; got " QLLD, n_folds);
+        return;
+    }
+
+    self->setPrivate(CID_CROSSVALIDATOR,
+        new QoreCrossValidator(static_cast<int>(n_folds), shuffle, seed));
+}
+
+//! Creates a copy of the CrossValidator instance
+/** @throw COPY-ERROR CrossValidator objects cannot be copied
+*/
+CrossValidator::copy() {
+    xsink->raiseException("COPY-ERROR", "CrossValidator objects cannot be copied");
+}
+
+//! Splits sample indices into k folds
+/** @param n_samples the total number of samples
+    @return a list of @ref CrossValidationFold hashes, one per fold
+
+    @par Example:
+    @code{.py}
+CrossValidator cv({"n_folds": 3, "shuffle": True, "seed": 42});
+list<hash<CrossValidationFold>> folds = cv.split(90);
+foreach hash<CrossValidationFold> fold in (folds) {
+    printf("Fold %d: %d train, %d test\n", fold.fold,
+        fold.train_indices.lsize(), fold.test_indices.lsize());
+}
+    @endcode
+
+    @throw ML-CROSS-VALIDATOR-ERROR n_samples < n_folds
+*/
+list<hash<CrossValidationFold>> CrossValidator::split(int n_samples) {
+    return cv->split(n_samples, xsink);
+}
+
+//! Returns the number of folds
+/** @return the k value
+*/
+int CrossValidator::getNumFolds() [flags=CONSTANT] {
+    return cv->getNumFolds();
+}

--- a/modules/ml/src/QC_DBSCAN.h
+++ b/modules/ml/src/QC_DBSCAN.h
@@ -58,7 +58,7 @@ private:
     std::string metric;
 
     //! Compute pairwise distance matrix
-    DLLLOCAL MatrixXd computeDistanceMatrix(const MatrixXd& data) const;
+    DLLLOCAL MatrixXd computeDistanceMatrix(const MatrixXd& data, ExceptionSink* xsink) const;
 
     //! Find neighbors of a point within epsilon
     DLLLOCAL std::vector<int> findNeighbors(const MatrixXd& dist_matrix, int point_idx) const;

--- a/modules/ml/src/QC_DBSCAN.qpp
+++ b/modules/ml/src/QC_DBSCAN.qpp
@@ -40,7 +40,6 @@ DBSCAN db({"epsilon": 0.5, "min_points": 5, "metric": "euclidean"});
 list<hash<DBSCANResult>> results = db.cluster(data_records);
     @endcode
 
-    @since ml 1.0
 */
 qclass DBSCAN [arg=QoreDBSCAN* dbscan; ns=Qore::ML; flags=final];
 

--- a/modules/ml/src/QC_GMM.h
+++ b/modules/ml/src/QC_GMM.h
@@ -50,6 +50,9 @@ public:
     //! Fit on an Eigen matrix
     DLLLOCAL void fit(const MatrixXd& data, ExceptionSink* xsink);
 
+    //! Online EM update with new data (thread-safe)
+    DLLLOCAL void update(const MatrixXd& data, ExceptionSink* xsink);
+
     //! Predict cluster membership for a single point
     DLLLOCAL QoreHashNode* predict(const RowVectorXd& point, ExceptionSink* xsink) const;
 
@@ -80,6 +83,7 @@ private:
     std::mt19937 rng;
     bool fitted = false;
     int n_features = 0;
+    int batch_count = 0;
 
     //! Model parameters
     std::vector<VectorXd> means;         // n_components means

--- a/modules/ml/src/QC_GMM.h
+++ b/modules/ml/src/QC_GMM.h
@@ -75,6 +75,13 @@ public:
     DLLLOCAL void setFieldNames(const std::vector<std::string>& names) { field_names = names; }
     DLLLOCAL const std::vector<std::string>& getFieldNames() const { return field_names; }
 
+    //! Serialize model state to binary
+    DLLLOCAL std::vector<uint8_t> serializeState() const;
+
+    //! Deserialize model state from binary
+    DLLLOCAL static QoreGMM* deserializeState(const uint8_t* data, size_t len,
+        ExceptionSink* xsink);
+
 private:
     int n_components;
     int max_iterations;

--- a/modules/ml/src/QC_GMM.qpp
+++ b/modules/ml/src/QC_GMM.qpp
@@ -58,7 +58,6 @@ hash<GMMResult> result = gmm.predict({"x": 1.05, "y": 0.95});
 printf("Cluster: %d, Probability: %f\n", result.cluster, result.max_probability);
     @endcode
 
-    @since ml 1.0
 */
 qclass GMM [arg=QoreGMM* gmm; ns=Qore::ML; flags=final];
 

--- a/modules/ml/src/QC_GMM.qpp
+++ b/modules/ml/src/QC_GMM.qpp
@@ -179,6 +179,46 @@ nothing GMM::fitMatrix(list<auto> matrix) {
     gmm->fit(mat, xsink);
 }
 
+//! Performs an online EM update with new hash-based data
+/** @param data a list of hashes with numeric fields
+
+    @par Example:
+    @code{.py}
+gmm.fit(initial_data);
+gmm.update(new_observations);  # refine clusters with new data
+    @endcode
+
+    @throw ML-GMM-ERROR model not fitted or dimension mismatch
+    @throw ML-DATA-ERROR data format errors
+*/
+nothing GMM::update(list<auto> data) {
+    std::vector<std::string> field_names;
+    MatrixXd matrix = qoreListOfHashesToMatrix(data, field_names, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    gmm->update(matrix, xsink);
+}
+
+//! Performs an online EM update with a numeric matrix
+/** @param matrix a list of lists of numeric values
+
+    @par Example:
+    @code{.py}
+gmm.updateMatrix(((1.5, 2.0), (3.0, 4.5)));
+    @endcode
+
+    @throw ML-GMM-ERROR model not fitted or dimension mismatch
+    @throw ML-DATA-ERROR data format errors
+*/
+nothing GMM::updateMatrix(list<auto> matrix) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    gmm->update(mat, xsink);
+}
+
 //! Predicts cluster membership for a single record
 /** @param record a hash with the same numeric fields used during training
 

--- a/modules/ml/src/QC_HoltWinters.h
+++ b/modules/ml/src/QC_HoltWinters.h
@@ -64,6 +64,13 @@ public:
     DLLLOCAL QoreValue getTrend(ExceptionSink* xsink);
     DLLLOCAL QoreListNode* getSeasonal(ExceptionSink* xsink);
 
+    //! Serialize model state to binary
+    DLLLOCAL std::vector<uint8_t> serializeState() const;
+
+    //! Deserialize model state from binary
+    DLLLOCAL static QoreHoltWinters* deserializeState(const uint8_t* data, size_t len,
+        ExceptionSink* xsink);
+
 private:
     int period;
     double alpha;

--- a/modules/ml/src/QC_HoltWinters.qpp
+++ b/modules/ml/src/QC_HoltWinters.qpp
@@ -41,7 +41,6 @@ hw.fit(historical_monthly_values);
 list<float> next_year = hw.forecast(12);
     @endcode
 
-    @since ml 1.0
 */
 qclass HoltWinters [arg=QoreHoltWinters* hw; ns=Qore::ML; flags=final];
 

--- a/modules/ml/src/QC_Imputer.h
+++ b/modules/ml/src/QC_Imputer.h
@@ -1,0 +1,94 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_Imputer.h
+
+    Qore ml module - Imputer class
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _QORE_MODULE_ML_QC_IMPUTER_H
+#define _QORE_MODULE_ML_QC_IMPUTER_H
+
+#include "ml_common.h"
+
+#include <mutex>
+#include <string>
+
+DLLEXPORT extern qore_classid_t CID_IMPUTER;
+DLLLOCAL extern QoreClass* QC_IMPUTER;
+
+DLLLOCAL void preinitImputerClass();
+DLLLOCAL QoreClass* initImputerClass(QoreNamespace& ns);
+
+//! Imputer — fills missing values (NaN) using a configurable strategy
+class QoreImputer : public AbstractPrivateData {
+public:
+    DLLLOCAL QoreImputer(const std::string& strategy, double constant_value)
+        : strategy(strategy), constant_value(constant_value) {
+    }
+
+    //! Compute fill values from training data
+    DLLLOCAL void fit(const MatrixXd& data, ExceptionSink* xsink);
+
+    //! Replace NaN values with fitted fill values
+    DLLLOCAL MatrixXd transform(const MatrixXd& data, ExceptionSink* xsink) const;
+
+    //! Fit and transform in one step
+    DLLLOCAL MatrixXd fitTransform(const MatrixXd& data, ExceptionSink* xsink);
+
+    //! Whether the imputer has been fitted
+    DLLLOCAL bool isFitted() const { return fitted; }
+
+    //! Get imputer info
+    DLLLOCAL QoreHashNode* getInfo(ExceptionSink* xsink) const;
+
+    //! Store field names
+    DLLLOCAL void setFieldNames(const std::vector<std::string>& names) { field_names = names; }
+    DLLLOCAL const std::vector<std::string>& getFieldNames() const { return field_names; }
+
+    //! Transform a single row (no lock, no fitted check)
+    DLLLOCAL RowVectorXd transformRow(const RowVectorXd& row, ExceptionSink* xsink) const;
+
+    //! Getters
+    DLLLOCAL int getNumFeatures() const { return n_features; }
+    DLLLOCAL const std::string& getStrategy() const { return strategy; }
+
+private:
+    std::string strategy;       // "mean", "median", "most_frequent", "constant"
+    double constant_value;
+    bool fitted = false;
+    int n_features = 0;
+
+    VectorXd fill_values;       // one per feature
+
+    std::vector<std::string> field_names;
+
+    mutable std::mutex mtx;
+
+    //! Compute the median of non-NaN values in a column
+    DLLLOCAL static double computeMedian(const MatrixXd& data, Eigen::Index col);
+
+    //! Compute the most frequent value of non-NaN values in a column
+    DLLLOCAL static double computeMostFrequent(const MatrixXd& data, Eigen::Index col);
+};
+
+#endif // _QORE_MODULE_ML_QC_IMPUTER_H

--- a/modules/ml/src/QC_Imputer.h
+++ b/modules/ml/src/QC_Imputer.h
@@ -72,6 +72,13 @@ public:
     DLLLOCAL int getNumFeatures() const { return n_features; }
     DLLLOCAL const std::string& getStrategy() const { return strategy; }
 
+    //! Serialize model state to binary
+    DLLLOCAL std::vector<uint8_t> serializeState() const;
+
+    //! Deserialize model state from binary
+    DLLLOCAL static QoreImputer* deserializeState(const uint8_t* data, size_t len,
+        ExceptionSink* xsink);
+
 private:
     std::string strategy;       // "mean", "median", "most_frequent", "constant"
     double constant_value;

--- a/modules/ml/src/QC_Imputer.qpp
+++ b/modules/ml/src/QC_Imputer.qpp
@@ -1,0 +1,249 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_Imputer.qpp
+
+    Qore ml module - Imputer class definition
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "qore/Qore.h"
+#include "QC_Imputer.h"
+
+extern const TypedHashDecl* hashdeclImputerInfo;
+
+//! The Imputer class fills missing values (NaN) using a configurable strategy
+/** Imputer replaces missing values (NaN or NOTHING) in numeric data with computed
+    fill values. Strategies include mean, median, most frequent, and constant.
+
+    @par Example:
+    @code{.py}
+Imputer imp({"strategy": "mean"});
+imp.fitMatrix(training_data);
+list<auto> filled = imp.transformMatrix(data_with_missing);
+    @endcode
+
+*/
+qclass Imputer [arg=QoreImputer* imputer; ns=Qore::ML; flags=final];
+
+//! Creates an Imputer instance
+/** @param options a hash with the following optional keys:
+    - \c strategy (string, default "mean"): imputation strategy — one of:
+      - \c "mean": replace with column mean
+      - \c "median": replace with column median
+      - \c "most_frequent": replace with most common value
+      - \c "constant": replace with a fixed value
+    - \c constant_value (float, default 0.0): fill value when strategy is "constant"
+
+    @throw ML-IMPUTER-ERROR invalid strategy
+*/
+Imputer::constructor(*hash<auto> options) {
+    const char* strategy = "mean";
+    double constant_value = 0.0;
+
+    if (options) {
+        QoreValue v = options->getKeyValue("strategy");
+        if (!v.isNullOrNothing() && v.getType() == NT_STRING) {
+            strategy = v.get<const QoreStringNode>()->c_str();
+        }
+        v = options->getKeyValue("constant_value");
+        if (!v.isNullOrNothing()) {
+            constant_value = v.getAsFloat();
+        }
+    }
+
+    if (strcmp(strategy, "mean") != 0 && strcmp(strategy, "median") != 0
+            && strcmp(strategy, "most_frequent") != 0 && strcmp(strategy, "constant") != 0) {
+        xsink->raiseException("ML-IMPUTER-ERROR",
+            "invalid strategy '%s': must be 'mean', 'median', 'most_frequent', or 'constant'",
+            strategy);
+        return;
+    }
+
+    self->setPrivate(CID_IMPUTER, new QoreImputer(strategy, constant_value));
+}
+
+//! Creates a copy of the Imputer instance
+/** @throw COPY-ERROR Imputer objects cannot be copied
+*/
+Imputer::copy() {
+    xsink->raiseException("COPY-ERROR", "Imputer objects cannot be copied");
+}
+
+//! Fits the imputer on a list of hash records
+/** @param data a list of hashes with numeric fields (NOTHING values treated as missing)
+
+    @throw ML-IMPUTER-ERROR empty data
+    @throw ML-DATA-ERROR data format errors
+*/
+nothing Imputer::fit(list<auto> data) {
+    std::vector<std::string> field_names;
+    MatrixXd matrix = qoreListOfHashesToMatrix(data, field_names, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    imputer->setFieldNames(field_names);
+    imputer->fit(matrix, xsink);
+}
+
+//! Fits the imputer on a numeric matrix
+/** @param matrix a list of lists of numeric values (NaN values treated as missing)
+
+    @throw ML-IMPUTER-ERROR empty data
+    @throw ML-DATA-ERROR data format errors
+*/
+nothing Imputer::fitMatrix(list<auto> matrix) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    imputer->fit(mat, xsink);
+}
+
+//! Transforms a single record by filling missing values
+/** @param record a hash with numeric fields
+    @return a hash with missing values replaced
+
+    @throw ML-IMPUTER-ERROR imputer not fitted or dimension mismatch
+*/
+hash<auto> Imputer::transform(hash<auto> record) {
+    const std::vector<std::string>& field_names = imputer->getFieldNames();
+    if (field_names.empty()) {
+        xsink->raiseException("ML-IMPUTER-ERROR",
+            "imputer was fitted with fitMatrix(); use transformMatrix() or fit() with hash records");
+        return QoreValue();
+    }
+    RowVectorXd point = qoreHashToRowVector(record, field_names, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    // Use matrix API for thread safety (holds the lock internally)
+    MatrixXd mat(1, point.size());
+    mat.row(0) = point;
+    MatrixXd result_mat = imputer->transform(mat, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    ReferenceHolder<QoreHashNode> rv(new QoreHashNode(autoTypeInfo), xsink);
+    for (size_t i = 0; i < field_names.size(); ++i) {
+        rv->setKeyValue(field_names[i].c_str(), result_mat(0, i), xsink);
+    }
+    return rv.release();
+}
+
+//! Transforms a numeric matrix by filling NaN values
+/** @param matrix a list of lists of numeric values
+    @return a list of lists with NaN values replaced
+
+    @throw ML-IMPUTER-ERROR imputer not fitted or dimension mismatch
+    @throw ML-DATA-ERROR data format errors
+*/
+list<list<float>> Imputer::transformMatrix(list<auto> matrix) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    MatrixXd result = imputer->transform(mat, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(autoTypeInfo), xsink);
+    for (Eigen::Index i = 0; i < result.rows(); ++i) {
+        ReferenceHolder<QoreListNode> row(new QoreListNode(floatTypeInfo), xsink);
+        for (Eigen::Index j = 0; j < result.cols(); ++j) {
+            row->push(result(i, j), xsink);
+        }
+        rv->push(row.release(), xsink);
+    }
+    return rv.release();
+}
+
+//! Fits and transforms in a single step
+/** @param data a list of hashes with numeric fields
+    @return a list of hashes with missing values replaced
+
+    @throw ML-IMPUTER-ERROR empty data
+    @throw ML-DATA-ERROR data format errors
+*/
+list<hash<auto>> Imputer::fitTransform(list<auto> data) {
+    std::vector<std::string> field_names;
+    MatrixXd matrix = qoreListOfHashesToMatrix(data, field_names, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    imputer->setFieldNames(field_names);
+    MatrixXd result = imputer->fitTransform(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(autoTypeInfo), xsink);
+    for (Eigen::Index i = 0; i < result.rows(); ++i) {
+        ReferenceHolder<QoreHashNode> row(new QoreHashNode(autoTypeInfo), xsink);
+        for (size_t j = 0; j < field_names.size(); ++j) {
+            row->setKeyValue(field_names[j].c_str(), result(i, j), xsink);
+        }
+        rv->push(row.release(), xsink);
+    }
+    return rv.release();
+}
+
+//! Fits and transforms a numeric matrix in a single step
+/** @param matrix a list of lists of numeric values
+    @return a list of lists with NaN values replaced
+
+    @throw ML-IMPUTER-ERROR empty data
+    @throw ML-DATA-ERROR data format errors
+*/
+list<list<float>> Imputer::fitTransformMatrix(list<auto> matrix) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    MatrixXd result = imputer->fitTransform(mat, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(autoTypeInfo), xsink);
+    for (Eigen::Index i = 0; i < result.rows(); ++i) {
+        ReferenceHolder<QoreListNode> row(new QoreListNode(floatTypeInfo), xsink);
+        for (Eigen::Index j = 0; j < result.cols(); ++j) {
+            row->push(result(i, j), xsink);
+        }
+        rv->push(row.release(), xsink);
+    }
+    return rv.release();
+}
+
+//! Returns True if the imputer has been fitted
+/** @return True if fit() or fitMatrix() has been called successfully
+*/
+bool Imputer::isFitted() [flags=CONSTANT] {
+    return imputer->isFitted();
+}
+
+//! Returns imputer information
+/** @return a @ref ImputerInfo hash with the imputer's parameters
+
+    @throw ML-IMPUTER-ERROR imputer not fitted
+*/
+hash<ImputerInfo> Imputer::getInfo() {
+    return imputer->getInfo(xsink);
+}

--- a/modules/ml/src/QC_IsolationForest.h
+++ b/modules/ml/src/QC_IsolationForest.h
@@ -90,6 +90,13 @@ public:
     DLLLOCAL void setFieldNames(const std::vector<std::string>& names) { field_names = names; }
     DLLLOCAL const std::vector<std::string>& getFieldNames() const { return field_names; }
 
+    //! Serialize model state to binary
+    DLLLOCAL std::vector<uint8_t> serializeState() const;
+
+    //! Deserialize model state from binary
+    DLLLOCAL static QoreIsolationForest* deserializeState(const uint8_t* data, size_t len,
+        ExceptionSink* xsink);
+
 private:
     int n_trees;
     int sample_size;

--- a/modules/ml/src/QC_IsolationForest.qpp
+++ b/modules/ml/src/QC_IsolationForest.qpp
@@ -59,7 +59,6 @@ hash<IsolationForestResult> result = iforest.score({"temperature": 85.0, "pressu
 printf("Anomaly score: %f, is anomaly: %y\n", result.anomaly_score, result.is_anomaly);
     @endcode
 
-    @since ml 1.0
 */
 qclass IsolationForest [arg=QoreIsolationForest* iforest; ns=Qore::ML; flags=final];
 

--- a/modules/ml/src/QC_KMeans.h
+++ b/modules/ml/src/QC_KMeans.h
@@ -78,6 +78,13 @@ public:
     DLLLOCAL void setFieldNames(const std::vector<std::string>& names) { field_names = names; }
     DLLLOCAL const std::vector<std::string>& getFieldNames() const { return field_names; }
 
+    //! Serialize model state to binary
+    DLLLOCAL std::vector<uint8_t> serializeState() const;
+
+    //! Deserialize model state from binary
+    DLLLOCAL static QoreKMeans* deserializeState(const uint8_t* data, size_t len,
+        ExceptionSink* xsink);
+
 private:
     int k;
     int max_iterations;

--- a/modules/ml/src/QC_KMeans.qpp
+++ b/modules/ml/src/QC_KMeans.qpp
@@ -42,7 +42,6 @@ km.fitMatrix(training_data);
 hash<KMeansResult> result = km.predict({"x": 1.0, "y": 2.0});
     @endcode
 
-    @since ml 1.0
 */
 qclass KMeans [arg=QoreKMeans* kmeans; ns=Qore::ML; flags=final];
 

--- a/modules/ml/src/QC_KNN.h
+++ b/modules/ml/src/QC_KNN.h
@@ -1,0 +1,94 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_KNN.h
+
+    Qore ml module - K-Nearest Neighbors class
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _QORE_MODULE_ML_QC_KNN_H
+#define _QORE_MODULE_ML_QC_KNN_H
+
+#include "ml_common.h"
+
+#include <mutex>
+#include <vector>
+
+DLLEXPORT extern qore_classid_t CID_KNN;
+DLLLOCAL extern QoreClass* QC_KNN;
+
+DLLLOCAL void preinitKNNClass();
+DLLLOCAL QoreClass* initKNNClass(QoreNamespace& ns);
+
+//! K-Nearest Neighbors implementation class
+class QoreKNN : public AbstractPrivateData {
+public:
+    //! Constructor with options
+    DLLLOCAL QoreKNN(int k, const std::string& metric, const std::string& task,
+        const std::string& weight_func);
+
+    //! Fit on feature matrix X and label vector y (thread-safe)
+    DLLLOCAL void fit(const MatrixXd& X, const VectorXd& y, ExceptionSink* xsink);
+
+    //! Predict for a single row vector
+    DLLLOCAL QoreHashNode* predict(const RowVectorXd& point, ExceptionSink* xsink) const;
+
+    //! Predict for multiple rows
+    DLLLOCAL QoreListNode* predictMatrix(const MatrixXd& X, ExceptionSink* xsink) const;
+
+    //! Whether the model has been fitted
+    DLLLOCAL bool isFitted() const { return fitted; }
+
+    //! Get k parameter
+    DLLLOCAL int getK() const { return k; }
+
+    //! Store field names for hash-based input
+    DLLLOCAL void setFieldNames(const std::vector<std::string>& names) { field_names = names; }
+    DLLLOCAL const std::vector<std::string>& getFieldNames() const { return field_names; }
+
+    //! Store the target field name
+    DLLLOCAL void setTargetField(const std::string& name) { target_field = name; }
+    DLLLOCAL const std::string& getTargetField() const { return target_field; }
+
+private:
+    int k;
+    std::string metric;       // "euclidean", "manhattan", "cosine"
+    std::string task;          // "classification", "regression"
+    std::string weight_func;   // "uniform", "distance"
+
+    MatrixXd ref_data;         // stored training data
+    VectorXd ref_labels;       // stored training labels
+    int n_features = 0;
+    bool fitted = false;
+    std::vector<std::string> field_names;
+    std::string target_field;
+
+    mutable std::mutex mtx;
+
+    //! Predict for a single point (must be called with mtx held)
+    DLLLOCAL QoreHashNode* predictInternal(const RowVectorXd& point, ExceptionSink* xsink) const;
+
+    //! Compute distance between two row vectors using the configured metric
+    DLLLOCAL double computeDistance(const RowVectorXd& a, const RowVectorXd& b) const;
+};
+
+#endif // _QORE_MODULE_ML_QC_KNN_H

--- a/modules/ml/src/QC_KNN.h
+++ b/modules/ml/src/QC_KNN.h
@@ -69,6 +69,13 @@ public:
     DLLLOCAL void setTargetField(const std::string& name) { target_field = name; }
     DLLLOCAL const std::string& getTargetField() const { return target_field; }
 
+    //! Serialize model state to binary
+    DLLLOCAL std::vector<uint8_t> serializeState() const;
+
+    //! Deserialize model state from binary
+    DLLLOCAL static QoreKNN* deserializeState(const uint8_t* data, size_t len,
+        ExceptionSink* xsink);
+
 private:
     int k;
     std::string metric;       // "euclidean", "manhattan", "cosine"

--- a/modules/ml/src/QC_KNN.qpp
+++ b/modules/ml/src/QC_KNN.qpp
@@ -1,0 +1,309 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_KNN.qpp
+
+    Qore ml module - KNN class definition
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "qore/Qore.h"
+#include "QC_KNN.h"
+
+// Extern declarations for hashdecls (defined in ml-module.cpp)
+extern const TypedHashDecl* hashdeclKNNClassificationResult;
+extern const TypedHashDecl* hashdeclKNNRegressionResult;
+
+//! The KNN class implements the K-Nearest Neighbors algorithm for classification and regression
+/** KNN is a lazy learner that stores training data and makes predictions by finding the k
+    closest data points to a query point. For classification, it uses majority voting (optionally
+    weighted by distance). For regression, it computes the (optionally weighted) mean of the
+    k nearest neighbors' target values.
+
+    Supports three distance metrics: Euclidean, Manhattan, and cosine distance.
+
+    @par Example:
+    @code{.py}
+# Classification
+KNN knn({"k": 5, "task": "classification", "weight_func": "distance"});
+knn.fit(training_data, "species");
+hash<auto> result = knn.predict({"sepal_length": 5.1, "sepal_width": 3.5});
+printf("Predicted class: %d, Confidence: %.2f\n", result.predicted_class, result.confidence);
+
+# Regression
+KNN knn_reg({"k": 3, "task": "regression", "metric": "manhattan"});
+knn_reg.fit(training_data, "price");
+hash<auto> result = knn_reg.predict({"sqft": 1500, "bedrooms": 3});
+printf("Predicted price: %.2f\n", result.prediction);
+    @endcode
+
+*/
+qclass KNN [arg=QoreKNN* knn; ns=Qore::ML; flags=final];
+
+//! Creates a KNN instance with the given options
+/** @param options a hash with the following keys:
+    - \c k (int, required): number of nearest neighbors to use; must be >= 1
+    - \c metric (string, default "euclidean"): distance metric; allowed values: "euclidean", "manhattan", "cosine"
+    - \c task (string, default "classification"): prediction task; allowed values: "classification", "regression"
+    - \c weight_func (string, default "uniform"): neighbor weighting; allowed values: "uniform", "distance"
+
+    @par Example:
+    @code{.py}
+KNN knn({"k": 5, "metric": "euclidean", "task": "classification", "weight_func": "distance"});
+    @endcode
+
+    @throw ML-KNN-ERROR invalid option values
+*/
+KNN::constructor(hash<auto> options) {
+    int64 k = 0;
+    const char* metric = "euclidean";
+    const char* task = "classification";
+    const char* weight_func = "uniform";
+
+    QoreValue v = options->getKeyValue("k");
+    if (v.isNullOrNothing()) {
+        xsink->raiseException("ML-KNN-ERROR",
+            "required option 'k' not provided");
+        return;
+    }
+    k = v.getAsBigInt();
+
+    v = options->getKeyValue("metric");
+    if (!v.isNullOrNothing() && v.getType() == NT_STRING) {
+        metric = v.get<const QoreStringNode>()->c_str();
+    }
+
+    v = options->getKeyValue("task");
+    if (!v.isNullOrNothing() && v.getType() == NT_STRING) {
+        task = v.get<const QoreStringNode>()->c_str();
+    }
+
+    v = options->getKeyValue("weight_func");
+    if (!v.isNullOrNothing() && v.getType() == NT_STRING) {
+        weight_func = v.get<const QoreStringNode>()->c_str();
+    }
+
+    if (k < 1) {
+        xsink->raiseException("ML-KNN-ERROR",
+            "k must be >= 1; got " QLLD, k);
+        return;
+    }
+
+    if (strcmp(metric, "euclidean") != 0 && strcmp(metric, "manhattan") != 0
+        && strcmp(metric, "cosine") != 0) {
+        xsink->raiseException("ML-KNN-ERROR",
+            "metric must be 'euclidean', 'manhattan', or 'cosine'; got '%s'", metric);
+        return;
+    }
+
+    if (strcmp(task, "classification") != 0 && strcmp(task, "regression") != 0) {
+        xsink->raiseException("ML-KNN-ERROR",
+            "task must be 'classification' or 'regression'; got '%s'", task);
+        return;
+    }
+
+    if (strcmp(weight_func, "uniform") != 0 && strcmp(weight_func, "distance") != 0) {
+        xsink->raiseException("ML-KNN-ERROR",
+            "weight_func must be 'uniform' or 'distance'; got '%s'", weight_func);
+        return;
+    }
+
+    self->setPrivate(CID_KNN,
+        new QoreKNN(static_cast<int>(k), metric, task, weight_func));
+}
+
+//! Creates a copy of the KNN instance
+/** @throw COPY-ERROR KNN objects cannot be copied
+*/
+KNN::copy() {
+    xsink->raiseException("COPY-ERROR", "KNN objects cannot be copied");
+}
+
+//! Trains the model on a list of hash records with a target field
+/** Extracts numeric fields (excluding the target) from the records as features,
+    and uses the target field as the label/target variable.
+
+    @param data a list of hashes where each hash represents a record
+    @param target_field the name of the field to predict
+
+    @par Example:
+    @code{.py}
+knn.fit(training_data, "species");
+    @endcode
+
+    @throw ML-DATA-ERROR if data is empty or has no numeric fields
+    @throw ML-KNN-ERROR if fitting fails
+*/
+nothing KNN::fit(list<auto> data, string target_field) {
+    // Extract field names from first record, excluding target
+    if (!data || data->empty()) {
+        xsink->raiseException("ML-DATA-ERROR", "empty data list provided");
+        return QoreValue();
+    }
+
+    QoreValue first = data->retrieveEntry(0);
+    if (first.getType() != NT_HASH) {
+        xsink->raiseException("ML-DATA-ERROR", "data list must contain hash elements");
+        return QoreValue();
+    }
+    const QoreHashNode* first_hash = first.get<const QoreHashNode>();
+    const char* target_str = target_field->c_str();
+
+    // Collect numeric field names excluding target
+    std::vector<std::string> feat_names;
+    ConstHashIterator hi(first_hash);
+    while (hi.next()) {
+        if (strcmp(hi.getKey(), target_str) == 0) {
+            continue;
+        }
+        QoreValue val = hi.get();
+        qore_type_t vt = val.getType();
+        if (vt == NT_INT || vt == NT_FLOAT || vt == NT_NUMBER) {
+            feat_names.push_back(hi.getKey());
+        }
+    }
+
+    if (feat_names.empty()) {
+        xsink->raiseException("ML-DATA-ERROR",
+            "no numeric feature fields found in data (excluding target '%s')",
+            target_str);
+        return QoreValue();
+    }
+
+    size_t n_rows = data->size();
+    size_t n_cols = feat_names.size();
+    MatrixXd X(n_rows, n_cols);
+    VectorXd y(n_rows);
+
+    for (size_t i = 0; i < n_rows; ++i) {
+        QoreValue row_val = data->retrieveEntry(i);
+        if (row_val.getType() != NT_HASH) {
+            xsink->raiseException("ML-DATA-ERROR", "data element %zu is not a hash", i);
+            return QoreValue();
+        }
+        const QoreHashNode* row = row_val.get<const QoreHashNode>();
+        for (size_t j = 0; j < n_cols; ++j) {
+            QoreValue fv = row->getKeyValue(feat_names[j].c_str());
+            X(i, j) = fv.getAsFloat();
+        }
+        QoreValue target_v = row->getKeyValue(target_str);
+        y(i) = target_v.getAsFloat();
+    }
+
+    knn->setFieldNames(feat_names);
+    knn->setTargetField(target_str);
+    knn->fit(X, y, xsink);
+}
+
+//! Trains the model on a numeric feature matrix and target vector
+/** @param matrix a list of lists where each inner list is a row of feature values
+    @param target a list of target values (class labels for classification, numeric values for regression)
+
+    @par Example:
+    @code{.py}
+knn.fitMatrix(((1.0, 2.0), (3.0, 4.0), (5.0, 6.0)), (0, 1, 0));
+    @endcode
+
+    @throw ML-DATA-ERROR if the matrix is empty or malformed
+    @throw ML-KNN-ERROR if fitting fails
+*/
+nothing KNN::fitMatrix(list<auto> matrix, list<auto> target) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    VectorXd y = qoreListToVector(target, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    knn->fit(mat, y, xsink);
+}
+
+//! Predicts the class or target value for a single record
+/** @param record a hash with the same numeric fields used during training
+
+    @return a hash with prediction results; the concrete type depends on the \c task option:
+    - for \c "classification": a @ref KNNClassificationResult hash with \c predicted_class,
+      \c confidence, and \c neighbors
+    - for \c "regression": a @ref KNNRegressionResult hash with \c prediction and \c neighbors
+
+    @par Example:
+    @code{.py}
+hash<auto> result = knn.predict({"sepal_length": 5.1, "sepal_width": 3.5});
+    @endcode
+
+    @throw ML-KNN-ERROR if the model has not been fitted or input dimensions mismatch
+*/
+hash<auto> KNN::predict(hash<auto> record) {
+    const std::vector<std::string>& feat_names = knn->getFieldNames();
+    if (feat_names.empty()) {
+        xsink->raiseException("ML-KNN-ERROR",
+            "model was fitted with fitMatrix(); use predictMatrix() or fit() with hash records");
+        return QoreValue();
+    }
+    RowVectorXd point = qoreHashToRowVector(record, feat_names, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    return knn->predict(point, xsink);
+}
+
+//! Predicts class or target values for multiple rows in matrix form
+/** @param matrix a list of lists where each inner list is a row of feature values
+
+    @return a list of result hashes (see predict() for the hash structure)
+
+    @par Example:
+    @code{.py}
+list<hash<auto>> results = knn.predictMatrix(((5.1, 3.5), (6.2, 2.8)));
+    @endcode
+
+    @throw ML-KNN-ERROR if the model has not been fitted or input dimensions mismatch
+    @throw ML-DATA-ERROR data format errors
+*/
+list<hash<auto>> KNN::predictMatrix(list<auto> matrix) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    return knn->predictMatrix(mat, xsink);
+}
+
+//! Returns True if the model has been fitted
+/** @return True if fit() or fitMatrix() has been called successfully
+
+    @par Example:
+    @code{.py}
+if (!knn.isFitted()) {
+    knn.fit(data, "target");
+}
+    @endcode
+*/
+bool KNN::isFitted() [flags=CONSTANT] {
+    return knn->isFitted();
+}
+
+//! Returns the k (number of neighbors) parameter
+/** @return the k parameter value
+*/
+int KNN::getK() [flags=CONSTANT] {
+    return knn->getK();
+}

--- a/modules/ml/src/QC_LOF.h
+++ b/modules/ml/src/QC_LOF.h
@@ -64,6 +64,13 @@ public:
     DLLLOCAL void setFieldNames(const std::vector<std::string>& names) { field_names = names; }
     DLLLOCAL const std::vector<std::string>& getFieldNames() const { return field_names; }
 
+    //! Serialize model state to binary
+    DLLLOCAL std::vector<uint8_t> serializeState() const;
+
+    //! Deserialize model state from binary
+    DLLLOCAL static QoreLOF* deserializeState(const uint8_t* data, size_t len,
+        ExceptionSink* xsink);
+
 private:
     int k;
     double threshold;

--- a/modules/ml/src/QC_LOF.qpp
+++ b/modules/ml/src/QC_LOF.qpp
@@ -66,7 +66,6 @@ hash<LOFResult> result = lof.score({"x": 10.0, "y": 10.0});
 printf("LOF score: %f, is anomaly: %y\n", result.lof_score, result.is_anomaly);
     @endcode
 
-    @since ml 1.0
 */
 qclass LOF [arg=QoreLOF* lof; ns=Qore::ML; flags=final];
 

--- a/modules/ml/src/QC_LinearRegression.h
+++ b/modules/ml/src/QC_LinearRegression.h
@@ -47,6 +47,9 @@ public:
     //! Fit on feature matrix X and target vector y (thread-safe)
     DLLLOCAL void fit(const MatrixXd& X, const VectorXd& y, ExceptionSink* xsink);
 
+    //! SGD update with new data (thread-safe)
+    DLLLOCAL void update(const MatrixXd& X, const VectorXd& y, double learning_rate, ExceptionSink* xsink);
+
     //! Predict for a single row vector
     DLLLOCAL QoreHashNode* predict(const RowVectorXd& point, ExceptionSink* xsink) const;
 

--- a/modules/ml/src/QC_LinearRegression.h
+++ b/modules/ml/src/QC_LinearRegression.h
@@ -79,6 +79,13 @@ public:
     DLLLOCAL void setTargetField(const std::string& name) { target_field = name; }
     DLLLOCAL const std::string& getTargetField() const { return target_field; }
 
+    //! Serialize model state to binary
+    DLLLOCAL std::vector<uint8_t> serializeState() const;
+
+    //! Deserialize model state from binary
+    DLLLOCAL static QoreLinearRegression* deserializeState(const uint8_t* data, size_t len,
+        ExceptionSink* xsink);
+
 private:
     bool fit_intercept;
     bool do_normalize;

--- a/modules/ml/src/QC_LinearRegression.qpp
+++ b/modules/ml/src/QC_LinearRegression.qpp
@@ -57,7 +57,6 @@ hash<LinearRegressionResult> result = lr.predict({"x1": 4.0, "x2": 5.0});
 printf("Prediction: %f, R-squared: %f\n", result.prediction, result.r_squared);
     @endcode
 
-    @since ml 1.0
 */
 qclass LinearRegression [arg=QoreLinearRegression* lr; ns=Qore::ML; flags=final];
 

--- a/modules/ml/src/QC_LinearRegression.qpp
+++ b/modules/ml/src/QC_LinearRegression.qpp
@@ -195,6 +195,83 @@ nothing LinearRegression::fitMatrix(list<auto> X, list<auto> y) {
     lr->fit(mat, target, xsink);
 }
 
+//! Performs a SGD online update with new hash-based data
+/** @param data a list of hashes with numeric fields plus the target field
+    @param learning_rate the step size for the gradient update
+
+    @par Example:
+    @code{.py}
+# Initial fit
+lr.fit(initial_data, "price");
+# Update with new data as it arrives
+lr.update(new_batch, 0.01);
+    @endcode
+
+    @throw ML-LINEAR-REGRESSION-ERROR model not fitted or dimension mismatch
+    @throw ML-DATA-ERROR data format errors
+*/
+nothing LinearRegression::update(list<auto> data, float learning_rate) {
+    const std::vector<std::string>& feat_names = lr->getFieldNames();
+    const std::string& target_name = lr->getTargetField();
+    if (feat_names.empty() || target_name.empty()) {
+        xsink->raiseException("ML-LINEAR-REGRESSION-ERROR",
+            "model was fitted with fitMatrix(); use updateMatrix() or fit() with hash records first");
+        return QoreValue();
+    }
+
+    if (!data || data->empty()) {
+        xsink->raiseException("ML-DATA-ERROR", "empty data list provided");
+        return QoreValue();
+    }
+
+    size_t n_rows = data->size();
+    size_t n_cols = feat_names.size();
+    MatrixXd X(n_rows, n_cols);
+    VectorXd y(n_rows);
+
+    for (size_t i = 0; i < n_rows; ++i) {
+        QoreValue row_val = data->retrieveEntry(i);
+        if (row_val.getType() != NT_HASH) {
+            xsink->raiseException("ML-DATA-ERROR", "data element %zu is not a hash", i);
+            return QoreValue();
+        }
+        const QoreHashNode* row = row_val.get<const QoreHashNode>();
+        for (size_t j = 0; j < n_cols; ++j) {
+            QoreValue v = row->getKeyValue(feat_names[j].c_str());
+            X(i, j) = v.getAsFloat();
+        }
+        QoreValue target_v = row->getKeyValue(target_name.c_str());
+        y(i) = target_v.getAsFloat();
+    }
+
+    lr->update(X, y, learning_rate, xsink);
+}
+
+//! Performs a SGD online update with a numeric matrix and target vector
+/** @param matrix a list of lists of numeric feature values
+    @param target a list of target values
+    @param learning_rate the step size for the gradient update
+
+    @par Example:
+    @code{.py}
+lr.updateMatrix(((1.0,), (2.0,), (3.0,)), (3.1, 5.2, 6.8), 0.01);
+    @endcode
+
+    @throw ML-LINEAR-REGRESSION-ERROR model not fitted or dimension mismatch
+    @throw ML-DATA-ERROR data format errors
+*/
+nothing LinearRegression::updateMatrix(list<auto> matrix, list<auto> target, float learning_rate) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    VectorXd y = qoreListToVector(target, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    lr->update(mat, y, learning_rate, xsink);
+}
+
 //! Predicts the target value for a single record
 /** @param record a hash with the same numeric fields used during training
 

--- a/modules/ml/src/QC_LogisticRegression.h
+++ b/modules/ml/src/QC_LogisticRegression.h
@@ -48,6 +48,9 @@ public:
     //! Fit on feature matrix X and target vector y (thread-safe)
     DLLLOCAL void fit(const MatrixXd& X, const VectorXd& y, ExceptionSink* xsink);
 
+    //! SGD update with new data (thread-safe)
+    DLLLOCAL void update(const MatrixXd& X, const VectorXd& y, double learning_rate, ExceptionSink* xsink);
+
     //! Predict for a single row vector
     DLLLOCAL QoreHashNode* predict(const RowVectorXd& point, ExceptionSink* xsink) const;
 

--- a/modules/ml/src/QC_LogisticRegression.h
+++ b/modules/ml/src/QC_LogisticRegression.h
@@ -1,0 +1,102 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_LogisticRegression.h
+
+    Qore ml module - LogisticRegression class
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _QORE_MODULE_ML_QC_LOGISTICREGRESSION_H
+#define _QORE_MODULE_ML_QC_LOGISTICREGRESSION_H
+
+#include "ml_common.h"
+
+#include <mutex>
+
+DLLEXPORT extern qore_classid_t CID_LOGISTICREGRESSION;
+DLLLOCAL extern QoreClass* QC_LOGISTICREGRESSION;
+
+DLLLOCAL void preinitLogisticRegressionClass();
+DLLLOCAL QoreClass* initLogisticRegressionClass(QoreNamespace& ns);
+
+//! Logistic regression implementation class using gradient descent
+class QoreLogisticRegression : public AbstractPrivateData {
+public:
+    //! Constructor with hyperparameters
+    DLLLOCAL QoreLogisticRegression(double learning_rate, int max_iterations, double tolerance,
+        double regularization, const std::string& penalty, bool fit_intercept);
+
+    //! Fit on feature matrix X and target vector y (thread-safe)
+    DLLLOCAL void fit(const MatrixXd& X, const VectorXd& y, ExceptionSink* xsink);
+
+    //! Predict for a single row vector
+    DLLLOCAL QoreHashNode* predict(const RowVectorXd& point, ExceptionSink* xsink) const;
+
+    //! Predict for multiple rows
+    DLLLOCAL QoreListNode* predictMatrix(const MatrixXd& X, ExceptionSink* xsink) const;
+
+    //! Whether the model has been fitted
+    DLLLOCAL bool isFitted() const { return fitted; }
+
+    //! Store field names for hash-based input
+    DLLLOCAL void setFieldNames(const std::vector<std::string>& names) { field_names = names; }
+    DLLLOCAL const std::vector<std::string>& getFieldNames() const { return field_names; }
+
+    //! Store the target field name
+    DLLLOCAL void setTargetField(const std::string& name) { target_field = name; }
+    DLLLOCAL const std::string& getTargetField() const { return target_field; }
+
+private:
+    //! Hyperparameters
+    double learning_rate;
+    int max_iterations;
+    double tolerance;
+    double regularization;
+    std::string penalty;    // "l2" or "none"
+    bool fit_intercept;
+
+    //! Model state
+    MatrixXd weights;               // n_classes x n_features (or 1 x n_features for binary)
+    VectorXd intercepts;            // n_classes (or 1 for binary)
+    std::vector<double> classes;    // unique class labels, sorted
+    bool is_binary = false;
+    int n_features = 0;
+    bool fitted = false;
+
+    //! Field names for hash-based API
+    std::vector<std::string> field_names;
+    std::string target_field;
+
+    //! Mutex protecting fit/predict
+    mutable std::mutex mtx;
+
+    //! Predict for a single point (must be called with mtx held)
+    DLLLOCAL QoreHashNode* predictInternal(const RowVectorXd& point, ExceptionSink* xsink) const;
+
+    //! Sigmoid activation function with clamping
+    DLLLOCAL double sigmoid(double z) const;
+
+    //! Softmax activation for multiclass
+    DLLLOCAL VectorXd softmax(const VectorXd& z) const;
+};
+
+#endif // _QORE_MODULE_ML_QC_LOGISTICREGRESSION_H

--- a/modules/ml/src/QC_LogisticRegression.h
+++ b/modules/ml/src/QC_LogisticRegression.h
@@ -68,6 +68,13 @@ public:
     DLLLOCAL void setTargetField(const std::string& name) { target_field = name; }
     DLLLOCAL const std::string& getTargetField() const { return target_field; }
 
+    //! Serialize model state to binary
+    DLLLOCAL std::vector<uint8_t> serializeState() const;
+
+    //! Deserialize model state from binary
+    DLLLOCAL static QoreLogisticRegression* deserializeState(const uint8_t* data, size_t len,
+        ExceptionSink* xsink);
+
 private:
     //! Hyperparameters
     double learning_rate;

--- a/modules/ml/src/QC_LogisticRegression.qpp
+++ b/modules/ml/src/QC_LogisticRegression.qpp
@@ -1,0 +1,311 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_LogisticRegression.qpp
+
+    Qore ml module - LogisticRegression class definition
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "qore/Qore.h"
+#include "QC_LogisticRegression.h"
+
+extern const TypedHashDecl* hashdeclLogisticRegressionResult;
+
+//! The LogisticRegression class implements logistic regression for binary and multiclass classification
+/** LogisticRegression fits a logistic model using gradient descent. For binary classification, it uses
+    the sigmoid function. For multiclass classification, it uses a one-vs-rest (OvR) strategy with
+    softmax normalization of the output probabilities.
+
+    Supports L2 regularization to prevent overfitting.
+
+    Each instance is independent and thread-safe for concurrent prediction after fitting.
+
+    @par Example:
+    @code{.py}
+# Create a logistic regression classifier
+LogisticRegression clf({"learning_rate": 0.01, "max_iterations": 100});
+
+# Train on data with a target field
+list<hash<auto>> training_data = (
+    {"sepal_length": 5.1, "sepal_width": 3.5, "species": 0},
+    {"sepal_length": 7.0, "sepal_width": 3.2, "species": 1},
+    {"sepal_length": 6.3, "sepal_width": 3.3, "species": 2},
+);
+clf.fit(training_data, "species");
+
+# Predict
+hash<LogisticRegressionResult> result = clf.predict({"sepal_length": 5.9, "sepal_width": 3.0});
+printf("Predicted class: %f, Probability: %f\n", result.predicted_class, result.max_probability);
+    @endcode
+
+*/
+qclass LogisticRegression [arg=QoreLogisticRegression* lr; ns=Qore::ML; flags=final];
+
+//! Creates a LogisticRegression with the given options
+/** @param options a hash with the following optional keys:
+    - \c learning_rate (float, default 0.01): step size for gradient descent
+    - \c max_iterations (int, default 100): maximum number of gradient descent iterations
+    - \c tolerance (float, default 1e-4): convergence tolerance on weight changes
+    - \c regularization (float, default 1.0): regularization strength (only used when penalty is "l2")
+    - \c penalty (string, default "l2"): regularization type; "l2" or "none"
+    - \c fit_intercept (bool, default True): whether to fit an intercept (bias) term
+
+    @par Example:
+    @code{.py}
+LogisticRegression clf({"learning_rate": 0.1, "penalty": "none"});
+    @endcode
+
+    @throw ML-LOGISTIC-REGRESSION-ERROR invalid option values
+*/
+LogisticRegression::constructor(*hash<auto> options) {
+    double learning_rate = 0.01;
+    int64 max_iterations = 100;
+    double tolerance = 1e-4;
+    double regularization_val = 1.0;
+    const char* penalty_str = "l2";
+    bool fit_intercept = true;
+
+    if (options) {
+        QoreValue v;
+        v = options->getKeyValue("learning_rate");
+        if (!v.isNullOrNothing()) {
+            learning_rate = v.getAsFloat();
+        }
+        v = options->getKeyValue("max_iterations");
+        if (!v.isNullOrNothing()) {
+            max_iterations = v.getAsBigInt();
+        }
+        v = options->getKeyValue("tolerance");
+        if (!v.isNullOrNothing()) {
+            tolerance = v.getAsFloat();
+        }
+        v = options->getKeyValue("regularization");
+        if (!v.isNullOrNothing()) {
+            regularization_val = v.getAsFloat();
+        }
+        v = options->getKeyValue("penalty");
+        if (!v.isNullOrNothing() && v.getType() == NT_STRING) {
+            penalty_str = v.get<const QoreStringNode>()->c_str();
+        }
+        v = options->getKeyValue("fit_intercept");
+        if (!v.isNullOrNothing()) {
+            fit_intercept = v.getAsBool();
+        }
+    }
+
+    if (learning_rate <= 0.0) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "learning_rate must be > 0; got %f", learning_rate);
+        return;
+    }
+    if (max_iterations < 1) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "max_iterations must be >= 1; got " QLLD, max_iterations);
+        return;
+    }
+    if (tolerance < 0.0) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "tolerance must be >= 0; got %f", tolerance);
+        return;
+    }
+    if (regularization_val < 0.0) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "regularization must be >= 0; got %f", regularization_val);
+        return;
+    }
+    if (strcmp(penalty_str, "l2") != 0 && strcmp(penalty_str, "none") != 0) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "penalty must be 'l2' or 'none'; got '%s'", penalty_str);
+        return;
+    }
+
+    self->setPrivate(CID_LOGISTICREGRESSION,
+        new QoreLogisticRegression(learning_rate, static_cast<int>(max_iterations),
+            tolerance, regularization_val, penalty_str, fit_intercept));
+}
+
+//! Creates a copy of the LogisticRegression
+/** @throw COPY-ERROR LogisticRegression objects cannot be copied
+*/
+LogisticRegression::copy() {
+    xsink->raiseException("COPY-ERROR", "LogisticRegression objects cannot be copied");
+}
+
+//! Trains the model on a list of hash records with a target field
+/** Extracts numeric fields (excluding the target) from the records as features,
+    and uses the target field as the class label.
+
+    @param data a list of hashes where each hash represents a record
+    @param target_field the name of the field containing the class labels
+
+    @par Example:
+    @code{.py}
+clf.fit(training_data, "species");
+    @endcode
+
+    @throw ML-DATA-ERROR if data is empty or has no numeric fields
+    @throw ML-LOGISTIC-REGRESSION-ERROR if fitting fails
+*/
+nothing LogisticRegression::fit(list<auto> data, string target_field) {
+    // Extract field names from first record, excluding target
+    if (!data || data->empty()) {
+        xsink->raiseException("ML-DATA-ERROR", "empty data list provided");
+        return QoreValue();
+    }
+
+    QoreValue first = data->retrieveEntry(0);
+    if (first.getType() != NT_HASH) {
+        xsink->raiseException("ML-DATA-ERROR", "data list must contain hash elements");
+        return QoreValue();
+    }
+    const QoreHashNode* first_hash = first.get<const QoreHashNode>();
+    const char* target_str = target_field->c_str();
+
+    // Collect numeric field names excluding target
+    std::vector<std::string> feat_names;
+    ConstHashIterator hi(first_hash);
+    while (hi.next()) {
+        if (strcmp(hi.getKey(), target_str) == 0) {
+            continue;
+        }
+        QoreValue val = hi.get();
+        qore_type_t vt = val.getType();
+        if (vt == NT_INT || vt == NT_FLOAT || vt == NT_NUMBER) {
+            feat_names.push_back(hi.getKey());
+        }
+    }
+
+    if (feat_names.empty()) {
+        xsink->raiseException("ML-DATA-ERROR",
+            "no numeric feature fields found in data (excluding target '%s')", target_str);
+        return QoreValue();
+    }
+
+    size_t n_rows = data->size();
+    size_t n_cols = feat_names.size();
+    MatrixXd X(n_rows, n_cols);
+    VectorXd y(n_rows);
+
+    for (size_t i = 0; i < n_rows; ++i) {
+        QoreValue row_val = data->retrieveEntry(i);
+        if (row_val.getType() != NT_HASH) {
+            xsink->raiseException("ML-DATA-ERROR", "data element %zu is not a hash", i);
+            return QoreValue();
+        }
+        const QoreHashNode* row = row_val.get<const QoreHashNode>();
+        for (size_t j = 0; j < n_cols; ++j) {
+            QoreValue v = row->getKeyValue(feat_names[j].c_str());
+            X(i, j) = v.getAsFloat();
+        }
+        QoreValue target_v = row->getKeyValue(target_str);
+        y(i) = target_v.getAsFloat();
+    }
+
+    lr->setFieldNames(feat_names);
+    lr->setTargetField(target_str);
+    lr->fit(X, y, xsink);
+}
+
+//! Trains the model on a numeric feature matrix and target vector
+/** @param matrix a list of lists where each inner list is a row of feature values
+    @param target a list of class labels (numeric values)
+
+    @par Example:
+    @code{.py}
+clf.fitMatrix(((5.1, 3.5), (7.0, 3.2), (6.3, 3.3)), (0, 1, 2));
+    @endcode
+
+    @throw ML-DATA-ERROR if the matrix is empty or malformed
+    @throw ML-LOGISTIC-REGRESSION-ERROR if fitting fails
+*/
+nothing LogisticRegression::fitMatrix(list<auto> matrix, list<auto> target) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    VectorXd y = qoreListToVector(target, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    lr->fit(mat, y, xsink);
+}
+
+//! Predicts the class for a single record
+/** @param record a hash with the same numeric fields used during training
+
+    @return a @ref LogisticRegressionResult hash with prediction details
+
+    @par Example:
+    @code{.py}
+hash<LogisticRegressionResult> result = clf.predict({"sepal_length": 5.9, "sepal_width": 3.0});
+printf("Class: %f, Probability: %f\n", result.predicted_class, result.max_probability);
+    @endcode
+
+    @throw ML-LOGISTIC-REGRESSION-ERROR if the model has not been fitted or input dimensions mismatch
+*/
+hash<LogisticRegressionResult> LogisticRegression::predict(hash<auto> record) {
+    const std::vector<std::string>& feat_names = lr->getFieldNames();
+    if (feat_names.empty()) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "model was fitted with fitMatrix(); use predictMatrix() or fit() with hash records");
+        return QoreValue();
+    }
+    RowVectorXd point = qoreHashToRowVector(record, feat_names, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    return lr->predict(point, xsink);
+}
+
+//! Predicts classes for multiple rows in matrix form
+/** @param matrix a list of lists where each inner list is a row of feature values
+
+    @return a list of @ref LogisticRegressionResult hashes
+
+    @par Example:
+    @code{.py}
+list<hash<LogisticRegressionResult>> results = clf.predictMatrix(((5.1, 3.5), (7.0, 3.2)));
+    @endcode
+
+    @throw ML-LOGISTIC-REGRESSION-ERROR if the model has not been fitted or input dimensions mismatch
+*/
+list<hash<LogisticRegressionResult>> LogisticRegression::predictMatrix(list<auto> matrix) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    return lr->predictMatrix(mat, xsink);
+}
+
+//! Returns True if the model has been trained
+/** @return True if fit() or fitMatrix() has been called successfully
+
+    @par Example:
+    @code{.py}
+if (!clf.isFitted()) {
+    clf.fit(data, "target");
+}
+    @endcode
+*/
+bool LogisticRegression::isFitted() [flags=CONSTANT] {
+    return lr->isFitted();
+}

--- a/modules/ml/src/QC_LogisticRegression.qpp
+++ b/modules/ml/src/QC_LogisticRegression.qpp
@@ -249,6 +249,81 @@ nothing LogisticRegression::fitMatrix(list<auto> matrix, list<auto> target) {
     lr->fit(mat, y, xsink);
 }
 
+//! Performs a SGD online update with new hash-based data
+/** @param data a list of hashes with numeric fields plus the target field
+    @param learning_rate the step size for the gradient update
+
+    @par Example:
+    @code{.py}
+clf.fit(initial_data, "category");
+clf.update(new_labeled_data, 0.01);  # refine with new examples
+    @endcode
+
+    @throw ML-LOGISTIC-REGRESSION-ERROR model not fitted or dimension mismatch
+    @throw ML-DATA-ERROR data format errors
+*/
+nothing LogisticRegression::update(list<auto> data, float learning_rate) {
+    const std::vector<std::string>& feat_names = lr->getFieldNames();
+    const std::string& target_name = lr->getTargetField();
+    if (feat_names.empty() || target_name.empty()) {
+        xsink->raiseException("ML-LOGISTIC-REGRESSION-ERROR",
+            "model was fitted with fitMatrix(); use updateMatrix() or fit() with hash records first");
+        return QoreValue();
+    }
+
+    if (!data || data->empty()) {
+        xsink->raiseException("ML-DATA-ERROR", "empty data list provided");
+        return QoreValue();
+    }
+
+    size_t n_rows = data->size();
+    size_t n_cols = feat_names.size();
+    MatrixXd X(n_rows, n_cols);
+    VectorXd y(n_rows);
+
+    for (size_t i = 0; i < n_rows; ++i) {
+        QoreValue row_val = data->retrieveEntry(i);
+        if (row_val.getType() != NT_HASH) {
+            xsink->raiseException("ML-DATA-ERROR", "data element %zu is not a hash", i);
+            return QoreValue();
+        }
+        const QoreHashNode* row = row_val.get<const QoreHashNode>();
+        for (size_t j = 0; j < n_cols; ++j) {
+            QoreValue v = row->getKeyValue(feat_names[j].c_str());
+            X(i, j) = v.getAsFloat();
+        }
+        QoreValue target_v = row->getKeyValue(target_name.c_str());
+        y(i) = target_v.getAsFloat();
+    }
+
+    lr->update(X, y, learning_rate, xsink);
+}
+
+//! Performs a SGD online update with a numeric matrix and target vector
+/** @param matrix a list of lists of numeric feature values
+    @param target a list of target values
+    @param learning_rate the step size for the gradient update
+
+    @par Example:
+    @code{.py}
+clf.updateMatrix(((5.1, 3.5), (6.2, 2.8)), (0, 1), 0.01);
+    @endcode
+
+    @throw ML-LOGISTIC-REGRESSION-ERROR model not fitted or dimension mismatch
+    @throw ML-DATA-ERROR data format errors
+*/
+nothing LogisticRegression::updateMatrix(list<auto> matrix, list<auto> target, float learning_rate) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    VectorXd y = qoreListToVector(target, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    lr->update(mat, y, learning_rate, xsink);
+}
+
 //! Predicts the class for a single record
 /** @param record a hash with the same numeric fields used during training
 

--- a/modules/ml/src/QC_MLPipeline.h
+++ b/modules/ml/src/QC_MLPipeline.h
@@ -1,0 +1,132 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_MLPipeline.h
+
+    Qore ml module - MLPipeline class
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _QORE_MODULE_ML_QC_MLPIPELINE_H
+#define _QORE_MODULE_ML_QC_MLPIPELINE_H
+
+#include "ml_common.h"
+#include "QC_StandardScaler.h"
+#include "QC_MinMaxScaler.h"
+#include "QC_Imputer.h"
+#include "QC_LinearRegression.h"
+#include "QC_KMeans.h"
+#include "QC_PCA.h"
+#include "QC_IsolationForest.h"
+#include "QC_LOF.h"
+#include "QC_GMM.h"
+
+#include <mutex>
+#include <string>
+#include <variant>
+
+DLLEXPORT extern qore_classid_t CID_MLPIPELINE;
+DLLLOCAL extern QoreClass* QC_MLPIPELINE;
+
+DLLLOCAL void preinitMLPipelineClass();
+DLLLOCAL QoreClass* initMLPipelineClass(QoreNamespace& ns);
+
+//! Pipeline step type
+enum class PipelineStepType {
+    STANDARD_SCALER,
+    MINMAX_SCALER,
+    IMPUTER,
+    PCA,
+    // Estimators (must be last step)
+    LINEAR_REGRESSION,
+    KMEANS,
+    ISOLATION_FOREST,
+    LOF,
+    GMM
+};
+
+//! A single pipeline step
+struct PipelineStep {
+    std::string name;
+    PipelineStepType type;
+    QoreObject* obj;    //!< borrowed reference to the Qore object (caller owns)
+};
+
+//! MLPipeline — chains preprocessors and an estimator into a single fit/predict unit
+class QoreMLPipeline : public AbstractPrivateData {
+public:
+    DLLLOCAL QoreMLPipeline() {}
+
+    //! destructor — release references to step objects
+    DLLLOCAL virtual void deref(ExceptionSink* xsink) override {
+        if (ROdereference()) {
+            for (auto& step : steps) {
+                if (step.obj) {
+                    step.obj->deref(xsink);
+                    step.obj = nullptr;
+                }
+            }
+            delete this;
+        }
+    }
+
+    //! Add a step to the pipeline
+    DLLLOCAL void addStep(const std::string& name, PipelineStepType type, QoreObject* obj);
+
+    //! Fit all steps: transformers are fit+transform sequentially, estimator is fit last
+    DLLLOCAL void fitMatrix(const MatrixXd& X, const VectorXd* y, ExceptionSink* xsink);
+
+    //! Transform through all transformer steps (no estimator)
+    DLLLOCAL MatrixXd transformMatrix(const MatrixXd& X, ExceptionSink* xsink) const;
+
+    //! Predict: transform through all transformers, then call estimator.predict
+    DLLLOCAL QoreHashNode* predict(const RowVectorXd& point, ExceptionSink* xsink) const;
+
+    //! PredictMatrix: transform + estimator.predictMatrix
+    DLLLOCAL QoreListNode* predictMatrix(const MatrixXd& X, ExceptionSink* xsink) const;
+
+    //! Whether the pipeline has been fitted
+    DLLLOCAL bool isFitted() const { return fitted; }
+
+    //! Get the number of steps
+    DLLLOCAL int getNumSteps() const { return static_cast<int>(steps.size()); }
+
+    //! Get step names
+    DLLLOCAL QoreListNode* getStepNames(ExceptionSink* xsink) const;
+
+private:
+    std::vector<PipelineStep> steps;
+    bool fitted = false;
+    mutable std::mutex mtx;
+
+    //! Check if a step type is a transformer (not an estimator)
+    DLLLOCAL static bool isTransformer(PipelineStepType type);
+
+    //! Apply a single transformer step to data
+    DLLLOCAL MatrixXd applyTransformer(const PipelineStep& step, const MatrixXd& data,
+        ExceptionSink* xsink) const;
+
+    //! Fit a single transformer step and return transformed data
+    DLLLOCAL MatrixXd fitTransformer(const PipelineStep& step, const MatrixXd& data,
+        ExceptionSink* xsink);
+};
+
+#endif // _QORE_MODULE_ML_QC_MLPIPELINE_H

--- a/modules/ml/src/QC_MLPipeline.h
+++ b/modules/ml/src/QC_MLPipeline.h
@@ -38,6 +38,8 @@
 #include "QC_IsolationForest.h"
 #include "QC_LOF.h"
 #include "QC_GMM.h"
+#include "QC_LogisticRegression.h"
+#include "QC_KNN.h"
 
 #include <mutex>
 #include <string>
@@ -60,7 +62,9 @@ enum class PipelineStepType {
     KMEANS,
     ISOLATION_FOREST,
     LOF,
-    GMM
+    GMM,
+    LOGISTIC_REGRESSION,
+    KNN_CLASSIFICATION
 };
 
 //! A single pipeline step

--- a/modules/ml/src/QC_MLPipeline.qpp
+++ b/modules/ml/src/QC_MLPipeline.qpp
@@ -225,6 +225,40 @@ nothing MLPipeline::addGMM(string name, object obj) {
         const_cast<QoreObject*>(obj));
 }
 
+//! Adds a LogisticRegression estimator (must be the last step)
+/** @param name a unique step name
+    @param obj a LogisticRegression instance
+
+    @throw ML-PIPELINE-ERROR invalid object type
+*/
+nothing MLPipeline::addLogisticRegression(string name, object obj) {
+    QoreLogisticRegression* s = static_cast<QoreLogisticRegression*>(
+        obj->getReferencedPrivateData(CID_LOGISTICREGRESSION, xsink));
+    if (*xsink) {
+        return QoreValue();
+    }
+    s->deref(xsink);
+    pipeline->addStep(name->c_str(), PipelineStepType::LOGISTIC_REGRESSION,
+        const_cast<QoreObject*>(obj));
+}
+
+//! Adds a KNN classification estimator (must be the last step)
+/** @param name a unique step name
+    @param obj a KNN instance configured for classification
+
+    @throw ML-PIPELINE-ERROR invalid object type
+*/
+nothing MLPipeline::addKNNClassification(string name, object obj) {
+    QoreKNN* s = static_cast<QoreKNN*>(
+        obj->getReferencedPrivateData(CID_KNN, xsink));
+    if (*xsink) {
+        return QoreValue();
+    }
+    s->deref(xsink);
+    pipeline->addStep(name->c_str(), PipelineStepType::KNN_CLASSIFICATION,
+        const_cast<QoreObject*>(obj));
+}
+
 //! Fits the pipeline on a numeric matrix (no target vector)
 /** @param matrix a list of lists of numeric values
 

--- a/modules/ml/src/QC_MLPipeline.qpp
+++ b/modules/ml/src/QC_MLPipeline.qpp
@@ -1,0 +1,327 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_MLPipeline.qpp
+
+    Qore ml module - MLPipeline class definition
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "qore/Qore.h"
+#include "QC_MLPipeline.h"
+
+//! The MLPipeline class chains preprocessing steps and an estimator into a single unit
+/** MLPipeline ensures that the same data transformations are applied consistently
+    during both training and prediction.
+
+    @par Example:
+    @code{.py}
+MLPipeline p();
+p.addStandardScaler("scaler", new StandardScaler());
+p.addEstimator("model", new LinearRegression({"fit_intercept": True}));
+p.fitMatrix(X_train, y_train);
+hash<auto> result = p.predictMatrix(X_test);
+    @endcode
+
+*/
+qclass MLPipeline [arg=QoreMLPipeline* pipeline; ns=Qore::ML; flags=final];
+
+//! Creates an empty MLPipeline
+/** Create a pipeline and add steps with addStandardScaler(), addMinMaxScaler(),
+    addImputer(), addPCA(), and estimator methods like addLinearRegression().
+
+    @par Example:
+    @code{.py}
+MLPipeline p();
+p.addStandardScaler("scaler", new StandardScaler());
+p.addLinearRegression("model", new LinearRegression({"fit_intercept": True}));
+    @endcode
+*/
+MLPipeline::constructor() {
+    self->setPrivate(CID_MLPIPELINE, new QoreMLPipeline());
+}
+
+//! Creates a copy of the MLPipeline instance
+/** @throw COPY-ERROR MLPipeline objects cannot be copied
+*/
+MLPipeline::copy() {
+    xsink->raiseException("COPY-ERROR", "MLPipeline objects cannot be copied");
+}
+
+//! Adds a StandardScaler step to the pipeline
+/** @param name a unique step name
+    @param obj a StandardScaler instance
+
+    @par Example:
+    @code{.py}
+p.addStandardScaler("scaler", new StandardScaler());
+    @endcode
+
+    @throw ML-PIPELINE-ERROR invalid object type
+*/
+nothing MLPipeline::addStandardScaler(string name, object obj) {
+    // Verify the object is a StandardScaler
+    QoreStandardScaler* s = static_cast<QoreStandardScaler*>(
+        obj->getReferencedPrivateData(CID_STANDARDSCALER, xsink));
+    if (*xsink) {
+        return QoreValue();
+    }
+    s->deref(xsink);
+    pipeline->addStep(name->c_str(), PipelineStepType::STANDARD_SCALER,
+        const_cast<QoreObject*>(obj));
+}
+
+//! Adds a MinMaxScaler step to the pipeline
+/** @param name a unique step name
+    @param obj a MinMaxScaler instance
+
+    @throw ML-PIPELINE-ERROR invalid object type
+*/
+nothing MLPipeline::addMinMaxScaler(string name, object obj) {
+    QoreMinMaxScaler* s = static_cast<QoreMinMaxScaler*>(
+        obj->getReferencedPrivateData(CID_MINMAXSCALER, xsink));
+    if (*xsink) {
+        return QoreValue();
+    }
+    s->deref(xsink);
+    pipeline->addStep(name->c_str(), PipelineStepType::MINMAX_SCALER,
+        const_cast<QoreObject*>(obj));
+}
+
+//! Adds an Imputer step to the pipeline
+/** @param name a unique step name
+    @param obj an Imputer instance
+
+    @throw ML-PIPELINE-ERROR invalid object type
+*/
+nothing MLPipeline::addImputer(string name, object obj) {
+    QoreImputer* s = static_cast<QoreImputer*>(
+        obj->getReferencedPrivateData(CID_IMPUTER, xsink));
+    if (*xsink) {
+        return QoreValue();
+    }
+    s->deref(xsink);
+    pipeline->addStep(name->c_str(), PipelineStepType::IMPUTER,
+        const_cast<QoreObject*>(obj));
+}
+
+//! Adds a PCA transformer step to the pipeline
+/** @param name a unique step name
+    @param obj a PCA instance
+
+    @throw ML-PIPELINE-ERROR invalid object type
+*/
+nothing MLPipeline::addPCA(string name, object obj) {
+    QorePCA* s = static_cast<QorePCA*>(
+        obj->getReferencedPrivateData(CID_PCA, xsink));
+    if (*xsink) {
+        return QoreValue();
+    }
+    s->deref(xsink);
+    pipeline->addStep(name->c_str(), PipelineStepType::PCA,
+        const_cast<QoreObject*>(obj));
+}
+
+//! Adds a LinearRegression estimator (must be the last step)
+/** @param name a unique step name
+    @param obj a LinearRegression instance
+
+    @throw ML-PIPELINE-ERROR invalid object type
+*/
+nothing MLPipeline::addLinearRegression(string name, object obj) {
+    QoreLinearRegression* s = static_cast<QoreLinearRegression*>(
+        obj->getReferencedPrivateData(CID_LINEARREGRESSION, xsink));
+    if (*xsink) {
+        return QoreValue();
+    }
+    s->deref(xsink);
+    pipeline->addStep(name->c_str(), PipelineStepType::LINEAR_REGRESSION,
+        const_cast<QoreObject*>(obj));
+}
+
+//! Adds a KMeans estimator (must be the last step)
+/** @param name a unique step name
+    @param obj a KMeans instance
+
+    @throw ML-PIPELINE-ERROR invalid object type
+*/
+nothing MLPipeline::addKMeans(string name, object obj) {
+    QoreKMeans* s = static_cast<QoreKMeans*>(
+        obj->getReferencedPrivateData(CID_KMEANS, xsink));
+    if (*xsink) {
+        return QoreValue();
+    }
+    s->deref(xsink);
+    pipeline->addStep(name->c_str(), PipelineStepType::KMEANS,
+        const_cast<QoreObject*>(obj));
+}
+
+//! Adds an IsolationForest estimator (must be the last step)
+/** @param name a unique step name
+    @param obj an IsolationForest instance
+
+    @throw ML-PIPELINE-ERROR invalid object type
+*/
+nothing MLPipeline::addIsolationForest(string name, object obj) {
+    QoreIsolationForest* s = static_cast<QoreIsolationForest*>(
+        obj->getReferencedPrivateData(CID_ISOLATIONFOREST, xsink));
+    if (*xsink) {
+        return QoreValue();
+    }
+    s->deref(xsink);
+    pipeline->addStep(name->c_str(), PipelineStepType::ISOLATION_FOREST,
+        const_cast<QoreObject*>(obj));
+}
+
+//! Adds an LOF estimator (must be the last step)
+/** @param name a unique step name
+    @param obj an LOF instance
+
+    @throw ML-PIPELINE-ERROR invalid object type
+*/
+nothing MLPipeline::addLOF(string name, object obj) {
+    QoreLOF* s = static_cast<QoreLOF*>(
+        obj->getReferencedPrivateData(CID_LOF, xsink));
+    if (*xsink) {
+        return QoreValue();
+    }
+    s->deref(xsink);
+    pipeline->addStep(name->c_str(), PipelineStepType::LOF,
+        const_cast<QoreObject*>(obj));
+}
+
+//! Adds a GMM estimator (must be the last step)
+/** @param name a unique step name
+    @param obj a GMM instance
+
+    @throw ML-PIPELINE-ERROR invalid object type
+*/
+nothing MLPipeline::addGMM(string name, object obj) {
+    QoreGMM* s = static_cast<QoreGMM*>(
+        obj->getReferencedPrivateData(CID_GMM, xsink));
+    if (*xsink) {
+        return QoreValue();
+    }
+    s->deref(xsink);
+    pipeline->addStep(name->c_str(), PipelineStepType::GMM,
+        const_cast<QoreObject*>(obj));
+}
+
+//! Fits the pipeline on a numeric matrix (no target vector)
+/** @param matrix a list of lists of numeric values
+
+    Use this for unsupervised estimators (KMeans, IsolationForest, etc.) or for
+    transformer-only pipelines.
+
+    @throw ML-PIPELINE-ERROR pipeline has no steps or step errors
+    @throw ML-DATA-ERROR data format errors
+*/
+nothing MLPipeline::fitMatrix(list<auto> matrix) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    pipeline->fitMatrix(mat, nullptr, xsink);
+}
+
+//! Fits the pipeline on a numeric matrix with a target vector
+/** @param matrix a list of lists of numeric values (features)
+    @param target a list of numeric values (targets)
+
+    Use this for supervised estimators (LinearRegression, etc.).
+
+    @throw ML-PIPELINE-ERROR pipeline has no steps or step errors
+    @throw ML-DATA-ERROR data format errors
+*/
+nothing MLPipeline::fitMatrixWithTarget(list<auto> matrix, list<auto> target) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    VectorXd y = qoreListToVector(target, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    pipeline->fitMatrix(mat, &y, xsink);
+}
+
+//! Transforms data through all transformer steps (no estimator applied)
+/** @param matrix a list of lists of numeric values
+    @return a list of lists of transformed values
+
+    @throw ML-PIPELINE-ERROR pipeline not fitted
+    @throw ML-DATA-ERROR data format errors
+*/
+list<list<float>> MLPipeline::transformMatrix(list<auto> matrix) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    MatrixXd result = pipeline->transformMatrix(mat, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(autoTypeInfo), xsink);
+    for (Eigen::Index i = 0; i < result.rows(); ++i) {
+        ReferenceHolder<QoreListNode> row(new QoreListNode(floatTypeInfo), xsink);
+        for (Eigen::Index j = 0; j < result.cols(); ++j) {
+            row->push(result(i, j), xsink);
+        }
+        rv->push(row.release(), xsink);
+    }
+    return rv.release();
+}
+
+//! Predicts on a numeric matrix (transform + estimator predict)
+/** @param matrix a list of lists of numeric values
+    @return a list of estimator-specific result hashes
+
+    @throw ML-PIPELINE-ERROR pipeline not fitted or last step is not an estimator
+    @throw ML-DATA-ERROR data format errors
+*/
+list<hash<auto>> MLPipeline::predictMatrix(list<auto> matrix) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    return pipeline->predictMatrix(mat, xsink);
+}
+
+//! Returns True if the pipeline has been fitted
+/** @return True if fitMatrix() has been called successfully
+*/
+bool MLPipeline::isFitted() [flags=CONSTANT] {
+    return pipeline->isFitted();
+}
+
+//! Returns the number of steps in the pipeline
+/** @return the number of steps
+*/
+int MLPipeline::getNumSteps() [flags=CONSTANT] {
+    return pipeline->getNumSteps();
+}
+
+//! Returns the step names
+/** @return a list of step name strings
+*/
+list<string> MLPipeline::getStepNames() {
+    return pipeline->getStepNames(xsink);
+}

--- a/modules/ml/src/QC_MinMaxScaler.h
+++ b/modules/ml/src/QC_MinMaxScaler.h
@@ -78,6 +78,13 @@ public:
     DLLLOCAL double getFeatureMin() const { return feature_min; }
     DLLLOCAL double getFeatureMax() const { return feature_max; }
 
+    //! Serialize model state to binary
+    DLLLOCAL std::vector<uint8_t> serializeState() const;
+
+    //! Deserialize model state from binary
+    DLLLOCAL static QoreMinMaxScaler* deserializeState(const uint8_t* data, size_t len,
+        ExceptionSink* xsink);
+
 private:
     double feature_min;
     double feature_max;

--- a/modules/ml/src/QC_MinMaxScaler.h
+++ b/modules/ml/src/QC_MinMaxScaler.h
@@ -1,0 +1,100 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_MinMaxScaler.h
+
+    Qore ml module - MinMaxScaler class
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _QORE_MODULE_ML_QC_MINMAXSCALER_H
+#define _QORE_MODULE_ML_QC_MINMAXSCALER_H
+
+#include "ml_common.h"
+
+#include <mutex>
+
+DLLEXPORT extern qore_classid_t CID_MINMAXSCALER;
+DLLLOCAL extern QoreClass* QC_MINMAXSCALER;
+
+DLLLOCAL void preinitMinMaxScalerClass();
+DLLLOCAL QoreClass* initMinMaxScalerClass(QoreNamespace& ns);
+
+//! MinMaxScaler — scales features to a configurable range [feature_min, feature_max]
+class QoreMinMaxScaler : public AbstractPrivateData {
+public:
+    DLLLOCAL QoreMinMaxScaler(double feature_min, double feature_max)
+        : feature_min(feature_min), feature_max(feature_max) {
+    }
+
+    //! Compute per-feature min/max from training data
+    DLLLOCAL void fit(const MatrixXd& data, ExceptionSink* xsink);
+
+    //! Scale data to [feature_min, feature_max]
+    DLLLOCAL MatrixXd transform(const MatrixXd& data, ExceptionSink* xsink) const;
+
+    //! Reverse the scaling
+    DLLLOCAL MatrixXd inverseTransform(const MatrixXd& data, ExceptionSink* xsink) const;
+
+    //! Fit and transform in one step
+    DLLLOCAL MatrixXd fitTransform(const MatrixXd& data, ExceptionSink* xsink);
+
+    //! Whether the scaler has been fitted
+    DLLLOCAL bool isFitted() const { return fitted; }
+
+    //! Get scaler info
+    DLLLOCAL QoreHashNode* getInfo(ExceptionSink* xsink) const;
+
+    //! Store field names for hash-based input
+    DLLLOCAL void setFieldNames(const std::vector<std::string>& names) { field_names = names; }
+    DLLLOCAL const std::vector<std::string>& getFieldNames() const { return field_names; }
+
+    //! Transform a single row (no lock, no fitted check)
+    DLLLOCAL RowVectorXd transformRow(const RowVectorXd& row, ExceptionSink* xsink) const;
+
+    //! Inverse-transform a single row (no lock, no fitted check)
+    DLLLOCAL RowVectorXd inverseTransformRow(const RowVectorXd& row, ExceptionSink* xsink) const;
+
+    //! Getters
+    DLLLOCAL int getNumFeatures() const { return n_features; }
+    DLLLOCAL double getFeatureMin() const { return feature_min; }
+    DLLLOCAL double getFeatureMax() const { return feature_max; }
+
+private:
+    double feature_min;
+    double feature_max;
+    bool fitted = false;
+    int n_features = 0;
+
+    VectorXd data_min;
+    VectorXd data_max;
+    VectorXd scale;     // (feature_max - feature_min) / (data_max - data_min)
+    VectorXd min_adj;   // feature_min - data_min * scale
+
+    std::vector<std::string> field_names;
+
+    mutable std::mutex mtx;
+
+    //! Compute scale and min_adj from data_min/data_max
+    DLLLOCAL void computeScaleFactors();
+};
+
+#endif // _QORE_MODULE_ML_QC_MINMAXSCALER_H

--- a/modules/ml/src/QC_MinMaxScaler.qpp
+++ b/modules/ml/src/QC_MinMaxScaler.qpp
@@ -1,0 +1,302 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_MinMaxScaler.qpp
+
+    Qore ml module - MinMaxScaler class definition
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "qore/Qore.h"
+#include "QC_MinMaxScaler.h"
+
+extern const TypedHashDecl* hashdeclMinMaxScalerInfo;
+
+//! The MinMaxScaler class scales features to a configurable range
+/** MinMaxScaler transforms features by scaling each feature to a given range,
+    typically [0, 1]. This is useful for algorithms that expect bounded input
+    (e.g., neural networks, distance-based algorithms).
+
+    @par Example:
+    @code{.py}
+MinMaxScaler scaler({"feature_min": 0.0, "feature_max": 1.0});
+scaler.fit(training_data);
+list<auto> scaled = scaler.transformMatrix(new_data);
+    @endcode
+
+*/
+qclass MinMaxScaler [arg=QoreMinMaxScaler* scaler; ns=Qore::ML; flags=final];
+
+//! Creates a MinMaxScaler instance
+/** @param options a hash with the following optional keys:
+    - \c feature_min (float, default 0.0): lower bound of the target range
+    - \c feature_max (float, default 1.0): upper bound of the target range
+
+    @throw ML-MIN-MAX-SCALER-ERROR feature_min >= feature_max
+*/
+MinMaxScaler::constructor(*hash<auto> options) {
+    double fmin = 0.0;
+    double fmax = 1.0;
+
+    if (options) {
+        QoreValue v = options->getKeyValue("feature_min");
+        if (!v.isNullOrNothing()) {
+            fmin = v.getAsFloat();
+        }
+        v = options->getKeyValue("feature_max");
+        if (!v.isNullOrNothing()) {
+            fmax = v.getAsFloat();
+        }
+    }
+
+    if (fmin >= fmax) {
+        xsink->raiseException("ML-MIN-MAX-SCALER-ERROR",
+            "feature_min (%.6f) must be less than feature_max (%.6f)", fmin, fmax);
+        return;
+    }
+
+    self->setPrivate(CID_MINMAXSCALER, new QoreMinMaxScaler(fmin, fmax));
+}
+
+//! Creates a copy of the MinMaxScaler instance
+/** @throw COPY-ERROR MinMaxScaler objects cannot be copied
+*/
+MinMaxScaler::copy() {
+    xsink->raiseException("COPY-ERROR", "MinMaxScaler objects cannot be copied");
+}
+
+//! Fits the scaler on a list of hash records
+/** @param data a list of hashes with numeric fields
+
+    @throw ML-MIN-MAX-SCALER-ERROR empty data
+    @throw ML-DATA-ERROR data format errors
+*/
+nothing MinMaxScaler::fit(list<auto> data) {
+    std::vector<std::string> field_names;
+    MatrixXd matrix = qoreListOfHashesToMatrix(data, field_names, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    scaler->setFieldNames(field_names);
+    scaler->fit(matrix, xsink);
+}
+
+//! Fits the scaler on a numeric matrix
+/** @param matrix a list of lists of numeric values
+
+    @throw ML-MIN-MAX-SCALER-ERROR empty data
+    @throw ML-DATA-ERROR data format errors
+*/
+nothing MinMaxScaler::fitMatrix(list<auto> matrix) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    scaler->fit(mat, xsink);
+}
+
+//! Transforms a single record
+/** @param record a hash with numeric fields
+    @return a hash with scaled values in [feature_min, feature_max]
+
+    @throw ML-MIN-MAX-SCALER-ERROR scaler not fitted or dimension mismatch
+*/
+hash<auto> MinMaxScaler::transform(hash<auto> record) {
+    const std::vector<std::string>& field_names = scaler->getFieldNames();
+    if (field_names.empty()) {
+        xsink->raiseException("ML-MIN-MAX-SCALER-ERROR",
+            "scaler was fitted with fitMatrix(); use transformMatrix() or fit() with hash records");
+        return QoreValue();
+    }
+    RowVectorXd point = qoreHashToRowVector(record, field_names, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    // Use matrix API for thread safety (holds the lock internally)
+    MatrixXd mat(1, point.size());
+    mat.row(0) = point;
+    MatrixXd result_mat = scaler->transform(mat, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    ReferenceHolder<QoreHashNode> rv(new QoreHashNode(autoTypeInfo), xsink);
+    for (size_t i = 0; i < field_names.size(); ++i) {
+        rv->setKeyValue(field_names[i].c_str(), result_mat(0, i), xsink);
+    }
+    return rv.release();
+}
+
+//! Transforms a numeric matrix
+/** @param matrix a list of lists of numeric values
+    @return a list of lists of scaled values
+
+    @throw ML-MIN-MAX-SCALER-ERROR scaler not fitted or dimension mismatch
+    @throw ML-DATA-ERROR data format errors
+*/
+list<list<float>> MinMaxScaler::transformMatrix(list<auto> matrix) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    MatrixXd result = scaler->transform(mat, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(autoTypeInfo), xsink);
+    for (Eigen::Index i = 0; i < result.rows(); ++i) {
+        ReferenceHolder<QoreListNode> row(new QoreListNode(floatTypeInfo), xsink);
+        for (Eigen::Index j = 0; j < result.cols(); ++j) {
+            row->push(result(i, j), xsink);
+        }
+        rv->push(row.release(), xsink);
+    }
+    return rv.release();
+}
+
+//! Inverse-transforms a single record
+/** @param record a hash with numeric fields
+    @return a hash with original-scale values
+
+    @throw ML-MIN-MAX-SCALER-ERROR scaler not fitted or dimension mismatch
+*/
+hash<auto> MinMaxScaler::inverseTransform(hash<auto> record) {
+    const std::vector<std::string>& field_names = scaler->getFieldNames();
+    if (field_names.empty()) {
+        xsink->raiseException("ML-MIN-MAX-SCALER-ERROR",
+            "scaler was fitted with fitMatrix(); use inverseTransformMatrix()");
+        return QoreValue();
+    }
+    RowVectorXd point = qoreHashToRowVector(record, field_names, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    // Use matrix API for thread safety (holds the lock internally)
+    MatrixXd mat(1, point.size());
+    mat.row(0) = point;
+    MatrixXd result_mat = scaler->inverseTransform(mat, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    ReferenceHolder<QoreHashNode> rv(new QoreHashNode(autoTypeInfo), xsink);
+    for (size_t i = 0; i < field_names.size(); ++i) {
+        rv->setKeyValue(field_names[i].c_str(), result_mat(0, i), xsink);
+    }
+    return rv.release();
+}
+
+//! Inverse-transforms a numeric matrix
+/** @param matrix a list of lists of scaled values
+    @return a list of lists of original-scale values
+
+    @throw ML-MIN-MAX-SCALER-ERROR scaler not fitted or dimension mismatch
+    @throw ML-DATA-ERROR data format errors
+*/
+list<list<float>> MinMaxScaler::inverseTransformMatrix(list<auto> matrix) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    MatrixXd result = scaler->inverseTransform(mat, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(autoTypeInfo), xsink);
+    for (Eigen::Index i = 0; i < result.rows(); ++i) {
+        ReferenceHolder<QoreListNode> row(new QoreListNode(floatTypeInfo), xsink);
+        for (Eigen::Index j = 0; j < result.cols(); ++j) {
+            row->push(result(i, j), xsink);
+        }
+        rv->push(row.release(), xsink);
+    }
+    return rv.release();
+}
+
+//! Fits and transforms in a single step
+/** @param data a list of hashes with numeric fields
+    @return a list of hashes with scaled values
+
+    @throw ML-MIN-MAX-SCALER-ERROR empty data
+    @throw ML-DATA-ERROR data format errors
+*/
+list<hash<auto>> MinMaxScaler::fitTransform(list<auto> data) {
+    std::vector<std::string> field_names;
+    MatrixXd matrix = qoreListOfHashesToMatrix(data, field_names, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    scaler->setFieldNames(field_names);
+    MatrixXd result = scaler->fitTransform(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(autoTypeInfo), xsink);
+    for (Eigen::Index i = 0; i < result.rows(); ++i) {
+        ReferenceHolder<QoreHashNode> row(new QoreHashNode(autoTypeInfo), xsink);
+        for (size_t j = 0; j < field_names.size(); ++j) {
+            row->setKeyValue(field_names[j].c_str(), result(i, j), xsink);
+        }
+        rv->push(row.release(), xsink);
+    }
+    return rv.release();
+}
+
+//! Fits and transforms a numeric matrix in a single step
+/** @param matrix a list of lists of numeric values
+    @return a list of lists of scaled values
+
+    @throw ML-MIN-MAX-SCALER-ERROR empty data
+    @throw ML-DATA-ERROR data format errors
+*/
+list<list<float>> MinMaxScaler::fitTransformMatrix(list<auto> matrix) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    MatrixXd result = scaler->fitTransform(mat, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(autoTypeInfo), xsink);
+    for (Eigen::Index i = 0; i < result.rows(); ++i) {
+        ReferenceHolder<QoreListNode> row(new QoreListNode(floatTypeInfo), xsink);
+        for (Eigen::Index j = 0; j < result.cols(); ++j) {
+            row->push(result(i, j), xsink);
+        }
+        rv->push(row.release(), xsink);
+    }
+    return rv.release();
+}
+
+//! Returns True if the scaler has been fitted
+/** @return True if fit() or fitMatrix() has been called successfully
+*/
+bool MinMaxScaler::isFitted() [flags=CONSTANT] {
+    return scaler->isFitted();
+}
+
+//! Returns scaler information
+/** @return a @ref MinMaxScalerInfo hash with the scaler's parameters
+
+    @throw ML-MIN-MAX-SCALER-ERROR scaler not fitted
+*/
+hash<MinMaxScalerInfo> MinMaxScaler::getInfo() {
+    return scaler->getInfo(xsink);
+}

--- a/modules/ml/src/QC_OnnxModel.qpp
+++ b/modules/ml/src/QC_OnnxModel.qpp
@@ -60,7 +60,6 @@ hash<auto> result = model.run({"input": ((1.0, 2.0, 3.0),)});
 printf("Output: %y\n", result);
     @endcode
 
-    @since ml 1.0
 */
 qclass OnnxModel [arg=QoreOnnxModel* model; ns=Qore::ML; flags=final; dom=FILESYSTEM];
 
@@ -112,7 +111,6 @@ OnnxModel model("/path/to/model.onnx", config);
     @throw ML-ONNX-ERROR if the model cannot be loaded or config is invalid
     @throw ML-ONNX-PROVIDER-ERROR if an execution provider cannot be initialized
 
-    @since ml 1.1
 */
 OnnxModel::constructor(string model_path, hash<OnnxSessionConfig> options) {
 #ifdef HAVE_ONNXRUNTIME
@@ -238,7 +236,6 @@ string provider = model.getProviderInfo();
 printf("Configured provider: %s\n", provider);
     @endcode
 
-    @since ml 1.1
 */
 string OnnxModel::getProviderInfo() [flags=CONSTANT] {
     return new QoreStringNode(model->getActiveProvider());

--- a/modules/ml/src/QC_PCA.h
+++ b/modules/ml/src/QC_PCA.h
@@ -74,6 +74,13 @@ public:
     DLLLOCAL void setFieldNames(const std::vector<std::string>& names) { field_names = names; }
     DLLLOCAL const std::vector<std::string>& getFieldNames() const { return field_names; }
 
+    //! Serialize model state to binary
+    DLLLOCAL std::vector<uint8_t> serializeState() const;
+
+    //! Deserialize model state from binary
+    DLLLOCAL static QorePCA* deserializeState(const uint8_t* data, size_t len,
+        ExceptionSink* xsink);
+
 private:
     //! Fit implementation (assumes lock is held)
     DLLLOCAL void doFit(const MatrixXd& data, ExceptionSink* xsink);

--- a/modules/ml/src/QC_PCA.qpp
+++ b/modules/ml/src/QC_PCA.qpp
@@ -41,7 +41,6 @@ pca.fitMatrix(training_data);
 hash<PCAResult> result = pca.transform({"x": 1.0, "y": 2.0, "z": 3.0});
     @endcode
 
-    @since ml 1.0
 */
 qclass PCA [arg=QorePCA* pca; ns=Qore::ML; flags=final];
 

--- a/modules/ml/src/QC_SeasonalDecomposition.qpp
+++ b/modules/ml/src/QC_SeasonalDecomposition.qpp
@@ -40,7 +40,6 @@ SeasonalDecomposition sd({"period": 12, "type": "additive"});
 list<hash<SeasonalDecompositionResult>> results = sd.decompose(monthly_values);
     @endcode
 
-    @since ml 1.0
 */
 qclass SeasonalDecomposition [arg=QoreSeasonalDecomposition* sd; ns=Qore::ML; flags=final];
 

--- a/modules/ml/src/QC_StandardScaler.h
+++ b/modules/ml/src/QC_StandardScaler.h
@@ -1,0 +1,99 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_StandardScaler.h
+
+    Qore ml module - StandardScaler class
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _QORE_MODULE_ML_QC_STANDARDSCALER_H
+#define _QORE_MODULE_ML_QC_STANDARDSCALER_H
+
+#include "ml_common.h"
+
+#include <mutex>
+
+DLLEXPORT extern qore_classid_t CID_STANDARDSCALER;
+DLLLOCAL extern QoreClass* QC_STANDARDSCALER;
+
+DLLLOCAL void preinitStandardScalerClass();
+DLLLOCAL QoreClass* initStandardScalerClass(QoreNamespace& ns);
+
+//! StandardScaler implementation — transforms features to zero mean and unit variance
+class QoreStandardScaler : public AbstractPrivateData {
+public:
+    DLLLOCAL QoreStandardScaler(bool with_mean, bool with_std)
+        : with_mean(with_mean), with_std(with_std) {
+    }
+
+    //! Compute mean and std from training data
+    DLLLOCAL void fit(const MatrixXd& data, ExceptionSink* xsink);
+
+    //! Transform data using fitted parameters
+    DLLLOCAL MatrixXd transform(const MatrixXd& data, ExceptionSink* xsink) const;
+
+    //! Reverse the transformation
+    DLLLOCAL MatrixXd inverseTransform(const MatrixXd& data, ExceptionSink* xsink) const;
+
+    //! Fit and transform in one step
+    DLLLOCAL MatrixXd fitTransform(const MatrixXd& data, ExceptionSink* xsink);
+
+    //! Whether the scaler has been fitted
+    DLLLOCAL bool isFitted() const { return fitted; }
+
+    //! Get model info as a Qore hash
+    DLLLOCAL QoreHashNode* getInfo(ExceptionSink* xsink) const;
+
+    //! Store field names for hash-based input
+    DLLLOCAL void setFieldNames(const std::vector<std::string>& names) { field_names = names; }
+    DLLLOCAL const std::vector<std::string>& getFieldNames() const { return field_names; }
+
+    //! Transform a single row (hash API helper, no lock, no fitted check)
+    DLLLOCAL RowVectorXd transformRow(const RowVectorXd& row, ExceptionSink* xsink) const;
+
+    //! Inverse-transform a single row (no lock, no fitted check)
+    DLLLOCAL RowVectorXd inverseTransformRow(const RowVectorXd& row, ExceptionSink* xsink) const;
+
+    //! Get number of features
+    DLLLOCAL int getNumFeatures() const { return n_features; }
+
+    //! Get the mean vector (for serialization)
+    DLLLOCAL const VectorXd& getMean() const { return mean_vec; }
+
+    //! Get the std vector (for serialization)
+    DLLLOCAL const VectorXd& getStd() const { return std_vec; }
+
+private:
+    bool with_mean;
+    bool with_std;
+    bool fitted = false;
+    int n_features = 0;
+
+    VectorXd mean_vec;
+    VectorXd std_vec;
+
+    std::vector<std::string> field_names;
+
+    mutable std::mutex mtx;
+};
+
+#endif // _QORE_MODULE_ML_QC_STANDARDSCALER_H

--- a/modules/ml/src/QC_StandardScaler.h
+++ b/modules/ml/src/QC_StandardScaler.h
@@ -82,6 +82,13 @@ public:
     //! Get the std vector (for serialization)
     DLLLOCAL const VectorXd& getStd() const { return std_vec; }
 
+    //! Serialize model state to binary
+    DLLLOCAL std::vector<uint8_t> serializeState() const;
+
+    //! Deserialize model state from binary
+    DLLLOCAL static QoreStandardScaler* deserializeState(const uint8_t* data, size_t len,
+        ExceptionSink* xsink);
+
 private:
     bool with_mean;
     bool with_std;

--- a/modules/ml/src/QC_StandardScaler.qpp
+++ b/modules/ml/src/QC_StandardScaler.qpp
@@ -1,0 +1,315 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    QC_StandardScaler.qpp
+
+    Qore ml module - StandardScaler class definition
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "qore/Qore.h"
+#include "QC_StandardScaler.h"
+
+extern const TypedHashDecl* hashdeclStandardScalerInfo;
+
+//! The StandardScaler class transforms features to zero mean and unit variance
+/** StandardScaler standardizes features by removing the mean and scaling to unit variance.
+    This is a common preprocessing step for many ML algorithms that are sensitive to
+    feature scales (e.g., PCA, gradient-based algorithms).
+
+    @par Example:
+    @code{.py}
+StandardScaler scaler({"with_mean": True, "with_std": True});
+scaler.fit(training_data);
+list<list<float>> scaled = scaler.transformMatrix(new_data);
+    @endcode
+
+*/
+qclass StandardScaler [arg=QoreStandardScaler* scaler; ns=Qore::ML; flags=final];
+
+//! Creates a StandardScaler instance
+/** @param options a hash with the following optional keys:
+    - \c with_mean (bool, default True): center features by subtracting the mean
+    - \c with_std (bool, default True): scale features by dividing by the standard deviation
+
+    @par Example:
+    @code{.py}
+StandardScaler scaler({"with_mean": True, "with_std": True});
+    @endcode
+*/
+StandardScaler::constructor(*hash<auto> options) {
+    bool with_mean = true;
+    bool with_std = true;
+
+    if (options) {
+        QoreValue v = options->getKeyValue("with_mean");
+        if (!v.isNullOrNothing()) {
+            with_mean = v.getAsBool();
+        }
+        v = options->getKeyValue("with_std");
+        if (!v.isNullOrNothing()) {
+            with_std = v.getAsBool();
+        }
+    }
+
+    self->setPrivate(CID_STANDARDSCALER, new QoreStandardScaler(with_mean, with_std));
+}
+
+//! Creates a copy of the StandardScaler instance
+/** @throw COPY-ERROR StandardScaler objects cannot be copied
+*/
+StandardScaler::copy() {
+    xsink->raiseException("COPY-ERROR", "StandardScaler objects cannot be copied");
+}
+
+//! Fits the scaler on a list of hash records
+/** @param data a list of hashes with numeric fields
+
+    @par Example:
+    @code{.py}
+scaler.fit(training_data);
+    @endcode
+
+    @throw ML-STANDARD-SCALER-ERROR empty data
+    @throw ML-DATA-ERROR data format errors
+*/
+nothing StandardScaler::fit(list<auto> data) {
+    std::vector<std::string> field_names;
+    MatrixXd matrix = qoreListOfHashesToMatrix(data, field_names, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    scaler->setFieldNames(field_names);
+    scaler->fit(matrix, xsink);
+}
+
+//! Fits the scaler on a numeric matrix
+/** @param matrix a list of lists of numeric values
+
+    @throw ML-STANDARD-SCALER-ERROR empty data
+    @throw ML-DATA-ERROR data format errors
+*/
+nothing StandardScaler::fitMatrix(list<auto> matrix) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    scaler->fit(mat, xsink);
+}
+
+//! Transforms a single record using the fitted scaler
+/** @param record a hash with numeric fields
+    @return a hash with the same field names and scaled values
+
+    @throw ML-STANDARD-SCALER-ERROR scaler not fitted or dimension mismatch
+*/
+hash<auto> StandardScaler::transform(hash<auto> record) {
+    const std::vector<std::string>& field_names = scaler->getFieldNames();
+    if (field_names.empty()) {
+        xsink->raiseException("ML-STANDARD-SCALER-ERROR",
+            "scaler was fitted with fitMatrix(); use transformMatrix() or fit() with hash records");
+        return QoreValue();
+    }
+    RowVectorXd point = qoreHashToRowVector(record, field_names, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    // Use matrix API for thread safety (holds the lock internally)
+    MatrixXd mat(1, point.size());
+    mat.row(0) = point;
+    MatrixXd result_mat = scaler->transform(mat, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    // Build output hash with same field names
+    ReferenceHolder<QoreHashNode> rv(new QoreHashNode(autoTypeInfo), xsink);
+    for (size_t i = 0; i < field_names.size(); ++i) {
+        rv->setKeyValue(field_names[i].c_str(), result_mat(0, i), xsink);
+    }
+    return rv.release();
+}
+
+//! Transforms a numeric matrix
+/** @param matrix a list of lists of numeric values
+    @return a list of lists of scaled values
+
+    @throw ML-STANDARD-SCALER-ERROR scaler not fitted or dimension mismatch
+    @throw ML-DATA-ERROR data format errors
+*/
+list<list<float>> StandardScaler::transformMatrix(list<auto> matrix) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    MatrixXd result = scaler->transform(mat, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    // Convert back to list of lists
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(autoTypeInfo), xsink);
+    for (Eigen::Index i = 0; i < result.rows(); ++i) {
+        ReferenceHolder<QoreListNode> row(new QoreListNode(floatTypeInfo), xsink);
+        for (Eigen::Index j = 0; j < result.cols(); ++j) {
+            row->push(result(i, j), xsink);
+        }
+        rv->push(row.release(), xsink);
+    }
+    return rv.release();
+}
+
+//! Inverse-transforms a single record
+/** @param record a hash with numeric fields
+    @return a hash with original-scale values
+
+    @throw ML-STANDARD-SCALER-ERROR scaler not fitted or dimension mismatch
+*/
+hash<auto> StandardScaler::inverseTransform(hash<auto> record) {
+    const std::vector<std::string>& field_names = scaler->getFieldNames();
+    if (field_names.empty()) {
+        xsink->raiseException("ML-STANDARD-SCALER-ERROR",
+            "scaler was fitted with fitMatrix(); use inverseTransformMatrix()");
+        return QoreValue();
+    }
+    RowVectorXd point = qoreHashToRowVector(record, field_names, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    // Use matrix API for thread safety (holds the lock internally)
+    MatrixXd mat(1, point.size());
+    mat.row(0) = point;
+    MatrixXd result_mat = scaler->inverseTransform(mat, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    ReferenceHolder<QoreHashNode> rv(new QoreHashNode(autoTypeInfo), xsink);
+    for (size_t i = 0; i < field_names.size(); ++i) {
+        rv->setKeyValue(field_names[i].c_str(), result_mat(0, i), xsink);
+    }
+    return rv.release();
+}
+
+//! Inverse-transforms a numeric matrix
+/** @param matrix a list of lists of scaled values
+    @return a list of lists of original-scale values
+
+    @throw ML-STANDARD-SCALER-ERROR scaler not fitted or dimension mismatch
+    @throw ML-DATA-ERROR data format errors
+*/
+list<list<float>> StandardScaler::inverseTransformMatrix(list<auto> matrix) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    MatrixXd result = scaler->inverseTransform(mat, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(autoTypeInfo), xsink);
+    for (Eigen::Index i = 0; i < result.rows(); ++i) {
+        ReferenceHolder<QoreListNode> row(new QoreListNode(floatTypeInfo), xsink);
+        for (Eigen::Index j = 0; j < result.cols(); ++j) {
+            row->push(result(i, j), xsink);
+        }
+        rv->push(row.release(), xsink);
+    }
+    return rv.release();
+}
+
+//! Fits and transforms in a single step
+/** @param data a list of hashes with numeric fields
+    @return a list of hashes with scaled values
+
+    @throw ML-STANDARD-SCALER-ERROR empty data
+    @throw ML-DATA-ERROR data format errors
+*/
+list<hash<auto>> StandardScaler::fitTransform(list<auto> data) {
+    std::vector<std::string> field_names;
+    MatrixXd matrix = qoreListOfHashesToMatrix(data, field_names, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    scaler->setFieldNames(field_names);
+    MatrixXd result = scaler->fitTransform(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    // Convert back to list of hashes
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(autoTypeInfo), xsink);
+    for (Eigen::Index i = 0; i < result.rows(); ++i) {
+        ReferenceHolder<QoreHashNode> row(new QoreHashNode(autoTypeInfo), xsink);
+        for (size_t j = 0; j < field_names.size(); ++j) {
+            row->setKeyValue(field_names[j].c_str(), result(i, j), xsink);
+        }
+        rv->push(row.release(), xsink);
+    }
+    return rv.release();
+}
+
+//! Fits and transforms a numeric matrix in a single step
+/** @param matrix a list of lists of numeric values
+    @return a list of lists of scaled values
+
+    @throw ML-STANDARD-SCALER-ERROR empty data
+    @throw ML-DATA-ERROR data format errors
+*/
+list<list<float>> StandardScaler::fitTransformMatrix(list<auto> matrix) {
+    MatrixXd mat = qoreListOfListsToMatrix(matrix, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    MatrixXd result = scaler->fitTransform(mat, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(autoTypeInfo), xsink);
+    for (Eigen::Index i = 0; i < result.rows(); ++i) {
+        ReferenceHolder<QoreListNode> row(new QoreListNode(floatTypeInfo), xsink);
+        for (Eigen::Index j = 0; j < result.cols(); ++j) {
+            row->push(result(i, j), xsink);
+        }
+        rv->push(row.release(), xsink);
+    }
+    return rv.release();
+}
+
+//! Returns True if the scaler has been fitted
+/** @return True if fit() or fitMatrix() has been called successfully
+*/
+bool StandardScaler::isFitted() [flags=CONSTANT] {
+    return scaler->isFitted();
+}
+
+//! Returns scaler information
+/** @return a @ref StandardScalerInfo hash with the scaler's parameters
+
+    @throw ML-STANDARD-SCALER-ERROR scaler not fitted
+*/
+hash<StandardScalerInfo> StandardScaler::getInfo() {
+    return scaler->getInfo(xsink);
+}

--- a/modules/ml/src/StandardScaler.cpp
+++ b/modules/ml/src/StandardScaler.cpp
@@ -1,0 +1,201 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    StandardScaler.cpp
+
+    Qore ml module - StandardScaler implementation
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "QC_StandardScaler.h"
+
+extern const TypedHashDecl* hashdeclStandardScalerInfo;
+
+void QoreStandardScaler::fit(const MatrixXd& data, ExceptionSink* xsink) {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (data.rows() == 0 || data.cols() == 0) {
+        xsink->raiseException("ML-STANDARD-SCALER-ERROR",
+            "cannot fit on empty data: provide at least one sample with one feature");
+        return;
+    }
+
+    n_features = static_cast<int>(data.cols());
+
+    // Compute mean per feature
+    mean_vec = data.colwise().mean();
+
+    // Compute std per feature
+    std_vec.resize(n_features);
+    for (int j = 0; j < n_features; ++j) {
+        double variance = (data.col(j).array() - mean_vec(j)).square().mean();
+        double std_val = std::sqrt(variance);
+        // Avoid division by zero: if std is near zero, set to 1.0
+        std_vec(j) = (std_val > 1e-10) ? std_val : 1.0;
+    }
+
+    fitted = true;
+}
+
+RowVectorXd QoreStandardScaler::transformRow(const RowVectorXd& row, ExceptionSink* xsink) const {
+    if (row.size() != n_features) {
+        xsink->raiseException("ML-STANDARD-SCALER-ERROR",
+            "input has %d features but scaler was fitted with %d features",
+            static_cast<int>(row.size()), n_features);
+        return RowVectorXd();
+    }
+
+    RowVectorXd result = row;
+    if (with_mean) {
+        result = result.array() - mean_vec.transpose().array();
+    }
+    if (with_std) {
+        result = result.array() / std_vec.transpose().array();
+    }
+    return result;
+}
+
+RowVectorXd QoreStandardScaler::inverseTransformRow(const RowVectorXd& row, ExceptionSink* xsink) const {
+    if (row.size() != n_features) {
+        xsink->raiseException("ML-STANDARD-SCALER-ERROR",
+            "input has %d features but scaler was fitted with %d features",
+            static_cast<int>(row.size()), n_features);
+        return RowVectorXd();
+    }
+
+    RowVectorXd result = row;
+    if (with_std) {
+        result = result.array() * std_vec.transpose().array();
+    }
+    if (with_mean) {
+        result = result.array() + mean_vec.transpose().array();
+    }
+    return result;
+}
+
+MatrixXd QoreStandardScaler::transform(const MatrixXd& data, ExceptionSink* xsink) const {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (!fitted) {
+        xsink->raiseException("ML-STANDARD-SCALER-ERROR",
+            "scaler has not been fitted: call fit() or fitMatrix() first");
+        return MatrixXd();
+    }
+    if (data.cols() != n_features) {
+        xsink->raiseException("ML-STANDARD-SCALER-ERROR",
+            "input has %d features but scaler was fitted with %d features",
+            static_cast<int>(data.cols()), n_features);
+        return MatrixXd();
+    }
+
+    MatrixXd result = data;
+    if (with_mean) {
+        result = result.rowwise() - mean_vec.transpose();
+    }
+    if (with_std) {
+        result = result.array().rowwise() / std_vec.transpose().array();
+    }
+    return result;
+}
+
+MatrixXd QoreStandardScaler::inverseTransform(const MatrixXd& data, ExceptionSink* xsink) const {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (!fitted) {
+        xsink->raiseException("ML-STANDARD-SCALER-ERROR",
+            "scaler has not been fitted: call fit() or fitMatrix() first");
+        return MatrixXd();
+    }
+    if (data.cols() != n_features) {
+        xsink->raiseException("ML-STANDARD-SCALER-ERROR",
+            "input has %d features but scaler was fitted with %d features",
+            static_cast<int>(data.cols()), n_features);
+        return MatrixXd();
+    }
+
+    MatrixXd result = data;
+    if (with_std) {
+        result = result.array().rowwise() * std_vec.transpose().array();
+    }
+    if (with_mean) {
+        result = result.rowwise() + mean_vec.transpose();
+    }
+    return result;
+}
+
+MatrixXd QoreStandardScaler::fitTransform(const MatrixXd& data, ExceptionSink* xsink) {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (data.rows() == 0 || data.cols() == 0) {
+        xsink->raiseException("ML-STANDARD-SCALER-ERROR",
+            "cannot fit on empty data: provide at least one sample with one feature");
+        return MatrixXd();
+    }
+
+    n_features = static_cast<int>(data.cols());
+
+    mean_vec = data.colwise().mean();
+
+    std_vec.resize(n_features);
+    for (int j = 0; j < n_features; ++j) {
+        double variance = (data.col(j).array() - mean_vec(j)).square().mean();
+        double std_val = std::sqrt(variance);
+        std_vec(j) = (std_val > 1e-10) ? std_val : 1.0;
+    }
+
+    fitted = true;
+
+    // Transform in place
+    MatrixXd result = data;
+    if (with_mean) {
+        result = result.rowwise() - mean_vec.transpose();
+    }
+    if (with_std) {
+        result = result.array().rowwise() / std_vec.transpose().array();
+    }
+    return result;
+}
+
+QoreHashNode* QoreStandardScaler::getInfo(ExceptionSink* xsink) const {
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (!fitted) {
+        xsink->raiseException("ML-STANDARD-SCALER-ERROR",
+            "scaler has not been fitted: call fit() or fitMatrix() first");
+        return nullptr;
+    }
+
+    ReferenceHolder<QoreListNode> mean_list(new QoreListNode(floatTypeInfo), xsink);
+    ReferenceHolder<QoreListNode> std_list(new QoreListNode(floatTypeInfo), xsink);
+    for (int j = 0; j < n_features; ++j) {
+        mean_list->push(mean_vec(j), xsink);
+        std_list->push(std_vec(j), xsink);
+    }
+
+    ReferenceHolder<QoreHashNode> rv(new QoreHashNode(hashdeclStandardScalerInfo, xsink), xsink);
+    rv->setKeyValue("mean", mean_list.release(), xsink);
+    rv->setKeyValue("std", std_list.release(), xsink);
+    rv->setKeyValue("n_features", static_cast<int64>(n_features), xsink);
+    rv->setKeyValue("with_mean", with_mean, xsink);
+    rv->setKeyValue("with_std", with_std, xsink);
+
+    return rv.release();
+}

--- a/modules/ml/src/StandardScaler.cpp
+++ b/modules/ml/src/StandardScaler.cpp
@@ -26,6 +26,7 @@
 */
 
 #include "QC_StandardScaler.h"
+#include "ml_serialization.h"
 
 extern const TypedHashDecl* hashdeclStandardScalerInfo;
 
@@ -198,4 +199,44 @@ QoreHashNode* QoreStandardScaler::getInfo(ExceptionSink* xsink) const {
     rv->setKeyValue("with_std", with_std, xsink);
 
     return rv.release();
+}
+
+std::vector<uint8_t> QoreStandardScaler::serializeState() const {
+    std::vector<uint8_t> buf;
+    // Hyperparameters
+    MLSerialization::writeBool(buf, with_mean);
+    MLSerialization::writeBool(buf, with_std);
+    // Model state
+    MLSerialization::writeInt32(buf, n_features);
+    MLSerialization::writeVector(buf, mean_vec);
+    MLSerialization::writeVector(buf, std_vec);
+    MLSerialization::writeStringVector(buf, field_names);
+    return buf;
+}
+
+QoreStandardScaler* QoreStandardScaler::deserializeState(const uint8_t* data, size_t len,
+    ExceptionSink* xsink) {
+    const uint8_t* ptr = data;
+    size_t remaining = len;
+
+    bool with_mean = MLSerialization::readBool(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    bool with_std = MLSerialization::readBool(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    int32_t n_features = MLSerialization::readInt32(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    VectorXd mean_vec = MLSerialization::readVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    VectorXd std_vec = MLSerialization::readVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::vector<std::string> field_names = MLSerialization::readStringVector(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+
+    std::unique_ptr<QoreStandardScaler> obj(new QoreStandardScaler(with_mean, with_std));
+    obj->n_features = n_features;
+    obj->mean_vec = std::move(mean_vec);
+    obj->std_vec = std::move(std_vec);
+    obj->field_names = std::move(field_names);
+    obj->fitted = true;
+    return obj.release();
 }

--- a/modules/ml/src/ml-module.cpp
+++ b/modules/ml/src/ml-module.cpp
@@ -27,6 +27,7 @@
 
 #include "qore/Qore.h"
 
+#include "ml_serialization.h"
 #include "QC_IsolationForest.h"
 #include "QC_DBSCAN.h"
 #include "QC_KMeans.h"
@@ -192,6 +193,56 @@ static void ml_module_init(QoreModuleInitContext& ctx, ExceptionSink& xsink) {
 
     // Add namespace-level functions
     init_ml_functions(MLNS);
+
+    // Register algorithm deserializers for model persistence
+    MLSerialization::registerAlgorithm("KMeans", [](const uint8_t* data, size_t len,
+        ExceptionSink* xsink) -> AbstractPrivateData* {
+        return QoreKMeans::deserializeState(data, len, xsink);
+    });
+    MLSerialization::registerAlgorithm("LinearRegression", [](const uint8_t* data, size_t len,
+        ExceptionSink* xsink) -> AbstractPrivateData* {
+        return QoreLinearRegression::deserializeState(data, len, xsink);
+    });
+    MLSerialization::registerAlgorithm("LogisticRegression", [](const uint8_t* data, size_t len,
+        ExceptionSink* xsink) -> AbstractPrivateData* {
+        return QoreLogisticRegression::deserializeState(data, len, xsink);
+    });
+    MLSerialization::registerAlgorithm("PCA", [](const uint8_t* data, size_t len,
+        ExceptionSink* xsink) -> AbstractPrivateData* {
+        return QorePCA::deserializeState(data, len, xsink);
+    });
+    MLSerialization::registerAlgorithm("IsolationForest", [](const uint8_t* data, size_t len,
+        ExceptionSink* xsink) -> AbstractPrivateData* {
+        return QoreIsolationForest::deserializeState(data, len, xsink);
+    });
+    MLSerialization::registerAlgorithm("LOF", [](const uint8_t* data, size_t len,
+        ExceptionSink* xsink) -> AbstractPrivateData* {
+        return QoreLOF::deserializeState(data, len, xsink);
+    });
+    MLSerialization::registerAlgorithm("GMM", [](const uint8_t* data, size_t len,
+        ExceptionSink* xsink) -> AbstractPrivateData* {
+        return QoreGMM::deserializeState(data, len, xsink);
+    });
+    MLSerialization::registerAlgorithm("HoltWinters", [](const uint8_t* data, size_t len,
+        ExceptionSink* xsink) -> AbstractPrivateData* {
+        return QoreHoltWinters::deserializeState(data, len, xsink);
+    });
+    MLSerialization::registerAlgorithm("KNN", [](const uint8_t* data, size_t len,
+        ExceptionSink* xsink) -> AbstractPrivateData* {
+        return QoreKNN::deserializeState(data, len, xsink);
+    });
+    MLSerialization::registerAlgorithm("StandardScaler", [](const uint8_t* data, size_t len,
+        ExceptionSink* xsink) -> AbstractPrivateData* {
+        return QoreStandardScaler::deserializeState(data, len, xsink);
+    });
+    MLSerialization::registerAlgorithm("MinMaxScaler", [](const uint8_t* data, size_t len,
+        ExceptionSink* xsink) -> AbstractPrivateData* {
+        return QoreMinMaxScaler::deserializeState(data, len, xsink);
+    });
+    MLSerialization::registerAlgorithm("Imputer", [](const uint8_t* data, size_t len,
+        ExceptionSink* xsink) -> AbstractPrivateData* {
+        return QoreImputer::deserializeState(data, len, xsink);
+    });
 }
 
 static void ml_module_ns_init(QoreNamespace* rns, QoreNamespace* qns, ExceptionSink& xsink) {

--- a/modules/ml/src/ml-module.cpp
+++ b/modules/ml/src/ml-module.cpp
@@ -37,6 +37,11 @@
 #include "QC_LOF.h"
 #include "QC_GMM.h"
 #include "QC_OnnxModel.h"
+#include "QC_StandardScaler.h"
+#include "QC_MinMaxScaler.h"
+#include "QC_Imputer.h"
+#include "QC_MLPipeline.h"
+#include "QC_CrossValidator.h"
 
 static void ml_module_init(QoreModuleInitContext& ctx, ExceptionSink& xsink);
 static void ml_module_ns_init(QoreNamespace* rns, QoreNamespace* qns, ExceptionSink& xsink);
@@ -75,6 +80,13 @@ DLLLOCAL TypedHashDecl* init_hashdecl_OnnxTensorInfo(QoreNamespace& ns);
 DLLLOCAL TypedHashDecl* init_hashdecl_OnnxProviderConfig(QoreNamespace& ns);
 DLLLOCAL TypedHashDecl* init_hashdecl_OnnxSessionConfig(QoreNamespace& ns);
 DLLLOCAL TypedHashDecl* init_hashdecl_OnnxModelInfo(QoreNamespace& ns);
+DLLLOCAL TypedHashDecl* init_hashdecl_StandardScalerInfo(QoreNamespace& ns);
+DLLLOCAL TypedHashDecl* init_hashdecl_MinMaxScalerInfo(QoreNamespace& ns);
+DLLLOCAL TypedHashDecl* init_hashdecl_ImputerInfo(QoreNamespace& ns);
+DLLLOCAL TypedHashDecl* init_hashdecl_ConfusionMatrixResult(QoreNamespace& ns);
+DLLLOCAL TypedHashDecl* init_hashdecl_ClassMetrics(QoreNamespace& ns);
+DLLLOCAL TypedHashDecl* init_hashdecl_ClassificationReport(QoreNamespace& ns);
+DLLLOCAL TypedHashDecl* init_hashdecl_CrossValidationFold(QoreNamespace& ns);
 DLLLOCAL TypedHashDecl* init_hashdecl_MLCapabilities(QoreNamespace& ns);
 
 // Global hashdecl pointers (referenced by generated QPP code)
@@ -92,6 +104,13 @@ const TypedHashDecl* hashdeclOnnxTensorInfo;
 const TypedHashDecl* hashdeclOnnxProviderConfig;
 const TypedHashDecl* hashdeclOnnxSessionConfig;
 const TypedHashDecl* hashdeclOnnxModelInfo;
+const TypedHashDecl* hashdeclStandardScalerInfo;
+const TypedHashDecl* hashdeclMinMaxScalerInfo;
+const TypedHashDecl* hashdeclImputerInfo;
+const TypedHashDecl* hashdeclConfusionMatrixResult;
+const TypedHashDecl* hashdeclClassMetrics;
+const TypedHashDecl* hashdeclClassificationReport;
+const TypedHashDecl* hashdeclCrossValidationFold;
 const TypedHashDecl* hashdeclMLCapabilities;
 
 // Forward declarations for function init (generated from ql_ml.qpp)
@@ -109,6 +128,11 @@ static void ml_module_init(QoreModuleInitContext& ctx, ExceptionSink& xsink) {
     preinitLOFClass();
     preinitGMMClass();
     preinitOnnxModelClass();
+    preinitStandardScalerClass();
+    preinitMinMaxScalerClass();
+    preinitImputerClass();
+    preinitMLPipelineClass();
+    preinitCrossValidatorClass();
 
     // Initialize hashdecls (store in globals for generated QPP code)
     hashdeclIsolationForestResult = init_hashdecl_IsolationForestResult(MLNS);
@@ -125,6 +149,13 @@ static void ml_module_init(QoreModuleInitContext& ctx, ExceptionSink& xsink) {
     hashdeclOnnxProviderConfig = init_hashdecl_OnnxProviderConfig(MLNS);
     hashdeclOnnxSessionConfig = init_hashdecl_OnnxSessionConfig(MLNS);
     hashdeclOnnxModelInfo = init_hashdecl_OnnxModelInfo(MLNS);
+    hashdeclStandardScalerInfo = init_hashdecl_StandardScalerInfo(MLNS);
+    hashdeclMinMaxScalerInfo = init_hashdecl_MinMaxScalerInfo(MLNS);
+    hashdeclImputerInfo = init_hashdecl_ImputerInfo(MLNS);
+    hashdeclConfusionMatrixResult = init_hashdecl_ConfusionMatrixResult(MLNS);
+    hashdeclClassMetrics = init_hashdecl_ClassMetrics(MLNS);
+    hashdeclClassificationReport = init_hashdecl_ClassificationReport(MLNS);
+    hashdeclCrossValidationFold = init_hashdecl_CrossValidationFold(MLNS);
     hashdeclMLCapabilities = init_hashdecl_MLCapabilities(MLNS);
 
     // Add classes to namespace (adds methods that may reference other classes)
@@ -138,6 +169,11 @@ static void ml_module_init(QoreModuleInitContext& ctx, ExceptionSink& xsink) {
     MLNS.addSystemClass(initLOFClass(MLNS));
     MLNS.addSystemClass(initGMMClass(MLNS));
     MLNS.addSystemClass(initOnnxModelClass(MLNS));
+    MLNS.addSystemClass(initStandardScalerClass(MLNS));
+    MLNS.addSystemClass(initMinMaxScalerClass(MLNS));
+    MLNS.addSystemClass(initImputerClass(MLNS));
+    MLNS.addSystemClass(initMLPipelineClass(MLNS));
+    MLNS.addSystemClass(initCrossValidatorClass(MLNS));
 
     // Add namespace-level functions
     init_ml_functions(MLNS);

--- a/modules/ml/src/ml-module.cpp
+++ b/modules/ml/src/ml-module.cpp
@@ -34,7 +34,9 @@
 #include "QC_PCA.h"
 #include "QC_SeasonalDecomposition.h"
 #include "QC_LinearRegression.h"
+#include "QC_LogisticRegression.h"
 #include "QC_LOF.h"
+#include "QC_KNN.h"
 #include "QC_GMM.h"
 #include "QC_OnnxModel.h"
 #include "QC_StandardScaler.h"
@@ -74,8 +76,11 @@ DLLLOCAL TypedHashDecl* init_hashdecl_PCAResult(QoreNamespace& ns);
 DLLLOCAL TypedHashDecl* init_hashdecl_SeasonalDecompositionResult(QoreNamespace& ns);
 DLLLOCAL TypedHashDecl* init_hashdecl_LinearRegressionResult(QoreNamespace& ns);
 DLLLOCAL TypedHashDecl* init_hashdecl_LinearRegressionModelInfo(QoreNamespace& ns);
+DLLLOCAL TypedHashDecl* init_hashdecl_LogisticRegressionResult(QoreNamespace& ns);
 DLLLOCAL TypedHashDecl* init_hashdecl_LOFResult(QoreNamespace& ns);
 DLLLOCAL TypedHashDecl* init_hashdecl_GMMResult(QoreNamespace& ns);
+DLLLOCAL TypedHashDecl* init_hashdecl_KNNClassificationResult(QoreNamespace& ns);
+DLLLOCAL TypedHashDecl* init_hashdecl_KNNRegressionResult(QoreNamespace& ns);
 DLLLOCAL TypedHashDecl* init_hashdecl_OnnxTensorInfo(QoreNamespace& ns);
 DLLLOCAL TypedHashDecl* init_hashdecl_OnnxProviderConfig(QoreNamespace& ns);
 DLLLOCAL TypedHashDecl* init_hashdecl_OnnxSessionConfig(QoreNamespace& ns);
@@ -98,8 +103,11 @@ const TypedHashDecl* hashdeclPCAResult;
 const TypedHashDecl* hashdeclSeasonalDecompositionResult;
 const TypedHashDecl* hashdeclLinearRegressionResult;
 const TypedHashDecl* hashdeclLinearRegressionModelInfo;
+const TypedHashDecl* hashdeclLogisticRegressionResult;
 const TypedHashDecl* hashdeclLOFResult;
 const TypedHashDecl* hashdeclGMMResult;
+const TypedHashDecl* hashdeclKNNClassificationResult;
+const TypedHashDecl* hashdeclKNNRegressionResult;
 const TypedHashDecl* hashdeclOnnxTensorInfo;
 const TypedHashDecl* hashdeclOnnxProviderConfig;
 const TypedHashDecl* hashdeclOnnxSessionConfig;
@@ -125,7 +133,9 @@ static void ml_module_init(QoreModuleInitContext& ctx, ExceptionSink& xsink) {
     preinitPCAClass();
     preinitSeasonalDecompositionClass();
     preinitLinearRegressionClass();
+    preinitLogisticRegressionClass();
     preinitLOFClass();
+    preinitKNNClass();
     preinitGMMClass();
     preinitOnnxModelClass();
     preinitStandardScalerClass();
@@ -143,8 +153,11 @@ static void ml_module_init(QoreModuleInitContext& ctx, ExceptionSink& xsink) {
     hashdeclSeasonalDecompositionResult = init_hashdecl_SeasonalDecompositionResult(MLNS);
     hashdeclLinearRegressionResult = init_hashdecl_LinearRegressionResult(MLNS);
     hashdeclLinearRegressionModelInfo = init_hashdecl_LinearRegressionModelInfo(MLNS);
+    hashdeclLogisticRegressionResult = init_hashdecl_LogisticRegressionResult(MLNS);
     hashdeclLOFResult = init_hashdecl_LOFResult(MLNS);
     hashdeclGMMResult = init_hashdecl_GMMResult(MLNS);
+    hashdeclKNNClassificationResult = init_hashdecl_KNNClassificationResult(MLNS);
+    hashdeclKNNRegressionResult = init_hashdecl_KNNRegressionResult(MLNS);
     hashdeclOnnxTensorInfo = init_hashdecl_OnnxTensorInfo(MLNS);
     hashdeclOnnxProviderConfig = init_hashdecl_OnnxProviderConfig(MLNS);
     hashdeclOnnxSessionConfig = init_hashdecl_OnnxSessionConfig(MLNS);
@@ -166,7 +179,9 @@ static void ml_module_init(QoreModuleInitContext& ctx, ExceptionSink& xsink) {
     MLNS.addSystemClass(initPCAClass(MLNS));
     MLNS.addSystemClass(initSeasonalDecompositionClass(MLNS));
     MLNS.addSystemClass(initLinearRegressionClass(MLNS));
+    MLNS.addSystemClass(initLogisticRegressionClass(MLNS));
     MLNS.addSystemClass(initLOFClass(MLNS));
+    MLNS.addSystemClass(initKNNClass(MLNS));
     MLNS.addSystemClass(initGMMClass(MLNS));
     MLNS.addSystemClass(initOnnxModelClass(MLNS));
     MLNS.addSystemClass(initStandardScalerClass(MLNS));

--- a/modules/ml/src/ml_common.cpp
+++ b/modules/ml/src/ml_common.cpp
@@ -27,6 +27,8 @@
 
 #include "ml_common.h"
 
+#include <limits>
+
 MatrixXd qoreListOfHashesToMatrix(const QoreListNode* data,
     std::vector<std::string>& field_names, ExceptionSink* xsink) {
 
@@ -116,7 +118,12 @@ MatrixXd qoreListOfListsToMatrix(const QoreListNode* data, ExceptionSink* xsink)
             return MatrixXd();
         }
         for (size_t j = 0; j < n_cols; ++j) {
-            matrix(i, j) = row->retrieveEntry(j).getAsFloat();
+            QoreValue v = row->retrieveEntry(j);
+            if (v.isNullOrNothing()) {
+                matrix(i, j) = std::numeric_limits<double>::quiet_NaN();
+            } else {
+                matrix(i, j) = v.getAsFloat();
+            }
         }
     }
 
@@ -159,7 +166,11 @@ RowVectorXd qoreHashToRowVector(const QoreHashNode* hash,
     RowVectorXd row(field_names.size());
     for (size_t j = 0; j < field_names.size(); ++j) {
         QoreValue v = hash->getKeyValue(field_names[j].c_str());
-        row(j) = v.getAsFloat();
+        if (v.isNullOrNothing()) {
+            row(j) = std::numeric_limits<double>::quiet_NaN();
+        } else {
+            row(j) = v.getAsFloat();
+        }
     }
     return row;
 }

--- a/modules/ml/src/ml_metrics.cpp
+++ b/modules/ml/src/ml_metrics.cpp
@@ -1,0 +1,525 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    ml_metrics.cpp
+
+    Qore ml module - evaluation metric implementations
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "ml_metrics.h"
+
+#include <algorithm>
+#include <map>
+
+extern const TypedHashDecl* hashdeclConfusionMatrixResult;
+extern const TypedHashDecl* hashdeclClassificationReport;
+extern const TypedHashDecl* hashdeclClassMetrics;
+
+// ---- Helpers ----
+
+std::vector<double> getUniqueLabels(const VectorXd& vec) {
+    std::set<double> unique;
+    for (Eigen::Index i = 0; i < vec.size(); ++i) {
+        unique.insert(vec(i));
+    }
+    return std::vector<double>(unique.begin(), unique.end());
+}
+
+static int checkVectorLengths(const VectorXd& y_true, const VectorXd& y_pred,
+        ExceptionSink* xsink) {
+    if (y_true.size() == 0) {
+        xsink->raiseException("ML-METRICS-ERROR", "y_true is empty");
+        return -1;
+    }
+    if (y_true.size() != y_pred.size()) {
+        xsink->raiseException("ML-METRICS-ERROR",
+            "y_true has %d elements but y_pred has %d elements; they must match",
+            static_cast<int>(y_true.size()), static_cast<int>(y_pred.size()));
+        return -1;
+    }
+    return 0;
+}
+
+// ---- Classification Metrics ----
+
+double mlAccuracy(const VectorXd& y_true, const VectorXd& y_pred, ExceptionSink* xsink) {
+    if (checkVectorLengths(y_true, y_pred, xsink)) {
+        return 0.0;
+    }
+    int correct = 0;
+    for (Eigen::Index i = 0; i < y_true.size(); ++i) {
+        if (y_true(i) == y_pred(i)) {
+            ++correct;
+        }
+    }
+    return static_cast<double>(correct) / y_true.size();
+}
+
+QoreHashNode* mlConfusionMatrix(const VectorXd& y_true, const VectorXd& y_pred,
+        ExceptionSink* xsink) {
+    if (checkVectorLengths(y_true, y_pred, xsink)) {
+        return nullptr;
+    }
+
+    // Get all unique labels from both vectors
+    std::set<double> all_labels;
+    for (Eigen::Index i = 0; i < y_true.size(); ++i) {
+        all_labels.insert(y_true(i));
+        all_labels.insert(y_pred(i));
+    }
+    std::vector<double> labels(all_labels.begin(), all_labels.end());
+    int n_classes = static_cast<int>(labels.size());
+
+    // Build label-to-index map
+    std::map<double, int> label_idx;
+    for (int i = 0; i < n_classes; ++i) {
+        label_idx[labels[i]] = i;
+    }
+
+    // Build confusion matrix
+    std::vector<std::vector<int>> cm(n_classes, std::vector<int>(n_classes, 0));
+    for (Eigen::Index i = 0; i < y_true.size(); ++i) {
+        int true_idx = label_idx[y_true(i)];
+        int pred_idx = label_idx[y_pred(i)];
+        cm[true_idx][pred_idx]++;
+    }
+
+    // Convert to Qore types
+    ReferenceHolder<QoreListNode> matrix_list(new QoreListNode(autoTypeInfo), xsink);
+    for (int i = 0; i < n_classes; ++i) {
+        ReferenceHolder<QoreListNode> row(new QoreListNode(bigIntTypeInfo), xsink);
+        for (int j = 0; j < n_classes; ++j) {
+            row->push(static_cast<int64>(cm[i][j]), xsink);
+        }
+        matrix_list->push(row.release(), xsink);
+    }
+
+    ReferenceHolder<QoreListNode> label_list(new QoreListNode(floatTypeInfo), xsink);
+    for (double lbl : labels) {
+        label_list->push(lbl, xsink);
+    }
+
+    ReferenceHolder<QoreHashNode> rv(new QoreHashNode(hashdeclConfusionMatrixResult, xsink), xsink);
+    rv->setKeyValue("matrix", matrix_list.release(), xsink);
+    rv->setKeyValue("labels", label_list.release(), xsink);
+
+    return rv.release();
+}
+
+// Per-class precision/recall/f1 helpers
+static void computePerClass(const VectorXd& y_true, const VectorXd& y_pred,
+        double class_label, int& tp, int& fp, int& fn) {
+    tp = 0;
+    fp = 0;
+    fn = 0;
+    for (Eigen::Index i = 0; i < y_true.size(); ++i) {
+        bool is_true = (y_true(i) == class_label);
+        bool is_pred = (y_pred(i) == class_label);
+        if (is_true && is_pred) {
+            ++tp;
+        } else if (!is_true && is_pred) {
+            ++fp;
+        } else if (is_true && !is_pred) {
+            ++fn;
+        }
+    }
+}
+
+static double mlPrecision(const VectorXd& y_true, const VectorXd& y_pred,
+        double class_label, ExceptionSink* xsink) {
+    if (checkVectorLengths(y_true, y_pred, xsink)) {
+        return 0.0;
+    }
+    int tp, fp, fn;
+    computePerClass(y_true, y_pred, class_label, tp, fp, fn);
+    int denom = tp + fp;
+    return (denom > 0) ? static_cast<double>(tp) / denom : 0.0;
+}
+
+static double mlRecall(const VectorXd& y_true, const VectorXd& y_pred,
+        double class_label, ExceptionSink* xsink) {
+    if (checkVectorLengths(y_true, y_pred, xsink)) {
+        return 0.0;
+    }
+    int tp, fp, fn;
+    computePerClass(y_true, y_pred, class_label, tp, fp, fn);
+    int denom = tp + fn;
+    return (denom > 0) ? static_cast<double>(tp) / denom : 0.0;
+}
+
+static double mlF1Score(const VectorXd& y_true, const VectorXd& y_pred,
+        double class_label, ExceptionSink* xsink) {
+    if (checkVectorLengths(y_true, y_pred, xsink)) {
+        return 0.0;
+    }
+    int tp, fp, fn;
+    computePerClass(y_true, y_pred, class_label, tp, fp, fn);
+    double prec = (tp + fp > 0) ? static_cast<double>(tp) / (tp + fp) : 0.0;
+    double rec = (tp + fn > 0) ? static_cast<double>(tp) / (tp + fn) : 0.0;
+    return (prec + rec > 0.0) ? 2.0 * prec * rec / (prec + rec) : 0.0;
+}
+
+QoreHashNode* mlClassificationReport(const VectorXd& y_true, const VectorXd& y_pred,
+        ExceptionSink* xsink) {
+    if (checkVectorLengths(y_true, y_pred, xsink)) {
+        return nullptr;
+    }
+
+    std::vector<double> labels = getUniqueLabels(y_true);
+    int n_classes = static_cast<int>(labels.size());
+    int n = static_cast<int>(y_true.size());
+
+    // Compute per-class metrics
+    double macro_prec = 0.0, macro_rec = 0.0, macro_f1 = 0.0;
+    double weighted_f1 = 0.0;
+    int total_correct = 0;
+
+    ReferenceHolder<QoreListNode> per_class(
+        new QoreListNode(hashdeclClassMetrics->getTypeInfo()), xsink);
+
+    for (int c = 0; c < n_classes; ++c) {
+        int tp, fp, fn;
+        computePerClass(y_true, y_pred, labels[c], tp, fp, fn);
+        int support = tp + fn;
+
+        double prec = (tp + fp > 0) ? static_cast<double>(tp) / (tp + fp) : 0.0;
+        double rec = (tp + fn > 0) ? static_cast<double>(tp) / (tp + fn) : 0.0;
+        double f1 = (prec + rec > 0.0) ? 2.0 * prec * rec / (prec + rec) : 0.0;
+
+        macro_prec += prec;
+        macro_rec += rec;
+        macro_f1 += f1;
+        weighted_f1 += f1 * support;
+        total_correct += tp;
+
+        ReferenceHolder<QoreHashNode> cm(new QoreHashNode(hashdeclClassMetrics, xsink), xsink);
+        // Format label as string
+        QoreStringNode* label_str = new QoreStringNode;
+        label_str->sprintf("%g", labels[c]);
+        cm->setKeyValue("label", label_str, xsink);
+        cm->setKeyValue("precision", prec, xsink);
+        cm->setKeyValue("recall", rec, xsink);
+        cm->setKeyValue("f1", f1, xsink);
+        cm->setKeyValue("support", static_cast<int64>(support), xsink);
+        per_class->push(cm.release(), xsink);
+    }
+
+    macro_prec /= n_classes;
+    macro_rec /= n_classes;
+    macro_f1 /= n_classes;
+    weighted_f1 = (n > 0) ? weighted_f1 / n : 0.0;
+    double accuracy = (n > 0) ? static_cast<double>(total_correct) / n : 0.0;
+
+    ReferenceHolder<QoreHashNode> rv(new QoreHashNode(hashdeclClassificationReport, xsink), xsink);
+    rv->setKeyValue("accuracy", accuracy, xsink);
+    rv->setKeyValue("per_class", per_class.release(), xsink);
+    rv->setKeyValue("macro_precision", macro_prec, xsink);
+    rv->setKeyValue("macro_recall", macro_rec, xsink);
+    rv->setKeyValue("macro_f1", macro_f1, xsink);
+    rv->setKeyValue("weighted_f1", weighted_f1, xsink);
+
+    return rv.release();
+}
+
+// ---- Regression Metrics ----
+
+double mlMSE(const VectorXd& y_true, const VectorXd& y_pred, ExceptionSink* xsink) {
+    if (checkVectorLengths(y_true, y_pred, xsink)) {
+        return 0.0;
+    }
+    return (y_true - y_pred).squaredNorm() / y_true.size();
+}
+
+double mlRMSE(const VectorXd& y_true, const VectorXd& y_pred, ExceptionSink* xsink) {
+    if (checkVectorLengths(y_true, y_pred, xsink)) {
+        return 0.0;
+    }
+    return std::sqrt((y_true - y_pred).squaredNorm() / y_true.size());
+}
+
+double mlMAE(const VectorXd& y_true, const VectorXd& y_pred, ExceptionSink* xsink) {
+    if (checkVectorLengths(y_true, y_pred, xsink)) {
+        return 0.0;
+    }
+    return (y_true - y_pred).cwiseAbs().mean();
+}
+
+double mlR2Score(const VectorXd& y_true, const VectorXd& y_pred, ExceptionSink* xsink) {
+    if (checkVectorLengths(y_true, y_pred, xsink)) {
+        return 0.0;
+    }
+    double ss_res = (y_true - y_pred).squaredNorm();
+    double y_mean = y_true.mean();
+    double ss_tot = (y_true.array() - y_mean).square().sum();
+    if (ss_tot < 1e-10) {
+        return (ss_res < 1e-10) ? 1.0 : 0.0;
+    }
+    return 1.0 - ss_res / ss_tot;
+}
+
+double mlExplainedVariance(const VectorXd& y_true, const VectorXd& y_pred, ExceptionSink* xsink) {
+    if (checkVectorLengths(y_true, y_pred, xsink)) {
+        return 0.0;
+    }
+    VectorXd residual = y_true - y_pred;
+    double var_residual = (residual.array() - residual.mean()).square().mean();
+    double var_y = (y_true.array() - y_true.mean()).square().mean();
+    if (var_y < 1e-10) {
+        return (var_residual < 1e-10) ? 1.0 : 0.0;
+    }
+    return 1.0 - var_residual / var_y;
+}
+
+// ---- Clustering Metrics ----
+
+double mlSilhouetteScore(const MatrixXd& data, const VectorXd& labels,
+        ExceptionSink* xsink) {
+    int n = static_cast<int>(data.rows());
+    if (n == 0) {
+        xsink->raiseException("ML-METRICS-ERROR", "data is empty");
+        return 0.0;
+    }
+    if (data.rows() != labels.size()) {
+        xsink->raiseException("ML-METRICS-ERROR",
+            "data has %d rows but labels has %d elements",
+            n, static_cast<int>(labels.size()));
+        return 0.0;
+    }
+
+    std::vector<double> unique = getUniqueLabels(labels);
+    int n_clusters = static_cast<int>(unique.size());
+    if (n_clusters < 2) {
+        xsink->raiseException("ML-METRICS-ERROR",
+            "silhouette score requires at least 2 clusters; got %d", n_clusters);
+        return 0.0;
+    }
+
+    // Build label-to-index map
+    std::map<double, int> label_idx;
+    for (int i = 0; i < n_clusters; ++i) {
+        label_idx[unique[i]] = i;
+    }
+
+    // Assign each point to its cluster index
+    std::vector<int> assignments(n);
+    for (int i = 0; i < n; ++i) {
+        assignments[i] = label_idx[labels(i)];
+    }
+
+    double total_silhouette = 0.0;
+    for (int i = 0; i < n; ++i) {
+        if (i % 100 == 0 && qore_check_cancel(xsink, "silhouette score")) {
+            return 0.0;
+        }
+
+        int my_cluster = assignments[i];
+
+        // Compute mean distance to same-cluster points (a_i)
+        double sum_same = 0.0;
+        int count_same = 0;
+        for (int j = 0; j < n; ++j) {
+            if (j != i && assignments[j] == my_cluster) {
+                sum_same += (data.row(i) - data.row(j)).norm();
+                ++count_same;
+            }
+        }
+        double a_i = (count_same > 0) ? sum_same / count_same : 0.0;
+
+        // Compute min mean distance to other clusters (b_i)
+        double b_i = std::numeric_limits<double>::max();
+        for (int c = 0; c < n_clusters; ++c) {
+            if (c == my_cluster) {
+                continue;
+            }
+            double sum_other = 0.0;
+            int count_other = 0;
+            for (int j = 0; j < n; ++j) {
+                if (assignments[j] == c) {
+                    sum_other += (data.row(i) - data.row(j)).norm();
+                    ++count_other;
+                }
+            }
+            if (count_other > 0) {
+                double mean_other = sum_other / count_other;
+                if (mean_other < b_i) {
+                    b_i = mean_other;
+                }
+            }
+        }
+
+        double max_ab = std::max(a_i, b_i);
+        double s_i = (max_ab > 1e-10) ? (b_i - a_i) / max_ab : 0.0;
+        total_silhouette += s_i;
+    }
+
+    return total_silhouette / n;
+}
+
+double mlDaviesBouldinScore(const MatrixXd& data, const VectorXd& labels,
+        ExceptionSink* xsink) {
+    int n = static_cast<int>(data.rows());
+    if (n == 0) {
+        xsink->raiseException("ML-METRICS-ERROR", "data is empty");
+        return 0.0;
+    }
+    if (data.rows() != labels.size()) {
+        xsink->raiseException("ML-METRICS-ERROR",
+            "data has %d rows but labels has %d elements",
+            n, static_cast<int>(labels.size()));
+        return 0.0;
+    }
+
+    std::vector<double> unique = getUniqueLabels(labels);
+    int n_clusters = static_cast<int>(unique.size());
+    if (n_clusters < 2) {
+        xsink->raiseException("ML-METRICS-ERROR",
+            "Davies-Bouldin score requires at least 2 clusters; got %d", n_clusters);
+        return 0.0;
+    }
+
+    std::map<double, int> label_idx;
+    for (int i = 0; i < n_clusters; ++i) {
+        label_idx[unique[i]] = i;
+    }
+
+    // Compute cluster centroids and within-cluster scatter (S_i)
+    int d = static_cast<int>(data.cols());
+    std::vector<VectorXd> centroids(n_clusters, VectorXd::Zero(d));
+    std::vector<int> counts(n_clusters, 0);
+
+    for (int i = 0; i < n; ++i) {
+        int c = label_idx[labels(i)];
+        centroids[c] += data.row(i).transpose();
+        counts[c]++;
+    }
+    for (int c = 0; c < n_clusters; ++c) {
+        if (counts[c] > 0) {
+            centroids[c] /= counts[c];
+        }
+    }
+
+    // S_i = average distance of points in cluster i to centroid i
+    std::vector<double> scatter(n_clusters, 0.0);
+    for (int i = 0; i < n; ++i) {
+        int c = label_idx[labels(i)];
+        scatter[c] += (data.row(i).transpose() - centroids[c]).norm();
+    }
+    for (int c = 0; c < n_clusters; ++c) {
+        if (counts[c] > 0) {
+            scatter[c] /= counts[c];
+        }
+    }
+
+    // DB index = (1/k) * sum_i max_{j!=i} (S_i + S_j) / d(c_i, c_j)
+    double db_sum = 0.0;
+    for (int i = 0; i < n_clusters; ++i) {
+        double max_ratio = 0.0;
+        for (int j = 0; j < n_clusters; ++j) {
+            if (j == i) {
+                continue;
+            }
+            double dist_ij = (centroids[i] - centroids[j]).norm();
+            if (dist_ij > 1e-10) {
+                double ratio = (scatter[i] + scatter[j]) / dist_ij;
+                if (ratio > max_ratio) {
+                    max_ratio = ratio;
+                }
+            }
+        }
+        db_sum += max_ratio;
+    }
+
+    return db_sum / n_clusters;
+}
+
+double mlCalinskiHarabaszScore(const MatrixXd& data, const VectorXd& labels,
+        ExceptionSink* xsink) {
+    int n = static_cast<int>(data.rows());
+    if (n == 0) {
+        xsink->raiseException("ML-METRICS-ERROR", "data is empty");
+        return 0.0;
+    }
+    if (data.rows() != labels.size()) {
+        xsink->raiseException("ML-METRICS-ERROR",
+            "data has %d rows but labels has %d elements",
+            n, static_cast<int>(labels.size()));
+        return 0.0;
+    }
+
+    std::vector<double> unique = getUniqueLabels(labels);
+    int n_clusters = static_cast<int>(unique.size());
+    if (n_clusters < 2) {
+        xsink->raiseException("ML-METRICS-ERROR",
+            "Calinski-Harabasz score requires at least 2 clusters; got %d", n_clusters);
+        return 0.0;
+    }
+    if (n_clusters >= n) {
+        xsink->raiseException("ML-METRICS-ERROR",
+            "Calinski-Harabasz score requires more samples (%d) than clusters (%d)",
+            n, n_clusters);
+        return 0.0;
+    }
+
+    std::map<double, int> label_idx;
+    for (int i = 0; i < n_clusters; ++i) {
+        label_idx[unique[i]] = i;
+    }
+
+    int d = static_cast<int>(data.cols());
+
+    // Overall centroid
+    VectorXd overall_centroid = data.colwise().mean();
+
+    // Cluster centroids and counts
+    std::vector<VectorXd> centroids(n_clusters, VectorXd::Zero(d));
+    std::vector<int> counts(n_clusters, 0);
+    for (int i = 0; i < n; ++i) {
+        int c = label_idx[labels(i)];
+        centroids[c] += data.row(i).transpose();
+        counts[c]++;
+    }
+    for (int c = 0; c < n_clusters; ++c) {
+        if (counts[c] > 0) {
+            centroids[c] /= counts[c];
+        }
+    }
+
+    // Between-cluster dispersion (B_k)
+    double bk = 0.0;
+    for (int c = 0; c < n_clusters; ++c) {
+        bk += counts[c] * (centroids[c] - overall_centroid).squaredNorm();
+    }
+
+    // Within-cluster dispersion (W_k)
+    double wk = 0.0;
+    for (int i = 0; i < n; ++i) {
+        int c = label_idx[labels(i)];
+        wk += (data.row(i).transpose() - centroids[c]).squaredNorm();
+    }
+
+    if (wk < 1e-10) {
+        return 0.0;
+    }
+
+    // CH = (B_k / (k-1)) / (W_k / (n-k))
+    return (bk / (n_clusters - 1)) / (wk / (n - n_clusters));
+}

--- a/modules/ml/src/ml_metrics.h
+++ b/modules/ml/src/ml_metrics.h
@@ -1,0 +1,88 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    ml_metrics.h
+
+    Qore ml module - evaluation metric function declarations
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _QORE_MODULE_ML_METRICS_H
+#define _QORE_MODULE_ML_METRICS_H
+
+#include "ml_common.h"
+
+#include <set>
+
+// ---- Classification Metrics ----
+
+//! Compute accuracy: fraction of correct predictions
+DLLLOCAL double mlAccuracy(const VectorXd& y_true, const VectorXd& y_pred, ExceptionSink* xsink);
+
+//! Compute confusion matrix as a Qore hash (ConfusionMatrixResult)
+DLLLOCAL QoreHashNode* mlConfusionMatrix(const VectorXd& y_true, const VectorXd& y_pred,
+    ExceptionSink* xsink);
+
+// Note: per-class precision/recall/f1 are available via mlClassificationReport()
+// The standalone functions are static in ml_metrics.cpp (implementation helpers only)
+
+//! Compute full classification report (ClassificationReport hashdecl)
+DLLLOCAL QoreHashNode* mlClassificationReport(const VectorXd& y_true, const VectorXd& y_pred,
+    ExceptionSink* xsink);
+
+// ---- Regression Metrics ----
+
+//! Mean Squared Error
+DLLLOCAL double mlMSE(const VectorXd& y_true, const VectorXd& y_pred, ExceptionSink* xsink);
+
+//! Root Mean Squared Error
+DLLLOCAL double mlRMSE(const VectorXd& y_true, const VectorXd& y_pred, ExceptionSink* xsink);
+
+//! Mean Absolute Error
+DLLLOCAL double mlMAE(const VectorXd& y_true, const VectorXd& y_pred, ExceptionSink* xsink);
+
+//! R² (coefficient of determination)
+DLLLOCAL double mlR2Score(const VectorXd& y_true, const VectorXd& y_pred, ExceptionSink* xsink);
+
+//! Explained variance score
+DLLLOCAL double mlExplainedVariance(const VectorXd& y_true, const VectorXd& y_pred,
+    ExceptionSink* xsink);
+
+// ---- Clustering Metrics ----
+
+//! Silhouette score (mean over all samples)
+DLLLOCAL double mlSilhouetteScore(const MatrixXd& data, const VectorXd& labels,
+    ExceptionSink* xsink);
+
+//! Davies-Bouldin index (lower is better)
+DLLLOCAL double mlDaviesBouldinScore(const MatrixXd& data, const VectorXd& labels,
+    ExceptionSink* xsink);
+
+//! Calinski-Harabasz index (higher is better)
+DLLLOCAL double mlCalinskiHarabaszScore(const MatrixXd& data, const VectorXd& labels,
+    ExceptionSink* xsink);
+
+// ---- Helpers ----
+
+//! Extract unique sorted class labels from a vector
+DLLLOCAL std::vector<double> getUniqueLabels(const VectorXd& vec);
+
+#endif // _QORE_MODULE_ML_METRICS_H

--- a/modules/ml/src/ml_serialization.cpp
+++ b/modules/ml/src/ml_serialization.cpp
@@ -1,0 +1,491 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    ml_serialization.cpp
+
+    Qore ml module - model serialization infrastructure
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "ml_serialization.h"
+
+#include <cstring>
+#include <map>
+
+namespace MLSerialization {
+
+// --- Algorithm registry ---
+
+static std::map<std::string, DeserializeFunc>& getRegistry() {
+    static std::map<std::string, DeserializeFunc> registry;
+    return registry;
+}
+
+void registerAlgorithm(const std::string& name, DeserializeFunc func) {
+    getRegistry()[name] = std::move(func);
+}
+
+DeserializeFunc getDeserializer(const std::string& name) {
+    auto& reg = getRegistry();
+    auto it = reg.find(name);
+    if (it != reg.end()) {
+        return it->second;
+    }
+    return nullptr;
+}
+
+// --- Helper: check remaining bytes ---
+
+static bool checkRemaining(size_t remaining, size_t needed, ExceptionSink* xsink) {
+    if (remaining < needed) {
+        xsink->raiseException("ML-DESERIALIZE-ERROR",
+            "unexpected end of data: need %zu bytes but only %zu remain",
+            needed, remaining);
+        return false;
+    }
+    return true;
+}
+
+// --- Write primitives ---
+
+void writeScalar(std::vector<uint8_t>& buf, double val) {
+    size_t pos = buf.size();
+    buf.resize(pos + sizeof(double));
+    std::memcpy(buf.data() + pos, &val, sizeof(double));
+}
+
+void writeInt32(std::vector<uint8_t>& buf, int32_t val) {
+    size_t pos = buf.size();
+    buf.resize(pos + sizeof(int32_t));
+    std::memcpy(buf.data() + pos, &val, sizeof(int32_t));
+}
+
+void writeInt64(std::vector<uint8_t>& buf, int64_t val) {
+    size_t pos = buf.size();
+    buf.resize(pos + sizeof(int64_t));
+    std::memcpy(buf.data() + pos, &val, sizeof(int64_t));
+}
+
+void writeUint16(std::vector<uint8_t>& buf, uint16_t val) {
+    size_t pos = buf.size();
+    buf.resize(pos + sizeof(uint16_t));
+    std::memcpy(buf.data() + pos, &val, sizeof(uint16_t));
+}
+
+void writeUint32(std::vector<uint8_t>& buf, uint32_t val) {
+    size_t pos = buf.size();
+    buf.resize(pos + sizeof(uint32_t));
+    std::memcpy(buf.data() + pos, &val, sizeof(uint32_t));
+}
+
+void writeUint64(std::vector<uint8_t>& buf, uint64_t val) {
+    size_t pos = buf.size();
+    buf.resize(pos + sizeof(uint64_t));
+    std::memcpy(buf.data() + pos, &val, sizeof(uint64_t));
+}
+
+void writeBool(std::vector<uint8_t>& buf, bool val) {
+    buf.push_back(val ? 1 : 0);
+}
+
+void writeString(std::vector<uint8_t>& buf, const std::string& s) {
+    writeUint32(buf, static_cast<uint32_t>(s.size()));
+    if (!s.empty()) {
+        size_t pos = buf.size();
+        buf.resize(pos + s.size());
+        std::memcpy(buf.data() + pos, s.data(), s.size());
+    }
+}
+
+void writeStringVector(std::vector<uint8_t>& buf, const std::vector<std::string>& v) {
+    writeUint32(buf, static_cast<uint32_t>(v.size()));
+    for (const auto& s : v) {
+        writeString(buf, s);
+    }
+}
+
+void writeDoubleVector(std::vector<uint8_t>& buf, const std::vector<double>& v) {
+    writeUint32(buf, static_cast<uint32_t>(v.size()));
+    for (double d : v) {
+        writeScalar(buf, d);
+    }
+}
+
+void writeIntVector(std::vector<uint8_t>& buf, const std::vector<int>& v) {
+    writeUint32(buf, static_cast<uint32_t>(v.size()));
+    for (int i : v) {
+        writeInt32(buf, i);
+    }
+}
+
+void writeVector(std::vector<uint8_t>& buf, const VectorXd& vec) {
+    writeInt32(buf, static_cast<int32_t>(vec.size()));
+    for (Eigen::Index i = 0; i < vec.size(); ++i) {
+        writeScalar(buf, vec(i));
+    }
+}
+
+void writeMatrix(std::vector<uint8_t>& buf, const MatrixXd& mat) {
+    writeInt32(buf, static_cast<int32_t>(mat.rows()));
+    writeInt32(buf, static_cast<int32_t>(mat.cols()));
+    for (Eigen::Index r = 0; r < mat.rows(); ++r) {
+        for (Eigen::Index c = 0; c < mat.cols(); ++c) {
+            writeScalar(buf, mat(r, c));
+        }
+    }
+}
+
+// --- Read primitives ---
+
+double readScalar(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink) {
+    if (!checkRemaining(remaining, sizeof(double), xsink)) {
+        return 0.0;
+    }
+    double val;
+    std::memcpy(&val, ptr, sizeof(double));
+    ptr += sizeof(double);
+    remaining -= sizeof(double);
+    return val;
+}
+
+int32_t readInt32(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink) {
+    if (!checkRemaining(remaining, sizeof(int32_t), xsink)) {
+        return 0;
+    }
+    int32_t val;
+    std::memcpy(&val, ptr, sizeof(int32_t));
+    ptr += sizeof(int32_t);
+    remaining -= sizeof(int32_t);
+    return val;
+}
+
+int64_t readInt64(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink) {
+    if (!checkRemaining(remaining, sizeof(int64_t), xsink)) {
+        return 0;
+    }
+    int64_t val;
+    std::memcpy(&val, ptr, sizeof(int64_t));
+    ptr += sizeof(int64_t);
+    remaining -= sizeof(int64_t);
+    return val;
+}
+
+uint16_t readUint16(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink) {
+    if (!checkRemaining(remaining, sizeof(uint16_t), xsink)) {
+        return 0;
+    }
+    uint16_t val;
+    std::memcpy(&val, ptr, sizeof(uint16_t));
+    ptr += sizeof(uint16_t);
+    remaining -= sizeof(uint16_t);
+    return val;
+}
+
+uint32_t readUint32(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink) {
+    if (!checkRemaining(remaining, sizeof(uint32_t), xsink)) {
+        return 0;
+    }
+    uint32_t val;
+    std::memcpy(&val, ptr, sizeof(uint32_t));
+    ptr += sizeof(uint32_t);
+    remaining -= sizeof(uint32_t);
+    return val;
+}
+
+uint64_t readUint64(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink) {
+    if (!checkRemaining(remaining, sizeof(uint64_t), xsink)) {
+        return 0;
+    }
+    uint64_t val;
+    std::memcpy(&val, ptr, sizeof(uint64_t));
+    ptr += sizeof(uint64_t);
+    remaining -= sizeof(uint64_t);
+    return val;
+}
+
+bool readBool(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink) {
+    if (!checkRemaining(remaining, 1, xsink)) {
+        return false;
+    }
+    bool val = (*ptr != 0);
+    ptr += 1;
+    remaining -= 1;
+    return val;
+}
+
+std::string readString(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink) {
+    uint32_t len = readUint32(ptr, remaining, xsink);
+    if (*xsink) {
+        return {};
+    }
+    if (!checkRemaining(remaining, len, xsink)) {
+        return {};
+    }
+    std::string result(reinterpret_cast<const char*>(ptr), len);
+    ptr += len;
+    remaining -= len;
+    return result;
+}
+
+std::vector<std::string> readStringVector(const uint8_t*& ptr, size_t& remaining,
+    ExceptionSink* xsink) {
+    uint32_t count = readUint32(ptr, remaining, xsink);
+    if (*xsink) {
+        return {};
+    }
+    std::vector<std::string> result;
+    result.reserve(count);
+    for (uint32_t i = 0; i < count; ++i) {
+        result.push_back(readString(ptr, remaining, xsink));
+        if (*xsink) {
+            return {};
+        }
+    }
+    return result;
+}
+
+std::vector<double> readDoubleVector(const uint8_t*& ptr, size_t& remaining,
+    ExceptionSink* xsink) {
+    uint32_t count = readUint32(ptr, remaining, xsink);
+    if (*xsink) {
+        return {};
+    }
+    std::vector<double> result;
+    result.reserve(count);
+    for (uint32_t i = 0; i < count; ++i) {
+        result.push_back(readScalar(ptr, remaining, xsink));
+        if (*xsink) {
+            return {};
+        }
+    }
+    return result;
+}
+
+std::vector<int> readIntVector(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink) {
+    uint32_t count = readUint32(ptr, remaining, xsink);
+    if (*xsink) {
+        return {};
+    }
+    std::vector<int> result;
+    result.reserve(count);
+    for (uint32_t i = 0; i < count; ++i) {
+        result.push_back(readInt32(ptr, remaining, xsink));
+        if (*xsink) {
+            return {};
+        }
+    }
+    return result;
+}
+
+VectorXd readVector(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink) {
+    int32_t size = readInt32(ptr, remaining, xsink);
+    if (*xsink) {
+        return VectorXd();
+    }
+    if (size < 0) {
+        xsink->raiseException("ML-DESERIALIZE-ERROR",
+            "invalid vector size: %d", size);
+        return VectorXd();
+    }
+    VectorXd vec(size);
+    for (int32_t i = 0; i < size; ++i) {
+        vec(i) = readScalar(ptr, remaining, xsink);
+        if (*xsink) {
+            return VectorXd();
+        }
+    }
+    return vec;
+}
+
+MatrixXd readMatrix(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink) {
+    int32_t rows = readInt32(ptr, remaining, xsink);
+    if (*xsink) {
+        return MatrixXd();
+    }
+    int32_t cols = readInt32(ptr, remaining, xsink);
+    if (*xsink) {
+        return MatrixXd();
+    }
+    if (rows < 0 || cols < 0) {
+        xsink->raiseException("ML-DESERIALIZE-ERROR",
+            "invalid matrix dimensions: %d x %d", rows, cols);
+        return MatrixXd();
+    }
+    MatrixXd mat(rows, cols);
+    for (int32_t r = 0; r < rows; ++r) {
+        for (int32_t c = 0; c < cols; ++c) {
+            mat(r, c) = readScalar(ptr, remaining, xsink);
+            if (*xsink) {
+                return MatrixXd();
+            }
+        }
+    }
+    return mat;
+}
+
+// --- CRC-32 ---
+
+uint32_t computeCRC32(const uint8_t* data, size_t len) {
+    // Standard CRC-32 with polynomial 0xEDB88320
+    uint32_t crc = 0xFFFFFFFF;
+    for (size_t i = 0; i < len; ++i) {
+        crc ^= data[i];
+        for (int bit = 0; bit < 8; ++bit) {
+            if (crc & 1) {
+                crc = (crc >> 1) ^ 0xEDB88320;
+            } else {
+                crc >>= 1;
+            }
+        }
+    }
+    return crc ^ 0xFFFFFFFF;
+}
+
+// --- High-level serialize/parse ---
+
+BinaryNode* serializeModel(const std::string& algorithm,
+    const std::vector<uint8_t>& model_data,
+    const std::string& hyperparams_json,
+    const std::vector<std::string>& field_names,
+    ExceptionSink* xsink) {
+
+    std::vector<uint8_t> buf;
+    buf.reserve(model_data.size() + algorithm.size() + hyperparams_json.size() + 256);
+
+    // Magic bytes
+    buf.insert(buf.end(), MAGIC, MAGIC + 4);
+
+    // Format version
+    writeUint16(buf, FORMAT_VERSION);
+
+    // Algorithm name
+    writeString(buf, algorithm);
+
+    // Hyperparameters JSON string
+    writeString(buf, hyperparams_json);
+
+    // Field names
+    writeStringVector(buf, field_names);
+
+    // Model data length + data
+    writeUint64(buf, static_cast<uint64_t>(model_data.size()));
+    buf.insert(buf.end(), model_data.begin(), model_data.end());
+
+    // CRC-32 over everything before the CRC
+    uint32_t crc = computeCRC32(buf.data(), buf.size());
+    writeUint32(buf, crc);
+
+    // Create BinaryNode
+    void* raw = malloc(buf.size());
+    if (!raw) {
+        xsink->raiseException("ML-SERIALIZE-ERROR", "memory allocation failed");
+        return nullptr;
+    }
+    std::memcpy(raw, buf.data(), buf.size());
+    return new BinaryNode(raw, buf.size());
+}
+
+ModelHeader parseModel(const void* data, size_t len, ExceptionSink* xsink) {
+    ModelHeader header;
+
+    if (len < 4 + 2 + 4) { // magic + version + minimum CRC
+        xsink->raiseException("ML-DESERIALIZE-ERROR",
+            "data too small to be a valid .qml file (%zu bytes)", len);
+        return header;
+    }
+
+    const uint8_t* raw = static_cast<const uint8_t*>(data);
+
+    // Verify magic
+    if (std::memcmp(raw, MAGIC, 4) != 0) {
+        xsink->raiseException("ML-DESERIALIZE-ERROR",
+            "invalid magic bytes: not a .qml file");
+        return header;
+    }
+
+    // Verify CRC (last 4 bytes)
+    if (len < 4) {
+        xsink->raiseException("ML-DESERIALIZE-ERROR",
+            "data too small to contain CRC");
+        return header;
+    }
+    uint32_t stored_crc;
+    std::memcpy(&stored_crc, raw + len - 4, sizeof(uint32_t));
+    uint32_t computed_crc = computeCRC32(raw, len - 4);
+    if (stored_crc != computed_crc) {
+        xsink->raiseException("ML-DESERIALIZE-ERROR",
+            "CRC mismatch: data is corrupted (stored=0x%08x computed=0x%08x)",
+            stored_crc, computed_crc);
+        return header;
+    }
+
+    // Parse fields
+    const uint8_t* ptr = raw + 4; // skip magic
+    size_t remaining = len - 4 - 4; // exclude magic and CRC
+
+    // Format version
+    uint16_t version = readUint16(ptr, remaining, xsink);
+    if (*xsink) {
+        return header;
+    }
+    if (version != FORMAT_VERSION) {
+        xsink->raiseException("ML-DESERIALIZE-ERROR",
+            "unsupported format version %u (expected %u)", version, FORMAT_VERSION);
+        return header;
+    }
+
+    // Algorithm name
+    header.algorithm = readString(ptr, remaining, xsink);
+    if (*xsink) {
+        return header;
+    }
+
+    // Hyperparameters JSON
+    header.hyperparams_json = readString(ptr, remaining, xsink);
+    if (*xsink) {
+        return header;
+    }
+
+    // Field names
+    header.field_names = readStringVector(ptr, remaining, xsink);
+    if (*xsink) {
+        return header;
+    }
+
+    // Model data
+    uint64_t model_data_len = readUint64(ptr, remaining, xsink);
+    if (*xsink) {
+        return header;
+    }
+    if (remaining < model_data_len) {
+        xsink->raiseException("ML-DESERIALIZE-ERROR",
+            "model data length %llu exceeds remaining bytes %zu",
+            static_cast<unsigned long long>(model_data_len), remaining);
+        return header;
+    }
+
+    header.model_data = ptr;
+    header.model_data_len = static_cast<size_t>(model_data_len);
+
+    return header;
+}
+
+} // namespace MLSerialization

--- a/modules/ml/src/ml_serialization.h
+++ b/modules/ml/src/ml_serialization.h
@@ -1,0 +1,103 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    ml_serialization.h
+
+    Qore ml module - model serialization infrastructure
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _QORE_MODULE_ML_SERIALIZATION_H
+#define _QORE_MODULE_ML_SERIALIZATION_H
+
+#include "ml_common.h"
+#include <vector>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <map>
+
+namespace MLSerialization {
+    // Write primitives
+    DLLLOCAL void writeMatrix(std::vector<uint8_t>& buf, const MatrixXd& mat);
+    DLLLOCAL void writeVector(std::vector<uint8_t>& buf, const VectorXd& vec);
+    DLLLOCAL void writeScalar(std::vector<uint8_t>& buf, double val);
+    DLLLOCAL void writeInt32(std::vector<uint8_t>& buf, int32_t val);
+    DLLLOCAL void writeInt64(std::vector<uint8_t>& buf, int64_t val);
+    DLLLOCAL void writeUint16(std::vector<uint8_t>& buf, uint16_t val);
+    DLLLOCAL void writeUint32(std::vector<uint8_t>& buf, uint32_t val);
+    DLLLOCAL void writeUint64(std::vector<uint8_t>& buf, uint64_t val);
+    DLLLOCAL void writeString(std::vector<uint8_t>& buf, const std::string& s);
+    DLLLOCAL void writeStringVector(std::vector<uint8_t>& buf, const std::vector<std::string>& v);
+    DLLLOCAL void writeBool(std::vector<uint8_t>& buf, bool val);
+    DLLLOCAL void writeDoubleVector(std::vector<uint8_t>& buf, const std::vector<double>& v);
+    DLLLOCAL void writeIntVector(std::vector<uint8_t>& buf, const std::vector<int>& v);
+
+    // Read primitives (advance ptr, decrement remaining, raise exception on underflow)
+    DLLLOCAL MatrixXd readMatrix(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink);
+    DLLLOCAL VectorXd readVector(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink);
+    DLLLOCAL double readScalar(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink);
+    DLLLOCAL int32_t readInt32(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink);
+    DLLLOCAL int64_t readInt64(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink);
+    DLLLOCAL uint16_t readUint16(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink);
+    DLLLOCAL uint32_t readUint32(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink);
+    DLLLOCAL uint64_t readUint64(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink);
+    DLLLOCAL std::string readString(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink);
+    DLLLOCAL std::vector<std::string> readStringVector(const uint8_t*& ptr, size_t& remaining,
+        ExceptionSink* xsink);
+    DLLLOCAL bool readBool(const uint8_t*& ptr, size_t& remaining, ExceptionSink* xsink);
+    DLLLOCAL std::vector<double> readDoubleVector(const uint8_t*& ptr, size_t& remaining,
+        ExceptionSink* xsink);
+    DLLLOCAL std::vector<int> readIntVector(const uint8_t*& ptr, size_t& remaining,
+        ExceptionSink* xsink);
+
+    // CRC-32
+    DLLLOCAL uint32_t computeCRC32(const uint8_t* data, size_t len);
+
+    // File format constants
+    constexpr uint8_t MAGIC[4] = {'Q', 'M', 'L', 0x01};
+    constexpr uint16_t FORMAT_VERSION = 1;
+
+    // Algorithm type registry
+    using DeserializeFunc = std::function<AbstractPrivateData*(const uint8_t*, size_t,
+        ExceptionSink*)>;
+    DLLLOCAL void registerAlgorithm(const std::string& name, DeserializeFunc func);
+    DLLLOCAL DeserializeFunc getDeserializer(const std::string& name);
+
+    // High-level save/load (native .qml format)
+    DLLLOCAL BinaryNode* serializeModel(const std::string& algorithm,
+        const std::vector<uint8_t>& model_data,
+        const std::string& hyperparams_json,
+        const std::vector<std::string>& field_names,
+        ExceptionSink* xsink);
+
+    // Parse the header and return algorithm name + model data
+    struct ModelHeader {
+        std::string algorithm;
+        std::string hyperparams_json;
+        std::vector<std::string> field_names;
+        const uint8_t* model_data;
+        size_t model_data_len;
+    };
+    DLLLOCAL ModelHeader parseModel(const void* data, size_t len, ExceptionSink* xsink);
+}
+
+#endif // _QORE_MODULE_ML_SERIALIZATION_H

--- a/modules/ml/src/ql_ml.qpp
+++ b/modules/ml/src/ql_ml.qpp
@@ -26,6 +26,7 @@
 */
 
 #include "qore/Qore.h"
+#include "ml_metrics.h"
 
 #include <Eigen/Dense>
 #ifdef HAVE_ONNXRUNTIME
@@ -48,9 +49,16 @@ extern const TypedHashDecl* hashdeclOnnxTensorInfo;
 extern const TypedHashDecl* hashdeclOnnxModelInfo;
 extern const TypedHashDecl* hashdeclOnnxProviderConfig;
 extern const TypedHashDecl* hashdeclOnnxSessionConfig;
+extern const TypedHashDecl* hashdeclStandardScalerInfo;
+extern const TypedHashDecl* hashdeclMinMaxScalerInfo;
+extern const TypedHashDecl* hashdeclImputerInfo;
+extern const TypedHashDecl* hashdeclConfusionMatrixResult;
+extern const TypedHashDecl* hashdeclClassMetrics;
+extern const TypedHashDecl* hashdeclClassificationReport;
+extern const TypedHashDecl* hashdeclCrossValidationFold;
 
 //! Result of Isolation Forest anomaly scoring
-/** @since ml 1.0
+/** Result of Isolation Forest anomaly scoring
 */
 hashdecl IsolationForestResult {
     //! anomaly score (0.0 = normal, 1.0 = anomalous)
@@ -64,7 +72,7 @@ hashdecl IsolationForestResult {
 }
 
 //! Result of DBSCAN clustering
-/** @since ml 1.0
+/** Result of DBSCAN clustering
 */
 hashdecl DBSCANResult {
     //! cluster label (-1 = noise/outlier)
@@ -76,7 +84,7 @@ hashdecl DBSCANResult {
 }
 
 //! Result of K-Means clustering
-/** @since ml 1.0
+/** Result of K-Means clustering
 */
 hashdecl KMeansResult {
     //! assigned cluster index (0-based)
@@ -88,7 +96,7 @@ hashdecl KMeansResult {
 }
 
 //! Holt-Winters forecast result
-/** @since ml 1.0
+/** Holt-Winters forecast result
 */
 hashdecl HoltWintersResult {
     //! forecasted value
@@ -102,7 +110,7 @@ hashdecl HoltWintersResult {
 }
 
 //! PCA transformation result
-/** @since ml 1.0
+/** PCA transformation result
 */
 hashdecl PCAResult {
     //! transformed values (principal components)
@@ -114,7 +122,7 @@ hashdecl PCAResult {
 }
 
 //! Seasonal decomposition result
-/** @since ml 1.0
+/** Seasonal decomposition result
 */
 hashdecl SeasonalDecompositionResult {
     //! trend component (NOTHING at edges where the moving average cannot be computed)
@@ -128,7 +136,7 @@ hashdecl SeasonalDecompositionResult {
 }
 
 //! Result of linear regression prediction
-/** @since ml 1.0
+/** Result of linear regression prediction
 */
 hashdecl LinearRegressionResult {
     //! predicted target value
@@ -145,7 +153,6 @@ hashdecl LinearRegressionResult {
 /** Use getModelInfo() to retrieve model parameters once, instead of extracting them from each
     individual @ref LinearRegressionResult returned by predict() or predictMatrix().
 
-    @since ml 1.0
 */
 hashdecl LinearRegressionModelInfo {
     //! model coefficients (one per feature)
@@ -159,7 +166,7 @@ hashdecl LinearRegressionModelInfo {
 }
 
 //! Result of Local Outlier Factor scoring
-/** @since ml 1.0
+/** Result of Local Outlier Factor scoring
 */
 hashdecl LOFResult {
     //! local outlier factor score (> 1.0 indicates anomaly)
@@ -173,7 +180,7 @@ hashdecl LOFResult {
 }
 
 //! Result of Gaussian Mixture Model prediction
-/** @since ml 1.0
+/** Result of Gaussian Mixture Model prediction
 */
 hashdecl GMMResult {
     //! most likely cluster assignment
@@ -187,7 +194,7 @@ hashdecl GMMResult {
 }
 
 //! ONNX tensor metadata
-/** @since ml 1.0
+/** ONNX tensor metadata
 */
 hashdecl OnnxTensorInfo {
     //! tensor name
@@ -213,7 +220,6 @@ hash<OnnxProviderConfig> cuda_cfg = <OnnxProviderConfig>{
 };
     @endcode
 
-    @since ml 1.1
 */
 hashdecl OnnxProviderConfig {
     //! provider name (e.g. "CUDA", "TensorRT", "OpenVINO", "CoreML", "DirectML", "CPU")
@@ -236,7 +242,6 @@ hash<OnnxSessionConfig> config = <OnnxSessionConfig>{
 ML::OnnxModel model("/path/to/model.onnx", config);
     @endcode
 
-    @since ml 1.1
 */
 hashdecl OnnxSessionConfig {
     //! execution providers in priority order; CPU is always available as fallback
@@ -259,7 +264,7 @@ hashdecl OnnxSessionConfig {
 }
 
 //! ONNX model metadata
-/** @since ml 1.0
+/** ONNX model metadata
 */
 hashdecl OnnxModelInfo {
     //! producer framework name (e.g. "pytorch", "sklearn")
@@ -273,13 +278,111 @@ hashdecl OnnxModelInfo {
     //! output tensor metadata
     list<hash<OnnxTensorInfo>> outputs;
     //! active execution provider name (e.g. "CPUExecutionProvider")
-    /** @since ml 1.1
-    */
     *string active_provider;
 }
 
+//! StandardScaler model information
+/** StandardScaler model information
+*/
+hashdecl StandardScalerInfo {
+    //! per-feature mean values
+    list<float> mean;
+    //! per-feature standard deviation values
+    list<float> std;
+    //! number of features
+    int n_features;
+    //! whether centering (mean subtraction) is enabled
+    bool with_mean;
+    //! whether scaling (std division) is enabled
+    bool with_std;
+}
+
+//! MinMaxScaler model information
+/** MinMaxScaler model information
+*/
+hashdecl MinMaxScalerInfo {
+    //! per-feature minimum values from training data
+    list<float> data_min;
+    //! per-feature maximum values from training data
+    list<float> data_max;
+    //! lower bound of target range
+    float feature_min;
+    //! upper bound of target range
+    float feature_max;
+    //! number of features
+    int n_features;
+}
+
+//! Imputer model information
+/** Imputer model information
+*/
+hashdecl ImputerInfo {
+    //! imputation strategy ("mean", "median", "most_frequent", "constant")
+    string strategy;
+    //! computed fill values per feature
+    list<float> fill_values;
+    //! number of features
+    int n_features;
+}
+
+//! Confusion matrix result
+/** Contains the n_classes x n_classes confusion matrix and the class labels
+*/
+hashdecl ConfusionMatrixResult {
+    //! the confusion matrix (rows = true labels, columns = predicted labels)
+    list<list<int>> matrix;
+    //! sorted class labels corresponding to matrix rows/columns
+    list<float> labels;
+}
+
+//! Per-class classification metrics
+/** Precision, recall, F1, and support for a single class
+*/
+hashdecl ClassMetrics {
+    //! class label as a string
+    string label;
+    //! precision (true positives / predicted positives)
+    float precision;
+    //! recall (true positives / actual positives)
+    float recall;
+    //! F1 score (harmonic mean of precision and recall)
+    float f1;
+    //! number of true instances of this class
+    int support;
+}
+
+//! Full classification report with per-class and aggregate metrics
+/** Contains accuracy, per-class metrics, and macro/weighted averages
+*/
+hashdecl ClassificationReport {
+    //! overall accuracy (fraction of correct predictions)
+    float accuracy;
+    //! per-class precision, recall, F1, and support
+    list<hash<ClassMetrics>> per_class;
+    //! unweighted mean of per-class precision
+    float macro_precision;
+    //! unweighted mean of per-class recall
+    float macro_recall;
+    //! unweighted mean of per-class F1
+    float macro_f1;
+    //! support-weighted mean of per-class F1
+    float weighted_f1;
+}
+
+//! Cross-validation fold with train and test indices
+/** Returned by CrossValidator::split()
+*/
+hashdecl CrossValidationFold {
+    //! indices of training samples for this fold
+    list<int> train_indices;
+    //! indices of test samples for this fold
+    list<int> test_indices;
+    //! fold number (0-based)
+    int fold;
+}
+
 //! ML module capability information
-/** @since ml 1.0
+/** ML module capability information
 */
 hashdecl MLCapabilities {
     //! whether ONNX Runtime support is compiled in
@@ -289,8 +392,6 @@ hashdecl MLCapabilities {
     //! Eigen version string
     string eigen_version;
     //! available ONNX execution providers (empty if no ONNX Runtime)
-    /** @since ml 1.1
-    */
     list<string> onnx_providers;
 }
 
@@ -309,7 +410,6 @@ printf("Eigen version: %s\n", caps.eigen_version);
 printf("ONNX support: %y\n", caps.has_onnx);
     @endcode
 
-    @since ml 1.0
 */
 hash<MLCapabilities> ml_get_capabilities() [flags=CONSTANT; dom=DEFAULT] {
     ReferenceHolder<QoreHashNode> rv(new QoreHashNode(hashdeclMLCapabilities, xsink), xsink);
@@ -331,6 +431,11 @@ hash<MLCapabilities> ml_get_capabilities() [flags=CONSTANT; dom=DEFAULT] {
     algos->push(new QoreStringNode("LinearRegression"), xsink);
     algos->push(new QoreStringNode("LOF"), xsink);
     algos->push(new QoreStringNode("GMM"), xsink);
+    algos->push(new QoreStringNode("StandardScaler"), xsink);
+    algos->push(new QoreStringNode("MinMaxScaler"), xsink);
+    algos->push(new QoreStringNode("Imputer"), xsink);
+    algos->push(new QoreStringNode("MLPipeline"), xsink);
+    algos->push(new QoreStringNode("CrossValidator"), xsink);
 #ifdef HAVE_ONNXRUNTIME
     algos->push(new QoreStringNode("OnnxModel"), xsink);
 #endif
@@ -366,7 +471,6 @@ list<string> providers = ml_get_onnx_providers();
 printf("Available providers: %y\n", providers);
     @endcode
 
-    @since ml 1.1
 */
 list<string> ml_get_onnx_providers() [flags=CONSTANT; dom=DEFAULT] {
 #ifdef HAVE_ONNXRUNTIME
@@ -380,6 +484,228 @@ list<string> ml_get_onnx_providers() [flags=CONSTANT; dom=DEFAULT] {
     return xsink->raiseException("MISSING-FEATURE-ERROR", "the ml module was not compiled with ONNX Runtime "
         "support; check MLCapabilities.has_onnx before calling this function");
 #endif
+}
+
+//! Computes classification accuracy (fraction of correct predictions)
+/** @param y_true a list of true class labels
+    @param y_pred a list of predicted class labels
+    @return accuracy from 0.0 (all wrong) to 1.0 (all correct)
+
+    @par Example:
+    @code{.py}
+float acc = ml_accuracy((1, 0, 1, 1, 0), (1, 0, 0, 1, 0));
+printf("Accuracy: %.1f%%\n", acc * 100);  # 80.0%
+    @endcode
+
+    @throw ML-METRICS-ERROR empty or mismatched inputs
+*/
+float ml_accuracy(list<auto> y_true, list<auto> y_pred) [dom=DEFAULT] {
+    VectorXd yt = qoreListToVector(y_true, xsink);
+    if (*xsink) { return QoreValue(); }
+    VectorXd yp = qoreListToVector(y_pred, xsink);
+    if (*xsink) { return QoreValue(); }
+    return mlAccuracy(yt, yp, xsink);
+}
+
+//! Computes a confusion matrix
+/** @param y_true a list of true class labels
+    @param y_pred a list of predicted class labels
+    @return a @ref ConfusionMatrixResult hash
+
+    @par Example:
+    @code{.py}
+hash<ConfusionMatrixResult> cm = ml_confusion_matrix((0, 0, 1, 1), (0, 1, 0, 1));
+printf("Matrix: %y\n", cm.matrix);  # ((1, 1), (1, 1))
+    @endcode
+
+    @throw ML-METRICS-ERROR empty or mismatched inputs
+*/
+hash<ConfusionMatrixResult> ml_confusion_matrix(list<auto> y_true, list<auto> y_pred) [dom=DEFAULT] {
+    VectorXd yt = qoreListToVector(y_true, xsink);
+    if (*xsink) { return QoreValue(); }
+    VectorXd yp = qoreListToVector(y_pred, xsink);
+    if (*xsink) { return QoreValue(); }
+    return mlConfusionMatrix(yt, yp, xsink);
+}
+
+//! Computes a full classification report with per-class and aggregate metrics
+/** @param y_true a list of true class labels
+    @param y_pred a list of predicted class labels
+    @return a @ref ClassificationReport hash
+
+    @par Example:
+    @code{.py}
+hash<ClassificationReport> report = ml_classification_report(y_true, y_pred);
+printf("Accuracy: %.2f, Macro F1: %.2f\n", report.accuracy, report.macro_f1);
+foreach hash<ClassMetrics> cls in (report.per_class) {
+    printf("  Class %s: precision=%.2f recall=%.2f f1=%.2f (n=%d)\n",
+        cls.label, cls.precision, cls.recall, cls.f1, cls.support);
+}
+    @endcode
+
+    @throw ML-METRICS-ERROR empty or mismatched inputs
+*/
+hash<ClassificationReport> ml_classification_report(list<auto> y_true, list<auto> y_pred) [dom=DEFAULT] {
+    VectorXd yt = qoreListToVector(y_true, xsink);
+    if (*xsink) { return QoreValue(); }
+    VectorXd yp = qoreListToVector(y_pred, xsink);
+    if (*xsink) { return QoreValue(); }
+    return mlClassificationReport(yt, yp, xsink);
+}
+
+//! Computes Mean Squared Error between true and predicted values
+/** @param y_true a list of true values
+    @param y_pred a list of predicted values
+    @return the MSE (0.0 = perfect predictions)
+
+    @par Example:
+    @code{.py}
+float mse = ml_mse((3.0, 5.0, 7.0), (2.8, 5.2, 7.1));
+    @endcode
+
+    @throw ML-METRICS-ERROR empty or mismatched inputs
+*/
+float ml_mse(list<auto> y_true, list<auto> y_pred) [dom=DEFAULT] {
+    VectorXd yt = qoreListToVector(y_true, xsink);
+    if (*xsink) { return QoreValue(); }
+    VectorXd yp = qoreListToVector(y_pred, xsink);
+    if (*xsink) { return QoreValue(); }
+    return mlMSE(yt, yp, xsink);
+}
+
+//! Computes Root Mean Squared Error
+/** @param y_true a list of true values
+    @param y_pred a list of predicted values
+    @return the RMSE (in the same units as the data)
+
+    @par Example:
+    @code{.py}
+float rmse = ml_rmse(actual_prices, predicted_prices);
+printf("Average prediction error: $%.2f\n", rmse);
+    @endcode
+
+    @throw ML-METRICS-ERROR empty or mismatched inputs
+*/
+float ml_rmse(list<auto> y_true, list<auto> y_pred) [dom=DEFAULT] {
+    VectorXd yt = qoreListToVector(y_true, xsink);
+    if (*xsink) { return QoreValue(); }
+    VectorXd yp = qoreListToVector(y_pred, xsink);
+    if (*xsink) { return QoreValue(); }
+    return mlRMSE(yt, yp, xsink);
+}
+
+//! Computes Mean Absolute Error
+/** @param y_true a list of true values
+    @param y_pred a list of predicted values
+    @return the MAE (in the same units as the data)
+
+    @par Example:
+    @code{.py}
+float mae = ml_mae(actual_delivery_days, predicted_delivery_days);
+printf("Predictions are off by %.1f days on average\n", mae);
+    @endcode
+
+    @throw ML-METRICS-ERROR empty or mismatched inputs
+*/
+float ml_mae(list<auto> y_true, list<auto> y_pred) [dom=DEFAULT] {
+    VectorXd yt = qoreListToVector(y_true, xsink);
+    if (*xsink) { return QoreValue(); }
+    VectorXd yp = qoreListToVector(y_pred, xsink);
+    if (*xsink) { return QoreValue(); }
+    return mlMAE(yt, yp, xsink);
+}
+
+//! Computes the R² (coefficient of determination) score
+/** @param y_true a list of true values
+    @param y_pred a list of predicted values
+    @return R² from -infinity to 1.0 (1.0 = perfect prediction)
+
+    @par Example:
+    @code{.py}
+float r2 = ml_r2_score(actual_prices, predicted_prices);
+printf("Model explains %.0f%% of the variance\n", r2 * 100);
+    @endcode
+
+    @throw ML-METRICS-ERROR empty or mismatched inputs
+*/
+float ml_r2_score(list<auto> y_true, list<auto> y_pred) [dom=DEFAULT] {
+    VectorXd yt = qoreListToVector(y_true, xsink);
+    if (*xsink) { return QoreValue(); }
+    VectorXd yp = qoreListToVector(y_pred, xsink);
+    if (*xsink) { return QoreValue(); }
+    return mlR2Score(yt, yp, xsink);
+}
+
+//! Computes the explained variance score
+/** @param y_true a list of true values
+    @param y_pred a list of predicted values
+    @return explained variance from -infinity to 1.0
+
+    @par Example:
+    @code{.py}
+float ev = ml_explained_variance(actual_values, predicted_values);
+printf("Model explains %.0f%% of the variance\n", ev * 100);
+    @endcode
+
+    @throw ML-METRICS-ERROR empty or mismatched inputs
+*/
+float ml_explained_variance(list<auto> y_true, list<auto> y_pred) [dom=DEFAULT] {
+    VectorXd yt = qoreListToVector(y_true, xsink);
+    if (*xsink) { return QoreValue(); }
+    VectorXd yp = qoreListToVector(y_pred, xsink);
+    if (*xsink) { return QoreValue(); }
+    return mlExplainedVariance(yt, yp, xsink);
+}
+
+//! Computes the silhouette score for clustering quality
+/** @param data a list of lists of numeric values (the data points)
+    @param labels a list of cluster assignments (one per data point)
+    @return silhouette score from -1.0 (poor) to 1.0 (excellent clustering)
+
+    @par Example:
+    @code{.py}
+float score = ml_silhouette_score(data_matrix, cluster_labels);
+printf("Clustering quality: %.2f\n", score);  # > 0.5 is generally good
+    @endcode
+
+    @throw ML-METRICS-ERROR empty data, mismatched sizes, or fewer than 2 clusters
+*/
+float ml_silhouette_score(list<auto> data, list<auto> labels) [dom=DEFAULT] {
+    MatrixXd mat = qoreListOfListsToMatrix(data, xsink);
+    if (*xsink) { return QoreValue(); }
+    VectorXd lbl = qoreListToVector(labels, xsink);
+    if (*xsink) { return QoreValue(); }
+    return mlSilhouetteScore(mat, lbl, xsink);
+}
+
+//! Computes the Davies-Bouldin index for clustering quality
+/** @param data a list of lists of numeric values (the data points)
+    @param labels a list of cluster assignments (one per data point)
+    @return Davies-Bouldin index (lower is better; 0.0 = perfect separation)
+
+    @throw ML-METRICS-ERROR empty data, mismatched sizes, or fewer than 2 clusters
+*/
+float ml_davies_bouldin_score(list<auto> data, list<auto> labels) [dom=DEFAULT] {
+    MatrixXd mat = qoreListOfListsToMatrix(data, xsink);
+    if (*xsink) { return QoreValue(); }
+    VectorXd lbl = qoreListToVector(labels, xsink);
+    if (*xsink) { return QoreValue(); }
+    return mlDaviesBouldinScore(mat, lbl, xsink);
+}
+
+//! Computes the Calinski-Harabasz index for clustering quality
+/** @param data a list of lists of numeric values (the data points)
+    @param labels a list of cluster assignments (one per data point)
+    @return Calinski-Harabasz index (higher is better)
+
+    @throw ML-METRICS-ERROR empty data, mismatched sizes, or fewer than 2 clusters
+*/
+float ml_calinski_harabasz_score(list<auto> data, list<auto> labels) [dom=DEFAULT] {
+    MatrixXd mat = qoreListOfListsToMatrix(data, xsink);
+    if (*xsink) { return QoreValue(); }
+    VectorXd lbl = qoreListToVector(labels, xsink);
+    if (*xsink) { return QoreValue(); }
+    return mlCalinskiHarabaszScore(mat, lbl, xsink);
 }
 
 ///@}

--- a/modules/ml/src/ql_ml.qpp
+++ b/modules/ml/src/ql_ml.qpp
@@ -27,6 +27,20 @@
 
 #include "qore/Qore.h"
 #include "ml_metrics.h"
+#include "ml_serialization.h"
+
+#include "QC_KMeans.h"
+#include "QC_LinearRegression.h"
+#include "QC_LogisticRegression.h"
+#include "QC_PCA.h"
+#include "QC_IsolationForest.h"
+#include "QC_LOF.h"
+#include "QC_GMM.h"
+#include "QC_HoltWinters.h"
+#include "QC_KNN.h"
+#include "QC_StandardScaler.h"
+#include "QC_MinMaxScaler.h"
+#include "QC_Imputer.h"
 
 #include <Eigen/Dense>
 #ifdef HAVE_ONNXRUNTIME
@@ -747,6 +761,505 @@ float ml_calinski_harabasz_score(list<auto> data, list<auto> labels) [dom=DEFAUL
     VectorXd lbl = qoreListToVector(labels, xsink);
     if (*xsink) { return QoreValue(); }
     return mlCalinskiHarabaszScore(mat, lbl, xsink);
+}
+
+//! Serializes a fitted ML model to binary format
+/** @param model a fitted ML model object (KMeans, LinearRegression, etc.)
+    @return binary data containing the serialized model
+
+    @par Example:
+    @code{.py}
+KMeans km({"k": 3, "seed": 42});
+km.fitMatrix(data);
+binary blob = ml_serialize(km);
+    @endcode
+
+    @throw ML-SERIALIZE-ERROR if the model is not fitted or the object type is unknown
+*/
+binary ml_serialize(object model) [dom=DEFAULT] {
+    // Try each known algorithm CID
+    std::string algorithm;
+    std::vector<uint8_t> model_data;
+    std::vector<std::string> field_names;
+
+    QoreKMeans* km = dynamic_cast<QoreKMeans*>(
+        model->getReferencedPrivateData(CID_KMEANS, xsink));
+    if (km) {
+        if (!km->isFitted()) {
+            km->deref(xsink);
+            xsink->raiseException("ML-SERIALIZE-ERROR",
+                "model has not been fitted: call fit() before serializing");
+            return QoreValue();
+        }
+        algorithm = "KMeans";
+        model_data = km->serializeState();
+        field_names = km->getFieldNames();
+        km->deref(xsink);
+        return MLSerialization::serializeModel(algorithm, model_data, "{}", field_names, xsink);
+    }
+    if (*xsink) { xsink->clear(); }
+
+    QoreLinearRegression* lr = dynamic_cast<QoreLinearRegression*>(
+        model->getReferencedPrivateData(CID_LINEARREGRESSION, xsink));
+    if (lr) {
+        if (!lr->isFitted()) {
+            lr->deref(xsink);
+            xsink->raiseException("ML-SERIALIZE-ERROR",
+                "model has not been fitted: call fit() before serializing");
+            return QoreValue();
+        }
+        algorithm = "LinearRegression";
+        model_data = lr->serializeState();
+        field_names = lr->getFieldNames();
+        lr->deref(xsink);
+        return MLSerialization::serializeModel(algorithm, model_data, "{}", field_names, xsink);
+    }
+    if (*xsink) { xsink->clear(); }
+
+    QoreLogisticRegression* logr = dynamic_cast<QoreLogisticRegression*>(
+        model->getReferencedPrivateData(CID_LOGISTICREGRESSION, xsink));
+    if (logr) {
+        if (!logr->isFitted()) {
+            logr->deref(xsink);
+            xsink->raiseException("ML-SERIALIZE-ERROR",
+                "model has not been fitted: call fit() before serializing");
+            return QoreValue();
+        }
+        algorithm = "LogisticRegression";
+        model_data = logr->serializeState();
+        field_names = logr->getFieldNames();
+        logr->deref(xsink);
+        return MLSerialization::serializeModel(algorithm, model_data, "{}", field_names, xsink);
+    }
+    if (*xsink) { xsink->clear(); }
+
+    QorePCA* pca = dynamic_cast<QorePCA*>(
+        model->getReferencedPrivateData(CID_PCA, xsink));
+    if (pca) {
+        if (!pca->isFitted()) {
+            pca->deref(xsink);
+            xsink->raiseException("ML-SERIALIZE-ERROR",
+                "model has not been fitted: call fit() before serializing");
+            return QoreValue();
+        }
+        algorithm = "PCA";
+        model_data = pca->serializeState();
+        field_names = pca->getFieldNames();
+        pca->deref(xsink);
+        return MLSerialization::serializeModel(algorithm, model_data, "{}", field_names, xsink);
+    }
+    if (*xsink) { xsink->clear(); }
+
+    QoreIsolationForest* iforest = dynamic_cast<QoreIsolationForest*>(
+        model->getReferencedPrivateData(CID_ISOLATIONFOREST, xsink));
+    if (iforest) {
+        if (!iforest->isFitted()) {
+            iforest->deref(xsink);
+            xsink->raiseException("ML-SERIALIZE-ERROR",
+                "model has not been fitted: call fit() before serializing");
+            return QoreValue();
+        }
+        algorithm = "IsolationForest";
+        model_data = iforest->serializeState();
+        field_names = iforest->getFieldNames();
+        iforest->deref(xsink);
+        return MLSerialization::serializeModel(algorithm, model_data, "{}", field_names, xsink);
+    }
+    if (*xsink) { xsink->clear(); }
+
+    QoreLOF* lof = dynamic_cast<QoreLOF*>(
+        model->getReferencedPrivateData(CID_LOF, xsink));
+    if (lof) {
+        if (!lof->isFitted()) {
+            lof->deref(xsink);
+            xsink->raiseException("ML-SERIALIZE-ERROR",
+                "model has not been fitted: call fit() before serializing");
+            return QoreValue();
+        }
+        algorithm = "LOF";
+        model_data = lof->serializeState();
+        field_names = lof->getFieldNames();
+        lof->deref(xsink);
+        return MLSerialization::serializeModel(algorithm, model_data, "{}", field_names, xsink);
+    }
+    if (*xsink) { xsink->clear(); }
+
+    QoreGMM* gmm = dynamic_cast<QoreGMM*>(
+        model->getReferencedPrivateData(CID_GMM, xsink));
+    if (gmm) {
+        if (!gmm->isFitted()) {
+            gmm->deref(xsink);
+            xsink->raiseException("ML-SERIALIZE-ERROR",
+                "model has not been fitted: call fit() before serializing");
+            return QoreValue();
+        }
+        algorithm = "GMM";
+        model_data = gmm->serializeState();
+        field_names = gmm->getFieldNames();
+        gmm->deref(xsink);
+        return MLSerialization::serializeModel(algorithm, model_data, "{}", field_names, xsink);
+    }
+    if (*xsink) { xsink->clear(); }
+
+    QoreHoltWinters* hw = dynamic_cast<QoreHoltWinters*>(
+        model->getReferencedPrivateData(CID_HOLTWINTERS, xsink));
+    if (hw) {
+        if (!hw->isFitted()) {
+            hw->deref(xsink);
+            xsink->raiseException("ML-SERIALIZE-ERROR",
+                "model has not been fitted: call fit() before serializing");
+            return QoreValue();
+        }
+        algorithm = "HoltWinters";
+        model_data = hw->serializeState();
+        hw->deref(xsink);
+        return MLSerialization::serializeModel(algorithm, model_data, "{}", field_names, xsink);
+    }
+    if (*xsink) { xsink->clear(); }
+
+    QoreKNN* knn = dynamic_cast<QoreKNN*>(
+        model->getReferencedPrivateData(CID_KNN, xsink));
+    if (knn) {
+        if (!knn->isFitted()) {
+            knn->deref(xsink);
+            xsink->raiseException("ML-SERIALIZE-ERROR",
+                "model has not been fitted: call fit() before serializing");
+            return QoreValue();
+        }
+        algorithm = "KNN";
+        model_data = knn->serializeState();
+        field_names = knn->getFieldNames();
+        knn->deref(xsink);
+        return MLSerialization::serializeModel(algorithm, model_data, "{}", field_names, xsink);
+    }
+    if (*xsink) { xsink->clear(); }
+
+    QoreStandardScaler* ss = dynamic_cast<QoreStandardScaler*>(
+        model->getReferencedPrivateData(CID_STANDARDSCALER, xsink));
+    if (ss) {
+        if (!ss->isFitted()) {
+            ss->deref(xsink);
+            xsink->raiseException("ML-SERIALIZE-ERROR",
+                "model has not been fitted: call fit() before serializing");
+            return QoreValue();
+        }
+        algorithm = "StandardScaler";
+        model_data = ss->serializeState();
+        field_names = ss->getFieldNames();
+        ss->deref(xsink);
+        return MLSerialization::serializeModel(algorithm, model_data, "{}", field_names, xsink);
+    }
+    if (*xsink) { xsink->clear(); }
+
+    QoreMinMaxScaler* mms = dynamic_cast<QoreMinMaxScaler*>(
+        model->getReferencedPrivateData(CID_MINMAXSCALER, xsink));
+    if (mms) {
+        if (!mms->isFitted()) {
+            mms->deref(xsink);
+            xsink->raiseException("ML-SERIALIZE-ERROR",
+                "model has not been fitted: call fit() before serializing");
+            return QoreValue();
+        }
+        algorithm = "MinMaxScaler";
+        model_data = mms->serializeState();
+        field_names = mms->getFieldNames();
+        mms->deref(xsink);
+        return MLSerialization::serializeModel(algorithm, model_data, "{}", field_names, xsink);
+    }
+    if (*xsink) { xsink->clear(); }
+
+    QoreImputer* imp = dynamic_cast<QoreImputer*>(
+        model->getReferencedPrivateData(CID_IMPUTER, xsink));
+    if (imp) {
+        if (!imp->isFitted()) {
+            imp->deref(xsink);
+            xsink->raiseException("ML-SERIALIZE-ERROR",
+                "model has not been fitted: call fit() before serializing");
+            return QoreValue();
+        }
+        algorithm = "Imputer";
+        model_data = imp->serializeState();
+        field_names = imp->getFieldNames();
+        imp->deref(xsink);
+        return MLSerialization::serializeModel(algorithm, model_data, "{}", field_names, xsink);
+    }
+    if (*xsink) { xsink->clear(); }
+
+    xsink->raiseException("ML-SERIALIZE-ERROR",
+        "unknown model type: object is not a supported ML algorithm");
+    return QoreValue();
+}
+
+//! Deserializes a binary blob back to an ML model object
+/** @param data binary data previously produced by ml_serialize()
+    @return the deserialized ML model object
+
+    @par Example:
+    @code{.py}
+binary blob = ml_serialize(km);
+object restored = ml_deserialize(blob);
+    @endcode
+
+    @throw ML-DESERIALIZE-ERROR if the data is invalid or corrupted
+*/
+object ml_deserialize(binary data) [dom=DEFAULT] {
+    const void* raw = data->getPtr();
+    size_t len = data->size();
+
+    MLSerialization::ModelHeader header = MLSerialization::parseModel(raw, len, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    auto deserializer = MLSerialization::getDeserializer(header.algorithm);
+    if (!deserializer) {
+        xsink->raiseException("ML-DESERIALIZE-ERROR",
+            "unknown algorithm '%s'", header.algorithm.c_str());
+        return QoreValue();
+    }
+
+    AbstractPrivateData* priv = deserializer(header.model_data, header.model_data_len, xsink);
+    if (*xsink || !priv) {
+        return QoreValue();
+    }
+
+    // Create the appropriate QoreObject
+    QoreObject* obj = nullptr;
+    if (header.algorithm == "KMeans") {
+        obj = new QoreObject(QC_KMEANS, getProgram());
+        obj->setPrivate(CID_KMEANS, priv);
+    } else if (header.algorithm == "LinearRegression") {
+        obj = new QoreObject(QC_LINEARREGRESSION, getProgram());
+        obj->setPrivate(CID_LINEARREGRESSION, priv);
+    } else if (header.algorithm == "LogisticRegression") {
+        obj = new QoreObject(QC_LOGISTICREGRESSION, getProgram());
+        obj->setPrivate(CID_LOGISTICREGRESSION, priv);
+    } else if (header.algorithm == "PCA") {
+        obj = new QoreObject(QC_PCA, getProgram());
+        obj->setPrivate(CID_PCA, priv);
+    } else if (header.algorithm == "IsolationForest") {
+        obj = new QoreObject(QC_ISOLATIONFOREST, getProgram());
+        obj->setPrivate(CID_ISOLATIONFOREST, priv);
+    } else if (header.algorithm == "LOF") {
+        obj = new QoreObject(QC_LOF, getProgram());
+        obj->setPrivate(CID_LOF, priv);
+    } else if (header.algorithm == "GMM") {
+        obj = new QoreObject(QC_GMM, getProgram());
+        obj->setPrivate(CID_GMM, priv);
+    } else if (header.algorithm == "HoltWinters") {
+        obj = new QoreObject(QC_HOLTWINTERS, getProgram());
+        obj->setPrivate(CID_HOLTWINTERS, priv);
+    } else if (header.algorithm == "KNN") {
+        obj = new QoreObject(QC_KNN, getProgram());
+        obj->setPrivate(CID_KNN, priv);
+    } else if (header.algorithm == "StandardScaler") {
+        obj = new QoreObject(QC_STANDARDSCALER, getProgram());
+        obj->setPrivate(CID_STANDARDSCALER, priv);
+    } else if (header.algorithm == "MinMaxScaler") {
+        obj = new QoreObject(QC_MINMAXSCALER, getProgram());
+        obj->setPrivate(CID_MINMAXSCALER, priv);
+    } else if (header.algorithm == "Imputer") {
+        obj = new QoreObject(QC_IMPUTER, getProgram());
+        obj->setPrivate(CID_IMPUTER, priv);
+    } else {
+        priv->deref(xsink);
+        xsink->raiseException("ML-DESERIALIZE-ERROR",
+            "unknown algorithm '%s'", header.algorithm.c_str());
+        return QoreValue();
+    }
+
+    return obj;
+}
+
+//! Saves a fitted ML model to a file in native binary (.qml) format
+/** @param model a fitted ML model object
+    @param path the file path to save to
+    @param options optional hash (reserved for future use)
+
+    @par Example:
+    @code{.py}
+KMeans km({"k": 3, "seed": 42});
+km.fitMatrix(data);
+ml_save_model(km, "/tmp/model.qml");
+    @endcode
+
+    @throw ML-SERIALIZE-ERROR if serialization fails
+    @throw FILE-ERROR if the file cannot be written
+*/
+nothing ml_save_model(object model, string path, *hash<auto> options) [dom=FILESYSTEM] {
+    // Serialize to binary
+    // We need to call the same logic as ml_serialize
+    // Try each known algorithm CID
+    std::string algorithm;
+    std::vector<uint8_t> model_data;
+    std::vector<std::string> field_names;
+    bool found = false;
+
+#define TRY_SERIALIZE_ALGO(CID_VAR, TYPE, NAME) \
+    if (!found) { \
+        TYPE* p = dynamic_cast<TYPE*>( \
+            model->getReferencedPrivateData(CID_VAR, xsink)); \
+        if (p) { \
+            if (!p->isFitted()) { \
+                p->deref(xsink); \
+                xsink->raiseException("ML-SERIALIZE-ERROR", \
+                    "model has not been fitted: call fit() before saving"); \
+                return QoreValue(); \
+            } \
+            algorithm = NAME; \
+            model_data = p->serializeState(); \
+            field_names = p->getFieldNames(); \
+            p->deref(xsink); \
+            found = true; \
+        } else if (*xsink) { xsink->clear(); } \
+    }
+
+    TRY_SERIALIZE_ALGO(CID_KMEANS, QoreKMeans, "KMeans")
+    TRY_SERIALIZE_ALGO(CID_LINEARREGRESSION, QoreLinearRegression, "LinearRegression")
+    TRY_SERIALIZE_ALGO(CID_LOGISTICREGRESSION, QoreLogisticRegression, "LogisticRegression")
+    TRY_SERIALIZE_ALGO(CID_PCA, QorePCA, "PCA")
+    TRY_SERIALIZE_ALGO(CID_ISOLATIONFOREST, QoreIsolationForest, "IsolationForest")
+    TRY_SERIALIZE_ALGO(CID_LOF, QoreLOF, "LOF")
+    TRY_SERIALIZE_ALGO(CID_GMM, QoreGMM, "GMM")
+    TRY_SERIALIZE_ALGO(CID_KNN, QoreKNN, "KNN")
+    TRY_SERIALIZE_ALGO(CID_STANDARDSCALER, QoreStandardScaler, "StandardScaler")
+    TRY_SERIALIZE_ALGO(CID_MINMAXSCALER, QoreMinMaxScaler, "MinMaxScaler")
+    TRY_SERIALIZE_ALGO(CID_IMPUTER, QoreImputer, "Imputer")
+
+    // HoltWinters has no field_names getter in the pattern above
+    if (!found) {
+        QoreHoltWinters* hw = dynamic_cast<QoreHoltWinters*>(
+            model->getReferencedPrivateData(CID_HOLTWINTERS, xsink));
+        if (hw) {
+            if (!hw->isFitted()) {
+                hw->deref(xsink);
+                xsink->raiseException("ML-SERIALIZE-ERROR",
+                    "model has not been fitted: call fit() before saving");
+                return QoreValue();
+            }
+            algorithm = "HoltWinters";
+            model_data = hw->serializeState();
+            hw->deref(xsink);
+            found = true;
+        } else if (*xsink) { xsink->clear(); }
+    }
+
+#undef TRY_SERIALIZE_ALGO
+
+    if (!found) {
+        xsink->raiseException("ML-SERIALIZE-ERROR",
+            "unknown model type: object is not a supported ML algorithm");
+        return QoreValue();
+    }
+
+    SimpleRefHolder<BinaryNode> blob(MLSerialization::serializeModel(
+        algorithm, model_data, "{}", field_names, xsink));
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    // Write to file
+    QoreFile f;
+    if (f.open2(xsink, path->c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644)) {
+        return QoreValue();
+    }
+    if (f.write(blob->getPtr(), blob->size(), xsink) < 0) {
+        return QoreValue();
+    }
+    return QoreValue();
+}
+
+//! Loads an ML model from a file
+/** @param path the file path to load from
+    @return the deserialized ML model object
+
+    @par Example:
+    @code{.py}
+object model = ml_load_model("/tmp/model.qml");
+    @endcode
+
+    @throw ML-DESERIALIZE-ERROR if the data is invalid or corrupted
+    @throw FILE-ERROR if the file cannot be read
+*/
+object ml_load_model(string path) [dom=FILESYSTEM] {
+    // Read file into binary
+    QoreFile f;
+    if (f.open2(xsink, path->c_str(), O_RDONLY)) {
+        return QoreValue();
+    }
+
+    // Read all data
+    SimpleRefHolder<BinaryNode> bin(f.readBinary(-1, -1, xsink));
+    if (*xsink || !bin) {
+        return QoreValue();
+    }
+
+    const void* raw = bin->getPtr();
+    size_t len = bin->size();
+
+    MLSerialization::ModelHeader header = MLSerialization::parseModel(raw, len, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    auto deserializer = MLSerialization::getDeserializer(header.algorithm);
+    if (!deserializer) {
+        xsink->raiseException("ML-DESERIALIZE-ERROR",
+            "unknown algorithm '%s'", header.algorithm.c_str());
+        return QoreValue();
+    }
+
+    AbstractPrivateData* priv = deserializer(header.model_data, header.model_data_len, xsink);
+    if (*xsink || !priv) {
+        return QoreValue();
+    }
+
+    // Create the appropriate QoreObject
+    QoreObject* obj = nullptr;
+    if (header.algorithm == "KMeans") {
+        obj = new QoreObject(QC_KMEANS, getProgram());
+        obj->setPrivate(CID_KMEANS, priv);
+    } else if (header.algorithm == "LinearRegression") {
+        obj = new QoreObject(QC_LINEARREGRESSION, getProgram());
+        obj->setPrivate(CID_LINEARREGRESSION, priv);
+    } else if (header.algorithm == "LogisticRegression") {
+        obj = new QoreObject(QC_LOGISTICREGRESSION, getProgram());
+        obj->setPrivate(CID_LOGISTICREGRESSION, priv);
+    } else if (header.algorithm == "PCA") {
+        obj = new QoreObject(QC_PCA, getProgram());
+        obj->setPrivate(CID_PCA, priv);
+    } else if (header.algorithm == "IsolationForest") {
+        obj = new QoreObject(QC_ISOLATIONFOREST, getProgram());
+        obj->setPrivate(CID_ISOLATIONFOREST, priv);
+    } else if (header.algorithm == "LOF") {
+        obj = new QoreObject(QC_LOF, getProgram());
+        obj->setPrivate(CID_LOF, priv);
+    } else if (header.algorithm == "GMM") {
+        obj = new QoreObject(QC_GMM, getProgram());
+        obj->setPrivate(CID_GMM, priv);
+    } else if (header.algorithm == "HoltWinters") {
+        obj = new QoreObject(QC_HOLTWINTERS, getProgram());
+        obj->setPrivate(CID_HOLTWINTERS, priv);
+    } else if (header.algorithm == "KNN") {
+        obj = new QoreObject(QC_KNN, getProgram());
+        obj->setPrivate(CID_KNN, priv);
+    } else if (header.algorithm == "StandardScaler") {
+        obj = new QoreObject(QC_STANDARDSCALER, getProgram());
+        obj->setPrivate(CID_STANDARDSCALER, priv);
+    } else if (header.algorithm == "MinMaxScaler") {
+        obj = new QoreObject(QC_MINMAXSCALER, getProgram());
+        obj->setPrivate(CID_MINMAXSCALER, priv);
+    } else if (header.algorithm == "Imputer") {
+        obj = new QoreObject(QC_IMPUTER, getProgram());
+        obj->setPrivate(CID_IMPUTER, priv);
+    } else {
+        priv->deref(xsink);
+        xsink->raiseException("ML-DESERIALIZE-ERROR",
+            "unknown algorithm '%s'", header.algorithm.c_str());
+        return QoreValue();
+    }
+
+    return obj;
 }
 
 ///@}

--- a/modules/ml/src/ql_ml.qpp
+++ b/modules/ml/src/ql_ml.qpp
@@ -42,8 +42,11 @@ extern const TypedHashDecl* hashdeclPCAResult;
 extern const TypedHashDecl* hashdeclSeasonalDecompositionResult;
 extern const TypedHashDecl* hashdeclLinearRegressionResult;
 extern const TypedHashDecl* hashdeclLinearRegressionModelInfo;
+extern const TypedHashDecl* hashdeclLogisticRegressionResult;
 extern const TypedHashDecl* hashdeclLOFResult;
 extern const TypedHashDecl* hashdeclGMMResult;
+extern const TypedHashDecl* hashdeclKNNClassificationResult;
+extern const TypedHashDecl* hashdeclKNNRegressionResult;
 extern const TypedHashDecl* hashdeclMLCapabilities;
 extern const TypedHashDecl* hashdeclOnnxTensorInfo;
 extern const TypedHashDecl* hashdeclOnnxModelInfo;
@@ -165,6 +168,20 @@ hashdecl LinearRegressionModelInfo {
     int n_features;
 }
 
+//! Result of logistic regression prediction
+/** Result of logistic regression prediction
+*/
+hashdecl LogisticRegressionResult {
+    //! predicted class label
+    float predicted_class;
+    //! probability of the predicted class
+    float max_probability;
+    //! probabilities for each class (in the same order as \c classes)
+    list<float> probabilities;
+    //! sorted list of class labels
+    list<float> classes;
+}
+
 //! Result of Local Outlier Factor scoring
 /** Result of Local Outlier Factor scoring
 */
@@ -191,6 +208,28 @@ hashdecl GMMResult {
     list<float> probabilities;
     //! log-likelihood of the data point
     float log_likelihood;
+}
+
+//! Result of KNN classification prediction
+/** Result of KNN classification prediction
+*/
+hashdecl KNNClassificationResult {
+    //! predicted class label
+    int predicted_class;
+    //! confidence (proportion of voting weight for the predicted class)
+    float confidence;
+    //! list of k nearest neighbor details (index, distance, label)
+    list<hash<auto>> neighbors;
+}
+
+//! Result of KNN regression prediction
+/** Result of KNN regression prediction
+*/
+hashdecl KNNRegressionResult {
+    //! predicted target value (weighted mean of k nearest neighbors)
+    float prediction;
+    //! list of k nearest neighbor details (index, distance, label)
+    list<hash<auto>> neighbors;
 }
 
 //! ONNX tensor metadata
@@ -429,7 +468,9 @@ hash<MLCapabilities> ml_get_capabilities() [flags=CONSTANT; dom=DEFAULT] {
     algos->push(new QoreStringNode("PCA"), xsink);
     algos->push(new QoreStringNode("SeasonalDecomposition"), xsink);
     algos->push(new QoreStringNode("LinearRegression"), xsink);
+    algos->push(new QoreStringNode("LogisticRegression"), xsink);
     algos->push(new QoreStringNode("LOF"), xsink);
+    algos->push(new QoreStringNode("KNN"), xsink);
     algos->push(new QoreStringNode("GMM"), xsink);
     algos->push(new QoreStringNode("StandardScaler"), xsink);
     algos->push(new QoreStringNode("MinMaxScaler"), xsink);

--- a/modules/ml/test/ml.qtest
+++ b/modules/ml/test/ml.qtest
@@ -109,6 +109,45 @@ public class MlTest inherits QUnit::Test {
         addTestCase("OnnxModel backward compat", \onnxBackwardCompatTest());
         addTestCase("OnnxModel empty providers", \onnxEmptyProvidersTest());
         addTestCase("OnnxModel CUDA conditional", \onnxCudaTest());
+        addTestCase("StandardScaler basic", \stdScalerBasicTest());
+        addTestCase("StandardScaler matrix API", \stdScalerMatrixTest());
+        addTestCase("StandardScaler inverse round-trip", \stdScalerInverseTest());
+        addTestCase("StandardScaler fitTransform", \stdScalerFitTransformTest());
+        addTestCase("StandardScaler options", \stdScalerOptionsTest());
+        addTestCase("StandardScaler error cases", \stdScalerErrorTest());
+        addTestCase("StandardScaler edge cases", \stdScalerEdgeCasesTest());
+        addTestCase("MinMaxScaler basic", \mmScalerBasicTest());
+        addTestCase("MinMaxScaler custom range", \mmScalerCustomRangeTest());
+        addTestCase("MinMaxScaler inverse round-trip", \mmScalerInverseTest());
+        addTestCase("MinMaxScaler constant feature", \mmScalerConstantFeatureTest());
+        addTestCase("MinMaxScaler error cases", \mmScalerErrorTest());
+        addTestCase("Imputer mean strategy", \imputerMeanTest());
+        addTestCase("Imputer median strategy", \imputerMedianTest());
+        addTestCase("Imputer most_frequent strategy", \imputerMostFrequentTest());
+        addTestCase("Imputer constant strategy", \imputerConstantTest());
+        addTestCase("Imputer error cases", \imputerErrorTest());
+        addTestCase("MLPipeline scaler + kmeans", \pipelineScalerKmeansTest());
+        addTestCase("MLPipeline scaler + linear regression", \pipelineScalerLRTest());
+        addTestCase("MLPipeline error cases", \pipelineErrorTest());
+        # Phase 2: Metrics and CrossValidator
+        addTestCase("ml_accuracy basic", \accuracyBasicTest());
+        addTestCase("ml_accuracy perfect", \accuracyPerfectTest());
+        addTestCase("ml_confusion_matrix", \confusionMatrixTest());
+        addTestCase("ml_classification_report", \classificationReportTest());
+        addTestCase("ml_mse and ml_rmse", \mseRmseTest());
+        addTestCase("ml_mae", \maeTest());
+        addTestCase("ml_r2_score", \r2ScoreTest());
+        addTestCase("ml_r2_score perfect", \r2PerfectTest());
+        addTestCase("ml_explained_variance", \explainedVarianceTest());
+        addTestCase("ml_silhouette_score", \silhouetteTest());
+        addTestCase("ml_davies_bouldin_score", \daviesBouldinTest());
+        addTestCase("ml_calinski_harabasz_score", \calinskiHarabaszTest());
+        addTestCase("metrics error cases", \metricsErrorTest());
+        addTestCase("CrossValidator basic", \cvBasicTest());
+        addTestCase("CrossValidator shuffle", \cvShuffleTest());
+        addTestCase("CrossValidator error cases", \cvErrorTest());
+        addTestCase("metrics integration with LR", \metricsIntegrationLRTest());
+        addTestCase("metrics integration with KMeans", \metricsIntegrationKMeansTest());
         set_return_value(main());
     }
 
@@ -130,11 +169,17 @@ public class MlTest inherits QUnit::Test {
         assertTrue(caps.native_algorithms.contains("LOF"));
         assertTrue(caps.native_algorithms.contains("GMM"));
 
+        assertTrue(caps.native_algorithms.contains("StandardScaler"));
+        assertTrue(caps.native_algorithms.contains("MinMaxScaler"));
+        assertTrue(caps.native_algorithms.contains("Imputer"));
+        assertTrue(caps.native_algorithms.contains("MLPipeline"));
+        assertTrue(caps.native_algorithms.contains("CrossValidator"));
+
         if (caps.has_onnx) {
             assertTrue(caps.native_algorithms.contains("OnnxModel"));
-            assertEq(10, caps.native_algorithms.size());
+            assertEq(15, caps.native_algorithms.size());
         } else {
-            assertEq(9, caps.native_algorithms.size());
+            assertEq(14, caps.native_algorithms.size());
         }
     }
 
@@ -2182,6 +2227,600 @@ public class MlTest inherits QUnit::Test {
         # Verify inference works on CUDA
         hash<auto> result = model.run({"X": ((3.0,),)});
         assertFloat(7.0, result.Y[0], 1e-4);
+    }
+
+    # --- StandardScaler tests ---
+
+    stdScalerBasicTest() {
+        ML::StandardScaler scaler();
+        assertFalse(scaler.isFitted());
+
+        # Known data: features with known mean/std
+        list<hash<auto>> data = (
+            {"a": 1.0, "b": 10.0},
+            {"a": 2.0, "b": 20.0},
+            {"a": 3.0, "b": 30.0},
+            {"a": 4.0, "b": 40.0},
+            {"a": 5.0, "b": 50.0},
+        );
+        scaler.fit(data);
+        assertTrue(scaler.isFitted());
+
+        hash<ML::StandardScalerInfo> info = scaler.getInfo();
+        assertEq(2, info.n_features);
+        assertTrue(info.with_mean);
+        assertTrue(info.with_std);
+        # mean of a = 3.0, mean of b = 30.0
+        assertFloat(3.0, info.mean[0], 1e-10);
+        assertFloat(30.0, info.mean[1], 1e-10);
+
+        # Transform a record — should have approximately zero mean
+        hash<auto> transformed = scaler.transform({"a": 3.0, "b": 30.0});
+        assertFloat(0.0, transformed.a, 1e-10);
+        assertFloat(0.0, transformed.b, 1e-10);
+    }
+
+    stdScalerMatrixTest() {
+        ML::StandardScaler scaler();
+        list<list<float>> data = (
+            (1.0, 10.0),
+            (2.0, 20.0),
+            (3.0, 30.0),
+            (4.0, 40.0),
+            (5.0, 50.0),
+        );
+        scaler.fitMatrix(data);
+        assertTrue(scaler.isFitted());
+
+        list<list<float>> result = scaler.transformMatrix(data);
+        assertEq(5, result.size());
+        # Mean point (3.0, 30.0) should transform to (0.0, 0.0)
+        assertFloat(0.0, result[2][0], 1e-10);
+        assertFloat(0.0, result[2][1], 1e-10);
+
+        # First point should be negative (below mean)
+        assertTrue(result[0][0] < 0.0);
+        # Last point should be positive (above mean)
+        assertTrue(result[4][0] > 0.0);
+    }
+
+    stdScalerInverseTest() {
+        ML::StandardScaler scaler();
+        list<list<float>> data = (
+            (1.0, 10.0),
+            (2.0, 20.0),
+            (3.0, 30.0),
+        );
+        scaler.fitMatrix(data);
+
+        list<list<float>> transformed = scaler.transformMatrix(data);
+        list<list<float>> recovered = scaler.inverseTransformMatrix(transformed);
+
+        # Round-trip should recover original data
+        for (int i = 0; i < 3; ++i) {
+            for (int j = 0; j < 2; ++j) {
+                assertFloat(data[i][j], recovered[i][j], 1e-10);
+            }
+        }
+    }
+
+    stdScalerFitTransformTest() {
+        ML::StandardScaler scaler();
+        list<hash<auto>> data = (
+            {"x": 1.0, "y": 100.0},
+            {"x": 3.0, "y": 300.0},
+            {"x": 5.0, "y": 500.0},
+        );
+        list<hash<auto>> result = scaler.fitTransform(data);
+        assertTrue(scaler.isFitted());
+        assertEq(3, result.size());
+        # Middle point should be zero
+        assertFloat(0.0, result[1].x, 1e-10);
+        assertFloat(0.0, result[1].y, 1e-10);
+    }
+
+    stdScalerOptionsTest() {
+        # with_mean=False: only scale, don't center
+        ML::StandardScaler scaler({"with_mean": False, "with_std": True});
+        list<list<float>> data = ((1.0,), (2.0,), (3.0,));
+        scaler.fitMatrix(data);
+        list<list<float>> result = scaler.transformMatrix(data);
+        # Not centered, but scaled by std
+        hash<ML::StandardScalerInfo> info = scaler.getInfo();
+        assertFalse(info.with_mean);
+        assertTrue(info.with_std);
+        # Values should not be centered but should be scaled
+        assertTrue(result[0][0] > 0.0);  # 1.0 / std > 0
+
+        # with_std=False: only center, don't scale
+        ML::StandardScaler scaler2({"with_mean": True, "with_std": False});
+        scaler2.fitMatrix(data);
+        list<list<float>> result2 = scaler2.transformMatrix(data);
+        # Centered but not scaled: mean is 2.0, so first point = 1.0 - 2.0 = -1.0
+        assertFloat(-1.0, result2[0][0], 1e-10);
+    }
+
+    stdScalerErrorTest() {
+        ML::StandardScaler scaler();
+        # Transform before fit
+        assertThrows("ML-STANDARD-SCALER-ERROR", sub() { scaler.transformMatrix(((1.0,),)); });
+        # Inverse before fit
+        assertThrows("ML-STANDARD-SCALER-ERROR", sub() { scaler.inverseTransformMatrix(((1.0,),)); });
+        # Copy error
+        assertThrows("COPY-ERROR", sub() { ML::StandardScaler s2 = scaler.copy(); });
+        # Empty data
+        assertThrows("ML-DATA-ERROR", sub() { scaler.fitMatrix(list()); });
+    }
+
+    stdScalerEdgeCasesTest() {
+        # Single sample
+        ML::StandardScaler scaler();
+        scaler.fitMatrix(((5.0, 10.0),));
+        assertTrue(scaler.isFitted());
+        list<list<float>> result = scaler.transformMatrix(((5.0, 10.0),));
+        # With single sample, std is 0 → treated as 1.0, so transform subtracts mean
+        assertFloat(0.0, result[0][0], 1e-10);
+
+        # Constant feature (zero variance)
+        ML::StandardScaler scaler2();
+        scaler2.fitMatrix(((3.0, 1.0), (3.0, 2.0), (3.0, 3.0)));
+        list<list<float>> result2 = scaler2.transformMatrix(((3.0, 2.0),));
+        assertFloat(0.0, result2[0][0], 1e-10);  # constant feature → 0 after centering
+    }
+
+    # --- MinMaxScaler tests ---
+
+    mmScalerBasicTest() {
+        ML::MinMaxScaler scaler();
+        assertFalse(scaler.isFitted());
+
+        list<hash<auto>> data = (
+            {"a": 0.0, "b": 100.0},
+            {"a": 5.0, "b": 200.0},
+            {"a": 10.0, "b": 300.0},
+        );
+        scaler.fit(data);
+        assertTrue(scaler.isFitted());
+
+        hash<ML::MinMaxScalerInfo> info = scaler.getInfo();
+        assertEq(2, info.n_features);
+        assertFloat(0.0, info.feature_min, 1e-10);
+        assertFloat(1.0, info.feature_max, 1e-10);
+
+        # Min values → 0.0
+        hash<auto> t1 = scaler.transform({"a": 0.0, "b": 100.0});
+        assertFloat(0.0, t1.a, 1e-10);
+        assertFloat(0.0, t1.b, 1e-10);
+
+        # Max values → 1.0
+        hash<auto> t2 = scaler.transform({"a": 10.0, "b": 300.0});
+        assertFloat(1.0, t2.a, 1e-10);
+        assertFloat(1.0, t2.b, 1e-10);
+
+        # Midpoint → 0.5
+        hash<auto> t3 = scaler.transform({"a": 5.0, "b": 200.0});
+        assertFloat(0.5, t3.a, 1e-10);
+        assertFloat(0.5, t3.b, 1e-10);
+    }
+
+    mmScalerCustomRangeTest() {
+        ML::MinMaxScaler scaler({"feature_min": -1.0, "feature_max": 1.0});
+        scaler.fitMatrix(((0.0,), (10.0,)));
+        list<list<float>> result = scaler.transformMatrix(((0.0,), (5.0,), (10.0,)));
+        assertFloat(-1.0, result[0][0], 1e-10);
+        assertFloat(0.0, result[1][0], 1e-10);
+        assertFloat(1.0, result[2][0], 1e-10);
+    }
+
+    mmScalerInverseTest() {
+        ML::MinMaxScaler scaler();
+        list<list<float>> data = ((1.0, 50.0), (3.0, 150.0), (5.0, 250.0));
+        scaler.fitMatrix(data);
+
+        list<list<float>> transformed = scaler.transformMatrix(data);
+        list<list<float>> recovered = scaler.inverseTransformMatrix(transformed);
+        for (int i = 0; i < 3; ++i) {
+            for (int j = 0; j < 2; ++j) {
+                assertFloat(data[i][j], recovered[i][j], 1e-10);
+            }
+        }
+    }
+
+    mmScalerConstantFeatureTest() {
+        # Feature with zero range → maps to feature_min
+        ML::MinMaxScaler scaler();
+        scaler.fitMatrix(((5.0, 1.0), (5.0, 2.0), (5.0, 3.0)));
+        list<list<float>> result = scaler.transformMatrix(((5.0, 2.0),));
+        assertFloat(0.0, result[0][0], 1e-10);  # constant feature → 0.0 (feature_min)
+        assertFloat(0.5, result[0][1], 1e-10);  # normal feature
+    }
+
+    mmScalerErrorTest() {
+        ML::MinMaxScaler scaler();
+        # Transform before fit
+        assertThrows("ML-MIN-MAX-SCALER-ERROR", sub() { scaler.transformMatrix(((1.0,),)); });
+        # Invalid range
+        assertThrows("ML-MIN-MAX-SCALER-ERROR", sub() { ML::MinMaxScaler s({"feature_min": 1.0, "feature_max": 0.0}); });
+        # Copy error
+        assertThrows("COPY-ERROR", sub() { ML::MinMaxScaler s2 = scaler.copy(); });
+    }
+
+    # --- Imputer tests ---
+
+    imputerMeanTest() {
+        ML::Imputer imp({"strategy": "mean"});
+        assertFalse(imp.isFitted());
+
+        # NOTHING in matrix data → treated as NaN, should be replaced with column mean
+        list<auto> data = (
+            (1.0, 10.0),
+            (2.0, NOTHING),
+            (3.0, 30.0),
+        );
+        imp.fitMatrix(data);
+        assertTrue(imp.isFitted());
+
+        hash<ML::ImputerInfo> info = imp.getInfo();
+        assertEq("mean", info.strategy);
+        assertEq(2, info.n_features);
+        # Mean of col 0 = 2.0, mean of col 1 (non-NaN) = (10+30)/2 = 20.0
+        assertFloat(2.0, info.fill_values[0], 1e-10);
+        assertFloat(20.0, info.fill_values[1], 1e-10);
+
+        list<list<float>> result = imp.transformMatrix(((NOTHING, NOTHING),));
+        assertFloat(2.0, result[0][0], 1e-10);
+        assertFloat(20.0, result[0][1], 1e-10);
+    }
+
+    imputerMedianTest() {
+        ML::Imputer imp({"strategy": "median"});
+        # Data: 1, 2, 3, 4, 5 → median = 3
+        list<list<float>> data = ((1.0,), (2.0,), (3.0,), (4.0,), (5.0,));
+        imp.fitMatrix(data);
+
+        list<list<float>> result = imp.transformMatrix(((NOTHING,),));
+        assertFloat(3.0, result[0][0], 1e-10);
+
+        # Even count: median of 1, 2, 3, 4 = 2.5
+        ML::Imputer imp2({"strategy": "median"});
+        imp2.fitMatrix(((1.0,), (2.0,), (3.0,), (4.0,)));
+        list<list<float>> result2 = imp2.transformMatrix(((NOTHING,),));
+        assertFloat(2.5, result2[0][0], 1e-10);
+    }
+
+    imputerMostFrequentTest() {
+        ML::Imputer imp({"strategy": "most_frequent"});
+        # Value 2.0 appears most often
+        list<list<float>> data = ((1.0,), (2.0,), (2.0,), (3.0,));
+        imp.fitMatrix(data);
+
+        list<list<float>> result = imp.transformMatrix(((NOTHING,),));
+        assertFloat(2.0, result[0][0], 1e-10);
+    }
+
+    imputerConstantTest() {
+        ML::Imputer imp({"strategy": "constant", "constant_value": -999.0});
+        imp.fitMatrix(((1.0, 2.0), (3.0, 4.0)));
+
+        list<list<float>> result = imp.transformMatrix(((NOTHING, NOTHING),));
+        assertFloat(-999.0, result[0][0], 1e-10);
+        assertFloat(-999.0, result[0][1], 1e-10);
+
+        # Non-NaN values should be preserved
+        list<list<float>> result2 = imp.transformMatrix(((5.0, NOTHING),));
+        assertFloat(5.0, result2[0][0], 1e-10);
+        assertFloat(-999.0, result2[0][1], 1e-10);
+    }
+
+    imputerErrorTest() {
+        ML::Imputer imp();
+        # Transform before fit
+        assertThrows("ML-IMPUTER-ERROR", sub() { imp.transformMatrix(((1.0,),)); });
+        # Invalid strategy
+        assertThrows("ML-IMPUTER-ERROR", sub() { ML::Imputer i({"strategy": "invalid"}); });
+        # Copy error
+        assertThrows("COPY-ERROR", sub() { ML::Imputer i2 = imp.copy(); });
+    }
+
+    # --- MLPipeline tests ---
+
+    pipelineScalerKmeansTest() {
+        ML::MLPipeline p();
+        assertFalse(p.isFitted());
+        assertEq(0, p.getNumSteps());
+
+        ML::StandardScaler scaler();
+        ML::KMeans km({"k": 2, "seed": 42});
+        p.addStandardScaler("scaler", scaler);
+        p.addKMeans("model", km);
+        assertEq(2, p.getNumSteps());
+        assertEq(("scaler", "model"), p.getStepNames());
+
+        # Two well-separated clusters
+        list<list<float>> data = (
+            (1.0, 1.0), (1.5, 1.5), (2.0, 2.0),
+            (10.0, 10.0), (10.5, 10.5), (11.0, 11.0),
+        );
+        p.fitMatrix(data);
+        assertTrue(p.isFitted());
+
+        # Predict should return KMeansResult hashes
+        list<hash<auto>> results = p.predictMatrix(data);
+        assertEq(6, results.size());
+        # First 3 should be same cluster, last 3 should be same cluster
+        assertEq(results[0].cluster, results[1].cluster);
+        assertEq(results[0].cluster, results[2].cluster);
+        assertEq(results[3].cluster, results[4].cluster);
+        assertEq(results[3].cluster, results[5].cluster);
+        # Two clusters should be different
+        assertTrue(results[0].cluster != results[3].cluster);
+    }
+
+    pipelineScalerLRTest() {
+        ML::MLPipeline p();
+        ML::StandardScaler scaler();
+        ML::LinearRegression lr({"fit_intercept": True});
+        p.addStandardScaler("scaler", scaler);
+        p.addLinearRegression("model", lr);
+
+        # y = 2*x + 1
+        list<list<float>> X = ((1.0,), (2.0,), (3.0,), (4.0,), (5.0,));
+        list<float> y = (3.0, 5.0, 7.0, 9.0, 11.0);
+        p.fitMatrixWithTarget(X, y);
+        assertTrue(p.isFitted());
+
+        # Predict on new data
+        list<hash<auto>> results = p.predictMatrix(((3.0,),));
+        assertEq(1, results.size());
+        assertFloat(7.0, results[0].prediction, 0.1);
+    }
+
+    pipelineErrorTest() {
+        ML::MLPipeline p();
+        # Predict before fit
+        assertThrows("ML-PIPELINE-ERROR", sub() { p.predictMatrix(((1.0,),)); });
+        # Fit with no steps
+        assertThrows("ML-PIPELINE-ERROR", sub() { p.fitMatrix(((1.0,),)); });
+        # Copy error
+        assertThrows("COPY-ERROR", sub() { ML::MLPipeline p2 = p.copy(); });
+    }
+
+    # --- Phase 2: Metrics tests ---
+
+    accuracyBasicTest() {
+        # 4 out of 5 correct = 0.8
+        float acc = ML::ml_accuracy((1, 0, 1, 1, 0), (1, 0, 0, 1, 0));
+        assertFloat(0.8, acc, 1e-10);
+    }
+
+    accuracyPerfectTest() {
+        # Perfect predictions
+        float acc = ML::ml_accuracy((0, 1, 2, 0, 1), (0, 1, 2, 0, 1));
+        assertFloat(1.0, acc, 1e-10);
+
+        # All wrong
+        float acc2 = ML::ml_accuracy((0, 0, 0), (1, 1, 1));
+        assertFloat(0.0, acc2, 1e-10);
+    }
+
+    confusionMatrixTest() {
+        # Binary: 2 true positives, 1 false positive, 1 false negative, 1 true negative
+        hash<ML::ConfusionMatrixResult> cm = ML::ml_confusion_matrix(
+            (0, 0, 1, 1, 1), (0, 1, 0, 1, 1));
+        assertEq(2, cm.labels.size());  # 2 classes
+        assertEq(2, cm.matrix.size());  # 2x2
+        # Row 0 (true=0): TN=1, FP=1
+        assertEq(1, cm.matrix[0][0]);
+        assertEq(1, cm.matrix[0][1]);
+        # Row 1 (true=1): FN=1, TP=2
+        assertEq(1, cm.matrix[1][0]);
+        assertEq(2, cm.matrix[1][1]);
+    }
+
+    classificationReportTest() {
+        hash<ML::ClassificationReport> report = ML::ml_classification_report(
+            (0, 0, 1, 1, 1), (0, 1, 0, 1, 1));
+        assertFloat(0.6, report.accuracy, 1e-10);  # 3/5 correct
+        assertEq(2, report.per_class.size());
+
+        # Check per-class metrics exist and are in valid range
+        foreach hash<ML::ClassMetrics> cls in (report.per_class) {
+            assertTrue(cls.precision >= 0.0 && cls.precision <= 1.0);
+            assertTrue(cls.recall >= 0.0 && cls.recall <= 1.0);
+            assertTrue(cls.f1 >= 0.0 && cls.f1 <= 1.0);
+            assertTrue(cls.support > 0);
+        }
+
+        # Macro averages should be in [0, 1]
+        assertTrue(report.macro_precision >= 0.0 && report.macro_precision <= 1.0);
+        assertTrue(report.macro_f1 >= 0.0 && report.macro_f1 <= 1.0);
+        assertTrue(report.weighted_f1 >= 0.0 && report.weighted_f1 <= 1.0);
+    }
+
+    mseRmseTest() {
+        # Known values: y_true = (1, 2, 3), y_pred = (1.1, 2.2, 2.7)
+        # Errors: (0.1, 0.2, -0.3), squared: (0.01, 0.04, 0.09), MSE = 0.14/3
+        float mse = ML::ml_mse((1.0, 2.0, 3.0), (1.1, 2.2, 2.7));
+        assertFloat(0.14 / 3.0, mse, 1e-10);
+
+        float rmse = ML::ml_rmse((1.0, 2.0, 3.0), (1.1, 2.2, 2.7));
+        assertFloat(sqrt(0.14 / 3.0), rmse, 1e-10);
+
+        # Perfect predictions → 0
+        assertFloat(0.0, ML::ml_mse((1.0, 2.0), (1.0, 2.0)), 1e-10);
+    }
+
+    maeTest() {
+        # MAE of (0.1, 0.2, 0.3) = 0.2
+        float mae = ML::ml_mae((1.0, 2.0, 3.0), (1.1, 2.2, 2.7));
+        assertFloat(0.2, mae, 1e-10);
+    }
+
+    r2ScoreTest() {
+        # y_true = (1, 2, 3), mean = 2
+        # SS_tot = 1 + 0 + 1 = 2
+        # y_pred = (1.1, 2.2, 2.7), SS_res = 0.01 + 0.04 + 0.09 = 0.14
+        # R² = 1 - 0.14/2 = 0.93
+        float r2 = ML::ml_r2_score((1.0, 2.0, 3.0), (1.1, 2.2, 2.7));
+        assertFloat(0.93, r2, 1e-10);
+    }
+
+    r2PerfectTest() {
+        # Perfect prediction → R² = 1.0
+        float r2 = ML::ml_r2_score((1.0, 2.0, 3.0), (1.0, 2.0, 3.0));
+        assertFloat(1.0, r2, 1e-10);
+    }
+
+    explainedVarianceTest() {
+        # Perfect prediction → 1.0
+        float ev = ML::ml_explained_variance((1.0, 2.0, 3.0), (1.0, 2.0, 3.0));
+        assertFloat(1.0, ev, 1e-10);
+
+        # Constant prediction of mean → should be near 0
+        float ev2 = ML::ml_explained_variance((1.0, 2.0, 3.0), (2.0, 2.0, 2.0));
+        assertFloat(0.0, ev2, 1e-10);
+    }
+
+    silhouetteTest() {
+        # Two perfectly separated clusters
+        list<list<float>> data = (
+            (0.0, 0.0), (0.1, 0.0), (0.0, 0.1),   # cluster 0
+            (10.0, 10.0), (10.1, 10.0), (10.0, 10.1),  # cluster 1
+        );
+        list<float> labels = (0, 0, 0, 1, 1, 1);
+        float score = ML::ml_silhouette_score(data, labels);
+        # Well-separated clusters should have score near 1.0
+        assertTrue(score > 0.9, sprintf("expected silhouette > 0.9, got %f", score));
+    }
+
+    daviesBouldinTest() {
+        # Well-separated clusters → low DB index
+        list<list<float>> data = (
+            (0.0, 0.0), (0.1, 0.0), (0.0, 0.1),
+            (10.0, 10.0), (10.1, 10.0), (10.0, 10.1),
+        );
+        list<float> labels = (0, 0, 0, 1, 1, 1);
+        float db = ML::ml_davies_bouldin_score(data, labels);
+        # Well-separated → should be near 0
+        assertTrue(db < 0.1, sprintf("expected DB < 0.1, got %f", db));
+    }
+
+    calinskiHarabaszTest() {
+        # Well-separated clusters → high CH index
+        list<list<float>> data = (
+            (0.0, 0.0), (0.1, 0.0), (0.0, 0.1),
+            (10.0, 10.0), (10.1, 10.0), (10.0, 10.1),
+        );
+        list<float> labels = (0, 0, 0, 1, 1, 1);
+        float ch = ML::ml_calinski_harabasz_score(data, labels);
+        # Well-separated → should be high
+        assertTrue(ch > 100.0, sprintf("expected CH > 100, got %f", ch));
+    }
+
+    metricsErrorTest() {
+        # Mismatched lengths
+        assertThrows("ML-METRICS-ERROR", sub() { ML::ml_accuracy((1, 2), (1,)); });
+        # Empty input
+        assertThrows("ML-DATA-ERROR", sub() { ML::ml_mse(list(), list()); });
+        # Silhouette with < 2 clusters
+        assertThrows("ML-METRICS-ERROR", sub() {
+            ML::ml_silhouette_score(((1.0,), (2.0,)), (0, 0));
+        });
+    }
+
+    # --- CrossValidator tests ---
+
+    cvBasicTest() {
+        ML::CrossValidator cv({"n_folds": 5});
+        assertEq(5, cv.getNumFolds());
+
+        list<hash<ML::CrossValidationFold>> folds = cv.split(100);
+        assertEq(5, folds.size());
+
+        # Each sample should appear in exactly one test fold
+        list<int> all_test;
+        foreach hash<ML::CrossValidationFold> fold in (folds) {
+            assertEq(80, fold.train_indices.size());
+            assertEq(20, fold.test_indices.size());
+            all_test += fold.test_indices;
+        }
+        # Sort and verify all 100 indices present
+        all_test = sort(all_test);
+        for (int i = 0; i < 100; ++i) {
+            assertEq(i, all_test[i]);
+        }
+    }
+
+    cvShuffleTest() {
+        # With shuffle + seed, results should be reproducible
+        ML::CrossValidator cv1({"n_folds": 3, "shuffle": True, "seed": 42});
+        ML::CrossValidator cv2({"n_folds": 3, "shuffle": True, "seed": 42});
+        list<hash<ML::CrossValidationFold>> folds1 = cv1.split(30);
+        list<hash<ML::CrossValidationFold>> folds2 = cv2.split(30);
+        assertEq(folds1[0].test_indices, folds2[0].test_indices);
+        assertEq(folds1[1].test_indices, folds2[1].test_indices);
+
+        # Without shuffle, indices are sequential
+        ML::CrossValidator cv3({"n_folds": 3, "shuffle": False});
+        list<hash<ML::CrossValidationFold>> folds3 = cv3.split(9);
+        assertEq((0, 1, 2), folds3[0].test_indices);
+        assertEq((3, 4, 5), folds3[1].test_indices);
+        assertEq((6, 7, 8), folds3[2].test_indices);
+    }
+
+    cvErrorTest() {
+        # n_folds < 2
+        assertThrows("ML-CROSS-VALIDATOR-ERROR", sub() {
+            ML::CrossValidator cv({"n_folds": 1});
+        });
+        # n_samples < n_folds
+        ML::CrossValidator cv({"n_folds": 5});
+        assertThrows("ML-CROSS-VALIDATOR-ERROR", sub() { cv.split(3); });
+        # Copy error
+        assertThrows("COPY-ERROR", sub() { ML::CrossValidator cv2 = cv.copy(); });
+    }
+
+    # --- Integration tests: metrics + algorithms ---
+
+    metricsIntegrationLRTest() {
+        # Train LinearRegression on y = 2x + 1, then evaluate with metrics
+        ML::LinearRegression lr({"fit_intercept": True});
+        list<list<float>> X = ((1.0,), (2.0,), (3.0,), (4.0,), (5.0,));
+        list<float> y = (3.0, 5.0, 7.0, 9.0, 11.0);
+        lr.fitMatrix(X, y);
+
+        # Get predictions
+        list<hash<ML::LinearRegressionResult>> results = lr.predictMatrix(X);
+        list<float> predictions;
+        foreach hash<ML::LinearRegressionResult> r in (results) {
+            push predictions, r.prediction;
+        }
+
+        # R² from metric function should match model's R²
+        float r2 = ML::ml_r2_score(y, predictions);
+        assertFloat(1.0, r2, 0.01);  # Linear fit on linear data → near-perfect
+
+        float mse = ML::ml_mse(y, predictions);
+        assertTrue(mse < 0.01, sprintf("expected MSE near 0, got %f", mse));
+    }
+
+    metricsIntegrationKMeansTest() {
+        # Cluster well-separated data, then evaluate with silhouette
+        ML::KMeans km({"k": 2, "seed": 42});
+        list<list<float>> data = (
+            (1.0, 1.0), (1.5, 1.5), (2.0, 2.0),
+            (10.0, 10.0), (10.5, 10.5), (11.0, 11.0),
+        );
+        km.fitMatrix(data);
+        list<hash<ML::KMeansResult>> results = km.predictMatrix(data);
+
+        list<float> labels;
+        foreach hash<ML::KMeansResult> r in (results) {
+            push labels, r.cluster.toFloat();
+        }
+
+        float sil = ML::ml_silhouette_score(data, labels);
+        assertTrue(sil > 0.8, sprintf("expected silhouette > 0.8, got %f", sil));
     }
 
     private assertFloat(float expected, auto actual, float tolerance) {

--- a/modules/ml/test/ml.qtest
+++ b/modules/ml/test/ml.qtest
@@ -170,6 +170,23 @@ public class MlTest inherits QUnit::Test {
         addTestCase("CrossValidator error cases", \cvErrorTest());
         addTestCase("metrics integration with LR", \metricsIntegrationLRTest());
         addTestCase("metrics integration with KMeans", \metricsIntegrationKMeansTest());
+        # Phase: Serialization
+        addTestCase("serialize KMeans round-trip", \serializeKMeansTest());
+        addTestCase("serialize LinearRegression round-trip", \serializeLRTest());
+        addTestCase("serialize LogisticRegression round-trip", \serializeLogRegTest());
+        addTestCase("serialize PCA round-trip", \serializePCATest());
+        addTestCase("serialize IsolationForest round-trip", \serializeIForestTest());
+        addTestCase("serialize LOF round-trip", \serializeLOFTest());
+        addTestCase("serialize GMM round-trip", \serializeGMMTest());
+        addTestCase("serialize HoltWinters round-trip", \serializeHWTest());
+        addTestCase("serialize KNN round-trip", \serializeKNNTest());
+        addTestCase("serialize StandardScaler round-trip", \serializeStdScalerTest());
+        addTestCase("serialize MinMaxScaler round-trip", \serializeMMScalerTest());
+        addTestCase("serialize Imputer round-trip", \serializeImputerTest());
+        addTestCase("serialize file save/load KMeans", \serializeFileKMeansTest());
+        addTestCase("serialize file save/load LinearRegression", \serializeFileLRTest());
+        addTestCase("serialize file save/load StandardScaler", \serializeFileStdScalerTest());
+        addTestCase("serialize error cases", \serializeErrorTest());
         set_return_value(main());
     }
 
@@ -3467,6 +3484,285 @@ public class MlTest inherits QUnit::Test {
         assertThrows("COPY-ERROR", sub() {
             ML::KNN knn2 = knn.copy();
         });
+    }
+
+    # --- Serialization tests ---
+
+    serializeKMeansTest() {
+        ML::KMeans km({"k": 3, "seed": 42});
+        km.fitMatrix(((1.0, 1.0), (1.1, 1.1), (5.0, 5.0), (5.1, 5.1), (9.0, 9.0), (9.1, 9.1)));
+
+        # Get predictions from original using matrix API
+        list<hash<ML::KMeansResult>> orig = km.predictMatrix(((1.05, 1.05),));
+
+        # Serialize and deserialize
+        binary blob = ML::ml_serialize(km);
+        assertGt(0, blob.size());
+
+        auto restored = ML::ml_deserialize(blob);
+        assertTrue(restored instanceof ML::KMeans);
+
+        # Predict with restored model
+        list<hash<ML::KMeansResult>> res = restored.predictMatrix(((1.05, 1.05),));
+        assertEq(orig[0].cluster, res[0].cluster);
+        assertFloat(orig[0].distance, res[0].distance, 1e-10);
+    }
+
+    serializeLRTest() {
+        ML::LinearRegression lr({"fit_intercept": True});
+        lr.fitMatrix(((1.0,), (2.0,), (3.0,), (4.0,), (5.0,)), (2.0, 4.0, 6.0, 8.0, 10.0));
+
+        list<hash<ML::LinearRegressionResult>> orig = lr.predictMatrix(((3.5,),));
+
+        binary blob = ML::ml_serialize(lr);
+        auto restored = ML::ml_deserialize(blob);
+        assertTrue(restored instanceof ML::LinearRegression);
+
+        list<hash<ML::LinearRegressionResult>> res = restored.predictMatrix(((3.5,),));
+        assertFloat(orig[0].prediction, res[0].prediction, 1e-10);
+        assertFloat(orig[0].intercept, res[0].intercept, 1e-10);
+        assertFloat(orig[0].r_squared, res[0].r_squared, 1e-10);
+    }
+
+    serializeLogRegTest() {
+        ML::LogisticRegression logr({"learning_rate": 0.5, "max_iterations": 200, "seed": 42});
+        logr.fitMatrix(
+            ((0.0, 0.0), (0.1, 0.1), (0.2, 0.2), (5.0, 5.0), (5.1, 5.1), (5.2, 5.2)),
+            (0, 0, 0, 1, 1, 1)
+        );
+
+        list<hash<ML::LogisticRegressionResult>> orig = logr.predictMatrix(((0.15, 0.15),));
+
+        binary blob = ML::ml_serialize(logr);
+        auto restored = ML::ml_deserialize(blob);
+        assertTrue(restored instanceof ML::LogisticRegression);
+
+        list<hash<ML::LogisticRegressionResult>> res = restored.predictMatrix(((0.15, 0.15),));
+        assertFloat(orig[0].predicted_class, res[0].predicted_class, 1e-10);
+        assertFloat(orig[0].max_probability, res[0].max_probability, 1e-10);
+    }
+
+    serializePCATest() {
+        ML::PCA pca({"n_components": 1});
+        pca.fitMatrix(((1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (7.0, 8.0)));
+
+        list<hash<ML::PCAResult>> orig = pca.transformMatrix(((4.0, 5.0),));
+
+        binary blob = ML::ml_serialize(pca);
+        auto restored = ML::ml_deserialize(blob);
+        assertTrue(restored instanceof ML::PCA);
+
+        list<hash<ML::PCAResult>> res = restored.transformMatrix(((4.0, 5.0),));
+        assertFloat(orig[0].components[0], res[0].components[0], 1e-10);
+        assertFloat(orig[0].total_explained_variance, res[0].total_explained_variance, 1e-10);
+    }
+
+    serializeIForestTest() {
+        ML::IsolationForest iforest({"n_trees": 10, "seed": 42});
+        iforest.fitMatrix(
+            ((1.0, 1.0), (1.1, 1.0), (1.0, 1.1), (1.1, 1.1),
+             (0.9, 0.9), (1.2, 1.2), (0.8, 1.0), (1.0, 0.8))
+        );
+
+        list<hash<ML::IsolationForestResult>> orig = iforest.scoreMatrix(((1.05, 1.05),));
+
+        binary blob = ML::ml_serialize(iforest);
+        auto restored = ML::ml_deserialize(blob);
+        assertTrue(restored instanceof ML::IsolationForest);
+
+        list<hash<ML::IsolationForestResult>> res = restored.scoreMatrix(((1.05, 1.05),));
+        assertFloat(orig[0].anomaly_score, res[0].anomaly_score, 1e-10);
+        assertFloat(orig[0].average_path_length, res[0].average_path_length, 1e-10);
+    }
+
+    serializeLOFTest() {
+        ML::LOF lof({"k": 2});
+        lof.fitMatrix(
+            ((1.0, 1.0), (1.1, 1.0), (1.0, 1.1), (1.1, 1.1),
+             (0.9, 0.9), (1.2, 1.2))
+        );
+
+        list<hash<ML::LOFResult>> orig = lof.scoreMatrix(((1.05, 1.05),));
+
+        binary blob = ML::ml_serialize(lof);
+        auto restored = ML::ml_deserialize(blob);
+        assertTrue(restored instanceof ML::LOF);
+
+        list<hash<ML::LOFResult>> res = restored.scoreMatrix(((1.05, 1.05),));
+        assertFloat(orig[0].lof_score, res[0].lof_score, 1e-10);
+        assertFloat(orig[0].k_distance, res[0].k_distance, 1e-10);
+    }
+
+    serializeGMMTest() {
+        ML::GMM gmm({"n_components": 2, "seed": 42});
+        gmm.fitMatrix(
+            ((1.0, 1.0), (1.1, 1.0), (1.0, 1.1), (5.0, 5.0), (5.1, 5.0), (5.0, 5.1))
+        );
+
+        list<hash<ML::GMMResult>> orig = gmm.predictMatrix(((1.05, 1.05),));
+
+        binary blob = ML::ml_serialize(gmm);
+        auto restored = ML::ml_deserialize(blob);
+        assertTrue(restored instanceof ML::GMM);
+
+        list<hash<ML::GMMResult>> res = restored.predictMatrix(((1.05, 1.05),));
+        assertEq(orig[0].cluster, res[0].cluster);
+        assertFloat(orig[0].max_probability, res[0].max_probability, 1e-10);
+    }
+
+    serializeHWTest() {
+        ML::HoltWinters hw({"period": 4, "alpha": 0.3, "beta": 0.1, "gamma": 0.1});
+        hw.fit((10.0, 15.0, 12.0, 8.0, 11.0, 16.0, 13.0, 9.0));
+
+        list<float> orig = hw.forecast(4);
+
+        binary blob = ML::ml_serialize(hw);
+        auto restored = ML::ml_deserialize(blob);
+        assertTrue(restored instanceof ML::HoltWinters);
+
+        list<float> res = restored.forecast(4);
+        assertEq(orig.size(), res.size());
+        for (int i = 0; i < orig.size(); ++i) {
+            assertFloat(orig[i], res[i], 1e-10);
+        }
+    }
+
+    serializeKNNTest() {
+        ML::KNN knn({"k": 3, "task": "classification"});
+        knn.fitMatrix(
+            ((1.0, 1.0), (1.1, 1.0), (1.0, 1.1), (5.0, 5.0), (5.1, 5.0), (5.0, 5.1)),
+            (0, 0, 0, 1, 1, 1)
+        );
+
+        list<hash<auto>> orig = knn.predictMatrix(((1.05, 1.05),));
+
+        binary blob = ML::ml_serialize(knn);
+        auto restored = ML::ml_deserialize(blob);
+        assertTrue(restored instanceof ML::KNN);
+
+        list<hash<auto>> res = restored.predictMatrix(((1.05, 1.05),));
+        assertEq(orig[0].predicted_class, res[0].predicted_class);
+        assertFloat(orig[0].confidence, res[0].confidence, 1e-10);
+    }
+
+    serializeStdScalerTest() {
+        ML::StandardScaler ss();
+        ss.fitMatrix(((1.0, 100.0), (2.0, 200.0), (3.0, 300.0), (4.0, 400.0)));
+
+        list<auto> orig_t = ss.transformMatrix(((2.5, 250.0),));
+
+        binary blob = ML::ml_serialize(ss);
+        auto restored = ML::ml_deserialize(blob);
+        assertTrue(restored instanceof ML::StandardScaler);
+
+        list<auto> res_t = restored.transformMatrix(((2.5, 250.0),));
+        assertEq(orig_t.size(), res_t.size());
+        for (int i = 0; i < orig_t[0].size(); ++i) {
+            assertFloat(orig_t[0][i], res_t[0][i], 1e-10);
+        }
+    }
+
+    serializeMMScalerTest() {
+        ML::MinMaxScaler mms({"feature_min": 0.0, "feature_max": 1.0});
+        mms.fitMatrix(((1.0, 10.0), (2.0, 20.0), (3.0, 30.0)));
+
+        list<auto> orig_t = mms.transformMatrix(((2.0, 20.0),));
+
+        binary blob = ML::ml_serialize(mms);
+        auto restored = ML::ml_deserialize(blob);
+        assertTrue(restored instanceof ML::MinMaxScaler);
+
+        list<auto> res_t = restored.transformMatrix(((2.0, 20.0),));
+        for (int i = 0; i < orig_t[0].size(); ++i) {
+            assertFloat(orig_t[0][i], res_t[0][i], 1e-10);
+        }
+    }
+
+    serializeImputerTest() {
+        ML::Imputer imp({"strategy": "mean"});
+        imp.fitMatrix(((1.0, 2.0), (3.0, 4.0), (5.0, 6.0)));
+
+        hash<ML::ImputerInfo> orig_info = imp.getInfo();
+
+        binary blob = ML::ml_serialize(imp);
+        auto restored = ML::ml_deserialize(blob);
+        assertTrue(restored instanceof ML::Imputer);
+
+        hash<ML::ImputerInfo> res_info = restored.getInfo();
+        assertEq(orig_info.strategy, res_info.strategy);
+        assertEq(orig_info.n_features, res_info.n_features);
+        for (int i = 0; i < orig_info.fill_values.size(); ++i) {
+            assertFloat(orig_info.fill_values[i], res_info.fill_values[i], 1e-10);
+        }
+    }
+
+    serializeFileKMeansTest() {
+        ML::KMeans km({"k": 2, "seed": 42});
+        km.fitMatrix(((1.0, 1.0), (1.1, 1.1), (5.0, 5.0), (5.1, 5.1)));
+
+        list<hash<ML::KMeansResult>> orig = km.predictMatrix(((1.05, 1.05),));
+
+        string tmpfile = "/tmp/test_ml_kmeans.qml";
+        on_exit { unlink(tmpfile); }
+        ML::ml_save_model(km, tmpfile);
+
+        auto restored = ML::ml_load_model(tmpfile);
+        assertTrue(restored instanceof ML::KMeans);
+
+        list<hash<ML::KMeansResult>> res = restored.predictMatrix(((1.05, 1.05),));
+        assertEq(orig[0].cluster, res[0].cluster);
+        assertFloat(orig[0].distance, res[0].distance, 1e-10);
+    }
+
+    serializeFileLRTest() {
+        ML::LinearRegression lr({"fit_intercept": True});
+        lr.fitMatrix(((1.0,), (2.0,), (3.0,)), (3.0, 5.0, 7.0));
+
+        list<hash<ML::LinearRegressionResult>> orig = lr.predictMatrix(((2.5,),));
+
+        string tmpfile = "/tmp/test_ml_lr.qml";
+        on_exit { unlink(tmpfile); }
+        ML::ml_save_model(lr, tmpfile);
+
+        auto restored = ML::ml_load_model(tmpfile);
+        assertTrue(restored instanceof ML::LinearRegression);
+
+        list<hash<ML::LinearRegressionResult>> res = restored.predictMatrix(((2.5,),));
+        assertFloat(orig[0].prediction, res[0].prediction, 1e-10);
+    }
+
+    serializeFileStdScalerTest() {
+        ML::StandardScaler ss();
+        ss.fitMatrix(((10.0, 200.0), (20.0, 400.0), (30.0, 600.0)));
+
+        list<auto> orig_t = ss.transformMatrix(((20.0, 400.0),));
+
+        string tmpfile = "/tmp/test_ml_stdscaler.qml";
+        on_exit { unlink(tmpfile); }
+        ML::ml_save_model(ss, tmpfile);
+
+        auto restored = ML::ml_load_model(tmpfile);
+        assertTrue(restored instanceof ML::StandardScaler);
+
+        list<auto> res_t = restored.transformMatrix(((20.0, 400.0),));
+        for (int i = 0; i < orig_t[0].size(); ++i) {
+            assertFloat(orig_t[0][i], res_t[0][i], 1e-10);
+        }
+    }
+
+    serializeErrorTest() {
+        # Serialize unfitted model
+        ML::KMeans km_unfitted({"k": 3});
+        assertThrows("ML-SERIALIZE-ERROR", sub() { ML::ml_serialize(km_unfitted); });
+
+        # Deserialize corrupted data
+        assertThrows("ML-DESERIALIZE-ERROR", sub() { ML::ml_deserialize(<abcdef>); });
+
+        # Deserialize truncated data (valid magic but too short)
+        assertThrows("ML-DESERIALIZE-ERROR", sub() { ML::ml_deserialize(<514d4c01>); });
+
+        # Load nonexistent file
+        assertThrows("FILE-OPEN2-ERROR", sub() { ML::ml_load_model("/nonexistent/path/model.qml"); });
     }
 
     private assertFloat(float expected, auto actual, float tolerance) {

--- a/modules/ml/test/ml.qtest
+++ b/modules/ml/test/ml.qtest
@@ -79,6 +79,15 @@ public class MlTest inherits QUnit::Test {
         addTestCase("LinearRegression error cases", \lrErrorTest());
         addTestCase("LinearRegression copy error", \lrCopyTest());
         addTestCase("LinearRegression getModelInfo", \lrGetModelInfoTest());
+        addTestCase("LogisticRegression binary classification", \logregBinaryTest());
+        addTestCase("LogisticRegression multiclass OvR", \logregMulticlassTest());
+        addTestCase("LogisticRegression hash API", \logregHashTest());
+        addTestCase("LogisticRegression probabilities sum to 1", \logregProbabilityTest());
+        addTestCase("LogisticRegression no regularization", \logregNoRegularizationTest());
+        addTestCase("LogisticRegression no intercept", \logregNoInterceptTest());
+        addTestCase("LogisticRegression convergence", \logregConvergenceTest());
+        addTestCase("LogisticRegression error cases", \logregErrorTest());
+        addTestCase("LogisticRegression copy error", \logregCopyTest());
         addTestCase("LOF basic outlier detection", \lofBasicTest());
         addTestCase("LOF k parameter", \lofKParamTest());
         addTestCase("LOF hash API", \lofHashTest());
@@ -86,6 +95,16 @@ public class MlTest inherits QUnit::Test {
         addTestCase("LOF deterministic", \lofDeterministicTest());
         addTestCase("LOF error cases", \lofErrorTest());
         addTestCase("LOF copy error", \lofCopyTest());
+        addTestCase("KNN classification basic", \knnClassificationBasicTest());
+        addTestCase("KNN classification distance weighting", \knnClassificationDistanceTest());
+        addTestCase("KNN regression basic", \knnRegressionBasicTest());
+        addTestCase("KNN regression distance weighting", \knnRegressionDistanceTest());
+        addTestCase("KNN hash API", \knnHashApiTest());
+        addTestCase("KNN manhattan metric", \knnManhattanTest());
+        addTestCase("KNN cosine metric", \knnCosineTest());
+        addTestCase("KNN predictMatrix", \knnPredictMatrixTest());
+        addTestCase("KNN error cases", \knnErrorTest());
+        addTestCase("KNN copy error", \knnCopyTest());
         addTestCase("GMM basic 2-cluster", \gmmBasicTest());
         addTestCase("GMM probabilities sum to 1", \gmmProbabilityTest());
         addTestCase("GMM diagonal covariance", \gmmDiagonalTest());
@@ -166,7 +185,9 @@ public class MlTest inherits QUnit::Test {
         assertTrue(caps.native_algorithms.contains("PCA"));
         assertTrue(caps.native_algorithms.contains("SeasonalDecomposition"));
         assertTrue(caps.native_algorithms.contains("LinearRegression"));
+        assertTrue(caps.native_algorithms.contains("LogisticRegression"));
         assertTrue(caps.native_algorithms.contains("LOF"));
+        assertTrue(caps.native_algorithms.contains("KNN"));
         assertTrue(caps.native_algorithms.contains("GMM"));
 
         assertTrue(caps.native_algorithms.contains("StandardScaler"));
@@ -177,9 +198,9 @@ public class MlTest inherits QUnit::Test {
 
         if (caps.has_onnx) {
             assertTrue(caps.native_algorithms.contains("OnnxModel"));
-            assertEq(15, caps.native_algorithms.size());
+            assertEq(17, caps.native_algorithms.size());
         } else {
-            assertEq(14, caps.native_algorithms.size());
+            assertEq(16, caps.native_algorithms.size());
         }
     }
 
@@ -1428,6 +1449,269 @@ public class MlTest inherits QUnit::Test {
         assertEq(info.coefficients, lr.getCoefficients());
         assertTrue(abs(info.intercept - lr.getIntercept()) < 1e-10);
         assertTrue(abs(info.r_squared - lr.getRSquared()) < 1e-10);
+    }
+
+    # ===================== LogisticRegression Tests =====================
+
+    logregBinaryTest() {
+        ML::LogisticRegression clf({"learning_rate": 0.5, "max_iterations": 200});
+        assertEq(False, clf.isFitted());
+
+        # Linearly separable binary classification: class 0 (x < 3), class 1 (x >= 3)
+        list<list<float>> X = (
+            (1.0,), (1.5,), (2.0,), (2.5,),
+            (3.5,), (4.0,), (4.5,), (5.0,),
+        );
+        list<float> y = (0, 0, 0, 0, 1, 1, 1, 1);
+        clf.fitMatrix(X, y);
+        assertTrue(clf.isFitted());
+
+        # Predict a point clearly in class 0
+        list<hash<ML::LogisticRegressionResult>> results = clf.predictMatrix(((1.0,),));
+        assertEq(0.0, results[0].predicted_class);
+        assertTrue(results[0].max_probability > 0.5);
+
+        # Predict a point clearly in class 1
+        results = clf.predictMatrix(((5.0,),));
+        assertEq(1.0, results[0].predicted_class);
+        assertTrue(results[0].max_probability > 0.5);
+
+        # Check that classes are sorted
+        assertEq(2, results[0].classes.size());
+        assertEq(0.0, results[0].classes[0]);
+        assertEq(1.0, results[0].classes[1]);
+    }
+
+    logregMulticlassTest() {
+        ML::LogisticRegression clf({"learning_rate": 0.1, "max_iterations": 500,
+            "regularization": 0.01});
+
+        # 3-class problem with well-separated feature ranges
+        list<list<float>> X = (
+            (0.0, 0.0), (0.5, 0.5), (1.0, 0.0), (0.0, 0.5), (0.5, 0.0), (1.0, 0.5),
+            (5.0, 5.0), (5.5, 5.5), (6.0, 5.0), (5.0, 5.5), (5.5, 5.0), (6.0, 5.5),
+            (10.0, 0.0), (10.5, 0.5), (11.0, 0.0), (10.0, 0.5), (10.5, 0.0), (11.0, 0.5),
+        );
+        list<float> y = (0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2);
+        clf.fitMatrix(X, y);
+        assertTrue(clf.isFitted());
+
+        # Predict class 0 region
+        list<hash<ML::LogisticRegressionResult>> results = clf.predictMatrix(((0.5, 0.25),));
+        assertEq(0.0, results[0].predicted_class);
+
+        # Predict class 1 region
+        results = clf.predictMatrix(((5.5, 5.25),));
+        assertEq(1.0, results[0].predicted_class);
+
+        # Predict class 2 region
+        results = clf.predictMatrix(((10.5, 0.25),));
+        assertEq(2.0, results[0].predicted_class);
+
+        # Check classes list
+        assertEq(3, results[0].classes.size());
+        assertEq(0.0, results[0].classes[0]);
+        assertEq(1.0, results[0].classes[1]);
+        assertEq(2.0, results[0].classes[2]);
+
+        # Check probabilities list has one per class
+        assertEq(3, results[0].probabilities.size());
+    }
+
+    logregHashTest() {
+        ML::LogisticRegression clf({"learning_rate": 0.5, "max_iterations": 200});
+
+        # Train with hash-based API
+        list<hash<auto>> data = (
+            {"x1": 1.0, "x2": 0.0, "label": 0},
+            {"x1": 1.5, "x2": 0.5, "label": 0},
+            {"x1": 2.0, "x2": 0.0, "label": 0},
+            {"x1": 2.5, "x2": 0.5, "label": 0},
+            {"x1": 5.0, "x2": 5.0, "label": 1},
+            {"x1": 5.5, "x2": 5.5, "label": 1},
+            {"x1": 6.0, "x2": 5.0, "label": 1},
+            {"x1": 6.5, "x2": 5.5, "label": 1},
+        );
+        clf.fit(data, "label");
+        assertTrue(clf.isFitted());
+
+        # Predict using hash
+        hash<ML::LogisticRegressionResult> result = clf.predict({"x1": 1.0, "x2": 0.0});
+        assertEq(0.0, result.predicted_class);
+        assertTrue(result.max_probability > 0.5);
+
+        result = clf.predict({"x1": 6.0, "x2": 5.0});
+        assertEq(1.0, result.predicted_class);
+        assertTrue(result.max_probability > 0.5);
+
+        # Predict using hash after fit() should not allow predictMatrix hash mode
+        assertThrows("ML-LOGISTIC-REGRESSION-ERROR", "fitMatrix", sub() {
+            ML::LogisticRegression clf2({"learning_rate": 0.1});
+            clf2.fitMatrix(((1.0,), (2.0,)), (0, 1));
+            clf2.predict({"x": 1.0});
+        });
+    }
+
+    logregProbabilityTest() {
+        ML::LogisticRegression clf({"learning_rate": 0.5, "max_iterations": 200});
+
+        # Binary
+        list<list<float>> X = ((1.0,), (2.0,), (3.0,), (4.0,));
+        list<float> y = (0, 0, 1, 1);
+        clf.fitMatrix(X, y);
+
+        list<hash<ML::LogisticRegressionResult>> results = clf.predictMatrix(((1.5,), (3.5,)));
+        for (int i = 0; i < results.size(); ++i) {
+            float prob_sum = 0.0;
+            for (int j = 0; j < results[i].probabilities.size(); ++j) {
+                prob_sum += results[i].probabilities[j];
+                assertTrue(results[i].probabilities[j] >= 0.0,
+                    sprintf("probability %d should be >= 0; got %f", j, results[i].probabilities[j]));
+                assertTrue(results[i].probabilities[j] <= 1.0,
+                    sprintf("probability %d should be <= 1; got %f", j, results[i].probabilities[j]));
+            }
+            assertTrue(abs(prob_sum - 1.0) < 1e-6,
+                sprintf("probabilities should sum to 1.0; got %f", prob_sum));
+        }
+
+        # Multiclass
+        ML::LogisticRegression clf3({"learning_rate": 0.5, "max_iterations": 300});
+        list<list<float>> X3 = (
+            (1.0,), (1.5,), (2.0,),
+            (5.0,), (5.5,), (6.0,),
+            (9.0,), (9.5,), (10.0,),
+        );
+        list<float> y3 = (0, 0, 0, 1, 1, 1, 2, 2, 2);
+        clf3.fitMatrix(X3, y3);
+
+        results = clf3.predictMatrix(((1.5,), (5.5,), (9.5,)));
+        for (int i = 0; i < results.size(); ++i) {
+            float prob_sum = 0.0;
+            for (int j = 0; j < results[i].probabilities.size(); ++j) {
+                prob_sum += results[i].probabilities[j];
+                assertTrue(results[i].probabilities[j] >= 0.0);
+            }
+            assertTrue(abs(prob_sum - 1.0) < 1e-6,
+                sprintf("multiclass probabilities should sum to 1.0; got %f", prob_sum));
+        }
+    }
+
+    logregNoRegularizationTest() {
+        ML::LogisticRegression clf({"learning_rate": 0.5, "max_iterations": 200, "penalty": "none"});
+
+        list<list<float>> X = ((1.0,), (2.0,), (3.0,), (4.0,));
+        list<float> y = (0, 0, 1, 1);
+        clf.fitMatrix(X, y);
+        assertTrue(clf.isFitted());
+
+        list<hash<ML::LogisticRegressionResult>> results = clf.predictMatrix(((1.0,), (4.0,)));
+        assertEq(0.0, results[0].predicted_class);
+        assertEq(1.0, results[1].predicted_class);
+    }
+
+    logregNoInterceptTest() {
+        ML::LogisticRegression clf({"learning_rate": 0.5, "max_iterations": 200,
+            "fit_intercept": False});
+
+        list<list<float>> X = ((1.0,), (2.0,), (3.0,), (4.0,));
+        list<float> y = (0, 0, 1, 1);
+        clf.fitMatrix(X, y);
+        assertTrue(clf.isFitted());
+
+        # Should still produce valid predictions
+        list<hash<ML::LogisticRegressionResult>> results = clf.predictMatrix(((1.0,), (4.0,)));
+        assertEq(2, results[0].probabilities.size());
+        assertEq(2, results[0].classes.size());
+    }
+
+    logregConvergenceTest() {
+        # Test with many iterations to achieve strong convergence on well-separated data
+        ML::LogisticRegression clf({"learning_rate": 1.0, "max_iterations": 2000,
+            "tolerance": 1e-10, "regularization": 0.001});
+
+        list<list<float>> X = (
+            (-3.0,), (-2.0,), (-1.0,), (0.0,),
+            (4.0,), (5.0,), (6.0,), (7.0,),
+        );
+        list<float> y = (0, 0, 0, 0, 1, 1, 1, 1);
+        clf.fitMatrix(X, y);
+        assertTrue(clf.isFitted());
+
+        # After convergence, predictions at extremes should be confident
+        list<hash<ML::LogisticRegressionResult>> results = clf.predictMatrix(((-3.0,), (7.0,)));
+        assertTrue(results[0].max_probability > 0.8,
+            sprintf("converged model should be confident for class 0; got %f", results[0].max_probability));
+        assertTrue(results[1].max_probability > 0.8,
+            sprintf("converged model should be confident for class 1; got %f", results[1].max_probability));
+    }
+
+    logregErrorTest() {
+        # Invalid learning_rate
+        assertThrows("ML-LOGISTIC-REGRESSION-ERROR", "learning_rate", sub() {
+            new ML::LogisticRegression({"learning_rate": 0.0});
+        });
+        assertThrows("ML-LOGISTIC-REGRESSION-ERROR", "learning_rate", sub() {
+            new ML::LogisticRegression({"learning_rate": -1.0});
+        });
+
+        # Invalid max_iterations
+        assertThrows("ML-LOGISTIC-REGRESSION-ERROR", "max_iterations", sub() {
+            new ML::LogisticRegression({"max_iterations": 0});
+        });
+
+        # Invalid tolerance
+        assertThrows("ML-LOGISTIC-REGRESSION-ERROR", "tolerance", sub() {
+            new ML::LogisticRegression({"tolerance": -1.0});
+        });
+
+        # Invalid regularization
+        assertThrows("ML-LOGISTIC-REGRESSION-ERROR", "regularization", sub() {
+            new ML::LogisticRegression({"regularization": -1.0});
+        });
+
+        # Invalid penalty
+        assertThrows("ML-LOGISTIC-REGRESSION-ERROR", "penalty", sub() {
+            new ML::LogisticRegression({"penalty": "l1"});
+        });
+
+        # Predict before fit
+        ML::LogisticRegression clf();
+        assertThrows("ML-LOGISTIC-REGRESSION-ERROR", "not been fitted", sub() {
+            clf.predictMatrix(((1.0,),));
+        });
+
+        # Fit with empty data
+        assertThrows("ML-DATA-ERROR", "empty", sub() {
+            ML::LogisticRegression clf2();
+            list<hash<auto>> empty_data = ();
+            clf2.fit(empty_data, "target");
+        });
+
+        # Fit with only one class
+        assertThrows("ML-LOGISTIC-REGRESSION-ERROR", "2 distinct classes", sub() {
+            ML::LogisticRegression clf2();
+            clf2.fitMatrix(((1.0,), (2.0,), (3.0,)), (0, 0, 0));
+        });
+
+        # Fit with mismatched X/y sizes
+        assertThrows("ML-LOGISTIC-REGRESSION-ERROR", "must match", sub() {
+            ML::LogisticRegression clf2();
+            clf2.fitMatrix(((1.0,), (2.0,)), (0, 1, 2));
+        });
+
+        # Predict with wrong number of features
+        ML::LogisticRegression clf3();
+        clf3.fitMatrix(((1.0, 2.0), (3.0, 4.0)), (0, 1));
+        assertThrows("ML-LOGISTIC-REGRESSION-ERROR", "features", sub() {
+            clf3.predictMatrix(((1.0,),));
+        });
+    }
+
+    logregCopyTest() {
+        ML::LogisticRegression clf();
+        assertThrows("COPY-ERROR", sub() {
+            ML::LogisticRegression clf2 = clf.copy();
+        });
     }
 
     # ===================== LOF Tests =====================
@@ -2821,6 +3105,206 @@ public class MlTest inherits QUnit::Test {
 
         float sil = ML::ml_silhouette_score(data, labels);
         assertTrue(sil > 0.8, sprintf("expected silhouette > 0.8, got %f", sil));
+    }
+
+    knnClassificationBasicTest() {
+        ML::KNN knn({"k": 3, "task": "classification"});
+        assertFalse(knn.isFitted());
+        assertEq(3, knn.getK());
+
+        list<list<float>> X = (
+            (0.0, 0.0), (0.5, 0.5), (1.0, 0.0), (0.0, 1.0), (0.5, 0.0),
+            (10.0, 10.0), (10.5, 10.5), (11.0, 10.0), (10.0, 11.0), (10.5, 10.0),
+        );
+        list<float> y = (0, 0, 0, 0, 0, 1, 1, 1, 1, 1);
+        knn.fitMatrix(X, y);
+        assertTrue(knn.isFitted());
+
+        list<hash<auto>> results = knn.predictMatrix(((0.2, 0.3),));
+        assertEq(1, results.size());
+        assertEq(0, results[0].predicted_class);
+        assertTrue(results[0].confidence > 0.9);
+        assertEq(3, results[0].neighbors.size());
+
+        results = knn.predictMatrix(((10.2, 10.3),));
+        assertEq(1, results[0].predicted_class);
+        assertTrue(results[0].confidence > 0.9);
+    }
+
+    knnClassificationDistanceTest() {
+        ML::KNN knn({"k": 3, "task": "classification", "weight_func": "distance"});
+
+        list<list<float>> X = (
+            (0.0, 0.0), (1.0, 0.0), (0.0, 1.0),
+            (10.0, 10.0), (11.0, 10.0), (10.0, 11.0),
+        );
+        list<float> y = (0, 0, 0, 1, 1, 1);
+        knn.fitMatrix(X, y);
+
+        list<hash<auto>> results = knn.predictMatrix(((0.1, 0.1),));
+        assertEq(1, results.size());
+        assertEq(0, results[0].predicted_class);
+        assertTrue(results[0].confidence > 0.5);
+        assertEq(3, results[0].neighbors.size());
+
+        results = knn.predictMatrix(((10.1, 10.1),));
+        assertEq(1, results[0].predicted_class);
+        assertTrue(results[0].confidence > 0.5);
+    }
+
+    knnRegressionBasicTest() {
+        ML::KNN knn({"k": 3, "task": "regression"});
+
+        list<list<float>> X = (
+            (1.0, 1.0), (2.0, 2.0), (3.0, 3.0), (4.0, 4.0), (5.0, 5.0),
+        );
+        list<float> y = (2.0, 4.0, 6.0, 8.0, 10.0);
+        knn.fitMatrix(X, y);
+
+        list<hash<auto>> results = knn.predictMatrix(((3.0, 3.0),));
+        assertEq(1, results.size());
+        assertFloat(6.0, results[0].prediction, 0.01);
+        assertEq(3, results[0].neighbors.size());
+    }
+
+    knnRegressionDistanceTest() {
+        ML::KNN knn({"k": 3, "task": "regression", "weight_func": "distance"});
+
+        list<list<float>> X = (
+            (0.0,), (1.0,), (2.0,), (3.0,), (4.0,),
+        );
+        list<float> y = (0.0, 10.0, 20.0, 30.0, 40.0);
+        knn.fitMatrix(X, y);
+
+        list<hash<auto>> results = knn.predictMatrix(((1.0,),));
+        assertFloat(10.0, results[0].prediction, 0.01);
+    }
+
+    knnHashApiTest() {
+        ML::KNN knn({"k": 3, "task": "classification"});
+
+        list<hash<auto>> data = (
+            {"x": 0.0, "y": 0.0, "class": 0},
+            {"x": 0.5, "y": 0.5, "class": 0},
+            {"x": 1.0, "y": 0.0, "class": 0},
+            {"x": 0.0, "y": 1.0, "class": 0},
+            {"x": 10.0, "y": 10.0, "class": 1},
+            {"x": 10.5, "y": 10.5, "class": 1},
+            {"x": 11.0, "y": 10.0, "class": 1},
+            {"x": 10.0, "y": 11.0, "class": 1},
+        );
+        knn.fit(data, "class");
+        assertTrue(knn.isFitted());
+
+        hash<auto> r = knn.predict({"x": 0.2, "y": 0.3});
+        assertEq(0, r.predicted_class);
+        assertTrue(r.confidence > 0.5);
+
+        r = knn.predict({"x": 10.2, "y": 10.3});
+        assertEq(1, r.predicted_class);
+        assertTrue(r.confidence > 0.5);
+    }
+
+    knnManhattanTest() {
+        ML::KNN knn({"k": 3, "task": "classification", "metric": "manhattan"});
+
+        list<list<float>> X = (
+            (0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (0.5, 0.5),
+            (10.0, 10.0), (11.0, 10.0), (10.0, 11.0), (10.5, 10.5),
+        );
+        list<float> y = (0, 0, 0, 0, 1, 1, 1, 1);
+        knn.fitMatrix(X, y);
+
+        list<hash<auto>> results = knn.predictMatrix(((0.3, 0.3),));
+        assertEq(0, results[0].predicted_class);
+
+        results = knn.predictMatrix(((10.3, 10.3),));
+        assertEq(1, results[0].predicted_class);
+    }
+
+    knnCosineTest() {
+        ML::KNN knn({"k": 3, "task": "classification", "metric": "cosine"});
+
+        list<list<float>> X = (
+            (1.0, 0.0), (2.0, 0.1), (3.0, 0.0),
+            (0.0, 1.0), (0.1, 2.0), (0.0, 3.0),
+        );
+        list<float> y = (0, 0, 0, 1, 1, 1);
+        knn.fitMatrix(X, y);
+
+        list<hash<auto>> results = knn.predictMatrix(((5.0, 0.1),));
+        assertEq(0, results[0].predicted_class);
+
+        results = knn.predictMatrix(((0.1, 5.0),));
+        assertEq(1, results[0].predicted_class);
+    }
+
+    knnPredictMatrixTest() {
+        ML::KNN knn({"k": 3, "task": "classification"});
+
+        list<list<float>> X = (
+            (0.0, 0.0), (1.0, 0.0), (0.0, 1.0),
+            (10.0, 10.0), (11.0, 10.0), (10.0, 11.0),
+        );
+        list<float> y = (0, 0, 0, 1, 1, 1);
+        knn.fitMatrix(X, y);
+
+        list<hash<auto>> results = knn.predictMatrix((
+            (0.5, 0.5),
+            (10.5, 10.5),
+            (0.1, 0.1),
+        ));
+        assertEq(3, results.size());
+        assertEq(0, results[0].predicted_class);
+        assertEq(1, results[1].predicted_class);
+        assertEq(0, results[2].predicted_class);
+
+        foreach hash<auto> r in (results) {
+            assertEq(3, r.neighbors.size());
+            foreach hash<auto> n in (r.neighbors) {
+                assertTrue(n.hasKey("index"));
+                assertTrue(n.hasKey("distance"));
+                assertTrue(n.hasKey("label"));
+                assertTrue(n.distance >= 0.0);
+            }
+        }
+    }
+
+    knnErrorTest() {
+        assertThrows("ML-KNN-ERROR", sub() { new ML::KNN({"k": 0}); });
+        assertThrows("ML-KNN-ERROR", sub() { new ML::KNN({"k": -1}); });
+        assertThrows("ML-KNN-ERROR", sub() { new ML::KNN({"metric": "euclidean"}); });
+        assertThrows("ML-KNN-ERROR", sub() { new ML::KNN({"k": 3, "metric": "invalid"}); });
+        assertThrows("ML-KNN-ERROR", sub() { new ML::KNN({"k": 3, "task": "invalid"}); });
+        assertThrows("ML-KNN-ERROR", sub() { new ML::KNN({"k": 3, "weight_func": "invalid"}); });
+
+        ML::KNN knn({"k": 3});
+        assertThrows("ML-KNN-ERROR", sub() { knn.predictMatrix(((1.0, 2.0),)); });
+
+        assertThrows("ML-KNN-ERROR", sub() {
+            ML::KNN knn2({"k": 10});
+            knn2.fitMatrix(((1.0,), (2.0,), (3.0,)), (0, 1, 0));
+        });
+
+        ML::KNN knn3({"k": 2});
+        knn3.fitMatrix(((1.0, 2.0), (3.0, 4.0), (5.0, 6.0)), (0, 1, 0));
+        assertThrows("ML-KNN-ERROR", sub() { knn3.predictMatrix(((1.0, 2.0, 3.0),)); });
+
+        assertThrows("ML-DATA-ERROR", sub() {
+            ML::KNN knn4({"k": 3});
+            knn4.fit((), "target");
+        });
+
+        ML::KNN knn5({"k": 2});
+        knn5.fitMatrix(((1.0, 2.0), (3.0, 4.0), (5.0, 6.0)), (0, 1, 0));
+        assertThrows("ML-KNN-ERROR", sub() { knn5.predict({"x": 1.0, "y": 2.0}); });
+    }
+
+    knnCopyTest() {
+        ML::KNN knn({"k": 3});
+        assertThrows("COPY-ERROR", sub() {
+            ML::KNN knn2 = knn.copy();
+        });
     }
 
     private assertFloat(float expected, auto actual, float tolerance) {

--- a/modules/ml/test/ml.qtest
+++ b/modules/ml/test/ml.qtest
@@ -79,6 +79,7 @@ public class MlTest inherits QUnit::Test {
         addTestCase("LinearRegression error cases", \lrErrorTest());
         addTestCase("LinearRegression copy error", \lrCopyTest());
         addTestCase("LinearRegression getModelInfo", \lrGetModelInfoTest());
+        addTestCase("LinearRegression SGD update", \lrUpdateTest());
         addTestCase("LogisticRegression binary classification", \logregBinaryTest());
         addTestCase("LogisticRegression multiclass OvR", \logregMulticlassTest());
         addTestCase("LogisticRegression hash API", \logregHashTest());
@@ -88,6 +89,7 @@ public class MlTest inherits QUnit::Test {
         addTestCase("LogisticRegression convergence", \logregConvergenceTest());
         addTestCase("LogisticRegression error cases", \logregErrorTest());
         addTestCase("LogisticRegression copy error", \logregCopyTest());
+        addTestCase("LogisticRegression SGD update", \logregUpdateTest());
         addTestCase("LOF basic outlier detection", \lofBasicTest());
         addTestCase("LOF k parameter", \lofKParamTest());
         addTestCase("LOF hash API", \lofHashTest());
@@ -113,6 +115,7 @@ public class MlTest inherits QUnit::Test {
         addTestCase("GMM reproducibility", \gmmReproducibilityTest());
         addTestCase("GMM error cases", \gmmErrorTest());
         addTestCase("GMM copy error", \gmmCopyTest());
+        addTestCase("GMM online EM update", \gmmUpdateTest());
         addTestCase("OnnxModel load and metadata", \onnxLoadTest());
         addTestCase("OnnxModel inference", \onnxInferenceTest());
         addTestCase("OnnxModel batch inference", \onnxBatchTest());
@@ -1451,6 +1454,54 @@ public class MlTest inherits QUnit::Test {
         assertTrue(abs(info.r_squared - lr.getRSquared()) < 1e-10);
     }
 
+    lrUpdateTest() {
+        ML::LinearRegression lr({"fit_intercept": True});
+
+        # Fit on y = 2x + 3
+        list<list<float>> X_init = ((1.0,), (2.0,), (3.0,), (4.0,), (5.0,));
+        list<float> y_init = (5.0, 7.0, 9.0, 11.0, 13.0);
+        lr.fitMatrix(X_init, y_init);
+
+        # Save initial coefficients
+        list<float> coefs_before = lr.getCoefficients();
+        float intercept_before = lr.getIntercept();
+
+        # Update with more data (same relationship, slightly noisy)
+        list<list<float>> X_update = ((6.0,), (7.0,), (8.0,), (9.0,), (10.0,));
+        list<float> y_update = (15.1, 16.9, 19.2, 20.8, 23.1);
+        lr.updateMatrix(X_update, y_update, 0.001);
+
+        # Model should still be fitted
+        assertTrue(lr.isFitted());
+
+        # Coefficients should have changed from the update
+        list<float> coefs_after = lr.getCoefficients();
+        float intercept_after = lr.getIntercept();
+        bool changed = (abs(coefs_after[0] - coefs_before[0]) > 1e-10)
+            || (abs(intercept_after - intercept_before) > 1e-10);
+        assertTrue(changed, "coefficients should change after update");
+
+        # Predict should still work
+        hash<ML::LinearRegressionResult> pred = lr.predictMatrix(((5.0,),))[0];
+        assertTrue(exists pred.prediction, "prediction should exist after update");
+
+        # Error cases: update before fit
+        ML::LinearRegression lr2({"fit_intercept": True});
+        assertThrows("ML-LINEAR-REGRESSION-ERROR", sub() {
+            lr2.updateMatrix(((1.0,),), (1.0,), 0.01);
+        });
+
+        # Dimension mismatch
+        assertThrows("ML-LINEAR-REGRESSION-ERROR", sub() {
+            lr.updateMatrix(((1.0, 2.0),), (1.0,), 0.01);
+        });
+
+        # X/y size mismatch
+        assertThrows("ML-LINEAR-REGRESSION-ERROR", sub() {
+            lr.updateMatrix(((1.0,), (2.0,)), (1.0,), 0.01);
+        });
+    }
+
     # ===================== LogisticRegression Tests =====================
 
     logregBinaryTest() {
@@ -1711,6 +1762,67 @@ public class MlTest inherits QUnit::Test {
         ML::LogisticRegression clf();
         assertThrows("COPY-ERROR", sub() {
             ML::LogisticRegression clf2 = clf.copy();
+        });
+    }
+
+    logregUpdateTest() {
+        ML::LogisticRegression clf({"learning_rate": 0.1, "max_iterations": 200});
+
+        # Fit on binary data: class 0 around x=1, class 1 around x=5
+        list<list<float>> X_init;
+        list<float> y_init;
+        for (int i = 0; i < 20; ++i) {
+            push X_init, (1.0 + (i % 5) * 0.1,);
+            push y_init, 0.0;
+        }
+        for (int i = 0; i < 20; ++i) {
+            push X_init, (5.0 + (i % 5) * 0.1,);
+            push y_init, 1.0;
+        }
+        clf.fitMatrix(X_init, y_init);
+
+        # Get initial prediction for a borderline point
+        hash<ML::LogisticRegressionResult> pred_before = clf.predictMatrix(((3.0,),))[0];
+
+        # Update with more data reinforcing the pattern
+        list<list<float>> X_update;
+        list<float> y_update;
+        for (int i = 0; i < 10; ++i) {
+            push X_update, (0.5 + (i % 3) * 0.1,);
+            push y_update, 0.0;
+        }
+        for (int i = 0; i < 10; ++i) {
+            push X_update, (5.5 + (i % 3) * 0.1,);
+            push y_update, 1.0;
+        }
+        clf.updateMatrix(X_update, y_update, 0.1);
+
+        # Model should still be fitted and predict
+        assertTrue(clf.isFitted());
+        hash<ML::LogisticRegressionResult> pred_after = clf.predictMatrix(((3.0,),))[0];
+        assertTrue(exists pred_after.predicted_class, "prediction should exist after update");
+
+        # Probabilities should still sum to ~1
+        float prob_sum = 0.0;
+        foreach float p in (pred_after.probabilities) {
+            prob_sum += p;
+        }
+        assertTrue(abs(prob_sum - 1.0) < 0.01, "probabilities should sum to ~1");
+
+        # Error cases: update before fit
+        ML::LogisticRegression clf2();
+        assertThrows("ML-LOGISTIC-REGRESSION-ERROR", sub() {
+            clf2.updateMatrix(((1.0,),), (0.0,), 0.01);
+        });
+
+        # Dimension mismatch
+        assertThrows("ML-LOGISTIC-REGRESSION-ERROR", sub() {
+            clf.updateMatrix(((1.0, 2.0),), (0.0,), 0.01);
+        });
+
+        # Unknown class in update target
+        assertThrows("ML-LOGISTIC-REGRESSION-ERROR", sub() {
+            clf.updateMatrix(((1.0,),), (99.0,), 0.01);
         });
     }
 
@@ -2049,6 +2161,56 @@ public class MlTest inherits QUnit::Test {
         ML::GMM gmm({"n_components": 2});
         assertThrows("COPY-ERROR", sub() {
             ML::GMM copy = gmm.copy();
+        });
+    }
+
+    gmmUpdateTest() {
+        ML::GMM gmm({"n_components": 2, "seed": 42});
+
+        # Initial fit on 2 clusters
+        list<list<float>> init_data;
+        for (int i = 0; i < 30; ++i) {
+            push init_data, (0.0 + (i % 5) * 0.1, 0.0 + (i % 5) * 0.1);
+        }
+        for (int i = 0; i < 30; ++i) {
+            push init_data, (10.0 + (i % 5) * 0.1, 10.0 + (i % 5) * 0.1);
+        }
+        gmm.fitMatrix(init_data);
+
+        # Save initial means
+        list<auto> means_before = gmm.getMeans();
+
+        # Update with shifted data
+        list<list<float>> update_data;
+        for (int i = 0; i < 20; ++i) {
+            push update_data, (1.0 + (i % 5) * 0.1, 1.0 + (i % 5) * 0.1);
+        }
+        for (int i = 0; i < 20; ++i) {
+            push update_data, (11.0 + (i % 5) * 0.1, 11.0 + (i % 5) * 0.1);
+        }
+        gmm.updateMatrix(update_data);
+
+        # Model should still be fitted
+        assertTrue(gmm.isFitted());
+
+        # Means should have shifted
+        list<auto> means_after = gmm.getMeans();
+        assertEq(2, means_after.size());
+
+        # Predict should still work
+        list<hash<ML::GMMResult>> preds = gmm.predictMatrix(((5.0, 5.0),));
+        assertEq(1, preds.size());
+        assertTrue(exists preds[0].cluster);
+
+        # Error cases: update before fit
+        ML::GMM gmm2({"n_components": 2});
+        assertThrows("ML-GMM-ERROR", sub() {
+            gmm2.updateMatrix(((1.0, 2.0),));
+        });
+
+        # Dimension mismatch
+        assertThrows("ML-GMM-ERROR", sub() {
+            gmm.updateMatrix(((1.0, 2.0, 3.0),));
         });
     }
 

--- a/qlib/DataProviderML/DataProviderML.qm
+++ b/qlib/DataProviderML/DataProviderML.qm
@@ -632,6 +632,117 @@ module DataProviderML {
                 }
             ),
         });
+
+        # register logistic-regression action
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": MLApp::AppName,
+            "path": "/logistic-regression",
+            "action": "logistic-regression",
+            "display_name": "Categorize Records",
+            "short_desc": "Predicts which category each record belongs to based on its features",
+            "desc": "Classifies records into categories — such as spam vs. not spam, risk levels, "
+                "or product types — by learning from labeled examples. For example, given customer "
+                "attributes like age, income, and spending score, the model learns which segment "
+                "each customer belongs to and predicts segments for new records.\n\n"
+                "Records accumulate in a window; when full, the model learns and produces "
+                "predictions. Each record receives:\n"
+                "- `predicted_class` — the category label\n"
+                "- `max_probability` — confidence in the prediction (e.g., `0.92` means 92%% "
+                "sure)\n"
+                "- `probabilities` — breakdown across all categories",
+            "action_code": DPAT_PIPELINE_PROCESSOR,
+            "processor_capabilities": DPC_AGGREGATE,
+            "cls": "DataProviderML::QoreLogisticRegressionProcessor",
+            "groups": ("ML Analytics",),
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                QoreLogisticRegressionProcessor::ConstructorOptions{
+                    "fields", "target_field", "window_size",
+                }, {
+                    "preselected": True,
+                    "required": True,
+                    "loc": "constructor",
+                }
+            ) + DataProviderActionCatalog::getActionOptionFromFields(
+                QoreLogisticRegressionProcessor::ConstructorOptions{
+                    "learning_rate", "max_iterations", "regularization",
+                    "penalty", "fit_intercept",
+                }, {
+                    "loc": "constructor",
+                }
+            ),
+        });
+
+        # register knn-classification action
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": MLApp::AppName,
+            "path": "/knn-classification",
+            "action": "knn-classification",
+            "display_name": "Classify by Similarity",
+            "short_desc": "Predicts each record's category based on its nearest neighbors",
+            "desc": "Classifies records by finding the most similar records in the training "
+                "data and using majority voting. For example, to classify a flower species, "
+                "the model finds the 5 most similar flowers in the training set and picks "
+                "the most common species among them.\n\n"
+                "Records accumulate in a window; when full, the model learns and produces "
+                "predictions. Each record receives:\n"
+                "- `predicted_class` — the category label from majority vote\n"
+                "- `confidence` — proportion of neighbors that agree (e.g., `0.80` means "
+                "4 of 5 neighbors voted the same way)",
+            "action_code": DPAT_PIPELINE_PROCESSOR,
+            "processor_capabilities": DPC_AGGREGATE,
+            "cls": "DataProviderML::QoreKNNClassificationProcessor",
+            "groups": ("ML Analytics",),
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                QoreKNNClassificationProcessor::ConstructorOptions{
+                    "fields", "target_field", "window_size", "k",
+                }, {
+                    "preselected": True,
+                    "required": True,
+                    "loc": "constructor",
+                }
+            ) + DataProviderActionCatalog::getActionOptionFromFields(
+                QoreKNNClassificationProcessor::ConstructorOptions{
+                    "metric", "weight_func",
+                }, {
+                    "loc": "constructor",
+                }
+            ),
+        });
+
+        # register knn-regression action
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": MLApp::AppName,
+            "path": "/knn-regression",
+            "action": "knn-regression",
+            "display_name": "Predict Numbers by Similarity",
+            "short_desc": "Predicts a numeric value based on similar records",
+            "desc": "Predicts a numeric value for each record by averaging the target values "
+                "of the most similar records in the training data. For example, to estimate "
+                "a house price, the model finds the 5 most similar houses and averages their "
+                "prices.\n\n"
+                "Records accumulate in a window; when full, the model learns and produces "
+                "predictions. Each record receives:\n"
+                "- `prediction` — the estimated numeric value (weighted average of neighbors)",
+            "action_code": DPAT_PIPELINE_PROCESSOR,
+            "processor_capabilities": DPC_AGGREGATE,
+            "cls": "DataProviderML::QoreKNNRegressionProcessor",
+            "groups": ("ML Analytics",),
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                QoreKNNRegressionProcessor::ConstructorOptions{
+                    "fields", "target_field", "window_size", "k",
+                }, {
+                    "preselected": True,
+                    "required": True,
+                    "loc": "constructor",
+                }
+            ) + DataProviderActionCatalog::getActionOptionFromFields(
+                QoreKNNRegressionProcessor::ConstructorOptions{
+                    "metric", "weight_func",
+                }, {
+                    "loc": "constructor",
+                }
+            ),
+        });
     };
 }
 
@@ -1041,5 +1152,46 @@ public namespace DataProviderML {
         int sample_count;
         #! The number of distinct clusters found in the batch
         int n_clusters;
+    }
+
+    #! Logistic regression classification event hashdecl
+    public hashdecl LogisticRegressionEventInfo {
+        #! The type of analysis that produced this result (always "logistic-regression")
+        string event_type = "logistic-regression";
+        #! The class label the model predicted for this record based on the input fields
+        float predicted_class;
+        #! How confident the model is in the prediction, from 0.0 (uncertain) to
+        #! 1.0 (very confident)
+        float max_probability;
+        #! The probability that this record belongs to each class; for example, with 3
+        #! classes the list might be (0.7, 0.2, 0.1) meaning 70%% chance of class 0
+        list<float> probabilities;
+        #! The original input values for the fields that were analyzed
+        hash<auto> record_values;
+    }
+
+    #! KNN classification event hashdecl
+    public hashdecl KNNClassificationEventInfo {
+        #! The type of analysis that produced this result (always "knn-classification")
+        string event_type = "knn-classification";
+        #! The class label predicted by majority vote of the nearest neighbors
+        int predicted_class;
+        #! How confident the prediction is, from 0.0 (no consensus) to 1.0 (all
+        #! neighbors agree); represents the proportion of voting weight for the
+        #! predicted class
+        float confidence;
+        #! The original input values for the fields that were analyzed
+        hash<auto> record_values;
+    }
+
+    #! KNN regression event hashdecl
+    public hashdecl KNNRegressionEventInfo {
+        #! The type of analysis that produced this result (always "knn-regression")
+        string event_type = "knn-regression";
+        #! The predicted numeric value, computed as the (optionally weighted) average
+        #! of the k nearest neighbors' target values
+        float prediction;
+        #! The original input values for the fields that were analyzed
+        hash<auto> record_values;
     }
 }

--- a/qlib/DataProviderML/DataProviderML.qm
+++ b/qlib/DataProviderML/DataProviderML.qm
@@ -411,6 +411,227 @@ module DataProviderML {
                 }
             ),
         });
+
+        # register standard-scaler action
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": MLApp::AppName,
+            "path": "/standard-scaler",
+            "action": "standard-scaler",
+            "display_name": "Put All Fields on the Same Scale",
+            "short_desc": "Makes fields comparable by adjusting each to a common scale",
+            "desc": "Makes fields with different ranges directly comparable. For example, if "
+                "\"age\" ranges from 18–65 and \"income\" ranges from 20,000–200,000, comparing "
+                "them directly would let income dominate. This processor adjusts each field so "
+                "they all center around `0` with similar spread.\n\n"
+                "**When to use**: before clustering (Find Natural Groups), anomaly detection "
+                "(Detect Unusual Data Points), or dimensionality reduction (Reduce Data "
+                "Complexity) — any time your fields have different units or ranges.\n\n"
+                "**Example**: standardizing `age`, `income`, and `credit_score` before "
+                "customer segmentation ensures each factor contributes equally.\n\n"
+                "Records accumulate in a window. The first window learns the typical values "
+                "for each field; subsequent windows apply the same adjustment. Each record "
+                "receives:\n"
+                "- `scaled_values` — the adjusted field values (centered around `0`)\n"
+                "- `record_values` — the original values for comparison",
+            "action_code": DPAT_PIPELINE_PROCESSOR,
+            "processor_capabilities": DPC_AGGREGATE,
+            "cls": "DataProviderML::QoreStandardScalerProcessor",
+            "groups": ("ML Analytics",),
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                QoreStandardScalerProcessor::ConstructorOptions{"fields", "window_size"}, {
+                    "preselected": True,
+                    "required": True,
+                    "loc": "constructor",
+                }
+            ),
+        });
+
+        # register min-max-scaler action
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": MLApp::AppName,
+            "path": "/min-max-scaler",
+            "action": "min-max-scaler",
+            "display_name": "Normalize Values to a Range",
+            "short_desc": "Converts field values to a fixed range like 0 to 1",
+            "desc": "Converts field values to fit within a specific range (default `0.0` to "
+                "`1.0`). For example, temperatures ranging from -20°C to 45°C become `0.0` "
+                "to `1.0`, making them easy to compare with humidity (0%%–100%%) or wind speed "
+                "(0–150 km/h).\n\n"
+                "**When to use**: preparing data for scoring models, heat maps, or progress "
+                "bars where you need values between fixed bounds. Also useful before feeding "
+                "data into pre-trained ONNX models that expect normalized input.\n\n"
+                "**Example**: normalizing `price`, `quantity`, and `weight` to `0`–`1` before "
+                "displaying a product similarity score.\n\n"
+                "Records accumulate in a window. The first window learns the minimum and "
+                "maximum of each field; subsequent windows apply the same normalization. Each "
+                "record receives:\n"
+                "- `scaled_values` — field values converted to the target range\n"
+                "- `record_values` — the original values for comparison",
+            "action_code": DPAT_PIPELINE_PROCESSOR,
+            "processor_capabilities": DPC_AGGREGATE,
+            "cls": "DataProviderML::QoreMinMaxScalerProcessor",
+            "groups": ("ML Analytics",),
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                QoreMinMaxScalerProcessor::ConstructorOptions{"fields", "window_size"}, {
+                    "preselected": True,
+                    "required": True,
+                    "loc": "constructor",
+                }
+            ) + DataProviderActionCatalog::getActionOptionFromFields(
+                QoreMinMaxScalerProcessor::ConstructorOptions{"feature_min", "feature_max"}, {
+                    "loc": "constructor",
+                }
+            ),
+        });
+
+        # register imputer action
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": MLApp::AppName,
+            "path": "/imputer",
+            "action": "imputer",
+            "display_name": "Fill In Missing Data",
+            "short_desc": "Automatically fills gaps in your data using smart defaults",
+            "desc": "Automatically fills in missing values in your data so downstream analysis "
+                "and ML steps can process complete records. For example, if 5%% of your sensor "
+                "readings are missing due to connectivity issues, this processor fills them in "
+                "with reasonable values based on the available data.\n\n"
+                "**Strategies**:\n"
+                "- **Average**: fill with the typical value (best for normally distributed data "
+                "like temperatures)\n"
+                "- **Middle value**: fill with the median (better when outliers are present, "
+                "e.g., transaction amounts)\n"
+                "- **Most common**: fill with the most frequently seen value (best for "
+                "categorical-like data such as status codes)\n"
+                "- **Fixed value**: fill with a specific number you choose (e.g., `0` or `-1` "
+                "as a sentinel)\n\n"
+                "Records accumulate in a window. The first window learns the fill values from "
+                "non-missing data; subsequent windows apply the same fill values. Each record "
+                "receives:\n"
+                "- `imputed_values` — the complete record with gaps filled in\n"
+                "- `missing_count` — how many fields were missing in this record\n"
+                "- `record_values` — the original values (with gaps) for comparison",
+            "action_code": DPAT_PIPELINE_PROCESSOR,
+            "processor_capabilities": DPC_AGGREGATE,
+            "cls": "DataProviderML::QoreImputerProcessor",
+            "groups": ("ML Analytics",),
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                QoreImputerProcessor::ConstructorOptions{"fields", "window_size"}, {
+                    "preselected": True,
+                    "required": True,
+                    "loc": "constructor",
+                }
+            ) + DataProviderActionCatalog::getActionOptionFromFields(
+                QoreImputerProcessor::ConstructorOptions{"strategy", "constant_value"}, {
+                    "preselected": True,
+                    "loc": "constructor",
+                }
+            ),
+        });
+
+        # register classification-metrics action
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": MLApp::AppName,
+            "path": "/classification-metrics",
+            "action": "classification-metrics",
+            "display_name": "Score Your Category Predictions",
+            "short_desc": "Checks how often your model picks the right category",
+            "desc": "Measures how well your model assigns items to the right category by "
+                "comparing what it predicted against what the correct answer actually was. "
+                "For example, if your spam filter labels 1,000 emails as \"spam\" or "
+                "\"not spam\", this tells you how often it got it right.\n\n"
+                "**What you get**:\n"
+                "- `accuracy` — what percentage of predictions were correct (e.g., `0.92` "
+                "means 92%% right)\n"
+                "- `per_class` — for each category, how reliable the model is: does it "
+                "catch most real cases (recall) without too many false alarms (precision)?\n"
+                "- `macro_f1` — overall quality score that treats every category equally, "
+                "even rare ones (ranges `0.0` to `1.0`; higher is better)\n"
+                "- `weighted_f1` — overall quality score weighted by how common each "
+                "category is\n\n"
+                "Records accumulate in a batch; when full, a single scorecard is emitted.",
+            "action_code": DPAT_PIPELINE_PROCESSOR,
+            "processor_capabilities": DPC_AGGREGATE,
+            "cls": "DataProviderML::QoreClassificationMetricsProcessor",
+            "groups": ("ML Analytics",),
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                QoreClassificationMetricsProcessor::ConstructorOptions{
+                    "predicted_field", "true_field", "window_size",
+                }, {
+                    "preselected": True,
+                    "required": True,
+                    "loc": "constructor",
+                }
+            ),
+        });
+
+        # register regression-metrics action
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": MLApp::AppName,
+            "path": "/regression-metrics",
+            "action": "regression-metrics",
+            "display_name": "Score Your Number Predictions",
+            "short_desc": "Checks how close your predicted numbers are to the actual values",
+            "desc": "Measures how close your model's predicted numbers are to the real values. "
+                "For example, if your model predicts house prices, this tells you how far off "
+                "the predictions are on average and how much of the price variation the model "
+                "captures.\n\n"
+                "**What you get**:\n"
+                "- `mae` — average prediction error in the same units as your data (e.g., "
+                "\"off by $12,000 on average\")\n"
+                "- `rmse` — similar to MAE but penalizes large errors more heavily\n"
+                "- `r2` — how much of the variation your model explains (`1.0` = perfect, "
+                "`0.0` = no better than always guessing the average)\n"
+                "- `mse` — average squared error (used internally by many algorithms)\n"
+                "- `explained_variance` — similar to R² but also detects systematic bias\n\n"
+                "Records accumulate in a batch; when full, a single scorecard is emitted.",
+            "action_code": DPAT_PIPELINE_PROCESSOR,
+            "processor_capabilities": DPC_AGGREGATE,
+            "cls": "DataProviderML::QoreRegressionMetricsProcessor",
+            "groups": ("ML Analytics",),
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                QoreRegressionMetricsProcessor::ConstructorOptions{
+                    "predicted_field", "true_field", "window_size",
+                }, {
+                    "preselected": True,
+                    "required": True,
+                    "loc": "constructor",
+                }
+            ),
+        });
+
+        # register clustering-metrics action
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": MLApp::AppName,
+            "path": "/clustering-metrics",
+            "action": "clustering-metrics",
+            "display_name": "Score Your Data Groupings",
+            "short_desc": "Checks whether your groups are distinct and meaningful",
+            "desc": "Measures whether the groups in your data are clearly separated or overlap "
+                "too much. For example, after segmenting customers into \"budget\", \"regular\", "
+                "and \"premium\" groups, this tells you whether the groups are genuinely distinct "
+                "or whether many customers sit on the boundary between groups.\n\n"
+                "**What you get**:\n"
+                "- `silhouette_score` — ranges from `-1.0` (groups overlap badly) to `1.0` "
+                "(perfectly separated); above `0.5` is generally good\n"
+                "- `davies_bouldin_score` — measures how much groups bleed into each other; "
+                "lower is better (`0.0` = no overlap at all)\n"
+                "- `calinski_harabasz_score` — measures how tight each group is compared to "
+                "how far apart the groups are; higher is better\n\n"
+                "Records accumulate in a batch; when full, a single scorecard is emitted.",
+            "action_code": DPAT_PIPELINE_PROCESSOR,
+            "processor_capabilities": DPC_AGGREGATE,
+            "cls": "DataProviderML::QoreClusteringMetricsProcessor",
+            "groups": ("ML Analytics",),
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                QoreClusteringMetricsProcessor::ConstructorOptions{
+                    "fields", "cluster_field", "window_size",
+                }, {
+                    "preselected": True,
+                    "required": True,
+                    "loc": "constructor",
+                }
+            ),
+        });
     };
 }
 
@@ -533,8 +754,6 @@ public namespace DataProviderML {
     }
 
     #! Isolation Forest anomaly event hashdecl
-    /** @since %DataProviderML 1.0
-    */
     public hashdecl IsolationForestAnomalyEventInfo {
         #! The type of analysis that produced this result (always "isolation-forest")
         string event_type = "isolation-forest";
@@ -550,8 +769,6 @@ public namespace DataProviderML {
     }
 
     #! DBSCAN clustering event hashdecl
-    /** @since %DataProviderML 1.0
-    */
     public hashdecl DBSCANClusteringEventInfo {
         #! The type of analysis that produced this result (always "dbscan-clustering")
         string event_type = "dbscan-clustering";
@@ -568,8 +785,6 @@ public namespace DataProviderML {
     }
 
     #! KMeans clustering event hashdecl
-    /** @since %DataProviderML 1.0
-    */
     public hashdecl KMeansClusteringEventInfo {
         #! The type of analysis that produced this result (always "kmeans-clustering")
         string event_type = "kmeans-clustering";
@@ -586,8 +801,6 @@ public namespace DataProviderML {
     }
 
     #! PCA event hashdecl
-    /** @since %DataProviderML 1.0
-    */
     public hashdecl PCAEventInfo {
         #! The type of analysis that produced this result (always "pca")
         string event_type = "pca";
@@ -603,8 +816,6 @@ public namespace DataProviderML {
     }
 
     #! Holt-Winters forecast event hashdecl
-    /** @since %DataProviderML 1.0
-    */
     public hashdecl HoltWintersForecastEventInfo inherits DataProvider::AnalyticsEventInfo {
         #! Predicted future value(s); one value per forecast step requested
         list<float> forecast;
@@ -623,8 +834,6 @@ public namespace DataProviderML {
     }
 
     #! Linear regression event hashdecl
-    /** @since %DataProviderML 1.0
-    */
     public hashdecl LinearRegressionEventInfo {
         #! The type of analysis that produced this result (always "linear-regression")
         string event_type = "linear-regression";
@@ -651,8 +860,6 @@ public namespace DataProviderML {
     }
 
     #! LOF anomaly event hashdecl
-    /** @since %DataProviderML 1.0
-    */
     public hashdecl LOFAnomalyEventInfo {
         #! The type of analysis that produced this result (always "lof")
         string event_type = "lof";
@@ -670,8 +877,6 @@ public namespace DataProviderML {
     }
 
     #! GMM clustering event hashdecl
-    /** @since %DataProviderML 1.0
-    */
     public hashdecl GMMClusteringEventInfo {
         #! The type of analysis that produced this result (always "gmm")
         string event_type = "gmm";
@@ -694,8 +899,6 @@ public namespace DataProviderML {
     }
 
     #! ONNX model inference event hashdecl
-    /** @since %DataProviderML 1.0
-    */
     public hashdecl OnnxInferenceEventInfo {
         #! The type of analysis that produced this result (always "onnx-model")
         string event_type = "onnx-model";
@@ -703,8 +906,6 @@ public namespace DataProviderML {
         string model_path;
         #! The hardware backend used to run the model (e.g., "CPUExecutionProvider" for CPU
         #! or "CUDAExecutionProvider" for GPU acceleration)
-        /** @since %DataProviderML 1.1
-        */
         string execution_provider;
         #! The original input values for the fields that were fed into the model
         hash<auto> record_values;
@@ -715,8 +916,6 @@ public namespace DataProviderML {
     }
 
     #! Seasonal decomposition event hashdecl
-    /** @since %DataProviderML 1.0
-    */
     public hashdecl SeasonalDecompositionEventInfo inherits DataProvider::AnalyticsEventInfo {
         #! The original data value before decomposition
         float observed;
@@ -738,5 +937,109 @@ public namespace DataProviderML {
         #! The number of data points in one complete seasonal cycle (e.g., 12 for monthly
         #! data with yearly patterns, 7 for daily data with weekly patterns)
         int period;
+    }
+
+    #! Standard scaler event hashdecl
+    public hashdecl StandardScalerEventInfo {
+        #! The type of analysis that produced this result (always "standard-scaler")
+        string event_type = "standard-scaler";
+        #! The original input values for the fields that were analyzed
+        hash<auto> record_values;
+        #! The scaled values for each field (zero mean, unit variance)
+        hash<auto> scaled_values;
+    }
+
+    #! Min-max scaler event hashdecl
+    public hashdecl MinMaxScalerEventInfo {
+        #! The type of analysis that produced this result (always "min-max-scaler")
+        string event_type = "min-max-scaler";
+        #! The original input values for the fields that were analyzed
+        hash<auto> record_values;
+        #! The scaled values for each field in the target range [feature_min, feature_max]
+        hash<auto> scaled_values;
+        #! The lower bound of the target range used for scaling
+        float feature_min;
+        #! The upper bound of the target range used for scaling
+        float feature_max;
+    }
+
+    #! Imputer event hashdecl
+    public hashdecl ImputerEventInfo {
+        #! The type of analysis that produced this result (always "imputer")
+        string event_type = "imputer";
+        #! The original input values for the fields that were analyzed; NOTHING values
+        #! indicate fields that were missing and have been filled
+        hash<auto> record_values;
+        #! The imputed values for each field with missing values replaced
+        hash<auto> imputed_values;
+        #! The number of fields that had missing (NOTHING) values in this record
+        int missing_count;
+        #! The imputation strategy used (mean, median, most_frequent, or constant)
+        string strategy;
+    }
+
+    #! Classification metrics event hashdecl
+    public hashdecl ClassificationMetricsEventInfo {
+        #! The type of analysis that produced this result (always "classification-metrics")
+        string event_type = "classification-metrics";
+        #! The fraction of predictions that were correct, from 0.0 (none correct) to
+        #! 1.0 (all correct); for example, 0.85 means 85%% of predictions matched the
+        #! true class
+        float accuracy;
+        #! The unweighted average F1 score across all classes; treats every class equally
+        #! regardless of how many samples it has; ranges from 0.0 to 1.0
+        float macro_f1;
+        #! The support-weighted average F1 score across all classes; gives more weight to
+        #! classes with more samples; ranges from 0.0 to 1.0
+        float weighted_f1;
+        #! Per-class breakdown with precision, recall, F1, and support for each class
+        list<hash<auto>> per_class;
+        #! The number of records evaluated in this batch
+        int sample_count;
+    }
+
+    #! Regression metrics event hashdecl
+    public hashdecl RegressionMetricsEventInfo {
+        #! The type of analysis that produced this result (always "regression-metrics")
+        string event_type = "regression-metrics";
+        #! Mean Squared Error: the average of squared differences between predicted and
+        #! actual values; lower is better; 0.0 means perfect predictions
+        float mse;
+        #! Root Mean Squared Error: the square root of MSE, in the same units as the
+        #! data; easier to interpret than MSE
+        float rmse;
+        #! Mean Absolute Error: the average absolute difference between predicted and
+        #! actual values; in the same units as the data; less sensitive to outliers
+        #! than MSE
+        float mae;
+        #! R-squared (coefficient of determination): how much of the variance in the
+        #! data the model explains; 1.0 = perfect, 0.0 = no better than predicting
+        #! the mean; can be negative for very poor models
+        float r2;
+        #! Explained variance: similar to R² but accounts for bias in predictions;
+        #! ranges from negative infinity to 1.0
+        float explained_variance;
+        #! The number of records evaluated in this batch
+        int sample_count;
+    }
+
+    #! Clustering metrics event hashdecl
+    public hashdecl ClusteringMetricsEventInfo {
+        #! The type of analysis that produced this result (always "clustering-metrics")
+        string event_type = "clustering-metrics";
+        #! Silhouette score: measures how similar each point is to its own cluster vs.
+        #! other clusters; ranges from -1.0 (poor) to 1.0 (excellent); above 0.5 is
+        #! generally considered good clustering
+        float silhouette_score;
+        #! Davies-Bouldin index: measures the average similarity between clusters;
+        #! lower is better; 0.0 means perfect separation between clusters
+        float davies_bouldin_score;
+        #! Calinski-Harabasz index: the ratio of between-cluster dispersion to
+        #! within-cluster dispersion; higher values indicate better-defined clusters
+        float calinski_harabasz_score;
+        #! The number of records evaluated in this batch
+        int sample_count;
+        #! The number of distinct clusters found in the batch
+        int n_clusters;
     }
 }

--- a/qlib/DataProviderML/MLProcessorsDataProvider.qc
+++ b/qlib/DataProviderML/MLProcessorsDataProvider.qc
@@ -43,6 +43,9 @@ public class MLProcessorsDataProvider inherits DataProvider::AbstractDataProvide
             "holt-winters": "QoreHoltWintersProcessor",
             "seasonal-decomposition": "QoreSeasonalDecompositionProcessor",
             "linear-regression": "QoreLinearRegressionProcessor",
+            "logistic-regression": "QoreLogisticRegressionProcessor",
+            "knn-classification": "QoreKNNClassificationProcessor",
+            "knn-regression": "QoreKNNRegressionProcessor",
             "lof": "QoreLOFProcessor",
             "gmm": "QoreGMMProcessor",
             "standard-scaler": "QoreStandardScalerProcessor",
@@ -104,6 +107,12 @@ public class MLProcessorsDataProvider inherits DataProvider::AbstractDataProvide
                 return new QoreSeasonalDecompositionProcessor();
             case "linear-regression":
                 return new QoreLinearRegressionProcessor();
+            case "logistic-regression":
+                return new QoreLogisticRegressionProcessor();
+            case "knn-classification":
+                return new QoreKNNClassificationProcessor();
+            case "knn-regression":
+                return new QoreKNNRegressionProcessor();
             case "lof":
                 return new QoreLOFProcessor();
             case "gmm":

--- a/qlib/DataProviderML/MLProcessorsDataProvider.qc
+++ b/qlib/DataProviderML/MLProcessorsDataProvider.qc
@@ -45,6 +45,12 @@ public class MLProcessorsDataProvider inherits DataProvider::AbstractDataProvide
             "linear-regression": "QoreLinearRegressionProcessor",
             "lof": "QoreLOFProcessor",
             "gmm": "QoreGMMProcessor",
+            "standard-scaler": "QoreStandardScalerProcessor",
+            "min-max-scaler": "QoreMinMaxScalerProcessor",
+            "imputer": "QoreImputerProcessor",
+            "classification-metrics": "QoreClassificationMetricsProcessor",
+            "regression-metrics": "QoreRegressionMetricsProcessor",
+            "clustering-metrics": "QoreClusteringMetricsProcessor",
         };
 
         #! Full child processor names including optional ones
@@ -102,6 +108,18 @@ public class MLProcessorsDataProvider inherits DataProvider::AbstractDataProvide
                 return new QoreLOFProcessor();
             case "gmm":
                 return new QoreGMMProcessor();
+            case "standard-scaler":
+                return new QoreStandardScalerProcessor();
+            case "min-max-scaler":
+                return new QoreMinMaxScalerProcessor();
+            case "imputer":
+                return new QoreImputerProcessor();
+            case "classification-metrics":
+                return new QoreClassificationMetricsProcessor();
+            case "regression-metrics":
+                return new QoreRegressionMetricsProcessor();
+            case "clustering-metrics":
+                return new QoreClusteringMetricsProcessor();
             case "onnx-model":
                 if (ML::ml_get_capabilities().has_onnx) {
                     return new QoreOnnxModelProcessor();

--- a/qlib/DataProviderML/QoreClassificationMetricsProcessor.qc
+++ b/qlib/DataProviderML/QoreClassificationMetricsProcessor.qc
@@ -1,0 +1,211 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QoreClassificationMetricsProcessor class definition
+
+/** QoreClassificationMetricsProcessor.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the DataProviderML module
+public namespace DataProviderML {
+#! Pipeline processor that measures how accurate classification predictions are
+/** Accumulates records containing predicted and true class labels, then computes
+    accuracy, macro F1, weighted F1, and per-class precision/recall/F1 metrics
+    using the ML::ml_classification_report() function.
+
+    On flush (or when the window is full), emits a single
+    ClassificationMetricsEventInfo event summarizing the batch.
+
+*/
+public class QoreClassificationMetricsProcessor inherits DataProvider::AbstractDataProvider {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "type": "QoreClassificationMetricsProcessor",
+            "supports_pipeline_processor": True,
+            "processor_capabilities": DPC_AGGREGATE,
+            "pipeline_processor_options": ConstructorOptions,
+        };
+
+        #! Constructor options
+        const ConstructorOptions = {
+            "predicted_field": <DataProviderOptionInfo>{
+                "display_name": "Predicted Category Field",
+                "short_desc": "Which field has the model's predicted category",
+                "desc": "The field in each record that contains what your model predicted. "
+                    "For example, if your spam filter writes its prediction to a field called "
+                    "`predicted_category` with values like `\"spam\"` or `\"not_spam\"`, "
+                    "enter `predicted_category` here",
+                "type": AbstractDataProviderTypeMap."string",
+                "required": True,
+            },
+            "true_field": <DataProviderOptionInfo>{
+                "display_name": "Correct Answer Field",
+                "short_desc": "Which field has the actual correct category",
+                "desc": "The field in each record that contains the correct answer — what the "
+                    "category actually was. For example, if a human reviewer labeled each email "
+                    "in a `true_category` field, enter `true_category` here",
+                "type": AbstractDataProviderTypeMap."string",
+                "required": True,
+            },
+            "window_size": <DataProviderOptionInfo>{
+                "display_name": "Batch Size",
+                "short_desc": "How many records to collect before scoring",
+                "desc": "How many records to collect before computing a quality score. All "
+                    "records in the batch are evaluated together.\n\n"
+                    "**Tip**: use at least `50` for meaningful scores; `200`+ for a detailed "
+                    "per-category breakdown",
+                "type": AbstractDataProviderTypeMap."int",
+                "required": True,
+                "example_value": 100,
+            },
+        };
+    }
+
+    private {
+        #! Configured predicted field name
+        string predicted_field;
+
+        #! Configured true field name
+        string true_field;
+
+        #! Configured window size
+        int window_size;
+
+        #! Accumulated records
+        list<hash<auto>> buffer;
+
+        #! Whether configured
+        bool configured = False;
+    }
+
+    #! Creates the object with no options (for data provider navigation)
+    constructor() {
+    }
+
+    #! Creates the object with the given options
+    constructor(hash<auto> options) {
+        *hash<auto> copts = checkOptions("CONSTRUCTOR-ERROR", ConstructorOptions, options);
+        predicted_field = copts.predicted_field;
+        true_field = copts.true_field;
+        window_size = copts.window_size;
+        if (window_size < 2) {
+            throw "CONSTRUCTOR-ERROR",
+                sprintf("window_size must be >= 2; got %d", window_size);
+        }
+        buffer = ();
+        configured = True;
+    }
+
+    #! Returns the name of this data provider
+    string getName() {
+        return "classification-metrics";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return "Compares predicted labels against actual labels to measure model accuracy; "
+            "accumulates records in batches and emits accuracy, macro F1, weighted F1, and "
+            "per-class precision/recall/F1 metrics";
+    }
+
+    #! Returns data provider static info
+    hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+
+    #! Accumulates records; emits metrics when window is full
+    private *auto processRecordImpl(auto record) {
+        if (!configured) {
+            throw "PROCESSOR-ERROR",
+                "QoreClassificationMetricsProcessor: not configured; provide constructor options";
+        }
+        push buffer, record;
+        if (buffer.lsize() >= window_size) {
+            list<auto> results = processWindow(buffer);
+            buffer = ();
+            return results;
+        }
+        return;
+    }
+
+    #! Flushes remaining buffered data
+    private *list<auto> flushRecordsImpl() {
+        if (!configured || !buffer) {
+            return;
+        }
+        if (buffer.lsize() >= 2) {
+            list<auto> results = processWindow(buffer);
+            buffer = ();
+            return results;
+        }
+        buffer = ();
+        return;
+    }
+
+    #! Processes a window of records through classification metrics
+    private list<auto> processWindow(list<hash<auto>> records) {
+        list<auto> y_true;
+        list<auto> y_pred;
+        foreach hash<auto> rec in (records) {
+            push y_true, DataProvider::AbstractDataProvider::getFieldValue(rec, true_field);
+            push y_pred, DataProvider::AbstractDataProvider::getFieldValue(rec, predicted_field);
+        }
+
+        hash<ML::ClassificationReport> report = ML::ml_classification_report(y_true, y_pred);
+
+        # convert per_class list to list<hash<auto>> for the event
+        list<hash<auto>> per_class;
+        foreach hash<ML::ClassMetrics> cls in (report.per_class) {
+            push per_class, {
+                "label": cls.label,
+                "precision": cls.precision,
+                "recall": cls.recall,
+                "f1": cls.f1,
+                "support": cls.support,
+            };
+        }
+
+        return (<ClassificationMetricsEventInfo>{
+            "event_type": "classification-metrics",
+            "accuracy": report.accuracy,
+            "macro_f1": report.macro_f1,
+            "weighted_f1": report.weighted_f1,
+            "per_class": per_class,
+            "sample_count": records.lsize(),
+        },);
+    }
+
+    #! Does not support bulk API
+    private bool supportsBulkApiImpl() {
+        return False;
+    }
+
+    #! Returns the processor capability bitfield
+    private int getProcessorCapabilitiesImpl() {
+        return DPC_AGGREGATE;
+    }
+
+    #! Returns the output type
+    private *DataProvider::AbstractDataProviderType getPipelineProcessorOutputTypeImpl() {
+        return new HashDeclDataType(
+            TypedHash::forName("DataProviderML::ClassificationMetricsEventInfo"));
+    }
+}
+}

--- a/qlib/DataProviderML/QoreClusteringMetricsProcessor.qc
+++ b/qlib/DataProviderML/QoreClusteringMetricsProcessor.qc
@@ -1,0 +1,216 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QoreClusteringMetricsProcessor class definition
+
+/** QoreClusteringMetricsProcessor.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the DataProviderML module
+public namespace DataProviderML {
+#! Pipeline processor that measures how well data was grouped into clusters
+/** Accumulates records containing cluster assignments and data fields, then
+    evaluates clustering quality using silhouette score, Davies-Bouldin index,
+    and Calinski-Harabasz index via the corresponding ML module functions.
+
+    On flush (or when the window is full), emits a single
+    ClusteringMetricsEventInfo event summarizing the batch.
+
+*/
+public class QoreClusteringMetricsProcessor inherits DataProvider::AbstractDataProvider {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "type": "QoreClusteringMetricsProcessor",
+            "supports_pipeline_processor": True,
+            "processor_capabilities": DPC_AGGREGATE,
+            "pipeline_processor_options": ConstructorOptions,
+        };
+
+        #! Constructor options
+        const ConstructorOptions = {
+            "fields": <DataProviderOptionInfo>{
+                "display_name": "Data Fields Used for Grouping",
+                "short_desc": "Which numeric fields were used to create the groups",
+                "desc": "The numeric fields that were used to group the data. For example, if "
+                    "customers were grouped by `age`, `income`, and `spending_score`, select "
+                    "those same fields here so the quality score can check whether the groups "
+                    "make sense.\n\n"
+                    "At least 1 field is required",
+                "type": new SoftListDataType(AbstractDataProviderTypeMap."string", True),
+                "required": True,
+                "input_field_names": True,
+            },
+            "cluster_field": <DataProviderOptionInfo>{
+                "display_name": "Group Assignment Field",
+                "short_desc": "Which field says which group each record belongs to",
+                "desc": "The field in each record that says which group it was assigned to "
+                    "(e.g., `cluster`, `segment`, `group_id`). This is typically a number "
+                    "like `0`, `1`, `2` assigned by a grouping step earlier in the pipeline",
+                "type": AbstractDataProviderTypeMap."string",
+                "required": True,
+            },
+            "window_size": <DataProviderOptionInfo>{
+                "display_name": "Batch Size",
+                "short_desc": "How many records to collect before scoring",
+                "desc": "How many records to collect before computing a quality score. All "
+                    "records in the batch are evaluated together. The batch must contain "
+                    "at least 2 distinct groups.\n\n"
+                    "**Tip**: use at least `50` for meaningful scores",
+                "type": AbstractDataProviderTypeMap."int",
+                "required": True,
+                "example_value": 100,
+            },
+        };
+    }
+
+    private {
+        #! Configured data field names
+        list<string> fields;
+
+        #! Configured cluster field name
+        string cluster_field;
+
+        #! Configured window size
+        int window_size;
+
+        #! Accumulated records
+        list<hash<auto>> buffer;
+
+        #! Whether configured
+        bool configured = False;
+    }
+
+    #! Creates the object with no options (for data provider navigation)
+    constructor() {
+    }
+
+    #! Creates the object with the given options
+    constructor(hash<auto> options) {
+        *hash<auto> copts = checkOptions("CONSTRUCTOR-ERROR", ConstructorOptions, options);
+        fields = DataProvider::AbstractDataProvider::parseFieldList(copts.fields);
+        if (!fields) {
+            throw "CONSTRUCTOR-ERROR", "no valid field names provided in 'fields' option";
+        }
+        cluster_field = copts.cluster_field;
+        window_size = copts.window_size;
+        if (window_size < 2) {
+            throw "CONSTRUCTOR-ERROR",
+                sprintf("window_size must be >= 2; got %d", window_size);
+        }
+        buffer = ();
+        configured = True;
+    }
+
+    #! Returns the name of this data provider
+    string getName() {
+        return "clustering-metrics";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return "Evaluates whether the clusters are well-separated and cohesive; "
+            "accumulates records in batches and emits silhouette score, Davies-Bouldin "
+            "index, and Calinski-Harabasz index";
+    }
+
+    #! Returns data provider static info
+    hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+
+    #! Accumulates records; emits metrics when window is full
+    private *auto processRecordImpl(auto record) {
+        if (!configured) {
+            throw "PROCESSOR-ERROR",
+                "QoreClusteringMetricsProcessor: not configured; provide constructor options";
+        }
+        push buffer, record;
+        if (buffer.lsize() >= window_size) {
+            list<auto> results = processWindow(buffer);
+            buffer = ();
+            return results;
+        }
+        return;
+    }
+
+    #! Flushes remaining buffered data
+    private *list<auto> flushRecordsImpl() {
+        if (!configured || !buffer) {
+            return;
+        }
+        if (buffer.lsize() >= 2) {
+            list<auto> results = processWindow(buffer);
+            buffer = ();
+            return results;
+        }
+        buffer = ();
+        return;
+    }
+
+    #! Processes a window of records through clustering metrics
+    private list<auto> processWindow(list<hash<auto>> records) {
+        # extract data matrix and cluster labels
+        list<list<float>> matrix;
+        list<float> labels;
+        hash<string, bool> unique_clusters;
+        foreach hash<auto> rec in (records) {
+            list<float> row;
+            foreach string f in (fields) {
+                push row, DataProvider::AbstractDataProvider::getFieldValue(rec, f).toFloat();
+            }
+            push matrix, row;
+            float label = DataProvider::AbstractDataProvider::getFieldValue(rec, cluster_field).toFloat();
+            push labels, label;
+            unique_clusters{string(label)} = True;
+        }
+
+        int n_clusters = unique_clusters.size();
+
+        float silhouette = ML::ml_silhouette_score(matrix, labels);
+        float davies_bouldin = ML::ml_davies_bouldin_score(matrix, labels);
+        float calinski_harabasz = ML::ml_calinski_harabasz_score(matrix, labels);
+
+        return (<ClusteringMetricsEventInfo>{
+            "event_type": "clustering-metrics",
+            "silhouette_score": silhouette,
+            "davies_bouldin_score": davies_bouldin,
+            "calinski_harabasz_score": calinski_harabasz,
+            "sample_count": records.lsize(),
+            "n_clusters": n_clusters,
+        },);
+    }
+
+    #! Does not support bulk API
+    private bool supportsBulkApiImpl() {
+        return False;
+    }
+
+    #! Returns the processor capability bitfield
+    private int getProcessorCapabilitiesImpl() {
+        return DPC_AGGREGATE;
+    }
+
+    #! Returns the output type
+    private *DataProvider::AbstractDataProviderType getPipelineProcessorOutputTypeImpl() {
+        return new HashDeclDataType(
+            TypedHash::forName("DataProviderML::ClusteringMetricsEventInfo"));
+    }
+}
+}

--- a/qlib/DataProviderML/QoreDBSCANClusteringProcessor.qc
+++ b/qlib/DataProviderML/QoreDBSCANClusteringProcessor.qc
@@ -28,7 +28,6 @@ public namespace DataProviderML {
 /** Accumulates records in windows and uses the ML::DBSCAN algorithm to
     cluster records when the window is full or on flush.
 
-    @since %DataProviderML 1.0
 */
 public class QoreDBSCANClusteringProcessor inherits DataProvider::AbstractDataProvider {
     public {

--- a/qlib/DataProviderML/QoreGMMProcessor.qc
+++ b/qlib/DataProviderML/QoreGMMProcessor.qc
@@ -28,7 +28,6 @@ public namespace DataProviderML {
 /** Accumulates records in windows and uses the ML::GMM algorithm to
     assign each record to a cluster with probability scores.
 
-    @since %DataProviderML 1.0
 */
 public class QoreGMMProcessor inherits DataProvider::AbstractDataProvider {
     public {

--- a/qlib/DataProviderML/QoreGMMProcessor.qc
+++ b/qlib/DataProviderML/QoreGMMProcessor.qc
@@ -78,6 +78,17 @@ public class QoreGMMProcessor inherits DataProvider::AbstractDataProvider {
                 "required": True,
                 "example_value": 3,
             },
+            "online": <DataProviderOptionInfo>{
+                "display_name": "Incremental Learning",
+                "short_desc": "Continuously improve groupings with new data",
+                "desc": "When enabled, the first batch of records creates the initial groups "
+                    "and each subsequent batch refines them, allowing group definitions to "
+                    "evolve as new data arrives. For example, customer segments can shift "
+                    "gradually as buying patterns change.\n\n"
+                    "When disabled, each batch creates completely new groups from scratch.\n\n"
+                    "Default: `True` (enabled)",
+                "type": AbstractDataProviderTypeMap."*bool",
+            },
             "covariance_type": <DataProviderOptionInfo>{
                 "display_name": "Covariance Type",
                 "short_desc": "How cluster shapes are modeled",
@@ -116,6 +127,12 @@ public class QoreGMMProcessor inherits DataProvider::AbstractDataProvider {
         #! Covariance type
         string covariance_type = "full";
 
+        #! Online learning mode
+        bool online = True;
+
+        #! Retained GMM instance for online learning
+        *ML::GMM gmm_model;
+
         #! Accumulated records
         list<hash<auto>> buffer;
 
@@ -151,6 +168,9 @@ public class QoreGMMProcessor inherits DataProvider::AbstractDataProvider {
         }
         if (exists copts.covariance_type) {
             covariance_type = copts.covariance_type;
+        }
+        if (exists copts.online) {
+            online = copts.online;
         }
         buffer = ();
         configured = True;
@@ -218,15 +238,25 @@ public class QoreGMMProcessor inherits DataProvider::AbstractDataProvider {
             push matrix, row;
         }
 
-        # create and fit GMM
-        ML::GMM gmm({
-            "n_components": n_components,
-            "covariance_type": covariance_type,
-        });
-        gmm.fitMatrix(matrix);
+        # fit or update the model
+        if (!gmm_model) {
+            gmm_model = new ML::GMM({
+                "n_components": n_components,
+                "covariance_type": covariance_type,
+            });
+            gmm_model.fitMatrix(matrix);
+        } else if (online) {
+            gmm_model.updateMatrix(matrix);
+        } else {
+            gmm_model = new ML::GMM({
+                "n_components": n_components,
+                "covariance_type": covariance_type,
+            });
+            gmm_model.fitMatrix(matrix);
+        }
 
         # predict cluster assignments
-        list<hash<ML::GMMResult>> predictions = gmm.predictMatrix(matrix);
+        list<hash<ML::GMMResult>> predictions = gmm_model.predictMatrix(matrix);
 
         # emit one event per record
         list<auto> events;

--- a/qlib/DataProviderML/QoreHoltWintersProcessor.qc
+++ b/qlib/DataProviderML/QoreHoltWintersProcessor.qc
@@ -31,7 +31,6 @@ public namespace DataProviderML {
 
     Inherits AbstractAnalyticsProcessor with ANALYTICS_MODE_RECORD.
 
-    @since %DataProviderML 1.0
 */
 public class QoreHoltWintersProcessor inherits DataProvider::AbstractAnalyticsProcessor {
     public {

--- a/qlib/DataProviderML/QoreImputerProcessor.qc
+++ b/qlib/DataProviderML/QoreImputerProcessor.qc
@@ -1,0 +1,293 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QoreImputerProcessor class definition
+
+/** QoreImputerProcessor.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the DataProviderML module
+public namespace DataProviderML {
+#! Pipeline processor that fills missing values using a configurable imputation strategy
+/** Accumulates records in windows and uses the ML::Imputer to replace NOTHING
+    (missing) values in the selected fields with computed fill values. The first
+    window fits the imputer (learning fill values from non-missing data); subsequent
+    windows apply the already-fitted imputer.
+
+    NOTHING values in the input records for the selected fields are treated as
+    missing values.
+
+*/
+public class QoreImputerProcessor inherits DataProvider::AbstractDataProvider {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "type": "QoreImputerProcessor",
+            "supports_pipeline_processor": True,
+            "processor_capabilities": DPC_AGGREGATE,
+            "pipeline_processor_options": ConstructorOptions,
+        };
+
+        #! Constructor options
+        const ConstructorOptions = {
+            "fields": <DataProviderOptionInfo>{
+                "display_name": "Fields to Fill",
+                "short_desc": "Which numeric fields may have missing values",
+                "desc": "The numeric fields from your data that may have gaps (missing values). "
+                    "For example, select `temperature`, `humidity`, and `pressure` if some "
+                    "sensor readings are occasionally missing.\n\n"
+                    "At least 1 field is required",
+                "type": new SoftListDataType(AbstractDataProviderTypeMap."string", True),
+                "required": True,
+                "input_field_names": True,
+            },
+            "window_size": <DataProviderOptionInfo>{
+                "display_name": "Batch Size",
+                "short_desc": "How many records to collect before processing",
+                "desc": "How many records to collect before processing them as a batch. The "
+                    "first batch is used to learn what values to fill in (e.g., the average "
+                    "temperature); all subsequent batches use those same fill values.\n\n"
+                    "**Tip**: use at least `50` so the fill values are representative; "
+                    "`200`+ if many records have gaps",
+                "type": AbstractDataProviderTypeMap."int",
+                "required": True,
+                "example_value": 100,
+            },
+            "strategy": <DataProviderOptionInfo>{
+                "display_name": "Fill Method",
+                "short_desc": "How to decide what value to fill in for gaps",
+                "desc": "How missing values are filled in. The method is learned from the "
+                    "first batch of records and applied consistently to all data",
+                "type": AbstractDataProviderTypeMap."*string",
+                "example_value": "mean",
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "value": "mean",
+                        "display_name": "Average Value",
+                        "desc": "Fill gaps with the average (mean) of the available values. "
+                            "Best for data that is roughly symmetric, like daily temperatures "
+                            "or response times",
+                    },
+                    <AllowedValueInfo>{
+                        "value": "median",
+                        "display_name": "Middle Value",
+                        "desc": "Fill gaps with the middle value (median). Better than the "
+                            "average when your data has extreme values — for example, "
+                            "transaction amounts where a few large purchases would skew "
+                            "the average",
+                    },
+                    <AllowedValueInfo>{
+                        "value": "most_frequent",
+                        "display_name": "Most Common Value",
+                        "desc": "Fill gaps with the most frequently occurring value. Best for "
+                            "data that tends to cluster around a specific value, like status "
+                            "codes or rating scores",
+                    },
+                    <AllowedValueInfo>{
+                        "value": "constant",
+                        "display_name": "Fixed Value",
+                        "desc": "Fill gaps with a specific number you choose (set in the "
+                            "\"Constant Fill Value\" option). Use this when you want a "
+                            "sentinel value like `0` or `-1` to mark where data was missing",
+                    },
+                ),
+            },
+            "constant_value": <DataProviderOptionInfo>{
+                "display_name": "Constant Fill Value",
+                "short_desc": "The specific number to use when Fill Method is Fixed Value",
+                "desc": "The number to use for filling gaps when the fill method is set to "
+                    "\"Fixed Value\". For example, `0` to fill with zero, or `-1` as a "
+                    "sentinel value; ignored when using other fill methods; default: `0.0`",
+                "type": AbstractDataProviderTypeMap."*float",
+                "example_value": 0.0,
+            },
+        };
+    }
+
+    private {
+        #! Configured field names
+        list<string> fields;
+
+        #! Configured window size
+        int window_size;
+
+        #! Imputation strategy
+        string strategy = "mean";
+
+        #! Constant fill value (used when strategy is "constant")
+        float constant_value = 0.0;
+
+        #! Retained Imputer instance (fitted on first window)
+        *ML::Imputer imputer;
+
+        #! Accumulated records
+        list<hash<auto>> buffer;
+
+        #! Whether configured
+        bool configured = False;
+    }
+
+    #! Creates the object with no options (for data provider navigation)
+    constructor() {
+    }
+
+    #! Creates the object with the given options
+    constructor(hash<auto> options) {
+        *hash<auto> copts = checkOptions("CONSTRUCTOR-ERROR", ConstructorOptions, options);
+        fields = DataProvider::AbstractDataProvider::parseFieldList(copts.fields);
+        if (!fields) {
+            throw "CONSTRUCTOR-ERROR", "no valid field names provided in 'fields' option";
+        }
+        window_size = copts.window_size;
+        if (window_size < 2) {
+            throw "CONSTRUCTOR-ERROR",
+                sprintf("window_size must be >= 2; got %d", window_size);
+        }
+        if (exists copts.strategy) {
+            strategy = copts.strategy;
+        }
+        if (exists copts.constant_value) {
+            constant_value = copts.constant_value;
+        }
+        buffer = ();
+        configured = True;
+    }
+
+    #! Returns the name of this data provider
+    string getName() {
+        return "imputer";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return "Fills missing (NOTHING) values in numeric fields using a configurable "
+            "strategy (mean, median, most_frequent, or constant); accumulates records "
+            "in windows, fits the imputer on the first window, and applies it to all "
+            "subsequent windows";
+    }
+
+    #! Returns data provider static info
+    hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+
+    #! Accumulates records; emits imputed records when window is full
+    private *auto processRecordImpl(auto record) {
+        if (!configured) {
+            throw "PROCESSOR-ERROR",
+                "QoreImputerProcessor: not configured; provide constructor options";
+        }
+        push buffer, record;
+        if (buffer.lsize() >= window_size) {
+            list<auto> results = processWindow(buffer);
+            buffer = ();
+            return results;
+        }
+        return;
+    }
+
+    #! Flushes remaining buffered data
+    private *list<auto> flushRecordsImpl() {
+        if (!configured || !buffer) {
+            return;
+        }
+        if (buffer.lsize() >= 2) {
+            list<auto> results = processWindow(buffer);
+            buffer = ();
+            return results;
+        }
+        buffer = ();
+        return;
+    }
+
+    #! Processes a window of records through Imputer
+    private list<auto> processWindow(list<hash<auto>> records) {
+        # extract matrix from fields; NOTHING values become NaN in the matrix
+        # which the Imputer treats as missing values
+        list<list<*float>> matrix;
+        foreach hash<auto> rec in (records) {
+            list<*float> row;
+            foreach string f in (fields) {
+                auto val = DataProvider::AbstractDataProvider::getFieldValue(rec, f);
+                if (exists val) {
+                    push row, val.toFloat();
+                } else {
+                    push row, NOTHING;
+                }
+            }
+            push matrix, row;
+        }
+
+        list<list<float>> imputed;
+        if (!imputer) {
+            # first window: create imputer with strategy options, fit and transform
+            imputer = new ML::Imputer({
+                "strategy": strategy,
+                "constant_value": constant_value,
+            });
+            imputer.fitMatrix(matrix);
+            imputed = imputer.transformMatrix(matrix);
+        } else {
+            # subsequent windows: apply the already-fitted imputer
+            imputed = imputer.transformMatrix(matrix);
+        }
+
+        # emit one event per record
+        list<auto> events;
+        for (int i = 0; i < records.lsize(); ++i) {
+            hash<auto> record_values;
+            hash<auto> imputed_values;
+            int missing_count = 0;
+            for (int j = 0; j < fields.lsize(); ++j) {
+                string f = fields[j];
+                auto orig = DataProvider::AbstractDataProvider::getFieldValue(records[i], f);
+                record_values{f} = orig;
+                imputed_values{f} = imputed[i][j];
+                if (!exists orig) {
+                    ++missing_count;
+                }
+            }
+            push events, <ImputerEventInfo>{
+                "event_type": "imputer",
+                "record_values": record_values,
+                "imputed_values": imputed_values,
+                "missing_count": missing_count,
+                "strategy": strategy,
+            };
+        }
+        return events;
+    }
+
+    #! Does not support bulk API
+    private bool supportsBulkApiImpl() {
+        return False;
+    }
+
+    #! Returns the processor capability bitfield
+    private int getProcessorCapabilitiesImpl() {
+        return DPC_AGGREGATE;
+    }
+
+    #! Returns the output type
+    private *DataProvider::AbstractDataProviderType getPipelineProcessorOutputTypeImpl() {
+        return new HashDeclDataType(
+            TypedHash::forName("DataProviderML::ImputerEventInfo"));
+    }
+}
+}

--- a/qlib/DataProviderML/QoreIsolationForestProcessor.qc
+++ b/qlib/DataProviderML/QoreIsolationForestProcessor.qc
@@ -28,7 +28,6 @@ public namespace DataProviderML {
 /** Accumulates records in windows and uses the ML::IsolationForest algorithm to
     score each record for anomalousness when the window is full or on flush.
 
-    @since %DataProviderML 1.0
 */
 public class QoreIsolationForestProcessor inherits DataProvider::AbstractDataProvider {
     public {

--- a/qlib/DataProviderML/QoreKMeansProcessor.qc
+++ b/qlib/DataProviderML/QoreKMeansProcessor.qc
@@ -29,7 +29,6 @@ public namespace DataProviderML {
     assign each record to a cluster centroid. Supports online learning:
     the first window fits the model, subsequent windows update it incrementally.
 
-    @since %DataProviderML 1.0
 */
 public class QoreKMeansProcessor inherits DataProvider::AbstractDataProvider {
     public {

--- a/qlib/DataProviderML/QoreKNNClassificationProcessor.qc
+++ b/qlib/DataProviderML/QoreKNNClassificationProcessor.qc
@@ -55,10 +55,13 @@ public class QoreKNNClassificationProcessor inherits DataProvider::AbstractDataP
             },
             "target_field": <DataProviderOptionInfo>{
                 "display_name": "Category Field",
-                "short_desc": "Which field contains the correct category",
-                "desc": "The field that says what category each record belongs to. For "
-                    "example, `customer_segment` or `risk_level`. The model looks at this "
-                    "field on the most similar records and picks the most common category",
+                "short_desc": "Which numeric field contains the category code",
+                "desc": "The field that contains a **numeric** category code for each record. "
+                    "For example, `risk_level` with values `0`, `1`, `2` or `segment_id` "
+                    "with values `1`, `2`, `3`. The model looks at this field on the most "
+                    "similar records and picks the most common value.\n\n"
+                    "**Note**: categories must be numeric (integers); use a numeric code "
+                    "for text categories (e.g., `0` = low, `1` = medium, `2` = high)",
                 "type": AbstractDataProviderTypeMap."string",
                 "required": True,
                 "input_field_names": True,

--- a/qlib/DataProviderML/QoreKNNClassificationProcessor.qc
+++ b/qlib/DataProviderML/QoreKNNClassificationProcessor.qc
@@ -1,0 +1,325 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QoreKNNClassificationProcessor class definition
+
+/** QoreKNNClassificationProcessor.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the DataProviderML module
+public namespace DataProviderML {
+#! Pipeline processor that classifies records using K-Nearest Neighbors
+/** Accumulates records in windows and uses the ML::KNN algorithm in classification
+    mode to predict class labels for each record based on its nearest neighbors.
+
+*/
+public class QoreKNNClassificationProcessor inherits DataProvider::AbstractDataProvider {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "type": "QoreKNNClassificationProcessor",
+            "supports_pipeline_processor": True,
+            "processor_capabilities": DPC_AGGREGATE,
+            "pipeline_processor_options": ConstructorOptions,
+        };
+
+        #! Constructor options
+        const ConstructorOptions = {
+            "fields": <DataProviderOptionInfo>{
+                "display_name": "Comparison Fields",
+                "short_desc": "Which numeric fields to use when finding similar records",
+                "desc": "The numeric fields used to determine which records are most similar. "
+                    "For example, to classify customers, select `age`, `income`, and "
+                    "`spending_score` — the model finds the most similar past customers "
+                    "to predict the category.\n\n"
+                    "At least 1 field is required",
+                "type": new SoftListDataType(AbstractDataProviderTypeMap."string", True),
+                "required": True,
+                "input_field_names": True,
+            },
+            "target_field": <DataProviderOptionInfo>{
+                "display_name": "Category Field",
+                "short_desc": "Which field contains the correct category",
+                "desc": "The field that says what category each record belongs to. For "
+                    "example, `customer_segment` or `risk_level`. The model looks at this "
+                    "field on the most similar records and picks the most common category",
+                "type": AbstractDataProviderTypeMap."string",
+                "required": True,
+                "input_field_names": True,
+            },
+            "window_size": <DataProviderOptionInfo>{
+                "display_name": "Batch Size",
+                "short_desc": "How many example records to learn from",
+                "desc": "How many labeled records to collect as the reference set. New "
+                    "records are compared against these examples to find the most similar "
+                    "ones. Must be larger than the number of neighbors.\n\n"
+                    "**Tip**: use at least `50`\u2013`200` for reliable results",
+                "type": AbstractDataProviderTypeMap."int",
+                "required": True,
+                "example_value": 100,
+            },
+            "k": <DataProviderOptionInfo>{
+                "display_name": "Number of Neighbors",
+                "short_desc": "How many similar records to look at",
+                "desc": "How many of the most similar records to consult when making a "
+                    "prediction. For example, `5` means \"look at the 5 most similar past "
+                    "records and go with the majority.\"\n\n"
+                    "**Tip**: start with `5`\u2013`10`; smaller values react more to "
+                    "individual records, larger values give smoother predictions",
+                "type": AbstractDataProviderTypeMap."int",
+                "required": True,
+                "example_value": 5,
+            },
+            "metric": <DataProviderOptionInfo>{
+                "display_name": "Similarity Method",
+                "short_desc": "How to measure how similar two records are",
+                "desc": "How to calculate the similarity between records",
+                "type": AbstractDataProviderTypeMap."*string",
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "value": "euclidean",
+                        "display_name": "Straight-Line Distance (default)",
+                        "desc": "Measures the direct distance between two records' values. "
+                            "Works well when all fields are on a similar scale (e.g., all in "
+                            "dollars, all in years)",
+                    },
+                    <AllowedValueInfo>{
+                        "value": "manhattan",
+                        "display_name": "Block Distance",
+                        "desc": "Measures distance by adding up the differences in each "
+                            "field separately. Less affected by a single field with a very "
+                            "large difference",
+                    },
+                    <AllowedValueInfo>{
+                        "value": "cosine",
+                        "display_name": "Direction Similarity",
+                        "desc": "Measures whether records point in the same direction rather "
+                            "than whether they have the same magnitude. Best for comparing "
+                            "proportions or patterns rather than absolute values",
+                    },
+                ),
+            },
+            "weight_func": <DataProviderOptionInfo>{
+                "display_name": "Neighbor Influence",
+                "short_desc": "Should closer neighbors count more?",
+                "desc": "Whether all similar records count equally, or closer ones have "
+                    "more say in the prediction",
+                "type": AbstractDataProviderTypeMap."*string",
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "value": "uniform",
+                        "display_name": "Equal Influence (default)",
+                        "desc": "All neighbors get an equal vote regardless of how close "
+                            "they are",
+                    },
+                    <AllowedValueInfo>{
+                        "value": "distance",
+                        "display_name": "Closer = More Influence",
+                        "desc": "Neighbors that are more similar to the new record have a "
+                            "bigger say in the prediction — a very similar record counts "
+                            "more than a somewhat similar one",
+                    },
+                ),
+            },
+        };
+    }
+
+    private {
+        #! Configured feature field names
+        list<string> fields;
+
+        #! Target field name
+        string target_field;
+
+        #! Configured window size
+        int window_size;
+
+        #! Number of neighbors
+        int k;
+
+        #! Distance metric
+        *string metric;
+
+        #! Weight function
+        *string weight_func;
+
+        #! Retained KNN model instance
+        *ML::KNN model;
+
+        #! Accumulated records
+        list<hash<auto>> buffer;
+
+        #! Whether configured
+        bool configured = False;
+    }
+
+    #! Creates the object with no options (for data provider navigation)
+    constructor() {
+    }
+
+    #! Creates the object with the given options
+    constructor(hash<auto> options) {
+        *hash<auto> copts = checkOptions("CONSTRUCTOR-ERROR", ConstructorOptions, options);
+        fields = DataProvider::AbstractDataProvider::parseFieldList(copts.fields);
+        if (!fields) {
+            throw "CONSTRUCTOR-ERROR", "no valid field names provided in 'fields' option";
+        }
+        target_field = copts.target_field;
+        if (!target_field.val()) {
+            throw "CONSTRUCTOR-ERROR", "target_field option is required";
+        }
+        window_size = copts.window_size;
+        if (window_size < 2) {
+            throw "CONSTRUCTOR-ERROR",
+                sprintf("window_size must be >= 2; got %d", window_size);
+        }
+        k = copts.k;
+        if (k < 1) {
+            throw "CONSTRUCTOR-ERROR",
+                sprintf("k must be >= 1; got %d", k);
+        }
+        if (window_size < k) {
+            throw "CONSTRUCTOR-ERROR",
+                sprintf("window_size (%d) must be >= k (%d); KNN requires at least "
+                    "as many data points as neighbors", window_size, k);
+        }
+        metric = copts.metric;
+        weight_func = copts.weight_func;
+        buffer = ();
+        configured = True;
+    }
+
+    #! Returns the name of this data provider
+    string getName() {
+        return "knn-classification";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return "Classifies records by finding the most similar records in the training "
+            "data and using majority voting; accumulates records in windows, fits a model, "
+            "and emits predicted category labels with confidence scores";
+    }
+
+    #! Returns data provider static info
+    hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+
+    #! Accumulates records; emits predictions when window is full
+    private *auto processRecordImpl(auto record) {
+        if (!configured) {
+            throw "PROCESSOR-ERROR",
+                "QoreKNNClassificationProcessor: not configured; provide constructor options";
+        }
+        push buffer, record;
+        if (buffer.lsize() >= window_size) {
+            list<auto> results = processWindow(buffer);
+            buffer = ();
+            return results;
+        }
+        return;
+    }
+
+    #! Flushes remaining buffered data
+    private *list<auto> flushRecordsImpl() {
+        if (!configured || !buffer) {
+            return;
+        }
+        if (buffer.lsize() >= k) {
+            list<auto> results = processWindow(buffer);
+            buffer = ();
+            return results;
+        }
+        buffer = ();
+        return;
+    }
+
+    #! Processes a window of records through KNN classification
+    private list<auto> processWindow(list<hash<auto>> records) {
+        # extract feature matrix and target vector
+        list<list<float>> matrix;
+        list<float> targets;
+        foreach hash<auto> rec in (records) {
+            list<float> row;
+            foreach string f in (fields) {
+                push row, DataProvider::AbstractDataProvider::getFieldValue(rec, f).toFloat();
+            }
+            push matrix, row;
+            push targets, DataProvider::AbstractDataProvider::getFieldValue(rec, target_field).toFloat();
+        }
+
+        # create options hash for the model
+        hash<auto> model_opts = {
+            "k": k,
+            "task": "classification",
+        };
+        if (exists metric) {
+            model_opts.metric = metric;
+        }
+        if (exists weight_func) {
+            model_opts.weight_func = weight_func;
+        }
+
+        # fit the model on the first window or if no model exists
+        if (!model) {
+            model = new ML::KNN(model_opts);
+            model.fitMatrix(matrix, targets);
+        } else {
+            # predict with existing model
+        }
+
+        # predict all records
+        list<hash<ML::KNNClassificationResult>> predictions = model.predictMatrix(matrix);
+
+        # emit one event per record
+        list<auto> events;
+        for (int i = 0; i < records.lsize(); ++i) {
+            hash<auto> record_values;
+            foreach string f in (fields) {
+                record_values{f} = DataProvider::AbstractDataProvider::getFieldValue(records[i], f);
+            }
+            record_values{target_field} = DataProvider::AbstractDataProvider::getFieldValue(
+                records[i], target_field);
+            push events, <KNNClassificationEventInfo>{
+                "event_type": "knn-classification",
+                "predicted_class": predictions[i].predicted_class,
+                "confidence": predictions[i].confidence,
+                "record_values": record_values,
+            };
+        }
+        return events;
+    }
+
+    #! Does not support bulk API
+    private bool supportsBulkApiImpl() {
+        return False;
+    }
+
+    #! Returns the processor capability bitfield
+    private int getProcessorCapabilitiesImpl() {
+        return DPC_AGGREGATE;
+    }
+
+    #! Returns the output type
+    private *DataProvider::AbstractDataProviderType getPipelineProcessorOutputTypeImpl() {
+        return new HashDeclDataType(TypedHash::forName("DataProviderML::KNNClassificationEventInfo"));
+    }
+}
+}

--- a/qlib/DataProviderML/QoreKNNRegressionProcessor.qc
+++ b/qlib/DataProviderML/QoreKNNRegressionProcessor.qc
@@ -1,0 +1,321 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QoreKNNRegressionProcessor class definition
+
+/** QoreKNNRegressionProcessor.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the DataProviderML module
+public namespace DataProviderML {
+#! Pipeline processor that predicts numeric values using K-Nearest Neighbors regression
+/** Accumulates records in windows and uses the ML::KNN algorithm in regression
+    mode to predict numeric target values for each record based on its nearest neighbors.
+
+*/
+public class QoreKNNRegressionProcessor inherits DataProvider::AbstractDataProvider {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "type": "QoreKNNRegressionProcessor",
+            "supports_pipeline_processor": True,
+            "processor_capabilities": DPC_AGGREGATE,
+            "pipeline_processor_options": ConstructorOptions,
+        };
+
+        #! Constructor options
+        const ConstructorOptions = {
+            "fields": <DataProviderOptionInfo>{
+                "display_name": "Comparison Fields",
+                "short_desc": "Which numeric fields to use when finding similar records",
+                "desc": "The numeric fields used to determine which records are most similar. "
+                    "For example, to predict a house price, select `sqft`, `bedrooms`, and "
+                    "`bathrooms` — the model finds the most similar past houses and averages "
+                    "their prices.\n\n"
+                    "At least 1 field is required",
+                "type": new SoftListDataType(AbstractDataProviderTypeMap."string", True),
+                "required": True,
+                "input_field_names": True,
+            },
+            "target_field": <DataProviderOptionInfo>{
+                "display_name": "Value to Predict",
+                "short_desc": "Which numeric field to estimate",
+                "desc": "The numeric field the model will predict for new records. For "
+                    "example, `price`, `delivery_days`, or `temperature`. The model "
+                    "averages this field from the most similar past records",
+                "type": AbstractDataProviderTypeMap."string",
+                "required": True,
+                "input_field_names": True,
+            },
+            "window_size": <DataProviderOptionInfo>{
+                "display_name": "Batch Size",
+                "short_desc": "How many example records to learn from",
+                "desc": "How many records to collect as the reference set. New records are "
+                    "compared against these examples to find the most similar ones. Must be "
+                    "larger than the number of neighbors.\n\n"
+                    "**Tip**: use at least `50`\u2013`200` for reliable results",
+                "type": AbstractDataProviderTypeMap."int",
+                "required": True,
+                "example_value": 100,
+            },
+            "k": <DataProviderOptionInfo>{
+                "display_name": "Number of Neighbors",
+                "short_desc": "How many similar records to average",
+                "desc": "How many of the most similar records to average when making a "
+                    "prediction. For example, `5` means \"find the 5 most similar past "
+                    "houses and average their prices.\"\n\n"
+                    "**Tip**: start with `5`\u2013`10`; smaller values react more to "
+                    "individual records, larger values give smoother predictions",
+                "type": AbstractDataProviderTypeMap."int",
+                "required": True,
+                "example_value": 5,
+            },
+            "metric": <DataProviderOptionInfo>{
+                "display_name": "Similarity Method",
+                "short_desc": "How to measure how similar two records are",
+                "desc": "How to calculate the similarity between records",
+                "type": AbstractDataProviderTypeMap."*string",
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "value": "euclidean",
+                        "display_name": "Straight-Line Distance (default)",
+                        "desc": "Measures the direct distance between two records' values. "
+                            "Works well when all fields are on a similar scale",
+                    },
+                    <AllowedValueInfo>{
+                        "value": "manhattan",
+                        "display_name": "Block Distance",
+                        "desc": "Measures distance by adding up the differences in each "
+                            "field separately. Less affected by a single field with a very "
+                            "large difference",
+                    },
+                    <AllowedValueInfo>{
+                        "value": "cosine",
+                        "display_name": "Direction Similarity",
+                        "desc": "Measures whether records point in the same direction rather "
+                            "than whether they have the same magnitude. Best for comparing "
+                            "proportions or patterns",
+                    },
+                ),
+            },
+            "weight_func": <DataProviderOptionInfo>{
+                "display_name": "Neighbor Influence",
+                "short_desc": "Should closer neighbors count more?",
+                "desc": "Whether all similar records count equally, or closer ones have "
+                    "more say in the prediction",
+                "type": AbstractDataProviderTypeMap."*string",
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "value": "uniform",
+                        "display_name": "Equal Influence (default)",
+                        "desc": "All neighbors contribute equally to the average",
+                    },
+                    <AllowedValueInfo>{
+                        "value": "distance",
+                        "display_name": "Closer = More Influence",
+                        "desc": "Records that are more similar to the new record have a "
+                            "bigger effect on the predicted value",
+                    },
+                ),
+            },
+        };
+    }
+
+    private {
+        #! Configured feature field names
+        list<string> fields;
+
+        #! Target field name
+        string target_field;
+
+        #! Configured window size
+        int window_size;
+
+        #! Number of neighbors
+        int k;
+
+        #! Distance metric
+        *string metric;
+
+        #! Weight function
+        *string weight_func;
+
+        #! Retained KNN model instance
+        *ML::KNN model;
+
+        #! Accumulated records
+        list<hash<auto>> buffer;
+
+        #! Whether configured
+        bool configured = False;
+    }
+
+    #! Creates the object with no options (for data provider navigation)
+    constructor() {
+    }
+
+    #! Creates the object with the given options
+    constructor(hash<auto> options) {
+        *hash<auto> copts = checkOptions("CONSTRUCTOR-ERROR", ConstructorOptions, options);
+        fields = DataProvider::AbstractDataProvider::parseFieldList(copts.fields);
+        if (!fields) {
+            throw "CONSTRUCTOR-ERROR", "no valid field names provided in 'fields' option";
+        }
+        target_field = copts.target_field;
+        if (!target_field.val()) {
+            throw "CONSTRUCTOR-ERROR", "target_field option is required";
+        }
+        window_size = copts.window_size;
+        if (window_size < 2) {
+            throw "CONSTRUCTOR-ERROR",
+                sprintf("window_size must be >= 2; got %d", window_size);
+        }
+        k = copts.k;
+        if (k < 1) {
+            throw "CONSTRUCTOR-ERROR",
+                sprintf("k must be >= 1; got %d", k);
+        }
+        if (window_size < k) {
+            throw "CONSTRUCTOR-ERROR",
+                sprintf("window_size (%d) must be >= k (%d); KNN requires at least "
+                    "as many data points as neighbors", window_size, k);
+        }
+        metric = copts.metric;
+        weight_func = copts.weight_func;
+        buffer = ();
+        configured = True;
+    }
+
+    #! Returns the name of this data provider
+    string getName() {
+        return "knn-regression";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return "Predicts numeric values by averaging the values of the most similar "
+            "records in the training data; accumulates records in windows, fits a model, "
+            "and emits predicted values for each record";
+    }
+
+    #! Returns data provider static info
+    hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+
+    #! Accumulates records; emits predictions when window is full
+    private *auto processRecordImpl(auto record) {
+        if (!configured) {
+            throw "PROCESSOR-ERROR",
+                "QoreKNNRegressionProcessor: not configured; provide constructor options";
+        }
+        push buffer, record;
+        if (buffer.lsize() >= window_size) {
+            list<auto> results = processWindow(buffer);
+            buffer = ();
+            return results;
+        }
+        return;
+    }
+
+    #! Flushes remaining buffered data
+    private *list<auto> flushRecordsImpl() {
+        if (!configured || !buffer) {
+            return;
+        }
+        if (buffer.lsize() >= k) {
+            list<auto> results = processWindow(buffer);
+            buffer = ();
+            return results;
+        }
+        buffer = ();
+        return;
+    }
+
+    #! Processes a window of records through KNN regression
+    private list<auto> processWindow(list<hash<auto>> records) {
+        # extract feature matrix and target vector
+        list<list<float>> matrix;
+        list<float> targets;
+        foreach hash<auto> rec in (records) {
+            list<float> row;
+            foreach string f in (fields) {
+                push row, DataProvider::AbstractDataProvider::getFieldValue(rec, f).toFloat();
+            }
+            push matrix, row;
+            push targets, DataProvider::AbstractDataProvider::getFieldValue(rec, target_field).toFloat();
+        }
+
+        # create options hash for the model
+        hash<auto> model_opts = {
+            "k": k,
+            "task": "regression",
+        };
+        if (exists metric) {
+            model_opts.metric = metric;
+        }
+        if (exists weight_func) {
+            model_opts.weight_func = weight_func;
+        }
+
+        # fit the model on the first window or if no model exists
+        if (!model) {
+            model = new ML::KNN(model_opts);
+            model.fitMatrix(matrix, targets);
+        } else {
+            # predict with existing model
+        }
+
+        # predict all records
+        list<hash<ML::KNNRegressionResult>> predictions = model.predictMatrix(matrix);
+
+        # emit one event per record
+        list<auto> events;
+        for (int i = 0; i < records.lsize(); ++i) {
+            hash<auto> record_values;
+            foreach string f in (fields) {
+                record_values{f} = DataProvider::AbstractDataProvider::getFieldValue(records[i], f);
+            }
+            record_values{target_field} = DataProvider::AbstractDataProvider::getFieldValue(
+                records[i], target_field);
+            push events, <KNNRegressionEventInfo>{
+                "event_type": "knn-regression",
+                "prediction": predictions[i].prediction,
+                "record_values": record_values,
+            };
+        }
+        return events;
+    }
+
+    #! Does not support bulk API
+    private bool supportsBulkApiImpl() {
+        return False;
+    }
+
+    #! Returns the processor capability bitfield
+    private int getProcessorCapabilitiesImpl() {
+        return DPC_AGGREGATE;
+    }
+
+    #! Returns the output type
+    private *DataProvider::AbstractDataProviderType getPipelineProcessorOutputTypeImpl() {
+        return new HashDeclDataType(TypedHash::forName("DataProviderML::KNNRegressionEventInfo"));
+    }
+}
+}

--- a/qlib/DataProviderML/QoreLinearRegressionProcessor.qc
+++ b/qlib/DataProviderML/QoreLinearRegressionProcessor.qc
@@ -92,6 +92,17 @@ public class QoreLinearRegressionProcessor inherits DataProvider::AbstractDataPr
                     "default: `False` (disabled)",
                 "type": AbstractDataProviderTypeMap."*bool",
             },
+            "online": <DataProviderOptionInfo>{
+                "display_name": "Incremental Learning",
+                "short_desc": "Continuously improve predictions with new data",
+                "desc": "When enabled, the first batch of records creates the initial model "
+                    "and each subsequent batch fine-tunes it, allowing predictions to improve "
+                    "as more data flows through the pipeline. For example, a price prediction "
+                    "model can adapt to market changes over time.\n\n"
+                    "When disabled, each batch trains a completely new model from scratch.\n\n"
+                    "Default: `True` (enabled)",
+                "type": AbstractDataProviderTypeMap."*bool",
+            },
         };
     }
 
@@ -110,6 +121,12 @@ public class QoreLinearRegressionProcessor inherits DataProvider::AbstractDataPr
 
         #! Normalize option
         bool do_normalize = False;
+
+        #! Online learning mode
+        bool online = True;
+
+        #! Retained LinearRegression instance for online learning
+        *ML::LinearRegression model;
 
         #! Accumulated records
         list<hash<auto>> buffer;
@@ -143,6 +160,9 @@ public class QoreLinearRegressionProcessor inherits DataProvider::AbstractDataPr
         }
         if (exists copts.normalize) {
             do_normalize = copts.normalize;
+        }
+        if (exists copts.online) {
+            online = copts.online;
         }
         buffer = ();
         configured = True;
@@ -208,15 +228,25 @@ public class QoreLinearRegressionProcessor inherits DataProvider::AbstractDataPr
             push targets, DataProvider::AbstractDataProvider::getFieldValue(rec, target_field).toFloat();
         }
 
-        # create and fit model
-        ML::LinearRegression lr({
-            "fit_intercept": fit_intercept,
-            "normalize": do_normalize,
-        });
-        lr.fitMatrix(matrix, targets);
+        # fit or update the model
+        if (!model) {
+            model = new ML::LinearRegression({
+                "fit_intercept": fit_intercept,
+                "normalize": do_normalize,
+            });
+            model.fitMatrix(matrix, targets);
+        } else if (online) {
+            model.updateMatrix(matrix, targets, 0.01);
+        } else {
+            model = new ML::LinearRegression({
+                "fit_intercept": fit_intercept,
+                "normalize": do_normalize,
+            });
+            model.fitMatrix(matrix, targets);
+        }
 
         # predict all records
-        list<hash<ML::LinearRegressionResult>> predictions = lr.predictMatrix(matrix);
+        list<hash<ML::LinearRegressionResult>> predictions = model.predictMatrix(matrix);
 
         # emit one event per record
         list<auto> events;

--- a/qlib/DataProviderML/QoreLinearRegressionProcessor.qc
+++ b/qlib/DataProviderML/QoreLinearRegressionProcessor.qc
@@ -28,7 +28,6 @@ public namespace DataProviderML {
 /** Accumulates records in windows and uses the ML::LinearRegression algorithm to
     fit a model and predict target values for each record.
 
-    @since %DataProviderML 1.0
 */
 public class QoreLinearRegressionProcessor inherits DataProvider::AbstractDataProvider {
     public {

--- a/qlib/DataProviderML/QoreLogisticRegressionProcessor.qc
+++ b/qlib/DataProviderML/QoreLogisticRegressionProcessor.qc
@@ -55,10 +55,12 @@ public class QoreLogisticRegressionProcessor inherits DataProvider::AbstractData
             },
             "target_field": <DataProviderOptionInfo>{
                 "display_name": "Category Field",
-                "short_desc": "Which field contains the correct category",
-                "desc": "The field that says what category each record actually belongs to. "
-                    "For example, `status` (with values like `\"approved\"` or `\"denied\"`), "
-                    "or `risk_level` (with values like `1`, `2`, `3`)",
+                "short_desc": "Which numeric field contains the category code",
+                "desc": "The field that contains a **numeric** category code for each record. "
+                    "For example, `risk_level` with values `1`, `2`, `3` or `approved` "
+                    "with values `0` (denied) and `1` (approved).\n\n"
+                    "**Note**: categories must be numeric; use a numeric code for text "
+                    "categories (e.g., `0` = denied, `1` = approved)",
                 "type": AbstractDataProviderTypeMap."string",
                 "required": True,
                 "input_field_names": True,

--- a/qlib/DataProviderML/QoreLogisticRegressionProcessor.qc
+++ b/qlib/DataProviderML/QoreLogisticRegressionProcessor.qc
@@ -124,6 +124,17 @@ public class QoreLogisticRegressionProcessor inherits DataProvider::AbstractData
                     },
                 ),
             },
+            "online": <DataProviderOptionInfo>{
+                "display_name": "Incremental Learning",
+                "short_desc": "Continuously improve categorization with new data",
+                "desc": "When enabled, the first batch of records creates the initial model "
+                    "and each subsequent batch refines it, allowing the categorization to "
+                    "improve as more labeled examples flow through the pipeline. For example, "
+                    "a spam filter can learn from newly labeled emails over time.\n\n"
+                    "When disabled, each batch trains a completely new model from scratch.\n\n"
+                    "Default: `True` (enabled)",
+                "type": AbstractDataProviderTypeMap."*bool",
+            },
             "fit_intercept": <DataProviderOptionInfo>{
                 "display_name": "Include Baseline",
                 "short_desc": "Include a baseline value in the model",
@@ -162,6 +173,9 @@ public class QoreLogisticRegressionProcessor inherits DataProvider::AbstractData
         #! Fit intercept option
         *bool fit_intercept;
 
+        #! Online learning mode
+        bool online = True;
+
         #! Retained model instance
         *ML::LogisticRegression model;
 
@@ -191,6 +205,9 @@ public class QoreLogisticRegressionProcessor inherits DataProvider::AbstractData
         if (window_size < 2) {
             throw "CONSTRUCTOR-ERROR",
                 sprintf("window_size must be >= 2; got %d", window_size);
+        }
+        if (exists copts.online) {
+            online = copts.online;
         }
         learning_rate = copts.learning_rate;
         max_iterations = copts.max_iterations;
@@ -279,12 +296,16 @@ public class QoreLogisticRegressionProcessor inherits DataProvider::AbstractData
             model_opts.fit_intercept = fit_intercept;
         }
 
-        # fit the model on the first window or if no model exists
+        # fit or update the model
         if (!model) {
             model = new ML::LogisticRegression(model_opts);
             model.fitMatrix(matrix, targets);
+        } else if (online) {
+            float lr = learning_rate ?? 0.01;
+            model.updateMatrix(matrix, targets, lr);
         } else {
-            # predict with existing model
+            model = new ML::LogisticRegression(model_opts);
+            model.fitMatrix(matrix, targets);
         }
 
         # predict all records

--- a/qlib/DataProviderML/QoreLogisticRegressionProcessor.qc
+++ b/qlib/DataProviderML/QoreLogisticRegressionProcessor.qc
@@ -1,0 +1,328 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QoreLogisticRegressionProcessor class definition
+
+/** QoreLogisticRegressionProcessor.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the DataProviderML module
+public namespace DataProviderML {
+#! Pipeline processor that performs logistic regression classification on data windows
+/** Accumulates records in windows and uses the ML::LogisticRegression algorithm to
+    fit a model and predict class labels for each record.
+
+*/
+public class QoreLogisticRegressionProcessor inherits DataProvider::AbstractDataProvider {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "type": "QoreLogisticRegressionProcessor",
+            "supports_pipeline_processor": True,
+            "processor_capabilities": DPC_AGGREGATE,
+            "pipeline_processor_options": ConstructorOptions,
+        };
+
+        #! Constructor options
+        const ConstructorOptions = {
+            "fields": <DataProviderOptionInfo>{
+                "display_name": "Fields to Analyze",
+                "short_desc": "Which numeric fields help decide the category",
+                "desc": "The numeric fields the model uses to decide which category each "
+                    "record belongs to. For example, if categorizing loan applications as "
+                    "approved/denied, select fields like `income`, `credit_score`, and "
+                    "`debt_ratio`.\n\n"
+                    "At least 1 field is required",
+                "type": new SoftListDataType(AbstractDataProviderTypeMap."string", True),
+                "required": True,
+                "input_field_names": True,
+            },
+            "target_field": <DataProviderOptionInfo>{
+                "display_name": "Category Field",
+                "short_desc": "Which field contains the correct category",
+                "desc": "The field that says what category each record actually belongs to. "
+                    "For example, `status` (with values like `\"approved\"` or `\"denied\"`), "
+                    "or `risk_level` (with values like `1`, `2`, `3`)",
+                "type": AbstractDataProviderTypeMap."string",
+                "required": True,
+                "input_field_names": True,
+            },
+            "window_size": <DataProviderOptionInfo>{
+                "display_name": "Batch Size",
+                "short_desc": "How many records to learn from before predicting",
+                "desc": "How many labeled records to collect before the model learns and "
+                    "starts predicting. The model studies these examples to understand the "
+                    "pattern between the input fields and the category.\n\n"
+                    "**Tip**: use at least 20\u201330 records per input field — for example, "
+                    "with 4 fields, use at least `80`\u2013`120` records",
+                "type": AbstractDataProviderTypeMap."int",
+                "required": True,
+                "example_value": 100,
+            },
+            "learning_rate": <DataProviderOptionInfo>{
+                "display_name": "Learning Speed",
+                "short_desc": "How quickly the model adjusts to the data",
+                "desc": "How big of a step the model takes when learning from each example. "
+                    "Smaller values are safer but slower; larger values are faster but may "
+                    "miss the best answer. Most users should leave this at the default.\n\n"
+                    "Default: `0.01`",
+                "type": AbstractDataProviderTypeMap."*float",
+            },
+            "max_iterations": <DataProviderOptionInfo>{
+                "display_name": "Maximum Learning Passes",
+                "short_desc": "How many times to review the data",
+                "desc": "The maximum number of times the model reviews the data to improve "
+                    "its understanding. More passes can improve accuracy but take longer. "
+                    "The model stops early if it has already found a good enough answer.\n\n"
+                    "Default: `1000`",
+                "type": AbstractDataProviderTypeMap."*int",
+            },
+            "regularization": <DataProviderOptionInfo>{
+                "display_name": "Overfitting Prevention",
+                "short_desc": "How strongly to prevent memorizing instead of learning",
+                "desc": "Controls how much the model is discouraged from memorizing the "
+                    "training data instead of learning general patterns. Higher values "
+                    "produce simpler, more general models. Lower values allow the model "
+                    "to fit the training data more closely.\n\n"
+                    "Default: `0.01`",
+                "type": AbstractDataProviderTypeMap."*float",
+            },
+            "penalty": <DataProviderOptionInfo>{
+                "display_name": "Overfitting Prevention Method",
+                "short_desc": "Whether to apply overfitting prevention",
+                "desc": "Whether and how to prevent the model from memorizing the training "
+                    "data. Enabled by default and recommended for most use cases",
+                "type": AbstractDataProviderTypeMap."*string",
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "value": "l2",
+                        "display_name": "Enabled (recommended)",
+                        "desc": "Prevents the model from relying too heavily on any single "
+                            "field; recommended for most use cases",
+                    },
+                    <AllowedValueInfo>{
+                        "value": "none",
+                        "display_name": "Disabled",
+                        "desc": "No overfitting prevention; use only when you have a very "
+                            "large dataset relative to the number of fields",
+                    },
+                ),
+            },
+            "fit_intercept": <DataProviderOptionInfo>{
+                "display_name": "Include Baseline",
+                "short_desc": "Include a baseline value in the model",
+                "desc": "Whether to include a baseline constant. This should almost always "
+                    "be enabled — it allows the model to account for the overall tendency "
+                    "in the data (e.g., if most applications are approved, the baseline "
+                    "captures that).\n\n"
+                    "Default: enabled",
+                "type": AbstractDataProviderTypeMap."*bool",
+            },
+        };
+    }
+
+    private {
+        #! Configured feature field names
+        list<string> fields;
+
+        #! Target field name
+        string target_field;
+
+        #! Configured window size
+        int window_size;
+
+        #! Learning rate
+        *float learning_rate;
+
+        #! Max iterations
+        *int max_iterations;
+
+        #! Regularization strength
+        *float regularization;
+
+        #! Penalty type
+        *string penalty;
+
+        #! Fit intercept option
+        *bool fit_intercept;
+
+        #! Retained model instance
+        *ML::LogisticRegression model;
+
+        #! Accumulated records
+        list<hash<auto>> buffer;
+
+        #! Whether configured
+        bool configured = False;
+    }
+
+    #! Creates the object with no options (for data provider navigation)
+    constructor() {
+    }
+
+    #! Creates the object with the given options
+    constructor(hash<auto> options) {
+        *hash<auto> copts = checkOptions("CONSTRUCTOR-ERROR", ConstructorOptions, options);
+        fields = DataProvider::AbstractDataProvider::parseFieldList(copts.fields);
+        if (!fields) {
+            throw "CONSTRUCTOR-ERROR", "no valid field names provided in 'fields' option";
+        }
+        target_field = copts.target_field;
+        if (!target_field.val()) {
+            throw "CONSTRUCTOR-ERROR", "target_field option is required";
+        }
+        window_size = copts.window_size;
+        if (window_size < 2) {
+            throw "CONSTRUCTOR-ERROR",
+                sprintf("window_size must be >= 2; got %d", window_size);
+        }
+        learning_rate = copts.learning_rate;
+        max_iterations = copts.max_iterations;
+        regularization = copts.regularization;
+        penalty = copts.penalty;
+        fit_intercept = copts.fit_intercept;
+        buffer = ();
+        configured = True;
+    }
+
+    #! Returns the name of this data provider
+    string getName() {
+        return "logistic-regression";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return "Performs logistic regression classification on data windows; accumulates "
+            "records, fits a model, and emits predicted category labels with probability "
+            "scores for each record";
+    }
+
+    #! Returns data provider static info
+    hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+
+    #! Accumulates records; emits predictions when window is full
+    private *auto processRecordImpl(auto record) {
+        if (!configured) {
+            throw "PROCESSOR-ERROR",
+                "QoreLogisticRegressionProcessor: not configured; provide constructor options";
+        }
+        push buffer, record;
+        if (buffer.lsize() >= window_size) {
+            list<auto> results = processWindow(buffer);
+            buffer = ();
+            return results;
+        }
+        return;
+    }
+
+    #! Flushes remaining buffered data
+    private *list<auto> flushRecordsImpl() {
+        if (!configured || !buffer) {
+            return;
+        }
+        if (buffer.lsize() >= 2) {
+            list<auto> results = processWindow(buffer);
+            buffer = ();
+            return results;
+        }
+        buffer = ();
+        return;
+    }
+
+    #! Processes a window of records through LogisticRegression
+    private list<auto> processWindow(list<hash<auto>> records) {
+        # extract feature matrix and target vector
+        list<list<float>> matrix;
+        list<float> targets;
+        foreach hash<auto> rec in (records) {
+            list<float> row;
+            foreach string f in (fields) {
+                push row, DataProvider::AbstractDataProvider::getFieldValue(rec, f).toFloat();
+            }
+            push matrix, row;
+            push targets, DataProvider::AbstractDataProvider::getFieldValue(rec, target_field).toFloat();
+        }
+
+        # create options hash for the model
+        hash<auto> model_opts;
+        if (exists learning_rate) {
+            model_opts.learning_rate = learning_rate;
+        }
+        if (exists max_iterations) {
+            model_opts.max_iterations = max_iterations;
+        }
+        if (exists regularization) {
+            model_opts.regularization = regularization;
+        }
+        if (exists penalty) {
+            model_opts.penalty = penalty;
+        }
+        if (exists fit_intercept) {
+            model_opts.fit_intercept = fit_intercept;
+        }
+
+        # fit the model on the first window or if no model exists
+        if (!model) {
+            model = new ML::LogisticRegression(model_opts);
+            model.fitMatrix(matrix, targets);
+        } else {
+            # predict with existing model
+        }
+
+        # predict all records
+        list<hash<ML::LogisticRegressionResult>> predictions = model.predictMatrix(matrix);
+
+        # emit one event per record
+        list<auto> events;
+        for (int i = 0; i < records.lsize(); ++i) {
+            hash<auto> record_values;
+            foreach string f in (fields) {
+                record_values{f} = DataProvider::AbstractDataProvider::getFieldValue(records[i], f);
+            }
+            record_values{target_field} = DataProvider::AbstractDataProvider::getFieldValue(
+                records[i], target_field);
+            push events, <LogisticRegressionEventInfo>{
+                "event_type": "logistic-regression",
+                "predicted_class": predictions[i].predicted_class,
+                "max_probability": predictions[i].max_probability,
+                "probabilities": predictions[i].probabilities,
+                "record_values": record_values,
+            };
+        }
+        return events;
+    }
+
+    #! Does not support bulk API
+    private bool supportsBulkApiImpl() {
+        return False;
+    }
+
+    #! Returns the processor capability bitfield
+    private int getProcessorCapabilitiesImpl() {
+        return DPC_AGGREGATE;
+    }
+
+    #! Returns the output type
+    private *DataProvider::AbstractDataProviderType getPipelineProcessorOutputTypeImpl() {
+        return new HashDeclDataType(TypedHash::forName("DataProviderML::LogisticRegressionEventInfo"));
+    }
+}
+}

--- a/qlib/DataProviderML/QoreMinMaxScalerProcessor.qc
+++ b/qlib/DataProviderML/QoreMinMaxScalerProcessor.qc
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
-#! Qore QoreLOFProcessor class definition
+#! Qore QoreMinMaxScalerProcessor class definition
 
-/** QoreLOFProcessor.qc Copyright 2026 Qore Technologies, s.r.o.
+/** QoreMinMaxScalerProcessor.qc Copyright 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -24,16 +24,18 @@
 
 #! Contains all public definitions in the DataProviderML module
 public namespace DataProviderML {
-#! Pipeline processor that detects anomalies using Local Outlier Factor
-/** Accumulates records in windows and uses the ML::LOF algorithm to
-    score each record for anomalousness based on local density.
+#! Pipeline processor that scales numeric features to a configurable range
+/** Accumulates records in windows and uses the ML::MinMaxScaler to transform
+    each record's selected fields into a bounded range (default [0, 1]). The first
+    window fits the scaler (learning per-feature min/max); subsequent windows apply
+    the already-fitted scaler.
 
 */
-public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
+public class QoreMinMaxScalerProcessor inherits DataProvider::AbstractDataProvider {
     public {
         #! Provider info
         const ProviderInfo = <DataProviderInfo>{
-            "type": "QoreLOFProcessor",
+            "type": "QoreMinMaxScalerProcessor",
             "supports_pipeline_processor": True,
             "processor_capabilities": DPC_AGGREGATE,
             "pipeline_processor_options": ConstructorOptions,
@@ -42,51 +44,45 @@ public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
         #! Constructor options
         const ConstructorOptions = {
             "fields": <DataProviderOptionInfo>{
-                "display_name": "Field Names",
-                "short_desc": "Numeric fields to analyze for anomalies",
-                "desc": "A comma-separated list of numeric field names from the input records "
-                    "to analyze; the algorithm compares each point's local neighborhood "
-                    "density to detect outliers; for example: \"temperature,pressure\"; "
-                    "at least 1 field is required",
+                "display_name": "Fields to Normalize",
+                "short_desc": "Which numeric fields to convert to the target range",
+                "desc": "The numeric fields from your data to normalize. For example, select "
+                    "`temperature`, `humidity`, and `wind_speed` to convert them all to the "
+                    "same range for easy comparison.\n\n"
+                    "At least 1 field is required",
                 "type": new SoftListDataType(AbstractDataProviderTypeMap."string", True),
                 "required": True,
                 "input_field_names": True,
             },
             "window_size": <DataProviderOptionInfo>{
-                "display_name": "Window Size",
-                "short_desc": "Number of records to analyze together",
-                "desc": "The number of records to collect before analyzing them for local "
-                    "anomalies; all records in a window are compared against each other; "
-                    "must be larger than the number of neighbors; must be at least 2.\n\n"
-                    "**Sizing guidance**: use at least `50`; should be several times larger "
-                    "than `k` (neighborhood size) for reliable results",
+                "display_name": "Batch Size",
+                "short_desc": "How many records to collect before processing",
+                "desc": "How many records to collect before processing them as a batch. The "
+                    "first batch is used to learn the minimum and maximum of each field; all "
+                    "subsequent batches are normalized using those learned values.\n\n"
+                    "**Tip**: use at least `50` for reliable results; `200`+ if your data "
+                    "has occasional extreme values (outliers)",
                 "type": AbstractDataProviderTypeMap."int",
                 "required": True,
                 "example_value": 100,
             },
-            "k": <DataProviderOptionInfo>{
-                "display_name": "Neighborhood Size",
-                "short_desc": "How many nearby points to compare against",
-                "desc": "The number of closest data points used to define each point's local "
-                    "neighborhood; larger values consider wider neighborhoods, making the "
-                    "algorithm less sensitive to small local variations; must be smaller "
-                    "than the window size.\n\n"
-                    "**Typical values**: `10`\u2013`20` for most use cases; increase for noisy "
-                    "data, decrease for small datasets; default: `20`",
-                "type": AbstractDataProviderTypeMap."*int",
-                "example_value": 20,
-            },
-            "threshold": <DataProviderOptionInfo>{
-                "display_name": "Anomaly Threshold",
-                "short_desc": "Score cutoff for flagging anomalies",
-                "desc": "The outlier score cutoff; a score of `1.0` means a point has the "
-                    "same density as its neighbors (normal); scores significantly above "
-                    "`1.0` indicate the point is in a less dense region than its neighbors "
-                    "(anomalous); lower thresholds flag more records.\n\n"
-                    "**Typical values**: `1.5` (standard \u2014 catches moderate outliers), "
-                    "`2.0` (conservative \u2014 only strong outliers); default: `1.5`",
+            "feature_min": <DataProviderOptionInfo>{
+                "display_name": "Target Minimum",
+                "short_desc": "Lowest value in the output range",
+                "desc": "The lowest value that normalized output will have. For example, set "
+                    "to `0.0` to have all values start at zero, or `-1.0` for a range centered "
+                    "around zero; default: `0.0`",
                 "type": AbstractDataProviderTypeMap."*float",
-                "example_value": 1.5,
+                "example_value": 0.0,
+            },
+            "feature_max": <DataProviderOptionInfo>{
+                "display_name": "Target Maximum",
+                "short_desc": "Highest value in the output range",
+                "desc": "The highest value that normalized output will have. For example, set "
+                    "to `1.0` for a 0-to-1 range, or `100.0` for a percentage scale; must be "
+                    "greater than the target minimum; default: `1.0`",
+                "type": AbstractDataProviderTypeMap."*float",
+                "example_value": 1.0,
             },
         };
     }
@@ -98,11 +94,14 @@ public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
         #! Configured window size
         int window_size;
 
-        #! Number of neighbors
-        int k = 20;
+        #! Target range minimum
+        float feature_min = 0.0;
 
-        #! Anomaly threshold
-        float threshold = 1.5;
+        #! Target range maximum
+        float feature_max = 1.0;
+
+        #! Retained MinMaxScaler instance (fitted on first window)
+        *ML::MinMaxScaler scaler;
 
         #! Accumulated records
         list<hash<auto>> buffer;
@@ -127,16 +126,16 @@ public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
             throw "CONSTRUCTOR-ERROR",
                 sprintf("window_size must be >= 2; got %d", window_size);
         }
-        if (exists copts.k) {
-            k = copts.k;
+        if (exists copts.feature_min) {
+            feature_min = copts.feature_min;
         }
-        if (window_size <= k) {
+        if (exists copts.feature_max) {
+            feature_max = copts.feature_max;
+        }
+        if (feature_min >= feature_max) {
             throw "CONSTRUCTOR-ERROR",
-                sprintf("window_size (%d) must be greater than k (%d); LOF requires at least "
-                    "k + 1 data points", window_size, k);
-        }
-        if (exists copts.threshold) {
-            threshold = copts.threshold;
+                sprintf("feature_min (%.6f) must be less than feature_max (%.6f)",
+                    feature_min, feature_max);
         }
         buffer = ();
         configured = True;
@@ -144,14 +143,14 @@ public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
 
     #! Returns the name of this data provider
     string getName() {
-        return "lof";
+        return "min-max-scaler";
     }
 
     #! Returns the data provider description
     *string getDesc() {
-        return "Detects anomalous data points using the Local Outlier Factor algorithm; "
-            "scores each record based on the local density deviation relative to "
-            "its neighbors";
+        return "Scales numeric features to a configurable range (default [0, 1]); "
+            "accumulates records in windows, fits the scaler on the first window, "
+            "and applies it to all subsequent windows";
     }
 
     #! Returns data provider static info
@@ -159,11 +158,11 @@ public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
         return ProviderInfo;
     }
 
-    #! Accumulates records; emits scored records when window is full
+    #! Accumulates records; emits scaled records when window is full
     private *auto processRecordImpl(auto record) {
         if (!configured) {
             throw "PROCESSOR-ERROR",
-                "QoreLOFProcessor: not configured; provide constructor options";
+                "QoreMinMaxScalerProcessor: not configured; provide constructor options";
         }
         push buffer, record;
         if (buffer.lsize() >= window_size) {
@@ -175,16 +174,11 @@ public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
     }
 
     #! Flushes remaining buffered data
-    /** @note If the buffer contains \c k or fewer records, the records are
-        discarded because LOF requires at least \a k + 1 data points
-        (k neighbors plus the query point). No results are emitted in this case.
-    */
     private *list<auto> flushRecordsImpl() {
         if (!configured || !buffer) {
             return;
         }
-        # need at least k+1 records to compute LOF
-        if (buffer.lsize() > k) {
+        if (buffer.lsize() >= 2) {
             list<auto> results = processWindow(buffer);
             buffer = ();
             return results;
@@ -193,7 +187,7 @@ public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
         return;
     }
 
-    #! Processes a window of records through LOF
+    #! Processes a window of records through MinMaxScaler
     private list<auto> processWindow(list<hash<auto>> records) {
         # extract matrix from fields
         list<list<float>> matrix;
@@ -205,30 +199,36 @@ public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
             push matrix, row;
         }
 
-        # create and fit LOF model
-        int actual_k = k < matrix.lsize() ? k : matrix.lsize() - 1;
-        ML::LOF lof({
-            "k": actual_k,
-            "threshold": threshold,
-        });
-        lof.fitMatrix(matrix);
-
-        # score all records
-        list<hash<ML::LOFResult>> scores = lof.scoreMatrix(matrix);
+        list<list<float>> scaled;
+        if (!scaler) {
+            # first window: create scaler with range options, fit and transform
+            scaler = new ML::MinMaxScaler({
+                "feature_min": feature_min,
+                "feature_max": feature_max,
+            });
+            scaler.fitMatrix(matrix);
+            scaled = scaler.transformMatrix(matrix);
+        } else {
+            # subsequent windows: apply the already-fitted scaler
+            scaled = scaler.transformMatrix(matrix);
+        }
 
         # emit one event per record
         list<auto> events;
         for (int i = 0; i < records.lsize(); ++i) {
             hash<auto> record_values;
-            foreach string f in (fields) {
+            hash<auto> scaled_values;
+            for (int j = 0; j < fields.lsize(); ++j) {
+                string f = fields[j];
                 record_values{f} = DataProvider::AbstractDataProvider::getFieldValue(records[i], f);
+                scaled_values{f} = scaled[i][j];
             }
-            push events, <LOFAnomalyEventInfo>{
-                "event_type": "lof",
-                "lof_score": scores[i].lof_score,
-                "is_anomaly": scores[i].is_anomaly,
-                "k_distance": scores[i].k_distance,
+            push events, <MinMaxScalerEventInfo>{
+                "event_type": "min-max-scaler",
                 "record_values": record_values,
+                "scaled_values": scaled_values,
+                "feature_min": feature_min,
+                "feature_max": feature_max,
             };
         }
         return events;
@@ -246,7 +246,8 @@ public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
 
     #! Returns the output type
     private *DataProvider::AbstractDataProviderType getPipelineProcessorOutputTypeImpl() {
-        return new HashDeclDataType(TypedHash::forName("DataProviderML::LOFAnomalyEventInfo"));
+        return new HashDeclDataType(
+            TypedHash::forName("DataProviderML::MinMaxScalerEventInfo"));
     }
 }
 }

--- a/qlib/DataProviderML/QoreOnnxModelProcessor.qc
+++ b/qlib/DataProviderML/QoreOnnxModelProcessor.qc
@@ -49,7 +49,6 @@ QoreOnnxModelProcessor gpu_proc({
 });
     @endcode
 
-    @since %DataProviderML 1.0
 */
 public class QoreOnnxModelProcessor inherits DataProvider::AbstractDataProvider {
     public {

--- a/qlib/DataProviderML/QorePCAProcessor.qc
+++ b/qlib/DataProviderML/QorePCAProcessor.qc
@@ -29,7 +29,6 @@ public namespace DataProviderML {
     transform each record into principal components when the window is full
     or on flush.
 
-    @since %DataProviderML 1.0
 */
 public class QorePCAProcessor inherits DataProvider::AbstractDataProvider {
     public {

--- a/qlib/DataProviderML/QoreRegressionMetricsProcessor.qc
+++ b/qlib/DataProviderML/QoreRegressionMetricsProcessor.qc
@@ -1,0 +1,205 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore QoreRegressionMetricsProcessor class definition
+
+/** QoreRegressionMetricsProcessor.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the DataProviderML module
+public namespace DataProviderML {
+#! Pipeline processor that measures prediction accuracy for numeric values
+/** Accumulates records containing predicted and true numeric values, then computes
+    MSE, RMSE, MAE, R², and explained variance using the corresponding ML module
+    functions.
+
+    On flush (or when the window is full), emits a single
+    RegressionMetricsEventInfo event summarizing the batch.
+
+*/
+public class QoreRegressionMetricsProcessor inherits DataProvider::AbstractDataProvider {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "type": "QoreRegressionMetricsProcessor",
+            "supports_pipeline_processor": True,
+            "processor_capabilities": DPC_AGGREGATE,
+            "pipeline_processor_options": ConstructorOptions,
+        };
+
+        #! Constructor options
+        const ConstructorOptions = {
+            "predicted_field": <DataProviderOptionInfo>{
+                "display_name": "Predicted Number Field",
+                "short_desc": "Which field has the model's predicted number",
+                "desc": "The field in each record that contains the number your model predicted. "
+                    "For example, if your model writes its price estimate to `predicted_price`, "
+                    "enter `predicted_price` here",
+                "type": AbstractDataProviderTypeMap."string",
+                "required": True,
+            },
+            "true_field": <DataProviderOptionInfo>{
+                "display_name": "Correct Answer Field",
+                "short_desc": "Which field has the actual correct number",
+                "desc": "The field in each record that contains the correct answer — what the "
+                    "number actually was. For example, if the real sale price is stored in "
+                    "`actual_price`, enter `actual_price` here",
+                "type": AbstractDataProviderTypeMap."string",
+                "required": True,
+            },
+            "window_size": <DataProviderOptionInfo>{
+                "display_name": "Batch Size",
+                "short_desc": "How many records to collect before scoring",
+                "desc": "How many records to collect before computing a quality score. All "
+                    "records in the batch are evaluated together.\n\n"
+                    "**Tip**: use at least `30` for meaningful scores; `200`+ for a stable "
+                    "assessment",
+                "type": AbstractDataProviderTypeMap."int",
+                "required": True,
+                "example_value": 100,
+            },
+        };
+    }
+
+    private {
+        #! Configured predicted field name
+        string predicted_field;
+
+        #! Configured true field name
+        string true_field;
+
+        #! Configured window size
+        int window_size;
+
+        #! Accumulated records
+        list<hash<auto>> buffer;
+
+        #! Whether configured
+        bool configured = False;
+    }
+
+    #! Creates the object with no options (for data provider navigation)
+    constructor() {
+    }
+
+    #! Creates the object with the given options
+    constructor(hash<auto> options) {
+        *hash<auto> copts = checkOptions("CONSTRUCTOR-ERROR", ConstructorOptions, options);
+        predicted_field = copts.predicted_field;
+        true_field = copts.true_field;
+        window_size = copts.window_size;
+        if (window_size < 2) {
+            throw "CONSTRUCTOR-ERROR",
+                sprintf("window_size must be >= 2; got %d", window_size);
+        }
+        buffer = ();
+        configured = True;
+    }
+
+    #! Returns the name of this data provider
+    string getName() {
+        return "regression-metrics";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return "Compares predicted numbers against actual values to measure prediction accuracy; "
+            "accumulates records in batches and emits MSE, RMSE, MAE, R², and explained "
+            "variance metrics";
+    }
+
+    #! Returns data provider static info
+    hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+
+    #! Accumulates records; emits metrics when window is full
+    private *auto processRecordImpl(auto record) {
+        if (!configured) {
+            throw "PROCESSOR-ERROR",
+                "QoreRegressionMetricsProcessor: not configured; provide constructor options";
+        }
+        push buffer, record;
+        if (buffer.lsize() >= window_size) {
+            list<auto> results = processWindow(buffer);
+            buffer = ();
+            return results;
+        }
+        return;
+    }
+
+    #! Flushes remaining buffered data
+    private *list<auto> flushRecordsImpl() {
+        if (!configured || !buffer) {
+            return;
+        }
+        if (buffer.lsize() >= 2) {
+            list<auto> results = processWindow(buffer);
+            buffer = ();
+            return results;
+        }
+        buffer = ();
+        return;
+    }
+
+    #! Processes a window of records through regression metrics
+    private list<auto> processWindow(list<hash<auto>> records) {
+        list<float> y_true;
+        list<float> y_pred;
+        foreach hash<auto> rec in (records) {
+            push y_true,
+                DataProvider::AbstractDataProvider::getFieldValue(rec, true_field).toFloat();
+            push y_pred,
+                DataProvider::AbstractDataProvider::getFieldValue(rec, predicted_field).toFloat();
+        }
+
+        float mse = ML::ml_mse(y_true, y_pred);
+        float rmse = ML::ml_rmse(y_true, y_pred);
+        float mae = ML::ml_mae(y_true, y_pred);
+        float r2 = ML::ml_r2_score(y_true, y_pred);
+        float explained_variance = ML::ml_explained_variance(y_true, y_pred);
+
+        return (<RegressionMetricsEventInfo>{
+            "event_type": "regression-metrics",
+            "mse": mse,
+            "rmse": rmse,
+            "mae": mae,
+            "r2": r2,
+            "explained_variance": explained_variance,
+            "sample_count": records.lsize(),
+        },);
+    }
+
+    #! Does not support bulk API
+    private bool supportsBulkApiImpl() {
+        return False;
+    }
+
+    #! Returns the processor capability bitfield
+    private int getProcessorCapabilitiesImpl() {
+        return DPC_AGGREGATE;
+    }
+
+    #! Returns the output type
+    private *DataProvider::AbstractDataProviderType getPipelineProcessorOutputTypeImpl() {
+        return new HashDeclDataType(
+            TypedHash::forName("DataProviderML::RegressionMetricsEventInfo"));
+    }
+}
+}

--- a/qlib/DataProviderML/QoreSeasonalDecompositionProcessor.qc
+++ b/qlib/DataProviderML/QoreSeasonalDecompositionProcessor.qc
@@ -30,7 +30,6 @@ public namespace DataProviderML {
 
     Inherits AbstractAnalyticsProcessor with ANALYTICS_MODE_WINDOW.
 
-    @since %DataProviderML 1.0
 */
 public class QoreSeasonalDecompositionProcessor inherits DataProvider::AbstractAnalyticsProcessor {
     public {

--- a/qlib/DataProviderML/QoreStandardScalerProcessor.qc
+++ b/qlib/DataProviderML/QoreStandardScalerProcessor.qc
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
-#! Qore QoreLOFProcessor class definition
+#! Qore QoreStandardScalerProcessor class definition
 
-/** QoreLOFProcessor.qc Copyright 2026 Qore Technologies, s.r.o.
+/** QoreStandardScalerProcessor.qc Copyright 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -24,16 +24,18 @@
 
 #! Contains all public definitions in the DataProviderML module
 public namespace DataProviderML {
-#! Pipeline processor that detects anomalies using Local Outlier Factor
-/** Accumulates records in windows and uses the ML::LOF algorithm to
-    score each record for anomalousness based on local density.
+#! Pipeline processor that standardizes numeric features to zero mean and unit variance
+/** Accumulates records in windows and uses the ML::StandardScaler to transform
+    each record's selected fields to zero mean and unit variance. The first window
+    fits the scaler (learning means and standard deviations); subsequent windows
+    apply the already-fitted scaler.
 
 */
-public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
+public class QoreStandardScalerProcessor inherits DataProvider::AbstractDataProvider {
     public {
         #! Provider info
         const ProviderInfo = <DataProviderInfo>{
-            "type": "QoreLOFProcessor",
+            "type": "QoreStandardScalerProcessor",
             "supports_pipeline_processor": True,
             "processor_capabilities": DPC_AGGREGATE,
             "pipeline_processor_options": ConstructorOptions,
@@ -42,51 +44,27 @@ public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
         #! Constructor options
         const ConstructorOptions = {
             "fields": <DataProviderOptionInfo>{
-                "display_name": "Field Names",
-                "short_desc": "Numeric fields to analyze for anomalies",
-                "desc": "A comma-separated list of numeric field names from the input records "
-                    "to analyze; the algorithm compares each point's local neighborhood "
-                    "density to detect outliers; for example: \"temperature,pressure\"; "
-                    "at least 1 field is required",
+                "display_name": "Fields to Scale",
+                "short_desc": "Which numeric fields to put on the same scale",
+                "desc": "The numeric fields from your data that should be adjusted to a common "
+                    "scale. For example, select `age`, `income`, and `credit_score` to make "
+                    "them comparable before grouping customers.\n\n"
+                    "At least 1 field is required",
                 "type": new SoftListDataType(AbstractDataProviderTypeMap."string", True),
                 "required": True,
                 "input_field_names": True,
             },
             "window_size": <DataProviderOptionInfo>{
-                "display_name": "Window Size",
-                "short_desc": "Number of records to analyze together",
-                "desc": "The number of records to collect before analyzing them for local "
-                    "anomalies; all records in a window are compared against each other; "
-                    "must be larger than the number of neighbors; must be at least 2.\n\n"
-                    "**Sizing guidance**: use at least `50`; should be several times larger "
-                    "than `k` (neighborhood size) for reliable results",
+                "display_name": "Batch Size",
+                "short_desc": "How many records to collect before processing",
+                "desc": "How many records to collect before processing them as a batch. The "
+                    "first batch is used to learn the typical range of each field; all "
+                    "subsequent batches are adjusted using those learned values.\n\n"
+                    "**Tip**: use at least `50` for reliable results; `200`+ if you have "
+                    "many fields or noisy data",
                 "type": AbstractDataProviderTypeMap."int",
                 "required": True,
                 "example_value": 100,
-            },
-            "k": <DataProviderOptionInfo>{
-                "display_name": "Neighborhood Size",
-                "short_desc": "How many nearby points to compare against",
-                "desc": "The number of closest data points used to define each point's local "
-                    "neighborhood; larger values consider wider neighborhoods, making the "
-                    "algorithm less sensitive to small local variations; must be smaller "
-                    "than the window size.\n\n"
-                    "**Typical values**: `10`\u2013`20` for most use cases; increase for noisy "
-                    "data, decrease for small datasets; default: `20`",
-                "type": AbstractDataProviderTypeMap."*int",
-                "example_value": 20,
-            },
-            "threshold": <DataProviderOptionInfo>{
-                "display_name": "Anomaly Threshold",
-                "short_desc": "Score cutoff for flagging anomalies",
-                "desc": "The outlier score cutoff; a score of `1.0` means a point has the "
-                    "same density as its neighbors (normal); scores significantly above "
-                    "`1.0` indicate the point is in a less dense region than its neighbors "
-                    "(anomalous); lower thresholds flag more records.\n\n"
-                    "**Typical values**: `1.5` (standard \u2014 catches moderate outliers), "
-                    "`2.0` (conservative \u2014 only strong outliers); default: `1.5`",
-                "type": AbstractDataProviderTypeMap."*float",
-                "example_value": 1.5,
             },
         };
     }
@@ -98,11 +76,8 @@ public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
         #! Configured window size
         int window_size;
 
-        #! Number of neighbors
-        int k = 20;
-
-        #! Anomaly threshold
-        float threshold = 1.5;
+        #! Retained StandardScaler instance (fitted on first window)
+        *ML::StandardScaler scaler;
 
         #! Accumulated records
         list<hash<auto>> buffer;
@@ -127,31 +102,20 @@ public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
             throw "CONSTRUCTOR-ERROR",
                 sprintf("window_size must be >= 2; got %d", window_size);
         }
-        if (exists copts.k) {
-            k = copts.k;
-        }
-        if (window_size <= k) {
-            throw "CONSTRUCTOR-ERROR",
-                sprintf("window_size (%d) must be greater than k (%d); LOF requires at least "
-                    "k + 1 data points", window_size, k);
-        }
-        if (exists copts.threshold) {
-            threshold = copts.threshold;
-        }
         buffer = ();
         configured = True;
     }
 
     #! Returns the name of this data provider
     string getName() {
-        return "lof";
+        return "standard-scaler";
     }
 
     #! Returns the data provider description
     *string getDesc() {
-        return "Detects anomalous data points using the Local Outlier Factor algorithm; "
-            "scores each record based on the local density deviation relative to "
-            "its neighbors";
+        return "Standardizes numeric features to zero mean and unit variance; "
+            "accumulates records in windows, fits the scaler on the first window, "
+            "and applies it to all subsequent windows";
     }
 
     #! Returns data provider static info
@@ -159,11 +123,11 @@ public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
         return ProviderInfo;
     }
 
-    #! Accumulates records; emits scored records when window is full
+    #! Accumulates records; emits scaled records when window is full
     private *auto processRecordImpl(auto record) {
         if (!configured) {
             throw "PROCESSOR-ERROR",
-                "QoreLOFProcessor: not configured; provide constructor options";
+                "QoreStandardScalerProcessor: not configured; provide constructor options";
         }
         push buffer, record;
         if (buffer.lsize() >= window_size) {
@@ -175,16 +139,11 @@ public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
     }
 
     #! Flushes remaining buffered data
-    /** @note If the buffer contains \c k or fewer records, the records are
-        discarded because LOF requires at least \a k + 1 data points
-        (k neighbors plus the query point). No results are emitted in this case.
-    */
     private *list<auto> flushRecordsImpl() {
         if (!configured || !buffer) {
             return;
         }
-        # need at least k+1 records to compute LOF
-        if (buffer.lsize() > k) {
+        if (buffer.lsize() >= 2) {
             list<auto> results = processWindow(buffer);
             buffer = ();
             return results;
@@ -193,7 +152,7 @@ public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
         return;
     }
 
-    #! Processes a window of records through LOF
+    #! Processes a window of records through StandardScaler
     private list<auto> processWindow(list<hash<auto>> records) {
         # extract matrix from fields
         list<list<float>> matrix;
@@ -205,30 +164,31 @@ public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
             push matrix, row;
         }
 
-        # create and fit LOF model
-        int actual_k = k < matrix.lsize() ? k : matrix.lsize() - 1;
-        ML::LOF lof({
-            "k": actual_k,
-            "threshold": threshold,
-        });
-        lof.fitMatrix(matrix);
-
-        # score all records
-        list<hash<ML::LOFResult>> scores = lof.scoreMatrix(matrix);
+        list<list<float>> scaled;
+        if (!scaler) {
+            # first window: fit and transform
+            scaler = new ML::StandardScaler();
+            scaler.fitMatrix(matrix);
+            scaled = scaler.transformMatrix(matrix);
+        } else {
+            # subsequent windows: apply the already-fitted scaler
+            scaled = scaler.transformMatrix(matrix);
+        }
 
         # emit one event per record
         list<auto> events;
         for (int i = 0; i < records.lsize(); ++i) {
             hash<auto> record_values;
-            foreach string f in (fields) {
+            hash<auto> scaled_values;
+            for (int j = 0; j < fields.lsize(); ++j) {
+                string f = fields[j];
                 record_values{f} = DataProvider::AbstractDataProvider::getFieldValue(records[i], f);
+                scaled_values{f} = scaled[i][j];
             }
-            push events, <LOFAnomalyEventInfo>{
-                "event_type": "lof",
-                "lof_score": scores[i].lof_score,
-                "is_anomaly": scores[i].is_anomaly,
-                "k_distance": scores[i].k_distance,
+            push events, <StandardScalerEventInfo>{
+                "event_type": "standard-scaler",
                 "record_values": record_values,
+                "scaled_values": scaled_values,
             };
         }
         return events;
@@ -246,7 +206,8 @@ public class QoreLOFProcessor inherits DataProvider::AbstractDataProvider {
 
     #! Returns the output type
     private *DataProvider::AbstractDataProviderType getPipelineProcessorOutputTypeImpl() {
-        return new HashDeclDataType(TypedHash::forName("DataProviderML::LOFAnomalyEventInfo"));
+        return new HashDeclDataType(
+            TypedHash::forName("DataProviderML::StandardScalerEventInfo"));
     }
 }
 }

--- a/qlib/QoreModelRegistry/ModelRegistry.qc
+++ b/qlib/QoreModelRegistry/ModelRegistry.qc
@@ -1,0 +1,460 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+/*  ModelRegistry.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Main QoreModelRegistry namespace
+public namespace QoreModelRegistry {
+
+#! Filesystem-backed ML model registry for versioning, tagging, and deployment management
+public class ModelRegistry {
+    private {
+        #! Base path for the model registry storage
+        string base_path;
+
+        #! In-memory index cache: model_name → {"versions": list, "mtime": date}
+        hash<string, hash<auto>> index_cache;
+
+        #! Mutex for thread-safe cache access
+        Mutex index_mutex();
+    }
+
+    #! Creates a new model registry backed by the given filesystem path
+    /** @param options a hash with the following keys:
+        - \c path (required): the base directory path for the registry storage
+    */
+    constructor(hash<auto> options) {
+%ifdef NoJson
+        throw "ML-REGISTRY-ERROR", "the QoreModelRegistry module requires the json "
+            "module (module-json) to be installed; install it and try again";
+%endif
+        *string path = options.path;
+        if (!path.val()) {
+            throw "ML-REGISTRY-ERROR", "required option 'path' not provided";
+        }
+        base_path = path;
+        # Create base directory if it doesn't exist
+        if (!is_dir(base_path)) {
+            mkdir_ex(base_path, 0755, True);
+        }
+    }
+
+    #! Registers a fitted model in the registry
+    /** @param model the fitted ML model object to register
+        @param options a hash with the following keys:
+        - \c name (required): the model name
+        - \c description: optional description
+        - \c metrics: optional hash of performance metrics
+        - \c tags: optional list of string tags
+        - \c training_data_hash: optional hash identifying training data
+
+        @return the version ID string for the registered model
+    */
+    string register(object model, hash<auto> options) {
+        *string name = options.name;
+        if (!name.val()) {
+            throw "ML-REGISTRY-ERROR", "required option 'name' not provided";
+        }
+
+        # Generate version ID: timestamp + random hex
+        string version_id = format_date("YYYYMMDDHHmmss", now()) + "_"
+            + get_random_bytes(4).toHex();
+
+        # Create model directory
+        string model_dir = base_path + DirSep + name;
+        if (!is_dir(model_dir)) {
+            mkdir_ex(model_dir, 0755, True);
+        }
+
+        # Serialize model to get size info
+        binary model_data = ML::ml_serialize(model);
+
+        # Save model to file
+        string model_file = model_dir + DirSep + "v_" + version_id + ".qml";
+        ML::ml_save_model(model, model_file);
+
+        # Build metadata
+        hash<auto> metadata = {
+            "version_id": version_id,
+            "name": name,
+            "algorithm": getAlgorithmName(model),
+            "created": format_date("YYYY-MM-DDTHH:mm:ssZ", now()),
+            "description": options.description,
+            "metrics": options.metrics,
+            "tags": options.tags ?? (),
+            "file_size": model_data.size(),
+            "format": "qml",
+            "training_data_hash": options.training_data_hash,
+        };
+
+        # Save metadata file
+        string meta_file = model_dir + DirSep + "v_" + version_id + ".meta.json";
+%ifndef NoJson
+        File f();
+        f.open(meta_file, O_CREAT | O_WRONLY | O_TRUNC);
+        f.write(make_json(metadata, JGF_ADD_FORMATTING));
+%endif
+
+        # Update registry index
+        updateIndex(model_dir, version_id, metadata);
+
+        return version_id;
+    }
+
+    #! Lists all versions of a named model
+    /** @param name the model name
+
+        @return a list of version metadata hashes, ordered oldest to newest
+    */
+    list<hash<auto>> listVersions(string name) {
+        string model_dir = base_path + DirSep + name;
+        hash<auto> index = loadIndex(model_dir);
+        return index.versions ?? ();
+    }
+
+    #! Loads a specific version of a model (or the latest version)
+    /** @param name the model name
+        @param version_id the version ID to load, or NOTHING/"latest" for the most recent version
+
+        @return the deserialized ML model object
+
+        @throw ML-REGISTRY-ERROR if the model or version is not found
+    */
+    object load(string name, *string version_id) {
+        string model_dir = base_path + DirSep + name;
+        if (!is_dir(model_dir)) {
+            throw "ML-REGISTRY-ERROR", sprintf("model '%s' not found", name);
+        }
+
+        if (!version_id.val() || version_id == "latest") {
+            # Find latest version
+            list<hash<auto>> versions = listVersions(name);
+            if (!versions) {
+                throw "ML-REGISTRY-ERROR", sprintf("no versions found for model '%s'", name);
+            }
+            version_id = versions.last().version_id;
+        }
+
+        string model_file = model_dir + DirSep + "v_" + version_id + ".qml";
+        if (!is_file(model_file)) {
+            throw "ML-REGISTRY-ERROR",
+                sprintf("version '%s' of model '%s' not found", version_id, name);
+        }
+
+        return ML::ml_load_model(model_file);
+    }
+
+    #! Tags a specific version of a model
+    /** @param name the model name
+        @param version_id the version ID to tag
+        @param tag_name the tag to apply
+
+        @throw ML-REGISTRY-ERROR if the version is not found
+    */
+    nothing tag(string name, string version_id, string tag_name) {
+        string model_dir = base_path + DirSep + name;
+        index_mutex.lock();
+        on_exit index_mutex.unlock();
+
+        hash<auto> index = loadIndexUnlocked(model_dir);
+
+        # Find version and add tag
+        bool found = False;
+        for (int i = 0; i < index.versions.size(); ++i) {
+            if (index.versions[i].version_id == version_id) {
+                if (!index.versions[i].tags.contains(tag_name)) {
+                    push index.versions[i].tags, tag_name;
+                }
+                found = True;
+                break;
+            }
+        }
+        if (!found) {
+            throw "ML-REGISTRY-ERROR",
+                sprintf("version '%s' not found for model '%s'", version_id, name);
+        }
+
+        saveIndexUnlocked(model_dir, index);
+    }
+
+    #! Loads the latest version of a model that has a specific tag
+    /** @param name the model name
+        @param tag_name the tag to search for
+
+        @return the deserialized ML model object
+
+        @throw ML-REGISTRY-ERROR if no version with the given tag is found
+    */
+    object loadByTag(string name, string tag_name) {
+        list<hash<auto>> versions = listVersions(name);
+        # Find latest version with the tag (search from end)
+        for (int i = versions.size() - 1; i >= 0; --i) {
+            if (versions[i].tags.contains(tag_name)) {
+                return load(name, versions[i].version_id);
+            }
+        }
+        throw "ML-REGISTRY-ERROR",
+            sprintf("no version with tag '%s' found for model '%s'", tag_name, name);
+    }
+
+    #! Prunes old versions of a model, keeping the latest N and optionally tagged versions
+    /** @param name the model name
+        @param options a hash with the following optional keys:
+        - \c keep_tagged (default True): if True, keep versions that have tags even if they are older
+        - \c keep_latest (default 5): the number of most recent versions to always keep
+
+        @return the number of versions deleted
+    */
+    int prune(string name, *hash<auto> options) {
+        bool keep_tagged = options.keep_tagged ?? True;
+        int keep_latest = options.keep_latest ?? 5;
+
+        string model_dir = base_path + DirSep + name;
+        index_mutex.lock();
+        on_exit index_mutex.unlock();
+
+        hash<auto> index = loadIndexUnlocked(model_dir);
+        list<hash<auto>> versions = index.versions ?? ();
+
+        if (versions.size() <= keep_latest) {
+            return 0;
+        }
+
+        int deleted = 0;
+        list<hash<auto>> kept();
+
+        # Always keep the latest N
+        int keep_from = versions.size() - keep_latest;
+        for (int i = 0; i < versions.size(); ++i) {
+            bool keep = (i >= keep_from);
+            if (!keep && keep_tagged && versions[i].tags.size() > 0) {
+                keep = True;
+            }
+            if (keep) {
+                push kept, versions[i];
+            } else {
+                # Delete model and metadata files
+                string model_file = model_dir + DirSep + "v_" + versions[i].version_id + ".qml";
+                string meta_file = model_dir + DirSep + "v_" + versions[i].version_id
+                    + ".meta.json";
+                if (is_file(model_file)) {
+                    unlink(model_file);
+                }
+                if (is_file(meta_file)) {
+                    unlink(meta_file);
+                }
+                ++deleted;
+            }
+        }
+
+        index.versions = kept;
+        saveIndexUnlocked(model_dir, index);
+        return deleted;
+    }
+
+    #! Lists all model names in the registry
+    /** @return a sorted list of model name strings
+    */
+    list<string> listModels() {
+        list<string> result();
+        Dir d();
+        if (!d.chdir(base_path)) {
+            return result;
+        }
+        foreach string entry in (d.listDirs()) {
+            push result, entry;
+        }
+        return sort(result);
+    }
+
+    #! Deletes a model and all its versions from the registry
+    /** @param name the model name
+
+        @throw ML-REGISTRY-ERROR if the model is not found
+    */
+    nothing deleteModel(string name) {
+        string model_dir = base_path + DirSep + name;
+        if (!is_dir(model_dir)) {
+            throw "ML-REGISTRY-ERROR", sprintf("model '%s' not found", name);
+        }
+        # Delete all files in directory
+        Dir d();
+        d.chdir(model_dir);
+        foreach string entry in (d.listFiles()) {
+            unlink(model_dir + DirSep + entry);
+        }
+        rmdir(model_dir);
+    }
+
+    #! Returns version metadata for a specific version
+    /** @param name the model name
+        @param version_id the version ID
+
+        @return the metadata hash for the version
+
+        @throw ML-REGISTRY-ERROR if the version is not found
+    */
+    hash<auto> getVersionMetadata(string name, string version_id) {
+        list<hash<auto>> versions = listVersions(name);
+        foreach hash<auto> v in (versions) {
+            if (v.version_id == version_id) {
+                return v;
+            }
+        }
+        throw "ML-REGISTRY-ERROR",
+            sprintf("version '%s' not found for model '%s'", version_id, name);
+    }
+
+    #! Removes a tag from a specific version
+    /** @param name the model name
+        @param version_id the version ID
+        @param tag_name the tag to remove
+
+        @throw ML-REGISTRY-ERROR if the version is not found
+    */
+    nothing untag(string name, string version_id, string tag_name) {
+        string model_dir = base_path + DirSep + name;
+        index_mutex.lock();
+        on_exit index_mutex.unlock();
+
+        hash<auto> index = loadIndexUnlocked(model_dir);
+
+        bool found = False;
+        for (int i = 0; i < index.versions.size(); ++i) {
+            if (index.versions[i].version_id == version_id) {
+                list<string> new_tags();
+                foreach string t in (index.versions[i].tags) {
+                    if (t != tag_name) {
+                        push new_tags, t;
+                    }
+                }
+                index.versions[i].tags = new_tags;
+                found = True;
+                break;
+            }
+        }
+        if (!found) {
+            throw "ML-REGISTRY-ERROR",
+                sprintf("version '%s' not found for model '%s'", version_id, name);
+        }
+
+        saveIndexUnlocked(model_dir, index);
+    }
+
+    #! Private: loads the registry index, using cache when available and current
+    /** Must be called with index_mutex held
+    */
+    private hash<auto> loadIndexUnlocked(string model_dir) {
+        string index_file = model_dir + DirSep + "registry.json";
+
+        # Check cache first
+        *hash<auto> cached = index_cache{model_dir};
+        if (cached) {
+            # Validate cache: check if file mtime has changed
+            if (is_file(index_file)) {
+                *hash<StatInfo> st = hstat(index_file);
+                if (st && st.mtime == cached.mtime) {
+                    return cached.index;
+                }
+            } else {
+                # File gone — cached data is stale
+                remove index_cache{model_dir};
+            }
+        }
+
+        # Cache miss or stale — read from disk
+        hash<auto> index;
+        if (!is_file(index_file)) {
+            index = {"versions": ()};
+        } else {
+%ifndef NoJson
+            string json_str = ReadOnlyFile::readTextFile(index_file);
+            index = parse_json(json_str);
+%else
+            index = {"versions": ()};
+%endif
+        }
+
+        # Update cache
+        *hash<StatInfo> st = is_file(index_file) ? hstat(index_file) : NOTHING;
+        index_cache{model_dir} = {
+            "index": index,
+            "mtime": st ? st.mtime : now(),
+        };
+
+        return index;
+    }
+
+    #! Private: saves the registry index to disk and updates cache
+    /** Must be called with index_mutex held
+    */
+    private nothing saveIndexUnlocked(string model_dir, hash<auto> index) {
+        string index_file = model_dir + DirSep + "registry.json";
+%ifndef NoJson
+        File f();
+        f.open(index_file, O_CREAT | O_WRONLY | O_TRUNC);
+        f.write(make_json(index, JGF_ADD_FORMATTING));
+%endif
+
+        # Update cache with new data and current mtime
+        *hash<StatInfo> st = is_file(index_file) ? hstat(index_file) : NOTHING;
+        index_cache{model_dir} = {
+            "index": index,
+            "mtime": st ? st.mtime : now(),
+        };
+    }
+
+    #! Private: thread-safe index load
+    private hash<auto> loadIndex(string model_dir) {
+        index_mutex.lock();
+        on_exit index_mutex.unlock();
+        return loadIndexUnlocked(model_dir);
+    }
+
+    #! Private: thread-safe index save
+    private nothing saveIndex(string model_dir, hash<auto> index) {
+        index_mutex.lock();
+        on_exit index_mutex.unlock();
+        saveIndexUnlocked(model_dir, index);
+    }
+
+    #! Private: atomically loads index, appends version, and saves
+    private nothing updateIndex(string model_dir, string version_id, hash<auto> metadata) {
+        index_mutex.lock();
+        on_exit index_mutex.unlock();
+        hash<auto> index = loadIndexUnlocked(model_dir);
+        push index.versions, metadata;
+        saveIndexUnlocked(model_dir, index);
+    }
+
+    #! Private: determines the algorithm name from a model object
+    private string getAlgorithmName(object model) {
+        # Determine algorithm name from class name
+        string class_name = model.className();
+        # Strip namespace prefix if present
+        if (class_name =~ /::/) {
+            class_name = (class_name =~ x/([^:]+)$/)[0];
+        }
+        return class_name;
+    }
+}
+
+} # namespace QoreModelRegistry

--- a/qlib/QoreModelRegistry/QoreModelRegistry.qm
+++ b/qlib/QoreModelRegistry/QoreModelRegistry.qm
@@ -1,0 +1,90 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! @file QoreModelRegistry.qm module providing a filesystem-backed ML model registry
+
+/*  QoreModelRegistry.qm Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+# minimum required Qore version
+%requires qore >= 2.0
+%modern
+
+%requires(reexport) DataProvider
+%requires ml
+%requires Mime
+%requires Util
+
+%try-module json
+%define NoJson
+%endtry
+
+module QoreModelRegistry {
+    version = "1.0.0";
+    desc = "user module providing a filesystem-backed ML model registry for versioning, tagging, and deployment management";
+    author = "David Nichols <david@qore.org>";
+    url = "http://qore.org";
+    license = "MIT";
+}
+
+/** @mainpage QoreModelRegistry Module
+
+    @tableofcontents
+
+    @section qoremodelregistryintro QoreModelRegistry Module Introduction
+
+    The %QoreModelRegistry module provides a filesystem-backed registry for managing
+    trained ML models. It supports versioning, tagging, pruning, and loading models —
+    enabling production workflows where models need to survive restarts, be compared
+    across versions, and be promoted to production.
+
+    @par Example:
+    @code{.py}
+%requires QoreModelRegistry
+%requires ml
+
+# Create a registry
+QoreModelRegistry::ModelRegistry reg({"path": "/var/models"});
+
+# Register a trained model
+ML::KMeans km({"k": 3, "seed": 42});
+km.fitMatrix(training_data);
+string vid = reg.register(km, {
+    "name": "customer-segments",
+    "description": "Customer segmentation model",
+    "tags": ("v1",),
+});
+
+# Load the latest version
+auto model = reg.load("customer-segments");
+
+# Tag for production
+reg.tag("customer-segments", vid, "production");
+
+# Load by tag
+auto prod_model = reg.loadByTag("customer-segments", "production");
+    @endcode
+
+    @section qoremodelregistryreleasenotes QoreModelRegistry Module Release Notes
+
+    @subsection qoremodelregistry_1_0 QoreModelRegistry Module Version 1.0
+    - Initial release with filesystem-backed registry
+    - Model registration, versioning, tagging, pruning, and comparison
+    - Supports all ml module algorithm types
+*/


### PR DESCRIPTION
## Summary

Comprehensive ML enhancement across 6 phases, adding preprocessing, evaluation metrics, new classification algorithms, online learning, model persistence, and a model registry to the `ml` binary module and `DataProviderML` user module.

### Phase 1: Data Preprocessing Pipeline
- **StandardScaler**, **MinMaxScaler**, **Imputer** — normalize, scale, and fill missing data
- **MLPipeline** — chain preprocessors + estimator into a single fit/predict unit
- 3 DataProvider processors: `standard-scaler`, `min-max-scaler`, `imputer`
- `NOTHING` values in input data treated as missing (NaN) for Imputer support

### Phase 2: Model Evaluation Metrics
- Classification: `ml_accuracy`, `ml_confusion_matrix`, `ml_classification_report`
- Regression: `ml_mse`, `ml_rmse`, `ml_mae`, `ml_r2_score`, `ml_explained_variance`
- Clustering: `ml_silhouette_score`, `ml_davies_bouldin_score`, `ml_calinski_harabasz_score`
- **CrossValidator** for k-fold cross-validation
- 3 DataProvider processors: `classification-metrics`, `regression-metrics`, `clustering-metrics`

### Phase 3: New Algorithms
- **LogisticRegression** — binary (sigmoid) + multiclass (one-vs-rest + softmax), L2 regularization
- **KNN** — k-nearest neighbors for classification and regression, 3 distance metrics
- 3 DataProvider processors: `logistic-regression`, `knn-classification`, `knn-regression`
- Both integrated into MLPipeline as supervised estimators

### Phase 4: Online Learning
- SGD updates for **LinearRegression** and **LogisticRegression**
- Online EM for **GMM**
- "Incremental Learning" option on DataProvider processors

### Phase 5: Model Persistence
- `ml_serialize` / `ml_deserialize` for in-memory round-trip
- `ml_save_model` / `ml_load_model` for file-based `.qml` native binary format
- CRC-32 integrity checking, versioned format, algorithm registry
- All 12 algorithms implement serialize/deserialize

### Phase 6: Model Registry
- New **QoreModelRegistry** user module (filesystem-backed)
- Version tracking, tagging, pruning, comparison
- Thread-safe with mutex-protected cached index
- `%try-module json` with clear error on missing dependency

### Cross-cutting
- All algorithms (new + existing) respect cooperative cancellation via `qore_check_cancel()`
- Business-friendly DataProvider action/option descriptions for non-expert users
- `AllowedValueInfo` with `display_name` on all enumerated options
- 160 tests, ~1300 assertions, valgrind clean
- 85 files changed, ~15,000 lines added

## Test plan

- [x] `modules/ml/test/ml.qtest` — 151 tests (1241 assertions)
- [x] `examples/test/qlib/DataProviderML/DataProviderMLProcessors.qtest` — 60 tests (599 assertions)  
- [x] `examples/test/qlib/QoreModelRegistry/QoreModelRegistry.qtest` — 9 tests (53 assertions)
- [x] Valgrind clean (0 definitely/indirectly/possibly lost)
- [x] All existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)