### PR TITLE
Add simulation and line coverage infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2118,6 +2118,7 @@ qore_user_module("qlib/QoreRagUtils" "QoreTokenizerUtils;OpenAiRestClient;Voyage
 qore_user_module("qlib/DpqlWebSocket" "DataProvider;HttpServerUtil;WebSocketHandler")
 qore_user_module("qlib/DebugProgramControl.qm" "DebugUtil")
 qore_user_module("qlib/HttpUtil.qm" "Util")
+qore_user_module("qlib/LineCoverage.qm" "")
 qore_user_module("qlib/HttpServerUtil.qm" "HttpUtil;Mime;Util;FileLocationHandler;Logger;modules/logger_bin/logger_bin")
 qore_user_module("qlib/MailMessage.qm" "Mime")
 

--- a/examples/test/qlib/DataProvider/Simulation.qtest
+++ b/examples/test/qlib/DataProvider/Simulation.qtest
@@ -58,12 +58,44 @@ class NoResponseRequestProvider inherits AbstractDataProvider {
     }
 }
 
+class MultiActionSimulationProvider inherits AbstractDataProvider {
+    private {
+        const ProviderInfo = <DataProviderInfo>{
+            "type": "MultiActionSimulationProvider",
+            "supports_request": True,
+            "supports_read": True,
+            "supports_create": True,
+            "supports_update": True,
+            "supports_upsert": True,
+            "supports_delete": True,
+        };
+    }
+
+    string getName() {
+        return "multi-action-simulation";
+    }
+
+    private hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+
+    private auto getExampleResponseDataImpl() {
+        return {"response": True};
+    }
+
+    private hash<auto> getExampleRecordDataImpl() {
+        return {"record": True};
+    }
+}
+
 class DataProviderSimulationTest inherits QUnit::Test {
     constructor() : Test("DataProviderSimulationTest", "1.0", \ARGV) {
         addTestCase("default request simulation records and returns example data",
             \testDefaultRequestSimulation());
         addTestCase("request simulation handles no response data",
             \testRequestSimulationWithNoResponse());
+        addTestCase("registered action type selects simulation shape",
+            \testRegisteredActionSimulationShape());
         addTestCase("volatile fields default to none",
             \testDefaultVolatileFields());
 
@@ -103,8 +135,68 @@ class DataProviderSimulationTest inherits QUnit::Test {
         assertEq("example", actions[0].fidelity);
     }
 
+    testRegisteredActionSimulationShape() {
+        string app = registerSimulationApp();
+        on_exit DataProviderActionCatalog::deregisterDynamicApp(app);
+
+        MultiActionSimulationProvider provider();
+        TestSimulationRecorder recorder();
+
+        assertEq({"response": True}, provider.simulateRequest(app,
+            "request-action", {"value": 1}, recorder));
+        assertEq({"record": True}, provider.simulateRequest(app,
+            "create-action", {"value": 1}, recorder));
+        assertEq(UpsertResultInserted, provider.simulateRequest(app,
+            "upsert-action", {"value": 1}, recorder));
+        assertEq(1, provider.simulateRequest(app, "update-action",
+            {"value": 1}, recorder));
+        assertEq(1, provider.simulateRequest(app, "delete-action",
+            {"value": 1}, recorder));
+        assertEq(({"record": True},), provider.simulateRequest(app,
+            "find-action", {"value": 1}, recorder));
+        assertEq({"record": True}, provider.simulateRequest(app,
+            "find-single-action", {"value": 1}, recorder));
+
+        assertEq(7, recorder.recorded(app).size());
+    }
+
     testDefaultVolatileFields() {
         AbstractDataProvider provider = DataProvider::getFactoryObject("null");
         assertEq((), provider.getSimulationVolatileFields("Null", "call"));
+    }
+
+    private string registerSimulationApp() {
+        string app = "SimulationTest" + get_random_string();
+        DataProviderActionCatalog::registerApp(<DataProviderAppInfo>{
+            "name": app,
+            "display_name": "Simulation Test",
+            "short_desc": "Simulation test app",
+            "desc": "Simulation test app",
+            "groups": (AppGroup::DataTransformation,),
+            "logo": "data",
+            "logo_mime_type": MimeTypeSvg,
+            "logo_file_name": "test.svg",
+            "dynamic": True,
+        });
+        registerSimulationAction(app, "request-action", DPAT_API);
+        registerSimulationAction(app, "create-action", DPAT_CREATE);
+        registerSimulationAction(app, "upsert-action", DPAT_UPSERT);
+        registerSimulationAction(app, "update-action", DPAT_UPDATE);
+        registerSimulationAction(app, "delete-action", DPAT_DELETE);
+        registerSimulationAction(app, "find-action", DPAT_FIND);
+        registerSimulationAction(app, "find-single-action", DPAT_FIND_SINGLE);
+        return app;
+    }
+
+    private registerSimulationAction(string app, string action, int action_code) {
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": app,
+            "path": "/",
+            "action": action,
+            "display_name": action,
+            "short_desc": action,
+            "desc": action,
+            "action_code": action_code,
+        });
     }
 }

--- a/examples/test/qlib/DataProvider/Simulation.qtest
+++ b/examples/test/qlib/DataProvider/Simulation.qtest
@@ -1,0 +1,110 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%modern
+
+%requires ../../../../qlib/QUnit.qm
+%requires ../../../../qlib/DataProvider
+
+%exec-class DataProviderSimulationTest
+
+class TestSimulationRecorder inherits AbstractSimulationRecorder {
+    private {
+        list<hash<auto>> actions = ();
+    }
+
+    record(string app, string action, auto input, string fidelity = "app-simulator") {
+        actions += {
+            "app": app,
+            "action": action,
+            "input": input,
+            "fidelity": fidelity,
+        };
+    }
+
+    list<hash<auto>> recorded(*string app, *string action) {
+        list<hash<auto>> rv = ();
+        foreach hash<auto> i in (actions) {
+            if ((!app || i.app == app) && (!action || i.action == action)) {
+                rv += i;
+            }
+        }
+        return rv;
+    }
+}
+
+class NoResponseRequestProvider inherits AbstractDataProvider {
+    private {
+        const ProviderInfo = <DataProviderInfo>{
+            "type": "NoResponseRequestProvider",
+            "supports_request": True,
+        };
+    }
+
+    string getName() {
+        return "no-response-request";
+    }
+
+    private *AbstractDataProviderType getRequestTypeImpl() {
+        return AbstractDataProviderType::get(AutoType);
+    }
+
+    private *AbstractDataProviderType getResponseTypeImpl() {
+        return AbstractDataProviderType::get(NothingType);
+    }
+
+    private hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+class DataProviderSimulationTest inherits QUnit::Test {
+    constructor() : Test("DataProviderSimulationTest", "1.0", \ARGV) {
+        addTestCase("default request simulation records and returns example data",
+            \testDefaultRequestSimulation());
+        addTestCase("request simulation handles no response data",
+            \testRequestSimulationWithNoResponse());
+        addTestCase("volatile fields default to none",
+            \testDefaultVolatileFields());
+
+        set_return_value(main());
+    }
+
+    testDefaultRequestSimulation() {
+        AbstractDataProvider provider = DataProvider::getFactoryObject("null");
+        TestSimulationRecorder recorder();
+
+        auto result = provider.simulateRequest("Null", "call", {"value": 1},
+            recorder);
+
+        assertEq({"a": "any value", "b": "any value"}, result);
+
+        list<hash<auto>> actions = recorder.recorded("Null", "call");
+        assertEq(1, actions.size());
+        assertEq("Null", actions[0].app);
+        assertEq("call", actions[0].action);
+        assertEq({"value": 1}, actions[0].input);
+        assertEq("example", actions[0].fidelity);
+        assertEq((), recorder.recorded("Other", "call"));
+    }
+
+    testRequestSimulationWithNoResponse() {
+        NoResponseRequestProvider provider();
+        TestSimulationRecorder recorder();
+
+        auto result = provider.simulateRequest("NoResponse", "call",
+            {"value": 1}, recorder);
+
+        assertEq(NULL, result);
+
+        list<hash<auto>> actions = recorder.recorded("NoResponse", "call");
+        assertEq(1, actions.size());
+        assertEq({"value": 1}, actions[0].input);
+        assertEq("example", actions[0].fidelity);
+    }
+
+    testDefaultVolatileFields() {
+        AbstractDataProvider provider = DataProvider::getFactoryObject("null");
+        assertEq((), provider.getSimulationVolatileFields("Null", "call"));
+    }
+}

--- a/examples/test/qlib/HttpServer/HttpServerHttp3Stress.qtest
+++ b/examples/test/qlib/HttpServer/HttpServerHttp3Stress.qtest
@@ -243,7 +243,7 @@ l50Xb2GWQesIt9k5jF5IOw==
         # via low throughput (testSkip if < 500 requests)
         date end_time = now_us() + 5s;
         int count = 0;
-        int errors = 0;
+        list<string> errors = ();
 
         while (now_us() < end_time) {
             try {
@@ -251,10 +251,14 @@ l50Xb2GWQesIt9k5jF5IOw==
                 if (resp.status_code == 200) {
                     count++;
                 } else {
-                    errors++;
+                    if (errors.size() < 10) {
+                        push errors, sprintf("unexpected status code: %d", resp.status_code);
+                    }
                 }
             } catch (hash<ExceptionInfo> ex) {
-                errors++;
+                if (errors.size() < 10) {
+                    push errors, sprintf("%s: %s", ex.err, ex.desc);
+                }
                 if (m_options.verbose > 1) {
                     printf("throughput error: %s: %s\n", ex.err, ex.desc);
                 }
@@ -267,7 +271,8 @@ l50Xb2GWQesIt9k5jF5IOw==
             return;
         }
 
-        assertEq(0, errors, "no errors during sustained throughput");
+        assertEq(0, errors.size(),
+            sprintf("no errors during sustained throughput: %y", errors));
         assertTrue(count > 0, sprintf("throughput > 0: %d requests in 5s", count));
 
         if (m_options.verbose) {
@@ -284,7 +289,7 @@ l50Xb2GWQesIt9k5jF5IOw==
         date end_time = now_us() + 5s;
         int count = 0;
         int total_bytes = 0;
-        int errors = 0;
+        list<string> errors = ();
 
         while (now_us() < end_time) {
             try {
@@ -296,10 +301,14 @@ l50Xb2GWQesIt9k5jF5IOw==
                         ? resp.body.toString("UTF-8") : resp.body;
                     total_bytes += body_str.size();
                 } else {
-                    errors++;
+                    if (errors.size() < 10) {
+                        push errors, sprintf("unexpected status code: %d", resp.status_code);
+                    }
                 }
             } catch (hash<ExceptionInfo> ex) {
-                errors++;
+                if (errors.size() < 10) {
+                    push errors, sprintf("%s: %s", ex.err, ex.desc);
+                }
                 if (m_options.verbose > 1) {
                     printf("large body throughput error: %s: %s\n", ex.err, ex.desc);
                 }
@@ -311,7 +320,8 @@ l50Xb2GWQesIt9k5jF5IOw==
             return;
         }
 
-        assertEq(0, errors, "no errors during large body throughput");
+        assertEq(0, errors.size(),
+            sprintf("no errors during large body throughput: %y", errors));
         assertTrue(count > 0, sprintf("throughput > 0: %d requests in 5s", count));
 
         if (m_options.verbose) {

--- a/examples/test/qlib/LineCoverage/LineCoverage.qtest
+++ b/examples/test/qlib/LineCoverage/LineCoverage.qtest
@@ -51,6 +51,9 @@ class LineCoverageTest inherits QUnit::Test {
             "new factory-created recorder has no loaded lines");
         assertEq(100.0, report.coverage_percent,
             "empty factory-created recorder has complete coverage");
+        assertThrows("RUNTIME-OVERLOAD-ERROR", sub() { recorder.start(); },
+            NOTHING,
+            "factory-created recorders require an explicit ProgramControl");
     }
 
     testRecorderReportsLineCoverage() {

--- a/examples/test/qlib/LineCoverage/LineCoverage.qtest
+++ b/examples/test/qlib/LineCoverage/LineCoverage.qtest
@@ -16,6 +16,7 @@
 class LineCoverageTest inherits QUnit::Test {
     private {
         const TargetFile = "line-coverage-target.q";
+        const MultiLineTargetFile = "line-coverage-multiline-target.q";
     }
 
     constructor() : QUnit::Test("LineCoverage", "1.0", \ARGV) {
@@ -25,6 +26,10 @@ class LineCoverageTest inherits QUnit::Test {
             \testCreateRecorder());
         addTestCase("Recorder reports covered and uncovered lines",
             \testRecorderReportsLineCoverage());
+        addTestCase("Recorder expands multi-line statements",
+            \testRecorderReportsMultilineStatements());
+        addTestCase("Recorder identifies statements across programs",
+            \testRecorderStatementReferencesIncludeProgramIds());
         addTestCase("Recorder reset and clear state",
             \testRecorderReset());
         set_return_value(main());
@@ -93,6 +98,59 @@ class LineCoverageTest inherits QUnit::Test {
             "statement summary is included");
     }
 
+    testRecorderReportsMultilineStatements() {
+        Program pgm = makeMultiLineTargetProgram();
+        ProgramControl pc = pgm.getProgram();
+        LineCoverage::Recorder recorder();
+
+        recorder.start(pc);
+        assertEq(6, pgm.callFunction("multi", 3),
+            "target function returns the multi-line expression value");
+        recorder.stop(pc);
+
+        hash<auto> report = recorder.snapshot();
+        foreach int line in ((3, 4, 5)) {
+            hash<auto> covered = getLine(report, MultiLineTargetFile, line);
+            assertTrue(covered.covered,
+                sprintf("multi-line statement source line %d is covered",
+                    line));
+            assertTrue(covered.statement_refs.size() > 0,
+                "line has statement references");
+            assertEq(pc.getProgramId(), covered.statement_refs[0].program_id,
+                "statement reference includes the program id");
+        }
+    }
+
+    testRecorderStatementReferencesIncludeProgramIds() {
+        Program pgm1 = makeTargetProgram();
+        Program pgm2 = makeTargetProgram();
+        ProgramControl pc1 = pgm1.getProgram();
+        ProgramControl pc2 = pgm2.getProgram();
+        LineCoverage::Recorder recorder();
+
+        recorder.start(pc1);
+        recorder.start(pc2);
+        assertEq(4, pgm1.callFunction("choose", 3));
+        assertEq(5, pgm2.callFunction("choose", 4));
+        recorder.stop(pc1);
+        recorder.stop(pc2);
+
+        hash<auto> positive = getLine(recorder.snapshot(), TargetFile, 5);
+        hash<auto> program_ids = {};
+        foreach hash<auto> ref in (positive.statement_refs) {
+            program_ids{ref.program_id.toString()} = True;
+            assertTrue(ref.statement_id > 0,
+                "statement reference includes the statement id");
+            assertTrue(ref.statement_key.val(),
+                "statement reference includes the compound statement key");
+        }
+
+        assertEq(2, program_ids.size(),
+            "line references distinguish statements from both programs");
+        assertTrue(program_ids{pc1.getProgramId().toString()}.toBool());
+        assertTrue(program_ids{pc2.getProgramId().toString()}.toBool());
+    }
+
     testRecorderReset() {
         Program pgm = makeTargetProgram();
         LineCoverage::Recorder recorder();
@@ -130,6 +188,17 @@ class LineCoverageTest inherits QUnit::Test {
             "    }",
             "    return rv;",
             "}").join("\n") + "\n", TargetFile);
+        return pgm;
+    }
+
+    private Program makeMultiLineTargetProgram() {
+        Program pgm(PO_NO_CHILD_PO_RESTRICTIONS | PO_ALLOW_DEBUGGER);
+        pgm.parse(("# target program",
+            "int sub multi(int value) {",
+            "    return value",
+            "        + 1",
+            "        + 2;",
+            "}").join("\n") + "\n", MultiLineTargetFile);
         return pgm;
     }
 

--- a/examples/test/qlib/LineCoverage/LineCoverage.qtest
+++ b/examples/test/qlib/LineCoverage/LineCoverage.qtest
@@ -21,6 +21,8 @@ class LineCoverageTest inherits QUnit::Test {
     constructor() : QUnit::Test("LineCoverage", "1.0", \ARGV) {
         addTestCase("ProgramControl exposes statement IDs",
             \testProgramControlStatementIds());
+        addTestCase("create_recorder returns a recorder",
+            \testCreateRecorder());
         addTestCase("Recorder reports covered and uncovered lines",
             \testRecorderReportsLineCoverage());
         addTestCase("Recorder reset and clear state",
@@ -40,6 +42,15 @@ class LineCoverageTest inherits QUnit::Test {
             "statement info resolves to the target source file");
         assertTrue(info.start_line > 0,
             "statement info includes a source start line");
+    }
+
+    testCreateRecorder() {
+        object recorder = LineCoverage::create_recorder();
+        hash<auto> report = recorder.snapshot();
+        assertEq(0, report.line_count,
+            "new factory-created recorder has no loaded lines");
+        assertEq(100.0, report.coverage_percent,
+            "empty factory-created recorder has complete coverage");
     }
 
     testRecorderReportsLineCoverage() {

--- a/examples/test/qlib/LineCoverage/LineCoverage.qtest
+++ b/examples/test/qlib/LineCoverage/LineCoverage.qtest
@@ -1,0 +1,132 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+# LineCoverage module tests
+#
+# Copyright (C) 2026 Qore Technologies, s.r.o.
+
+%modern
+%allow-debugger
+
+%requires ../../../../qlib/LineCoverage.qm
+%requires ../../../../qlib/QUnit.qm
+
+%exec-class LineCoverageTest
+
+class LineCoverageTest inherits QUnit::Test {
+    private {
+        const TargetFile = "line-coverage-target.q";
+    }
+
+    constructor() : QUnit::Test("LineCoverage", "1.0", \ARGV) {
+        addTestCase("ProgramControl exposes statement IDs",
+            \testProgramControlStatementIds());
+        addTestCase("Recorder reports covered and uncovered lines",
+            \testRecorderReportsLineCoverage());
+        addTestCase("Recorder reset and clear state",
+            \testRecorderReset());
+        set_return_value(main());
+    }
+
+    testProgramControlStatementIds() {
+        Program pgm = makeTargetProgram();
+        ProgramControl pc = pgm.getProgram();
+        list<int> statement_ids = pc.getStatementIds();
+
+        assertTrue(statement_ids.size() > 0,
+            "ProgramControl exposes registered statement IDs");
+        hash<auto> info = pc.getStatementIdInfo(statement_ids[0]);
+        assertEq(TargetFile, info.source.val() ? info.source : info.file,
+            "statement info resolves to the target source file");
+        assertTrue(info.start_line > 0,
+            "statement info includes a source start line");
+    }
+
+    testRecorderReportsLineCoverage() {
+        Program pgm = makeTargetProgram();
+        ProgramControl pc = pgm.getProgram();
+        LineCoverage::Recorder recorder();
+
+        recorder.start(pc);
+        assertEq(4, pgm.callFunction("choose", 3),
+            "target function returns the positive branch value");
+        recorder.stop(pc);
+
+        hash<auto> report = recorder.snapshot();
+        assertTrue(report.line_count >= 5,
+            "report includes executable target lines");
+        assertTrue(report.covered_line_count > 0,
+            "report includes covered lines");
+        assertTrue(report.coverage_percent > 0.0
+                && report.coverage_percent < 100.0,
+            "one branch remains uncovered");
+
+        hash<auto> positive = getLine(report, TargetFile, 5);
+        assertTrue(positive.covered,
+            "executed positive branch line is covered");
+        assertTrue(positive.hit_count > 0,
+            "covered line records hits");
+
+        hash<auto> negative = getLine(report, TargetFile, 7);
+        assertFalse(negative.covered,
+            "unexecuted negative branch line is not covered");
+        assertEq(0, negative.hit_count,
+            "uncovered line has no hits");
+
+        assertTrue(report.files{TargetFile}.line_count >= 5,
+            "file summary includes target source lines");
+        assertTrue(report.statements.size() >= report.line_count,
+            "statement summary is included");
+    }
+
+    testRecorderReset() {
+        Program pgm = makeTargetProgram();
+        LineCoverage::Recorder recorder();
+        recorder.loadProgram(pgm.getProgram());
+        hash<auto> loaded_report = recorder.snapshot();
+        assertTrue(loaded_report.line_count > 0,
+            "preloaded recorder has statement locations");
+
+        recorder.reset();
+        hash<auto> report = recorder.snapshot();
+        assertEq(loaded_report.line_count, report.line_count,
+            "reset preserves line locations");
+        assertEq(0, report.covered_line_count,
+            "reset clears line hits");
+        assertEq(0.0, report.coverage_percent,
+            "reset preserves uncovered executable lines");
+
+        recorder.clear();
+        report = recorder.snapshot();
+        assertEq(0, report.line_count,
+            "clear removes line locations");
+        assertEq(100.0, report.coverage_percent,
+            "empty coverage report has complete coverage");
+    }
+
+    private Program makeTargetProgram() {
+        Program pgm(PO_NO_CHILD_PO_RESTRICTIONS | PO_ALLOW_DEBUGGER);
+        pgm.parse(("# target program",
+            "int sub choose(int value) {",
+            "    int rv = 0;",
+            "    if (value > 0) {",
+            "        rv = value + 1;",
+            "    } else {",
+            "        rv = -1;",
+            "    }",
+            "    return rv;",
+            "}").join("\n") + "\n", TargetFile);
+        return pgm;
+    }
+
+    private hash<auto> getLine(hash<auto> report, string file, int line) {
+        foreach hash<auto> candidate in (report.lines) {
+            if (candidate.file == file && candidate.line == line) {
+                return candidate;
+            }
+        }
+        fail(sprintf("coverage line %s:%d was not found in %y", file,
+            line, report.lines));
+        return {};
+    }
+}

--- a/examples/test/qlib/LineCoverage/LineCoverage.qtest
+++ b/examples/test/qlib/LineCoverage/LineCoverage.qtest
@@ -17,6 +17,7 @@ class LineCoverageTest inherits QUnit::Test {
     private {
         const TargetFile = "line-coverage-target.q";
         const MultiLineTargetFile = "line-coverage-multiline-target.q";
+        const FunctionEntryTargetFile = "line-coverage-function-entry-target.q";
     }
 
     constructor() : QUnit::Test("LineCoverage", "1.0", \ARGV) {
@@ -28,6 +29,12 @@ class LineCoverageTest inherits QUnit::Test {
             \testRecorderReportsLineCoverage());
         addTestCase("Recorder expands multi-line statements",
             \testRecorderReportsMultilineStatements());
+        addTestCase("Recorder counts function entry lines once",
+            \testRecorderDoesNotDoubleCountFunctionEntry());
+        addTestCase("Recorder counts exception lines once",
+            \testRecorderDoesNotDoubleCountException());
+        addTestCase("Recorder preserves function-entry-only lines",
+            \testRecorderPreservesFunctionEntryOnlyLines());
         addTestCase("Recorder identifies statements across programs",
             \testRecorderStatementReferencesIncludeProgramIds());
         addTestCase("Recorder reset and clear state",
@@ -121,6 +128,55 @@ class LineCoverageTest inherits QUnit::Test {
         }
     }
 
+    testRecorderDoesNotDoubleCountFunctionEntry() {
+        ProgramControl pc = ProgramControl::getProgram();
+        LineCoverage::Recorder recorder();
+        int target_line = 0;
+
+        recorder.start(pc);
+        assertEq(42, currentProgramFunctionEntryTarget(\target_line),
+            "current-program target function returns its value");
+        recorder.stop(pc);
+
+        hash<auto> entry = getCurrentProgramLine(recorder.snapshot(),
+            target_line);
+        assertEq(1, entry.hit_count,
+            "function entry source line is counted once");
+    }
+
+    testRecorderDoesNotDoubleCountException() {
+        ProgramControl pc = ProgramControl::getProgram();
+        LineCoverage::Recorder recorder();
+        int target_line = 0;
+
+        recorder.start(pc);
+        assertEq("DIVISION-BY-ZERO",
+            currentProgramExceptionTarget(\target_line),
+            "current-program target catches the expected exception");
+        recorder.stop(pc);
+
+        hash<auto> throwing = getCurrentProgramLine(recorder.snapshot(),
+            target_line);
+        assertEq(1, throwing.hit_count,
+            "throwing source line is counted once");
+    }
+
+    testRecorderPreservesFunctionEntryOnlyLines() {
+        Program pgm = makeFunctionEntryTargetProgram();
+        ProgramControl pc = pgm.getProgram();
+        LineCoverage::Recorder recorder();
+
+        recorder.start(pc);
+        assertEq(42, pgm.callFunction("entry"),
+            "target function returns its value");
+        recorder.stop(pc);
+
+        hash<auto> entry = getLine(recorder.snapshot(),
+            FunctionEntryTargetFile, 3);
+        assertEq(1, entry.hit_count,
+            "function-entry-only source line is still counted");
+    }
+
     testRecorderStatementReferencesIncludeProgramIds() {
         Program pgm1 = makeTargetProgram();
         Program pgm2 = makeTargetProgram();
@@ -200,6 +256,39 @@ class LineCoverageTest inherits QUnit::Test {
             "        + 2;",
             "}").join("\n") + "\n", MultiLineTargetFile);
         return pgm;
+    }
+
+    private Program makeFunctionEntryTargetProgram() {
+        Program pgm(PO_NO_CHILD_PO_RESTRICTIONS | PO_ALLOW_DEBUGGER);
+        pgm.parse(("# target program",
+            "int sub entry() {",
+            "    return 42;",
+            "}").join("\n") + "\n", FunctionEntryTargetFile);
+        return pgm;
+    }
+
+    private int currentProgramFunctionEntryTarget(reference<int> target_line) {
+        target_line = get_all_thread_call_stacks(){gettid()}[0].line;
+        return 42;
+    }
+
+    private string currentProgramExceptionTarget(reference<int> target_line) {
+        int tid = gettid();
+        try {
+            target_line = get_all_thread_call_stacks(){gettid()}[0].line + 1;
+            tid = tid / (tid - tid);
+        } catch (hash<ExceptionInfo> ex) {
+            return ex.err;
+        }
+        return "NO-EXCEPTION";
+    }
+
+    private hash<auto> getCurrentProgramLine(hash<auto> report, int line) {
+        ProgramControl pc = ProgramControl::getProgram();
+        hash<auto> info = pc.getStatementIdInfo(pc.findStatementId("",
+            line));
+        string file = info.source.val() ? info.source : info.file;
+        return getLine(report, file, line);
     }
 
     private hash<auto> getLine(hash<auto> report, string file, int line) {

--- a/examples/test/qore/debug/test-debug.qtest
+++ b/examples/test/qore/debug/test-debug.qtest
@@ -166,6 +166,42 @@ class MyDebugProgram inherits DebugProgram {
 
 }
 
+class NoopDebugProgram inherits DebugProgram {
+    onAttach(ProgramControl pgm, reference runState, reference runToStatementId) {
+        runState = DebugRun;
+    }
+
+    onDetach(ProgramControl pgm, reference runState, reference runToStatementId) {
+        runState = DebugDetach;
+    }
+
+    onStep(ProgramControl pgm, int blockStatementId, *int statementId,
+            *int breakpointId, reference flow, reference runState,
+            reference runToStatementId) {
+        runState = DebugRun;
+    }
+
+    onFunctionEnter(ProgramControl pgm, int statementId, reference runState,
+            reference runToStatementId) {
+        runState = DebugRun;
+    }
+
+    onFunctionExit(ProgramControl pgm, int statementId, reference returnValue,
+            reference runState, reference runToStatementId) {
+        runState = DebugRun;
+    }
+
+    onException(ProgramControl pgm, int statementId, hash ex, reference dismiss,
+            reference runState, reference runToStatementId) {
+        runState = DebugRun;
+    }
+
+    onExit(ProgramControl pgm, int statementId, reference returnValue,
+            reference runState, reference runToStatementId) {
+        runState = DebugDetach;
+    }
+}
+
 %exec-class DebugTest
 
 class DebugTest inherits QUnit::Test {
@@ -191,6 +227,7 @@ class DebugTest inherits QUnit::Test {
         addTestCase("SingleThreadDebugTest", \singleThreadDebugTest());
         addTestCase("SingleThreadBreakpointTest", \singleThreadBreakpointTest());
         addTestCase("MultiThreadBreakTest", \multiThreadBreakTest());   # problem in valrind because of timing ?
+        addTestCase("ConcurrentAttachDetachTest", \concurrentAttachDetachTest());
         addTestCase("InterruptedCountTest", \interruptedCountTest());
         #addTestCase("MultiThreadDebugTest", \multiThreadDebugTest());
 
@@ -585,6 +622,46 @@ class DebugTest inherits QUnit::Test {
     }
 
     multiThreadDebugTest() {
+    }
+
+    attachDetachWorker(Counter ready, Counter start_gate, Counter done) {
+        ready.dec();
+        start_gate.waitForZero(10s);
+        int total = 0;
+        for (int i = 0; i < 5000; ++i) {
+            total += i;
+        }
+        done.dec();
+    }
+
+    concurrentAttachDetachTest() {
+        int worker_count = 8;
+        Counter ready(worker_count);
+        Counter start_gate(1);
+        Counter done(worker_count);
+        NoopDebugProgram dbg();
+        for (int i = 0; i < worker_count; ++i) {
+            background attachDetachWorker(ready, start_gate, done);
+        }
+
+        testAssertionValue("workers entered debug target program",
+            ready.waitForZero(10s), 0);
+
+        for (int i = 0; i < 50; ++i) {
+            dbg.addProgram(thisProgram);
+            testAssertionValue("break attached debug program",
+                dbg.breakProgram(thisProgram), 0);
+            dbg.removeProgram(thisProgram);
+        }
+
+        dbg.addProgram(thisProgram);
+        testAssertionValue("break attached debug program before release",
+            dbg.breakProgram(thisProgram), 0);
+        start_gate.dec();
+        testAssertionValue("workers finished under debugger attach",
+            done.waitForZero(10s), 0);
+        dbg.removeProgram(thisProgram);
+        dbg.waitForTerminationAndClear();
     }
 
     interruptedCountTest() {

--- a/examples/test/qore/debug/test-debug.qtest
+++ b/examples/test/qore/debug/test-debug.qtest
@@ -202,6 +202,18 @@ class NoopDebugProgram inherits DebugProgram {
     }
 }
 
+*DebugProgram self_clearing_debug_program;
+bool self_clearing_attached = False;
+
+class SelfClearingDebugProgram inherits NoopDebugProgram {
+    onAttach(ProgramControl pgm, reference runState,
+            reference runToStatementId) {
+        self_clearing_attached = True;
+        self_clearing_debug_program = NOTHING;
+        runState = DebugDetach;
+    }
+}
+
 %exec-class DebugTest
 
 class DebugTest inherits QUnit::Test {
@@ -228,6 +240,8 @@ class DebugTest inherits QUnit::Test {
         addTestCase("SingleThreadBreakpointTest", \singleThreadBreakpointTest());
         addTestCase("MultiThreadBreakTest", \multiThreadBreakTest());   # problem in valrind because of timing ?
         addTestCase("ConcurrentAttachDetachTest", \concurrentAttachDetachTest());
+        addTestCase("DebugCallbackLifetimeTest",
+            \debugCallbackLifetimeTest());
         addTestCase("InterruptedCountTest", \interruptedCountTest());
         #addTestCase("MultiThreadDebugTest", \multiThreadDebugTest());
 
@@ -662,6 +676,18 @@ class DebugTest inherits QUnit::Test {
             done.waitForZero(10s), 0);
         dbg.removeProgram(thisProgram);
         dbg.waitForTerminationAndClear();
+    }
+
+    debugCallbackLifetimeTest() {
+        self_clearing_attached = False;
+        self_clearing_debug_program = new SelfClearingDebugProgram();
+        self_clearing_debug_program.addProgram(thisProgram);
+        int trigger_attach = 1;
+        assertEq(1, trigger_attach);
+        assertTrue(self_clearing_attached,
+            "debug callback ran after addProgram()");
+        assertEq(NOTHING, self_clearing_debug_program,
+            "debug callback can release its last Qore reference");
     }
 
     interruptedCountTest() {

--- a/include/qore/QoreDebugProgram.h
+++ b/include/qore/QoreDebugProgram.h
@@ -6,7 +6,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -86,6 +86,9 @@ public:
    //! creates the object
    DLLEXPORT QoreDebugProgram();
 
+   DLLLOCAL virtual void refForCallback();
+
+   DLLLOCAL virtual void derefForCallback(ExceptionSink* xsink);
 
    DLLEXPORT void addProgram(QoreProgram *pgm, ExceptionSink* xsink);
    DLLEXPORT void removeProgram(QoreProgram *pgm);
@@ -153,5 +156,3 @@ public:
 };
 
 #endif /* INCLUDE_QORE_QOREDEBUGPROGRAM_H_ */
-
-

--- a/include/qore/QoreDebugProgram.h
+++ b/include/qore/QoreDebugProgram.h
@@ -133,13 +133,16 @@ public:
 
    /**
     * Break specific program thread
-    * @return 0 if the operation was successful, -1 if the target program does not allow debugging, -2 if xxx
+    * @return 0 if the operation was successful, -1 if the target program does not allow debugging, -2 if the
+    * target program is not attached, or -3 if the thread is not active in the target program or cannot run debugger
+    * callbacks
     */
    DLLEXPORT int breakProgramThread(QoreProgram *pgm, int tid) const;
 
    /**
     * Break program, i.e. all threads
-    * @return 0 if the operation was successful, -1 if the target program does not allow debugging, -2 if xxx
+    * @return 0 if the operation was successful, -1 if the target program does not allow debugging, -2 if the
+    * target program is not attached, or -3 if no active target program thread can run debugger callbacks
     */
    DLLEXPORT int breakProgram(QoreProgram *pgm) const;
 

--- a/include/qore/intern/QC_DebugProgram.h
+++ b/include/qore/intern/QC_DebugProgram.h
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -83,6 +83,12 @@ private:
 public:
    DLLLOCAL QoreDebugProgramWithQoreObject(QoreObject* n_qo): qo(n_qo) {
       //printd(5, "QoreDebugProgramWithCoreObject::QoreDebugProgramWithCoreObject() this: %p, qo: %p\n", this, n_qo);
+   }
+   DLLLOCAL virtual void refForCallback() override {
+      qo->ref();
+   }
+   DLLLOCAL virtual void derefForCallback(ExceptionSink* xsink) override {
+      qo->deref(xsink);
    }
    DLLLOCAL virtual void onAttach(QoreProgram *pgm, DebugRunStateEnum &rs, const AbstractStatement* &rts, ExceptionSink* xsink) {
       //printd(5, "QoreDebugProgramWithCoreObject::onAttach() this: %p, pgm: %p\n", this, pgm);

--- a/include/qore/intern/QC_Http3ClientPollOperationBase.h
+++ b/include/qore/intern/QC_Http3ClientPollOperationBase.h
@@ -159,6 +159,13 @@ public:
     DLLLOCAL QoreListNode* registerStream(int64_t stream_id, AbstractAsyncAction* action,
         bool& need_cancel, ExceptionSink* xsink);
 
+    //! Dispatches responses that arrived before the completion action was registered
+    DLLLOCAL void dispatchBufferedResponses(int64_t stream_id, AbstractAsyncAction* action,
+        QoreListNode* buffered, ExceptionSink* xsink);
+
+    //! Complete a stream normally: removes and derefs the action without signaling an error
+    DLLLOCAL bool completeStream(int64_t stream_id, ExceptionSink* xsink);
+
     //! Mark a client-side HTTP/3 response stream for incremental body delivery
     DLLLOCAL int setStreamStreaming(int64_t stream_id, ExceptionSink* xsink);
 

--- a/include/qore/intern/qore_program_private.h
+++ b/include/qore/intern/qore_program_private.h
@@ -2911,6 +2911,23 @@ typedef std::map<QoreProgram*, qore_program_private*> qore_program_map_t;
 class QoreDebugProgram;
 
 class qore_debug_program_private {
+private:
+    class CallbackRef {
+    public:
+        DLLLOCAL CallbackRef(QoreDebugProgram* n_dpgm, ExceptionSink* n_xsink)
+                : dpgm(n_dpgm), xsink(n_xsink) {
+            dpgm->refForCallback();
+        }
+
+        DLLLOCAL ~CallbackRef() {
+            dpgm->derefForCallback(xsink);
+        }
+
+    private:
+        QoreDebugProgram* dpgm;
+        ExceptionSink* xsink;
+    };
+
 public:
     DLLLOCAL qore_debug_program_private(QoreDebugProgram* n_dpgm) : dpgm(n_dpgm) {}
 
@@ -2975,12 +2992,14 @@ public:
 
     DLLLOCAL void onAttach(QoreProgram* pgm, DebugRunStateEnum& rs, const AbstractStatement*& rts,
             ExceptionSink* xsink) {
+        CallbackRef cr(dpgm, xsink);
         AutoQoreCounterDec ad(&debug_program_counter);
         dpgm->onAttach(pgm, rs, rts, xsink);
     }
 
     DLLLOCAL void onDetach(QoreProgram* pgm, DebugRunStateEnum& rs, const AbstractStatement*& rts,
             ExceptionSink* xsink) {
+        CallbackRef cr(dpgm, xsink);
         AutoQoreCounterDec ad(&debug_program_counter);
         dpgm->onDetach(pgm, rs, rts, xsink);
     }
@@ -2994,12 +3013,14 @@ public:
     */
     DLLLOCAL void onStep(QoreProgram* pgm, const StatementBlock* blockStatement, const AbstractStatement* statement,
             unsigned bkptId, int& flow, DebugRunStateEnum& rs, const AbstractStatement*& rts, ExceptionSink* xsink) {
+        CallbackRef cr(dpgm, xsink);
         AutoQoreCounterDec ad(&debug_program_counter);
         dpgm->onStep(pgm, blockStatement, statement, bkptId, flow, rs, rts, xsink);
     }
 
     DLLLOCAL void onFunctionEnter(QoreProgram* pgm, const StatementBlock* statement, DebugRunStateEnum& rs,
             const AbstractStatement*& rts, ExceptionSink* xsink) {
+        CallbackRef cr(dpgm, xsink);
         AutoQoreCounterDec ad(&debug_program_counter);
         dpgm->onFunctionEnter(pgm, statement, rs, rts, xsink);
     }
@@ -3009,6 +3030,7 @@ public:
     */
     DLLLOCAL void onFunctionExit(QoreProgram* pgm, const StatementBlock* statement, QoreValue& returnValue,
             DebugRunStateEnum& rs, const AbstractStatement*& rts, ExceptionSink* xsink) {
+        CallbackRef cr(dpgm, xsink);
         AutoQoreCounterDec ad(&debug_program_counter);
         dpgm->onFunctionExit(pgm, statement, returnValue, rs, rts, xsink);
     }
@@ -3017,6 +3039,7 @@ public:
     */
     DLLLOCAL void onException(QoreProgram* pgm, const AbstractStatement* statement, DebugRunStateEnum& rs,
             const AbstractStatement*& rts, ExceptionSink* xsink) {
+        CallbackRef cr(dpgm, xsink);
         AutoQoreCounterDec ad(&debug_program_counter);
         dpgm->onException(pgm, statement, rs, rts, xsink);
     }
@@ -3025,6 +3048,7 @@ public:
     */
     DLLLOCAL void onExit(QoreProgram* pgm, const StatementBlock* statement, QoreValue& returnValue,
             DebugRunStateEnum& rs, const AbstractStatement*& rts, ExceptionSink* xsink) {
+        CallbackRef cr(dpgm, xsink);
         AutoQoreCounterDec ad(&debug_program_counter);
         dpgm->onExit(pgm, statement, returnValue, rs, rts, xsink);
     }

--- a/include/qore/intern/qore_program_private.h
+++ b/include/qore/intern/qore_program_private.h
@@ -2497,7 +2497,7 @@ public:
         AutoLocker al(tlock);
         for (auto& i : pgm_data_map) {
             if (i.first->gettid() == tid) {
-                if (!i.first->canRunDebugCallbacks()) {
+                if (!i.first->canRunDebugCallbacks() || !i.first->isActiveProgram(pgm)) {
                     return -1;
                 }
                 i.second->dbgBreak();
@@ -2507,15 +2507,18 @@ public:
         return -1;
     }
 
-    DLLLOCAL void breakProgram() {
+    DLLLOCAL bool breakProgram() {
         printd(5, "qore_program_private::breakProgram(), this: %p\n", this);
         AutoLocker al(tlock);
+        bool rv = false;
         for (auto& i : pgm_data_map) {
-            if (!i.first->canRunDebugCallbacks()) {
+            if (!i.first->canRunDebugCallbacks() || !i.first->isActiveProgram(pgm)) {
                 continue;
             }
             i.second->dbgBreak();
+            rv = true;
         }
+        return rv;
     }
 
     DLLLOCAL void assignBreakpoint(QoreBreakpoint* bkpt, ExceptionSink *xsink) {
@@ -3080,10 +3083,10 @@ public:
         qore_program_map_t::iterator i = qore_program_map.find(pgm);
         printd(5, "qore_debug_program_private::breakProgram(), this: %p, pgm: %p, i: %p, end: %p\n", this, pgm, i,
             qore_program_map.end());
-        if (i == qore_program_map.end())
+        if (i == qore_program_map.end()) {
             return -2;
-        i->second->breakProgram();
-        return 0;
+        }
+        return i->second->breakProgram() ? 0 : -3;
     }
 
     DLLLOCAL void waitForTerminationAndClear(ExceptionSink* xsink) {

--- a/include/qore/intern/qore_program_private.h
+++ b/include/qore/intern/qore_program_private.h
@@ -57,6 +57,7 @@ extern QoreHashNode* ENV;
 class QoreSandboxManager;
 
 #include <algorithm>
+#include <atomic>
 #include <cerrno>
 #include <cstdarg>
 #include <map>
@@ -245,21 +246,21 @@ public:
     */
     DLLLOCAL void dbgBreak() {
         printd(5, "ThreadLocalProgramData::dbgBreak(), this: %p\n", this);
-        breakFlag = true;
+        breakFlag.store(true, std::memory_order_release);
     }
     /**
         Executed from any thread to set pending attach flag
     */
     DLLLOCAL void dbgPendingAttach() {
         printd(5, "ThreadLocalProgramData::dbgPendingAttach(), this: %p\n", this);
-        attachFlag = 1;
+        attachFlag.store(1, std::memory_order_release);
     }
     /**
         Executed from any thread to set pending detach flag
     */
     DLLLOCAL void dbgPendingDetach() {
         printd(5, "ThreadLocalProgramData::dbgPendingDetach(), this: %p\n", this);
-        attachFlag = -1;
+        attachFlag.store(-1, std::memory_order_release);
     }
 
     /**
@@ -270,7 +271,9 @@ public:
     }
 
     DLLLOCAL bool runtimeCheck() const {
-        return runState != DBG_RS_DETACH || attachFlag || breakFlag;
+        return runState != DBG_RS_DETACH
+            || attachFlag.load(std::memory_order_acquire)
+            || breakFlag.load(std::memory_order_acquire);
     }
 
 private:
@@ -294,11 +297,10 @@ private:
         runToStatement = rts;
     }
     // set to true by any process do break running program asap
-    volatile bool breakFlag = false;
+    std::atomic<bool> breakFlag{false};
     // called from running thread
     DLLLOCAL inline void checkBreakFlag() {
-        if (breakFlag && runState != DBG_RS_DETACH) {
-            breakFlag = false;
+        if (runState != DBG_RS_DETACH && breakFlag.exchange(false, std::memory_order_acq_rel)) {
             if (runState != DBG_RS_STOPPED) {
                 runState = DBG_RS_STEP;
             }
@@ -306,18 +308,16 @@ private:
         }
     }
     // to call onAttach when debug is attached or detached, -1 .. detach, 1 .. attach
-    int attachFlag = 0;
+    std::atomic<int> attachFlag{0};
     DLLLOCAL inline void checkAttach(ExceptionSink* xsink) {
-        if (attachFlag && runState != DBG_RS_STOPPED) {
-            if (attachFlag > 0) {
+        int flag = attachFlag.load(std::memory_order_acquire);
+        if (flag && runState != DBG_RS_STOPPED) {
+            if (flag > 0) {
                 dbgAttach(xsink);
-                //if (rs != DBG_RS_DETACH) {   // TODO: why this exception ?
-                attachFlag = 0;
-                //}
-            } else if (attachFlag < 0) {
+            } else if (flag < 0) {
                 dbgDetach(xsink);
-                attachFlag = 0;
             }
+            attachFlag.compare_exchange_strong(flag, 0, std::memory_order_acq_rel);
         }
     }
 };
@@ -2456,6 +2456,9 @@ public:
         printd(5, "qore_program_private::attachDebug, dpgm: %p, pgm_data_map: size:%d, begin: %p, end: %p\n", dpgm,
             pgm_data_map.size(), pgm_data_map.begin(), pgm_data_map.end());
         for (auto& i : pgm_data_map) {
+            if (!i.first->canRunDebugCallbacks()) {
+                continue;
+            }
             i.second->dbgPendingAttach();
             i.second->dbgBreak();
         }
@@ -2472,6 +2475,9 @@ public:
         printd(5, "qore_program_private::detachDebug, dpgm: %p, pgm_data_map: size:%d, begin: %p, end: %p\n", dpgm,
             pgm_data_map.size(), pgm_data_map.begin(), pgm_data_map.end());
         for (auto& i : pgm_data_map) {
+            if (!i.first->canRunDebugCallbacks()) {
+                continue;
+            }
             i.second->dbgPendingDetach();
         }
         // debug_program_counter may be non zero to finish pending calls. Just this instance cannot be deleted, it's
@@ -2491,6 +2497,9 @@ public:
         AutoLocker al(tlock);
         for (auto& i : pgm_data_map) {
             if (i.first->gettid() == tid) {
+                if (!i.first->canRunDebugCallbacks()) {
+                    return -1;
+                }
                 i.second->dbgBreak();
                 return 0;
             }
@@ -2502,6 +2511,9 @@ public:
         printd(5, "qore_program_private::breakProgram(), this: %p\n", this);
         AutoLocker al(tlock);
         for (auto& i : pgm_data_map) {
+            if (!i.first->canRunDebugCallbacks()) {
+                continue;
+            }
             i.second->dbgBreak();
         }
     }

--- a/include/qore/intern/qore_program_private.h
+++ b/include/qore/intern/qore_program_private.h
@@ -2576,6 +2576,18 @@ public:
         return statementIds[statementId-1];
     }
 
+    DLLLOCAL QoreListNode* getStatementIds(ExceptionSink* xsink) const {
+        ReferenceHolder<QoreListNode> rv(new QoreListNode(bigIntTypeInfo), xsink);
+        AutoLocker al(&plock);
+        for (size_t i = 0; i < statementIds.size(); ++i) {
+            if (statementIds[i]) {
+                rv->push(static_cast<int64>(i + 1), xsink);
+                assert(!*xsink);
+            }
+        }
+        return rv.release();
+    }
+
     DLLLOCAL unsigned getProgramId() const {
         return programId;
     }

--- a/include/qore/intern/qore_thread_intern.h
+++ b/include/qore/intern/qore_thread_intern.h
@@ -1109,6 +1109,7 @@ public:
    DLLLOCAL bool saveProgram(bool runtime, ExceptionSink* xsink);
    DLLLOCAL void del(ExceptionSink* xsink);
    DLLLOCAL bool canRunDebugCallbacks() const;
+   DLLLOCAL bool isActiveProgram(QoreProgram* pgm) const;
 
    //! Clears thread-local data in all referenced programs without unregistering the thread
    /** Clears the thread-local hash (tld) for each program this thread has data in.

--- a/include/qore/intern/qore_thread_intern.h
+++ b/include/qore/intern/qore_thread_intern.h
@@ -6,7 +6,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2025 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -1108,6 +1108,7 @@ public:
    DLLLOCAL void delProgram(QoreProgram* pgm);
    DLLLOCAL bool saveProgram(bool runtime, ExceptionSink* xsink);
    DLLLOCAL void del(ExceptionSink* xsink);
+   DLLLOCAL bool canRunDebugCallbacks() const;
 
    //! Clears thread-local data in all referenced programs without unregistering the thread
    /** Clears the thread-local hash (tld) for each program this thread has data in.

--- a/lib/QC_DebugProgram.qpp
+++ b/lib/QC_DebugProgram.qpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
@@ -224,7 +224,7 @@ abstract DebugProgram::onExit(ProgramControl[QoreProgram] pgm, int statement, re
 
 //! Break particular program thread
 /**
-  * @return 0 if the operation was successful, returns -1 if the program does not allow debugging (i.e. @ref Qore::PO_NO_DEBUGGING is set), -2 if the program has not been set as a debug target, or -3 if the given thread is not active in the target program
+  * @return 0 if the operation was successful, returns -1 if the program does not allow debugging (i.e. @ref Qore::PO_NO_DEBUGGING is set), -2 if the program has not been set as a debug target, or -3 if the given thread is not active in the target program or cannot run debugger callbacks
   */
 int DebugProgram::breakProgramThread(ProgramControl[QoreProgram] pgm, int tid) {
    return dpgm->breakProgramThread(*pgm, tid);

--- a/lib/QC_DebugProgram.qpp
+++ b/lib/QC_DebugProgram.qpp
@@ -232,7 +232,7 @@ int DebugProgram::breakProgramThread(ProgramControl[QoreProgram] pgm, int tid) {
 
 //! Break program, i.e. all threads
 /**
-  * @return 0 if the operation was successful, returns -1 if the program does not allow debugging (i.e. @ref Qore::PO_NO_DEBUGGING is set) or -2 if the program has not been set as a debug target
+  * @return 0 if the operation was successful, returns -1 if the program does not allow debugging (i.e. @ref Qore::PO_NO_DEBUGGING is set), -2 if the program has not been set as a debug target, or -3 if no active target program thread can run debugger callbacks
   */
 int DebugProgram::breakProgram(ProgramControl[QoreProgram] pgm) {
    return dpgm->breakProgram(*pgm);

--- a/lib/QC_Http3ClientPollOperationBase.qpp
+++ b/lib/QC_Http3ClientPollOperationBase.qpp
@@ -581,9 +581,14 @@ void Http3ClientPollOperationPriv::fireReadyCallback(ExceptionSink* xsink) {
 
 void Http3ClientPollOperationPriv::checkCapacity(int max_streams, ExceptionSink* xsink) {
     AutoLocker al(stream_lock);
-    if (max_streams && active_stream_count >= max_streams) {
+    int effective_max_streams = max_streams;
+    if (quic_stream_limit
+            && (!effective_max_streams || quic_stream_limit < effective_max_streams)) {
+        effective_max_streams = quic_stream_limit;
+    }
+    if (effective_max_streams && active_stream_count >= effective_max_streams) {
         xsink->raiseException("HTTP3-CAPACITY-ERROR",
-            "connection at capacity: %d/%d streams", active_stream_count, max_streams);
+            "connection at capacity: %d/%d streams", active_stream_count, effective_max_streams);
     }
 }
 
@@ -692,17 +697,7 @@ int64_t Http3ClientPollOperationPriv::submitRequest(const char* method, const ch
 
     // Dispatch any buffered responses (race: response arrived before register)
     if (buffered) {
-        // Dispatch buffered responses through the action
-        for (size_t i = 0; i < buffered->size(); ++i) {
-            QoreValue v = buffered->retrieveEntry(i);
-            if (v.getType() == NT_HASH) {
-                // retrieveEntry() returns the list-owned value without
-                // taking a reference.  PromiseAction takes ownership of the
-                // QoreValue passed to execute(), while buffered->deref()
-                // below releases the list-owned reference.
-                action->execute(v.refSelf(), xsink);
-            }
-        }
+        dispatchBufferedResponses(stream_id, action, buffered, xsink);
         buffered->deref(xsink);
     }
 
@@ -811,6 +806,81 @@ bool Http3ClientPollOperationPriv::cancelStream(int64_t stream_id, ExceptionSink
         stream_capacity_cond.signal();
     }
     return true;
+}
+
+bool Http3ClientPollOperationPriv::completeStream(int64_t stream_id, ExceptionSink* xsink) {
+    std::string sid = std::to_string(stream_id);
+
+    AutoLocker al(stream_lock);
+    pending_stream_ids.erase(sid);
+
+    auto it = stream_actions.find(sid);
+    if (it == stream_actions.end()) {
+        return false;
+    }
+
+    ChannelAction* ch_action = dynamic_cast<ChannelAction*>(it->second);
+    if (ch_action && ch_action->isSseInstallEligible()) {
+        auto completed_it = completed_channel_actions.find(sid);
+        if (completed_it != completed_channel_actions.end()) {
+            completed_it->second->deref(xsink);
+        }
+        completed_channel_actions[sid] = ch_action;
+    } else {
+        it->second->deref(xsink);
+    }
+    stream_actions.erase(it);
+
+    assert(active_stream_count > 0);
+    if (active_stream_count > 0) {
+        --active_stream_count;
+    }
+    if (stream_blocked_waiters > 0) {
+        stream_capacity_cond.signal();
+    }
+    return true;
+}
+
+void Http3ClientPollOperationPriv::dispatchBufferedResponses(int64_t stream_id,
+        AbstractAsyncAction* action, QoreListNode* buffered, ExceptionSink* xsink) {
+    if (!action || !buffered) {
+        return;
+    }
+
+    // Keep the action alive while completeStream() drops stream_actions' ref
+    // before dispatching a buffered final response.
+    action->ref();
+    for (size_t i = 0; i < buffered->size(); ++i) {
+        QoreValue v = buffered->retrieveEntry(i);
+        if (v.getType() != NT_HASH) {
+            continue;
+        }
+
+        QoreHashNode* resp = v.get<QoreHashNode>();
+        bool is_end = resp->getKeyValue("end_stream").getAsBool();
+        if (is_end) {
+            completeStream(stream_id, xsink);
+        }
+
+        const QoreStringNode* err_str =
+            resp->getKeyValue("err").get<const QoreStringNode>();
+        const QoreStringNode* desc_str =
+            resp->getKeyValue("desc").get<const QoreStringNode>();
+        if (err_str) {
+            std::string err_copy = err_str->c_str();
+            std::string desc_copy = desc_str ? desc_str->c_str() : "";
+            action->executeError(err_copy.c_str(), desc_copy.c_str(), xsink);
+        } else {
+            action->execute(v.refSelf(), xsink);
+        }
+        if (is_end) {
+            if (action->isStreaming()) {
+                action->complete(xsink);
+            }
+            break;
+        }
+    }
+    action->deref(xsink);
 }
 
 void Http3ClientPollOperationPriv::waitStreamCapacity(int64_t timeout_ms) {
@@ -1212,7 +1282,7 @@ nothing Http3ClientPollOperationBase::setStreamStreaming(int stream_id) {
 /** @param stream_id the QUIC stream ID
     @param promise the Promise to resolve with the response (pure C++ dispatch)
 
-    @return hash with: "need_cancel" (bool), "buffered" (list or NOTHING)
+    @return hash with: "need_cancel" (bool)
 */
 *hash<auto> Http3ClientPollOperationBase::registerStreamWithPromise(int stream_id, Promise[QorePromise] promise) {
     bool need_cancel = false;
@@ -1230,15 +1300,19 @@ nothing Http3ClientPollOperationBase::setStreamStreaming(int stream_id) {
     // initial ref (priv->registerStream did not take ownership in that
     // branch).
     QoreListNode* buffered = priv->registerStream(stream_id, *action, need_cancel, xsink);
+    AbstractAsyncAction* registered_action = nullptr;
     if (!need_cancel && !*xsink) {
-        action.release();
+        registered_action = action.release();
+    }
+    if (buffered) {
+        if (registered_action) {
+            priv->dispatchBufferedResponses(stream_id, registered_action, buffered, xsink);
+        }
+        buffered->deref(xsink);
     }
 
     ReferenceHolder<QoreHashNode> rv(new QoreHashNode(autoTypeInfo), xsink);
     rv->setKeyValue("need_cancel", need_cancel, xsink);
-    if (buffered) {
-        rv->setKeyValue("buffered", buffered, xsink);
-    }
     return rv.release();
 }
 
@@ -1251,7 +1325,7 @@ nothing Http3ClientPollOperationBase::setStreamStreaming(int stream_id) {
     @param promise the Promise to resolve with the response
     @param notifier EventNotifier to signal after the Promise is resolved
 
-    @return hash with: "need_cancel" (bool), "buffered" (list or NOTHING)
+    @return hash with: "need_cancel" (bool)
 
     @since %Qore 2.3
 */
@@ -1274,15 +1348,19 @@ nothing Http3ClientPollOperationBase::setStreamStreaming(int stream_id) {
     // Ownership: priv->registerStream takes the ref on success; see
     // registerStreamWithPromise for the rationale.
     QoreListNode* buffered = priv->registerStream(stream_id, *action, need_cancel, xsink);
+    AbstractAsyncAction* registered_action = nullptr;
     if (!need_cancel && !*xsink) {
-        action.release();
+        registered_action = action.release();
+    }
+    if (buffered) {
+        if (registered_action) {
+            priv->dispatchBufferedResponses(stream_id, registered_action, buffered, xsink);
+        }
+        buffered->deref(xsink);
     }
 
     ReferenceHolder<QoreHashNode> rv(new QoreHashNode(autoTypeInfo), xsink);
     rv->setKeyValue("need_cancel", need_cancel, xsink);
-    if (buffered) {
-        rv->setKeyValue("buffered", buffered, xsink);
-    }
     return rv.release();
 }
 
@@ -1298,7 +1376,7 @@ nothing Http3ClientPollOperationBase::setStreamStreaming(int stream_id) {
     callers that do not intend to install SSE state must leave this \c False to avoid
     holding the action for the lifetime of the connection
 
-    @return hash with: "need_cancel" (bool), "buffered" (list or NOTHING)
+    @return hash with: "need_cancel" (bool)
 */
 *hash<auto> Http3ClientPollOperationBase::registerStreamWithChannel(int stream_id, object channel,
         *EventNotifier[QoreEventNotifier] notifier,
@@ -1336,15 +1414,19 @@ nothing Http3ClientPollOperationBase::setStreamStreaming(int stream_id) {
     // Ownership: priv->registerStream takes the ref on success; see
     // registerStreamWithPromise for the rationale.
     QoreListNode* buffered = priv->registerStream(stream_id, *action, need_cancel, xsink);
+    AbstractAsyncAction* registered_action = nullptr;
     if (!need_cancel && !*xsink) {
-        action.release();
+        registered_action = action.release();
+    }
+    if (buffered) {
+        if (registered_action) {
+            priv->dispatchBufferedResponses(stream_id, registered_action, buffered, xsink);
+        }
+        buffered->deref(xsink);
     }
 
     ReferenceHolder<QoreHashNode> rv(new QoreHashNode(autoTypeInfo), xsink);
     rv->setKeyValue("need_cancel", need_cancel, xsink);
-    if (buffered) {
-        rv->setKeyValue("buffered", buffered, xsink);
-    }
     return rv.release();
 }
 
@@ -1386,18 +1468,18 @@ nothing Http3ClientPollOperationBase::setStreamStreaming(int stream_id) {
     // registerStreamWithPromise for the rationale.
     QoreListNode* buffered = priv->registerStream(stream_id, *action, need_cancel, xsink);
     if (*xsink) {
+        if (buffered) {
+            buffered->deref(xsink);
+        }
         return QoreValue();
     }
+    AbstractAsyncAction* registered_action = nullptr;
     if (!need_cancel) {
-        action.release();
+        registered_action = action.release();
     }
     if (buffered) {
-        for (size_t i = 0, e = buffered->size(); i < e; ++i) {
-            action->execute(buffered->retrieveEntry(i).refSelf(), xsink);
-            if (*xsink) {
-                buffered->deref(xsink);
-                return QoreValue();
-            }
+        if (registered_action) {
+            priv->dispatchBufferedResponses(stream_id, registered_action, buffered, xsink);
         }
         buffered->deref(xsink);
     }

--- a/lib/QC_ProgramControl.qpp
+++ b/lib/QC_ProgramControl.qpp
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -328,6 +328,22 @@ hash<StatementInfo> ProgramControl::getStatementIdInfo(int statementId, bool lis
       ph->setKeyValueIntern("breakpoints", l);
    }
    return h;
+}
+
+//! Returns the stable statement IDs registered in this Program
+/**
+   Statement IDs are returned in parse-registration order and can be passed to
+   @ref Qore::ProgramControl::getStatementIdInfo() "ProgramControl::getStatementIdInfo()".
+
+   @return a list of statement IDs visible to debugger-domain callers
+
+   @since %Qore 2.3.1
+*/
+list<int> ProgramControl::getStatementIds() {
+   if (!p->checkAllowDebugging(xsink)) {
+      return QoreValue();
+   }
+   return qore_program_private::get(*p)->getStatementIds(xsink);
 }
 
 //! Find statement related to position in file

--- a/lib/QoreProgram.cpp
+++ b/lib/QoreProgram.cpp
@@ -2412,6 +2412,14 @@ QoreDebugProgram::~QoreDebugProgram() {
    delete priv;
 }
 
+void QoreDebugProgram::refForCallback() {
+   ref();
+}
+
+void QoreDebugProgram::derefForCallback(ExceptionSink* xsink) {
+   deref(xsink);
+}
+
 void QoreDebugProgram::onAttach(QoreProgram *pgm, DebugRunStateEnum &rs, const AbstractStatement* &rts, ExceptionSink* xsink) {
     printd(5, "QoreDebugProgram::onAttach() this: %p\n", this);
     rs = DBG_RS_RUN;

--- a/lib/QoreSocket.cpp
+++ b/lib/QoreSocket.cpp
@@ -1382,10 +1382,17 @@ public:
         if (!armed->load(std::memory_order_acquire)) {
             return getPollInfo(xsink);
         }
+        if (!ready_events) {
+            return getPollInfo(xsink);
+        }
+        int matched_events = ready_events & (events | SOCK_POLLERR);
+        if (!matched_events) {
+            return getPollInfo(xsink);
+        }
         ready = true;
-        output_events = ((ready_events & SOCK_POLLERR) || isPollableClosed())
+        output_events = ((matched_events & SOCK_POLLERR) || isPollableClosed())
             ? SOCK_POLLERR
-            : (ready_events ? (ready_events & events) : events);
+            : (matched_events & events);
         return nullptr;
     }
 

--- a/lib/QoreSocketObject.cpp
+++ b/lib/QoreSocketObject.cpp
@@ -1210,6 +1210,58 @@ static QoreObject* qore_socket_object_make_pollable_wrapper(QoreSocketObject* s)
     return new QoreObject(QC_ABSTRACTPOLLABLEIOOBJECTBASE, getProgram(), s);
 }
 
+static int qore_socket_object_parse_http2_request_headers(const QoreHashNode* headers, std::string& method,
+        std::string& path, std::vector<std::pair<std::string, std::string>>& request_headers,
+        ExceptionSink* xsink) {
+    if (!headers) {
+        xsink->raiseException("HTTP2-ERROR", "HTTP/2 request headers are required");
+        return -1;
+    }
+
+    request_headers.reserve(headers->size() + 4);
+    auto append = [&](const std::string& key, const char* sval) {
+        if (key == ":method") {
+            if (sval && *sval) {
+                method = sval;
+            }
+        } else if (key == ":path") {
+            if (sval && *sval) {
+                path = sval;
+            }
+        }
+        request_headers.emplace_back(key, sval ? sval : "");
+    };
+
+    ConstHashIterator hi(headers);
+    while (hi.next()) {
+        const char* key = hi.getKey();
+        QoreValue val = hi.get();
+        std::string skey(key);
+        if (val.getType() == NT_STRING) {
+            append(skey, val.get<const QoreStringNode>()->c_str());
+        } else if (val.getType() == NT_LIST) {
+            const QoreListNode* l = val.get<const QoreListNode>();
+            for (size_t i = 0; i < l->size(); ++i) {
+                QoreValue elem = l->retrieveEntry(i);
+                if (elem.getType() == NT_STRING) {
+                    append(skey, elem.get<const QoreStringNode>()->c_str());
+                }
+            }
+        }
+    }
+
+    if (method.empty()) {
+        xsink->raiseException("HTTP2-ERROR", "HTTP/2 request ':method' header is missing or empty");
+        return -1;
+    }
+    if (path.empty()) {
+        xsink->raiseException("HTTP2-ERROR", "HTTP/2 request ':path' header is missing or empty");
+        return -1;
+    }
+
+    return 0;
+}
+
 static std::shared_ptr<QuicSession> qore_socket_object_get_quic_session(const QoreSocketObject* s,
         int64_t session_id) {
     my_socket_priv* priv = my_socket_priv::getPriv(*const_cast<QoreSocketObject*>(s));
@@ -1615,50 +1667,7 @@ public:
 
 private:
     DLLLOCAL void parseRequestHeaders(const QoreHashNode* headers, ExceptionSink* xsink) {
-        if (!headers) {
-            xsink->raiseException("HTTP2-ERROR", "HTTP/2 request headers are required");
-            return;
-        }
-
-        request_headers.reserve(headers->size() + 4);
-        auto append = [&](const std::string& key, const char* sval) {
-            if (key == ":method") {
-                if (sval && *sval) {
-                    method = sval;
-                }
-            } else if (key == ":path") {
-                if (sval && *sval) {
-                    path = sval;
-                }
-            }
-            request_headers.emplace_back(key, sval ? sval : "");
-        };
-
-        ConstHashIterator hi(headers);
-        while (hi.next()) {
-            const char* key = hi.getKey();
-            QoreValue val = hi.get();
-            std::string skey(key);
-            if (val.getType() == NT_STRING) {
-                append(skey, val.get<const QoreStringNode>()->c_str());
-            } else if (val.getType() == NT_LIST) {
-                const QoreListNode* l = val.get<const QoreListNode>();
-                for (size_t i = 0; i < l->size(); ++i) {
-                    QoreValue elem = l->retrieveEntry(i);
-                    if (elem.getType() == NT_STRING) {
-                        append(skey, elem.get<const QoreStringNode>()->c_str());
-                    }
-                }
-            }
-        }
-
-        if (method.empty()) {
-            xsink->raiseException("HTTP2-ERROR", "HTTP/2 request ':method' header is missing or empty");
-            return;
-        }
-        if (path.empty()) {
-            xsink->raiseException("HTTP2-ERROR", "HTTP/2 request ':path' header is missing or empty");
-        }
+        qore_socket_object_parse_http2_request_headers(headers, method, path, request_headers, xsink);
     }
 
     QoreSocketObject* sock;
@@ -5341,6 +5350,35 @@ int QoreSocketObject::submitHttp2ConnectResponse(int32_t stream_id, int status_c
 
 static int32_t qore_socket_object_submit_http2_request(QoreSocketObject* s, const QoreHashNode* headers,
         const void* body, size_t body_len, ExceptionSink* xsink, bool streaming, bool wake_controller) {
+    // Fast path: if the caller is already running on the async I/O
+    // controller's I/O thread (ex: an HCIO poll operation's continuePoll
+    // submitting a request as it transitions through state), dispatching
+    // through the controller would deadlock because assertNotOnIoThread() would
+    // raise SOCKET-SYNC-ON-IO-THREAD-ERROR before we even reached the H2
+    // session. But the underlying h2->submitRequest() is a non-blocking
+    // nghttp2 enqueue (no socket I/O happens in the call), so it is safe to
+    // invoke inline on the I/O thread.  This mirrors the same pattern used
+    // by setHttp2StreamStreaming(), sendHttp2StreamDataForAsyncPoll(), and
+    // readHttp2StreamDataForAsyncPoll(); the only socket APIs the I/O
+    // thread is permitted to take are the ones that do not themselves wait
+    // on socket readiness. No wakeIoThread() is needed: we are the I/O
+    // thread; the next continuePoll cycle picks up the new stream.
+    if (qore_on_async_io_thread()) {
+        std::string method;
+        std::string path;
+        std::vector<std::pair<std::string, std::string>> request_headers;
+        if (qore_socket_object_parse_http2_request_headers(headers, method, path, request_headers, xsink)) {
+            return -1;
+        }
+        Http2SessionPtr h2 = qore_socket_object_get_h2_session(s);
+        if (!h2) {
+            xsink->raiseException("HTTP2-ERROR", "no HTTP/2 session active");
+            return -1;
+        }
+        return h2->submitRequest(method.c_str(), path.c_str(), request_headers,
+            body, body_len, xsink, streaming);
+    }
+
     QoreSocketObjectHttp2EnqueuePollOperation* poller =
         new QoreSocketObjectHttp2EnqueuePollOperation(s, headers, body, body_len, streaming, wake_controller, xsink);
     if (*xsink) {
@@ -6056,6 +6094,33 @@ bool QoreSocketObject::isQuic() const {
 static int64_t qore_socket_object_submit_quic_request(QoreSocketObject* s, const char* method, const char* path,
         const QoreHashNode* headers, const void* body, size_t body_len, ExceptionSink* xsink,
         bool streaming, bool wake_controller, const char* owner_name) {
+    // Fast path: see qore_socket_object_submit_http2_request for the
+    // full rationale.  In short: when the caller is already on the
+    // async I/O controller's I/O thread (ex: an HCIO H3 poll
+    // operation's continuePoll), dispatching the submission through
+    // the controller would self-deadlock because assertNotOnIoThread()
+    // raises SOCKET-SYNC-ON-IO-THREAD-ERROR. QuicSession::submitRequest
+    // / submitRequestStreaming are non-blocking ngtcp2/nghttp3 enqueues
+    // (no socket I/O happens in the call), so they are safe to invoke
+    // inline on the I/O thread. This mirrors the pattern already used by
+    // sendQuicClientStreamDataForAsyncPoll() etc. The only socket
+    // APIs the I/O thread is permitted to call are the ones that do not
+    // themselves wait on socket readiness. No wakeIoThread() is needed:
+    // we are the I/O thread.
+    if (qore_on_async_io_thread()) {
+        std::shared_ptr<QuicSession> session = qore_socket_object_get_first_quic_session(s);
+        if (!session) {
+            xsink->raiseException("HTTP3-ERROR", "no HTTP/3 session active");
+            return -1;
+        }
+        strcase_str_map_t header_map;
+        qore_socket_object_set_quic_headers(header_map, headers);
+        if (streaming) {
+            return session->submitRequestStreaming(method, path, header_map, xsink);
+        }
+        return session->submitRequest(method, path, header_map, body, body_len, xsink);
+    }
+
     return qore_socket_object_exec_quic_enqueue_int(s,
         new QoreSocketObjectQuicEnqueuePollOperation(s, method, path, headers, body, body_len, streaming,
             wake_controller),

--- a/lib/ql_debug.cpp
+++ b/lib/ql_debug.cpp
@@ -29,6 +29,7 @@
 */
 
 #include <qore/Qore.h>
+#include <qore/QoreDebugProgram.h>
 #include <qore/QoreSocketObject.h>
 #include <qore/QoreFuture.h>
 #include <qore/AsyncCompletionAction.h>
@@ -268,6 +269,76 @@ static void ut_asyncio_construction(UnitTestCounters& c) {
     UT_ASSERT(c, ctrl->getAutostop(), "autostop defaults to true");
     ctrl->deref(&xsink);
     UT_ASSERT(c, !xsink, "cleanup succeeds without exception");
+}
+
+class ForeignThreadDebugProgram : public QoreDebugProgram {
+public:
+    std::atomic<int> attach_count{0};
+    std::atomic<int> step_count{0};
+
+    DLLLOCAL void onAttach(QoreProgram* pgm, DebugRunStateEnum& rs, const AbstractStatement*& rts,
+            ExceptionSink* xsink) override {
+        ++attach_count;
+        rs = DBG_RS_STEP;
+    }
+
+    DLLLOCAL void onStep(QoreProgram* pgm, const StatementBlock* blockStatement, const AbstractStatement* statement,
+            unsigned bkptId, int& flow, DebugRunStateEnum& rs, const AbstractStatement*& rts,
+            ExceptionSink* xsink) override {
+        ++step_count;
+        rs = DBG_RS_STEP;
+    }
+};
+
+static void ut_debug_skips_foreign_thread_callbacks(UnitTestCounters& c) {
+    ExceptionSink xsink;
+    QoreProgram* pgm = new QoreProgram();
+    pgm->parse("%modern\nint sub foreign_debug_target() { int i = 0; ++i; return i; }\n",
+        "foreign-debug-test", &xsink, nullptr, 0);
+    UT_ASSERT(c, !xsink, "foreign debug target program parses");
+    if (xsink) {
+        xsink.clear();
+        pgm->waitForTerminationAndDeref(&xsink);
+        return;
+    }
+
+    ForeignThreadDebugProgram dbg;
+    dbg.addProgram(pgm, &xsink);
+    UT_ASSERT(c, !xsink, "debugger attaches to target program");
+
+    std::atomic<bool> thread_error{false};
+    std::atomic<int64_t> thread_result{0};
+    std::thread th([&]() {
+        QoreForeignThreadHelper fth;
+        if (!fth) {
+            thread_error.store(true, std::memory_order_release);
+            return;
+        }
+
+        ExceptionSink txsink;
+        QoreValue rv = pgm->callFunction("foreign_debug_target", nullptr, &txsink);
+        if (txsink) {
+            thread_error.store(true, std::memory_order_release);
+            txsink.clear();
+        } else {
+            thread_result.store(rv.getAsBigInt(), std::memory_order_release);
+        }
+        rv.discard(&txsink);
+    });
+    th.join();
+
+    UT_ASSERT(c, !thread_error.load(std::memory_order_acquire), "foreign thread executes Qore target");
+    UT_ASSERT_EQ(c, 1, thread_result.load(std::memory_order_acquire), "foreign thread target return value");
+    UT_ASSERT_EQ(c, 0, dbg.attach_count.load(std::memory_order_acquire),
+        "foreign thread does not run debugger attach callback");
+    UT_ASSERT_EQ(c, 0, dbg.step_count.load(std::memory_order_acquire),
+        "foreign thread does not run debugger step callback");
+
+    dbg.removeProgram(pgm);
+    dbg.waitForTerminationAndClear(&xsink);
+    UT_ASSERT(c, !xsink, "debugger cleanup succeeds");
+    pgm->waitForTerminationAndDeref(&xsink);
+    UT_ASSERT(c, !xsink, "foreign debug target program cleanup succeeds");
 }
 
 static void ut_asyncio_autostop(UnitTestCounters& c) {
@@ -2680,9 +2751,24 @@ static QoreValue f_dbg_force_fd_swap_next_wait(const QoreListNode* params, Runti
 }
 #endif
 
+static QoreHashNode* make_unit_test_result(UnitTestCounters& c, ExceptionSink* xsink) {
+    QoreHashNode* result = new QoreHashNode(autoTypeInfo);
+    result->setKeyValue("test_count", c.test_count, xsink);
+    result->setKeyValue("pass_count", c.pass_count, xsink);
+    result->setKeyValue("fail_count", c.fail_count, xsink);
+    return result;
+}
+
+static QoreValue f_run_debug_unit_tests(const QoreListNode* params, RuntimeConfig& rc, ExceptionSink* xsink) {
+    UnitTestCounters c;
+    ut_debug_skips_foreign_thread_callbacks(c);
+    return make_unit_test_result(c, xsink);
+}
+
 static QoreValue f_run_unit_tests(const QoreListNode* params, RuntimeConfig& rc, ExceptionSink* xsink) {
     UnitTestCounters c;
 
+    ut_debug_skips_foreign_thread_callbacks(c);
     ut_asyncio_construction(c);
     ut_asyncio_autostop(c);
     ut_asyncio_start_stop(c);
@@ -2734,11 +2820,7 @@ static QoreValue f_run_unit_tests(const QoreListNode* params, RuntimeConfig& rc,
     ut_manager_proxy_h1_connect(c);
     ut_manager_proxy_h3_rejected(c);
 
-    QoreHashNode* result = new QoreHashNode(autoTypeInfo);
-    result->setKeyValue("test_count", c.test_count, xsink);
-    result->setKeyValue("pass_count", c.pass_count, xsink);
-    result->setKeyValue("fail_count", c.fail_count, xsink);
-    return result;
+    return make_unit_test_result(c, xsink);
 }
 
 void init_debug_functions(QoreNamespace& qns) {
@@ -2746,6 +2828,7 @@ void init_debug_functions(QoreNamespace& qns) {
         autoTypeInfo, QORE_PARAM_NO_ARG, "node", softBoolOrNothingTypeInfo, QORE_PARAM_NO_ARG, "shallow");
     qns.addBuiltinVariant("dbg_global_vars", f_dbg_global_vars, QCF_NO_FLAGS, QDOM_DEFAULT, listTypeInfo);
     qns.addBuiltinVariant("dbg_get_ns_info", f_dbg_get_ns_info, QCF_NO_FLAGS, QDOM_DEFAULT, hashTypeInfo);
+    qns.addBuiltinVariant("run_debug_unit_tests", f_run_debug_unit_tests, QCF_NO_FLAGS, QDOM_DEFAULT, hashTypeInfo);
     qns.addBuiltinVariant("run_unit_tests", f_run_unit_tests, QCF_NO_FLAGS, QDOM_DEFAULT, hashTypeInfo);
 #ifdef DEBUG
     qns.addBuiltinVariant("dbg_force_fd_swap_next_wait", f_dbg_force_fd_swap_next_wait,

--- a/lib/ql_debug.cpp
+++ b/lib/ql_debug.cpp
@@ -37,6 +37,7 @@
 #include "qore/intern/ql_debug.h"
 #include "qore/intern/ql_type.h"
 #include "qore/intern/AsyncIoControllerPriv.h"
+#include "qore/intern/QC_Counter.h"
 #include "qore/intern/QC_Socket.h"
 #include "qore/intern/QC_Future.h"
 #include "qore/intern/QC_FutureImpl.h"
@@ -290,22 +291,49 @@ public:
     }
 };
 
-static void ut_debug_skips_foreign_thread_callbacks(UnitTestCounters& c) {
+static void ut_debug_skips_foreign_thread_callbacks(UnitTestCounters& c, QoreProgram* parent) {
     ExceptionSink xsink;
-    QoreProgram* pgm = new QoreProgram();
-    pgm->parse("%modern\nint sub foreign_debug_target() { int i = 0; ++i; return i; }\n",
+    QoreProgram* pgm = parent
+        ? new QoreProgram(parent, PO_NO_CHILD_PO_RESTRICTIONS | PO_ALLOW_DEBUGGER)
+        : new QoreProgram(PO_NO_CHILD_PO_RESTRICTIONS | PO_ALLOW_DEBUGGER);
+    pgm->parse("%modern\n"
+        "our Counter ready;\n"
+        "our Counter release;\n"
+        "int sub foreign_debug_target() {\n"
+        "    ready.dec();\n"
+        "    release.waitForZero();\n"
+        "    int i = 0;\n"
+        "    ++i;\n"
+        "    return i;\n"
+        "}\n"
+        "hash<auto> sub wait_foreign_debug_target() {\n"
+        "    ready.waitForZero();\n"
+        "    return {};\n"
+        "}\n"
+        "hash<auto> sub release_foreign_debug_target() {\n"
+        "    release.dec();\n"
+        "    return {};\n"
+        "}\n",
         "foreign-debug-test", &xsink, nullptr, 0);
     UT_ASSERT(c, !xsink, "foreign debug target program parses");
     if (xsink) {
+        xsink.handleExceptions();
+        xsink.clear();
+        pgm->waitForTerminationAndDeref(&xsink);
+        return;
+    }
+    pgm->setGlobalVarValue("ready", new QoreObject(QC_COUNTER, pgm, new Counter(1)), &xsink);
+    UT_ASSERT(c, !xsink, "foreign debug target ready counter initializes");
+    pgm->setGlobalVarValue("release", new QoreObject(QC_COUNTER, pgm, new Counter(1)), &xsink);
+    UT_ASSERT(c, !xsink, "foreign debug target release counter initializes");
+    if (xsink) {
+        xsink.handleExceptions();
         xsink.clear();
         pgm->waitForTerminationAndDeref(&xsink);
         return;
     }
 
     ForeignThreadDebugProgram dbg;
-    dbg.addProgram(pgm, &xsink);
-    UT_ASSERT(c, !xsink, "debugger attaches to target program");
-
     std::atomic<bool> thread_error{false};
     std::atomic<int64_t> thread_result{0};
     std::thread th([&]() {
@@ -318,6 +346,7 @@ static void ut_debug_skips_foreign_thread_callbacks(UnitTestCounters& c) {
         ExceptionSink txsink;
         QoreValue rv = pgm->callFunction("foreign_debug_target", nullptr, &txsink);
         if (txsink) {
+            txsink.handleExceptions();
             thread_error.store(true, std::memory_order_release);
             txsink.clear();
         } else {
@@ -325,6 +354,32 @@ static void ut_debug_skips_foreign_thread_callbacks(UnitTestCounters& c) {
         }
         rv.discard(&txsink);
     });
+
+    QoreValue wait_rv = pgm->callFunction("wait_foreign_debug_target", nullptr, &xsink);
+    wait_rv.discard(&xsink);
+    UT_ASSERT(c, !xsink, "foreign thread enters Qore target");
+    if (xsink) {
+        xsink.handleExceptions();
+        xsink.clear();
+    }
+
+    dbg.addProgram(pgm, &xsink);
+    UT_ASSERT(c, !xsink, "debugger attaches to active foreign target program");
+    int break_rc = dbg.breakProgram(pgm);
+    UT_ASSERT_EQ(c, -3, break_rc,
+        "breakProgram reports no interruptible active target program threads");
+
+    dbg.removeProgram(pgm);
+    dbg.waitForTerminationAndClear(&xsink);
+    UT_ASSERT(c, !xsink, "debugger cleanup succeeds");
+
+    QoreValue release_rv = pgm->callFunction("release_foreign_debug_target", nullptr, &xsink);
+    release_rv.discard(&xsink);
+    UT_ASSERT(c, !xsink, "foreign debug target release succeeds");
+    if (xsink) {
+        xsink.handleExceptions();
+        xsink.clear();
+    }
     th.join();
 
     UT_ASSERT(c, !thread_error.load(std::memory_order_acquire), "foreign thread executes Qore target");
@@ -334,9 +389,6 @@ static void ut_debug_skips_foreign_thread_callbacks(UnitTestCounters& c) {
     UT_ASSERT_EQ(c, 0, dbg.step_count.load(std::memory_order_acquire),
         "foreign thread does not run debugger step callback");
 
-    dbg.removeProgram(pgm);
-    dbg.waitForTerminationAndClear(&xsink);
-    UT_ASSERT(c, !xsink, "debugger cleanup succeeds");
     pgm->waitForTerminationAndDeref(&xsink);
     UT_ASSERT(c, !xsink, "foreign debug target program cleanup succeeds");
 }
@@ -2761,14 +2813,14 @@ static QoreHashNode* make_unit_test_result(UnitTestCounters& c, ExceptionSink* x
 
 static QoreValue f_run_debug_unit_tests(const QoreListNode* params, RuntimeConfig& rc, ExceptionSink* xsink) {
     UnitTestCounters c;
-    ut_debug_skips_foreign_thread_callbacks(c);
+    ut_debug_skips_foreign_thread_callbacks(c, rc.getProgram());
     return make_unit_test_result(c, xsink);
 }
 
 static QoreValue f_run_unit_tests(const QoreListNode* params, RuntimeConfig& rc, ExceptionSink* xsink) {
     UnitTestCounters c;
 
-    ut_debug_skips_foreign_thread_callbacks(c);
+    ut_debug_skips_foreign_thread_callbacks(c, rc.getProgram());
     ut_asyncio_construction(c);
     ut_asyncio_autostop(c);
     ut_asyncio_start_stop(c);

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -750,6 +750,10 @@ bool ThreadProgramData::canRunDebugCallbacks() const {
     return !td->foreign;
 }
 
+bool ThreadProgramData::isActiveProgram(QoreProgram* pgm) const {
+    return td->current_pgm == pgm;
+}
+
 void ThreadProgramData::del(ExceptionSink* xsink) {
     // first purge all data
     {

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -746,6 +746,10 @@ bool ThreadProgramData::saveProgram(bool runtime, ExceptionSink* xsink) {
     return true;
 }
 
+bool ThreadProgramData::canRunDebugCallbacks() const {
+    return !td->foreign;
+}
+
 void ThreadProgramData::del(ExceptionSink* xsink) {
     // first purge all data
     {
@@ -2294,7 +2298,7 @@ void ProgramThreadCountContextHelper::set(ExceptionSink* xsink, QoreProgram* pgm
         "init_tlpd:%d\n", this, td->tlpd, save_frameCount, old_frameCount, init_tlpd
     );
 
-    if (!td->tlpd->dbgIsAttached()) {
+    if (td->tpd->canRunDebugCallbacks() && !td->tlpd->dbgIsAttached()) {
         // find if tlpd is in lower context and if not then notify dbgAttach()
         if (isFirstThreadLocalProgramData(td->tlpd)) {
             td->tlpd->dbgAttach(xsink);

--- a/qlib/DataProvider/AbstractDataProvider.qc
+++ b/qlib/DataProvider/AbstractDataProvider.qc
@@ -6981,6 +6981,74 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
         @since DataProvider 3.4
     */
     private auto simulateRequestImpl(string app, string action, auto input, AbstractSimulationRecorder recorder) {
+        if (*hash<DataProviderActionInfo> action_info = DataProviderActionCatalog::getAppAction(app, action)) {
+            return simulateRequestForActionCode(app, action, input, recorder, action_info.action_code);
+        }
+
+        return simulateRequestFromCapabilities(app, action, input, recorder);
+    }
+
+    private auto simulateRequestForActionCode(string app, string action, auto input, AbstractSimulationRecorder recorder,
+            int action_code) {
+        switch (action_code) {
+            case DPAT_API:
+                if (supportsRequest()) {
+                    recorder.record(app, action, input, "example");
+                    if (exists (auto rv = getExampleResponseData())) {
+                        return rv;
+                    }
+                    return NULL;
+                }
+                break;
+
+            case DPAT_CREATE:
+                if (supportsCreate()) {
+                    recorder.record(app, action, input, "example");
+                    return getExampleRecordData();
+                }
+                break;
+
+            case DPAT_UPSERT:
+                if (supportsUpsert()) {
+                    recorder.record(app, action, input, "example");
+                    return UpsertResultInserted;
+                }
+                break;
+
+            case DPAT_UPDATE:
+                if (supportsUpdate()) {
+                    recorder.record(app, action, input, "example");
+                    return 1;
+                }
+                break;
+
+            case DPAT_DELETE:
+                if (supportsDelete()) {
+                    recorder.record(app, action, input, "example");
+                    return 1;
+                }
+                break;
+
+            case DPAT_FIND:
+                if (supportsRead()) {
+                    recorder.record(app, action, input, "example");
+                    return (getExampleRecordData(),);
+                }
+                break;
+
+            case DPAT_FIND_SINGLE:
+                if (supportsRead()) {
+                    recorder.record(app, action, input, "example");
+                    return getExampleRecordData();
+                }
+                break;
+        }
+
+        return simulateUnsupportedRequest(app, action, input, recorder);
+    }
+
+    private auto simulateRequestFromCapabilities(string app, string action, auto input,
+            AbstractSimulationRecorder recorder) {
         if (supportsRequest()) {
             recorder.record(app, action, input, "example");
             if (exists (auto rv = getExampleResponseData())) {
@@ -7005,6 +7073,10 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
             return getExampleRecordData();
         }
 
+        return simulateUnsupportedRequest(app, action, input, recorder);
+    }
+
+    private auto simulateUnsupportedRequest(string app, string action, auto input, AbstractSimulationRecorder recorder) {
         recorder.record(app, action, input, "unsupported");
         throw "DRY-RUN-NOT-SUPPORTED", sprintf("data provider %y of class %y cannot simulate action %y",
             getName(), self.className(), action);

--- a/qlib/DataProvider/AbstractDataProvider.qc
+++ b/qlib/DataProvider/AbstractDataProvider.qc
@@ -44,6 +44,26 @@ public const UpsertResultUnchanged = "unchanged";
 public const UpsertResultDeleted = "deleted";
 #/@}
 
+#! Base class for recording simulated data-provider requests
+/** @since DataProvider 3.4
+*/
+public class AbstractSimulationRecorder {
+    #! Records a simulated data-provider action
+    /** @param app the data-provider application name
+        @param action the data-provider action name
+        @param input the input data passed to the action
+        @param fidelity the simulation fidelity marker
+    */
+    abstract record(string app, string action, auto input, string fidelity = "app-simulator");
+
+    #! Returns recorded simulated data-provider actions
+    /** @param app optional data-provider application filter
+        @param action optional data-provider action filter
+        @return recorded simulated actions matching the optional filters
+    */
+    abstract list<hash<auto>> recorded(*string app, *string action);
+}
+
 #! Base option info with common fields shared by DataProviderOptionInfo, ActionOptionInfo, and ConnectionOptionInfo
 /** @since %DataProvider 3.1
 */
@@ -3989,6 +4009,41 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
         return {};
     }
 
+    #! Returns simulated response data for a request without side effects
+    /** The default implementation records the attempted action with fidelity
+        \c "example" and returns structural example data based on the provider
+        capabilities. Data-provider subclasses can override
+        \c simulateRequestImpl() to provide app-specific dry-run behavior.
+
+        @param app stable data-provider application name used in recorder entries
+        @param action data-provider action name
+        @param input input record passed to the action
+        @param recorder simulation recorder owned by the caller
+
+        @return simulated response data
+
+        @throw DRY-RUN-NOT-SUPPORTED when no structural example can be produced
+
+        @since DataProvider 3.4
+    */
+    auto simulateRequest(string app, string action, auto input, AbstractSimulationRecorder recorder) {
+        return simulateRequestImpl(app, action, input, recorder);
+    }
+
+    #! Returns volatile input paths for simulated action signature hashing
+    /** Returned paths are relative to the action input root.
+
+        @param app stable data-provider application name
+        @param action data-provider action name
+
+        @return volatile input paths that callers should remove before hashing
+
+        @since DataProvider 3.4
+    */
+    softlist<string> getSimulationVolatileFields(string app, string action) {
+        return getSimulationVolatileFieldsImpl(app, action);
+    }
+
     #! Returns connection info if the data provider supports connections, otherwise returns @ref NOTHING
     /** @return connection info if the data provider supports connections, otherwise returns @ref NOTHING
 
@@ -6913,6 +6968,58 @@ public class AbstractDataProvider inherits Logger::LoggerWrapper, Qore::Serializ
     */
     private hash<auto> getExampleRecordDataWithOptionsImpl(*hash<auto> options) {
         return getExampleRecordDataImpl();
+    }
+
+    #! Returns simulated response data for a request without side effects
+    /** @param app stable data-provider application name used in recorder entries
+        @param action data-provider action name
+        @param input input record passed to the action
+        @param recorder simulation recorder owned by the caller
+
+        @return simulated response data
+
+        @since DataProvider 3.4
+    */
+    private auto simulateRequestImpl(string app, string action, auto input, AbstractSimulationRecorder recorder) {
+        if (supportsRequest()) {
+            recorder.record(app, action, input, "example");
+            if (exists (auto rv = getExampleResponseData())) {
+                return rv;
+            }
+            return NULL;
+        }
+        if (supportsCreate()) {
+            recorder.record(app, action, input, "example");
+            return getExampleRecordData();
+        }
+        if (supportsUpsert()) {
+            recorder.record(app, action, input, "example");
+            return UpsertResultInserted;
+        }
+        if (supportsUpdate() || supportsDelete()) {
+            recorder.record(app, action, input, "example");
+            return 1;
+        }
+        if (supportsRead()) {
+            recorder.record(app, action, input, "example");
+            return getExampleRecordData();
+        }
+
+        recorder.record(app, action, input, "unsupported");
+        throw "DRY-RUN-NOT-SUPPORTED", sprintf("data provider %y of class %y cannot simulate action %y",
+            getName(), self.className(), action);
+    }
+
+    #! Returns volatile input paths for simulated action signature hashing
+    /** @param app stable data-provider application name
+        @param action data-provider action name
+
+        @return volatile input paths that callers should remove before hashing
+
+        @since DataProvider 3.4
+    */
+    private softlist<string> getSimulationVolatileFieldsImpl(string app, string action) {
+        return ();
     }
 
     #! Returns reference data of the given kind if available

--- a/qlib/DataProvider/DataProvider.qm
+++ b/qlib/DataProvider/DataProvider.qm
@@ -50,7 +50,7 @@
 %endtry
 
 module DataProvider {
-    version = "3.3.0";
+    version = "3.4.0";
     desc = "user module for data integration patterns and data and API introspection";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -1026,6 +1026,13 @@ if (errors) {
     @endcode
 
     @section dataprovider_relnotes Release Notes
+
+    @subsection dataprovider_v3_4 DataProvider v3.4
+    - added @ref DataProvider::AbstractSimulationRecorder "AbstractSimulationRecorder" and
+      @ref DataProvider::AbstractDataProvider::simulateRequest() "AbstractDataProvider::simulateRequest()" for
+      side-effect-free dry-run execution
+    - added @ref DataProvider::AbstractDataProvider::getSimulationVolatileFields()
+      "AbstractDataProvider::getSimulationVolatileFields()" for simulation signature hashing
 
     @subsection dataprovider_v3_3 DataProvider v3.3
     - added 67 generic DPQL expressions for use in data-driven contexts (arithmetic, string

--- a/qlib/HttpClientIo/Http3ClientPollOperationImpl.qc
+++ b/qlib/HttpClientIo/Http3ClientPollOperationImpl.qc
@@ -48,7 +48,10 @@ public namespace HttpClientIo {
 public class Http3ClientPollOperation inherits Http3ClientPollOperationBase, HttpClientPollOperation {
     public {
         #! Maximum STREAM_ID_BLOCKED retries before signaling capacity error
-        const MaxStreamBlockedRetries = 3;
+        const MaxStreamBlockedRetries = 14;
+
+        #! Maximum STREAM_ID_BLOCKED retry backoff in milliseconds
+        const MaxStreamBlockedBackoffMs = 128;
     }
 
     private {
@@ -67,6 +70,64 @@ public class Http3ClientPollOperation inherits Http3ClientPollOperationBase, Htt
 
         #! Lock protecting stream listener registration and dispatch
         Mutex stream_listener_mutex();
+    }
+
+    #! Submits a request to the QUIC layer, waiting briefly for stream ID credit if needed
+    /** QUIC stream limits are cumulative, not just active-stream based.  A fast
+        sequential caller can consume the peer's advertised stream ID credit
+        before the peer's MAX_STREAMS update is processed, especially on slower
+        CI runners.  Treat STREAM_ID_BLOCKED as transient backpressure first;
+        only surface capacity after a bounded condition-wait retry budget.
+    */
+    private int submitQuicRequestWithStreamCredit(Socket sock, string method, string path,
+            hash<auto> req_headers, *data body, bool streaming, int max_streams) {
+        int retries = 0;
+        while (True) {
+            try {
+                if (streaming) {
+                    return sock.submitQuicRequestStreaming(method, path, req_headers);
+                }
+                return sock.submitQuicRequest(method, path, req_headers, body);
+            } catch (hash<ExceptionInfo> ex) {
+                if (ex.err == "QUIC-ERROR" && ex.desc =~ /STREAM_ID_BLOCKED/
+                        && retries < MaxStreamBlockedRetries) {
+                    ++retries;
+                    int backoff_val = 1 << (retries - 1);
+                    if (backoff_val > MaxStreamBlockedBackoffMs) {
+                        backoff_val = MaxStreamBlockedBackoffMs;
+                    }
+                    log(LoggerLevel::DEBUG,
+                        "STREAM_ID_BLOCKED retry %d/%d (backoff %dms)",
+                        retries, MaxStreamBlockedRetries, backoff_val);
+                    self.waitStreamCapacity(backoff_val);
+                    if (!self.isReady()) {
+                        throw "HTTP3-STATE-ERROR",
+                            sprintf("connection closed during STREAM_ID_BLOCKED "
+                                "retry (state: %y)", self.getState());
+                    }
+                    continue;
+                }
+                if (ex.err == "QUIC-ERROR" && ex.desc =~ /STREAM_ID_BLOCKED/) {
+                    int captured_active = self.getActiveStreamCount();
+                    if (captured_active && (!max_streams || captured_active < max_streams)) {
+                        self.setQuicStreamLimit(captured_active);
+                    }
+                    log(LoggerLevel::DEBUG,
+                        "STREAM_ID_BLOCKED after %d retries - signaling "
+                        "capacity error (active: %d, quic_limit: %d)",
+                        MaxStreamBlockedRetries, captured_active,
+                        self.getQuicStreamLimit());
+                    throw "HTTP3-CAPACITY-ERROR",
+                        sprintf("QUIC stream limit reached on connection"
+                            " (active_streams: %d)", captured_active);
+                }
+                if (ex.err == "QUIC-HTTP3-ERROR" || ex.err == "QUIC-READ-ERROR"
+                        || ex.err == "QUIC-RECV-ERROR") {
+                    self.setSubmitError(ex.err, ex.desc);
+                }
+                rethrow;
+            }
+        }
     }
 
     #! Creates the poll operation for a new QUIC connection
@@ -203,59 +264,9 @@ public class Http3ClientPollOperation inherits Http3ClientPollOperationBase, Htt
 
         Socket sock = self.getSocket();
         int stream_id;
-        int retries = 0;
         try {
-            while (True) {
-                try {
-                    if (streaming) {
-                        stream_id = sock.submitQuicRequestStreaming(method, path, req_headers);
-                    } else {
-                        stream_id = sock.submitQuicRequest(method, path, req_headers, body);
-                    }
-                    break;
-                } catch (hash<ExceptionInfo> ex) {
-                    if (ex.err == "QUIC-ERROR" && ex.desc =~ /STREAM_ID_BLOCKED/
-                            && retries < MaxStreamBlockedRetries) {
-                        ++retries;
-                        # Backoff: 1ms, 2ms, 4ms
-                        int backoff_val = 1 << (retries - 1);
-                        log(LoggerLevel::DEBUG,
-                            "STREAM_ID_BLOCKED retry %d/%d (backoff %dms)",
-                            retries, MaxStreamBlockedRetries, backoff_val);
-                        # Wait on condition — signaled when continuePoll()
-                        # drains completed streams and frees stream slots.
-                        self.waitStreamCapacity(backoff_val);
-
-                        if (!self.isReady()) {
-                            throw "HTTP3-STATE-ERROR",
-                                sprintf("connection closed during STREAM_ID_BLOCKED "
-                                    "retry (state: %y)", self.getState());
-                        }
-                        continue;
-                    }
-                    if (ex.err == "QUIC-ERROR" && ex.desc =~ /STREAM_ID_BLOCKED/) {
-                        # Retries exhausted — record the limit
-                        int captured_active = self.getActiveStreamCount();
-                        if (!max_streams || captured_active < max_streams) {
-                            self.setQuicStreamLimit(captured_active);
-                        }
-                        log(LoggerLevel::DEBUG,
-                            "STREAM_ID_BLOCKED after %d retries — signaling "
-                            "capacity error (active: %d, quic_limit: %d)",
-                            MaxStreamBlockedRetries, captured_active,
-                            self.getQuicStreamLimit());
-                        throw "HTTP3-CAPACITY-ERROR",
-                            sprintf("QUIC stream limit reached on connection"
-                                " (active_streams: %d)", captured_active);
-                    }
-                    # Connection death errors — mark as closed immediately
-                    if (ex.err == "QUIC-HTTP3-ERROR" || ex.err == "QUIC-READ-ERROR"
-                            || ex.err == "QUIC-RECV-ERROR") {
-                        self.setSubmitError(ex.err, ex.desc);
-                    }
-                    rethrow;
-                }
-            }
+            stream_id = submitQuicRequestWithStreamCredit(sock, method, path,
+                req_headers, body, streaming, max_streams);
         } catch () {
             # Ensure submits_in_progress is decremented on all failure paths
             self.endSubmitFail();
@@ -277,19 +288,6 @@ public class Http3ClientPollOperation inherits Http3ClientPollOperationBase, Htt
             throw "HTTP3-STATE-ERROR",
                 sprintf("connection closed during request submission (state: %y)",
                     self.getState());
-        }
-
-        # Deliver any buffered responses by resolving the Promise directly
-        if (reg_result.buffered) {
-            foreach hash<auto> resp in (reg_result.buffered) {
-                resp.protocol = "h3";
-                if (resp.end_stream.toBool()) {
-                    # Final response — resolve the Promise and clean up
-                    try { promise.set(resp); } catch () {}
-                    self.cancelStream(stream_id);
-                    break;
-                }
-            }
         }
 
         return stream_id;
@@ -339,41 +337,9 @@ public class Http3ClientPollOperation inherits Http3ClientPollOperationBase, Htt
 
         Socket sock = self.getSocket();
         int stream_id;
-        int retries = 0;
         try {
-            while (True) {
-                try {
-                    stream_id = sock.submitQuicRequest(method, path, req_headers, body);
-                    break;
-                } catch (hash<ExceptionInfo> ex) {
-                    if (ex.err == "QUIC-ERROR" && ex.desc =~ /STREAM_ID_BLOCKED/
-                            && retries < MaxStreamBlockedRetries) {
-                        ++retries;
-                        int backoff_val = 1 << (retries - 1);
-                        self.waitStreamCapacity(backoff_val);
-                        if (!self.isReady()) {
-                            throw "HTTP3-STATE-ERROR",
-                                sprintf("connection closed during STREAM_ID_BLOCKED "
-                                    "retry (state: %y)", self.getState());
-                        }
-                        continue;
-                    }
-                    if (ex.err == "QUIC-ERROR" && ex.desc =~ /STREAM_ID_BLOCKED/) {
-                        int captured_active = self.getActiveStreamCount();
-                        if (!max_streams || captured_active < max_streams) {
-                            self.setQuicStreamLimit(captured_active);
-                        }
-                        throw "HTTP3-CAPACITY-ERROR",
-                            sprintf("QUIC stream limit reached on connection"
-                                " (active_streams: %d)", captured_active);
-                    }
-                    if (ex.err == "QUIC-HTTP3-ERROR" || ex.err == "QUIC-READ-ERROR"
-                            || ex.err == "QUIC-RECV-ERROR") {
-                        self.setSubmitError(ex.err, ex.desc);
-                    }
-                    rethrow;
-                }
-            }
+            stream_id = submitQuicRequestWithStreamCredit(sock, method, path,
+                req_headers, body, False, max_streams);
         } catch () {
             self.endSubmitFail();
             rethrow;
@@ -393,20 +359,6 @@ public class Http3ClientPollOperation inherits Http3ClientPollOperationBase, Htt
             throw "HTTP3-STATE-ERROR",
                 sprintf("connection closed during request submission (state: %y)",
                     self.getState());
-        }
-
-        # Deliver buffered responses directly — also signal notifier since the
-        # CompositeAction won't fire for data buffered before registration
-        if (reg_result.buffered) {
-            foreach hash<auto> resp in (reg_result.buffered) {
-                resp.protocol = "h3";
-                if (resp.end_stream.toBool()) {
-                    try { promise.set(resp); } catch () {}
-                    notifier.notify();
-                    self.cancelStream(stream_id);
-                    break;
-                }
-            }
         }
 
         return stream_id;
@@ -459,11 +411,8 @@ public class Http3ClientPollOperation inherits Http3ClientPollOperationBase, Htt
         Socket sock = self.getSocket();
         int stream_id;
         try {
-            if (streaming) {
-                stream_id = sock.submitQuicRequestStreaming(method, path, req_headers);
-            } else {
-                stream_id = sock.submitQuicRequest(method, path, req_headers, body);
-            }
+            stream_id = submitQuicRequestWithStreamCredit(sock, method, path,
+                req_headers, body, streaming, max_streams);
         } catch () {
             self.endSubmitFail();
             rethrow;
@@ -484,14 +433,6 @@ public class Http3ClientPollOperation inherits Http3ClientPollOperationBase, Htt
             throw "HTTP3-STATE-ERROR",
                 sprintf("connection closed during request submission (state: %y)",
                     self.getState());
-        }
-
-        # Deliver any responses that arrived during the submit-to-registration window
-        if (reg_result.buffered) {
-            foreach hash<auto> resp in (reg_result.buffered) {
-                resp.protocol = "h3";
-                channel.send(resp);
-            }
         }
 
         return stream_id;
@@ -546,7 +487,8 @@ public class Http3ClientPollOperation inherits Http3ClientPollOperationBase, Htt
         Socket sock = self.getSocket();
         int stream_id;
         try {
-            stream_id = sock.submitQuicRequest(method, path, req_headers, body);
+            stream_id = submitQuicRequestWithStreamCredit(sock, method, path,
+                req_headers, body, False, max_streams);
         } catch () {
             self.endSubmitFail();
             rethrow;

--- a/qlib/LineCoverage.qm
+++ b/qlib/LineCoverage.qm
@@ -95,6 +95,8 @@ public namespace LineCoverage {
             hash<auto> attached_programs = {};
             hash<auto> statement_locations = {};
             hash<auto> statement_hits = {};
+            hash<auto> pending_function_entries = {};
+            hash<auto> last_callbacks = {};
         }
 
         #! Creates a recorder
@@ -228,7 +230,13 @@ public namespace LineCoverage {
                 *int breakpointId, reference flow, reference rs,
                 reference runToStatementId) {
             if (statementId) {
+                flushPendingFunctionEntry(
+                    statementLocationKey(pgm, statementId));
                 recordStatement(pgm, statementId);
+                setLastCallback("step", statementLocationKey(pgm,
+                    statementId));
+            } else {
+                setLastCallback("block", NOTHING);
             }
             rs = DebugStep;
         }
@@ -236,26 +244,45 @@ public namespace LineCoverage {
         onFunctionEnter(ProgramControl pgm, int statementId, reference rs,
                 reference runToStatementId) {
             if (statementId) {
-                recordStatement(pgm, statementId);
+                pushPendingFunctionEntry(pgm, statementId);
+                setLastCallback("function-enter", statementLocationKey(pgm,
+                    statementId));
             }
             rs = DebugStep;
         }
 
         onFunctionExit(ProgramControl pgm, int statementId, reference result,
                 reference rs, reference runToStatementId) {
+            if (statementId) {
+                flushPendingFunctionEntry(NOTHING,
+                    statementLocationKey(pgm, statementId));
+                setLastCallback("function-exit", statementLocationKey(pgm,
+                    statementId));
+            }
             rs = DebugStep;
         }
 
         onException(ProgramControl pgm, int statementId, hash<auto> ex,
                 reference dismiss, reference rs, reference runToStatementId) {
             if (statementId) {
-                recordStatement(pgm, statementId);
+                string loc_key = statementLocationKey(pgm, statementId);
+                flushPendingFunctionEntry(loc_key);
+                if (!isLastCallback("step", loc_key)) {
+                    recordStatement(pgm, statementId);
+                }
+                setLastCallback("exception", loc_key);
             }
             rs = DebugStep;
         }
 
         onExit(ProgramControl pgm, int statementId, reference result,
                 reference rs, reference runToStatementId) {
+            if (statementId) {
+                flushPendingFunctionEntry(NOTHING,
+                    statementLocationKey(pgm, statementId));
+                setLastCallback("exit", statementLocationKey(pgm,
+                    statementId));
+            }
             rs = DebugStep;
         }
 
@@ -280,6 +307,63 @@ public namespace LineCoverage {
             string key = statementKey(pgm.getProgramId(), statement_id);
             AutoLock al(m);
             statement_hits{key} = (statement_hits{key} ?? 0) + 1;
+        }
+
+        private pushPendingFunctionEntry(ProgramControl pgm,
+                int statement_id) {
+            ensureStatementInfo(pgm, statement_id);
+            string tid = gettid().toString();
+            hash<auto> pending = {
+                "pgm": pgm,
+                "statement_id": statement_id,
+                "location_key": statementLocationKey(pgm, statement_id),
+            };
+            AutoLock al(m);
+            list<auto> stack = pending_function_entries{tid} ?? ();
+            push stack, pending;
+            pending_function_entries{tid} = stack;
+        }
+
+        private flushPendingFunctionEntry(*string duplicate_location_key,
+                *string matching_location_key) {
+            string tid = gettid().toString();
+            *hash<auto> pending;
+            {
+                AutoLock al(m);
+                list<auto> stack = pending_function_entries{tid} ?? ();
+                if (!stack) {
+                    return;
+                }
+                pending = pop stack;
+                if (matching_location_key
+                        && pending.location_key != matching_location_key) {
+                    push stack, pending;
+                    pending = NOTHING;
+                }
+                if (stack) {
+                    pending_function_entries{tid} = stack;
+                } else {
+                    delete pending_function_entries{tid};
+                }
+            }
+            if (pending && pending.location_key != duplicate_location_key) {
+                recordStatement(pending.pgm, pending.statement_id);
+            }
+        }
+
+        private setLastCallback(string kind, *string location_key) {
+            AutoLock al(m);
+            last_callbacks{gettid().toString()} = {
+                "kind": kind,
+                "location_key": location_key,
+            };
+        }
+
+        private bool isLastCallback(string kind, string location_key) {
+            AutoLock al(m);
+            *hash<auto> last = last_callbacks{gettid().toString()};
+            return last && last.kind == kind
+                && last.location_key == location_key;
         }
 
         private hash<auto> normalizeStatementInfo(ProgramControl pgm,
@@ -390,6 +474,13 @@ public namespace LineCoverage {
 
         private string statementKey(int program_id, int statement_id) {
             return sprintf("%d:%d", program_id, statement_id);
+        }
+
+        private string statementLocationKey(ProgramControl pgm,
+                int statement_id) {
+            hash<auto> loc = normalizeStatementInfo(pgm, statement_id);
+            return sprintf("%d:%s:%d:%d", loc.program_id, loc.file, loc.line,
+                loc.end_line);
         }
 
         private string lineKey(string file, int line) {

--- a/qlib/LineCoverage.qm
+++ b/qlib/LineCoverage.qm
@@ -1,0 +1,375 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! @file LineCoverage.qm Program statement line coverage helper
+
+/*  LineCoverage.qm Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+# minimum required Qore version
+%requires qore >= 2.3
+
+%modern
+%no-debugging
+%allow-debugger
+%no-child-restrictions
+
+module LineCoverage {
+    version = "0.1";
+    desc = "user module providing Qore Program line coverage collection";
+    author = "Qore Technologies, s.r.o.";
+    url = "https://qoretechnologies.com";
+    license = "MIT";
+}
+
+/** @mainpage LineCoverage Module
+
+    @tableofcontents
+
+    @section linecoverageintro Introduction to the LineCoverage Module
+
+    The %LineCoverage module provides a stable Qore-level API for collecting
+    source-line coverage from @ref Qore::Program "Program" execution.  It uses
+    the supported @ref Qore::ProgramControl "ProgramControl" statement metadata
+    API and debugger step callbacks; callers receive deterministic hashes and
+    lists instead of depending on debugger internals.
+
+    @subsection lc_v0_1 v0.1
+    - initial @ref LineCoverage::Recorder "Recorder" API
+    - line, file, and statement hit summaries
+*/
+
+#! Namespace for Qore Program line coverage collection
+public namespace LineCoverage {
+    #! Records executed statement locations for one or more Program instances
+    /**
+        The recorder attaches to @ref Qore::ProgramControl "ProgramControl"
+        instances and keeps stepping without blocking debugged threads.  Call
+        @ref start() before executing code, @ref stop() when collection should
+        end, and @ref snapshot() to retrieve a deterministic report.
+
+        The report has this shape:
+        - \c line_count: number of executable source lines seen
+        - \c covered_line_count: executable source lines with at least one hit
+        - \c coverage_percent: covered_line_count / line_count * 100
+        - \c statement_count: number of executable statements seen
+        - \c covered_statement_count: executable statements with at least one hit
+        - \c lines: sorted list of per-line hashes
+        - \c files: hash keyed by file, with per-file totals
+        - \c statements: sorted list of per-statement hashes
+    */
+    public class Recorder inherits DebugProgram {
+        private {
+            Mutex m();
+            hash<auto> attached_programs = {};
+            hash<auto> statement_locations = {};
+            hash<auto> statement_hits = {};
+        }
+
+        #! Creates a recorder
+        /** @param options reserved for future extension */
+        constructor(*hash<auto> options) {
+        }
+
+        destructor() {
+            try {
+                stopAll();
+            } catch () {
+            }
+        }
+
+        #! Attaches to a program and preloads its statement locations
+        /** @param pgm program to cover; defaults to the current Program */
+        public start(*ProgramControl pgm) {
+            ProgramControl p = pgm ?? ProgramControl::getProgram();
+            loadProgram(p);
+            int program_id = p.getProgramId();
+            bool should_add = False;
+            {
+                AutoLock al(m);
+                if (!attached_programs{program_id.toString()}.toBool()) {
+                    attached_programs{program_id.toString()} = True;
+                    should_add = True;
+                }
+            }
+            if (should_add) {
+                try {
+                    addProgram(p);
+                } catch (hash<ExceptionInfo> ex) {
+                    AutoLock al(m);
+                    delete attached_programs{program_id.toString()};
+                    throw ex.err, ex.desc, ex.arg;
+                }
+            }
+        }
+
+        #! Detaches from a program
+        /** @param pgm program to stop covering; defaults to the current Program */
+        public stop(*ProgramControl pgm) {
+            ProgramControl p = pgm ?? ProgramControl::getProgram();
+            string program_id = p.getProgramId().toString();
+            {
+                AutoLock al(m);
+                if (!attached_programs{program_id}.toBool()) {
+                    return;
+                }
+            }
+            removeProgram(p);
+            AutoLock al(m);
+            delete attached_programs{program_id};
+        }
+
+        #! Detaches from all currently attached programs
+        public stopAll() {
+            foreach ProgramControl p in (getAllPrograms()) {
+                string program_id = p.getProgramId().toString();
+                {
+                    AutoLock al(m);
+                    if (!attached_programs{program_id}.toBool()) {
+                        continue;
+                    }
+                }
+                removeProgram(p);
+                AutoLock al(m);
+                delete attached_programs{program_id};
+            }
+        }
+
+        #! Preloads statement locations without attaching the debugger
+        public loadProgram(ProgramControl pgm) {
+            foreach int statement_id in (pgm.getStatementIds()) {
+                ensureStatementInfo(pgm, statement_id);
+            }
+        }
+
+        #! Clears collected hits while preserving loaded statement locations
+        public reset() {
+            AutoLock al(m);
+            statement_hits = {};
+        }
+
+        #! Clears all collected statement locations and hits
+        public clear() {
+            AutoLock al(m);
+            statement_locations = {};
+            statement_hits = {};
+        }
+
+        #! Returns a deterministic coverage report
+        public hash<auto> snapshot() {
+            AutoLock al(m);
+            list<auto> statements = getStatementsLocked();
+            list<auto> lines = getLinesLocked(statements);
+            hash<auto> files = getFilesLocked(lines);
+            int covered_line_count = 0;
+            foreach hash<auto> line in (lines) {
+                if (line.covered.toBool()) {
+                    ++covered_line_count;
+                }
+            }
+            int covered_statement_count = 0;
+            foreach hash<auto> statement in (statements) {
+                if (statement.hit_count.toInt() > 0) {
+                    ++covered_statement_count;
+                }
+            }
+            int line_count = lines.size();
+            return {
+                "line_count": line_count,
+                "covered_line_count": covered_line_count,
+                "coverage_percent": line_count
+                    ? covered_line_count * 100.0 / line_count : 100.0,
+                "statement_count": statements.size(),
+                "covered_statement_count": covered_statement_count,
+                "lines": lines,
+                "files": files,
+                "statements": statements,
+            };
+        }
+
+        onAttach(ProgramControl pgm, reference rs, reference runToStatementId) {
+            loadProgram(pgm);
+            rs = DebugStep;
+        }
+
+        onDetach(ProgramControl pgm, reference rs, reference runToStatementId) {
+        }
+
+        onStep(ProgramControl pgm, int blockStatementId, *int statementId,
+                *int breakpointId, reference flow, reference rs,
+                reference runToStatementId) {
+            if (statementId) {
+                recordStatement(pgm, statementId);
+            }
+            rs = DebugStep;
+        }
+
+        onFunctionEnter(ProgramControl pgm, int statementId, reference rs,
+                reference runToStatementId) {
+            if (statementId) {
+                recordStatement(pgm, statementId);
+            }
+            rs = DebugStep;
+        }
+
+        onFunctionExit(ProgramControl pgm, int statementId, reference result,
+                reference rs, reference runToStatementId) {
+            rs = DebugStep;
+        }
+
+        onException(ProgramControl pgm, int statementId, hash<auto> ex,
+                reference dismiss, reference rs, reference runToStatementId) {
+            if (statementId) {
+                recordStatement(pgm, statementId);
+            }
+            rs = DebugStep;
+        }
+
+        onExit(ProgramControl pgm, int statementId, reference result,
+                reference rs, reference runToStatementId) {
+            rs = DebugStep;
+        }
+
+        private ensureStatementInfo(ProgramControl pgm, int statement_id) {
+            string key = statementKey(pgm.getProgramId(), statement_id);
+            {
+                AutoLock al(m);
+                if (exists statement_locations{key}) {
+                    return;
+                }
+            }
+
+            hash<auto> loc = normalizeStatementInfo(pgm, statement_id);
+            AutoLock al(m);
+            if (!exists statement_locations{key}) {
+                statement_locations{key} = loc;
+            }
+        }
+
+        private recordStatement(ProgramControl pgm, int statement_id) {
+            ensureStatementInfo(pgm, statement_id);
+            string key = statementKey(pgm.getProgramId(), statement_id);
+            AutoLock al(m);
+            statement_hits{key} = (statement_hits{key} ?? 0) + 1;
+        }
+
+        private hash<auto> normalizeStatementInfo(ProgramControl pgm,
+                int statement_id) {
+            hash<auto> info = pgm.getStatementIdInfo(statement_id);
+            int offset = info.offset ?? 0;
+            string source = info.source ?? "";
+            string label = info.file ?? "";
+            string file = source.val() ? source : label;
+            if (!file.val()) {
+                file = "<unknown>";
+            }
+            hash<auto> rv = {
+                "program_id": pgm.getProgramId(),
+                "statement_id": statement_id,
+                "statement_key": statementKey(pgm.getProgramId(),
+                    statement_id),
+                "file": file,
+                "line": (info.start_line ?? 0) + offset,
+                "end_line": (info.end_line ?? info.start_line ?? 0) + offset,
+                "start_line": info.start_line ?? 0,
+                "source_offset": offset,
+            };
+            if (source.val()) {
+                rv.source_label = label;
+            }
+            return rv;
+        }
+
+        private list<auto> getStatementsLocked() {
+            list<auto> rv = ();
+            foreach string key in (sort(map $1.toString(),
+                    keys statement_locations)) {
+                hash<auto> statement = statement_locations{key};
+                statement.hit_count = statement_hits{key} ?? 0;
+                statement.covered = statement.hit_count.toInt() > 0;
+                rv += statement;
+            }
+            return rv;
+        }
+
+        private list<auto> getLinesLocked(list<auto> statements) {
+            hash<auto> line_map = {};
+            foreach hash<auto> statement in (statements) {
+                string key = lineKey(statement.file, statement.line);
+                hash<auto> line = line_map{key} ?? {
+                    "file": statement.file,
+                    "line": statement.line,
+                    "end_line": statement.end_line,
+                    "statement_count": 0,
+                    "hit_count": 0,
+                    "covered": False,
+                    "statement_ids": (),
+                };
+                line.statement_count = line.statement_count.toInt() + 1;
+                line.hit_count = line.hit_count.toInt()
+                    + statement.hit_count.toInt();
+                line.covered = line.covered.toBool()
+                    || statement.hit_count.toInt() > 0;
+                list<auto> ids = line.statement_ids;
+                ids += statement.statement_id;
+                line.statement_ids = ids;
+                line_map{key} = line;
+            }
+
+            list<auto> rv = ();
+            foreach string key in (sort(map $1.toString(), keys line_map)) {
+                rv += line_map{key};
+            }
+            return rv;
+        }
+
+        private hash<auto> getFilesLocked(list<auto> lines) {
+            hash<auto> files = {};
+            foreach hash<auto> line in (lines) {
+                hash<auto> file = files{line.file} ?? {
+                    "file": line.file,
+                    "line_count": 0,
+                    "covered_line_count": 0,
+                    "hit_count": 0,
+                };
+                file.line_count = file.line_count.toInt() + 1;
+                if (line.covered.toBool()) {
+                    file.covered_line_count =
+                        file.covered_line_count.toInt() + 1;
+                }
+                file.hit_count = file.hit_count.toInt()
+                    + line.hit_count.toInt();
+                file.coverage_percent = file.line_count.toInt()
+                    ? file.covered_line_count.toInt() * 100.0
+                        / file.line_count.toInt()
+                    : 100.0;
+                files{line.file} = file;
+            }
+            return files;
+        }
+
+        private string statementKey(int program_id, int statement_id) {
+            return sprintf("%d:%d", program_id, statement_id);
+        }
+
+        private string lineKey(string file, int line) {
+            return sprintf("%s:%d", file, line);
+        }
+    }
+}

--- a/qlib/LineCoverage.qm
+++ b/qlib/LineCoverage.qm
@@ -52,11 +52,23 @@ module LineCoverage {
 
     @subsection lc_v0_1 v0.1
     - initial @ref LineCoverage::Recorder "Recorder" API
+    - initial @ref LineCoverage::create_recorder() "create_recorder()" API
     - line, file, and statement hit summaries
 */
 
 #! Namespace for Qore Program line coverage collection
 public namespace LineCoverage {
+    #! Creates a line coverage recorder
+    /** This function provides a stable dynamic API for code that loads the
+        module at runtime and cannot refer to @ref Recorder at parse time.
+
+        @param options reserved for future extension
+        @return a new @ref Recorder object
+    */
+    public object sub create_recorder(*hash<auto> options) {
+        return new Recorder(options);
+    }
+
     #! Records executed statement locations for one or more Program instances
     /**
         The recorder attaches to @ref Qore::ProgramControl "ProgramControl"

--- a/qlib/LineCoverage.qm
+++ b/qlib/LineCoverage.qm
@@ -84,6 +84,8 @@ public namespace LineCoverage {
         - \c statement_count: number of executable statements seen
         - \c covered_statement_count: executable statements with at least one hit
         - \c lines: sorted list of per-line hashes
+          - each line has \c statement_refs with \c program_id, \c statement_id,
+            and \c statement_key for the statements mapped to that line
         - \c files: hash keyed by file, with per-file totals
         - \c statements: sorted list of per-statement hashes
     */
@@ -322,25 +324,36 @@ public namespace LineCoverage {
         private list<auto> getLinesLocked(list<auto> statements) {
             hash<auto> line_map = {};
             foreach hash<auto> statement in (statements) {
-                string key = lineKey(statement.file, statement.line);
-                hash<auto> line = line_map{key} ?? {
-                    "file": statement.file,
-                    "line": statement.line,
-                    "end_line": statement.end_line,
-                    "statement_count": 0,
-                    "hit_count": 0,
-                    "covered": False,
-                    "statement_ids": (),
-                };
-                line.statement_count = line.statement_count.toInt() + 1;
-                line.hit_count = line.hit_count.toInt()
-                    + statement.hit_count.toInt();
-                line.covered = line.covered.toBool()
-                    || statement.hit_count.toInt() > 0;
-                list<auto> ids = line.statement_ids;
-                ids += statement.statement_id;
-                line.statement_ids = ids;
-                line_map{key} = line;
+                int start_line = statement.line.toInt();
+                int end_line = statement.end_line.toInt();
+                if (end_line < start_line) {
+                    end_line = start_line;
+                }
+                for (int line_no = start_line; line_no <= end_line; ++line_no) {
+                    string key = lineKey(statement.file, line_no);
+                    hash<auto> line = line_map{key} ?? {
+                        "file": statement.file,
+                        "line": line_no,
+                        "end_line": line_no,
+                        "statement_count": 0,
+                        "hit_count": 0,
+                        "covered": False,
+                        "statement_refs": (),
+                    };
+                    line.statement_count = line.statement_count.toInt() + 1;
+                    line.hit_count = line.hit_count.toInt()
+                        + statement.hit_count.toInt();
+                    line.covered = line.covered.toBool()
+                        || statement.hit_count.toInt() > 0;
+                    list<auto> refs = line.statement_refs;
+                    refs += {
+                        "program_id": statement.program_id,
+                        "statement_id": statement.statement_id,
+                        "statement_key": statement.statement_key,
+                    };
+                    line.statement_refs = refs;
+                    line_map{key} = line;
+                }
             }
 
             list<auto> rv = ();

--- a/qlib/LineCoverage.qm
+++ b/qlib/LineCoverage.qm
@@ -73,8 +73,9 @@ public namespace LineCoverage {
     /**
         The recorder attaches to @ref Qore::ProgramControl "ProgramControl"
         instances and keeps stepping without blocking debugged threads.  Call
-        @ref start() before executing code, @ref stop() when collection should
-        end, and @ref snapshot() to retrieve a deterministic report.
+        @ref start() with an explicit @ref Qore::ProgramControl
+        "ProgramControl" before executing code, @ref stop() when collection
+        should end, and @ref snapshot() to retrieve a deterministic report.
 
         The report has this shape:
         - \c line_count: number of executable source lines seen
@@ -107,11 +108,10 @@ public namespace LineCoverage {
         }
 
         #! Attaches to a program and preloads its statement locations
-        /** @param pgm program to cover; defaults to the current Program */
-        public start(*ProgramControl pgm) {
-            ProgramControl p = pgm ?? ProgramControl::getProgram();
-            loadProgram(p);
-            int program_id = p.getProgramId();
+        /** @param pgm program to cover */
+        public start(ProgramControl pgm) {
+            loadProgram(pgm);
+            int program_id = pgm.getProgramId();
             bool should_add = False;
             {
                 AutoLock al(m);
@@ -122,7 +122,7 @@ public namespace LineCoverage {
             }
             if (should_add) {
                 try {
-                    addProgram(p);
+                    addProgram(pgm);
                 } catch (hash<ExceptionInfo> ex) {
                     AutoLock al(m);
                     delete attached_programs{program_id.toString()};
@@ -132,17 +132,16 @@ public namespace LineCoverage {
         }
 
         #! Detaches from a program
-        /** @param pgm program to stop covering; defaults to the current Program */
-        public stop(*ProgramControl pgm) {
-            ProgramControl p = pgm ?? ProgramControl::getProgram();
-            string program_id = p.getProgramId().toString();
+        /** @param pgm program to stop covering */
+        public stop(ProgramControl pgm) {
+            string program_id = pgm.getProgramId().toString();
             {
                 AutoLock al(m);
                 if (!attached_programs{program_id}.toBool()) {
                     return;
                 }
             }
-            removeProgram(p);
+            removeProgram(pgm);
             AutoLock al(m);
             delete attached_programs{program_id};
         }


### PR DESCRIPTION
Summary:
- add the data provider simulation contract
- add ProgramControl statement-id metadata and the LineCoverage module
- harden debugger attachment so Qore code cannot force callbacks on foreign host threads

Tests:
- cmake --build build-debug -j4
- cmake --build build -j4
- LD_LIBRARY_PATH=/home/david/src/qore/git/qore/build-debug ./build-debug/qore --enable-debug examples/test/qore/debug/test-debug.qtest
- LD_LIBRARY_PATH=/home/david/src/qore/git/qore/build-debug ./build-debug/qore --enable-debug examples/test/qlib/LineCoverage/LineCoverage.qtest
- LD_LIBRARY_PATH=/home/david/src/qore/git/qore/build-debug ./build-debug/qore --enable-debug examples/test/qore/classes/AsyncIoController/asyncio_unit_tests.qtest
- LD_LIBRARY_PATH=/home/david/src/qore/git/qore/build-debug valgrind --leak-check=full --error-exitcode=1 ./build-debug/qore -b --enable-debug --modern -e <run_debug_unit_tests smoke>
- LD_LIBRARY_PATH=/home/david/src/qore/git/qore/build-debug valgrind --leak-check=full --error-exitcode=1 ./build-debug/qore -b --enable-debug examples/test/qlib/LineCoverage/LineCoverage.qtest
- QORE_BINARY=/home/david/src/qore/git/qore/build-debug/qore QORE_TEST_OPTS=--enable-debug ./run_tests.sh -d qlib/LineCoverage