### PR TITLE
feat: tokenizer C API and TextFeatures subword integration (Phase 14.3/14.4)

### DIFF
--- a/design/ml-enhancement-plan.md
+++ b/design/ml-enhancement-plan.md
@@ -15,8 +15,10 @@ PolynomialFeatures, SelectKBest, RFE, DateTimeFeatures, TextFeatures).
 Phase 13 is **core complete** (13.1 concept drift detection: ADWIN, Page-Hinkley, DDM;
 13.2 streaming feature computation: RollingStats, EWMA; 13.3 data validation:
 DataProfile, SchemaValidation — remaining: 13.4 experiment tracking).
-Phase 14 is **in progress** (14.3 vector similarity functions complete —
-remaining: Arrow/Parquet, ONNX export, LLM embedding pipeline, tokenizer C API).
+Phase 14 is **in progress** (14.1 removed — covered by gRPC module; 14.3 vector
+similarity + TextFeatures subword integration complete; 14.4 tokenizer C API
+complete — remaining: ONNX export (low priority), AI Gateway chunker integration
+(Qorus repo)).
 
 ## Current State (after Phases 1–9)
 
@@ -1666,14 +1668,17 @@ search enable RAG and semantic search pipelines.
 
 ### Components
 
-#### 14.1 Apache Arrow / Parquet Support (C++ module, optional)
+#### 14.1 Apache Arrow / Parquet Support — REMOVED
 
-- Read/write Parquet files (the standard format for data lake storage)
-- Zero-copy Arrow ↔ DataFrame conversion
-- Arrow IPC for cross-process data sharing
-- Optional dependency: `libarrow` / `libparquet`
+~~Originally planned: Parquet I/O, Arrow IPC, Arrow↔DataFrame conversion.~~
 
-#### 14.2 ONNX Export (extend ml module)
+**Superseded**: Parquet I/O already exists in the DataFrame module. Full Arrow
+support (IPC, streaming, cross-process sharing) is provided by the gRPC module
+(`module-grpc`). The only remaining gap would be an Arrow↔DataFrame bridge for
+in-process conversion, but this is a small utility if needed — not a phase-level
+effort. Defer to customer demand.
+
+#### 14.2 ONNX Export (extend ml module) — LOW PRIORITY
 
 Complete Phase 5's ONNX export plan — export native Qore models to ONNX format for
 deployment in any ONNX Runtime environment. Requires optional `libprotobuf` dependency.

--- a/modules/ml/CMakeLists.txt
+++ b/modules/ml/CMakeLists.txt
@@ -140,6 +140,7 @@ set(ML_CPP_SRC
     src/PolynomialFeatures.cpp
     src/SelectKBest.cpp
     src/RFE.cpp
+    src/ml_tokenizer_bridge.cpp
     src/ADWIN.cpp
     src/PageHinkley.cpp
     src/DDM.cpp

--- a/modules/ml/src/QC_TextFeatures.h
+++ b/modules/ml/src/QC_TextFeatures.h
@@ -31,7 +31,9 @@ DLLLOCAL QoreClass* initTextFeaturesClass(QoreNamespace& ns);
 */
 class QoreTextFeatures : public AbstractPrivateData {
 public:
-    DLLLOCAL QoreTextFeatures(const std::string& mode, int max_features, int min_df);
+    DLLLOCAL QoreTextFeatures(const std::string& mode, int max_features, int min_df,
+        const std::string& tokenizer_mode = "whitespace", void* tokenizer_handle = nullptr);
+    DLLLOCAL ~QoreTextFeatures();
 
     //! Learn vocabulary from a list of text documents
     DLLLOCAL void fit(const QoreListNode* documents, ExceptionSink* xsink);
@@ -56,10 +58,15 @@ public:
         size_t len, ExceptionSink* xsink);
 
 private:
-    //! Tokenize a text string into lowercase alphanumeric tokens
-    DLLLOCAL static std::vector<std::string> tokenize(const std::string& text);
+    //! Tokenize a text string (whitespace or subword depending on mode)
+    DLLLOCAL std::vector<std::string> tokenize(const std::string& text) const;
+
+    //! Whitespace tokenizer (built-in, no external dependency)
+    DLLLOCAL static std::vector<std::string> tokenizeWhitespace(const std::string& text);
 
     std::string mode;       //!< "tfidf" or "count"
+    std::string tokenizer_mode;  //!< "whitespace" or "subword"
+    void* tokenizer_handle = nullptr;  //!< opaque handle to tokenizer C API (if subword)
     int max_features;       //!< maximum vocabulary size (0 = unlimited)
     int min_df;             //!< minimum document frequency
     std::map<std::string, int> vocabulary;  //!< word -> index (sorted for determinism)

--- a/modules/ml/src/QC_TextFeatures.qpp
+++ b/modules/ml/src/QC_TextFeatures.qpp
@@ -10,6 +10,7 @@
 
 #include "qore/Qore.h"
 #include "QC_TextFeatures.h"
+#include "ml_tokenizer_bridge.h"
 
 //! Converts text documents into numeric feature vectors using bag-of-words or TF-IDF weighting
 /** Use this to turn customer reviews, support tickets, or log messages into numbers
@@ -42,11 +43,19 @@ qclass TextFeatures [arg=QoreTextFeatures* tf; ns=Qore::ML; flags=final];
       by document frequency (0 = no limit, default 0)
     - \c min_df (*int): minimum document frequency; minimum number of documents a word
       must appear in to be included in the vocabulary (default 1)
+    - \c tokenizer_mode (*string): tokenization method:
+      - \c "whitespace" (default): built-in alphanumeric tokenizer (no external dependencies)
+      - \c "subword": use HuggingFace BPE/WordPiece/Unigram tokenization via the tokenizer
+        module (must be loaded and tokenizer_config provided)
+    - \c tokenizer_config (*hash): parsed tokenizer.json config hash for subword mode
+      (required when tokenizer_mode is "subword")
 */
 TextFeatures::constructor(*hash<auto> options) {
     std::string mode = "tfidf";
     int max_features = 0;
     int min_df = 1;
+    std::string tokenizer_mode = "whitespace";
+    void* tok_handle = nullptr;
 
     if (options) {
         QoreValue v = options->getKeyValue("mode");
@@ -84,9 +93,44 @@ TextFeatures::constructor(*hash<auto> options) {
                 return;
             }
         }
+
+        v = options->getKeyValue("tokenizer_mode");
+        if (!v.isNullOrNothing()) {
+            if (v.getType() != NT_STRING) {
+                xsink->raiseException("ML-TEXT-FEATURES-ERROR",
+                    "'tokenizer_mode' option must be a string");
+                return;
+            }
+            const char* tm = v.get<const QoreStringNode>()->c_str();
+            if (strcmp(tm, "whitespace") != 0 && strcmp(tm, "subword") != 0) {
+                xsink->raiseException("ML-TEXT-FEATURES-ERROR",
+                    "invalid tokenizer_mode '%s': must be 'whitespace' or 'subword'", tm);
+                return;
+            }
+            tokenizer_mode = tm;
+        }
+
+        if (tokenizer_mode == "subword") {
+            v = options->getKeyValue("tokenizer_config");
+            if (v.isNullOrNothing() || v.getType() != NT_HASH) {
+                xsink->raiseException("ML-TEXT-FEATURES-ERROR",
+                    "tokenizer_config (parsed tokenizer.json hash) is required "
+                    "when tokenizer_mode is 'subword'");
+                return;
+            }
+            char error_buf[256];
+            tok_handle = ml_tokenizer_create(v.get<const QoreHashNode>(),
+                error_buf, sizeof(error_buf));
+            if (!tok_handle) {
+                xsink->raiseException("ML-TEXT-FEATURES-ERROR",
+                    "failed to create tokenizer: %s", error_buf);
+                return;
+            }
+        }
     }
 
-    self->setPrivate(CID_TEXTFEATURES, new QoreTextFeatures(mode, max_features, min_df));
+    self->setPrivate(CID_TEXTFEATURES,
+        new QoreTextFeatures(mode, max_features, min_df, tokenizer_mode, tok_handle));
 }
 
 //! TextFeatures objects cannot be copied

--- a/modules/ml/src/TextFeatures.cpp
+++ b/modules/ml/src/TextFeatures.cpp
@@ -10,15 +10,25 @@
 
 #include "QC_TextFeatures.h"
 #include "ml_serialization.h"
+#include "ml_tokenizer_bridge.h"
 
 #include <algorithm>
 #include <unordered_map>
 
-QoreTextFeatures::QoreTextFeatures(const std::string& mode, int max_features, int min_df)
-    : mode(mode), max_features(max_features), min_df(min_df) {
+QoreTextFeatures::QoreTextFeatures(const std::string& mode, int max_features, int min_df,
+    const std::string& tokenizer_mode, void* tokenizer_handle)
+    : mode(mode), tokenizer_mode(tokenizer_mode), tokenizer_handle(tokenizer_handle),
+      max_features(max_features), min_df(min_df) {
 }
 
-std::vector<std::string> QoreTextFeatures::tokenize(const std::string& text) {
+QoreTextFeatures::~QoreTextFeatures() {
+    if (tokenizer_handle) {
+        ml_tokenizer_destroy(tokenizer_handle);
+        tokenizer_handle = nullptr;
+    }
+}
+
+std::vector<std::string> QoreTextFeatures::tokenizeWhitespace(const std::string& text) {
     std::vector<std::string> tokens;
     std::string token;
     for (char c : text) {
@@ -33,6 +43,24 @@ std::vector<std::string> QoreTextFeatures::tokenize(const std::string& text) {
         tokens.push_back(token);
     }
     return tokens;
+}
+
+std::vector<std::string> QoreTextFeatures::tokenize(const std::string& text) const {
+    if (tokenizer_mode == "subword" && tokenizer_handle) {
+        int32_t count = 0;
+        char** tok_result = ml_tokenizer_tokenize(tokenizer_handle,
+            text.c_str(), text.size(), &count);
+        if (tok_result && count > 0) {
+            std::vector<std::string> tokens;
+            tokens.reserve(count);
+            for (int32_t i = 0; i < count; ++i) {
+                tokens.push_back(tok_result[i]);
+            }
+            ml_tokenizer_free_tokens(tok_result, count);
+            return tokens;
+        }
+    }
+    return tokenizeWhitespace(text);
 }
 
 void QoreTextFeatures::fit(const QoreListNode* documents, ExceptionSink* xsink) {
@@ -232,6 +260,7 @@ QoreListNode* QoreTextFeatures::getVocabulary(ExceptionSink* xsink) const {
 std::vector<uint8_t> QoreTextFeatures::serializeState() const {
     std::vector<uint8_t> buf;
     MLSerialization::writeString(buf, mode);
+    MLSerialization::writeString(buf, tokenizer_mode);
     MLSerialization::writeInt32(buf, max_features);
     MLSerialization::writeInt32(buf, min_df);
     MLSerialization::writeInt32(buf, n_docs);
@@ -259,6 +288,8 @@ QoreTextFeatures* QoreTextFeatures::deserializeState(const uint8_t* data,
     size_t remaining = len;
 
     std::string mode = MLSerialization::readString(ptr, remaining, xsink);
+    if (*xsink) { return nullptr; }
+    std::string tok_mode = MLSerialization::readString(ptr, remaining, xsink);
     if (*xsink) { return nullptr; }
     int max_features = MLSerialization::readInt32(ptr, remaining, xsink);
     if (*xsink) { return nullptr; }
@@ -289,7 +320,7 @@ QoreTextFeatures* QoreTextFeatures::deserializeState(const uint8_t* data,
     std::vector<std::string> fnames = MLSerialization::readStringVector(ptr, remaining, xsink);
     if (*xsink) { return nullptr; }
 
-    auto* tf = new QoreTextFeatures(mode, max_features, min_df);
+    auto* tf = new QoreTextFeatures(mode, max_features, min_df, tok_mode);
     tf->n_docs = n_docs;
     tf->n_features = n_features;
     tf->vocabulary = std::move(vocab);

--- a/modules/ml/src/ml_tokenizer_bridge.cpp
+++ b/modules/ml/src/ml_tokenizer_bridge.cpp
@@ -1,0 +1,97 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    ml_tokenizer_bridge.cpp
+
+    Lazy dlsym bridge to the tokenizer module's C API
+
+    Since Qore loads binary modules with RTLD_GLOBAL, the tokenizer
+    module's extern "C" symbols are in the global symbol table when
+    it's loaded. We use dlsym(RTLD_DEFAULT, ...) to find them lazily
+    on first use.
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+    MIT License
+*/
+
+#include "ml_tokenizer_bridge.h"
+
+#include <atomic>
+#include <dlfcn.h>
+
+// Function pointer types matching the tokenizer C API
+typedef void* (*create_fn)(const QoreHashNode*, char*, size_t);
+typedef int32_t (*count_fn)(void*, const char*, size_t);
+typedef char** (*tokenize_fn)(void*, const char*, size_t, int32_t*);
+typedef void (*free_tokens_fn)(char**, int32_t);
+typedef void (*destroy_fn)(void*);
+
+// Cached function pointers (resolved lazily)
+static std::atomic<bool> resolved{false};
+static std::atomic<bool> available{false};
+static create_fn fn_create = nullptr;
+static count_fn fn_count = nullptr;
+static tokenize_fn fn_tokenize = nullptr;
+static free_tokens_fn fn_free_tokens = nullptr;
+static destroy_fn fn_destroy = nullptr;
+
+static void resolve() {
+    if (resolved.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    fn_create = (create_fn)dlsym(RTLD_DEFAULT, "qore_tokenizer_create");
+    fn_count = (count_fn)dlsym(RTLD_DEFAULT, "qore_tokenizer_count_tokens");
+    fn_tokenize = (tokenize_fn)dlsym(RTLD_DEFAULT, "qore_tokenizer_tokenize");
+    fn_free_tokens = (free_tokens_fn)dlsym(RTLD_DEFAULT, "qore_tokenizer_free_tokens");
+    fn_destroy = (destroy_fn)dlsym(RTLD_DEFAULT, "qore_tokenizer_destroy");
+
+    available.store(fn_create && fn_count && fn_tokenize && fn_free_tokens && fn_destroy,
+        std::memory_order_relaxed);
+    resolved.store(true, std::memory_order_release);
+}
+
+bool ml_tokenizer_available() {
+    resolve();
+    return available.load(std::memory_order_relaxed);
+}
+
+void* ml_tokenizer_create(const QoreHashNode* config,
+    char* error_buf, size_t error_buf_len) {
+    resolve();
+    if (!fn_create) {
+        if (error_buf && error_buf_len > 0) {
+            snprintf(error_buf, error_buf_len,
+                "tokenizer module not loaded; load it with %%requires tokenizer");
+        }
+        return nullptr;
+    }
+    return fn_create(config, error_buf, error_buf_len);
+}
+
+int32_t ml_tokenizer_count_tokens(void* handle, const char* text, size_t text_len) {
+    if (!fn_count) {
+        return -1;
+    }
+    return fn_count(handle, text, text_len);
+}
+
+char** ml_tokenizer_tokenize(void* handle, const char* text, size_t text_len,
+    int32_t* count_out) {
+    if (!fn_tokenize) {
+        if (count_out) { *count_out = 0; }
+        return nullptr;
+    }
+    return fn_tokenize(handle, text, text_len, count_out);
+}
+
+void ml_tokenizer_free_tokens(char** tokens, int32_t count) {
+    if (fn_free_tokens) {
+        fn_free_tokens(tokens, count);
+    }
+}
+
+void ml_tokenizer_destroy(void* handle) {
+    if (fn_destroy) {
+        fn_destroy(handle);
+    }
+}

--- a/modules/ml/src/ml_tokenizer_bridge.h
+++ b/modules/ml/src/ml_tokenizer_bridge.h
@@ -1,0 +1,45 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    ml_tokenizer_bridge.h
+
+    Lazy dlsym bridge to the tokenizer module's C API
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+    MIT License
+*/
+
+#ifndef _QORE_MODULE_ML_ML_TOKENIZER_BRIDGE_H
+#define _QORE_MODULE_ML_ML_TOKENIZER_BRIDGE_H
+
+#include "qore/Qore.h"
+
+#include <cstdint>
+
+//! Check if the tokenizer C API is available (module loaded)
+DLLLOCAL bool ml_tokenizer_available();
+
+//! Create a tokenizer from a parsed config hash
+/** @return opaque handle, or nullptr on error (error_buf filled)
+*/
+DLLLOCAL void* ml_tokenizer_create(const QoreHashNode* config,
+    char* error_buf, size_t error_buf_len);
+
+//! Count tokens in text
+/** @return token count, or -1 on error
+*/
+DLLLOCAL int32_t ml_tokenizer_count_tokens(void* handle,
+    const char* text, size_t text_len);
+
+//! Tokenize text to token strings
+/** @return array of strings (caller frees with ml_tokenizer_free_tokens)
+*/
+DLLLOCAL char** ml_tokenizer_tokenize(void* handle,
+    const char* text, size_t text_len, int32_t* count_out);
+
+//! Free token array
+DLLLOCAL void ml_tokenizer_free_tokens(char** tokens, int32_t count);
+
+//! Destroy tokenizer handle
+DLLLOCAL void ml_tokenizer_destroy(void* handle);
+
+#endif

--- a/modules/tokenizer/CMakeLists.txt
+++ b/modules/tokenizer/CMakeLists.txt
@@ -71,6 +71,7 @@ set(TOK_QPP_SRC
 # C++ source files
 set(TOK_CPP_SRC
     src/tokenizer-module.cpp
+    src/tokenizer-c-api.cpp
     src/HFTokenizer.cpp
     src/normalizers/AbstractNormalizer.cpp
     src/normalizers/BertNormalizer.cpp

--- a/modules/tokenizer/src/tokenizer-c-api.cpp
+++ b/modules/tokenizer/src/tokenizer-c-api.cpp
@@ -1,0 +1,163 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+    tokenizer-c-api.cpp
+
+    C-linkage API for cross-module tokenizer access via dlsym()
+
+    Qore loads all binary modules with RTLD_GLOBAL, so these symbols are
+    automatically visible to all subsequently loaded modules. Consumers
+    call dlsym(RTLD_DEFAULT, "qore_tokenizer_count_tokens") etc.
+
+    Copyright (C) 2026 Qore Technologies, s.r.o.
+    MIT License
+*/
+
+#include "HFTokenizer.h"
+
+#include <cstring>
+
+using namespace QoreTokenizer;
+
+extern "C" {
+
+//! Create a tokenizer from a parsed Qore hash (tokenizer.json config)
+/** @param config parsed tokenizer.json as a QoreHashNode*
+    @param error_buf buffer for error message (filled on failure)
+    @param error_buf_len size of error buffer
+    @return opaque tokenizer handle, or nullptr on error
+*/
+DLLEXPORT void* qore_tokenizer_create(const QoreHashNode* config,
+    char* error_buf, size_t error_buf_len) {
+    if (!config) {
+        if (error_buf && error_buf_len > 0) {
+            snprintf(error_buf, error_buf_len, "config hash is null");
+        }
+        return nullptr;
+    }
+
+    ExceptionSink xsink;
+    auto* tokenizer = new QoreHFTokenizer(config, &xsink);
+    if (xsink) {
+        if (error_buf && error_buf_len > 0) {
+            const QoreValue desc = xsink.getExceptionDesc();
+            if (desc.getType() == NT_STRING) {
+                snprintf(error_buf, error_buf_len, "%s",
+                    desc.get<const QoreStringNode>()->c_str());
+            } else {
+                snprintf(error_buf, error_buf_len, "tokenizer initialization failed");
+            }
+        }
+        delete tokenizer;
+        return nullptr;
+    }
+
+    return static_cast<void*>(tokenizer);
+}
+
+//! Count tokens in text
+/** @param handle tokenizer handle from qore_tokenizer_create()
+    @param text UTF-8 text to tokenize
+    @param text_len length of text in bytes
+    @return number of tokens, or -1 on error
+*/
+DLLEXPORT int32_t qore_tokenizer_count_tokens(void* handle,
+    const char* text, size_t text_len) {
+    if (!handle || !text) {
+        return -1;
+    }
+
+    auto* tokenizer = static_cast<QoreHFTokenizer*>(handle);
+    ExceptionSink xsink;
+
+    SimpleRefHolder<QoreStringNode> qtext(new QoreStringNode(text, text_len, QCS_UTF8));
+    ReferenceHolder<QoreHashNode> result(tokenizer->encode(qtext.release(),
+        nullptr, true, &xsink), &xsink);
+
+    if (xsink || !result) {
+        return -1;
+    }
+
+    QoreValue ids_val = result->getKeyValue("input_ids");
+    if (ids_val.getType() != NT_LIST) {
+        return -1;
+    }
+
+    return (int32_t)ids_val.get<const QoreListNode>()->size();
+}
+
+//! Tokenize text to token strings
+/** @param handle tokenizer handle
+    @param text UTF-8 text
+    @param text_len length in bytes
+    @param count_out receives the number of tokens
+    @return array of token strings (caller frees with qore_tokenizer_free_tokens), or nullptr on error
+*/
+DLLEXPORT char** qore_tokenizer_tokenize(void* handle,
+    const char* text, size_t text_len, int32_t* count_out) {
+    if (!handle || !text || !count_out) {
+        if (count_out) { *count_out = 0; }
+        return nullptr;
+    }
+
+    auto* tokenizer = static_cast<QoreHFTokenizer*>(handle);
+    ExceptionSink xsink;
+
+    SimpleRefHolder<QoreStringNode> qtext(new QoreStringNode(text, text_len, QCS_UTF8));
+    ReferenceHolder<QoreHashNode> result(tokenizer->encode(qtext.release(),
+        nullptr, true, &xsink), &xsink);
+
+    if (xsink || !result) {
+        *count_out = 0;
+        return nullptr;
+    }
+
+    QoreValue tokens_val = result->getKeyValue("tokens");
+    if (tokens_val.getType() != NT_LIST) {
+        *count_out = 0;
+        return nullptr;
+    }
+
+    const QoreListNode* tokens = tokens_val.get<const QoreListNode>();
+    int32_t n = (int32_t)tokens->size();
+
+    char** token_array = (char**)malloc(sizeof(char*) * n);
+    if (!token_array) {
+        *count_out = 0;
+        return nullptr;
+    }
+
+    for (int32_t i = 0; i < n; ++i) {
+        QoreValue tv = tokens->retrieveEntry(i);
+        if (tv.getType() == NT_STRING) {
+            const QoreStringNode* s = tv.get<const QoreStringNode>();
+            token_array[i] = strdup(s->c_str());
+        } else {
+            token_array[i] = strdup("");
+        }
+    }
+
+    *count_out = n;
+    return token_array;
+}
+
+//! Free token string array from qore_tokenizer_tokenize()
+DLLEXPORT void qore_tokenizer_free_tokens(char** tokens, int32_t count) {
+    if (!tokens) {
+        return;
+    }
+    for (int32_t i = 0; i < count; ++i) {
+        free(tokens[i]);
+    }
+    free(tokens);
+}
+
+//! Destroy tokenizer handle
+DLLEXPORT void qore_tokenizer_destroy(void* handle) {
+    if (handle) {
+        auto* tokenizer = static_cast<QoreHFTokenizer*>(handle);
+        ExceptionSink xsink;
+        tokenizer->deref(&xsink);
+    }
+}
+
+} // extern "C"


### PR DESCRIPTION
## Summary

- **Phase 14.4**: Add `extern "C"` DLLEXPORT API to the tokenizer module for cross-module C++ access via `dlsym(RTLD_DEFAULT, ...)`
- **Phase 14.3B**: Add optional subword tokenization to ml TextFeatures via lazy dlsym bridge

### Tokenizer C API (5 functions)
- `qore_tokenizer_create()` — create from parsed QoreHashNode* config
- `qore_tokenizer_count_tokens()` — count tokens (primary chunking use case)
- `qore_tokenizer_tokenize()` — get token strings
- `qore_tokenizer_free_tokens()` / `qore_tokenizer_destroy()` — cleanup

Since Qore loads modules with `RTLD_GLOBAL`, these symbols are automatically visible to all modules. Thread-safe (wraps QoreHFTokenizer shared_mutex).

### TextFeatures Integration
- New `tokenizer_mode` option: `"whitespace"` (default) or `"subword"`
- New `tokenizer_config` option: parsed tokenizer.json hash for subword mode
- Lazy dlsym bridge with atomic function pointers for thread-safe resolution
- Graceful degradation: clear error if tokenizer not loaded, whitespace always works

### Motivation
The AI Gateway chunker estimates tokens as `text.length() / 4` — breaks for CJK, code, URLs. This C API enables accurate token counting using the real model tokenizer. AI Gateway integration (Qorus repo) is a separate follow-up using `%requires tokenizer` directly.

## Test plan
- [x] All 255 ml tests pass (1864 assertions)
- [x] All 22 tokenizer tests pass (103 assertions)
- [x] Tokenizer C API symbols verified exported via `nm`
- [x] Whitespace mode works without tokenizer loaded
- [x] Subword mode without config gives clear error
- [ ] CI pipeline


🤖 Generated with [Claude Code](https://claude.com/claude-code)