### PR TITLE
feat: add SGLang REST client and data provider modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2032,6 +2032,7 @@ qore_user_module("qlib/VoyageRestClient.qm" "ConnectionProvider;Mime;RestClient;
 qore_user_module("qlib/GrokRestClient.qm" "ConnectionProvider;Mime;RestClient;RestClientIo;HttpClientStreamingIo")
 qore_user_module("qlib/HuggingFaceRestClient.qm" "ConnectionProvider;Mime;RestClient;RestClientIo")
 qore_user_module("qlib/OpenAiRestClient.qm" "ConnectionProvider;Mime;RestClient")
+qore_user_module("qlib/SgLangRestClient.qm" "ConnectionProvider;Mime;RestClient;RestClientIo;HttpClientStreamingIo")
 qore_user_module("qlib/PerplexityRestClient.qm" "ConnectionProvider;Mime;RestClient;RestClientIo;HttpClientStreamingIo")
 qore_user_module("qlib/ServiceNowRestClient.qm" "ConnectionProvider;Mime;RestClient")
 qore_user_module("qlib/LemlistRestClient.qm" "ConnectionProvider;Mime;RestClient")
@@ -2093,6 +2094,7 @@ qore_user_module("qlib/VoyageDataProvider" "VoyageRestClient;ConnectionProvider;
 qore_user_module("qlib/GrokDataProvider" "GrokRestClient;ConnectionProvider;Mime;RestClient;RestClientIo;DataProvider" "grok-logo.svg")
 qore_user_module("qlib/HuggingFaceDataProvider" "HuggingFaceRestClient;ConnectionProvider;Mime;RestClient;RestClientIo;DataProvider" "huggingface-logo.svg")
 qore_user_module("qlib/OpenAiDataProvider" "OpenAiRestClient;ConnectionProvider;Mime;RestClient;DataProvider" "openai-logo.svg")
+qore_user_module("qlib/SgLangDataProvider" "SgLangRestClient;ConnectionProvider;Mime;RestClient;RestClientIo;DataProvider" "sglang-logo.svg")
 qore_user_module("qlib/PerplexityDataProvider" "PerplexityRestClient;ConnectionProvider;Mime;RestClient;DataProvider" "perplexity-logo.svg")
 
 # base 9 modules

--- a/doxygen/lang/120_modules.dox.tmpl
+++ b/doxygen/lang/120_modules.dox.tmpl
@@ -328,6 +328,10 @@ ModuleName/
         <a href="../../modules/DataProvider/html/index.html#dataproviderintro">data provider</a> API for OpenAI cloud services
     |user|<a href="../../modules/OpenAiRestClient/html/index.html#openairestclientintro">OpenAiRestClient</a>|providing APIs for \
         communicating with OpenAI cloud REST APIs
+    |user|<a href="../../modules/SgLangDataProvider/html/index.html#sglangdataproviderintro">SgLangDataProvider</a>|Provides a \
+        <a href="../../modules/DataProvider/html/index.html#dataproviderintro">data provider</a> API for SGLang LLM inference services
+    |user|<a href="../../modules/SgLangRestClient/html/index.html#sglangrestclientintro">SgLangRestClient</a>|providing APIs for \
+        communicating with SGLang REST APIs
     |user|<a href="../../modules/PerplexityDataProvider/html/index.html#perplexitydataproviderintro">PerplexityDataProvider</a>|Provides a \
         <a href="../../modules/DataProvider/html/index.html#dataproviderintro">data provider</a> API for Perplexity AI services
     |user|<a href="../../modules/PerplexityRestClient/html/index.html#perplexityrestclientintro">PerplexityRestClient</a>|providing APIs for \

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -1745,6 +1745,12 @@ cargo install tree-sitter-cli@0.26.5
         deferred completions, and conversation context store; built with RestClientIo for async HTTP/2+3
     - <a href="../../modules/GrokRestClient/html/index.html#grokrestclientintro">GrokRestClient</a> module
       - initial release: REST client for xAI Grok API with SSE streaming support
+    - <a href="../../modules/SgLangRestClient/html/index.html#sglangrestclientintro">SgLangRestClient</a> module
+      - initial release: REST client for <a href="https://github.com/sgl-project/sglang">SGLang</a>
+        LLM inference servers with SSE streaming support and required model connection option
+    - <a href="../../modules/SgLangDataProvider/html/index.html#sglangdataproviderintro">SgLangDataProvider</a> module
+      - initial release: data provider for SGLang with chat completions, text completions, native
+        generate endpoint, and model listing
     - <a href="../../modules/OpenAiDataProvider/html/index.html#openaidataproviderintro">OpenAiDataProvider</a> module
       - missing APIs and actions to handle image analysis
         (<a href="https://github.com/qoretechnologies/qore/issues/4947">issue 4947</a>)

--- a/examples/test/qlib/SgLangDataProvider/SgLangDataProvider.qtest
+++ b/examples/test/qlib/SgLangDataProvider/SgLangDataProvider.qtest
@@ -1,0 +1,369 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%modern
+%allow-injection
+
+%requires ../../../../qlib/Util.qm
+%requires ../../../../qlib/QUnit.qm
+%requires ../../../../qlib/Logger.qm
+%requires ../../../../qlib/DataProvider
+%requires ../../../../qlib/SgLangDataProvider
+
+%try-module json
+%define NoJson
+%endtry
+
+%exec-class SgLangDataProviderTest
+
+class FakeSgLangRestClientIo inherits SgLangRestClient::SgLangRestClientIo {
+    public {
+        hash<auto> last_request;
+        string last_method;
+        string last_path;
+        hash<auto> response_body;
+    }
+
+    constructor() : SgLangRestClientIo({"model": "test-model"}) {
+    }
+
+    hash<RestClient::RestResponseInfo> restDoRequest(string method, string path, auto body, *hash<auto> hdr) {
+        last_method = method;
+        last_path = path;
+        last_request = body;
+        if (!response_body) {
+            response_body = {
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "created": 1234567890,
+                "model": "test-model",
+                "choices": (
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Hello!",
+                        },
+                        "finish_reason": "stop",
+                    },
+                ),
+                "usage": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 3,
+                    "total_tokens": 8,
+                },
+            };
+        }
+        return <RestClient::RestResponseInfo>{
+            "status_code": 200,
+            "body": response_body,
+        };
+    }
+
+    hash<RestClient::RestResponseInfo> restGet(string path, *hash<auto> hdr) {
+        return restDoRequest("GET", path, NOTHING, hdr);
+    }
+
+    hash<RestClient::RestResponseInfo> restPost(string path, auto body, *hash<auto> hdr) {
+        return restDoRequest("POST", path, body, hdr);
+    }
+
+    *string getModel() {
+        return "test-model";
+    }
+}
+
+public class SgLangDataProviderTest inherits QUnit::Test {
+    public {
+        Logger logger;
+
+        # command-line options
+        const MyOpts = Opts + {
+            "conn": "c,connection=s",
+        };
+
+        const OptionColumn = 22;
+    }
+
+    constructor() : Test("SgLangDataProvider Test", "1.0", \ARGV, MyOpts) {
+        addTestCase("sanity test", \sanityTest());
+        addTestCase("child providers", \childProvidersTest());
+        addTestCase("model injection", \modelInjectionTest());
+        addTestCase("model override", \modelOverrideTest());
+        addTestCase("chat completion", \chatCompletionTest());
+        addTestCase("simple chat", \simpleChatTest());
+        addTestCase("completions", \completionsTest());
+        addTestCase("generate", \generateTest());
+        addTestCase("action catalog", \actionCatalogTest());
+        addTestCase("negative tests", \negativeTest());
+
+        # Return for compatibility with test harness that checks return value.
+        set_return_value(main());
+    }
+
+    checkModule() {
+%ifdef NoJson
+        testSkip("no json module");
+%endif
+    }
+
+    sanityTest() {
+        checkModule();
+%ifndef NoJson
+        FakeSgLangRestClientIo rest();
+        SgLangDataProvider prov(rest);
+        assertEq("sglang", prov.getName());
+        assertEq("test-model", prov.getModel());
+%endif
+    }
+
+    childProvidersTest() {
+        checkModule();
+%ifndef NoJson
+        FakeSgLangRestClientIo rest();
+        SgLangDataProvider prov(rest);
+        *list<string> children = prov.getChildProviderNames();
+        assertTrue(children.contains("multi-chat"));
+        assertTrue(children.contains("simple-chat"));
+        assertTrue(children.contains("completions"));
+        assertTrue(children.contains("generate"));
+        assertTrue(children.contains("models"));
+        assertEq(5, children.size());
+
+        # verify each child can be instantiated
+        foreach string name in (children) {
+            AbstractDataProvider child = prov.getChildProviderEx(name);
+            assertEq(name, child.getName());
+        }
+%endif
+    }
+
+    modelInjectionTest() {
+        checkModule();
+%ifndef NoJson
+        FakeSgLangRestClientIo rest();
+        SgLangChatCompletionDataProvider prov(rest);
+
+        # request without model should get connection model injected
+        hash<auto> req = {
+            "messages": (
+                {
+                    "role": "user",
+                    "content": "hello",
+                },
+            ),
+        };
+        prov.doRequest(req);
+        assertEq("test-model", rest.last_request.model);
+%endif
+    }
+
+    modelOverrideTest() {
+        checkModule();
+%ifndef NoJson
+        FakeSgLangRestClientIo rest();
+        SgLangChatCompletionDataProvider prov(rest);
+
+        # request with explicit model should NOT be overridden
+        hash<auto> req = {
+            "model": "custom-model",
+            "messages": (
+                {
+                    "role": "user",
+                    "content": "hello",
+                },
+            ),
+        };
+        prov.doRequest(req);
+        assertEq("custom-model", rest.last_request.model);
+%endif
+    }
+
+    chatCompletionTest() {
+        checkModule();
+%ifndef NoJson
+        FakeSgLangRestClientIo rest();
+        SgLangChatCompletionDataProvider prov(rest);
+
+        hash<auto> req = {
+            "messages": (
+                {
+                    "role": "user",
+                    "content": "What is 2+2?",
+                },
+            ),
+            "temperature": 0.5,
+        };
+        hash<auto> resp = prov.doRequest(req);
+        assertEq("POST", rest.last_method);
+        assertEq("chat/completions", rest.last_path);
+        assertEq("user", rest.last_request.messages[0].role);
+        assertEq("What is 2+2?", rest.last_request.messages[0].content);
+        assertEq(0.5, rest.last_request.temperature);
+        assertEq("chatcmpl-test", resp.id);
+        assertEq("Hello!", resp.choices[0].message.content);
+        assertEq(8, resp.usage.total_tokens);
+%endif
+    }
+
+    simpleChatTest() {
+        checkModule();
+%ifndef NoJson
+        FakeSgLangRestClientIo rest();
+        SgLangSimpleChatCompletionDataProvider prov(rest);
+
+        hash<auto> req = {
+            "role": "user",
+            "content": "Hi there!",
+        };
+        hash<auto> resp = prov.doRequest(req);
+        assertEq("POST", rest.last_method);
+        assertEq("chat/completions", rest.last_path);
+        # verify messages array was created from role/content
+        assertEq("user", rest.last_request.messages[0].role);
+        assertEq("Hi there!", rest.last_request.messages[0].content);
+        # verify single choice extracted from choices list
+        assertEq("Hello!", resp.choice.message.content);
+%endif
+    }
+
+    completionsTest() {
+        checkModule();
+%ifndef NoJson
+        FakeSgLangRestClientIo rest();
+        rest.response_body = {
+            "id": "cmpl-test",
+            "object": "text_completion",
+            "created": 1234567890,
+            "model": "test-model",
+            "choices": (
+                {
+                    "text": "is 42.",
+                    "index": 0,
+                    "finish_reason": "stop",
+                },
+            ),
+            "usage": {
+                "prompt_tokens": 5,
+                "completion_tokens": 3,
+                "total_tokens": 8,
+            },
+        };
+        SgLangCompletionsDataProvider prov(rest);
+
+        hash<auto> req = {
+            "prompt": "The meaning of life",
+        };
+        hash<auto> resp = prov.doRequest(req);
+        assertEq("POST", rest.last_method);
+        assertEq("completions", rest.last_path);
+        assertEq("The meaning of life", rest.last_request.prompt);
+        assertEq("test-model", rest.last_request.model);
+        assertEq("cmpl-test", resp.id);
+        assertEq("is 42.", resp.choices[0].text);
+%endif
+    }
+
+    generateTest() {
+        checkModule();
+%ifndef NoJson
+        FakeSgLangRestClientIo rest();
+        rest.response_body = {
+            "text": "Paris is the capital of France.",
+            "meta_info": {
+                "id": "gen-test",
+                "finish_reason": "stop",
+                "prompt_tokens": 8,
+                "completion_tokens": 7,
+            },
+        };
+        SgLangGenerateDataProvider prov(rest);
+
+        hash<auto> req = {
+            "text": "What is the capital of France?",
+            "sampling_params": {
+                "max_new_tokens": 64,
+                "temperature": 0.7,
+            },
+        };
+        hash<auto> resp = prov.doRequest(req);
+        assertEq("POST", rest.last_method);
+        # native endpoint should bypass /v1/ prefix
+        assertEq("../generate", rest.last_path);
+        assertEq("What is the capital of France?", rest.last_request.text);
+        assertEq("Paris is the capital of France.", resp.text);
+        assertEq("stop", resp.meta_info.finish_reason);
+%endif
+    }
+
+    actionCatalogTest() {
+        {
+            hash<DataProviderActionInfo> action = DataProviderActionCatalog::getAppAction(
+                SgLangDataProvider::AppName, "multi-chat"
+            );
+            assertEq("/multi-chat", action.path);
+            assertEq(DPAT_API, action.action_code);
+        }
+        {
+            hash<DataProviderActionInfo> action = DataProviderActionCatalog::getAppAction(
+                SgLangDataProvider::AppName, "simple-chat"
+            );
+            assertEq("/simple-chat", action.path);
+            assertEq(DPAT_API, action.action_code);
+        }
+        {
+            hash<DataProviderActionInfo> action = DataProviderActionCatalog::getAppAction(
+                SgLangDataProvider::AppName, "completions"
+            );
+            assertEq("/completions", action.path);
+            assertEq(DPAT_API, action.action_code);
+        }
+        {
+            hash<DataProviderActionInfo> action = DataProviderActionCatalog::getAppAction(
+                SgLangDataProvider::AppName, "generate"
+            );
+            assertEq("/generate", action.path);
+            assertEq(DPAT_API, action.action_code);
+        }
+    }
+
+    negativeTest() {
+        checkModule();
+%ifndef NoJson
+        FakeSgLangRestClientIo rest();
+
+        # chat completion: messages with wrong type should throw
+        {
+            SgLangChatCompletionDataProvider prov(rest);
+            assertThrows("RUNTIME-TYPE-ERROR", \prov.doRequest(), ({"messages": "not a list"},));
+        }
+
+        # simple chat: missing content should throw
+        {
+            SgLangSimpleChatCompletionDataProvider prov(rest);
+            assertThrows("RUNTIME-TYPE-ERROR", \prov.doRequest(), ({"role": 123},));
+        }
+
+        # unknown child provider returns NOTHING
+        {
+            SgLangDataProvider prov(rest);
+            assertNothing(prov.getChildProvider("nonexistent"));
+        }
+
+        # factory creates correct provider
+        {
+            SgLangDataProviderFactory factory();
+            assertEq("sglang", factory.getInfo().name);
+        }
+%endif
+    }
+
+    private usageIntern() {
+        TestReporter::usageIntern(OptionColumn);
+        printOption("-c,--connection=ARG", "set connection name", OptionColumn);
+    }
+
+    private error(string fmt) {
+        throw "OPTION-ERROR", sprintf("%s: ERROR: %s", get_script_name(), vsprintf(fmt, argv));
+    }
+}

--- a/examples/test/qlib/SgLangRestClient/SgLangRestClient.qtest
+++ b/examples/test/qlib/SgLangRestClient/SgLangRestClient.qtest
@@ -1,0 +1,275 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%modern
+
+%requires ../../../../qlib/Util.qm
+%requires ../../../../qlib/QUnit.qm
+%requires ../../../../qlib/Mime.qm
+%requires ../../../../qlib/Logger.qm
+%requires ../../../../qlib/HttpServerUtil.qm
+%requires ../../../../qlib/ConnectionProvider
+%requires ../../../../qlib/RestClient.qm
+%requires ../../../../qlib/RestClientIo.qm
+%requires ../../../../qlib/HttpClientStreamingIo
+%requires ../../../../qlib/SgLangRestClient.qm
+
+%try-module json >= 1.5
+%define NoJson
+%endtry
+
+%exec-class Main
+
+class FakeSgLangStreamRest inherits SgLangRestClient::SgLangRestClient {
+    public {
+        string content_type;
+        *string content_encoding;
+        *string transfer_encoding;
+        list<binary> chunks;
+        int chunk_idx;
+        string last_parse_data;
+    }
+
+    constructor(string content_type, *string content_encoding, *string transfer_encoding, *list<binary> chunks)
+            : SgLangRestClient::SgLangRestClient({"model": "test-model"}, True) {
+        self.content_type = content_type;
+        self.content_encoding = content_encoding;
+        self.transfer_encoding = transfer_encoding;
+        self.chunks = chunks ?? ();
+    }
+
+    hash<auto> send(data payload, string method, string path, hash<auto> headers, bool decode_errors,
+            *reference<hash<auto>> info) {
+        if (info) {
+            info = {};
+        }
+        return {
+            "status_code": 200,
+            "status_message": "OK",
+            "content-type": content_type,
+            "content-encoding": content_encoding,
+            "transfer-encoding": transfer_encoding,
+        };
+    }
+
+    hash<auto> readHTTPChunk(timeout to) {
+        if (chunk_idx >= chunks.lsize()) {
+            return {
+                "body": NOTHING,
+            };
+        }
+        return {
+            "body": chunks[chunk_idx++],
+        };
+    }
+
+    hash<SseMessageInfo> parseServerSentEvent(string str) {
+        last_parse_data = str;
+        return <SseMessageInfo>{
+            "data": "ok",
+        };
+    }
+
+    hash<SseMessageInfo> readServerSentEvent(*string encoding, timeout to) {
+        last_parse_data = "direct";
+        return <SseMessageInfo>{
+            "data": "ok",
+        };
+    }
+
+    disconnect() {
+    }
+}
+
+public class Main inherits QUnit::Test {
+    private {
+        *SgLangRestClient::SgLangRestConnection rc;
+        Logger logger;
+
+        # command-line options
+        const MyOpts = Opts + {
+            "conn": "c,connection=s",
+        };
+
+        const OptionColumn = 22;
+    }
+
+    constructor() : Test("SgLangRestClientTest", "1.0", \ARGV, MyOpts) {
+        addTestCase("connection tests", \connectionTest());
+        addTestCase("model tests", \modelTest());
+        addTestCase("sse stream tests", \sseStreamTest());
+        addTestCase("poll tests", \pollTest());
+
+        try {
+            setupConnection();
+        } catch (hash<ExceptionInfo> ex) {
+            if (m_options.verbose > 2) {
+                printf("%s\n", get_exception_string(ex));
+            } else if (m_options.verbose) {
+                printf("%s: %s\n", ex.err, ex.desc);
+            }
+        }
+
+        # Return for compatibility with test harness that checks return value.
+        set_return_value(main());
+    }
+
+    setUp() {
+        Logger logger("test", LoggerLevel::getLevelInfo());
+        if (m_options.verbose > 2) {
+            logger.addAppender(new StdoutAppender());
+        }
+    }
+
+    tearDown() {
+    }
+
+    checkModule() {
+%ifdef NoJson
+        testSkip("no json module");
+%endif
+    }
+
+    connectionTest() {
+        checkModule();
+        hash<auto> fake_opts = {
+            "model": "test-model",
+        };
+        {
+            SgLangRestConnection rc("test", "test", NOTHING, NOTHING, fake_opts);
+            assertTrue(rc instanceof SgLangRestConnection);
+            assertEq("sglang", rc.getType());
+
+            SgLangRestClient client = rc.get(False);
+            # issue #3321: check default timeouts
+            assertEq(45000, client.getTimeout());
+            assertEq(45000, client.getConnectTimeout());
+
+            # verify async client can be created
+            SgLangRestClientIo async_client = rc.getAsync(False);
+            assertTrue(async_client instanceof SgLangRestClientIo);
+        }
+    }
+
+    modelTest() {
+        checkModule();
+        {
+            # test model stored on sync client
+            SgLangRestClient client({"model": "my-llama-model"}, True);
+            assertEq("my-llama-model", client.getModel());
+        }
+        {
+            # test model stored on async client
+            SgLangRestClientIo client({"model": "my-mistral-model"});
+            assertEq("my-mistral-model", client.getModel());
+        }
+        {
+            # test no model
+            SgLangRestClient client({}, True);
+            assertNothing(client.getModel());
+        }
+        {
+            # test model from connection
+            SgLangRestConnection rc("test", "test", NOTHING, NOTHING, {"model": "conn-model"});
+            SgLangRestClient client = rc.get(False);
+            assertEq("conn-model", client.getModel());
+
+            SgLangRestClientIo async_client = rc.getAsync(False);
+            assertEq("conn-model", async_client.getModel());
+        }
+    }
+
+    sseStreamTest() {
+        FakeSgLangStreamRest rest("text/event-stream; charset=utf-8", NOTHING, "chunked",
+            (binary("data: hi\n\n"),));
+        SgLangRestClient::SgLangSseStream stream(rest, "chat/completions", "{}", NOTHING, 1s);
+        hash<SseMessageInfo> event = stream.readEvent();
+        assertEq("ok", event.data);
+        assertTrue(rest.last_parse_data =~ /data: hi/);
+
+        FakeSgLangStreamRest bad_rest("application/json", NOTHING, "chunked",
+            (binary("data: hi\n\n"),));
+        assertThrows("SSE-ERROR", sub () {
+            new SgLangRestClient::SgLangSseStream(bad_rest, "chat/completions", "{}", NOTHING, 1s);
+        });
+    }
+
+    pollTest() {
+        if (!rc) {
+            testSkip("no connection");
+        }
+
+        {
+            # first test a standard ping
+            hash<PingInfo> ping = rc.ping(True);
+            assertTrue(ping.ok);
+            assertEq("OK", ping.info);
+
+            TestPollingConnectionMonitor monitor(logger);
+            on_exit delete monitor;
+
+            monitor.add(rc);
+            hash<auto> info = monitor.waitForResult();
+            on_error if (info.ex) {
+                printf("%s\n", get_exception_string(info.ex));
+            }
+            assertEq("OK", info.result);
+        }
+    }
+
+    private usageIntern() {
+        TestReporter::usageIntern(OptionColumn);
+        printOption("-c,--connection=ARG", "set connection name", OptionColumn);
+    }
+
+    private error(string fmt) {
+        throw "OPTION-ERROR", sprintf("%s: ERROR: %s", get_script_name(), vsprintf(fmt, argv));
+    }
+
+    private setupConnection() {
+        *string conn_name = m_options.conn ?? ENV.SGLANG_CONNECTION;
+        if (!conn_name.val()) {
+            error("missing -c,--connection option or SGLANG_CONNECTION environment variable");
+        }
+
+        AbstractConnection conn = get_connection(conn_name);
+        if (!(conn instanceof SgLangRestConnection)) {
+            error("connection %y is type %y; expecting \"SgLangRestConnection\"", conn_name, conn.className());
+        }
+        rc = conn;
+    }
+}
+
+class TestPollingConnectionMonitor inherits PollingConnectionMonitor {
+    private {
+        Queue msgq();
+    }
+
+    constructor(*Logger logger) : PollingConnectionMonitor(logger) {
+        ping_timeout = 5s;
+    }
+
+    hash<auto> waitForResult() {
+        return msgq.get();
+    }
+
+    private failedToStartPing(string name, hash<ExceptionInfo> ex) {
+        PollingConnectionMonitor::failedToStartPing(name, ex);
+        msgq.push({"name": name, "result": "error", "ex": ex});
+    }
+
+    private handlePingSuccess(string name, date delta, *bool oldok) {
+        PollingConnectionMonitor::handlePingSuccess(name, delta, oldok);
+        msgq.push({"name": name, "result": "OK"});
+    }
+
+    private handlePingFailed(string name, date delta, hash<ExceptionInfo> ex) {
+        PollingConnectionMonitor::handlePingFailed(name, delta, ex);
+        msgq.push({"name": name, "result": "error", "ex": ex});
+    }
+
+    private handlePingTimeout(string name, date delta) {
+        PollingConnectionMonitor::handlePingTimeout(name, delta);
+        msgq.push({"name": name, "result": "timeout"});
+    }
+}

--- a/qlib/ConnectionProvider/ConnectionSchemeCache.qc
+++ b/qlib/ConnectionProvider/ConnectionSchemeCache.qc
@@ -195,6 +195,8 @@ public class ConnectionSchemeCache {
 
             "sfrests": "SalesforceRestClient",
 
+            "sglang": "SgLangRestClient",
+
             # provided by the xml module
             "sfsoap": "SalesforceSoapClient",
             "sfsoaps": "SalesforceSoapClient",

--- a/qlib/DataProvider/DataProvider.qc
+++ b/qlib/DataProvider/DataProvider.qc
@@ -229,6 +229,7 @@ public class DataProvider {
             "sax": "SaxDataProvider",
             "servicenowrest": "ServiceNowRestDataProvider",
             "lemlist": "LemlistDataProvider",
+            "sglang": "SgLangDataProvider",
             "shippo": "ShippoDataProvider",
             "shipstation": "ShipStationDataProvider",
             "customerio": "CustomerIoDataProvider",

--- a/qlib/SgLangDataProvider/SgLangChatCompletionDataProvider.qc
+++ b/qlib/SgLangDataProvider/SgLangChatCompletionDataProvider.qc
@@ -1,0 +1,551 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore SgLangDataProvider module definition
+
+/** SgLangChatCompletionDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! contains all public definitions in the SgLangDataProvider module
+public namespace SgLangDataProvider {
+#! The SGLang chat completion data provider
+public class SgLangChatCompletionDataProvider inherits SgLangDataProviderCommon {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "multi-chat",
+            "type": "SgLangChatCompletionDataProvider",
+            "constructor_options": ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = SgLangChatCompletionRequestType;
+
+        #! Response type
+        const ResponseType = SgLangChatCompletionResponseType;
+    }
+
+    #! Creates the object from the arguments
+    constructor(*RestClientIo::RestClientIo rest) : SgLangDataProviderCommon(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return doRestCommand("POST", "chat/completions", injectModel(req)).body;
+    }
+
+    #! Returns the description of a successful request message, if any
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    private hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Chat completion request message data type
+public class SgLangMessageDataType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "role": {
+                "display_name": "Role",
+                "short_desc": "The role of the author of this message",
+                "desc": "The role of the author of this message",
+                "type": AbstractDataProviderTypeMap."string",
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "display_name": "User",
+                        "short_desc": "The author of the message is the user",
+                        "desc": "The author of the message is the user",
+                        "value": "user",
+                    },
+                    <AllowedValueInfo>{
+                        "display_name": "System",
+                        "short_desc": "The author of the message is the system",
+                        "desc": "The author of the message is the system",
+                        "value": "system",
+                    },
+                    <AllowedValueInfo>{
+                        "display_name": "Assistant",
+                        "short_desc": "The author of the message is an assistant",
+                        "desc": "The author of the message is an assistant",
+                        "value": "assistant",
+                    },
+                    <AllowedValueInfo>{
+                        "display_name": "Tool",
+                        "short_desc": "The author of the message is a tool",
+                        "desc": "The author of the message is a tool",
+                        "value": "tool",
+                    },
+                ),
+                "default_value": "user",
+            },
+            "content": {
+                "display_name": "Content",
+                "short_desc": "The contents of the message",
+                "desc": "The contents of the message",
+                "type": AbstractDataProviderTypeMap."*string",
+                "example_value": "What is the capital of France?",
+            },
+            "name": {
+                "display_name": "Name",
+                "short_desc": "An optional name for the participant",
+                "desc": "An optional name for the participant. Provides the model information to differentiate "
+                    "between participants of the same role",
+                "type": AbstractDataProviderTypeMap."*string",
+            },
+            "tool_calls": {
+                "display_name": "Tool Calls",
+                "short_desc": "The tool calls generated by the model",
+                "desc": "The tool calls generated by the model, such as function calls",
+                "type": AbstractDataProviderTypeMap."*list",
+            },
+            "tool_call_id": {
+                "display_name": "Tool Call ID",
+                "short_desc": "Tool call that this message is responding to",
+                "desc": "Tool call that this message is responding to",
+                "type": AbstractDataProviderTypeMap."*string",
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangMessage") {
+        addQoreFields(Fields);
+    }
+}
+
+#! Chat completion message constant
+public const SgLangMessageDataType = new SgLangMessageDataType();
+
+#! Chat completion response message data type
+public class SgLangCompletionMessageDataType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = SgLangMessageDataType::Fields{"role", "content", "tool_calls"};
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangCompletionMessage") {
+        addQoreFields(Fields);
+    }
+}
+
+#! Constant for the completion message data type
+public const SgLangCompletionMessageDataType = new SgLangCompletionMessageDataType();
+
+#! The function data type
+public class SgLangFunctionDataType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "description": {
+                "display_name": "Description",
+                "short_desc": "A description of what the function does",
+                "desc": "A description of what the function does, used by the model to choose when and how to "
+                    "call the function",
+                "type": AbstractDataProviderTypeMap."*string",
+            },
+            "name": {
+                "display_name": "Name",
+                "short_desc": "The name of the function to be called",
+                "desc": "The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores "
+                    "and dashes, with a maximum length of 64",
+                "type": AbstractDataProviderTypeMap."string",
+            },
+            "parameters": {
+                "display_name": "Parameters",
+                "short_desc": "The parameters the function accepts",
+                "desc": "The parameters the function accepts, described as a JSON Schema object",
+                "type": AbstractDataProviderTypeMap."*hash",
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangFunction") {
+        addQoreFields(Fields);
+    }
+}
+
+#! Constant for the function data type
+public const SgLangFunctionDataType = new SgLangFunctionDataType();
+
+#! The tool data type
+public class SgLangToolDataType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "type": {
+                "display_name": "Type",
+                "short_desc": "The type of the tool",
+                "desc": "The type of the tool. Currently, only `function` is supported",
+                "type": AbstractDataProviderTypeMap."string",
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "display_name": "Function",
+                        "short_desc": "For a function",
+                        "desc": "For a function",
+                        "value": "function",
+                    },
+                ),
+                "default_value": "function",
+            },
+            "function": {
+                "display_name": "Function",
+                "short_desc": "Describes the function to be called",
+                "desc": "Describes the function to be called",
+                "type": SgLangFunctionDataType,
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangTool") {
+        addQoreFields(Fields);
+    }
+}
+
+#! Constant for the tool data type
+public const SgLangToolDataType = new SgLangToolDataType();
+
+#! The chat completion request type
+public class SgLangChatCompletionRequestType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "messages": {
+                "display_name": "Messages",
+                "short_desc": "A list of messages comprising the conversation so far",
+                "desc": "A list of messages comprising the conversation so far",
+                "type": new ListDataType("SgLangMessages", SgLangMessageDataType),
+            },
+            "model": {
+                "display_name": "Model ID",
+                "short_desc": "Model to use for the chat completion",
+                "desc": "Model to use for the chat completion. If not provided, the connection's configured "
+                    "model will be used",
+                "type": AbstractDataProviderTypeMap."*string",
+                "attr": {
+                    "ref_data": "models",
+                },
+            },
+            "frequency_penalty": {
+                "display_name": "Frequency Penalty",
+                "short_desc": "Penalty to reduce repeated tokens in the output",
+                "desc": "Number between `-2.0` and `2.0`. Positive values penalize new tokens based on their "
+                    "existing frequency in the text so far, decreasing the model's likelihood to repeat the "
+                    "same line verbatim",
+                "type": AbstractDataProviderTypeMap."*float",
+            },
+            "max_tokens": {
+                "display_name": "Max Tokens",
+                "short_desc": "The maximum number of tokens to generate",
+                "desc": "The maximum number of tokens that can be generated in the chat completion",
+                "type": AbstractDataProviderTypeMap."*int",
+            },
+            "n": {
+                "display_name": "Number of Choices",
+                "short_desc": "The number of choices to generate for each input message",
+                "desc": "How many chat completion choices to generate for each input message. Keep `n` as "
+                    "`1` (the default) to minimize costs",
+                "type": AbstractDataProviderTypeMap."*int",
+            },
+            "presence_penalty": {
+                "display_name": "Presence Penalty",
+                "short_desc": "Penalty to encourage new topics",
+                "desc": "Number between `-2.0` and `2.0`. Positive values penalize new tokens based on "
+                    "whether they appear in the text so far, increasing the model's likelihood to talk "
+                    "about new topics",
+                "type": AbstractDataProviderTypeMap."*float",
+            },
+            "response_format": {
+                "display_name": "Response Format",
+                "short_desc": "The response format",
+                "desc": "An object specifying the format that the model must output.\n\n"
+                    "Setting to `{\"type\": \"json_object\"}` enables JSON mode, which guarantees the "
+                    "message the model generates is valid JSON",
+                "type": AbstractDataProviderTypeMap."*hash",
+            },
+            "seed": {
+                "display_name": "Seed",
+                "short_desc": "A value for deterministic sampling",
+                "desc": "If specified, the system will make a best effort to sample deterministically, "
+                    "such that repeated requests with the same seed and parameters should return the "
+                    "same result",
+                "type": AbstractDataProviderTypeMap."*int",
+            },
+            "stop": {
+                "display_name": "Stop Sequences",
+                "short_desc": "Up to 4 sequences where the API will stop generating",
+                "desc": "Up to 4 sequences where the API will stop generating further tokens",
+                "type": AbstractDataProviderTypeMap."any",
+            },
+            "stream": {
+                "display_name": "Stream?",
+                "short_desc": "Set to enable partial message deltas",
+                "desc": "If set, partial message deltas will be sent as server-sent events as they become "
+                    "available, with the stream terminated by a `data: [DONE]` message",
+                "type": AbstractDataProviderTypeMap."*bool",
+            },
+            "temperature": {
+                "display_name": "Sampling Temperature",
+                "short_desc": "The sampling temperature to use, between 0 and 2",
+                "desc": "What sampling temperature to use, between `0` and `2`. Higher values like `0.8` "
+                    "will make the output more random, while lower values like `0.2` will make it more "
+                    "focused and deterministic.\n\n"
+                    "We generally recommend altering this or `top_p` but not both",
+                "type": AbstractDataProviderTypeMap."*float",
+            },
+            "top_p": {
+                "display_name": "Top P",
+                "short_desc": "Top p nucleus sampling value",
+                "desc": "An alternative to sampling with temperature, called nucleus sampling, where the "
+                    "model considers the results of the tokens with `top_p` probability mass. So `0.1` "
+                    "means only the tokens comprising the top 10% probability mass are considered.\n\n"
+                    "We generally recommend altering this or `temperature` but not both",
+                "type": AbstractDataProviderTypeMap."*float",
+            },
+            "tools": {
+                "display_name": "Tools",
+                "short_desc": "A list of tools the model may call",
+                "desc": "A list of tools the model may call. Currently, only functions are supported as a "
+                    "tool. Use this to provide a list of functions the model may generate JSON inputs for",
+                "type": new ListDataType("*SgLangToolList", SgLangToolDataType, True),
+            },
+            "tool_choice": {
+                "display_name": "Tool Choice",
+                "short_desc": "Controls which tool is called by the model",
+                "desc": "Controls which (if any) tool is called by the model.\n\n"
+                    "- `none`: the model will not call any tool and instead generates a message\n"
+                    "- `auto`: the model can pick between generating a message or calling one or more tools\n"
+                    "- `required`: the model must call one or more tools",
+                "type": AbstractDataProviderTypeMap."any",
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "display_name": "None",
+                        "short_desc": "The model will not call any tool",
+                        "desc": "The model will not call any tool and instead generates a message",
+                        "value": "none",
+                    },
+                    <AllowedValueInfo>{
+                        "display_name": "Auto",
+                        "short_desc": "The model can pick between generating a message or calling tools",
+                        "desc": "The model can pick between generating a message or calling one or more tools",
+                        "value": "auto",
+                    },
+                    <AllowedValueInfo>{
+                        "display_name": "Required",
+                        "short_desc": "The model must call one or more tools",
+                        "desc": "The model must call one or more tools",
+                        "value": "required",
+                    },
+                ),
+            },
+            "user": {
+                "display_name": "User",
+                "short_desc": "A unique identifier representing your end-user",
+                "desc": "A unique identifier representing your end-user",
+                "type": AbstractDataProviderTypeMap."*string",
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangChatCompletionRequest") {
+        addQoreFields(Fields);
+    }
+}
+
+#! The chat completion request type constant
+public const SgLangChatCompletionRequestType = new SgLangChatCompletionRequestType();
+
+#! Chat completion response choice type
+public class SgLangChoiceDataType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "index": {
+                "display_name": "Index",
+                "short_desc": "The index of the chat completion choice",
+                "desc": "The index of the chat completion choice",
+                "type": AbstractDataProviderTypeMap."int",
+            },
+            "message": {
+                "display_name": "Message",
+                "short_desc": "Information comprising a message",
+                "desc": "Information comprising a message",
+                "type": SgLangCompletionMessageDataType,
+            },
+            "logprobs": {
+                "display_name": "Log Probability",
+                "short_desc": "Log probability information for the message",
+                "desc": "Log probability information for the message",
+                "type": AbstractDataProviderTypeMap."*hash",
+            },
+            "finish_reason": {
+                "display_name": "Finish Reason",
+                "short_desc": "The reason the model stopped generating tokens",
+                "desc": "The reason the model stopped generating tokens",
+                "type": AbstractDataProviderTypeMap."string",
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "display_name": "Stop",
+                        "short_desc": "Natural stop point or provided stop sequence",
+                        "desc": "The model hit a natural stop point or a provided stop sequence",
+                        "value": "stop",
+                    },
+                    <AllowedValueInfo>{
+                        "display_name": "Length",
+                        "short_desc": "Maximum number of tokens reached",
+                        "desc": "The maximum number of tokens was reached",
+                        "value": "length",
+                    },
+                    <AllowedValueInfo>{
+                        "display_name": "Tool Calls",
+                        "short_desc": "The model called a tool",
+                        "desc": "The model called a tool",
+                        "value": "tool_calls",
+                    },
+                ),
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangChoice") {
+        addQoreFields(Fields);
+    }
+}
+
+#! Constant for the chat completion response choice type
+public const SgLangChoiceDataType = new SgLangChoiceDataType();
+
+#! The chat completion usage type
+public class SgLangChatCompletionUsageDataType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "prompt_tokens": {
+                "display_name": "Prompt Tokens",
+                "short_desc": "Number of tokens in the prompt",
+                "desc": "Number of tokens in the prompt",
+                "type": AbstractDataProviderTypeMap."int",
+            },
+            "completion_tokens": {
+                "display_name": "Completion Tokens",
+                "short_desc": "Number of tokens in the generated completion",
+                "desc": "Number of tokens in the generated completion",
+                "type": AbstractDataProviderTypeMap."int",
+            },
+            "total_tokens": {
+                "display_name": "Total Tokens",
+                "short_desc": "Total number of tokens used in the request",
+                "desc": "Total number of tokens used in the request (prompt + completion)",
+                "type": AbstractDataProviderTypeMap."int",
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangChatCompletionUsage") {
+        addQoreFields(Fields);
+    }
+}
+
+#! Constant for the chat completion usage type
+public const SgLangChatCompletionUsageDataType = new SgLangChatCompletionUsageDataType();
+
+#! The chat completion response type
+public class SgLangChatCompletionResponseType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "id": {
+                "display_name": "ID",
+                "short_desc": "The ID of the response",
+                "desc": "The ID of the response",
+                "type": AbstractDataProviderTypeMap."string",
+            },
+            "object": {
+                "display_name": "Object",
+                "short_desc": "The type of response",
+                "desc": "The type of response",
+                "type": AbstractDataProviderTypeMap."string",
+            },
+            "created": {
+                "display_name": "Creation Timestamp",
+                "short_desc": "The date and time the response was created",
+                "desc": "The date and time the response was created",
+                "type": AbstractDataProviderTypeMap."date",
+            },
+            "model": {
+                "display_name": "Model ID",
+                "short_desc": "Model used to create the response",
+                "desc": "Model used to create the response",
+                "type": AbstractDataProviderTypeMap."string",
+            },
+            "choices": {
+                "display_name": "Choices",
+                "short_desc": "A list of chat completion choices",
+                "desc": "A list of chat completion choices",
+                "type": new ListDataType("SgLangChoicesList", SgLangChoiceDataType),
+            },
+            "usage": {
+                "display_name": "Usage",
+                "short_desc": "Usage statistics for the completion request",
+                "desc": "Usage statistics for the completion request",
+                "type": SgLangChatCompletionUsageDataType,
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangChatCompletionResponse") {
+        addQoreFields(Fields);
+    }
+}
+
+#! The chat completion response type constant
+public const SgLangChatCompletionResponseType = new SgLangChatCompletionResponseType();
+}

--- a/qlib/SgLangDataProvider/SgLangCompletionsDataProvider.qc
+++ b/qlib/SgLangDataProvider/SgLangCompletionsDataProvider.qc
@@ -1,0 +1,277 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore SgLangDataProvider module definition
+
+/** SgLangCompletionsDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! contains all public definitions in the SgLangDataProvider module
+public namespace SgLangDataProvider {
+#! The SGLang text completions data provider
+public class SgLangCompletionsDataProvider inherits SgLangDataProviderCommon {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "completions",
+            "type": "SgLangCompletionsDataProvider",
+            "constructor_options": ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = SgLangCompletionsRequestType;
+
+        #! Response type
+        const ResponseType = SgLangCompletionsResponseType;
+    }
+
+    #! Creates the object from the arguments
+    constructor(*RestClientIo::RestClientIo rest) : SgLangDataProviderCommon(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Makes a request and returns the response
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return doRestCommand("POST", "completions", injectModel(req)).body;
+    }
+
+    #! Returns the description of a successful request message, if any
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    private hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Text completion choice type
+public class SgLangCompletionChoiceDataType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "text": {
+                "display_name": "Text",
+                "short_desc": "The generated text",
+                "desc": "The generated text completion",
+                "type": AbstractDataProviderTypeMap."string",
+            },
+            "index": {
+                "display_name": "Index",
+                "short_desc": "The index of the completion choice",
+                "desc": "The index of the completion choice",
+                "type": AbstractDataProviderTypeMap."int",
+            },
+            "logprobs": {
+                "display_name": "Log Probability",
+                "short_desc": "Log probability information",
+                "desc": "Log probability information for the completion",
+                "type": AbstractDataProviderTypeMap."*hash",
+            },
+            "finish_reason": {
+                "display_name": "Finish Reason",
+                "short_desc": "The reason the model stopped generating tokens",
+                "desc": "The reason the model stopped generating tokens",
+                "type": AbstractDataProviderTypeMap."string",
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "display_name": "Stop",
+                        "short_desc": "Natural stop point or provided stop sequence",
+                        "desc": "The model hit a natural stop point or a provided stop sequence",
+                        "value": "stop",
+                    },
+                    <AllowedValueInfo>{
+                        "display_name": "Length",
+                        "short_desc": "Maximum number of tokens reached",
+                        "desc": "The maximum number of tokens was reached",
+                        "value": "length",
+                    },
+                ),
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangCompletionChoice") {
+        addQoreFields(Fields);
+    }
+}
+
+#! Constant for the text completion choice type
+public const SgLangCompletionChoiceDataType = new SgLangCompletionChoiceDataType();
+
+#! The text completions request type
+public class SgLangCompletionsRequestType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "prompt": {
+                "display_name": "Prompt",
+                "short_desc": "The prompt to generate completions for",
+                "desc": "The prompt to generate completions for. Can be a string or a list of strings",
+                "type": AbstractDataProviderTypeMap."any",
+                "example_value": "The meaning of life is",
+            },
+            "model": {
+                "display_name": "Model ID",
+                "short_desc": "Model to use for the completion",
+                "desc": "Model to use for the completion. If not provided, the connection's configured "
+                    "model will be used",
+                "type": AbstractDataProviderTypeMap."*string",
+                "attr": {
+                    "ref_data": "models",
+                },
+            },
+            "max_tokens": {
+                "display_name": "Max Tokens",
+                "short_desc": "The maximum number of tokens to generate",
+                "desc": "The maximum number of tokens to generate in the completion",
+                "type": AbstractDataProviderTypeMap."*int",
+            },
+            "temperature": {
+                "display_name": "Temperature",
+                "short_desc": "Sampling temperature between 0 and 2",
+                "desc": "What sampling temperature to use, between `0` and `2`",
+                "type": AbstractDataProviderTypeMap."*float",
+            },
+            "top_p": {
+                "display_name": "Top P",
+                "short_desc": "Top p nucleus sampling value",
+                "desc": "An alternative to sampling with temperature, called nucleus sampling",
+                "type": AbstractDataProviderTypeMap."*float",
+            },
+            "n": {
+                "display_name": "Number of Completions",
+                "short_desc": "How many completions to generate",
+                "desc": "How many completions to generate for the prompt",
+                "type": AbstractDataProviderTypeMap."*int",
+            },
+            "stop": {
+                "display_name": "Stop Sequences",
+                "short_desc": "Sequences where the API will stop generating",
+                "desc": "Up to 4 sequences where the API will stop generating further tokens",
+                "type": AbstractDataProviderTypeMap."any",
+            },
+            "echo": {
+                "display_name": "Echo?",
+                "short_desc": "Echo back the prompt in addition to the completion",
+                "desc": "If `True`, echo back the prompt in addition to the completion",
+                "type": AbstractDataProviderTypeMap."*bool",
+            },
+            "suffix": {
+                "display_name": "Suffix",
+                "short_desc": "The suffix that comes after a completion of inserted text",
+                "desc": "The suffix that comes after a completion of inserted text",
+                "type": AbstractDataProviderTypeMap."*string",
+            },
+            "frequency_penalty": {
+                "display_name": "Frequency Penalty",
+                "short_desc": "Penalty for repeated tokens",
+                "desc": "Number between `-2.0` and `2.0`. Positive values penalize new tokens based on "
+                    "their existing frequency",
+                "type": AbstractDataProviderTypeMap."*float",
+            },
+            "presence_penalty": {
+                "display_name": "Presence Penalty",
+                "short_desc": "Penalty to encourage new topics",
+                "desc": "Number between `-2.0` and `2.0`. Positive values penalize new tokens based on "
+                    "whether they appear in the text so far",
+                "type": AbstractDataProviderTypeMap."*float",
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangCompletionsRequest") {
+        addQoreFields(Fields);
+    }
+}
+
+#! The text completions request type constant
+public const SgLangCompletionsRequestType = new SgLangCompletionsRequestType();
+
+#! The text completions response type
+public class SgLangCompletionsResponseType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "id": {
+                "display_name": "ID",
+                "short_desc": "The ID of the response",
+                "desc": "The ID of the response",
+                "type": AbstractDataProviderTypeMap."string",
+            },
+            "object": {
+                "display_name": "Object",
+                "short_desc": "The type of response",
+                "desc": "The type of response",
+                "type": AbstractDataProviderTypeMap."string",
+            },
+            "created": {
+                "display_name": "Creation Timestamp",
+                "short_desc": "The date and time the response was created",
+                "desc": "The date and time the response was created",
+                "type": AbstractDataProviderTypeMap."date",
+            },
+            "model": {
+                "display_name": "Model ID",
+                "short_desc": "Model used to create the completion",
+                "desc": "Model used to create the completion",
+                "type": AbstractDataProviderTypeMap."string",
+            },
+            "choices": {
+                "display_name": "Choices",
+                "short_desc": "A list of completion choices",
+                "desc": "A list of completion choices",
+                "type": new ListDataType("SgLangCompletionChoicesList", SgLangCompletionChoiceDataType),
+            },
+            "usage": {
+                "display_name": "Usage",
+                "short_desc": "Usage statistics for the completion request",
+                "desc": "Usage statistics for the completion request",
+                "type": SgLangChatCompletionUsageDataType,
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangCompletionsResponse") {
+        addQoreFields(Fields);
+    }
+}
+
+#! The text completions response type constant
+public const SgLangCompletionsResponseType = new SgLangCompletionsResponseType();
+}

--- a/qlib/SgLangDataProvider/SgLangDataProvider.qc
+++ b/qlib/SgLangDataProvider/SgLangDataProvider.qc
@@ -1,0 +1,99 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore SgLangDataProvider module definition
+
+/** SgLangDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! contains all public definitions in the SgLangDataProvider module
+public namespace SgLangDataProvider {
+#! The SGLang data provider class
+public class SgLangDataProvider inherits SgLangDataProviderCommon {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "sglang",
+            "type": "SgLangDataProvider",
+            "supports_children": True,
+            "constructor_options": ConstructorOptions,
+            "children_can_support_apis": True,
+        };
+    }
+
+    private {
+        #! Dynamic child data providers
+        static hash<string, Reflection::Class> childMap = DefaultChildMap;
+
+        #! Child data providers
+        const DefaultChildMap = {
+            "completions": Class::forName("SgLangDataProvider::SgLangCompletionsDataProvider"),
+            "generate": Class::forName("SgLangDataProvider::SgLangGenerateDataProvider"),
+            "models": Class::forName("SgLangDataProvider::SgLangModelsDataProvider"),
+            "multi-chat": Class::forName("SgLangDataProvider::SgLangChatCompletionDataProvider"),
+            "simple-chat": Class::forName("SgLangDataProvider::SgLangSimpleChatCompletionDataProvider"),
+        };
+    }
+
+    #! Creates the object from the arguments
+    constructor(*RestClientIo::RestClientIo rest) : SgLangDataProviderCommon(rest) {
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) : SgLangDataProviderCommon(options) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Register a new child data provider
+    static registerChild(string pathname, Reflection::Class cls) {
+        if (childMap{pathname}) {
+            throw "SGLANG-CHILD-ERROR", sprintf("child %y already registered", pathname);
+        }
+        childMap{pathname} = cls;
+    }
+
+    #! Return data provider summary info
+    *list<hash<DataProviderSummaryInfo>> getChildProviderSummaryInfo() {
+        return map $1.getConstant("ProviderSummaryInfo").getValue(), childMap.iterator();
+    }
+
+    #! Returns a list of child data provider names, if any
+    private *list<string> getChildProviderNamesImpl() {
+        return keys childMap;
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    private *AbstractDataProvider getChildProviderImpl(string name) {
+        *Class cls = childMap{name};
+        if (!cls) {
+            return;
+        }
+        return cls.newObject(rest);
+    }
+
+    #! Returns data provider static info
+    private hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/SgLangDataProvider/SgLangDataProvider.qm
+++ b/qlib/SgLangDataProvider/SgLangDataProvider.qm
@@ -1,0 +1,228 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore SgLangDataProvider module definition
+
+/*  SgLangDataProvider.qm Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+# minimum required Qore version
+%requires qore >= 2.0
+# assume local scope for variables, do not use "$" signs
+%modern
+
+%requires(reexport) DataProvider
+%requires(reexport) SgLangRestClient
+%requires RestClientIo
+
+module SgLangDataProvider {
+    version = "1.0";
+    desc = "user module providing a data provider API for SGLang LLM services";
+    author = "David Nichols <david@qore.org>";
+    url = "http://qore.org";
+    license = "MIT";
+    init = sub () {
+        # register the data provider factory
+        DataProvider::registerFactory(new SgLangDataProviderFactory());
+
+        # register the data provider application
+        DataProviderActionCatalog::registerApp(<DataProviderAppInfo>{
+            "name": SgLangDataProvider::AppName,
+            "display_name": "SGLang",
+            "short_desc": "SGLang LLM inference server",
+            "desc": "Integration with [SGLang](https://github.com/sgl-project/sglang), a self-hosted "
+                "OpenAI-compatible LLM inference server.\n\n"
+                "Supported operations:\n"
+                "- **Chat completions**: multi-message and single-message chat\n"
+                "- **Text completions**: text completion generation\n"
+                "- **Native generate**: SGLang-native generation endpoint\n"
+                "- **Models**: list available models",
+            "scheme": "sglang",
+            "logo": SgLangLogo,
+            "logo_file_name": "sglang-logo.svg",
+            "logo_mime_type": MimeTypeSvg,
+            "groups": (DataProvider::AppGroup::AiLlm,),
+        });
+
+        # register all supported actions
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": SgLangDataProvider::AppName,
+            "path": "/multi-chat",
+            "action": "multi-chat",
+            "display_name": "Multi Chat",
+            "short_desc": "Chat with a model by sending multiple messages",
+            "desc": "Chat with an LLM model by sending multiple messages at once and potentially "
+                "getting multiple replies",
+            "action_code": DPAT_API,
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                SgLangChatCompletionRequestType::Fields{"messages",}, {
+                    "preselected": True,
+                    "required": True,
+                }
+            ) + DataProviderActionCatalog::getActionOptionFromFields(
+                SgLangChatCompletionRequestType::Fields{"model",}, {
+                    "preselected": True,
+                }
+            ) + DataProviderActionCatalog::getActionOptionFromFields(
+                SgLangChatCompletionRequestType::Fields - ("model", "messages")
+            ),
+            "output_type": SgLangChatCompletionDataProvider::ResponseType,
+        });
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": SgLangDataProvider::AppName,
+            "path": "/simple-chat",
+            "action": "simple-chat",
+            "display_name": "Simple Chat",
+            "short_desc": "Chat with a model by sending a single message",
+            "desc": "Chat with an LLM model by sending a single message and receiving a single reply",
+            "action_code": DPAT_API,
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                SgLangSimpleChatCompletionRequestType::Fields{"role", "content"}, {
+                    "preselected": True,
+                    "required": True,
+                }
+            ) + DataProviderActionCatalog::getActionOptionFromFields(
+                SgLangSimpleChatCompletionRequestType::Fields{"model",}, {
+                    "preselected": True,
+                }
+            ) + DataProviderActionCatalog::getActionOptionFromFields(
+                SgLangSimpleChatCompletionRequestType::Fields - ("model", "role", "content")
+            ),
+            "output_type": SgLangSimpleChatCompletionDataProvider::ResponseType,
+        });
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": SgLangDataProvider::AppName,
+            "path": "/completions",
+            "action": "completions",
+            "display_name": "Text Completion",
+            "short_desc": "Generate text completions from a prompt",
+            "desc": "Generate text completions from a prompt using the OpenAI-compatible "
+                "completions endpoint",
+            "action_code": DPAT_API,
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                SgLangCompletionsRequestType::Fields{"prompt",}, {
+                    "preselected": True,
+                    "required": True,
+                }
+            ) + DataProviderActionCatalog::getActionOptionFromFields(
+                SgLangCompletionsRequestType::Fields{"model",}, {
+                    "preselected": True,
+                }
+            ) + DataProviderActionCatalog::getActionOptionFromFields(
+                SgLangCompletionsRequestType::Fields - ("model", "prompt")
+            ),
+            "output_type": SgLangCompletionsDataProvider::ResponseType,
+        });
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": SgLangDataProvider::AppName,
+            "path": "/generate",
+            "action": "generate",
+            "display_name": "Native Generate",
+            "short_desc": "Generate text using the native SGLang endpoint",
+            "desc": "Generate text using the native SGLang `/generate` endpoint with full control "
+                "over sampling parameters.\n\n"
+                "**Note**: this endpoint is SGLang-specific and not part of the OpenAI-compatible API",
+            "action_code": DPAT_API,
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                SgLangGenerateRequestType::Fields{"text",}, {
+                    "preselected": True,
+                    "required": True,
+                }
+            ) + DataProviderActionCatalog::getActionOptionFromFields(
+                SgLangGenerateRequestType::Fields - "text"
+            ),
+            "output_type": SgLangGenerateDataProvider::ResponseType,
+        });
+    };
+}
+
+/** @mainpage SgLangDataProvider Module
+
+    @tableofcontents
+
+    @section sglangdataproviderintro Introduction to the SgLangDataProvider Module
+
+    The %SgLangDataProvider module provides a @ref dataproviderintro "data provider" API for
+    SGLang LLM inference services.
+
+    SGLang is a self-hosted OpenAI-compatible LLM inference server that supports both OpenAI-compatible
+    endpoints (\c /v1/chat/completions, \c /v1/completions, \c /v1/models) and native SGLang endpoints
+    (\c /generate).
+
+    @section sglangdataprovider_examples Examples
+
+    @subsection sglangdataprovider_chat Chat Completion
+
+    @code{.py}
+%requires SgLangDataProvider
+
+SgLangRestConnection rc = get_connection("my-sglang-connection");
+SgLangDataProvider::SgLangDataProvider prov(rc.getAsync());
+
+AbstractDataProvider chat = prov.getChildProvider("multi-chat");
+hash<auto> result = chat.doRequest({
+    "messages": (
+        {
+            "role": "user",
+            "content": "What is the capital of France?",
+        },
+    ),
+});
+printf("Response: %s\n", result.choices[0].message.content);
+    @endcode
+
+    @subsection sglangdataprovider_simple_chat Simple Chat
+
+    @code{.py}
+AbstractDataProvider simple = prov.getChildProvider("simple-chat");
+hash<auto> result = simple.doRequest({
+    "role": "user",
+    "content": "Hello!",
+});
+printf("Response: %s\n", result.choice.message.content);
+    @endcode
+
+    @subsection sglangdataprovider_generate Native Generate
+
+    @code{.py}
+AbstractDataProvider gen = prov.getChildProvider("generate");
+hash<auto> result = gen.doRequest({
+    "text": "The meaning of life is",
+    "sampling_params": {
+        "max_new_tokens": 64,
+        "temperature": 0.7,
+    },
+});
+printf("Generated: %s\n", result.text);
+    @endcode
+
+    @section sglangdataprovider_relnotes Release Notes
+
+    @subsection sglangdataprovider_v1_0 SgLangDataProvider v1.0
+    - initial release of the module
+*/
+
+#! contains all public definitions in the SgLangDataProvider module
+public namespace SgLangDataProvider {
+#! SGLang app name
+public const AppName = "SGLang";
+
+#! Logo file
+public const SgLangLogo = File::readTextFile(get_script_dir() + "/sglang-logo.svg");
+}

--- a/qlib/SgLangDataProvider/SgLangDataProviderCommon.qc
+++ b/qlib/SgLangDataProvider/SgLangDataProviderCommon.qc
@@ -1,0 +1,252 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore SgLangDataProvider module definition
+
+/** SgLangDataProviderCommon.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! contains all public definitions in the SgLangDataProvider module
+public namespace SgLangDataProvider {
+#! The SGLang data provider common base class
+/** Uses RestClientIo for async-capable multiplexed HTTP connections.
+*/
+public class SgLangDataProviderCommon inherits DataProvider::AbstractDataProvider {
+    public {
+        #! The default SGLang URL
+        const DefaultSgLangUrl = "http://localhost:30000/";
+
+        #! The default SGLang API version
+        const DefaultSgLangApiVersion = "v1";
+
+        #! Constructor options
+        const ConstructorOptions = {
+            "apikey": <DataProviderOptionInfo>{
+                "display_name": "SGLang API Key",
+                "short_desc": "Optional API key for authentication",
+                "type": AbstractDataProviderTypeMap."*string",
+                "desc": "An optional API key for authentication with the SGLang server; sent as the "
+                    "`Authorization: Bearer` header.\n\n"
+                    "Most SGLang deployments do not require authentication",
+            },
+            "model": <DataProviderOptionInfo>{
+                "display_name": "Model",
+                "short_desc": "The model served by the SGLang instance",
+                "type": AbstractDataProviderTypeMap."string",
+                "desc": "The model name served by this SGLang instance "
+                    "(e.g., `meta-llama/Meta-Llama-3.1-8B-Instruct`). This value is auto-injected "
+                    "into API requests when not explicitly specified in the request body",
+            },
+            "restclient": <DataProviderOptionInfo>{
+                "display_name": "REST Client",
+                "short_desc": "The REST client object to use",
+                "type": AbstractDataProviderType::get(
+                    new Type("RestClientIo::RestClientIo"), NOTHING, {
+                        DTT_ClientOnly: True,
+                    }),
+                "desc": "The REST client object to use",
+            },
+            "restclient_options": <DataProviderOptionInfo>{
+                "display_name": "REST Client Options",
+                "short_desc": "The options to use when creating a REST client",
+                "type": AbstractDataProviderType::get(AutoHashType, NOTHING, {
+                    DTT_ClientOnly: True,
+                }),
+                "desc": "Options to the RestClientIo constructor; only used if a RestClientIo object is "
+                    "created for a call",
+            },
+            "api": <DataProviderOptionInfo>{
+                "display_name": "API Version",
+                "short_desc": "The API version to use",
+                "type": AbstractDataProviderTypeMap."string",
+                "desc": "The API version to use",
+                "default_value": DefaultSgLangApiVersion,
+            },
+        };
+
+        #! IO errors for REST retries
+        const RetrySet = {
+            "SOCKET-CLOSED": True,
+        };
+
+        #! Max retries
+        const MaxIoRetries = 5;
+    }
+
+    private {
+        #! The REST client object for API calls (async-capable)
+        *RestClientIo::RestClientIo rest;
+
+        #! The model configured for this connection
+        *string model;
+    }
+
+    #! Creates the object from a RestClientIo client
+    constructor(RestClientIo::RestClientIo rest) {
+        self.rest = rest;
+        # extract model from rest client if it supports getModel()
+        if (rest.hasCallableMethod("getModel")) {
+            model = call_object_method(rest, "getModel");
+        }
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        *hash<auto> copts = checkOptions("CONSTRUCTOR-ERROR", ConstructorOptions, options);
+        if (copts.restclient) {
+            rest = copts.restclient;
+            if (rest.hasCallableMethod("getModel")) {
+                model = call_object_method(rest, "getModel");
+            }
+        }
+        if (copts.model) {
+            model = copts.model;
+        }
+
+        if (!rest) {
+            hash<auto> opts;
+            opts += copts.restclient_options + {
+                "api": copts.api,
+                "model": copts.model,
+            };
+            if (copts.apikey) {
+                opts.apikey = copts.apikey;
+            }
+            rest = new SgLangRestClient::SgLangRestClientIo(opts);
+        }
+    }
+
+    #! Returns the model configured for this provider
+    *string getModel() {
+        return model;
+    }
+
+    #! Returns the REST client object
+    *RestClientIo::RestClientIo getRestClient() {
+        return rest;
+    }
+
+    #! Injects model into request body if not already present
+    hash<auto> injectModel(hash<auto> req) {
+        if (!req.model && model) {
+            req.model = model;
+        }
+        return req;
+    }
+
+    #! Accepts a LoggerInterface object for logging (or clears it)
+    setLogger(*LoggerInterface logger) {
+        LoggerWrapper::setLogger(logger);
+    }
+
+    #! Returns information on supported reference data
+    /** @return a hash of supported reference data; keys in the hash returned are supported in calls to
+        \c getReferenceData()
+
+        @since DataProvider 3.0
+    */
+    *hash<string, bool> getSupportedReferenceData() {
+        return {
+            "models": True,
+        };
+    }
+
+    #! Returns reference data of the given kind if available
+    /** @param type the unique type name of the reference data
+        @param action_opts an optional hash of action options when called when working with an app action
+
+        @return a list of allowed values for this data
+
+        @since DataProvider 3.0
+    */
+    private *list<hash<AllowedValueInfo>> getReferenceDataImpl(string type, *hash<auto> action_opts) {
+        switch (type) {
+            case "models": return getReferenceModels();
+        }
+    }
+
+    #! Returns available models
+    private *list<hash<AllowedValueInfo>> getReferenceModels() {
+        list<hash<AllowedValueInfo>> rv;
+        try {
+            foreach hash<auto> mdl in (doRestCommand("GET", "models").body."data") {
+                string desc = mdl.id;
+                rv += <AllowedValueInfo>{
+                    "display_name": mdl.id,
+                    "short_desc": desc,
+                    "desc": desc,
+                    "value": mdl.id,
+                };
+            }
+        } catch (hash<ExceptionInfo> ex) {
+            log(LoggerLevel::ERROR, "getReferenceModels: %s: %s", ex.err, ex.desc);
+        }
+        return rv;
+    }
+
+    #! Makes a REST call and returns the response; handles I/O errors with retries
+    private hash<auto> doRestCommand(string method, string path, auto body, *hash<auto> hdr) {
+        int retries = 0;
+        while (True) {
+            try {
+                debug("REST %y %y body: %y", method, path, body);
+                switch (method.upr()) {
+                    case "GET":
+                        return rest.restGet(path, hdr);
+                    case "POST":
+                        return rest.restPost(path, body, hdr);
+                    case "PUT":
+                        return rest.restPut(path, body, hdr);
+                    case "DELETE":
+                        return rest.restDel(path, body, hdr);
+                    default:
+                        return rest.restDoRequest(method, path, body, hdr);
+                }
+            } catch (hash<ExceptionInfo> ex) {
+                if (retry(ex, \retries)) {
+                    continue;
+                }
+                rethrow ex.err, sprintf("%s (request path: %y)", ex.desc,
+                    ex.arg.request_path ?? path), ex.arg;
+            }
+        }
+    }
+
+    #! Makes a REST call to a native SGLang endpoint (not under /v1/)
+    /** Native SGLang endpoints like \c /generate and \c /get_model_info are not under the
+        \c /v1/ API prefix. This method bypasses the connection path to reach them.
+    */
+    private hash<auto> doNativeRestCommand(string method, string path, auto body, *hash<auto> hdr) {
+        return doRestCommand(method, "../" + path, body, hdr);
+    }
+
+    #! Returns True if the error indicates that the operation should be retried
+    private bool retry(hash<ExceptionInfo> ex, reference<int> retries) {
+        if (RetrySet{ex.err}) {
+            if (++retries == MaxIoRetries) {
+                error("Maximum retries exceeded (%d)", retries);
+                return False;
+            }
+            warn("Technical error making REST call: %s: %s; retrying", ex.err, ex.desc);
+            return True;
+        }
+        return False;
+    }
+}
+}

--- a/qlib/SgLangDataProvider/SgLangDataProviderFactory.qc
+++ b/qlib/SgLangDataProvider/SgLangDataProviderFactory.qc
@@ -1,0 +1,56 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore SgLangDataProviderFactory class definition
+
+/** SgLangDataProviderFactory.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the SgLangDataProvider module
+public namespace SgLangDataProvider {
+#! The SGLang data provider factory
+public class SgLangDataProviderFactory inherits AbstractDataProviderFactory {
+    private {
+        #! Data provider type info
+        static Class cls = new Class("SgLangDataProvider");
+
+        #! Factory info
+        const FactoryInfo = <DataProviderFactoryInfo>{
+            "name": "sglang",
+            "desc": "SGLang LLM API data provider factory",
+            "children_can_support_apis": True,
+        };
+    }
+
+    #! Returns static factory information without \a provider_info
+    private hash<DataProviderFactoryInfo> getInfoImpl() {
+        return FactoryInfo;
+    }
+
+    #! Returns static provider information
+    private hash<DataProviderInfo> getProviderInfoImpl() {
+        return SgLangDataProvider::ProviderInfo;
+    }
+
+    #! Returns the class for the data provider object
+    private Class getClassImpl() {
+        return cls;
+    }
+}
+}

--- a/qlib/SgLangDataProvider/SgLangGenerateDataProvider.qc
+++ b/qlib/SgLangDataProvider/SgLangGenerateDataProvider.qc
@@ -1,0 +1,283 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore SgLangDataProvider module definition
+
+/** SgLangGenerateDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! contains all public definitions in the SgLangDataProvider module
+public namespace SgLangDataProvider {
+#! The SGLang native generate data provider
+/** This provider uses the native SGLang \c /generate endpoint which is
+    not under the \c /v1/ OpenAI-compatible API prefix.
+*/
+public class SgLangGenerateDataProvider inherits SgLangDataProviderCommon {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "generate",
+            "type": "SgLangGenerateDataProvider",
+            "constructor_options": ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = SgLangGenerateRequestType;
+
+        #! Response type
+        const ResponseType = SgLangGenerateResponseType;
+    }
+
+    #! Creates the object from the arguments
+    constructor(*RestClientIo::RestClientIo rest) : SgLangDataProviderCommon(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Makes a request and returns the response
+    /** Uses the native SGLang \c /generate endpoint (not under \c /v1/).
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return doNativeRestCommand("POST", "generate", req).body;
+    }
+
+    #! Returns the description of a successful request message, if any
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    private hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! The sampling parameters data type for the native generate endpoint
+public class SgLangSamplingParamsDataType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "max_new_tokens": {
+                "display_name": "Max New Tokens",
+                "short_desc": "Maximum number of output tokens",
+                "desc": "Maximum number of output tokens to generate (default: `128`)",
+                "type": AbstractDataProviderTypeMap."*int",
+            },
+            "temperature": {
+                "display_name": "Temperature",
+                "short_desc": "Sampling temperature",
+                "desc": "Sampling temperature for randomness in token selection",
+                "type": AbstractDataProviderTypeMap."*float",
+            },
+            "top_p": {
+                "display_name": "Top P",
+                "short_desc": "Nucleus sampling threshold",
+                "desc": "Nucleus sampling threshold. `0.1` means only the tokens comprising the top 10% "
+                    "probability mass are considered",
+                "type": AbstractDataProviderTypeMap."*float",
+            },
+            "top_k": {
+                "display_name": "Top K",
+                "short_desc": "Restrict to top-k tokens",
+                "desc": "Restrict sampling to the top-k tokens",
+                "type": AbstractDataProviderTypeMap."*int",
+            },
+            "min_p": {
+                "display_name": "Min P",
+                "short_desc": "Minimum probability threshold",
+                "desc": "Minimum probability threshold for token selection",
+                "type": AbstractDataProviderTypeMap."*float",
+            },
+            "frequency_penalty": {
+                "display_name": "Frequency Penalty",
+                "short_desc": "Penalize token frequency",
+                "desc": "Penalize tokens based on their frequency in the text so far. Range: `-2.0` to `2.0`",
+                "type": AbstractDataProviderTypeMap."*float",
+            },
+            "presence_penalty": {
+                "display_name": "Presence Penalty",
+                "short_desc": "Penalize previously sampled tokens",
+                "desc": "Penalize tokens that have appeared in the text so far. Range: `-2.0` to `2.0`",
+                "type": AbstractDataProviderTypeMap."*float",
+            },
+            "stop": {
+                "display_name": "Stop Words",
+                "short_desc": "Stop word(s) to end generation",
+                "desc": "Stop word(s) that end generation when encountered",
+                "type": AbstractDataProviderTypeMap."any",
+            },
+            "ignore_eos": {
+                "display_name": "Ignore EOS?",
+                "short_desc": "Continue past end-of-sequence token",
+                "desc": "If `True`, continue generating past the end-of-sequence token",
+                "type": AbstractDataProviderTypeMap."*bool",
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangSamplingParams") {
+        addQoreFields(Fields);
+    }
+}
+
+#! Constant for the sampling parameters data type
+public const SgLangSamplingParamsDataType = new SgLangSamplingParamsDataType();
+
+#! The native generate request type
+public class SgLangGenerateRequestType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "text": {
+                "display_name": "Text",
+                "short_desc": "The prompt text to generate from",
+                "desc": "The prompt text to generate completions from",
+                "type": AbstractDataProviderTypeMap."string",
+                "example_value": "What is the capital of France?",
+            },
+            "sampling_params": {
+                "display_name": "Sampling Parameters",
+                "short_desc": "Parameters controlling the generation",
+                "desc": "Parameters controlling the generation process, including temperature, top_p, "
+                    "max_new_tokens, and other sampling settings",
+                "type": SgLangSamplingParamsDataType.getOrNothingType(),
+            },
+            "return_logprob": {
+                "display_name": "Return Log Probabilities?",
+                "short_desc": "Whether to return log probabilities",
+                "desc": "If `True`, return log probabilities for each generated token",
+                "type": AbstractDataProviderTypeMap."*bool",
+            },
+            "logprob_start_len": {
+                "display_name": "Log Prob Start Length",
+                "short_desc": "Number of prompt tokens to skip for log probs",
+                "desc": "Number of prompt tokens to skip before returning log probabilities",
+                "type": AbstractDataProviderTypeMap."*int",
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangGenerateRequest") {
+        addQoreFields(Fields);
+    }
+}
+
+#! The native generate request type constant
+public const SgLangGenerateRequestType = new SgLangGenerateRequestType();
+
+#! The meta info data type for generate responses
+public class SgLangGenerateMetaInfoDataType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "id": {
+                "display_name": "Request ID",
+                "short_desc": "The request identifier",
+                "desc": "The request identifier",
+                "type": AbstractDataProviderTypeMap."*string",
+            },
+            "finish_reason": {
+                "display_name": "Finish Reason",
+                "short_desc": "The reason generation stopped",
+                "desc": "The reason generation stopped",
+                "type": AbstractDataProviderTypeMap."*string",
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "display_name": "Stop",
+                        "short_desc": "Natural stop point or stop word reached",
+                        "desc": "Generation stopped at a natural stop point or stop word",
+                        "value": "stop",
+                    },
+                    <AllowedValueInfo>{
+                        "display_name": "Length",
+                        "short_desc": "Maximum token limit reached",
+                        "desc": "The maximum number of tokens was reached",
+                        "value": "length",
+                    },
+                ),
+            },
+            "prompt_tokens": {
+                "display_name": "Prompt Tokens",
+                "short_desc": "Number of tokens in the prompt",
+                "desc": "Number of tokens in the prompt",
+                "type": AbstractDataProviderTypeMap."*int",
+            },
+            "completion_tokens": {
+                "display_name": "Completion Tokens",
+                "short_desc": "Number of tokens generated",
+                "desc": "Number of tokens generated in the completion",
+                "type": AbstractDataProviderTypeMap."*int",
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangGenerateMetaInfo") {
+        addQoreFields(Fields);
+    }
+}
+
+#! Constant for the meta info data type
+public const SgLangGenerateMetaInfoDataType = new SgLangGenerateMetaInfoDataType();
+
+#! The native generate response type
+public class SgLangGenerateResponseType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "text": {
+                "display_name": "Text",
+                "short_desc": "The generated text",
+                "desc": "The generated text output",
+                "type": AbstractDataProviderTypeMap."string",
+            },
+            "meta_info": {
+                "display_name": "Meta Info",
+                "short_desc": "Metadata about the generation",
+                "desc": "Metadata about the generation, including token counts and finish reason",
+                "type": SgLangGenerateMetaInfoDataType,
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangGenerateResponse") {
+        addQoreFields(Fields);
+    }
+}
+
+#! The native generate response type constant
+public const SgLangGenerateResponseType = new SgLangGenerateResponseType();
+}

--- a/qlib/SgLangDataProvider/SgLangModelsDataProvider.qc
+++ b/qlib/SgLangDataProvider/SgLangModelsDataProvider.qc
@@ -1,0 +1,146 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore SgLangDataProvider module definition
+
+/** SgLangModelsDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! contains all public definitions in the SgLangDataProvider module
+public namespace SgLangDataProvider {
+#! The SGLang models data provider
+public class SgLangModelsDataProvider inherits SgLangDataProviderCommon {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "models",
+            "type": "SgLangModelsDataProvider",
+            "constructor_options": ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Response type
+        const ResponseType = SgLangModelsResponseType;
+    }
+
+    #! Creates the object from the arguments
+    constructor(*RestClientIo::RestClientIo rest) : SgLangDataProviderCommon(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Makes a request and returns the response
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        return doRestCommand("GET", "models").body;
+    }
+
+    #! Returns the description of a successful request message, if any
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    private hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! The model data type
+public class SgLangModelDataType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "id": {
+                "display_name": "Model ID",
+                "short_desc": "The model identifier",
+                "desc": "The model identifier",
+                "type": AbstractDataProviderTypeMap."string",
+            },
+            "object": {
+                "display_name": "Object",
+                "short_desc": "The object type",
+                "desc": "The object type, always `model`",
+                "type": AbstractDataProviderTypeMap."string",
+            },
+            "created": {
+                "display_name": "Created",
+                "short_desc": "The creation timestamp",
+                "desc": "The Unix timestamp when the model was created",
+                "type": AbstractDataProviderTypeMap."*int",
+            },
+            "owned_by": {
+                "display_name": "Owned By",
+                "short_desc": "The model owner",
+                "desc": "The organization or entity that owns the model",
+                "type": AbstractDataProviderTypeMap."*string",
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangModel") {
+        addQoreFields(Fields);
+    }
+}
+
+#! Constant for the model data type
+public const SgLangModelDataType = new SgLangModelDataType();
+
+#! The models list response type
+public class SgLangModelsResponseType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "object": {
+                "display_name": "Object",
+                "short_desc": "The object type",
+                "desc": "The object type, always `list`",
+                "type": AbstractDataProviderTypeMap."string",
+            },
+            "data": {
+                "display_name": "Models",
+                "short_desc": "List of available models",
+                "desc": "List of available models on the SGLang server",
+                "type": new ListDataType("SgLangModelsList", SgLangModelDataType),
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangModelsResponse") {
+        addQoreFields(Fields);
+    }
+}
+
+#! The models response type constant
+public const SgLangModelsResponseType = new SgLangModelsResponseType();
+}

--- a/qlib/SgLangDataProvider/SgLangSimpleChatCompletionDataProvider.qc
+++ b/qlib/SgLangDataProvider/SgLangSimpleChatCompletionDataProvider.qc
@@ -1,0 +1,131 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore SgLangDataProvider module definition
+
+/** SgLangSimpleChatCompletionDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! contains all public definitions in the SgLangDataProvider module
+public namespace SgLangDataProvider {
+#! The SGLang simple chat completion data provider
+public class SgLangSimpleChatCompletionDataProvider inherits SgLangDataProviderCommon {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "simple-chat",
+            "type": "SgLangSimpleChatCompletionDataProvider",
+            "constructor_options": ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = SgLangSimpleChatCompletionRequestType;
+
+        #! Response type
+        const ResponseType = SgLangSimpleChatCompletionResponseType;
+    }
+
+    #! Creates the object from the arguments
+    constructor(*RestClientIo::RestClientIo rest) : SgLangDataProviderCommon(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        req.messages = ({
+            "role": remove req.role,
+            "content": remove req.content,
+            "name": remove req.name,
+        },);
+        hash<auto> rv = doRestCommand("POST", "chat/completions", injectModel(req)).body;
+        rv.choice = remove rv.choices[0];
+        return rv;
+    }
+
+    #! Returns the description of a successful request message, if any
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    private hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! The simple chat completion request type
+public class SgLangSimpleChatCompletionRequestType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = SgLangMessageDataType::Fields{"role", "content", "name"} +
+            SgLangChatCompletionRequestType::Fields - ("messages", "n");
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangSimpleChatCompletionRequest") {
+        addQoreFields(Fields);
+    }
+}
+
+#! The simple chat completion request type constant
+public const SgLangSimpleChatCompletionRequestType = new SgLangSimpleChatCompletionRequestType();
+
+#! The simple chat completion response type
+public class SgLangSimpleChatCompletionResponseType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = SgLangChatCompletionResponseType::Fields - "choices" + {
+            "choice": {
+                "display_name": "Choice",
+                "short_desc": "The single chat completion choice returned by the server",
+                "desc": "The single chat completion choice returned by the server",
+                "type": SgLangChoiceDataType,
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("SgLangSimpleChatCompletionResponse") {
+        addQoreFields(Fields);
+    }
+}
+
+#! The simple chat completion response type constant
+public const SgLangSimpleChatCompletionResponseType = new SgLangSimpleChatCompletionResponseType();
+}

--- a/qlib/SgLangDataProvider/sglang-logo.svg
+++ b/qlib/SgLangDataProvider/sglang-logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <rect width="100" height="100" rx="16" fill="#1a1a2e"/>
+  <text x="50" y="42" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" font-size="16" fill="#e94560">SG</text>
+  <text x="50" y="68" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" font-size="14" fill="#0f3460">Lang</text>
+</svg>

--- a/qlib/SgLangRestClient.qm
+++ b/qlib/SgLangRestClient.qm
@@ -1,0 +1,689 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! @file SgLangRestClient.qm Qore user module for calling SGLang REST services
+
+/*  SgLangRestClient.qm Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+# minimum qore version
+%requires qore >= 2.0
+
+# don't use "$" for vars, members, and methods, assume local variable scope
+%modern
+
+%requires(reexport) Mime >= 1.3
+%requires(reexport) RestClient >= 1.3.1
+%requires(reexport) RestClientIo
+%requires(reexport) ConnectionProvider >= 1.4
+%requires HttpClientStreamingIo
+
+module SgLangRestClient {
+    version = "1.0";
+    desc = "user module for calling SGLang REST API services";
+    author = "David Nichols <david@qore.org>";
+    url = "https://qore.org";
+    license = "MIT";
+    init = sub () {
+        ConnectionSchemeCache::registerScheme("sglang", SgLangRestConnection::ConnectionScheme);
+    };
+}
+
+/** @mainpage SgLangRestClient Module
+
+    @tableofcontents
+
+    @section sglangrestclientintro SgLangRestClient Introduction
+
+    The %SgLangRestClient module provides an API for calling SGLang REST API services.
+
+    SGLang is a self-hosted OpenAI-compatible LLM inference server. This module provides
+    REST client and connection classes for communicating with SGLang instances.
+
+    To use this module, use \c "%requires SgLangRestClient" in your code.
+
+    All the public symbols in the module are defined in the SgLangRestClient namespace.
+
+    The main classes are:
+    - @ref SgLangRestClient::SgLangRestClient "SgLangRestClient":
+      this class provides the REST client API for communication with the SGLang REST
+      API; it also automates authentication and authorization to the target
+    - @ref SgLangRestClient::SgLangRestConnection "SgLangRestConnection":
+      provides a REST connection object to SGLang services (based on the
+      @ref connectionproviderintro "ConnectionProvider" module)
+
+    @par Example:
+    @code{.py}
+#!/usr/bin/env qore
+
+%modern
+
+%requires SgLangRestClient
+%requires ConnectionProvider
+
+SgLangRestClient rest({"url": "http://localhost:30000", "model": "meta-llama/Meta-Llama-3.1-8B-Instruct"});
+hash<auto> ans = rest.get("/models");
+printf("%Y\n", ans.body);
+    @endcode
+
+    @par Streaming Example:
+    @code{.py}
+SgLangRestClient rest({"url": "http://localhost:30000", "model": "meta-llama/Meta-Llama-3.1-8B-Instruct"});
+SgLangSseStream stream = rest.openChatCompletionStream({
+    "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+    "stream": True,
+    "messages": (
+        {
+            "role": "user",
+            "content": "Hello!",
+        },
+    ),
+});
+while (hash<SseMessageInfo> evt = stream.readEvent(5s)) {
+    if (evt.data == "[DONE]") {
+        break;
+    }
+    printf("%s\n", evt.data);
+}
+stream.close();
+    @endcode
+
+    @section sglangrestclientrelnotes Release Notes
+
+    @subsection sglangrestclientv1_0 SgLangRestClient v1.0
+    - the initial version of the %SgLangRestClient module
+*/
+
+%try-module json
+%define NoJson
+%endtry
+
+#! the SgLangRestClient namespace contains all the objects in the SgLangRestClient module
+public namespace SgLangRestClient {
+#! Common base class for SgLangRestClient functionality (statics and constants only)
+public class SgLangRestClientBase {
+    public {
+        #! Default SGLang REST API URL
+        const DefaultUrl = "http://localhost:30000";
+
+        #! Default SGLang API version
+        const DefaultApiVersion = "v1";
+
+        #! Default constructor options
+        const DefaultOptions = {
+            "url": DefaultUrl,
+            "api": DefaultApiVersion,
+            "data": "json",
+        };
+
+        #! Default ping method
+        const DefaultPingMethod = "GET";
+
+        #! Default ping path (no leading slash - relative to base path)
+        const DefaultPingPath = "models";
+
+        #! Default ping headers
+        const DefaultPingHeaders = {
+            "Accept": MimeTypeJson,
+        };
+    }
+
+    #! returns options for the constructor
+    static hash<auto> getOptions(hash<auto> opts) {
+        hash<auto!> rv = {} + DefaultOptions + opts;
+        # set default_path for RestClientIo (uses this instead of setConnectionPath)
+        if (!rv.default_path) {
+            rv.default_path = "/" + (opts.api ?? DefaultApiVersion);
+        }
+        # ensure Accept header is JSON
+        if (!rv.headers."Accept") {
+            rv.headers."Accept" = MimeTypeJson;
+        }
+        # map apikey to Authorization Bearer header (optional for SGLang)
+        if (rv.apikey) {
+            rv.headers."Authorization" = "Bearer " + rv.apikey;
+            remove rv.apikey;
+        }
+        return rv;
+    }
+}
+
+#! this class provides the REST client API for communication with SGLang servers
+/** The \c model option specifies the model served by the SGLang instance.
+    Authentication is optional; if an API key is provided via the \c apikey option,
+    it is sent as the \c Authorization: \c Bearer header.
+*/
+public class SgLangRestClient inherits RestClient::RestClient, SgLangRestClientBase {
+    private {
+        #! The model configured for this connection
+        *string model;
+    }
+
+    #! creates the object with the given options
+    /**
+        @par Example:
+        @code{.py}
+SgLangRestClient rest(opts);
+        @endcode
+
+        @param opts valid options are all the options for the @ref RestClient::RestClient "RestClient" class; note
+        that the URL is set by default if not provided (see @ref DefaultUrl).
+        The \c model option specifies the model served by the SGLang instance.
+        The \c apikey option provides optional authentication.
+        @param do_not_connect if \c False (the default), then a connection is returned already connected to the
+        remote server
+
+        @throw RESTCLIENT-ERROR invalid option passed to constructor, unsupported data serialization, etc
+    */
+    constructor(hash<auto> opts, *softbool do_not_connect)
+            : RestClient(SgLangRestClientBase::getOptions(opts), True) {
+        if (validator instanceof NullRestSchemaValidator) {
+            setConnectionPath(opts.api.val() ? string(opts.api) : DefaultApiVersion);
+        }
+        model = opts.model;
+    }
+
+    #! Returns the model configured for this connection
+    *string getModel() {
+        return model;
+    }
+
+    #! Opens a Server-Sent Events stream for chat completions
+    SgLangSseStream openChatCompletionStream(hash<auto> req, *hash<auto> hdr, *timeout to) {
+        return new SgLangSseStream(self, "chat/completions", req, hdr, to);
+    }
+}
+
+#! SSE connection for SGLang chat completion streams
+public class SgLangSseStream {
+    private {
+        SgLangRestClient rest;
+        bool chunked;
+        string content_encoding;
+        StringOutputStream ostream;
+        TransformOutputStream dstream;
+        bool use_decompressor;
+        timeout timeout_ms = 15s;
+        bool closed;
+
+        const SseMimeType = "text/event-stream";
+    }
+
+    #! Creates the stream connection
+    constructor(SgLangRestClient rest, string path, *auto body, *hash<auto> hdr, *timeout to) {
+        self.rest = rest;
+        if (to) {
+            timeout_ms = to;
+        }
+        hash<auto> headers = rest.getDefaultHeaders() + (hdr ?? {});
+        headers.Accept = SseMimeType;
+        data payload;
+        if (exists body) {
+            payload = getSerializedBody(body, \headers);
+        }
+        string full_path = buildPath(path);
+        hash<auto> info;
+        hash<auto> resp = rest.send(payload, "POST", full_path, headers, False, \info);
+        if (resp.status_code != 200) {
+            throw "SSE-ERROR", sprintf("unexpected status code %d %s", resp.status_code, resp.status_message);
+        }
+        string content_type = normalizeContentType(resp."content-type");
+        if (content_type != SseMimeType) {
+            throw "SSE-ERROR", sprintf("expected Content-Type %y but got %y", SseMimeType, resp."content-type");
+        }
+        if (resp."content-encoding".val()) {
+            content_encoding = tolower(resp."content-encoding");
+        }
+        if (resp."transfer-encoding".val()) {
+            string transfer_encoding = tolower(resp."transfer-encoding");
+            if (transfer_encoding == "chunked") {
+                chunked = True;
+            } else {
+                throw "SSE-ERROR", sprintf("unsupported Transfer-Encoding: %y", resp."transfer-encoding");
+            }
+        }
+        setupDecompression();
+    }
+
+    #! Reads the next SSE message
+    *hash<SseMessageInfo> readEvent(*timeout to) {
+        if (closed) {
+            return;
+        }
+        timeout use_to = to ?? timeout_ms;
+        if (chunked) {
+            hash<auto> hh = rest.readHTTPChunk(use_to);
+            if (!hh.body) {
+                return;
+            }
+            if (use_decompressor) {
+                dstream.write(hh.body);
+            } else {
+                ostream.write(hh.body);
+            }
+            return rest.parseServerSentEvent(ostream.getData());
+        }
+        return rest.readServerSentEvent(content_encoding, use_to);
+    }
+
+    #! Closes the stream connection
+    close() {
+        if (!closed) {
+            closed = True;
+            rest.disconnect();
+        }
+    }
+
+    private string buildPath(string path) {
+        string rv = path;
+        rv =~ s/^\/+//;
+        rv = "/" + rv;
+        *string base = rest.getConnectionPath();
+        if (base.val() && base != "/") {
+            base =~ s/\/+$//;
+            if (base !~ /^\//) {
+                base = "/" + base;
+            }
+            rv = base + rv;
+        }
+        *string defp = rest.getDefaultPath();
+        if (defp.val() && defp != "/") {
+            defp =~ s/\/+$//;
+            if (defp !~ /^\//) {
+                defp = "/" + defp;
+            }
+            rv = defp + rv;
+        }
+        return rv;
+    }
+
+    private data getSerializedBody(data body, reference<hash<auto>> headers) {
+        if (body.typeCode() == NT_STRING) {
+            if (!headers."Content-Type") {
+                headers."Content-Type" = "application/json";
+            }
+            return body;
+        }
+%ifdef NoJson
+        throw "SSE-ERROR", "json module is required to serialize SSE request body";
+%else
+        if (!headers."Content-Type") {
+            headers."Content-Type" = "application/json";
+        }
+        return call_function_args("to_json", (body,));
+%endif
+    }
+
+    private setupDecompression() {
+        if (!chunked) {
+            return;
+        }
+        ostream = new StringOutputStream();
+        Transform decompressor;
+        switch (content_encoding) {
+            case "deflate":
+                use_decompressor = True;
+                decompressor = get_decompressor(Qore::COMPRESSION_ALG_ZLIB);
+                break;
+            case "gzip":
+                use_decompressor = True;
+                decompressor = get_decompressor(Qore::COMPRESSION_ALG_GZIP);
+                break;
+            case "bzip2":
+                use_decompressor = True;
+                decompressor = get_decompressor(Qore::COMPRESSION_ALG_BZIP2);
+                break;
+            case NOTHING:
+            case "identity":
+                use_decompressor = False;
+                break;
+
+            default:
+                throw "ENCODING-ERROR", sprintf("Don't know how to handle Content-Encoding %y", content_encoding);
+        }
+        if (use_decompressor) {
+            dstream = new TransformOutputStream(ostream, decompressor);
+        }
+    }
+
+    private static string normalizeContentType(*string content_type) {
+        if (!content_type.val()) {
+            return "";
+        }
+        string rv = content_type;
+        rv =~ s/\s*;.*$//;
+        rv =~ s/^\s+//;
+        rv =~ s/\s+$//;
+        return tolower(rv);
+    }
+}
+
+#! Class for SGLang REST connections; returns @ref SgLangRestClient objects
+/** This class implements all options of @ref RestClient::RestConnection "RestClientConnection"
+
+    @see @ref SgLangRestClient::SgLangRestClient::constructor() for more information on the above options
+*/
+public class SgLangRestConnection inherits RestClient::RestConnection {
+    public {
+        #! Default SGLang REST API URL
+        const DefaultUrl = "sglang://localhost:30000";
+
+        #! Connection entry info
+        const ConnectionScheme = <ConnectionSchemeInfo>{
+            "display_name": "SGLang REST Connection",
+            "short_desc": "A connection to an SGLang LLM inference server",
+            "desc": "A connection to an [SGLang](https://github.com/sgl-project/sglang) LLM inference "
+                "server.\n\n"
+                "SGLang is a self-hosted OpenAI-compatible inference server. The `model` option "
+                "specifies the model served by the SGLang instance and is auto-injected into API "
+                "requests. The connection uses the `sglang://` URL scheme which maps to `http://` "
+                "for local servers",
+            "cls": Class::forName("SgLangRestConnection"),
+            "auto_url": True,
+            "schemes": {
+                "sglang": True,
+            },
+            "base_scheme_map": {
+                "http": "sglang",
+            },
+            "options": RestConnection::ConnectionScheme.options + {
+                "model": <ConnectionOptionInfo>{
+                    "display_name": "Model",
+                    "short_desc": "The model served by the SGLang instance",
+                    "type": "string",
+                    "desc": "The model served by the SGLang instance "
+                        "(e.g., `meta-llama/Meta-Llama-3.1-8B-Instruct`). This value is auto-injected "
+                        "into API requests when not explicitly specified in the request body",
+                    "preselected": True,
+                },
+                "apikey": <ConnectionOptionInfo>{
+                    "display_name": "API Key",
+                    "short_desc": "Optional API key for authentication",
+                    "type": "string",
+                    "desc": "An optional API key for authentication with the SGLang server; sent as the "
+                        "`Authorization: Bearer` header.\n\n"
+                        "Most SGLang deployments do not require authentication",
+                    "sensitive": True,
+                },
+                "api": <ConnectionOptionInfo>{
+                    "display_name": "API Version",
+                    "short_desc": "The API version to use",
+                    "desc": "The API version to use",
+                    "type": "string",
+                    "default_value": SgLangRestClientBase::DefaultApiVersion,
+                },
+                "ping_headers": RestConnection::ConnectionScheme.options.ping_headers + <ConnectionOptionInfo>{
+                    "default_value": SgLangRestClientBase::DefaultPingHeaders,
+                },
+                "ping_method": RestConnection::ConnectionScheme.options.ping_method + <ConnectionOptionInfo>{
+                    "default_value": SgLangRestClientBase::DefaultPingMethod,
+                },
+                "ping_path": RestConnection::ConnectionScheme.options.ping_path + <ConnectionOptionInfo>{
+                    "default_value": SgLangRestClientBase::DefaultPingPath,
+                },
+            },
+            "required_options": "model",
+        };
+    }
+
+    #! creates the SgLangRestConnection object
+    /** @param name the name of the connection
+        @param description connection description
+        @param url connection URL (potentially with password info)
+        @param attributes various attributes. See below
+        @param options connection options
+
+        See @ref ConnectionProvider::AbstractConnection::constructor() for \c attributes and \c options reference.
+
+        @throw CONNECTION-OPTION-ERROR missing or invalid connection option
+    */
+    constructor(string name, string description, string url = DefaultUrl,
+            hash<auto> attributes = {}, hash<auto> options = {})
+            : RestConnection(name, description, url, attributes, options) {
+    }
+
+    #! creates the SgLangRestConnection object
+    /** @param config with the following keys:
+        - name (required string): the connection name
+        - display_name (optional string): the display name
+        - short_desc (optional string): a short description in plain text
+        - desc (optional string): a long description with markdown formatting
+        - url (required string): the connection URL
+        - opts (optional hash): connection options
+        - logger (optional LoggerInterface object): logger for the connection
+        @param attr optional connection attributes
+        - monitor (optional bool): should the connection be monitored? Default: True
+        - enabled (optional bool): is the connection enabled? Default: True
+        - locked (optional bool): is the connection locked? Default: False
+        - debug_data (optional bool): debug data? Default: False
+        - tags (optional hash): tags for the connection; no default value
+
+        @throw CONNECTION-OPTION-ERROR missing or invalid connection option or attribute
+    */
+    constructor(hash<auto> config, *hash<auto> attr)
+            : RestConnection(config + (exists config.url ? {} : {"url": DefaultUrl}), attr) {
+    }
+
+    #! returns \c "sglang"
+    string getType() {
+        return "sglang";
+    }
+
+    #! returns @ref True as this connection returns a data provider with the \c getDataProvider() method
+    /** @return @ref True as this connection returns a data provider with the \c getDataProvider() method
+
+        @see @ref getDataProvider()
+    */
+    bool hasDataProvider() {
+        return True;
+    }
+
+    #! returns a data provider object for this connection
+    /** @param constructor_options any additional constructor options for the data provider
+
+        @return a data provider object for this connection
+    */
+    DataProvider::AbstractDataProvider getDataProvider(*hash<auto> constructor_options) {
+        # to avoid circular dependencies, this object loads the SgLangDataProvider and creates the data provider
+        # object dynamically
+        load_module("SgLangDataProvider");
+        return create_object("SgLangDataProvider", getAsync());
+    }
+
+    #! Sets child data provider capabilities
+    private setChildCapabilities() {
+        children_can_support_apis = True;
+    }
+
+    #! returns a @ref SgLangRestClient object
+    /** @param connect if @ref True "True", then the connection is returned already connected
+        @param rtopts this connection type does not accept any runtime options, so this parameter is ignored
+
+        @return a @ref SgLangRestClient object
+    */
+    private SgLangRestClient getImpl(bool connect = True, *hash<auto> rtopts) {
+        return new SgLangRestClient(getConnectionOptions(rtopts), !connect);
+    }
+
+    #! Returns an async-I/O-capable connection object
+    private object getAsyncImpl(bool connect = True, *hash<auto> rtopts) {
+        return new SgLangRestClientIo(getConnectionOptions(rtopts));
+    }
+
+    #! Returns the ConnectionSchemeInfo hash for this object
+    private hash<ConnectionSchemeInfo> getConnectionSchemeInfoImpl() {
+        return ConnectionScheme;
+    }
+}
+
+#! REST client for SGLang REST API using multiplexed HTTP connections
+/** @see SgLangRestClient for more information
+*/
+public class SgLangRestClientIo inherits RestClientIo::RestClientIo, SgLangRestClientBase {
+    private {
+        #! The model configured for this connection
+        *string model;
+    }
+
+    #! Creates the object with the given options
+    /** @param opts constructor options
+        @param shared_mgr optional shared connection manager
+    */
+    constructor(hash<auto> opts, *HttpClientIo::HttpClientConnectionManager shared_mgr)
+            : RestClientIo(SgLangRestClientBase::getOptions(opts), shared_mgr) {
+        model = opts.model;
+    }
+
+    #! Returns the model configured for this connection
+    *string getModel() {
+        return model;
+    }
+
+    #! Opens a Server-Sent Events stream for chat completions using async I/O
+    /** Uses HttpClientIo and SseStreamReader for incremental SSE event delivery
+        across HTTP/1.x, HTTP/2, and HTTP/3.
+
+        @param req the request body (will be serialized to JSON)
+        @param hdr optional additional request headers
+        @param to optional timeout for SSE event reading
+
+        @return an SSE stream object for reading events incrementally
+
+        @par Example:
+        @code{.py}
+SgLangRestClientIo rest({"url": "http://localhost:30000", "model": "meta-llama/Meta-Llama-3.1-8B-Instruct"});
+SgLangSseStreamIo stream = rest.openChatCompletionStream({
+    "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+    "stream": True,
+    "messages": ({"role": "user", "content": "Hello!"},),
+});
+while (*hash<SseMessageInfo> evt = stream.readEvent()) {
+    printf("Event: %y\n", evt.data);
+}
+        @endcode
+    */
+    SgLangSseStreamIo openChatCompletionStream(hash<auto> req, *hash<auto> hdr, *timeout to) {
+        return new SgLangSseStreamIo(self, "chat/completions", req, hdr, to);
+    }
+}
+
+#! SSE stream for SGLang chat completions using async I/O (HttpClientIo + SseStreamReader)
+/** Works across HTTP/1.x, HTTP/2, and HTTP/3 via HttpClientIo's multiplexed
+    connection manager.
+
+    @note This class is \b not thread-safe.  Use from a single reader thread.
+*/
+public class SgLangSseStreamIo {
+    private {
+        #! SSE stream reader
+        HttpClientStreamingIo::SseStreamReader reader;
+
+        #! Timeout for SSE event reading
+        timeout timeout_ms = 15s;
+
+        #! True when the stream has been closed
+        bool closed = False;
+    }
+
+    #! Creates the SSE stream connection
+    /** @param rest the SgLangRestClientIo instance
+        @param path the API endpoint path (e.g., "chat/completions")
+        @param body the request body (serialized to JSON)
+        @param hdr optional additional request headers
+        @param to optional timeout for SSE event reading
+    */
+    constructor(SgLangRestClientIo rest, string path, *auto body, *hash<auto> hdr, *timeout to) {
+        if (to) {
+            timeout_ms = to;
+        }
+        hash<auto> headers = rest.getDefaultHeaders() + (hdr ?? {});
+        headers.Accept = "text/event-stream";
+
+        # Serialize body to JSON
+        *data payload;
+        if (exists body) {
+%ifdef NoJson
+            throw "SSE-ERROR", "json module is required to serialize SSE request body";
+%else
+            if (body.typeCode() != NT_STRING) {
+                if (!headers."Content-Type") {
+                    headers."Content-Type" = "application/json";
+                }
+                payload = call_function_args("to_json", (body,));
+            } else {
+                if (!headers."Content-Type") {
+                    headers."Content-Type" = "application/json";
+                }
+                payload = body;
+            }
+%endif
+        }
+
+        # Build full path
+        string full_path = buildPath(rest, path);
+
+        # Acquire stream and start SSE streaming
+        HttpClientIo::HttpClientConnectionManager mgr = rest.getConnectionManager();
+        HttpClientIo::HttpClientStreamHandle stream = mgr.acquireStream(rest.getUrl());
+        stream.startStreaming("POST", full_path, headers, False, payload);
+
+        reader = new HttpClientStreamingIo::SseStreamReader(stream);
+    }
+
+    #! Reads the next SSE event
+    /** @param to optional timeout override
+        @return the parsed SSE event, or NOTHING on timeout or stream end
+    */
+    *hash<SseMessageInfo> readEvent(*timeout to) {
+        if (closed) {
+            return NOTHING;
+        }
+        return reader.readEvent(to ?? timeout_ms);
+    }
+
+    #! Returns True if the stream has ended
+    bool isDone() {
+        return closed || reader.isDone();
+    }
+
+    #! Closes the stream
+    close() {
+        if (!closed) {
+            closed = True;
+            reader.cancel();
+        }
+    }
+
+    #! Builds the full API path from connection path + relative path
+    private static string buildPath(RestClientIo::RestClientIo rest, string path) {
+        string rv = path;
+        rv =~ s/^\/+//;
+        rv = "/" + rv;
+        *string base = rest.getConnectionPath();
+        if (base.val() && base != "/") {
+            base =~ s/\/+$//;
+            if (base !~ /^\//) {
+                base = "/" + base;
+            }
+            rv = base + rv;
+        }
+        return rv;
+    }
+}
+}


### PR DESCRIPTION
## Summary

- Add `SgLangRestClient.qm` module for communicating with [SGLang](https://github.com/sgl-project/sglang) LLM inference servers
  - `SgLangRestClient` / `SgLangRestClientIo` with required `model` connection option and optional `apikey` auth
  - `SgLangRestConnection` with `sglang://` URL scheme (maps to `http://` for local servers)
  - SSE streaming support for chat completions (both sync and async variants)
- Add `SgLangDataProvider` module with OpenAI-compatible and native SGLang endpoints
  - Chat completions (multi-message and single-message), text completions, native `/generate`, model listing
  - Automatic model injection from connection config into API requests
  - Factory, action catalog, and reference data registration

## Test plan

- [x] `SgLangRestClient.qtest` — 4 test cases, 13 assertions (connection, model storage, SSE stream, URL scheme)
- [x] `SgLangDataProvider.qtest` — 10 test cases, 51 assertions (model injection/override, chat/simple-chat/completions/generate, action catalog, negative tests)
- [x] Verified module loading: `load_module("SgLangRestClient")` and `load_module("SgLangDataProvider")` succeed
- [ ] CI pipeline validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)