### PR TITLE
fix: direct Queue push for HTTP/3 CONNECT tunnel data delivery

### DIFF
--- a/include/qore/QoreSocketObject.h
+++ b/include/qore/QoreSocketObject.h
@@ -779,6 +779,31 @@ public:
     DLLEXPORT QoreValue readQuicConnectStreamData(int64_t session_id, int64_t stream_id,
         ExceptionSink* xsink);
 
+    //! Register a Queue for direct CONNECT stream data delivery
+    /** Data arriving on the CONNECT tunnel is pushed directly to the Queue
+        from the QUIC receive callback, bypassing the intermediate buffer.
+        Any pre-buffered data is flushed to the Queue on registration.
+
+        @param session_id the QUIC session ID
+        @param stream_id the HTTP/3 stream ID
+        @param queue the Queue to push data to (caller must ensure lifetime)
+        @param xsink exception sink
+
+        @since %Qore 2.3
+    */
+    DLLEXPORT void registerQuicConnectStreamQueue(int64_t session_id, int64_t stream_id,
+        Queue* queue, ExceptionSink* xsink);
+
+    //! Deregister a Queue for a CONNECT stream
+    /** @param session_id the QUIC session ID
+        @param stream_id the HTTP/3 stream ID
+        @param xsink exception sink
+
+        @since %Qore 2.3
+    */
+    DLLEXPORT void deregisterQuicConnectStreamQueue(int64_t session_id, int64_t stream_id,
+        ExceptionSink* xsink);
+
     //! Read body data from a dispatched HTTP/3 stream (headers-only mode)
     /** Blocks until body data is available, the stream completes, or the timeout expires.
         @param session_id the QUIC session ID

--- a/include/qore/QoreSocketObject.h
+++ b/include/qore/QoreSocketObject.h
@@ -784,9 +784,14 @@ public:
         from the QUIC receive callback, bypassing the intermediate buffer.
         Any pre-buffered data is flushed to the Queue on registration.
 
+        Ownership: the caller transfers ownership of one reference (+1 ref) to
+        the underlying QuicSession.  The reference will be released when the
+        registration ends (END_STREAM, stream close, cleanup, or session
+        destruction).
+
         @param session_id the QUIC session ID
         @param stream_id the HTTP/3 stream ID
-        @param queue the Queue to push data to (caller must ensure lifetime)
+        @param queue the Queue; ownership of one reference is transferred
         @param xsink exception sink
 
         @since %Qore 2.3

--- a/include/qore/intern/QuicSession.h
+++ b/include/qore/intern/QuicSession.h
@@ -35,6 +35,7 @@
 #include "qore/common.h"
 #include "qore/intern/QuicCommon.h"
 #include <qore/InputStream.h>
+#include <qore/QoreQueue.h>  // includes Queue class (AbstractPrivateData + QoreQueue)
 
 #include <ngtcp2/ngtcp2.h>
 #include <ngtcp2/ngtcp2_crypto.h>
@@ -715,6 +716,23 @@ public:
     */
     DLLLOCAL QoreValue readConnectStreamData(int64_t stream_id, ExceptionSink* xsink);
 
+    //! Register a Queue for direct data delivery on a CONNECT stream
+    /** Once registered, h3RecvDataCallback pushes data directly to the Queue
+        instead of buffering in connect_stream_data_.  Any data already buffered
+        is flushed to the Queue immediately.  When END_STREAM arrives, a NOTHING
+        sentinel is pushed and the registration is automatically removed.
+
+        @param stream_id the HTTP/3 stream ID
+        @param queue pointer to the Queue (caller must ensure lifetime exceeds registration)
+    */
+    DLLLOCAL void registerConnectStreamQueue(int64_t stream_id, Queue* queue);
+
+    //! Deregister a Queue for a CONNECT stream without pushing a sentinel
+    /** Called during stream cleanup when the handler has already exited.
+        @param stream_id the HTTP/3 stream ID
+    */
+    DLLLOCAL void deregisterConnectStreamQueue(int64_t stream_id);
+
     //! Returns true if extended CONNECT protocol is enabled locally (server)
     DLLLOCAL bool isExtendedConnectSupported() const {
         return is_server_;  // Server always enables via setupHttp3()
@@ -1205,11 +1223,23 @@ private:
     std::atomic<bool> has_active_input_streams_{false};
 
     //! Per-stream receive buffer for extended CONNECT bidirectional tunnel data
-    /** WebSocket frames received from client, separate from normal request body.
+    /** Fallback buffer for data that arrives before a Queue is registered.
+        Once a Queue is registered via registerConnectStreamQueue(), data bypasses
+        this buffer and is pushed directly to the Queue.
         Protected by connect_data_mutex_.
     */
     std::unordered_map<int64_t, std::vector<uint8_t>> connect_stream_data_;
-    std::mutex connect_data_mutex_;  //!< protects connect_stream_data_
+
+    //! Per-stream Queue for direct data delivery to CONNECT handlers
+    /** When registered, h3RecvDataCallback pushes data directly to the Queue
+        instead of buffering in connect_stream_data_.  Eliminates dependency on
+        the I/O poll loop for data delivery, making CONNECT tunnel data available
+        to the handler immediately when QUIC packets are processed.
+        Protected by connect_data_mutex_.
+    */
+    std::unordered_map<int64_t, Queue*> connect_stream_queues_;
+
+    std::mutex connect_data_mutex_;  //!< protects connect_stream_data_ and connect_stream_queues_
 
     //! Per-stream incoming datagram queue (RFC 9221/9297)
     /** Keyed by stream_id.  recvDatagramCallback routes datagrams here based on

--- a/include/qore/intern/QuicSession.h
+++ b/include/qore/intern/QuicSession.h
@@ -722,8 +722,12 @@ public:
         is flushed to the Queue immediately.  When END_STREAM arrives, a NOTHING
         sentinel is pushed and the registration is automatically removed.
 
+        Ownership: the caller transfers ownership of one reference (+1 ref) to
+        QuicSession.  QuicSession will call deref() when the registration ends
+        (END_STREAM, stream close, cleanup, or session destruction).
+
         @param stream_id the HTTP/3 stream ID
-        @param queue pointer to the Queue (caller must ensure lifetime exceeds registration)
+        @param queue pointer to the Queue; ownership of one reference is transferred
     */
     DLLLOCAL void registerConnectStreamQueue(int64_t stream_id, Queue* queue);
 

--- a/lib/QC_Socket.qpp
+++ b/lib/QC_Socket.qpp
@@ -6438,6 +6438,59 @@ nothing Socket::cleanupQuicStream(int session_id, int stream_id) {
     s->cleanupQuicStream(session_id, stream_id, xsink);
 }
 
+//! Register a Queue for direct data delivery on an HTTP/3 CONNECT tunnel stream
+/** Data arriving on the CONNECT tunnel is pushed directly to the Queue from the
+    QUIC receive callback, bypassing the intermediate buffer and eliminating the
+    dependency on the I/O poll loop for data delivery.
+
+    Any data that was buffered before registration is flushed to the Queue
+    immediately.  When END_STREAM arrives, a @ref nothing sentinel is pushed
+    and the registration is automatically removed.
+
+    @param session_id the QUIC session ID
+    @param stream_id the HTTP/3 stream ID
+    @param queue the Queue for data delivery (must be unlimited, i.e. created with max = -1)
+
+    @throw QUIC-ERROR if session_id or stream_id is invalid
+
+    @since %Qore 2.3
+*/
+nothing Socket::registerQuicConnectStreamQueue(int session_id, int stream_id, Queue[Queue] queue) {
+    if (session_id <= 0) {
+        xsink->raiseException("QUIC-ERROR", "invalid session_id %lld: must be > 0", (long long)session_id);
+        return QoreValue();
+    }
+    if (stream_id < 0) {
+        xsink->raiseException("QUIC-ERROR", "invalid stream_id %lld: must be >= 0", (long long)stream_id);
+        return QoreValue();
+    }
+    // Queue must be unlimited to ensure pushAndTakeRef() never blocks inside
+    // ngtcp2/nghttp3 callbacks where blocking would stall all QUIC I/O
+    if (queue->getMax() != -1) {
+        xsink->raiseException("QUIC-ERROR", "Queue must be unlimited (max = -1) for "
+            "CONNECT stream data delivery; got max = %lld", (long long)queue->getMax());
+        return QoreValue();
+    }
+    // Transfer the reference to QuicSession — it will deref() on cleanup
+    s->registerQuicConnectStreamQueue(session_id, stream_id, queue.release(), xsink);
+}
+
+//! Deregister a Queue for an HTTP/3 CONNECT tunnel stream
+/** @param session_id the QUIC session ID
+    @param stream_id the HTTP/3 stream ID
+
+    @since %Qore 2.3
+*/
+nothing Socket::deregisterQuicConnectStreamQueue(int session_id, int stream_id) {
+    if (session_id <= 0) {
+        return QoreValue();
+    }
+    if (stream_id < 0) {
+        return QoreValue();
+    }
+    s->deregisterQuicConnectStreamQueue(session_id, stream_id, xsink);
+}
+
 //! Reset an HTTP/3 stream by shutting down the read side and cleaning up
 /** Sends a STOP_SENDING signal to the peer for the given stream and removes the stream
     from the QUIC session.

--- a/lib/QoreSocketObject.cpp
+++ b/lib/QoreSocketObject.cpp
@@ -1553,6 +1553,30 @@ QoreValue QoreSocketObject::readQuicConnectStreamData(int64_t session_id, int64_
     return session->readConnectStreamData(stream_id, xsink);
 }
 
+void QoreSocketObject::registerQuicConnectStreamQueue(int64_t session_id, int64_t stream_id,
+        Queue* queue, ExceptionSink* xsink) {
+    AutoLocker al(priv->m);
+    qore_socket_private* sp = qore_socket_private::get(*priv->socket);
+    std::shared_ptr<QuicSession> session = sp->getQuicSession(session_id);
+    if (!session) {
+        xsink->raiseException("QUIC-ERROR", "no QUIC session with id %lld on this socket",
+            (long long)session_id);
+        return;
+    }
+    session->registerConnectStreamQueue(stream_id, queue);
+}
+
+void QoreSocketObject::deregisterQuicConnectStreamQueue(int64_t session_id, int64_t stream_id,
+        ExceptionSink* xsink) {
+    AutoLocker al(priv->m);
+    qore_socket_private* sp = qore_socket_private::get(*priv->socket);
+    std::shared_ptr<QuicSession> session = sp->getQuicSession(session_id);
+    if (!session) {
+        return;  // silently ignore — session may already be gone during cleanup
+    }
+    session->deregisterConnectStreamQueue(stream_id);
+}
+
 BinaryNode* QoreSocketObject::readQuicStreamDataBlock(int64_t session_id, int64_t stream_id,
         int timeout_ms, ExceptionSink* xsink) {
     // Get the session WITHOUT holding the socket lock — the session is reference-counted

--- a/lib/QuicSession.cpp
+++ b/lib/QuicSession.cpp
@@ -2166,6 +2166,19 @@ QoreValue QuicSession::readConnectStreamData(int64_t stream_id, ExceptionSink* x
 
 void QuicSession::registerConnectStreamQueue(int64_t stream_id, Queue* queue) {
     ExceptionSink xsink;
+
+    // Check body_complete under mtx_ FIRST to maintain consistent lock ordering
+    // (mtx_ -> connect_data_mutex_), matching cleanupStream() and callbacks.
+    bool already_complete = false;
+    {
+        std::lock_guard<std::recursive_mutex> lock(mtx_);
+        auto sit = streams_.find(stream_id);
+        if (sit != streams_.end() && sit->second->body_complete) {
+            already_complete = true;
+        }
+    }
+
+    // Now do all Queue/buffer work under connect_data_mutex_ only
     std::lock_guard<std::mutex> lg(connect_data_mutex_);
 
     // Deref any existing queue for this stream (shouldn't happen, but be safe)
@@ -2187,18 +2200,13 @@ void QuicSession::registerConnectStreamQueue(int64_t stream_id, Queue* queue) {
     }
     connect_stream_data_.erase(stream_id);
 
-    // Check if END_STREAM already arrived before registration
-    {
-        std::lock_guard<std::recursive_mutex> lock(mtx_);
-        auto sit = streams_.find(stream_id);
-        if (sit != streams_.end() && sit->second->body_complete) {
-            printd(5, "QuicSession::registerConnectStreamQueue() stream_id=" QLLD
-                " END_STREAM already received, pushing sentinel\n", stream_id);
-            queue->pushAndTakeRef(QoreValue());
-            connect_stream_queues_[stream_id] = nullptr;
-            queue->deref(&xsink);
-            connect_stream_queues_.erase(stream_id);
-        }
+    // If END_STREAM already arrived before registration, push sentinel and release
+    if (already_complete) {
+        printd(5, "QuicSession::registerConnectStreamQueue() stream_id=" QLLD
+            " END_STREAM already received, pushing sentinel\n", stream_id);
+        queue->pushAndTakeRef(QoreValue());
+        connect_stream_queues_.erase(stream_id);
+        queue->deref(&xsink);
     }
 }
 
@@ -3524,33 +3532,38 @@ int QuicSession::h3EndStreamCallback(nghttp3_conn* /* conn */, int64_t stream_id
                                       void* conn_user_data, void* /* stream_user_data */) {
     auto* session = static_cast<QuicSession*>(conn_user_data);
 
-    // For CONNECT tunnel streams, set body_complete and push the NOTHING sentinel
-    // directly to the registered Queue.  Do NOT call markStreamComplete() — the
-    // stream was already dispatched via h3EndHeaders and must not be re-dispatched.
-    auto it = session->streams_.find(stream_id);
-    if (it != session->streams_.end() && it->second->is_connect) {
-        it->second->body_complete = true;
-        // Push NOTHING sentinel to registered Queue (if any) and release reference
-        {
-            ExceptionSink xsink;
-            std::lock_guard<std::mutex> lg(session->connect_data_mutex_);
-            auto qit = session->connect_stream_queues_.find(stream_id);
-            if (qit != session->connect_stream_queues_.end()) {
-                Queue* q = qit->second;
-                session->connect_stream_queues_.erase(qit);
-                q->pushAndTakeRef(QoreValue());
-                q->deref(&xsink);
-                printd(5, "QuicSession::h3EndStreamCallback() stream_id=" QLLD
-                    " CONNECT tunnel END_STREAM — sentinel pushed to Queue\n", stream_id);
-            } else {
-                printd(5, "QuicSession::h3EndStreamCallback() stream_id=" QLLD
-                    " CONNECT tunnel END_STREAM — no Queue registered\n", stream_id);
+    try {
+        // For CONNECT tunnel streams, set body_complete and push the NOTHING sentinel
+        // directly to the registered Queue.  Do NOT call markStreamComplete() — the
+        // stream was already dispatched via h3EndHeaders and must not be re-dispatched.
+        auto it = session->streams_.find(stream_id);
+        if (it != session->streams_.end() && it->second->is_connect) {
+            it->second->body_complete = true;
+            // Push NOTHING sentinel to registered Queue (if any) and release reference
+            {
+                ExceptionSink xsink;
+                std::lock_guard<std::mutex> lg(session->connect_data_mutex_);
+                auto qit = session->connect_stream_queues_.find(stream_id);
+                if (qit != session->connect_stream_queues_.end()) {
+                    Queue* q = qit->second;
+                    session->connect_stream_queues_.erase(qit);
+                    q->pushAndTakeRef(QoreValue());
+                    q->deref(&xsink);
+                    printd(5, "QuicSession::h3EndStreamCallback() stream_id=" QLLD
+                        " CONNECT tunnel END_STREAM — sentinel pushed to Queue\n",
+                        stream_id);
+                } else {
+                    printd(5, "QuicSession::h3EndStreamCallback() stream_id=" QLLD
+                        " CONNECT tunnel END_STREAM — no Queue registered\n", stream_id);
+                }
             }
+            return 0;
         }
-        return 0;
-    }
 
-    session->markStreamComplete(stream_id);
+        session->markStreamComplete(stream_id);
+    } catch (...) {
+        return NGHTTP3_ERR_CALLBACK_FAILURE;
+    }
     return 0;
 }
 

--- a/lib/QuicSession.cpp
+++ b/lib/QuicSession.cpp
@@ -224,6 +224,14 @@ QuicSession::~QuicSession() {
         SSL_CTX_free(ssl_ctx_);
         ssl_ctx_ = nullptr;
     }
+    // Release any remaining Queue references
+    if (!connect_stream_queues_.empty()) {
+        ExceptionSink xsink;
+        for (auto& [id, q] : connect_stream_queues_) {
+            q->deref(&xsink);
+        }
+        connect_stream_queues_.clear();
+    }
 }
 
 // ===== Factory Methods =====
@@ -2156,6 +2164,54 @@ QoreValue QuicSession::readConnectStreamData(int64_t stream_id, ExceptionSink* x
     return bin.release();
 }
 
+void QuicSession::registerConnectStreamQueue(int64_t stream_id, Queue* queue) {
+    ExceptionSink xsink;
+    std::lock_guard<std::mutex> lg(connect_data_mutex_);
+
+    // Deref any existing queue for this stream (shouldn't happen, but be safe)
+    auto existing = connect_stream_queues_.find(stream_id);
+    if (existing != connect_stream_queues_.end()) {
+        existing->second->deref(&xsink);
+    }
+    connect_stream_queues_[stream_id] = queue;
+
+    // Flush any data that was buffered before the Queue was registered
+    auto it = connect_stream_data_.find(stream_id);
+    if (it != connect_stream_data_.end() && !it->second.empty()) {
+        SimpleRefHolder<BinaryNode> bin(new BinaryNode());
+        bin->append(it->second.data(), it->second.size());
+        printd(5, "QuicSession::registerConnectStreamQueue() stream_id=" QLLD
+            " flushing %d buffered bytes to Queue\n", stream_id, (int)it->second.size());
+        queue->pushAndTakeRef(bin.release());
+        it->second.clear();
+    }
+    connect_stream_data_.erase(stream_id);
+
+    // Check if END_STREAM already arrived before registration
+    {
+        std::lock_guard<std::recursive_mutex> lock(mtx_);
+        auto sit = streams_.find(stream_id);
+        if (sit != streams_.end() && sit->second->body_complete) {
+            printd(5, "QuicSession::registerConnectStreamQueue() stream_id=" QLLD
+                " END_STREAM already received, pushing sentinel\n", stream_id);
+            queue->pushAndTakeRef(QoreValue());
+            connect_stream_queues_[stream_id] = nullptr;
+            queue->deref(&xsink);
+            connect_stream_queues_.erase(stream_id);
+        }
+    }
+}
+
+void QuicSession::deregisterConnectStreamQueue(int64_t stream_id) {
+    ExceptionSink xsink;
+    std::lock_guard<std::mutex> lg(connect_data_mutex_);
+    auto it = connect_stream_queues_.find(stream_id);
+    if (it != connect_stream_queues_.end()) {
+        it->second->deref(&xsink);
+        connect_stream_queues_.erase(it);
+    }
+}
+
 // ===== Stream Management =====
 // THREADING INVARIANT: getOrCreateStream() and markStreamComplete() must only be
 // called while holding mtx_. All current call paths satisfy this:
@@ -2332,6 +2388,17 @@ void QuicSession::cleanupStream(int64_t stream_id) {
         streams_.erase(it);
     }
     stream_notifiers_.erase(stream_id);
+    // Deregister Queue and release reference — the handler has already exited
+    {
+        ExceptionSink xsink;
+        std::lock_guard<std::mutex> lg(connect_data_mutex_);
+        auto qit = connect_stream_queues_.find(stream_id);
+        if (qit != connect_stream_queues_.end()) {
+            qit->second->deref(&xsink);
+            connect_stream_queues_.erase(qit);
+        }
+        connect_stream_data_.erase(stream_id);
+    }
 }
 
 int QuicSession::resetStream(int64_t stream_id) {
@@ -2737,15 +2804,22 @@ int QuicSession::streamCloseCallback(ngtcp2_conn* /* conn */, uint32_t flags,
         session->body_data_.erase(stream_id);
         session->streaming_body_data_.erase(stream_id);
 
-        // Clean up extended CONNECT tunnel data — only erase if the buffer
-        // is already empty.  readConnectStreamData() drains with swap(), so
-        // once the caller reads the last chunk the entry is empty.  If data
-        // is still buffered (e.g. stream closed before the caller has read
-        // it all), preserve the buffer so the caller can still retrieve it.
-        // The entry with an empty vector has negligible overhead and is
-        // cleaned up when the QuicSession is destroyed.
+        // Clean up extended CONNECT tunnel data and Queue registration
         {
+            ExceptionSink xsink;
             std::lock_guard<std::mutex> lg(session->connect_data_mutex_);
+            // Push NOTHING sentinel to registered Queue if still active, then release ref
+            auto qit = session->connect_stream_queues_.find(stream_id);
+            if (qit != session->connect_stream_queues_.end()) {
+                Queue* q = qit->second;
+                session->connect_stream_queues_.erase(qit);
+                q->pushAndTakeRef(QoreValue());
+                q->deref(&xsink);
+                printd(5, "QuicSession::streamCloseCallback() stream_id=" QLLD
+                    " pushed sentinel to Queue on stream close\n", stream_id);
+            }
+            // Clean up fallback buffer — only erase if empty (data may still
+            // be needed by readConnectStreamData callers)
             auto cit = session->connect_stream_data_.find(stream_id);
             if (cit != session->connect_stream_data_.end() && cit->second.empty()) {
                 session->connect_stream_data_.erase(cit);
@@ -3351,12 +3425,28 @@ int QuicSession::h3RecvDataCallback(nghttp3_conn* /* conn */, int64_t stream_id,
         printd(5, "h3RecvDataCallback() stream_id=" QLLD " datalen=%d body_total=%d\n",
             stream_id, (int)datalen, (int)(stream->body.size() + datalen));
 
-        // RFC 9220: Extended CONNECT tunnel — buffer data separately for readConnectStreamData()
+        // RFC 9220: Extended CONNECT tunnel — deliver data to handler
         if (stream->is_connect) {
             {
                 std::lock_guard<std::mutex> lg(session->connect_data_mutex_);
-                auto& buf = session->connect_stream_data_[stream_id];
-                buf.insert(buf.end(), data, data + datalen);
+                auto qit = session->connect_stream_queues_.find(stream_id);
+                if (qit != session->connect_stream_queues_.end()) {
+                    // Direct push to registered Queue — data is available to
+                    // the handler immediately without waiting for the I/O loop
+                    SimpleRefHolder<BinaryNode> bin(new BinaryNode());
+                    bin->append(data, datalen);
+                    qit->second->pushAndTakeRef(bin.release());
+                    printd(5, "h3RecvDataCallback() stream_id=" QLLD
+                        " datalen=%d direct-push to Queue\n",
+                        stream_id, (int)datalen);
+                } else {
+                    // Fallback: buffer for later (Queue not yet registered)
+                    auto& buf = session->connect_stream_data_[stream_id];
+                    buf.insert(buf.end(), data, data + datalen);
+                    printd(5, "h3RecvDataCallback() stream_id=" QLLD
+                        " datalen=%d buffered (no Queue registered)\n",
+                        stream_id, (int)datalen);
+                }
             }
             // Extend flow control
             ngtcp2_conn_extend_max_stream_offset(session->conn_, stream_id,
@@ -3434,16 +3524,29 @@ int QuicSession::h3EndStreamCallback(nghttp3_conn* /* conn */, int64_t stream_id
                                       void* conn_user_data, void* /* stream_user_data */) {
     auto* session = static_cast<QuicSession*>(conn_user_data);
 
-    // For CONNECT tunnel streams, set body_complete directly without calling
-    // markStreamComplete() — the stream was already dispatched via h3EndHeaders
-    // and we must NOT push it to completed_streams_ again (which would cause a
-    // spurious second dispatch).  Setting body_complete lets isStreamComplete()
-    // return true so drainStreamQueues() pushes the NOTHING sentinel.
+    // For CONNECT tunnel streams, set body_complete and push the NOTHING sentinel
+    // directly to the registered Queue.  Do NOT call markStreamComplete() — the
+    // stream was already dispatched via h3EndHeaders and must not be re-dispatched.
     auto it = session->streams_.find(stream_id);
     if (it != session->streams_.end() && it->second->is_connect) {
         it->second->body_complete = true;
-        printd(5, "QuicSession::h3EndStreamCallback() stream_id=" QLLD
-            " CONNECT tunnel END_STREAM\n", stream_id);
+        // Push NOTHING sentinel to registered Queue (if any) and release reference
+        {
+            ExceptionSink xsink;
+            std::lock_guard<std::mutex> lg(session->connect_data_mutex_);
+            auto qit = session->connect_stream_queues_.find(stream_id);
+            if (qit != session->connect_stream_queues_.end()) {
+                Queue* q = qit->second;
+                session->connect_stream_queues_.erase(qit);
+                q->pushAndTakeRef(QoreValue());
+                q->deref(&xsink);
+                printd(5, "QuicSession::h3EndStreamCallback() stream_id=" QLLD
+                    " CONNECT tunnel END_STREAM — sentinel pushed to Queue\n", stream_id);
+            } else {
+                printd(5, "QuicSession::h3EndStreamCallback() stream_id=" QLLD
+                    " CONNECT tunnel END_STREAM — no Queue registered\n", stream_id);
+            }
+        }
         return 0;
     }
 

--- a/qlib/HttpServerAsyncIo/Http3ServerPollOperation.qc
+++ b/qlib/HttpServerAsyncIo/Http3ServerPollOperation.qc
@@ -111,14 +111,6 @@ public class Http3ServerPollOperation inherits AbstractPollOperation {
         #! Mutex for thread safety between I/O thread (continuePoll) and handler
         #! thread (startSendResponse)
         Mutex op_lock();
-
-        #! Queues for delivering data to CONNECT stream handlers
-        #! (composite key "session_id:stream_id" → Queue)
-        /** Registered by the I/O controller when dispatching extended CONNECT handlers.
-            Data is drained from the per-stream buffer to these Queues after each poll
-            cycle.  NOTHING is pushed as a sentinel when the stream closes.
-        */
-        hash<string, Queue> stream_queues;
     }
 
     #! Creates the poll operation
@@ -199,10 +191,6 @@ public class Http3ServerPollOperation inherits AbstractPollOperation {
                     }
                     try {
                         auto poll_info = current_op.continuePoll();
-                        # Drain data for registered CONNECT streams after each poll cycle
-                        if (stream_queues) {
-                            drainStreamQueues();
-                        }
 
                         # QUIC is a long-running multiplexed operation:
                         # continuePoll() always returns poll info (never NOTHING).
@@ -567,54 +555,6 @@ public class Http3ServerPollOperation inherits AbstractPollOperation {
         if (current_op) {
             try { current_op.abort(); } catch () {}
         }
-    }
-
-    #! Registers a Queue for delivering data to a CONNECT stream handler
-    /** Called by the I/O controller when dispatching an extended CONNECT handler.
-        The Queue must be unlimited (created with no max size) to ensure non-blocking pushes.
-
-        @param session_id the QUIC session ID
-        @param stream_id the HTTP/3 stream ID
-        @param queue the unlimited Queue for data delivery
-
-        @note Must be called on the I/O controller thread before the handler starts reading.
-    */
-    registerStreamQueue(int session_id, int stream_id, Queue queue) {
-        AutoLock al(op_lock);
-        stream_queues{sprintf("%d:%d", session_id, stream_id)} = queue;
-    }
-
-    #! Internal: drains buffered data for registered CONNECT streams into their Queues
-    /** Called after each continuePoll() cycle on the I/O controller thread.
-        Uses readQuicConnectStreamData() (non-blocking) to read available data from
-        each registered stream's buffer and pushes it to the corresponding Queue.
-        When a stream is complete (END_STREAM received), a NOTHING sentinel is pushed
-        and the Queue registration is removed.
-    */
-    private drainStreamQueues() {
-        list<string> completed;
-        foreach string key in (keys stream_queues) {
-            # Parse composite key "session_id:stream_id"
-            list<string> parts = key.split(":");
-            int session_id = int(parts[0]);
-            int stream_id = int(parts[1]);
-            Queue queue = stream_queues{key};
-            # Drain all available data from the per-stream buffer
-            while (True) {
-                *binary data = sock.readQuicConnectStreamData(session_id, stream_id);
-                if (!data) {
-                    break;
-                }
-                queue.push(data);
-            }
-            # Check if the stream has received END_STREAM
-            if (sock.isQuicStreamComplete(session_id, stream_id)) {
-                queue.push(NOTHING);
-                completed += key;
-            }
-        }
-        # Remove completed streams outside the iteration loop
-        map remove stream_queues{$1}, completed;
     }
 
     #! Internal: starts the read request operation

--- a/qlib/HttpServerAsyncIo/HttpAsyncSocketIoController.qc
+++ b/qlib/HttpServerAsyncIo/HttpAsyncSocketIoController.qc
@@ -1077,13 +1077,16 @@ public class HttpAsyncSocketIoController {
         bool body_streaming = request.hdr && !request.headers_end_stream;
 
         # For non-WebSocket extended CONNECT: create unlimited Queue for async data
-        # delivery.  WebSocket CONNECT handlers have their own framing mechanism
-        # and read connect_stream_data_ directly — registering a Queue would
-        # consume the data before the WebSocket handler sees it.
+        # delivery.  Data is pushed directly from the QUIC receive callback to the
+        # Queue, eliminating the I/O poll loop dependency for data delivery.
+        # WebSocket CONNECT handlers have their own framing mechanism and read
+        # connect_stream_data_ directly — registering a Queue would consume the
+        # data before the WebSocket handler sees it.
         *Queue stream_data_queue;
         if (is_extended_connect && !is_websocket_connect) {
             stream_data_queue = new Queue();
-            h3op.registerStreamQueue(session_id, stream_id, stream_data_queue);
+            listener.registerQuicConnectStreamQueue(session_id, stream_id,
+                stream_data_queue);
         }
 
         # Create send-and-wake wrapper for handler threads (HTTP/3 version).


### PR DESCRIPTION
## Summary

- Eliminates intermediate buffer and I/O poll loop dependency for HTTP/3 extended CONNECT (RFC 9220) bidirectional streaming data delivery
- Data is now pushed directly from `h3RecvDataCallback()` to the handler's Queue via `pushAndTakeRef()`, making it available immediately when QUIC packets are processed
- Removes `drainStreamQueues()` polling mechanism from `Http3ServerPollOperation`
- Queue reference is properly managed by `QuicSession` (ref on register, deref on all termination paths including END_STREAM, stream close, cleanup, and session destruction)

## Motivation

CI failure in `Http3BidiStreaming.qtest` on Kubernetes — the `testFlowControlBackpressure` handler received 0 bytes because the I/O thread's `drainStreamQueues()` didn't run within the handler's 10s Queue read timeout. Root cause: Kubernetes CFS CPU bandwidth throttling (not simple CPU contention) can completely freeze all threads in a pod when the CPU quota is exceeded, stalling the I/O poll loop that previously drove data delivery.

The fix is a performance optimization, not a workaround — direct callback-to-Queue push is the architecturally correct design that eliminates an unnecessary intermediate buffer and polling dependency.

## Test plan

- [x] `Http3BidiStreaming.qtest` — 5/5 test cases pass (echo, large payload, early close, backpressure, throughput)
- [x] `Http2BidiStreaming.qtest` — 5/5 test cases pass (unchanged, confirms no regression)
- [x] Full HTTP/QUIC test suite — 22/22 tests pass (Http3, HttpServer, HttpClientIo)
- [x] 5 consecutive runs of bidi streaming test — all pass
- [x] Valgrind — 0 bytes definitely/indirectly/possibly lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)