### PR TITLE
feat: add ICU-backed i18n module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,18 @@ if (APPLE)
     )
     if (_brew_result EQUAL 0 AND _brew_prefix)
         list(APPEND CMAKE_PREFIX_PATH "${_brew_prefix}")
+        # ICU is keg-only in Homebrew, so add its prefix explicitly for
+        # find_package(ICU) and pkg-config based discovery.
+        execute_process(
+            COMMAND brew --prefix icu4c
+            OUTPUT_VARIABLE _brew_icu_prefix
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+            RESULT_VARIABLE _brew_icu_result
+        )
+        if (_brew_icu_result EQUAL 0 AND _brew_icu_prefix)
+            list(APPEND CMAKE_PREFIX_PATH "${_brew_icu_prefix}")
+        endif()
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,6 +370,7 @@ set(QORE_BIN_FILES
     bin/qdbg-server
     bin/qdbg-remote
     bin/qdbg-vsc-adapter
+    bin/qore-i18n
     bin/qore-openapi3-gen
     bin/qore-asyncapi-gen
     bin/qdiff

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,6 +449,18 @@ find_package(BZip2 REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PCRE2 REQUIRED libpcre2-8)
 
+# ICU is required so the bundled i18n module is always built and available.
+pkg_check_modules(ICU QUIET icu-uc icu-i18n)
+if(ICU_FOUND)
+    if(ICU_VERSION)
+        message(STATUS "Found ICU: ${ICU_VERSION}")
+    else()
+        message(STATUS "Found ICU")
+    endif()
+else()
+    find_package(ICU COMPONENTS uc i18n REQUIRED)
+endif()
+
 # c-ares is required for asynchronous DNS resolution in socket I/O.
 pkg_check_modules(CARES QUIET libcares)
 if(CARES_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2057,6 +2057,8 @@ add_subdirectory(modules/reflection)
 add_subdirectory(modules/logger_bin)
 # linenoise module
 add_subdirectory(modules/linenoise)
+# i18n module
+add_subdirectory(modules/i18n)
 # krb5 module
 add_subdirectory(modules/krb5)
 # mongodb module (optional, requires libmongoc)

--- a/bin/qore-i18n
+++ b/bin/qore-i18n
@@ -1,0 +1,1030 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+# @file qore-i18n CLI tool for managing Qore native i18n catalogs
+
+/*  Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%modern
+
+%requires astparser
+%requires json
+%requires Util
+
+%exec-class QoreI18nCmd
+
+class QoreI18nCmd {
+    public {
+        const Version = "0.1";
+
+        const ExtractOpts = {
+            "output":       "o,output=s",
+            "locale":       "l,locale=s",
+            "marker":       "m,marker=s@",
+            "fail-dynamic": "fail-dynamic",
+            "verbose":      "v,verbose:i+",
+            "help":         "h,help",
+        };
+
+        const StatsOpts = {
+            "locale":     "l,locale=s@",
+            "format":     "f,format=s",
+            "fail-under": "fail-under=i",
+            "help":       "h,help",
+        };
+
+        const PseudoOpts = {
+            "output": "o,output=s",
+            "from":   "from=s",
+            "locale": "l,locale=s",
+            "help":   "h,help",
+        };
+
+        const PoOpts = {
+            "output": "o,output=s",
+            "locale": "l,locale=s",
+            "help":   "h,help",
+        };
+    }
+
+    private {
+        hash<auto> extract_messages = {};
+        list<hash<auto>> extract_warnings = ();
+    }
+
+    constructor() {
+        if (!ARGV) {
+            usage();
+            exit(1);
+        }
+
+        string command = shift ARGV;
+        try {
+            switch (command) {
+                case "extract":
+                    runExtract();
+                    break;
+                case "stats":
+                    runStats();
+                    break;
+                case "pseudo":
+                    runPseudo();
+                    break;
+                case "export-po":
+                    runExportPo();
+                    break;
+                case "import-po":
+                    runImportPo();
+                    break;
+                case "help":
+                case "--help":
+                case "-h":
+                    usage();
+                    break;
+                default:
+                    stderr.printf("Error: unknown command '%s'\n\n", command);
+                    usage();
+                    exit(1);
+            }
+        } catch (hash<ExceptionInfo> ex) {
+            stderr.printf("Error: %s: %s\n", ex.err, ex.desc);
+            exit(1);
+        }
+    }
+
+    private usage() {
+        printf("qore-i18n v%s - Manage Qore native i18n catalogs\n\n", Version);
+        printf("Usage: qore-i18n <command> [options] <files...>\n\n");
+        printf("Commands:\n");
+        printf("  extract      Extract t()/tn()/tc() calls from Qore source into a native JSON catalog\n");
+        printf("  stats        Report translated/fuzzy/needs-review/stale coverage for native catalogs\n");
+        printf("  pseudo       Generate an ASCII pseudolocale catalog preserving placeholders\n");
+        printf("  export-po    Export one native-catalog locale to simple gettext PO interchange\n");
+        printf("  import-po    Import a simple gettext PO file into a native JSON catalog\n\n");
+        printf("Examples:\n");
+        printf("  qore-i18n extract -o catalogs/root.json src/app.q\n");
+        printf("  qore-i18n stats --fail-under=95 catalogs/cs.json\n");
+        printf("  qore-i18n pseudo -o catalogs/qps-ploc.json catalogs/root.json\n");
+    }
+
+    private runExtract() {
+        GetOpt g(ExtractOpts);
+        hash<auto> opt = g.parse3(\ARGV);
+        if (opt.help) {
+            extractUsage();
+            return;
+        }
+        if (!ARGV) {
+            throw "I18N-CLI-ERROR", "extract requires at least one source file";
+        }
+
+        string locale = opt.locale ?? "root";
+        hash<auto> markers = getMarkers(opt.marker);
+        extract_messages = {};
+        extract_warnings = ();
+
+        foreach string path in (cast<list<string>>(ARGV)) {
+            if (!is_readable(path)) {
+                throw "I18N-CLI-ERROR", sprintf("cannot read source file '%s'", path);
+            }
+            extractFile(path, markers, opt.verbose);
+        }
+
+        foreach hash<auto> warning in (extract_warnings) {
+            stderr.printf("%s:%d: warning: %s\n", warning.path, warning.line, warning.message);
+        }
+        if (opt{"fail-dynamic"} && extract_warnings) {
+            throw "I18N-DYNAMIC-KEY-ERROR", "dynamic i18n call arguments were found";
+        }
+
+        hash<auto> catalog = {
+            "schema_version": 1,
+            "locales": {
+                locale: {
+                    "messages": extract_messages,
+                },
+            },
+        };
+        writeOutput(opt.output, make_json(catalog, JGF_ADD_FORMATTING));
+    }
+
+    private extractUsage() {
+        printf("Usage: qore-i18n extract [options] <source-files...>\n\n");
+        printf("Options:\n");
+        printf("  -o, --output=FILE       Output native catalog JSON (default: stdout)\n");
+        printf("  -l, --locale=LOCALE     Output locale key (default: root)\n");
+        printf("  -m, --marker=NAME       Marker to extract; repeatable (default: t, tn, tc)\n");
+        printf("      --fail-dynamic      Fail if a marker call uses dynamic source/id arguments\n");
+        printf("  -v, --verbose           Increase progress output\n");
+        printf("  -h, --help              Show this help\n");
+    }
+
+    private runStats() {
+        GetOpt g(StatsOpts);
+        hash<auto> opt = g.parse3(\ARGV);
+        if (opt.help) {
+            statsUsage();
+            return;
+        }
+        if (!ARGV) {
+            throw "I18N-CLI-ERROR", "stats requires at least one catalog file";
+        }
+        string format = opt.format ?? "text";
+        if (format != "text" && format != "json") {
+            throw "I18N-CLI-ERROR", "stats --format must be 'text' or 'json'";
+        }
+
+        list<hash<auto>> rows = ();
+        foreach string path in (cast<list<string>>(ARGV)) {
+            hash<auto> catalog = loadJsonFile(path);
+            rows += getStatsRows(path, catalog, opt.locale);
+        }
+
+        if (format == "json") {
+            writeOutput(NOTHING, make_json(rows, JGF_ADD_FORMATTING));
+        } else {
+            printStats(rows);
+        }
+
+        if (exists opt{"fail-under"}) {
+            int min = opt{"fail-under"};
+            foreach hash<auto> row in (rows) {
+                if (row.coverage < min) {
+                    exit(2);
+                }
+            }
+        }
+    }
+
+    private statsUsage() {
+        printf("Usage: qore-i18n stats [options] <catalog-files...>\n\n");
+        printf("Options:\n");
+        printf("  -l, --locale=LOCALE     Locale to report; repeatable (default: all)\n");
+        printf("  -f, --format=FORMAT     text|json (default: text)\n");
+        printf("      --fail-under=N      Exit 2 if translated coverage is below N percent\n");
+        printf("  -h, --help              Show this help\n");
+    }
+
+    private runPseudo() {
+        GetOpt g(PseudoOpts);
+        hash<auto> opt = g.parse3(\ARGV);
+        if (opt.help) {
+            pseudoUsage();
+            return;
+        }
+        if (ARGV.size() != 1) {
+            throw "I18N-CLI-ERROR", "pseudo requires exactly one catalog file";
+        }
+
+        string source_locale = opt.from ?? "root";
+        string pseudo_locale = opt.locale ?? "qps-ploc";
+        hash<auto> catalog = loadJsonFile(string(ARGV[0]));
+        hash<auto> source = getLocale(catalog, source_locale);
+        hash<auto> pseudo_messages = {};
+
+        foreach string id in (keys source.messages) {
+            auto value = source.messages{id};
+            pseudo_messages{id} = makePseudoEntry(id, value);
+        }
+
+        hash<auto> out = {
+            "schema_version": 1,
+            "locales": {
+                pseudo_locale: {
+                    "messages": pseudo_messages,
+                },
+            },
+        };
+        writeOutput(opt.output, make_json(out, JGF_ADD_FORMATTING));
+    }
+
+    private pseudoUsage() {
+        printf("Usage: qore-i18n pseudo [options] <catalog-file>\n\n");
+        printf("Options:\n");
+        printf("      --from=LOCALE       Source locale to pseudo-localize (default: root)\n");
+        printf("  -l, --locale=LOCALE     Pseudolocale name (default: qps-ploc)\n");
+        printf("  -o, --output=FILE       Output native catalog JSON (default: stdout)\n");
+        printf("  -h, --help              Show this help\n");
+    }
+
+    private runExportPo() {
+        GetOpt g(PoOpts);
+        hash<auto> opt = g.parse3(\ARGV);
+        if (opt.help) {
+            exportPoUsage();
+            return;
+        }
+        if (ARGV.size() != 1) {
+            throw "I18N-CLI-ERROR", "export-po requires exactly one catalog file";
+        }
+        string locale = opt.locale ?? "root";
+        hash<auto> catalog = loadJsonFile(string(ARGV[0]));
+        hash<auto> loc = getLocale(catalog, locale);
+        writeOutput(opt.output, buildPo(locale, loc.messages));
+    }
+
+    private exportPoUsage() {
+        printf("Usage: qore-i18n export-po [options] <catalog-file>\n\n");
+        printf("Options:\n");
+        printf("  -l, --locale=LOCALE     Locale to export (default: root)\n");
+        printf("  -o, --output=FILE       Output PO file (default: stdout)\n");
+        printf("  -h, --help              Show this help\n");
+    }
+
+    private runImportPo() {
+        GetOpt g(PoOpts);
+        hash<auto> opt = g.parse3(\ARGV);
+        if (opt.help) {
+            importPoUsage();
+            return;
+        }
+        if (ARGV.size() != 1) {
+            throw "I18N-CLI-ERROR", "import-po requires exactly one PO file";
+        }
+        string locale = opt.locale ?? "root";
+        hash<auto> messages = parsePo(ReadOnlyFile::readTextFile(string(ARGV[0])));
+        hash<auto> catalog = {
+            "schema_version": 1,
+            "locales": {
+                locale: {
+                    "messages": messages,
+                },
+            },
+        };
+        writeOutput(opt.output, make_json(catalog, JGF_ADD_FORMATTING));
+    }
+
+    private importPoUsage() {
+        printf("Usage: qore-i18n import-po [options] <po-file>\n\n");
+        printf("Options:\n");
+        printf("  -l, --locale=LOCALE     Locale for the imported catalog (default: root)\n");
+        printf("  -o, --output=FILE       Output native catalog JSON (default: stdout)\n");
+        printf("  -h, --help              Show this help\n");
+    }
+
+    private hash<auto> getMarkers(*list<string> configured) {
+        hash<auto> rv = {};
+        list<string> marker_list = configured ?? ("t", "tn", "tc");
+        foreach string marker in (marker_list) {
+            if (!marker || marker.find(" ") >= 0) {
+                throw "I18N-CLI-ERROR", sprintf("invalid marker '%s'", marker);
+            }
+            rv{marker} = True;
+        }
+        return rv;
+    }
+
+    private extractFile(string path, hash<auto> markers, *int verbose) {
+        if (verbose) {
+            stderr.printf("extracting: %s\n", path);
+        }
+
+        string source = ReadOnlyFile::readTextFile(path);
+        list<string> lines = source.split("\n");
+        AstParser parser();
+        parser.setConditionalParsing(True);
+        *AstTree tree = parser.parseString(source);
+        if (!exists tree || parser.getErrorCount()) {
+            throw "I18N-PARSE-ERROR", sprintf("could not parse '%s': %N", path, parser.getDiagnostics());
+        }
+
+        list<auto> nodes = tree.getNodesInfo();
+        *list<hash<auto>> comments = tree.getComments();
+        visitNodes(nodes, lines, path, comments ?? (), markers);
+    }
+
+    private visitNodes(list<auto> nodes, list<string> lines, string path, list<hash<auto>> comments,
+            hash<auto> markers) {
+        foreach hash<auto> node in (nodes) {
+            if (node.type == "call_expression") {
+                extractCall(node, lines, path, comments, markers);
+            }
+            if (exists node.children) {
+                visitNodes(node.children, lines, path, comments, markers);
+            }
+        }
+    }
+
+    private extractCall(hash<auto> node, list<string> lines, string path, list<hash<auto>> comments,
+            hash<auto> markers) {
+        *hash<auto> function = childByField(node, "function");
+        *hash<auto> args = childByType(node, "argument_list");
+        if (!exists function || !exists args) {
+            return;
+        }
+
+        string marker = markerBaseName(extractSourceText(lines, function.loc));
+        if (!exists markers{marker}) {
+            return;
+        }
+
+        list<auto> arg_nodes = args.children ?? ();
+        int line = int(node.loc.start_line) + 1;
+        list<string> extraction_comments = i18nCommentsBefore(comments, line);
+
+        switch (marker) {
+            case "t": {
+                *string source = arg_nodes.size() >= 1 ? literalString(arg_nodes[0]) : NOTHING;
+                if (!exists source) {
+                    extract_warnings += warning(path, line, "dynamic t() source is not extractable");
+                    return;
+                }
+                addSingular(source, source, source, path, line, extraction_comments);
+                break;
+            }
+            case "tc": {
+                *string id = arg_nodes.size() >= 1 ? literalString(arg_nodes[0]) : NOTHING;
+                *string source = arg_nodes.size() >= 2 ? literalString(arg_nodes[1]) : NOTHING;
+                if (!exists id || !exists source) {
+                    extract_warnings += warning(path, line, "dynamic tc() id/source is not extractable");
+                    return;
+                }
+                addSingular(id, source, source, path, line, extraction_comments);
+                break;
+            }
+            case "tn": {
+                *string singular = arg_nodes.size() >= 2 ? literalString(arg_nodes[1]) : NOTHING;
+                *string plural = arg_nodes.size() >= 3 ? literalString(arg_nodes[2]) : NOTHING;
+                if (!exists singular || !exists plural) {
+                    extract_warnings += warning(path, line, "dynamic tn() singular/plural source is not extractable");
+                    return;
+                }
+                addPlural(singular, singular, plural, path, line, extraction_comments);
+                break;
+            }
+        }
+    }
+
+    private addSingular(string id, string source, string message,
+            string path, int line, list<string> extraction_comments) {
+        if (exists extract_messages{id}) {
+            auto entry = extract_messages{id};
+            entry = mergeMetadata(entry, path, line, extraction_comments);
+            extract_messages{id} = entry;
+            return;
+        }
+
+        extract_messages{id} = {
+            "source": source,
+            "message": message,
+            "state": "translated",
+            "source_refs": (sprintf("%s:%d", path, line),),
+        };
+        if (extraction_comments) {
+            extract_messages{id}.extraction_comments = extraction_comments;
+        }
+    }
+
+    private addPlural(string id, string singular, string plural,
+            string path, int line, list<string> extraction_comments) {
+        if (exists extract_messages{id}) {
+            auto entry = extract_messages{id};
+            entry = mergeMetadata(entry, path, line, extraction_comments);
+            extract_messages{id} = entry;
+            return;
+        }
+
+        extract_messages{id} = {
+            "source": singular,
+            "plural_source": plural,
+            "forms": {
+                "one": singular,
+                "other": plural,
+            },
+            "state": "translated",
+            "source_refs": (sprintf("%s:%d", path, line),),
+        };
+        if (extraction_comments) {
+            extract_messages{id}.extraction_comments = extraction_comments;
+        }
+    }
+
+    private auto mergeMetadata(auto entry, string path, int line, list<string> extraction_comments) {
+        if (entry.typeCode() != NT_HASH) {
+            return entry;
+        }
+        string ref = sprintf("%s:%d", path, line);
+        if (!exists entry.source_refs) {
+            entry.source_refs = (ref,);
+        } else if (!containsString(entry.source_refs, ref)) {
+            entry.source_refs += ref;
+        }
+        if (extraction_comments) {
+            if (!exists entry.extraction_comments) {
+                entry.extraction_comments = extraction_comments;
+            } else {
+                foreach string comment in (extraction_comments) {
+                    if (!containsString(entry.extraction_comments, comment)) {
+                        entry.extraction_comments += comment;
+                    }
+                }
+            }
+        }
+        return entry;
+    }
+
+    private hash<auto> warning(string path, int line, string message) {
+        return {
+            "path": path,
+            "line": line,
+            "message": message,
+        };
+    }
+
+    private *hash<auto> childByField(hash<auto> node, string field) {
+        if (!exists node.children) {
+            return NOTHING;
+        }
+        foreach hash<auto> child in (node.children) {
+            if (exists child.field && child.field == field) {
+                return child;
+            }
+        }
+        return NOTHING;
+    }
+
+    private *hash<auto> childByType(hash<auto> node, string type) {
+        if (!exists node.children) {
+            return NOTHING;
+        }
+        foreach hash<auto> child in (node.children) {
+            if (child.type == type) {
+                return child;
+            }
+        }
+        return NOTHING;
+    }
+
+    private string markerBaseName(string name) {
+        name = trim(name);
+        int i = name.rfind("::");
+        if (i >= 0) {
+            name = name.substr(i + 2);
+        }
+        i = name.rfind(".");
+        if (i >= 0) {
+            name = name.substr(i + 1);
+        }
+        return name;
+    }
+
+    private *string literalString(hash<auto> node) {
+        if (exists node.text) {
+            string text = string(node.text);
+            if (isQuotedString(text)) {
+                return decodeQuotedString(text);
+            }
+        }
+        if (!exists node.children) {
+            return NOTHING;
+        }
+
+        if (node.type == "string") {
+            string rv = "";
+            foreach hash<auto> child in (node.children) {
+                *string part = literalString(child);
+                if (!exists part) {
+                    return NOTHING;
+                }
+                rv += part;
+            }
+            return rv;
+        }
+
+        if (node.children.size() == 1) {
+            return literalString(node.children[0]);
+        }
+        return NOTHING;
+    }
+
+    private bool isQuotedString(string text) {
+        return text.size() >= 2
+            && ((text.substr(0, 1) == "\"" && text.substr(text.size() - 1, 1) == "\"")
+                || (text.substr(0, 1) == "'" && text.substr(text.size() - 1, 1) == "'"));
+    }
+
+    private string decodeQuotedString(string raw) {
+        string body = raw.substr(1, raw.size() - 2);
+        string out = "";
+        for (int i = 0; i < body.size(); ++i) {
+            string ch = body.substr(i, 1);
+            if (ch != "\\" || i + 1 >= body.size()) {
+                out += ch;
+                continue;
+            }
+            string next = body.substr(++i, 1);
+            switch (next) {
+                case "n": out += "\n"; break;
+                case "r": out += "\r"; break;
+                case "t": out += "\t"; break;
+                case "\\": out += "\\"; break;
+                case "\"": out += "\""; break;
+                case "'": out += "'"; break;
+                default: out += next; break;
+            }
+        }
+        return out;
+    }
+
+    private list<string> i18nCommentsBefore(list<hash<auto>> comments, int line) {
+        list<string> rv = ();
+        foreach hash<auto> comment in (comments) {
+            int comment_line = int(comment.loc.lastLine);
+            if (comment_line >= line || line - comment_line > 3) {
+                continue;
+            }
+            *list<string> m = regex_extract(trim(string(comment.text)), "^#\\s*i18n:\\s*(.*)$");
+            if (exists m && m) {
+                rv += m[0];
+            }
+        }
+        return rv;
+    }
+
+    private string extractSourceText(list<string> lines, hash<auto> loc) {
+        int fl = int(loc.start_line);
+        int fc = int(loc.start_column);
+        int ll = int(loc.end_line);
+        int lc = int(loc.end_column);
+        if (fl < 0 || fl >= lines.size()) {
+            return "";
+        }
+        if (ll >= lines.size()) {
+            ll = lines.size() - 1;
+        }
+        if (fl == ll) {
+            string line = lines[fl];
+            if (fc < 0) {
+                fc = 0;
+            }
+            if (lc > line.size()) {
+                lc = line.size();
+            }
+            return fc >= line.size() ? "" : line.substr(fc, lc - fc);
+        }
+
+        string rv = "";
+        for (int i = fl; i <= ll; ++i) {
+            string line = lines[i];
+            if (i == fl) {
+                rv += line.substr(fc);
+            } else if (i == ll) {
+                rv += "\n" + line.substr(0, lc);
+            } else {
+                rv += "\n" + line;
+            }
+        }
+        return rv;
+    }
+
+    private hash<auto> loadJsonFile(string path) {
+        if (!is_readable(path)) {
+            throw "I18N-CLI-ERROR", sprintf("cannot read catalog file '%s'", path);
+        }
+        hash<auto> catalog = parse_json(ReadOnlyFile::readTextFile(path));
+        if (catalog.schema_version != 1 || !exists catalog.locales) {
+            throw "I18N-CATALOG-ERROR", sprintf("'%s' is not a native i18n schema v1 catalog", path);
+        }
+        return catalog;
+    }
+
+    private hash<auto> getLocale(hash<auto> catalog, string locale) {
+        if (!exists catalog.locales{locale}) {
+            throw "I18N-CATALOG-ERROR", sprintf("catalog does not contain locale '%s'", locale);
+        }
+        hash<auto> loc = catalog.locales{locale};
+        if (!exists loc.messages) {
+            throw "I18N-CATALOG-ERROR", sprintf("catalog locale '%s' does not contain messages", locale);
+        }
+        return loc;
+    }
+
+    private list<hash<auto>> getStatsRows(string path, hash<auto> catalog, *list<string> locales) {
+        list<hash<auto>> rows = ();
+        list<string> locale_names = locales ?? cast<list<string>>(keys catalog.locales);
+        foreach string locale in (locale_names) {
+            hash<auto> loc = getLocale(catalog, locale);
+            hash<auto> row = getStatsRow(path, locale, loc.messages);
+            rows += row;
+        }
+        return rows;
+    }
+
+    private hash<auto> getStatsRow(string path, string locale, hash<auto> messages) {
+        hash<auto> row = {
+            "file": path,
+            "locale": locale,
+            "total": 0,
+            "translated": 0,
+            "fuzzy": 0,
+            "needs_review": 0,
+            "stale": 0,
+            "untranslated": 0,
+            "coverage": 100,
+        };
+
+        foreach string id in (keys messages) {
+            ++row.total;
+            string state = messageState(messages{id});
+            switch (state) {
+                case "translated": ++row.translated; break;
+                case "fuzzy": ++row.fuzzy; break;
+                case "needs-review": ++row.needs_review; break;
+                case "stale": ++row.stale; break;
+                default: ++row.untranslated; break;
+            }
+        }
+        row.coverage = row.total ? int(row.translated * 100 / row.total) : 100;
+        return row;
+    }
+
+    private string messageState(auto value) {
+        if (value.typeCode() == NT_STRING) {
+            return "translated";
+        }
+        if (value.typeCode() == NT_HASH) {
+            return value.state ?? "translated";
+        }
+        return "untranslated";
+    }
+
+    private printStats(list<hash<auto>> rows) {
+        printf("%-28s %-14s %7s %7s %7s %12s %7s %8s\n",
+            "file", "locale", "total", "ok", "fuzzy", "needs-review", "stale", "coverage");
+        foreach hash<auto> row in (rows) {
+            printf("%-28s %-14s %7d %7d %7d %12d %7d %7d%%\n",
+                basename(row.file), row.locale, row.total, row.translated, row.fuzzy,
+                row.needs_review, row.stale, row.coverage);
+        }
+    }
+
+    private auto makePseudoEntry(string id, auto value) {
+        if (value.typeCode() == NT_STRING) {
+            return pseudoString(string(value));
+        }
+        if (value.typeCode() != NT_HASH) {
+            return value;
+        }
+
+        hash<auto> out = {};
+        if (exists value.source) {
+            out.source = value.source;
+        }
+        if (exists value.plural_source) {
+            out.plural_source = value.plural_source;
+        }
+        if (exists value.forms) {
+            hash<auto> forms = {};
+            foreach string key in (keys value.forms) {
+                forms{key} = pseudoString(string(value.forms{key}));
+            }
+            out.forms = forms;
+        } else {
+            out.message = pseudoString(string(value.message ?? id));
+        }
+        out.state = "translated";
+        return out;
+    }
+
+    private string pseudoString(string text) {
+        string out = "[!! ";
+        bool placeholder = False;
+        for (int i = 0; i < text.size(); ++i) {
+            string ch = text.substr(i, 1);
+            if (ch == "{") {
+                placeholder = True;
+                out += ch;
+                continue;
+            }
+            if (ch == "}") {
+                placeholder = False;
+                out += ch;
+                continue;
+            }
+            out += placeholder ? ch : pseudoChar(ch);
+        }
+        return out + " !!]";
+    }
+
+    private string pseudoChar(string ch) {
+        switch (ch.lwr()) {
+            case "a":
+            case "e":
+            case "i":
+            case "o":
+            case "u":
+                return ch + ch;
+        }
+        return ch;
+    }
+
+    private string buildPo(string locale, hash<auto> messages) {
+        string out = "";
+        out += "msgid \"\"\n";
+        out += "msgstr \"\"\n";
+        out += poQuotedLine("Content-Type: text/plain; charset=UTF-8\\n");
+        out += poQuotedLine("Language: " + locale + "\\n");
+        out += "\n";
+
+        foreach string id in (keys messages) {
+            auto value = messages{id};
+            hash<auto> entry = normalizedEntry(id, value);
+            if (exists entry.extraction_comments) {
+                foreach string comment in (entry.extraction_comments) {
+                    out += "#. " + comment + "\n";
+                }
+            }
+            if (exists entry.source_refs) {
+                out += "#: " + entry.source_refs.join(" ") + "\n";
+            }
+            if (entry.state != "translated") {
+                out += "#, fuzzy\n";
+                out += "#. qore-state: " + entry.state + "\n";
+            }
+            if (id != entry.source) {
+                out += "msgctxt " + poString(id) + "\n";
+            }
+            out += "msgid " + poString(entry.source) + "\n";
+            if (exists entry.forms) {
+                out += "msgid_plural " + poString(entry.plural_source) + "\n";
+                out += "msgstr[0] " + poString(entry.forms.one ?? "") + "\n";
+                out += "msgstr[1] " + poString(entry.forms.other ?? "") + "\n";
+            } else {
+                out += "msgstr " + poString(entry.message ?? "") + "\n";
+            }
+            out += "\n";
+        }
+        return out;
+    }
+
+    private hash<auto> normalizedEntry(string id, auto value) {
+        if (value.typeCode() == NT_STRING) {
+            return {
+                "source": id,
+                "message": string(value),
+                "state": "translated",
+            };
+        }
+        hash<auto> entry = value;
+        if (!exists entry.source) {
+            entry.source = id;
+        }
+        if (!exists entry.state) {
+            entry.state = "translated";
+        }
+        return entry;
+    }
+
+    private string poQuotedLine(string text) {
+        return poString(text) + "\n";
+    }
+
+    private string poString(string text) {
+        string out = "\"";
+        for (int i = 0; i < text.size(); ++i) {
+            string ch = text.substr(i, 1);
+            switch (ch) {
+                case "\\": out += "\\\\"; break;
+                case "\"": out += "\\\""; break;
+                case "\n": out += "\\n"; break;
+                case "\r": out += "\\r"; break;
+                case "\t": out += "\\t"; break;
+                default: out += ch; break;
+            }
+        }
+        return out + "\"";
+    }
+
+    private hash<auto> parsePo(string data) {
+        list<string> lines = data.split("\n");
+        hash<auto> messages = {};
+        hash<auto!> entry = {};
+        string active = "";
+
+        foreach string raw_line in (lines) {
+            string line = trim(raw_line);
+            if (!line) {
+                *hash<auto!> finished = makePoMessage(entry);
+                if (exists finished) {
+                    messages{finished.id} = finished.value;
+                }
+                entry = {};
+                active = "";
+                continue;
+            }
+            if (line.startsWith("#,")) {
+                entry.flags = splitWords(line.substr(2));
+                continue;
+            }
+            if (line.startsWith("#:")) {
+                entry.source_refs = splitWords(line.substr(2));
+                continue;
+            }
+            if (line.startsWith("#.")) {
+                string comment = trim(line.substr(2));
+                if (comment.startsWith("qore-state:")) {
+                    entry.state = trim(comment.substr(11));
+                } else {
+                    if (!exists entry.extraction_comments) {
+                        entry.extraction_comments = ();
+                    }
+                    entry.extraction_comments += comment;
+                }
+                continue;
+            }
+            if (line.startsWith("msgctxt ")) {
+                entry.context = parsePoLiteral(line.substr(8));
+                active = "context";
+                continue;
+            }
+            if (line.startsWith("msgid_plural ")) {
+                entry.plural = parsePoLiteral(line.substr(13));
+                active = "plural";
+                continue;
+            }
+            if (line.startsWith("msgid ")) {
+                if (exists entry.id) {
+                    *hash<auto!> finished = makePoMessage(entry);
+                    if (exists finished) {
+                        messages{finished.id} = finished.value;
+                    }
+                    entry = {};
+                }
+                entry.id = parsePoLiteral(line.substr(6));
+                active = "id";
+                continue;
+            }
+            if (line.startsWith("msgstr[0] ")) {
+                entry.str0 = parsePoLiteral(line.substr(10));
+                active = "str0";
+                continue;
+            }
+            if (line.startsWith("msgstr[1] ")) {
+                entry.str1 = parsePoLiteral(line.substr(10));
+                active = "str1";
+                continue;
+            }
+            if (line.startsWith("msgstr ")) {
+                entry.str = parsePoLiteral(line.substr(7));
+                active = "str";
+                continue;
+            }
+            if (line.startsWith("\"")) {
+                entry = appendPoContinuation(entry, active, parsePoLiteral(line));
+            }
+        }
+
+        *hash<auto!> finished = makePoMessage(entry);
+        if (exists finished) {
+            messages{finished.id} = finished.value;
+        }
+        return messages;
+    }
+
+    private list<string> splitWords(string s) {
+        list<string> out = ();
+        foreach string part in (trim(s).split(" ")) {
+            part = trim(part);
+            if (part) {
+                out += part;
+            }
+        }
+        return out;
+    }
+
+    private hash<auto!> appendPoContinuation(hash<auto!> entry, string active, string value) {
+        switch (active) {
+            case "context": entry.context += value; break;
+            case "id": entry.id += value; break;
+            case "plural": entry.plural += value; break;
+            case "str0": entry.str0 += value; break;
+            case "str1": entry.str1 += value; break;
+            case "str": entry.str += value; break;
+        }
+        return entry;
+    }
+
+    private *hash<auto!> makePoMessage(hash<auto!> entry) {
+        if (!exists entry.id || (!entry.id && !exists entry.context)) {
+            return NOTHING;
+        }
+
+        string id = entry.context ?? entry.id;
+        string state = entry.state ?? (exists entry.flags && containsString(entry.flags, "fuzzy") ? "fuzzy" : "translated");
+        hash<auto!> value = {};
+        if (exists entry.plural) {
+            value = {
+                "source": entry.id,
+                "plural_source": entry.plural,
+                "forms": {
+                    "one": entry.str0 ?? entry.id,
+                    "other": entry.str1 ?? entry.plural,
+                },
+                "state": state,
+            };
+        } else {
+            value = {
+                "source": entry.id,
+                "message": entry.str ?? entry.id,
+                "state": state,
+            };
+        }
+        if (exists entry.source_refs) {
+            value.source_refs = entry.source_refs;
+        }
+        if (exists entry.extraction_comments) {
+            value.extraction_comments = entry.extraction_comments;
+        }
+        return {"id": id, "value": value};
+    }
+
+    private string parsePoLiteral(string value) {
+        value = trim(value);
+        if (!isQuotedString(value)) {
+            return value;
+        }
+        return decodeQuotedString(value);
+    }
+
+    private bool containsString(list<auto> values, string needle) {
+        foreach auto value in (values) {
+            if (string(value) == needle) {
+                return True;
+            }
+        }
+        return False;
+    }
+
+    private writeOutput(*string path, string data) {
+        if (exists path) {
+            File f();
+            f.open2(path, O_CREAT | O_WRONLY | O_TRUNC);
+            f.write(data);
+            f.close();
+        } else {
+            print(data);
+            if (!data.endsWith("\n")) {
+                printf("\n");
+            }
+        }
+    }
+}

--- a/bin/qore-i18n
+++ b/bin/qore-i18n
@@ -36,6 +36,9 @@ class QoreI18nCmd {
     public {
         const Version = "0.1";
 
+        #! Color output helper
+        static Util::TerminalColor color;
+
         const ExtractOpts = {
             "output":       "o,output=s",
             "locale":       "l,locale=s",
@@ -72,6 +75,8 @@ class QoreI18nCmd {
     }
 
     constructor() {
+        color = new Util::TerminalColor(!removeNoColorOption());
+
         if (!ARGV) {
             usage();
             exit(1);
@@ -101,29 +106,67 @@ class QoreI18nCmd {
                     usage();
                     break;
                 default:
-                    stderr.printf("Error: unknown command '%s'\n\n", command);
+                    stderr.printf("%s unknown command '%s'\n\n", color.error("ERROR:"), command);
                     usage();
                     exit(1);
             }
         } catch (hash<ExceptionInfo> ex) {
-            stderr.printf("Error: %s: %s\n", ex.err, ex.desc);
+            stderr.printf("%s %s: %s\n", color.error("ERROR:"), ex.err, ex.desc);
             exit(1);
         }
     }
 
+    private bool removeNoColorOption() {
+        bool no_color = False;
+        list<string> args = ();
+        foreach string arg in (ARGV) {
+            if (arg == "-C" || arg == "--no-color") {
+                no_color = True;
+            } else {
+                args += arg;
+            }
+        }
+        ARGV = args;
+        return no_color;
+    }
+
     private usage() {
-        printf("qore-i18n v%s - Manage Qore native i18n catalogs\n\n", Version);
-        printf("Usage: qore-i18n <command> [options] <files...>\n\n");
-        printf("Commands:\n");
-        printf("  extract      Extract t()/tn()/tc() calls from Qore source into a native JSON catalog\n");
-        printf("  stats        Report translated/fuzzy/needs-review/stale coverage for native catalogs\n");
-        printf("  pseudo       Generate an ASCII pseudolocale catalog preserving placeholders\n");
-        printf("  export-po    Export one native-catalog locale to simple gettext PO interchange\n");
-        printf("  import-po    Import a simple gettext PO file into a native JSON catalog\n\n");
-        printf("Examples:\n");
-        printf("  qore-i18n extract -o catalogs/root.json src/app.q\n");
-        printf("  qore-i18n stats --fail-under=95 catalogs/cs.json\n");
-        printf("  qore-i18n pseudo -o catalogs/qps-ploc.json catalogs/root.json\n");
+        int key_width = 18;
+
+        printf("%s v%s - Manage Qore native i18n catalogs\n\n", color.bold("qore-i18n"), Version);
+        printf("%s\n", color.bold("USAGE"));
+        printf("  %s %s %s\n\n", color.bold("qore-i18n"), color.key("<command>"),
+            color.dim("[options] <files...>"));
+
+        printf("%s\n", color.bold("COMMANDS"));
+        printHelpLine(color.key("extract"), "Extract t()/tn()/tc() calls from Qore source into a native JSON catalog",
+            key_width);
+        printHelpLine(color.key("stats"), "Report translated/fuzzy/needs-review/stale coverage for native catalogs",
+            key_width);
+        printHelpLine(color.key("pseudo"), "Generate an ASCII pseudolocale catalog preserving placeholders",
+            key_width);
+        printHelpLine(color.key("export-po"), "Export one native-catalog locale to simple gettext PO interchange",
+            key_width);
+        printHelpLine(color.key("import-po"), "Import a simple gettext PO file into a native JSON catalog",
+            key_width);
+
+        printf("\n%s\n", color.bold("GLOBAL OPTIONS"));
+        printHelpLine(color.key("-C, --no-color"), "Disable colored output", key_width);
+        printHelpLine(color.key("-h, --help"), "Show this help", key_width);
+
+        printf("\n%s\n", color.bold("EXAMPLES"));
+        printf("  %s\n", color.key("qore-i18n extract -o catalogs/root.json src/app.q"));
+        printf("  %s\n", color.key("qore-i18n stats --fail-under=95 catalogs/cs.json"));
+        printf("  %s\n", color.key("qore-i18n pseudo -o catalogs/qps-ploc.json catalogs/root.json"));
+    }
+
+    private static printHelpLine(string colored, string desc, int width) {
+        printf("  %s %s\n", Util::TerminalColor::padRight(colored, width), desc);
+    }
+
+    private static printCommonOptionHelp(int key_width) {
+        printHelpLine(color.key("-C, --no-color"), "Disable colored output", key_width);
+        printHelpLine(color.key("-h, --help"), "Show this help", key_width);
     }
 
     private runExtract() {
@@ -150,7 +193,8 @@ class QoreI18nCmd {
         }
 
         foreach hash<auto> warning in (extract_warnings) {
-            stderr.printf("%s:%d: warning: %s\n", warning.path, warning.line, warning.message);
+            stderr.printf("%s:%d: %s: %s\n", color.key(warning.path), warning.line,
+                color.warning("warning"), warning.message);
         }
         if (opt{"fail-dynamic"} && extract_warnings) {
             throw "I18N-DYNAMIC-KEY-ERROR", "dynamic i18n call arguments were found";
@@ -168,14 +212,17 @@ class QoreI18nCmd {
     }
 
     private extractUsage() {
-        printf("Usage: qore-i18n extract [options] <source-files...>\n\n");
-        printf("Options:\n");
-        printf("  -o, --output=FILE       Output native catalog JSON (default: stdout)\n");
-        printf("  -l, --locale=LOCALE     Output locale key (default: root)\n");
-        printf("  -m, --marker=NAME       Marker to extract; repeatable (default: t, tn, tc)\n");
-        printf("      --fail-dynamic      Fail if a marker call uses dynamic source/id arguments\n");
-        printf("  -v, --verbose           Increase progress output\n");
-        printf("  -h, --help              Show this help\n");
+        int key_width = 26;
+        printf("%s\n", color.bold("USAGE"));
+        printf("  %s %s %s %s\n\n", color.bold("qore-i18n"), color.type("extract"),
+            color.dim("[options]"), color.key("<source-files...>"));
+        printf("%s\n", color.bold("OPTIONS"));
+        printHelpLine(color.key("-o, --output=FILE"), "Output native catalog JSON (default: stdout)", key_width);
+        printHelpLine(color.key("-l, --locale=LOCALE"), "Output locale key (default: root)", key_width);
+        printHelpLine(color.key("-m, --marker=NAME"), "Marker to extract; repeatable (default: t, tn, tc)", key_width);
+        printHelpLine(color.key("--fail-dynamic"), "Fail if a marker call uses dynamic source/id arguments", key_width);
+        printHelpLine(color.key("-v, --verbose"), "Increase progress output", key_width);
+        printCommonOptionHelp(key_width);
     }
 
     private runStats() {
@@ -216,12 +263,15 @@ class QoreI18nCmd {
     }
 
     private statsUsage() {
-        printf("Usage: qore-i18n stats [options] <catalog-files...>\n\n");
-        printf("Options:\n");
-        printf("  -l, --locale=LOCALE     Locale to report; repeatable (default: all)\n");
-        printf("  -f, --format=FORMAT     text|json (default: text)\n");
-        printf("      --fail-under=N      Exit 2 if translated coverage is below N percent\n");
-        printf("  -h, --help              Show this help\n");
+        int key_width = 26;
+        printf("%s\n", color.bold("USAGE"));
+        printf("  %s %s %s %s\n\n", color.bold("qore-i18n"), color.type("stats"),
+            color.dim("[options]"), color.key("<catalog-files...>"));
+        printf("%s\n", color.bold("OPTIONS"));
+        printHelpLine(color.key("-l, --locale=LOCALE"), "Locale to report; repeatable (default: all)", key_width);
+        printHelpLine(color.key("-f, --format=FORMAT"), "text|json (default: text)", key_width);
+        printHelpLine(color.key("--fail-under=N"), "Exit 2 if translated coverage is below N percent", key_width);
+        printCommonOptionHelp(key_width);
     }
 
     private runPseudo() {
@@ -258,12 +308,15 @@ class QoreI18nCmd {
     }
 
     private pseudoUsage() {
-        printf("Usage: qore-i18n pseudo [options] <catalog-file>\n\n");
-        printf("Options:\n");
-        printf("      --from=LOCALE       Source locale to pseudo-localize (default: root)\n");
-        printf("  -l, --locale=LOCALE     Pseudolocale name (default: qps-ploc)\n");
-        printf("  -o, --output=FILE       Output native catalog JSON (default: stdout)\n");
-        printf("  -h, --help              Show this help\n");
+        int key_width = 26;
+        printf("%s\n", color.bold("USAGE"));
+        printf("  %s %s %s %s\n\n", color.bold("qore-i18n"), color.type("pseudo"),
+            color.dim("[options]"), color.key("<catalog-file>"));
+        printf("%s\n", color.bold("OPTIONS"));
+        printHelpLine(color.key("--from=LOCALE"), "Source locale to pseudo-localize (default: root)", key_width);
+        printHelpLine(color.key("-l, --locale=LOCALE"), "Pseudolocale name (default: qps-ploc)", key_width);
+        printHelpLine(color.key("-o, --output=FILE"), "Output native catalog JSON (default: stdout)", key_width);
+        printCommonOptionHelp(key_width);
     }
 
     private runExportPo() {
@@ -283,11 +336,14 @@ class QoreI18nCmd {
     }
 
     private exportPoUsage() {
-        printf("Usage: qore-i18n export-po [options] <catalog-file>\n\n");
-        printf("Options:\n");
-        printf("  -l, --locale=LOCALE     Locale to export (default: root)\n");
-        printf("  -o, --output=FILE       Output PO file (default: stdout)\n");
-        printf("  -h, --help              Show this help\n");
+        int key_width = 26;
+        printf("%s\n", color.bold("USAGE"));
+        printf("  %s %s %s %s\n\n", color.bold("qore-i18n"), color.type("export-po"),
+            color.dim("[options]"), color.key("<catalog-file>"));
+        printf("%s\n", color.bold("OPTIONS"));
+        printHelpLine(color.key("-l, --locale=LOCALE"), "Locale to export (default: root)", key_width);
+        printHelpLine(color.key("-o, --output=FILE"), "Output PO file (default: stdout)", key_width);
+        printCommonOptionHelp(key_width);
     }
 
     private runImportPo() {
@@ -314,11 +370,14 @@ class QoreI18nCmd {
     }
 
     private importPoUsage() {
-        printf("Usage: qore-i18n import-po [options] <po-file>\n\n");
-        printf("Options:\n");
-        printf("  -l, --locale=LOCALE     Locale for the imported catalog (default: root)\n");
-        printf("  -o, --output=FILE       Output native catalog JSON (default: stdout)\n");
-        printf("  -h, --help              Show this help\n");
+        int key_width = 26;
+        printf("%s\n", color.bold("USAGE"));
+        printf("  %s %s %s %s\n\n", color.bold("qore-i18n"), color.type("import-po"),
+            color.dim("[options]"), color.key("<po-file>"));
+        printf("%s\n", color.bold("OPTIONS"));
+        printHelpLine(color.key("-l, --locale=LOCALE"), "Locale for the imported catalog (default: root)", key_width);
+        printHelpLine(color.key("-o, --output=FILE"), "Output native catalog JSON (default: stdout)", key_width);
+        printCommonOptionHelp(key_width);
     }
 
     private hash<auto> getMarkers(*list<string> configured) {
@@ -335,7 +394,7 @@ class QoreI18nCmd {
 
     private extractFile(string path, hash<auto> markers, *int verbose) {
         if (verbose) {
-            stderr.printf("extracting: %s\n", path);
+            stderr.printf("%s %s\n", color.info("extracting:"), path);
         }
 
         string source = ReadOnlyFile::readTextFile(path);
@@ -708,13 +767,37 @@ class QoreI18nCmd {
     }
 
     private printStats(list<hash<auto>> rows) {
-        printf("%-28s %-14s %7s %7s %7s %12s %7s %8s\n",
-            "file", "locale", "total", "ok", "fuzzy", "needs-review", "stale", "coverage");
+        printf("%s %s %s %s %s %s %s %s\n",
+            Util::TerminalColor::padRight(color.bold("file"), 28),
+            Util::TerminalColor::padRight(color.bold("locale"), 14),
+            Util::TerminalColor::padLeft(color.bold("total"), 7),
+            Util::TerminalColor::padLeft(color.bold("ok"), 7),
+            Util::TerminalColor::padLeft(color.bold("fuzzy"), 7),
+            Util::TerminalColor::padLeft(color.bold("needs-review"), 12),
+            Util::TerminalColor::padLeft(color.bold("stale"), 7),
+            Util::TerminalColor::padLeft(color.bold("coverage"), 8));
         foreach hash<auto> row in (rows) {
-            printf("%-28s %-14s %7d %7d %7d %12d %7d %7d%%\n",
-                basename(row.file), row.locale, row.total, row.translated, row.fuzzy,
-                row.needs_review, row.stale, row.coverage);
+            printf("%s %s %s %s %s %s %s %s\n",
+                Util::TerminalColor::padRight(color.key(basename(row.file)), 28),
+                Util::TerminalColor::padRight(color.type(row.locale), 14),
+                Util::TerminalColor::padLeft(color.number(string(row.total)), 7),
+                Util::TerminalColor::padLeft(color.success(string(row.translated)), 7),
+                Util::TerminalColor::padLeft(color.warning(string(row.fuzzy)), 7),
+                Util::TerminalColor::padLeft(color.warning(string(row.needs_review)), 12),
+                Util::TerminalColor::padLeft(color.error(string(row.stale)), 7),
+                Util::TerminalColor::padLeft(formatCoverage(row.coverage), 8));
         }
+    }
+
+    private string formatCoverage(int coverage) {
+        string value = sprintf("%d%%", coverage);
+        if (coverage >= 95) {
+            return color.success(value);
+        }
+        if (coverage >= 80) {
+            return color.warning(value);
+        }
+        return color.error(value);
     }
 
     private auto makePseudoEntry(string id, auto value) {

--- a/debian/qore-misc-tools.install
+++ b/debian/qore-misc-tools.install
@@ -6,6 +6,7 @@ usr/bin/qklist
 usr/bin/qls
 usr/bin/qore-asyncapi-gen
 usr/bin/qore-extract-qm-metadata
+usr/bin/qore-i18n
 usr/bin/qore-openapi3-gen
 usr/bin/qpatch
 usr/bin/qschema
@@ -22,6 +23,7 @@ usr/share/man/man1/qklist.1*
 usr/share/man/man1/qls.1*
 usr/share/man/man1/qore-asyncapi-gen.1*
 usr/share/man/man1/qore-extract-qm-metadata.1*
+usr/share/man/man1/qore-i18n.1*
 usr/share/man/man1/qore-openapi3-gen.1*
 usr/share/man/man1/qpatch.1*
 usr/share/man/man1/qschema.1*

--- a/doxygen/lang/120_modules.dox.tmpl
+++ b/doxygen/lang/120_modules.dox.tmpl
@@ -241,6 +241,9 @@ ModuleName/
         for reading HTTP streaming responses, including Server-Sent Events (SSE)
     |user|<a href="../../modules/HueRestClient/html/index.html#huerestclientintro">HueRestClient</a>|providing APIs for \
         communicating with Philips Hue cloud REST APIs
+    |binary|<a href="../../modules/i18n/html/index.html#i18nintro">i18n</a>|Provides ICU-backed internationalization \
+        primitives including native message catalogs, CLDR plural selection, locale negotiation, explicit-locale \
+        number/date/currency formatting, collation, and the \c qore-i18n catalog management tool
     |user|<a href="../../modules/JdbcFirebirdSqlUtil/html/index.html#jdbcfirebirdsqlutilintro">JdbcFirebirdSqlUtil</a>|Provides a high-level \
         DB-independent API for working with Firebird database objects using \
         <a href="../../modules/XdbcFirebirdSqlUtilBase/html/index.html#xdbcfirebirdsqlutilbaseintro">XdbcFirebirdSqlUtilBase</a> and the binary \

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -275,7 +275,7 @@ code<int(string)> func = int sub(int x) { return x; };  # PARSE-TYPE-ERROR: para
     @endparblock
 
     @subsection qore_2_3_0_new_features New Features in Qore
-    @par New Required Libraries: nghttp2, ngtcp2, nghttp3, c-ares, Brotli, Zstd, LZ4, Eigen3, libprotobuf, and Kerberos 5
+    @par New Required Libraries: nghttp2, ngtcp2, nghttp3, c-ares, Brotli, Zstd, LZ4, ICU, Eigen3, libprotobuf, and Kerberos 5
     @parblock
     The following libraries are now required build dependencies for %Qore and cannot be disabled at build time:
     - <b>nghttp2:</b> HTTP/2 support is always available
@@ -290,6 +290,9 @@ code<int(string)> func = int sub(int x) { return x; };  # PARSE-TYPE-ERROR: para
       used by the new @ref mlintro "ml" binary module for linear algebra operations.
       On macOS, CMake now automatically detects MacPorts (\c /opt/local) and Homebrew prefixes for
       finding Eigen3 and other dependencies.
+    - <b><a href="https://icu.unicode.org/">ICU</a></b>: provides Unicode CLDR locale data for the
+      new @ref i18nintro "i18n" binary module, including message catalog fallback, plural rules,
+      locale negotiation, number/date/currency formatting, and collation
     - <b><a href="https://protobuf.dev/">libprotobuf</a></b>: provides the \c protobuf
       built-in module for dynamic Protocol Buffer schema loading, encoding, and decoding
     - <b>Kerberos 5 / GSSAPI</b>: provides the @ref krb5intro "krb5" built-in module
@@ -298,15 +301,15 @@ code<int(string)> func = int sub(int x) { return x; };  # PARSE-TYPE-ERROR: para
     Systems that previously built %Qore without these libraries will need to install the development packages:
     - <b>Debian/Ubuntu:</b> \c libnghttp2-dev, \c libngtcp2-dev, \c libngtcp2-crypto-ossl-dev,
       \c libnghttp3-dev, \c libbrotli-dev, \c libzstd-dev, \c liblz4-dev, \c libeigen3-dev,
-      \c libprotobuf-dev, \c libkrb5-dev, \c libcares-dev
+      \c libicu-dev, \c libprotobuf-dev, \c libkrb5-dev, \c libcares-dev
     - <b>RHEL/Fedora:</b> \c nghttp2-devel, \c ngtcp2-devel, \c ngtcp2-crypto-ossl-devel,
       \c nghttp3-devel, \c brotli-devel, \c libzstd-devel, \c lz4-devel, \c eigen3-devel,
-      \c protobuf-devel, \c krb5-devel, \c c-ares-devel
+      \c libicu-devel, \c protobuf-devel, \c krb5-devel, \c c-ares-devel
     - <b>Alpine:</b> \c nghttp2-dev, \c ngtcp2-dev, \c ngtcp2-crypto-ossl-dev,
       \c nghttp3-dev, \c brotli-dev, \c zstd-dev, \c lz4-dev, \c eigen-dev, \c protobuf-dev,
-      \c krb5-dev, \c c-ares-dev
-    - <b>macOS (Homebrew):</b> \c eigen, \c protobuf, \c krb5, \c c-ares
-    - <b>macOS (MacPorts):</b> \c eigen3, \c protobuf3-cpp, \c kerberos5, \c c-ares
+      \c icu-dev, \c icu-data-full, \c krb5-dev, \c c-ares-dev
+    - <b>macOS (Homebrew):</b> \c eigen, \c icu4c, \c protobuf, \c krb5, \c c-ares
+    - <b>macOS (MacPorts):</b> \c eigen3, \c icu, \c protobuf3-cpp, \c kerberos5, \c c-ares
 
     The following @ref Qore::Option "Option" namespace constants are now always \c True:
     - @ref Qore::Option::HAVE_BROTLI "Option::HAVE_BROTLI"

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -113,9 +113,10 @@
     - Unicode-aware case conversion (1-to-many uppercase mappings, fixed UTF-8 corruption bug)
 
     <i>Modules and integrations:</i>
-    - new builtin modules: @ref dataframeintro "dataframe", @ref krb5intro "krb5",
-      @ref linenoiseintro "linenoise", @ref mlintro "ml", @ref mongodbintro "mongodb", @ref ocrintro "ocr",
-      @ref protobufintro "protobuf", @ref tokenizerintro "tokenizer"
+    - new builtin modules: @ref dataframeintro "dataframe", @ref i18nintro "i18n",
+      @ref krb5intro "krb5", @ref linenoiseintro "linenoise", @ref mlintro "ml",
+      @ref mongodbintro "mongodb", @ref ocrintro "ocr", @ref protobufintro "protobuf",
+      @ref tokenizerintro "tokenizer"
     - new HTTP / async I/O modules: @ref httpclientiointro "HttpClientIo",
       @ref ftpclientiointro "FtpClientIo", @ref httputilintro "HttpUtil"
     - dozens of new user modules covering AI/LLM (@ref anthropicrestclientintro "Anthropic",
@@ -1219,6 +1220,20 @@ cargo install tree-sitter-cli@0.26.5
       - Eigen3-backed float64 columns for SIMD-friendly numeric operations
       - thread-safe with \c std::mutex, cooperative cancellation via \c qore_check_cancel()
       - \c dom=FILESYSTEM on CSV/Parquet I/O, \c dom=DATABASE on database I/O
+    - @ref i18nintro "i18n" module
+      - new builtin module providing ICU-backed internationalization and localization primitives
+      - native schema-versioned message catalogs with deterministic locale fallback, placeholder validation,
+        metadata state handling, layered JSON catalog loading, and \c QORE_CATALOG_DIR discovery
+      - CLDR plural APIs: \c plural_category(), \c plural_form(), and catalog \c tn() entries with exact-value
+        selectors and per-locale plural forms while keeping \c Util::plural() as an English two-form helper
+      - BCP 47 locale canonicalization, likely-subtag expansion, \c Accept-Language parsing, and effective-locale
+        negotiation for HTTP/API workflows
+      - explicit-locale number parsing/formatting, currency formatting, date/time style and skeleton formatting,
+        collation compare/sort-key APIs, and backend version introspection
+      - thread-local locale controls using the \c LOCALE_CONTROL functional domain; catalog file APIs use
+        \c FILESYSTEM
+      - \c qore-i18n tool for AST-based extraction, catalog statistics, pseudolocalization, and simple PO
+        import/export
     - @ref krb5intro "krb5" module
       - new builtin module providing Kerberos 5 and GSSAPI primitives for credential caches,
         keytabs, principals, service tickets, GSSAPI initiator and acceptor contexts,

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -1224,6 +1224,7 @@ cargo install tree-sitter-cli@0.26.5
       - new builtin module providing ICU-backed internationalization and localization primitives
       - native schema-versioned message catalogs with deterministic locale fallback, placeholder validation,
         metadata state handling, layered JSON catalog loading, and \c QORE_CATALOG_DIR discovery
+      - automatic Unicode bidi isolation of interpolated placeholder values for RTL requested locales
       - CLDR plural APIs: \c plural_category(), \c plural_form(), and catalog \c tn() entries with exact-value
         selectors and per-locale plural forms while keeping \c Util::plural() as an English two-form helper
       - BCP 47 locale canonicalization, likely-subtag expansion, \c Accept-Language parsing, and effective-locale

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -1231,8 +1231,8 @@ cargo install tree-sitter-cli@0.26.5
         negotiation for HTTP/API workflows
       - explicit-locale number parsing/formatting, currency formatting, date/time style and skeleton formatting,
         collation compare/sort-key APIs, and backend version introspection
-      - thread-local locale controls using the \c LOCALE_CONTROL functional domain; catalog file APIs use
-        \c FILESYSTEM
+      - thread-local locale controls and explicit locale-context capture/apply helpers using the
+        \c LOCALE_CONTROL functional domain; catalog file APIs use \c FILESYSTEM
       - \c qore-i18n tool for AST-based extraction, catalog statistics, pseudolocalization, and simple PO
         import/export
     - @ref krb5intro "krb5" module

--- a/examples/test/docker_test/test-macos.sh
+++ b/examples/test/docker_test/test-macos.sh
@@ -26,10 +26,25 @@ if [ "$PM" = "macports" ]; then
 elif [ "$PM" = "homebrew" ]; then
     eval "$(/opt/homebrew/bin/brew shellenv)"
     HB="$(brew --prefix)"
+
+    # Self-heal: install build-critical Homebrew packages that may be
+    # missing from a stale Tart VM image (image was built before the
+    # package was added to qore-test-base/prep-macos.sh).  CMakeLists
+    # requires Eigen3, c-ares, Kerberos, and ICU unconditionally. brew
+    # install is idempotent (no-op if already installed), so this is safe
+    # to run on a fresh image too.
+    REQUIRED_BREW_PKGS=(eigen krb5 c-ares icu4c)
+    for pkg in "${REQUIRED_BREW_PKGS[@]}"; do
+        if ! brew list "$pkg" >/dev/null 2>&1; then
+            echo "=== Installing missing Homebrew package: $pkg ==="
+            brew install "$pkg"
+        fi
+    done
+
     # Add keg-only package paths so CMake/find_program can locate them
     export PATH="${HB}/opt/bison/bin:${HB}/opt/flex/bin:${PATH}"
     # Ensure linker and pkg-config find Homebrew libraries (including keg-only)
-    KEG_PKGS=(openssl@3 libxml2 libxslt zlib bzip2 expat readline ncurses libffi sqlite openldap krb5 c-ares libarchive curl libtool ossp-uuid libyaml)
+    KEG_PKGS=(icu4c openssl@3 libxml2 libxslt zlib bzip2 expat readline ncurses libffi sqlite openldap krb5 c-ares libarchive curl libtool ossp-uuid libyaml)
     for pkg in "${KEG_PKGS[@]}"; do
         kp="$(brew --prefix "$pkg" 2>/dev/null)" || continue
         [ -d "$kp/lib/pkgconfig" ] && export PKG_CONFIG_PATH="$kp/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
@@ -39,21 +54,6 @@ elif [ "$PM" = "homebrew" ]; then
     export LDFLAGS="-L${HB}/lib ${LDFLAGS:-}"
     export CPPFLAGS="-I${HB}/include ${CPPFLAGS:-}"
     export PKG_CONFIG_PATH="${HB}/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
-
-    # Self-heal: install build-critical Homebrew packages that may be
-    # missing from a stale Tart VM image (image was built before the
-    # package was added to qore-test-base/prep-macos.sh).  CMakeLists
-    # requires Eigen3 unconditionally for the ml/kalman modules; the
-    # build aborts at find_package(Eigen3 REQUIRED) if it isn't
-    # present.  brew install is idempotent (no-op if already installed)
-    # so this is safe to run on a fresh image too.
-    REQUIRED_BREW_PKGS=(eigen krb5 c-ares)
-    for pkg in "${REQUIRED_BREW_PKGS[@]}"; do
-        if ! brew list "$pkg" >/dev/null 2>&1; then
-            echo "=== Installing missing Homebrew package: $pkg ==="
-            brew install "$pkg"
-        fi
-    done
 fi
 
 # Add cargo bin to PATH (tree-sitter CLI installed via cargo)
@@ -96,7 +96,8 @@ case "$PM" in
         ;;
     homebrew)
         # Homebrew on Apple Silicon; include keg-only package prefixes for CMake
-        CMAKE_PREFIX="/opt/homebrew;/opt/homebrew/opt/openssl@3;/opt/homebrew/opt/libxml2;/opt/homebrew/opt/ossp-uuid"
+        HB_PREFIX="${HB:-/opt/homebrew}"
+        CMAKE_PREFIX="${HB_PREFIX};${HB_PREFIX}/opt/icu4c;${HB_PREFIX}/opt/openssl@3;${HB_PREFIX}/opt/libxml2;${HB_PREFIX}/opt/ossp-uuid"
         ;;
     *)
         CMAKE_PREFIX=""

--- a/man/qore-i18n.1
+++ b/man/qore-i18n.1
@@ -1,0 +1,98 @@
+.\" qore-i18n.1 - man page for qore-i18n
+.\"
+.\" Copyright (C) 2026 Qore Technologies, s.r.o.
+.\"
+.TH QORE-I18N 1 "2026 May 16" "Qore 2.3" "Qore Programming Language"
+.SH NAME
+qore\-i18n \- manage Qore native internationalization catalogs
+.SH SYNOPSIS
+.B qore\-i18n
+\fIcommand\fP
+[\fIoptions\fP]
+\fIfile\fP...
+.SH DESCRIPTION
+\fBqore\-i18n\fR manages Qore native i18n catalog files.  The tool can
+extract static \fBt()\fP, \fBtn()\fP, and \fBtc()\fP marker calls from Qore
+source using the \fBastparser\fP module, report catalog coverage, generate an
+ASCII pseudolocale, and exchange simple messages through gettext PO files.
+.SH COMMANDS
+.TP
+.B extract
+Extract static marker calls into a native JSON catalog.
+.TP
+.B stats
+Report translated, fuzzy, needs-review, and stale counts per locale.
+.TP
+.B pseudo
+Generate a pseudolocale catalog while preserving placeholders.
+.TP
+.B export-po
+Export one catalog locale to simple gettext PO interchange.
+.TP
+.B import-po
+Import a simple gettext PO file into a native JSON catalog.
+.SH EXTRACT OPTIONS
+.TP
+.BR \-o ", " \-\-output =\fIfile\fP
+Write native catalog JSON to \fIfile\fP (default: stdout).
+.TP
+.BR \-l ", " \-\-locale =\fIlocale\fP
+Output locale key (default: \fBroot\fP).
+.TP
+.BR \-m ", " \-\-marker =\fIname\fP
+Marker to extract; repeatable (default: \fBt\fP, \fBtn\fP, \fBtc\fP).
+.TP
+.BR \-\-fail\-dynamic
+Fail if a marker call uses a dynamic source or id argument.
+.SH STATS OPTIONS
+.TP
+.BR \-l ", " \-\-locale =\fIlocale\fP
+Locale to report; repeatable (default: all locales).
+.TP
+.BR \-f ", " \-\-format =\fIformat\fP
+Output format: \fBtext\fP (default) or \fBjson\fP.
+.TP
+.BR \-\-fail\-under =\fIn\fP
+Exit with status 2 when translated coverage is below \fIn\fP percent.
+.SH PSEUDO OPTIONS
+.TP
+.BR \-\-from =\fIlocale\fP
+Source locale to pseudo-localize (default: \fBroot\fP).
+.TP
+.BR \-l ", " \-\-locale =\fIlocale\fP
+Pseudolocale name (default: \fBqps-ploc\fP).
+.TP
+.BR \-o ", " \-\-output =\fIfile\fP
+Write native catalog JSON to \fIfile\fP (default: stdout).
+.SH PO OPTIONS
+.TP
+.BR \-l ", " \-\-locale =\fIlocale\fP
+Locale to export or import (default: \fBroot\fP).
+.TP
+.BR \-o ", " \-\-output =\fIfile\fP
+Write output to \fIfile\fP (default: stdout).
+.SH EXAMPLES
+Extract a root catalog:
+.RS
+.B qore\-i18n extract \-o catalogs/root.json src/app.q
+.RE
+.PP
+Fail CI below 95 percent translated coverage:
+.RS
+.B qore\-i18n stats \-\-fail\-under=95 catalogs/cs.json
+.RE
+.PP
+Generate a pseudolocale:
+.RS
+.B qore\-i18n pseudo \-o catalogs/qps\-ploc.json catalogs/root.json
+.RE
+.SH SEE ALSO
+.BR qore (1),
+.BR qore\-openapi3\-gen (1),
+.BR qore\-asyncapi\-gen (1)
+.SH AUTHORS
+Qore Technologies, s.r.o.
+.SH COPYRIGHT
+Copyright \(co 2026 Qore Technologies, s.r.o.
+.br
+Licensed under MIT.

--- a/modules/astparser/test/astparser.qtest
+++ b/modules/astparser/test/astparser.qtest
@@ -9,13 +9,9 @@
 %requires ../../../qlib/Util.qm
 %requires ../../../qlib/QUnit.qm
 
-%try-module astparser
-%define NoAstParser
-%endtry
+%requires astparser
 
-%ifndef NoAstParser
 %define HasAstTreeSearcher
-%endif
 
 %exec-class AstParserTest
 
@@ -376,9 +372,6 @@ sub test() {
     }
 
     constructor() : Test("AstParserTest", "1.0") {
-%ifdef NoAstParser
-        addTestCase("astparser module not available", \testNoModule());
-%else
         addTestCase("Basic parsing", \testBasicParsing());
         addTestCase("Parse file", \testParseFile());
         addTestCase("Diagnostics", \testDiagnostics());
@@ -493,15 +486,9 @@ sub test() {
         addTestCase("Resolve definition cross-doc", \testResolveDefinitionCrossDoc());
         addTestCase("Scope symbols with parse errors", \testScopeSymbolsWithErrors());
 %endif
-%endif
         set_return_value(main());
     }
 
-%ifdef NoAstParser
-    testNoModule() {
-        testSkip("astparser module not available");
-    }
-%else
     # Helper: find a child node by its field name in a CST node hash
     private static *hash<auto> findChildByField(hash<auto> node, string fieldName) {
         if (!node.children) {
@@ -3461,6 +3448,4 @@ sub broken(int x) {
         assertTrue(exists matching, "findMatchingSymbols returns results despite errors");
         assertGt(0, matching.size(), "MyClass found by findMatchingSymbols");
     }
-
-%endif
 }

--- a/modules/i18n/CMakeLists.txt
+++ b/modules/i18n/CMakeLists.txt
@@ -20,19 +20,15 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-find_package(PkgConfig QUIET)
-set(ICU_FOUND FALSE)
-if (PkgConfig_FOUND)
-    pkg_check_modules(ICU QUIET icu-uc icu-i18n)
-endif()
-
 if (NOT ICU_FOUND)
-    find_package(ICU COMPONENTS uc i18n QUIET)
-endif()
+    find_package(PkgConfig QUIET)
+    if (PkgConfig_FOUND)
+        pkg_check_modules(ICU QUIET icu-uc icu-i18n)
+    endif()
 
-if (NOT ICU_FOUND)
-    message(STATUS "ICU not found - i18n module will NOT be built")
-    return()
+    if (NOT ICU_FOUND)
+        find_package(ICU COMPONENTS uc i18n REQUIRED)
+    endif()
 endif()
 
 message(STATUS "ICU found - building i18n module")
@@ -67,7 +63,11 @@ set(I18N_CPP_SRC
 )
 
 set(QORE_DOX_I18N_TMPL_SRC
+    docs/catalogs.dox.tmpl
+    docs/cli.dox.tmpl
+    docs/locale-formatting.dox.tmpl
     docs/mainpage.dox.tmpl
+    docs/plural.dox.tmpl
 )
 
 qore_wrap_qpp_value(I18N_QPP_SOURCES DOXLIST _dox_src ${I18N_QPP_SRC})
@@ -83,11 +83,16 @@ endif()
 target_link_libraries(${i18n_module_name} ${ICU_LIBRARIES})
 add_dependencies(${i18n_module_name} libqore I18N_QPP_GENERATED_FILES)
 
-set(MODULE_DOX_INPUT ${CMAKE_BINARY_DIR}/modules/i18n/mainpage.dox ${_dox_src})
+if (DOXYGEN_FOUND)
+    qore_wrap_dox(QORE_DOX_I18N_SRC ${QORE_DOX_I18N_TMPL_SRC})
+    set(MODULE_DOX_INPUT ${QORE_DOX_I18N_SRC} ${_dox_src})
+else()
+    set(MODULE_DOX_INPUT ${CMAKE_BINARY_DIR}/modules/i18n/mainpage.dox ${_dox_src})
+endif()
+
 qore_binary_module_qore(${i18n_module_name} "${VERSION}" "/${VERSION}")
 
 if (DOXYGEN_FOUND)
-    qore_wrap_dox(QORE_DOX_I18N_SRC ${QORE_DOX_I18N_TMPL_SRC})
     add_custom_target(QORE_I18N_MOD_DOX_FILES DEPENDS ${QORE_DOX_I18N_SRC})
     add_dependencies(docs-i18n QORE_I18N_MOD_DOX_FILES)
 endif()

--- a/modules/i18n/CMakeLists.txt
+++ b/modules/i18n/CMakeLists.txt
@@ -62,6 +62,7 @@ set(I18N_QPP_SRC
 )
 
 set(I18N_CPP_SRC
+    src/i18n-catalog-json.cpp
     src/i18n-module.cpp
 )
 

--- a/modules/i18n/CMakeLists.txt
+++ b/modules/i18n/CMakeLists.txt
@@ -57,6 +57,7 @@ include_directories(${CMAKE_BINARY_DIR}/include)
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
 set(I18N_QPP_SRC
+    src/QC_MessageCatalog.qpp
     src/ql_i18n.qpp
 )
 

--- a/modules/i18n/CMakeLists.txt
+++ b/modules/i18n/CMakeLists.txt
@@ -1,0 +1,91 @@
+# I18n module CMake configuration
+#
+# Copyright (C) 2026 Qore Technologies, s.r.o.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+find_package(PkgConfig QUIET)
+set(ICU_FOUND FALSE)
+if (PkgConfig_FOUND)
+    pkg_check_modules(ICU QUIET icu-uc icu-i18n)
+endif()
+
+if (NOT ICU_FOUND)
+    find_package(ICU COMPONENTS uc i18n QUIET)
+endif()
+
+if (NOT ICU_FOUND)
+    message(STATUS "ICU not found - i18n module will NOT be built")
+    return()
+endif()
+
+message(STATUS "ICU found - building i18n module")
+
+# Bootstrap values normally provided by installed QoreConfig.cmake.
+if (NOT QORE_MODULES_DIR)
+    set(QORE_MODULES_DIR ${MODULE_DIR})
+endif()
+
+if (NOT QORE_LIBRARY)
+    set(QORE_LIBRARY libqore)
+endif()
+
+set(QORE_API_VERSION ${MODULE_API_MAJOR}.${MODULE_API_MINOR})
+
+include(${CMAKE_SOURCE_DIR}/cmake/QoreMacros.cmake)
+### end of bootstrap values
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${CMAKE_BINARY_DIR}/include)
+include_directories(${CMAKE_SOURCE_DIR}/include)
+
+set(I18N_QPP_SRC
+    src/ql_i18n.qpp
+)
+
+set(I18N_CPP_SRC
+    src/i18n-module.cpp
+)
+
+set(QORE_DOX_I18N_TMPL_SRC
+    docs/mainpage.dox.tmpl
+)
+
+qore_wrap_qpp_value(I18N_QPP_SOURCES DOXLIST _dox_src ${I18N_QPP_SRC})
+add_custom_target(I18N_QPP_GENERATED_FILES DEPENDS qpp ${I18N_QPP_SOURCES})
+
+set(i18n_module_name "i18n")
+
+add_library(${i18n_module_name} MODULE ${I18N_CPP_SRC} ${I18N_QPP_SOURCES})
+target_include_directories(${i18n_module_name} PRIVATE ${ICU_INCLUDE_DIRS})
+if (ICU_LIBRARY_DIRS)
+    target_link_directories(${i18n_module_name} PRIVATE ${ICU_LIBRARY_DIRS})
+endif()
+target_link_libraries(${i18n_module_name} ${ICU_LIBRARIES})
+add_dependencies(${i18n_module_name} libqore I18N_QPP_GENERATED_FILES)
+
+set(MODULE_DOX_INPUT ${CMAKE_BINARY_DIR}/modules/i18n/mainpage.dox ${_dox_src})
+qore_binary_module_qore(${i18n_module_name} "${VERSION}" "/${VERSION}")
+
+if (DOXYGEN_FOUND)
+    qore_wrap_dox(QORE_DOX_I18N_SRC ${QORE_DOX_I18N_TMPL_SRC})
+    add_custom_target(QORE_I18N_MOD_DOX_FILES DEPENDS ${QORE_DOX_I18N_SRC})
+    add_dependencies(docs-i18n QORE_I18N_MOD_DOX_FILES)
+endif()

--- a/modules/i18n/docs/catalogs.dox.tmpl
+++ b/modules/i18n/docs/catalogs.dox.tmpl
@@ -1,0 +1,80 @@
+/** @page i18ncatalogs Message Catalogs
+
+    \c I18n::MessageCatalog stores schema-versioned native catalogs passed as Qore data. Lookup uses source strings by
+    default and supports stable symbolic ids with \c tc(). Locale fallback is deterministic:
+    \c fr-CA-u-nu-latn falls back through \c fr-CA, \c fr, and \c root for catalog identity.
+
+    @section i18ncatalogsnative Native Catalog Data
+
+    @code{.py}
+%requires i18n
+
+hash<auto> native_catalog = {
+    "schema_version": I18n::get_catalog_schema_version(),
+    "locales": {
+        "root": {"messages": {"Hello, {name}": "Hello, {name}"}},
+        "cs": {"messages": {
+            "Hello, {name}": {
+                "message": "Ahoj, {name}",
+                "state": "translated",
+            },
+            "1 file": {
+                "plural_source": "{count} files",
+                "forms": {
+                    "one": "{count} soubor",
+                    "few": "{count} soubory",
+                    "other": "{count} souboru",
+                },
+                "state": "translated",
+            },
+            "workflow.greeting": {
+                "source": "Hello, {name}",
+                "message": "Nazdar, {name}",
+                "state": "translated",
+            },
+        }},
+    },
+};
+
+I18n::MessageCatalog catalog(native_catalog);
+printf("%s\n", catalog.t("Hello, {name}", "cs-CZ", {"name": "Petr"}));
+printf("%s\n", catalog.tn(2, "1 file", "{count} files", "cs"));
+printf("%s\n", catalog.tc("workflow.greeting", "Hello, {name}", "cs", {"name": "Eva"}));
+    @endcode
+
+    @section i18ncatalogsjson JSON Catalogs
+
+    The same native shape can be stored as UTF-8 JSON and loaded without evaluating catalog text as Qore code:
+
+    @code{.py}
+hash<auto> catalog_data = I18n::load_native_catalog("catalog.json");
+I18n::MessageCatalog catalog_from_file("catalog.json");
+I18n::MessageCatalog layered_catalog(("base.json", "override.json"));
+    @endcode
+
+    File-loading APIs and constructors are tagged with the \c FILESYSTEM functional domain and enforce a bounded file
+    size. JSON parsing is strict, rejects duplicate object keys, and validates UTF-8 strings.
+
+    @section i18ncatalogsdiscovery Discovery
+
+    Discovery uses \c QORE_CATALOG_DIR by default and can be overridden explicitly. Returned files are already ordered
+    for deterministic composition: lower precedence first, with \c root before more-specific locale files.
+
+    @code{.py}
+list<string> files = I18n::discover_catalog_files("billing", "cs-CZ", {
+    "search_path": ("/opt/qore/catalogs",),
+    "override_path": "/etc/qore/catalogs",
+});
+I18n::MessageCatalog billing_catalog(files);
+    @endcode
+
+    Runtime state policy follows gettext's conservative behavior by default: \c fuzzy, \c needs-review, and
+    \c stale entries are stored but not used at runtime. Pass \c {"use_unreviewed": True} to the constructor to preview
+    those entries in development.
+
+    Catalog construction validates placeholders. Plain translations must preserve exactly the placeholders from the
+    source text. Plural forms must preserve all non-\c count source placeholders and may use \c count for the selected
+    numeric value. Message formatting fails if a required placeholder argument is missing. Placeholder output is
+    wrapped in Unicode bidi isolation marks automatically for RTL requested locales such as Arabic, Hebrew, Persian,
+    and Urdu.
+*/

--- a/modules/i18n/docs/cli.dox.tmpl
+++ b/modules/i18n/docs/cli.dox.tmpl
@@ -14,5 +14,6 @@ qore-i18n import-po -l cs -o catalogs/cs.json catalogs/cs.po
     Dynamic source strings or ids are reported as warnings and can be made fatal with \c --fail-dynamic.
     The \c stats command reports translated, fuzzy, needs-review, stale, and coverage counts and can fail CI with
     \c --fail-under. PO import/export is intentionally simple interchange for plain messages and two-form source
-    plurals; richer per-locale forms remain represented in the native catalog.
+    plurals; richer per-locale forms remain represented in the native catalog. Human-readable help, warning, error,
+    and text statistics output is colorized when stdout is a terminal; pass \c -C or \c --no-color to disable colors.
 */

--- a/modules/i18n/docs/cli.dox.tmpl
+++ b/modules/i18n/docs/cli.dox.tmpl
@@ -1,0 +1,18 @@
+/** @page i18ncli Catalog Management CLI
+
+    The \c qore-i18n tool provides the first catalog-management workflow:
+
+    @code{.sh}
+qore-i18n extract -o catalogs/root.json src/app.q
+qore-i18n stats --fail-under=95 catalogs/cs.json
+qore-i18n pseudo -o catalogs/qps-ploc.json catalogs/root.json
+qore-i18n export-po -l cs -o catalogs/cs.po catalogs/cs.json
+qore-i18n import-po -l cs -o catalogs/cs.json catalogs/cs.po
+    @endcode
+
+    Extraction uses the \c astparser module and recognizes static \c t(), \c tn(), and \c tc() calls by default.
+    Dynamic source strings or ids are reported as warnings and can be made fatal with \c --fail-dynamic.
+    The \c stats command reports translated, fuzzy, needs-review, stale, and coverage counts and can fail CI with
+    \c --fail-under. PO import/export is intentionally simple interchange for plain messages and two-form source
+    plurals; richer per-locale forms remain represented in the native catalog.
+*/

--- a/modules/i18n/docs/locale-formatting.dox.tmpl
+++ b/modules/i18n/docs/locale-formatting.dox.tmpl
@@ -1,0 +1,68 @@
+/** @page i18nlocaleformatting Locale, Formatting, and Collation
+
+    @section i18nlocalenegotiation Locale Negotiation
+
+    Locale utilities canonicalize BCP 47 tags, strip Unicode formatting extensions from catalog identity, parse
+    HTTP \c Accept-Language headers, and choose an effective catalog locale from an explicit available-locale list.
+
+    @code{.py}
+%requires i18n
+
+printf("%s\n", I18n::canonicalize_locale("en_US")); # en-US
+printf("%s\n", I18n::add_likely_subtags("sr"));     # sr-Cyrl-RS
+printf("%y\n", I18n::get_locale_fallback_chain("fr-CA-u-nu-latn"));
+
+string locale = I18n::negotiate_locale(
+    "fr-CA, fr;q=0.8, en;q=0.5",
+    ("en", "fr", "root")
+);
+printf("%s\n", locale); # fr
+    @endcode
+
+    \c I18n::parse_accept_language() returns a preference-sorted list of hashes containing \c locale, \c q, \c index,
+    and \c wildcard keys. Header parsing is bounded and rejects malformed \c q values instead of guessing.
+    Negotiation also uses ICU likely-subtags so broad requests such as \c sr can match an available
+    \c sr-Cyrl catalog.
+
+    The module also exposes a thread-local ambient locale for request/task integration:
+
+    @code{.py}
+I18n::set_thread_locale("cs-CZ");
+assertEq("cs-CZ", I18n::get_thread_locale());
+hash<auto> locale_context = I18n::capture_locale_context();
+I18n::clear_thread_locale();
+I18n::apply_locale_context(locale_context);
+    @endcode
+
+    Explicit-locale APIs remain the stable default. Raw \c Queue handoff does not propagate the ambient locale; pass an
+    explicit context object from \c I18n::capture_locale_context() or a locale string across queue boundaries.
+
+    @section i18nformatting Formatting and Collation
+
+    Number and currency formatting use explicit locale arguments and do not change existing core machine-format
+    functions. Collation APIs expose compare, binary sort-key, and collation-version primitives; sort keys are for
+    cache-local ordering unless they are tagged with locale, collation options, backend, ICU/CLDR versions, and
+    collation version.
+
+    @code{.py}
+%requires i18n
+
+printf("%s\n", I18n::format_number("1234.50", "en-US"));
+printf("%y\n", I18n::parse_number("1,234.50", "en-US"));
+printf("%s\n", I18n::format_currency("12.5", "USD", "en-US"));
+printf("%s\n", I18n::format_datetime(2020-05-04T15:06:07Z, "en-US",
+    {"date_style": "medium", "time_style": "none"}));
+printf("%s\n", I18n::format_datetime(2020-05-04T15:06:07Z, "en-US", {"skeleton": "yMMMd"}));
+assertLt(0, I18n::compare_strings("a", "b", "en-US"));
+binary key = I18n::get_sort_key("file-001", "en-US-u-kn-true");
+    @endcode
+
+    @section i18nversions Backend Versions
+
+    The module exposes ICU and CLDR data versions so deployments can report the locale-data backend in diagnostics:
+
+    @code{.py}
+hash<auto> info = I18n::get_backend_info();
+printf("backend=%s icu=%s cldr=%s\n", info.backend, info.icu_version, info.cldr_version);
+    @endcode
+*/

--- a/modules/i18n/docs/mainpage.dox.tmpl
+++ b/modules/i18n/docs/mainpage.dox.tmpl
@@ -44,6 +44,45 @@ printf("%s\n", I18n::plural_category("1", "lv"));
 printf("%s\n", I18n::plural_category("1.0", "lv"));
     @endcode
 
+    @section i18n_catalogs Message Catalogs
+
+    \c I18n::MessageCatalog stores schema-versioned native catalogs passed as Qore data. Lookup uses source strings by
+    default and supports stable symbolic ids with \c tc(). Locale fallback is deterministic:
+    \c fr-CA-u-nu-latn falls back through \c fr-CA, \c fr, and \c root for catalog identity.
+
+    @code{.py}
+%requires i18n
+
+hash<auto> native_catalog = {
+    "schema_version": I18n::get_catalog_schema_version(),
+    "locales": {
+        "root": {"messages": {"Hello, {name}": "Hello, {name}"}},
+        "cs": {"messages": {
+            "Hello, {name}": {
+                "message": "Ahoj, {name}",
+                "state": "translated",
+            },
+            "workflow.greeting": {
+                "source": "Hello, {name}",
+                "message": "Nazdar, {name}",
+                "state": "translated",
+            },
+        }},
+    },
+};
+
+I18n::MessageCatalog catalog(native_catalog);
+printf("%s\n", catalog.t("Hello, {name}", "cs-CZ", {"name": "Petr"}));
+printf("%s\n", catalog.tc("workflow.greeting", "Hello, {name}", "cs", {"name": "Eva"}));
+    @endcode
+
+    Runtime state policy follows gettext's conservative behavior by default: \c fuzzy, \c needs-review, and
+    \c stale entries are stored but not used at runtime. Pass \c {"use_unreviewed": True} to the constructor to preview
+    those entries in development.
+
+    Catalog construction validates simple placeholders. Translations must preserve exactly the placeholders from the
+    source text, and message formatting fails if a required placeholder argument is missing.
+
     @section i18n_versions Backend Versions
 
     The module exposes ICU and CLDR data versions so deployments can report the locale-data backend in diagnostics:
@@ -55,7 +94,7 @@ printf("backend=%s icu=%s cldr=%s\n", info.backend, info.icu_version, info.cldr_
 
     @section i18n_scope Current Scope
 
-    This module is the initial implementation target for issue #5334. Catalog loading, extraction tooling, rich
-    message formatting, locale-aware number/date/currency formatting, collation, request-locale propagation, and
+    This module is the implementation target for issue #5334. Catalog file loading, extraction tooling, rich message
+    formatting, locale-aware number/date/currency formatting, collation, request-locale propagation, and
     machine-translation workflow support are planned follow-up phases in the same issue.
 */

--- a/modules/i18n/docs/mainpage.dox.tmpl
+++ b/modules/i18n/docs/mainpage.dox.tmpl
@@ -92,6 +92,7 @@ printf("%s\n", catalog.tc("workflow.greeting", "Hello, {name}", "cs", {"name": "
 %requires i18n
 
 printf("%s\n", I18n::canonicalize_locale("en_US")); # en-US
+printf("%s\n", I18n::add_likely_subtags("sr"));     # sr-Cyrl-RS
 printf("%y\n", I18n::get_locale_fallback_chain("fr-CA-u-nu-latn"));
 
 string locale = I18n::negotiate_locale(
@@ -103,6 +104,8 @@ printf("%s\n", locale); # fr
 
     \c I18n::parse_accept_language() returns a preference-sorted list of hashes containing \c locale, \c q, \c index,
     and \c wildcard keys. Header parsing is bounded and rejects malformed \c q values instead of guessing.
+    Negotiation also uses ICU likely-subtags so broad requests such as \c sr can match an available
+    \c sr-Cyrl catalog.
 
     @section i18n_versions Backend Versions
 
@@ -116,6 +119,6 @@ printf("backend=%s icu=%s cldr=%s\n", info.backend, info.icu_version, info.cldr_
     @section i18n_scope Current Scope
 
     This module is the implementation target for issue #5334. Catalog file loading, extraction tooling, rich message
-    formatting, locale-aware number/date/currency formatting, collation, likely-subtags, request-locale propagation,
-    and machine-translation workflow support are planned follow-up phases in the same issue.
+    formatting, locale-aware number/date/currency formatting, collation, request-locale propagation, and
+    machine-translation workflow support are planned follow-up phases in the same issue.
 */

--- a/modules/i18n/docs/mainpage.dox.tmpl
+++ b/modules/i18n/docs/mainpage.dox.tmpl
@@ -114,7 +114,9 @@ I18n::MessageCatalog billing_catalog(files);
 
     Catalog construction validates placeholders. Plain translations must preserve exactly the placeholders from the
     source text. Plural forms must preserve all non-\c count source placeholders and may use \c count for the selected
-    numeric value. Message formatting fails if a required placeholder argument is missing.
+    numeric value. Message formatting fails if a required placeholder argument is missing. Placeholder output is
+    wrapped in Unicode bidi isolation marks automatically for RTL requested locales such as Arabic, Hebrew, Persian,
+    and Urdu.
 
     @section i18n_locale Locale Negotiation
 

--- a/modules/i18n/docs/mainpage.dox.tmpl
+++ b/modules/i18n/docs/mainpage.dox.tmpl
@@ -97,6 +97,17 @@ I18n::MessageCatalog layered_catalog(("base.json", "override.json"));
     File-loading APIs and constructors are tagged with the \c FILESYSTEM functional domain and enforce a bounded file
     size. JSON parsing is strict, rejects duplicate object keys, and validates UTF-8 strings.
 
+    Discovery uses \c QORE_CATALOG_DIR by default and can be overridden explicitly. Returned files are already ordered
+    for deterministic composition: lower precedence first, with \c root before more-specific locale files.
+
+    @code{.py}
+list<string> files = I18n::discover_catalog_files("billing", "cs-CZ", {
+    "search_path": ("/opt/qore/catalogs",),
+    "override_path": "/etc/qore/catalogs",
+});
+I18n::MessageCatalog billing_catalog(files);
+    @endcode
+
     Runtime state policy follows gettext's conservative behavior by default: \c fuzzy, \c needs-review, and
     \c stale entries are stored but not used at runtime. Pass \c {"use_unreviewed": True} to the constructor to preview
     those entries in development.
@@ -169,7 +180,7 @@ printf("backend=%s icu=%s cldr=%s\n", info.backend, info.icu_version, info.cldr_
 
     @section i18n_scope Current Scope
 
-    This module is the implementation target for issue #5334. Catalog search-path discovery, extraction tooling,
-    rich message formatting, date/time skeleton formatting, request-locale propagation, and machine-translation workflow
-    support are planned follow-up phases in the same issue.
+    This module is the implementation target for issue #5334. Extraction tooling, rich message formatting, date/time
+    skeleton formatting, request-locale propagation, and machine-translation workflow support are planned follow-up
+    phases in the same issue.
 */

--- a/modules/i18n/docs/mainpage.dox.tmpl
+++ b/modules/i18n/docs/mainpage.dox.tmpl
@@ -162,6 +162,7 @@ I18n::clear_thread_locale();
 %requires i18n
 
 printf("%s\n", I18n::format_number("1234.50", "en-US"));
+printf("%y\n", I18n::parse_number("1,234.50", "en-US"));
 printf("%s\n", I18n::format_currency("12.5", "USD", "en-US"));
 printf("%s\n", I18n::format_datetime(2020-05-04T15:06:07Z, "en-US",
     {"date_style": "medium", "time_style": "none"}));

--- a/modules/i18n/docs/mainpage.dox.tmpl
+++ b/modules/i18n/docs/mainpage.dox.tmpl
@@ -62,6 +62,15 @@ hash<auto> native_catalog = {
                 "message": "Ahoj, {name}",
                 "state": "translated",
             },
+            "1 file": {
+                "plural_source": "{count} files",
+                "forms": {
+                    "one": "{count} soubor",
+                    "few": "{count} soubory",
+                    "other": "{count} souboru",
+                },
+                "state": "translated",
+            },
             "workflow.greeting": {
                 "source": "Hello, {name}",
                 "message": "Nazdar, {name}",
@@ -73,6 +82,7 @@ hash<auto> native_catalog = {
 
 I18n::MessageCatalog catalog(native_catalog);
 printf("%s\n", catalog.t("Hello, {name}", "cs-CZ", {"name": "Petr"}));
+printf("%s\n", catalog.tn(2, "1 file", "{count} files", "cs"));
 printf("%s\n", catalog.tc("workflow.greeting", "Hello, {name}", "cs", {"name": "Eva"}));
     @endcode
 
@@ -80,8 +90,9 @@ printf("%s\n", catalog.tc("workflow.greeting", "Hello, {name}", "cs", {"name": "
     \c stale entries are stored but not used at runtime. Pass \c {"use_unreviewed": True} to the constructor to preview
     those entries in development.
 
-    Catalog construction validates simple placeholders. Translations must preserve exactly the placeholders from the
-    source text, and message formatting fails if a required placeholder argument is missing.
+    Catalog construction validates placeholders. Plain translations must preserve exactly the placeholders from the
+    source text. Plural forms must preserve all non-\c count source placeholders and may use \c count for the selected
+    numeric value. Message formatting fails if a required placeholder argument is missing.
 
     @section i18n_locale Locale Negotiation
 

--- a/modules/i18n/docs/mainpage.dox.tmpl
+++ b/modules/i18n/docs/mainpage.dox.tmpl
@@ -118,6 +118,22 @@ printf("%s\n", locale); # fr
     Negotiation also uses ICU likely-subtags so broad requests such as \c sr can match an available
     \c sr-Cyrl catalog.
 
+    @section i18n_formatting Formatting and Collation
+
+    Number and currency formatting use explicit locale arguments and do not change existing core machine-format
+    functions. Collation APIs expose compare, binary sort-key, and collation-version primitives; sort keys are for
+    cache-local ordering unless they are tagged with locale, collation options, backend, ICU/CLDR versions, and
+    collation version.
+
+    @code{.py}
+%requires i18n
+
+printf("%s\n", I18n::format_number("1234.50", "en-US"));
+printf("%s\n", I18n::format_currency("12.5", "USD", "en-US"));
+assertLt(0, I18n::compare_strings("a", "b", "en-US"));
+binary key = I18n::get_sort_key("file-001", "en-US-u-kn-true");
+    @endcode
+
     @section i18n_versions Backend Versions
 
     The module exposes ICU and CLDR data versions so deployments can report the locale-data backend in diagnostics:
@@ -130,6 +146,6 @@ printf("backend=%s icu=%s cldr=%s\n", info.backend, info.icu_version, info.cldr_
     @section i18n_scope Current Scope
 
     This module is the implementation target for issue #5334. Catalog file loading, extraction tooling, rich message
-    formatting, locale-aware number/date/currency formatting, collation, request-locale propagation, and
-    machine-translation workflow support are planned follow-up phases in the same issue.
+    formatting, locale-aware date/time formatting, request-locale propagation, and machine-translation workflow support
+    are planned follow-up phases in the same issue.
 */

--- a/modules/i18n/docs/mainpage.dox.tmpl
+++ b/modules/i18n/docs/mainpage.dox.tmpl
@@ -4,206 +4,36 @@
 
     @section i18nintro i18n Module Introduction
 
-    The \c i18n module provides internationalization primitives backed by ICU and CLDR locale data.
+    The \c i18n module provides ICU-backed internationalization primitives for Qore. ICU development
+    and runtime libraries are required so this bundled binary module is always built and available.
 
-    The first runtime surface exposes backend/data version introspection and CLDR plural selection. The legacy
-    \c Util::plural() helper remains an English two-form helper; non-English pluralization requires caller-supplied
-    forms keyed by CLDR category.
+    Locale-sensitive behavior is intentionally exposed through explicit \c Qore::I18n APIs. Existing
+    core machine-format functions keep their default behavior; use this module when output or parsing
+    must follow CLDR locale data.
 
-    @section i18n_plural Plural Selection
+    @section i18noverview Overview
 
-    Use \c I18n::plural_category() to inspect the CLDR category for a numeric value:
+    - @subpage i18nplural
+    - @subpage i18ncatalogs
+    - @subpage i18nlocaleformatting
+    - @subpage i18ncli
 
-    @code{.py}
-%requires i18n
-
-printf("%s\n", I18n::plural_category(1, "en"));      # one
-printf("%s\n", I18n::plural_category(2, "ru"));      # few
-printf("%s\n", I18n::plural_category(5, "ru"));      # many
-printf("%s\n", I18n::plural_category(2, "en", {"type": "ordinal"})); # two
-    @endcode
-
-    Use \c I18n::plural_form() to select among strings supplied by the caller:
-
-    @code{.py}
-hash<auto> forms = {
-    "=0": "no files",
-    "one": "file",
-    "other": "files",
-};
-
-string form = I18n::plural_form(count, "en", forms);
-string msg = count == 0 ? form : sprintf("%d %s", count, form);
-printf("%s\n", msg);
-    @endcode
-
-    String operands preserve visible fraction digits, which matters for CLDR plural rules in some locales:
-
-    @code{.py}
-printf("%s\n", I18n::plural_category("1", "lv"));
-printf("%s\n", I18n::plural_category("1.0", "lv"));
-    @endcode
-
-    @section i18n_catalogs Message Catalogs
-
-    \c I18n::MessageCatalog stores schema-versioned native catalogs passed as Qore data. Lookup uses source strings by
-    default and supports stable symbolic ids with \c tc(). Locale fallback is deterministic:
-    \c fr-CA-u-nu-latn falls back through \c fr-CA, \c fr, and \c root for catalog identity.
+    @section i18nquickstart Quick Example
 
     @code{.py}
 %requires i18n
 
-hash<auto> native_catalog = {
-    "schema_version": I18n::get_catalog_schema_version(),
-    "locales": {
-        "root": {"messages": {"Hello, {name}": "Hello, {name}"}},
-        "cs": {"messages": {
-            "Hello, {name}": {
-                "message": "Ahoj, {name}",
-                "state": "translated",
-            },
-            "1 file": {
-                "plural_source": "{count} files",
-                "forms": {
-                    "one": "{count} soubor",
-                    "few": "{count} soubory",
-                    "other": "{count} souboru",
-                },
-                "state": "translated",
-            },
-            "workflow.greeting": {
-                "source": "Hello, {name}",
-                "message": "Nazdar, {name}",
-                "state": "translated",
-            },
-        }},
-    },
-};
-
-I18n::MessageCatalog catalog(native_catalog);
-printf("%s\n", catalog.t("Hello, {name}", "cs-CZ", {"name": "Petr"}));
-printf("%s\n", catalog.tn(2, "1 file", "{count} files", "cs"));
-printf("%s\n", catalog.tc("workflow.greeting", "Hello, {name}", "cs", {"name": "Eva"}));
-    @endcode
-
-    The same native shape can be stored as UTF-8 JSON and loaded without evaluating catalog text as Qore code:
-
-    @code{.py}
-hash<auto> catalog_data = I18n::load_native_catalog("catalog.json");
-I18n::MessageCatalog catalog_from_file("catalog.json");
-I18n::MessageCatalog layered_catalog(("base.json", "override.json"));
-    @endcode
-
-    File-loading APIs and constructors are tagged with the \c FILESYSTEM functional domain and enforce a bounded file
-    size. JSON parsing is strict, rejects duplicate object keys, and validates UTF-8 strings.
-
-    Discovery uses \c QORE_CATALOG_DIR by default and can be overridden explicitly. Returned files are already ordered
-    for deterministic composition: lower precedence first, with \c root before more-specific locale files.
-
-    @code{.py}
-list<string> files = I18n::discover_catalog_files("billing", "cs-CZ", {
-    "search_path": ("/opt/qore/catalogs",),
-    "override_path": "/etc/qore/catalogs",
-});
-I18n::MessageCatalog billing_catalog(files);
-    @endcode
-
-    Runtime state policy follows gettext's conservative behavior by default: \c fuzzy, \c needs-review, and
-    \c stale entries are stored but not used at runtime. Pass \c {"use_unreviewed": True} to the constructor to preview
-    those entries in development.
-
-    Catalog construction validates placeholders. Plain translations must preserve exactly the placeholders from the
-    source text. Plural forms must preserve all non-\c count source placeholders and may use \c count for the selected
-    numeric value. Message formatting fails if a required placeholder argument is missing. Placeholder output is
-    wrapped in Unicode bidi isolation marks automatically for RTL requested locales such as Arabic, Hebrew, Persian,
-    and Urdu.
-
-    @section i18n_locale Locale Negotiation
-
-    Locale utilities canonicalize BCP 47 tags, strip Unicode formatting extensions from catalog identity, parse
-    HTTP \c Accept-Language headers, and choose an effective catalog locale from an explicit available-locale list.
-
-    @code{.py}
-%requires i18n
-
-printf("%s\n", I18n::canonicalize_locale("en_US")); # en-US
-printf("%s\n", I18n::add_likely_subtags("sr"));     # sr-Cyrl-RS
-printf("%y\n", I18n::get_locale_fallback_chain("fr-CA-u-nu-latn"));
-
-string locale = I18n::negotiate_locale(
-    "fr-CA, fr;q=0.8, en;q=0.5",
-    ("en", "fr", "root")
-);
-printf("%s\n", locale); # fr
-    @endcode
-
-    \c I18n::parse_accept_language() returns a preference-sorted list of hashes containing \c locale, \c q, \c index,
-    and \c wildcard keys. Header parsing is bounded and rejects malformed \c q values instead of guessing.
-    Negotiation also uses ICU likely-subtags so broad requests such as \c sr can match an available
-    \c sr-Cyrl catalog.
-
-    The module also exposes a thread-local ambient locale for request/task integration:
-
-    @code{.py}
-I18n::set_thread_locale("cs-CZ");
-assertEq("cs-CZ", I18n::get_thread_locale());
-hash<auto> locale_context = I18n::capture_locale_context();
-I18n::clear_thread_locale();
-I18n::apply_locale_context(locale_context);
-    @endcode
-
-    Explicit-locale APIs remain the stable default. Raw \c Queue handoff does not propagate the ambient locale; pass an
-    explicit context object from \c I18n::capture_locale_context() or a locale string across queue boundaries.
-
-    @section i18n_formatting Formatting and Collation
-
-    Number and currency formatting use explicit locale arguments and do not change existing core machine-format
-    functions. Collation APIs expose compare, binary sort-key, and collation-version primitives; sort keys are for
-    cache-local ordering unless they are tagged with locale, collation options, backend, ICU/CLDR versions, and
-    collation version.
-
-    @code{.py}
-%requires i18n
-
-printf("%s\n", I18n::format_number("1234.50", "en-US"));
-printf("%y\n", I18n::parse_number("1,234.50", "en-US"));
+printf("%s\n", I18n::plural_category(2, "ru"));
 printf("%s\n", I18n::format_currency("12.5", "USD", "en-US"));
-printf("%s\n", I18n::format_datetime(2020-05-04T15:06:07Z, "en-US",
-    {"date_style": "medium", "time_style": "none"}));
-printf("%s\n", I18n::format_datetime(2020-05-04T15:06:07Z, "en-US", {"skeleton": "yMMMd"}));
-assertLt(0, I18n::compare_strings("a", "b", "en-US"));
-binary key = I18n::get_sort_key("file-001", "en-US-u-kn-true");
+
+hash<auto> catalog_data = I18n::load_native_catalog("catalog.json");
+I18n::MessageCatalog catalog(catalog_data);
+printf("%s\n", catalog.t("Hello, {name}", "cs-CZ", {"name": "Petr"}));
     @endcode
 
-    @section i18n_cli Catalog Management CLI
+    @section i18nscope Current Scope
 
-    The \c qore-i18n tool provides the first catalog-management workflow:
-
-    @code
-qore-i18n extract -o catalogs/root.json src/app.q
-qore-i18n stats --fail-under=95 catalogs/cs.json
-qore-i18n pseudo -o catalogs/qps-ploc.json catalogs/root.json
-qore-i18n export-po -l cs -o catalogs/cs.po catalogs/cs.json
-qore-i18n import-po -l cs -o catalogs/cs.json catalogs/cs.po
-    @endcode
-
-    Extraction uses the \c astparser module and recognizes static \c t(), \c tn(), and \c tc() calls by default.
-    Dynamic source strings or ids are reported as warnings and can be made fatal with \c --fail-dynamic.
-    The \c stats command reports translated, fuzzy, needs-review, stale, and coverage counts and can fail CI with
-    \c --fail-under. PO import/export is intentionally simple interchange for plain messages and two-form source
-    plurals; richer per-locale forms remain represented in the native catalog.
-
-    @section i18n_versions Backend Versions
-
-    The module exposes ICU and CLDR data versions so deployments can report the locale-data backend in diagnostics:
-
-    @code{.py}
-hash<auto> info = I18n::get_backend_info();
-printf("backend=%s icu=%s cldr=%s\n", info.backend, info.icu_version, info.cldr_version);
-    @endcode
-
-    @section i18n_scope Current Scope
-
-    This module is the implementation target for issue #5334. Rich message formatting, request-locale propagation
-    helpers, and machine-translation workflow support are planned follow-up phases in the same issue.
+    This module is the implementation target for issue #5334. Rich message formatting, request-locale
+    propagation helpers, and machine-translation workflow support are planned follow-up phases in the
+    same issue.
 */

--- a/modules/i18n/docs/mainpage.dox.tmpl
+++ b/modules/i18n/docs/mainpage.dox.tmpl
@@ -147,11 +147,13 @@ printf("%s\n", locale); # fr
     @code{.py}
 I18n::set_thread_locale("cs-CZ");
 assertEq("cs-CZ", I18n::get_thread_locale());
+hash<auto> locale_context = I18n::capture_locale_context();
 I18n::clear_thread_locale();
+I18n::apply_locale_context(locale_context);
     @endcode
 
     Explicit-locale APIs remain the stable default. Raw \c Queue handoff does not propagate the ambient locale; pass an
-    explicit context object or locale string across queue boundaries.
+    explicit context object from \c I18n::capture_locale_context() or a locale string across queue boundaries.
 
     @section i18n_formatting Formatting and Collation
 

--- a/modules/i18n/docs/mainpage.dox.tmpl
+++ b/modules/i18n/docs/mainpage.dox.tmpl
@@ -130,6 +130,8 @@ printf("%s\n", locale); # fr
 
 printf("%s\n", I18n::format_number("1234.50", "en-US"));
 printf("%s\n", I18n::format_currency("12.5", "USD", "en-US"));
+printf("%s\n", I18n::format_datetime(2020-05-04T15:06:07Z, "en-US",
+    {"date_style": "medium", "time_style": "none"}));
 assertLt(0, I18n::compare_strings("a", "b", "en-US"));
 binary key = I18n::get_sort_key("file-001", "en-US-u-kn-true");
     @endcode
@@ -146,6 +148,6 @@ printf("backend=%s icu=%s cldr=%s\n", info.backend, info.icu_version, info.cldr_
     @section i18n_scope Current Scope
 
     This module is the implementation target for issue #5334. Catalog file loading, extraction tooling, rich message
-    formatting, locale-aware date/time formatting, request-locale propagation, and machine-translation workflow support
-    are planned follow-up phases in the same issue.
+    formatting, date/time skeleton formatting, request-locale propagation, and machine-translation workflow support are
+    planned follow-up phases in the same issue.
 */

--- a/modules/i18n/docs/mainpage.dox.tmpl
+++ b/modules/i18n/docs/mainpage.dox.tmpl
@@ -83,6 +83,27 @@ printf("%s\n", catalog.tc("workflow.greeting", "Hello, {name}", "cs", {"name": "
     Catalog construction validates simple placeholders. Translations must preserve exactly the placeholders from the
     source text, and message formatting fails if a required placeholder argument is missing.
 
+    @section i18n_locale Locale Negotiation
+
+    Locale utilities canonicalize BCP 47 tags, strip Unicode formatting extensions from catalog identity, parse
+    HTTP \c Accept-Language headers, and choose an effective catalog locale from an explicit available-locale list.
+
+    @code{.py}
+%requires i18n
+
+printf("%s\n", I18n::canonicalize_locale("en_US")); # en-US
+printf("%y\n", I18n::get_locale_fallback_chain("fr-CA-u-nu-latn"));
+
+string locale = I18n::negotiate_locale(
+    "fr-CA, fr;q=0.8, en;q=0.5",
+    ("en", "fr", "root")
+);
+printf("%s\n", locale); # fr
+    @endcode
+
+    \c I18n::parse_accept_language() returns a preference-sorted list of hashes containing \c locale, \c q, \c index,
+    and \c wildcard keys. Header parsing is bounded and rejects malformed \c q values instead of guessing.
+
     @section i18n_versions Backend Versions
 
     The module exposes ICU and CLDR data versions so deployments can report the locale-data backend in diagnostics:
@@ -95,6 +116,6 @@ printf("backend=%s icu=%s cldr=%s\n", info.backend, info.icu_version, info.cldr_
     @section i18n_scope Current Scope
 
     This module is the implementation target for issue #5334. Catalog file loading, extraction tooling, rich message
-    formatting, locale-aware number/date/currency formatting, collation, request-locale propagation, and
-    machine-translation workflow support are planned follow-up phases in the same issue.
+    formatting, locale-aware number/date/currency formatting, collation, likely-subtags, request-locale propagation,
+    and machine-translation workflow support are planned follow-up phases in the same issue.
 */

--- a/modules/i18n/docs/mainpage.dox.tmpl
+++ b/modules/i18n/docs/mainpage.dox.tmpl
@@ -86,6 +86,17 @@ printf("%s\n", catalog.tn(2, "1 file", "{count} files", "cs"));
 printf("%s\n", catalog.tc("workflow.greeting", "Hello, {name}", "cs", {"name": "Eva"}));
     @endcode
 
+    The same native shape can be stored as UTF-8 JSON and loaded without evaluating catalog text as Qore code:
+
+    @code{.py}
+hash<auto> catalog_data = I18n::load_native_catalog("catalog.json");
+I18n::MessageCatalog catalog_from_file("catalog.json");
+I18n::MessageCatalog layered_catalog(("base.json", "override.json"));
+    @endcode
+
+    File-loading APIs and constructors are tagged with the \c FILESYSTEM functional domain and enforce a bounded file
+    size. JSON parsing is strict, rejects duplicate object keys, and validates UTF-8 strings.
+
     Runtime state policy follows gettext's conservative behavior by default: \c fuzzy, \c needs-review, and
     \c stale entries are stored but not used at runtime. Pass \c {"use_unreviewed": True} to the constructor to preview
     those entries in development.
@@ -158,7 +169,7 @@ printf("backend=%s icu=%s cldr=%s\n", info.backend, info.icu_version, info.cldr_
 
     @section i18n_scope Current Scope
 
-    This module is the implementation target for issue #5334. Catalog file loading, extraction tooling, rich message
-    formatting, date/time skeleton formatting, request-locale propagation, and machine-translation workflow support are
-    planned follow-up phases in the same issue.
+    This module is the implementation target for issue #5334. Catalog search-path discovery, extraction tooling,
+    rich message formatting, date/time skeleton formatting, request-locale propagation, and machine-translation workflow
+    support are planned follow-up phases in the same issue.
 */

--- a/modules/i18n/docs/mainpage.dox.tmpl
+++ b/modules/i18n/docs/mainpage.dox.tmpl
@@ -118,6 +118,17 @@ printf("%s\n", locale); # fr
     Negotiation also uses ICU likely-subtags so broad requests such as \c sr can match an available
     \c sr-Cyrl catalog.
 
+    The module also exposes a thread-local ambient locale for request/task integration:
+
+    @code{.py}
+I18n::set_thread_locale("cs-CZ");
+assertEq("cs-CZ", I18n::get_thread_locale());
+I18n::clear_thread_locale();
+    @endcode
+
+    Explicit-locale APIs remain the stable default. Raw \c Queue handoff does not propagate the ambient locale; pass an
+    explicit context object or locale string across queue boundaries.
+
     @section i18n_formatting Formatting and Collation
 
     Number and currency formatting use explicit locale arguments and do not change existing core machine-format

--- a/modules/i18n/docs/mainpage.dox.tmpl
+++ b/modules/i18n/docs/mainpage.dox.tmpl
@@ -165,6 +165,7 @@ printf("%s\n", I18n::format_number("1234.50", "en-US"));
 printf("%s\n", I18n::format_currency("12.5", "USD", "en-US"));
 printf("%s\n", I18n::format_datetime(2020-05-04T15:06:07Z, "en-US",
     {"date_style": "medium", "time_style": "none"}));
+printf("%s\n", I18n::format_datetime(2020-05-04T15:06:07Z, "en-US", {"skeleton": "yMMMd"}));
 assertLt(0, I18n::compare_strings("a", "b", "en-US"));
 binary key = I18n::get_sort_key("file-001", "en-US-u-kn-true");
     @endcode

--- a/modules/i18n/docs/mainpage.dox.tmpl
+++ b/modules/i18n/docs/mainpage.dox.tmpl
@@ -170,6 +170,24 @@ assertLt(0, I18n::compare_strings("a", "b", "en-US"));
 binary key = I18n::get_sort_key("file-001", "en-US-u-kn-true");
     @endcode
 
+    @section i18n_cli Catalog Management CLI
+
+    The \c qore-i18n tool provides the first catalog-management workflow:
+
+    @code
+qore-i18n extract -o catalogs/root.json src/app.q
+qore-i18n stats --fail-under=95 catalogs/cs.json
+qore-i18n pseudo -o catalogs/qps-ploc.json catalogs/root.json
+qore-i18n export-po -l cs -o catalogs/cs.po catalogs/cs.json
+qore-i18n import-po -l cs -o catalogs/cs.json catalogs/cs.po
+    @endcode
+
+    Extraction uses the \c astparser module and recognizes static \c t(), \c tn(), and \c tc() calls by default.
+    Dynamic source strings or ids are reported as warnings and can be made fatal with \c --fail-dynamic.
+    The \c stats command reports translated, fuzzy, needs-review, stale, and coverage counts and can fail CI with
+    \c --fail-under. PO import/export is intentionally simple interchange for plain messages and two-form source
+    plurals; richer per-locale forms remain represented in the native catalog.
+
     @section i18n_versions Backend Versions
 
     The module exposes ICU and CLDR data versions so deployments can report the locale-data backend in diagnostics:
@@ -181,7 +199,6 @@ printf("backend=%s icu=%s cldr=%s\n", info.backend, info.icu_version, info.cldr_
 
     @section i18n_scope Current Scope
 
-    This module is the implementation target for issue #5334. Extraction tooling, rich message formatting, date/time
-    skeleton formatting, request-locale propagation, and machine-translation workflow support are planned follow-up
-    phases in the same issue.
+    This module is the implementation target for issue #5334. Rich message formatting, request-locale propagation
+    helpers, and machine-translation workflow support are planned follow-up phases in the same issue.
 */

--- a/modules/i18n/docs/mainpage.dox.tmpl
+++ b/modules/i18n/docs/mainpage.dox.tmpl
@@ -1,0 +1,61 @@
+/** @mainpage Qore i18n Module
+
+    @tableofcontents
+
+    @section i18nintro i18n Module Introduction
+
+    The \c i18n module provides internationalization primitives backed by ICU and CLDR locale data.
+
+    The first runtime surface exposes backend/data version introspection and CLDR plural selection. The legacy
+    \c Util::plural() helper remains an English two-form helper; non-English pluralization requires caller-supplied
+    forms keyed by CLDR category.
+
+    @section i18n_plural Plural Selection
+
+    Use \c I18n::plural_category() to inspect the CLDR category for a numeric value:
+
+    @code{.py}
+%requires i18n
+
+printf("%s\n", I18n::plural_category(1, "en"));      # one
+printf("%s\n", I18n::plural_category(2, "ru"));      # few
+printf("%s\n", I18n::plural_category(5, "ru"));      # many
+printf("%s\n", I18n::plural_category(2, "en", {"type": "ordinal"})); # two
+    @endcode
+
+    Use \c I18n::plural_form() to select among strings supplied by the caller:
+
+    @code{.py}
+hash<auto> forms = {
+    "=0": "no files",
+    "one": "file",
+    "other": "files",
+};
+
+string form = I18n::plural_form(count, "en", forms);
+string msg = count == 0 ? form : sprintf("%d %s", count, form);
+printf("%s\n", msg);
+    @endcode
+
+    String operands preserve visible fraction digits, which matters for CLDR plural rules in some locales:
+
+    @code{.py}
+printf("%s\n", I18n::plural_category("1", "lv"));
+printf("%s\n", I18n::plural_category("1.0", "lv"));
+    @endcode
+
+    @section i18n_versions Backend Versions
+
+    The module exposes ICU and CLDR data versions so deployments can report the locale-data backend in diagnostics:
+
+    @code{.py}
+hash<auto> info = I18n::get_backend_info();
+printf("backend=%s icu=%s cldr=%s\n", info.backend, info.icu_version, info.cldr_version);
+    @endcode
+
+    @section i18n_scope Current Scope
+
+    This module is the initial implementation target for issue #5334. Catalog loading, extraction tooling, rich
+    message formatting, locale-aware number/date/currency formatting, collation, request-locale propagation, and
+    machine-translation workflow support are planned follow-up phases in the same issue.
+*/

--- a/modules/i18n/docs/plural.dox.tmpl
+++ b/modules/i18n/docs/plural.dox.tmpl
@@ -1,0 +1,41 @@
+/** @page i18nplural Plural Selection
+
+    The \c Util::plural() helper remains an English two-form helper. Non-English pluralization
+    requires caller-supplied forms keyed by CLDR category.
+
+    @section i18npluralcategory Plural Categories
+
+    Use \c I18n::plural_category() to inspect the CLDR category for a numeric value:
+
+    @code{.py}
+%requires i18n
+
+printf("%s\n", I18n::plural_category(1, "en"));      # one
+printf("%s\n", I18n::plural_category(2, "ru"));      # few
+printf("%s\n", I18n::plural_category(5, "ru"));      # many
+printf("%s\n", I18n::plural_category(2, "en", {"type": "ordinal"})); # two
+    @endcode
+
+    @section i18npluralforms Plural Forms
+
+    Use \c I18n::plural_form() to select among strings supplied by the caller:
+
+    @code{.py}
+hash<auto> forms = {
+    "=0": "no files",
+    "one": "file",
+    "other": "files",
+};
+
+string form = I18n::plural_form(count, "en", forms);
+string msg = count == 0 ? form : sprintf("%d %s", count, form);
+printf("%s\n", msg);
+    @endcode
+
+    String operands preserve visible fraction digits, which matters for CLDR plural rules in some locales:
+
+    @code{.py}
+printf("%s\n", I18n::plural_category("1", "lv"));
+printf("%s\n", I18n::plural_category("1.0", "lv"));
+    @endcode
+*/

--- a/modules/i18n/src/QC_MessageCatalog.qpp
+++ b/modules/i18n/src/QC_MessageCatalog.qpp
@@ -44,6 +44,8 @@
 namespace {
 
 constexpr int64 I18N_CATALOG_SCHEMA_VERSION = 1;
+constexpr int64 I18N_CATALOG_DEFAULT_MAX_FILE_LEN = 16 * 1024 * 1024;
+constexpr int64 I18N_CATALOG_MAX_FILE_LEN = 256 * 1024 * 1024;
 
 struct I18nCatalogMessage {
     std::string source;
@@ -433,6 +435,30 @@ static bool i18n_catalog_contains_placeholder(const std::set<std::string>& place
     return placeholders.find(name) != placeholders.end();
 }
 
+static int64 i18n_catalog_get_max_file_len_option(const QoreHashNode* opts, ExceptionSink* xsink) {
+    if (!opts) {
+        return I18N_CATALOG_DEFAULT_MAX_FILE_LEN;
+    }
+
+    QoreValue value = opts->getKeyValue("max_file_len");
+    if (value.isNullOrNothing()) {
+        return I18N_CATALOG_DEFAULT_MAX_FILE_LEN;
+    }
+    if (value.getType() != NT_INT) {
+        xsink->raiseException("I18N-CATALOG-ERROR",
+            "opts.max_file_len must be an int; got type '%s'", value.getTypeName());
+        return 0;
+    }
+
+    int64 max_file_len = value.getAsBigInt();
+    if (max_file_len < 1 || max_file_len > I18N_CATALOG_MAX_FILE_LEN) {
+        xsink->raiseException("I18N-CATALOG-ERROR",
+            "opts.max_file_len must be between 1 and %lld bytes", I18N_CATALOG_MAX_FILE_LEN);
+        return 0;
+    }
+    return max_file_len;
+}
+
 } // namespace
 
 class QoreMessageCatalog : public AbstractPrivateData {
@@ -478,6 +504,14 @@ public:
                 return;
             }
         }
+    }
+
+    DLLLOCAL void loadCatalogFile(const QoreStringNode* path, int64 max_file_len, ExceptionSink* xsink) {
+        ReferenceHolder<QoreHashNode> catalog(i18n_load_native_catalog_json(path, max_file_len, xsink), xsink);
+        if (*xsink) {
+            return;
+        }
+        loadCatalog(*catalog, xsink);
     }
 
     DLLLOCAL QoreStringNode* translate(const QoreStringNode* id_arg, const QoreStringNode* source_arg,
@@ -1034,8 +1068,8 @@ private:
 };
 
 //! Message catalog for locale-aware text lookup and simple placeholder formatting.
-/** The class stores an immutable, schema-versioned native catalog passed as Qore data. Catalog file loading is
-    intentionally separate from this class so filesystem sandboxing can be applied by the future loader API.
+/** The class stores an immutable, schema-versioned native catalog passed as Qore data or loaded from UTF-8 JSON
+    catalog files. File-loading constructors are tagged with the \c FILESYSTEM functional domain.
 
     Native catalog shape:
     @code{.py}
@@ -1091,6 +1125,46 @@ MessageCatalog::constructor(hash<auto> native_catalog, *hash<auto> opts) {
     self->setPrivate(CID_MESSAGECATALOG, holder.release());
 }
 
+//! Creates a message catalog from one native catalog JSON file.
+/** @param path path to a UTF-8 native catalog JSON file
+
+    @throw FILE-READ-ERROR if the file cannot be read
+    @throw I18N-CATALOG-JSON-ERROR if the file does not contain valid native catalog JSON
+    @throw I18N-CATALOG-ERROR if the catalog schema or placeholders are invalid
+*/
+MessageCatalog::constructor(string path) [dom=FILESYSTEM] {
+    std::unique_ptr<QoreMessageCatalog> holder(new QoreMessageCatalog());
+    holder->loadCatalogFile(path, I18N_CATALOG_DEFAULT_MAX_FILE_LEN, xsink);
+    if (*xsink) {
+        return;
+    }
+    self->setPrivate(CID_MESSAGECATALOG, holder.release());
+}
+
+//! Creates a message catalog from one native catalog JSON file with options.
+/** @param path path to a UTF-8 native catalog JSON file
+    @param opts options hash; \c "use_unreviewed" allows \c fuzzy, \c needs-review, and \c stale entries at runtime;
+        \c "max_file_len" sets the maximum accepted file size in bytes
+
+    @throw FILE-READ-ERROR if the file cannot be read
+    @throw I18N-CATALOG-JSON-ERROR if the file does not contain valid native catalog JSON
+    @throw I18N-CATALOG-ERROR if the catalog schema, placeholders, or options are invalid
+*/
+MessageCatalog::constructor(string path, *hash<auto> opts) [dom=FILESYSTEM] {
+    bool use_unreviewed = opts && opts->getKeyValue("use_unreviewed").getAsBool();
+    int64 max_file_len = i18n_catalog_get_max_file_len_option(opts, xsink);
+    if (*xsink) {
+        return;
+    }
+
+    std::unique_ptr<QoreMessageCatalog> holder(new QoreMessageCatalog(use_unreviewed));
+    holder->loadCatalogFile(path, max_file_len, xsink);
+    if (*xsink) {
+        return;
+    }
+    self->setPrivate(CID_MESSAGECATALOG, holder.release());
+}
+
 //! Creates a message catalog by merging native catalog hashes in order.
 /** Later catalog hashes override earlier hashes per whole message id.
 
@@ -1106,6 +1180,62 @@ MessageCatalog::constructor(list<hash<auto>> native_catalogs) {
         }
         QoreValue value = native_catalogs->retrieveEntry(i);
         holder->loadCatalog(value.get<const QoreHashNode>(), xsink);
+        if (*xsink) {
+            return;
+        }
+    }
+    self->setPrivate(CID_MESSAGECATALOG, holder.release());
+}
+
+//! Creates a message catalog by merging native catalog JSON files in order.
+/** Later catalog files override earlier files per whole message id.
+
+    @param paths list of UTF-8 native catalog JSON file paths
+
+    @throw FILE-READ-ERROR if a file cannot be read
+    @throw I18N-CATALOG-JSON-ERROR if a file does not contain valid native catalog JSON
+    @throw I18N-CATALOG-ERROR if any catalog schema or placeholders are invalid
+*/
+MessageCatalog::constructor(list<string> paths) [dom=FILESYSTEM] {
+    std::unique_ptr<QoreMessageCatalog> holder(new QoreMessageCatalog());
+    for (size_t i = 0; i < paths->size(); ++i) {
+        if (i && !(i % 100) && qore_check_cancel(xsink, "loading i18n catalog files")) {
+            return;
+        }
+        const QoreStringNode* path = paths->retrieveEntry(i).get<const QoreStringNode>();
+        holder->loadCatalogFile(path, I18N_CATALOG_DEFAULT_MAX_FILE_LEN, xsink);
+        if (*xsink) {
+            return;
+        }
+    }
+    self->setPrivate(CID_MESSAGECATALOG, holder.release());
+}
+
+//! Creates a message catalog by merging native catalog JSON files in order with options.
+/** Later catalog files override earlier files per whole message id.
+
+    @param paths list of UTF-8 native catalog JSON file paths
+    @param opts options hash; \c "use_unreviewed" allows \c fuzzy, \c needs-review, and \c stale entries at runtime;
+        \c "max_file_len" sets the maximum accepted file size in bytes for each file
+
+    @throw FILE-READ-ERROR if a file cannot be read
+    @throw I18N-CATALOG-JSON-ERROR if a file does not contain valid native catalog JSON
+    @throw I18N-CATALOG-ERROR if any catalog schema, placeholders, or options are invalid
+*/
+MessageCatalog::constructor(list<string> paths, *hash<auto> opts) [dom=FILESYSTEM] {
+    bool use_unreviewed = opts && opts->getKeyValue("use_unreviewed").getAsBool();
+    int64 max_file_len = i18n_catalog_get_max_file_len_option(opts, xsink);
+    if (*xsink) {
+        return;
+    }
+
+    std::unique_ptr<QoreMessageCatalog> holder(new QoreMessageCatalog(use_unreviewed));
+    for (size_t i = 0; i < paths->size(); ++i) {
+        if (i && !(i % 100) && qore_check_cancel(xsink, "loading i18n catalog files")) {
+            return;
+        }
+        const QoreStringNode* path = paths->retrieveEntry(i).get<const QoreStringNode>();
+        holder->loadCatalogFile(path, max_file_len, xsink);
         if (*xsink) {
             return;
         }

--- a/modules/i18n/src/QC_MessageCatalog.qpp
+++ b/modules/i18n/src/QC_MessageCatalog.qpp
@@ -66,6 +66,9 @@ struct I18nCatalogDecimalInfo {
     int32_t fraction_digits = 0;
 };
 
+static constexpr const char* I18N_BIDI_FSI = "\xE2\x81\xA8";
+static constexpr const char* I18N_BIDI_PDI = "\xE2\x81\xA9";
+
 static const char* i18n_catalog_icu_error_name(UErrorCode status) {
     return u_errorName(status);
 }
@@ -249,6 +252,28 @@ static std::string i18n_catalog_normalize_locale(const std::string& raw) {
     }
 
     return locale.empty() ? "root" : locale;
+}
+
+static bool i18n_catalog_is_rtl_locale(const std::string& raw) {
+    std::string locale = i18n_catalog_normalize_locale(raw);
+    size_t pos = locale.find('-');
+    std::string language = pos == std::string::npos ? locale : locale.substr(0, pos);
+    std::transform(language.begin(), language.end(), language.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    return language == "ar" || language == "dv" || language == "fa" || language == "he" || language == "iw"
+        || language == "ks" || language == "ku" || language == "nqo" || language == "ps" || language == "sd"
+        || language == "ug" || language == "ur" || language == "yi";
+}
+
+static void i18n_catalog_append_placeholder_value(std::string& out, const char* value, bool bidi_isolate) {
+    if (bidi_isolate) {
+        out += I18N_BIDI_FSI;
+    }
+    out += value;
+    if (bidi_isolate) {
+        out += I18N_BIDI_PDI;
+    }
 }
 
 static bool i18n_catalog_qore_value_to_utf8(QoreValue value, std::string& out, ExceptionSink* xsink,
@@ -543,10 +568,10 @@ public:
             if (!i18n_catalog_validate_placeholders(id, fallback, xsink)) {
                 return nullptr;
             }
-            return formatMessage(fallback, args, xsink);
+            return formatMessage(fallback, args, i18n_catalog_is_rtl_locale(locale), xsink);
         }
 
-        return formatMessage(*msg, args, xsink);
+        return formatMessage(*msg, args, i18n_catalog_is_rtl_locale(locale), xsink);
     }
 
     DLLLOCAL QoreStringNode* translatePlural(const QoreStringNode* id_arg, const QoreStringNode* singular_arg,
@@ -586,7 +611,7 @@ public:
             if (!validatePluralPlaceholders(id, fallback, xsink)) {
                 return nullptr;
             }
-            return formatPluralMessage(fallback, value, "en", args, xsink);
+            return formatPluralMessage(fallback, value, "en", args, i18n_catalog_is_rtl_locale(locale), xsink);
         }
 
         if (!msg->plural) {
@@ -595,7 +620,7 @@ public:
             return nullptr;
         }
 
-        return formatPluralMessage(*msg, value, locale, args, xsink);
+        return formatPluralMessage(*msg, value, locale, args, i18n_catalog_is_rtl_locale(locale), xsink);
     }
 
     DLLLOCAL QoreListNode* getFallbackChain(const QoreStringNode* locale_arg, ExceptionSink* xsink) const {
@@ -967,7 +992,7 @@ private:
     }
 
     DLLLOCAL QoreStringNode* formatText(const std::string& text, const QoreHashNode* args,
-            const I18nCatalogDecimalInfo* count, ExceptionSink* xsink) const {
+            const I18nCatalogDecimalInfo* count, bool bidi_isolate, ExceptionSink* xsink) const {
         std::string out;
         out.reserve(text.size());
 
@@ -995,7 +1020,7 @@ private:
 
             std::string name = text.substr(i + 1, end - i - 1);
             if (count && name == "count") {
-                out += count->formatted;
+                i18n_catalog_append_placeholder_value(out, count->formatted.c_str(), bidi_isolate);
                 i = end;
                 continue;
             }
@@ -1017,7 +1042,7 @@ private:
             if (*xsink) {
                 return nullptr;
             }
-            out += str->c_str();
+            i18n_catalog_append_placeholder_value(out, str->c_str(), bidi_isolate);
             i = end;
         }
 
@@ -1025,12 +1050,12 @@ private:
     }
 
     DLLLOCAL QoreStringNode* formatMessage(const I18nCatalogMessage& msg, const QoreHashNode* args,
-            ExceptionSink* xsink) const {
-        return formatText(msg.message, args, nullptr, xsink);
+            bool bidi_isolate, ExceptionSink* xsink) const {
+        return formatText(msg.message, args, nullptr, bidi_isolate, xsink);
     }
 
     DLLLOCAL QoreStringNode* formatPluralMessage(const I18nCatalogMessage& msg, QoreValue value,
-            const std::string& locale, const QoreHashNode* args, ExceptionSink* xsink) const {
+            const std::string& locale, const QoreHashNode* args, bool bidi_isolate, ExceptionSink* xsink) const {
         I18nCatalogDecimalInfo decimal;
         if (!i18n_catalog_value_to_decimal_info(value, decimal, xsink)) {
             return nullptr;
@@ -1044,7 +1069,7 @@ private:
                     return nullptr;
                 }
                 if (exact.canonical == decimal.canonical) {
-                    return formatText(entry.second, args, &decimal, xsink);
+                    return formatText(entry.second, args, &decimal, bidi_isolate, xsink);
                 }
             }
         }
@@ -1063,7 +1088,7 @@ private:
             return nullptr;
         }
 
-        return formatText(form->second, args, &decimal, xsink);
+        return formatText(form->second, args, &decimal, bidi_isolate, xsink);
     }
 };
 

--- a/modules/i18n/src/QC_MessageCatalog.qpp
+++ b/modules/i18n/src/QC_MessageCatalog.qpp
@@ -1,0 +1,743 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+  QC_MessageCatalog.qpp
+
+  Qore i18n MessageCatalog class
+
+  Copyright (C) 2026 Qore Technologies, s.r.o.
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+*/
+
+#include "i18n-module.h"
+
+#include <algorithm>
+#include <cctype>
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+constexpr int64 I18N_CATALOG_SCHEMA_VERSION = 1;
+
+struct I18nCatalogMessage {
+    std::string source;
+    std::string message;
+    std::string state = "translated";
+    std::set<std::string> placeholders;
+};
+
+using I18nMessageMap = std::unordered_map<std::string, I18nCatalogMessage>;
+using I18nLocaleMap = std::unordered_map<std::string, I18nMessageMap>;
+
+static bool i18n_catalog_is_ascii_ident_start(char c) {
+    return std::isalpha(static_cast<unsigned char>(c)) || c == '_';
+}
+
+static bool i18n_catalog_is_ascii_ident_char(char c) {
+    return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
+}
+
+static bool i18n_catalog_is_allowed_state(const std::string& state) {
+    return state == "translated" || state == "fuzzy" || state == "needs-review" || state == "stale";
+}
+
+static bool i18n_catalog_check_locale_length(const std::string& locale, ExceptionSink* xsink, const char* field) {
+    if (locale.size() > 255) {
+        xsink->raiseException("I18N-CATALOG-ERROR", "%s is too long; maximum supported length is 255 bytes", field);
+        return false;
+    }
+    return true;
+}
+
+static std::string i18n_catalog_normalize_locale(const std::string& raw) {
+    std::string locale = raw.empty() ? "root" : raw;
+    std::replace(locale.begin(), locale.end(), '_', '-');
+
+    std::string lower = locale;
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    size_t ext = lower.find("-u-");
+    if (ext != std::string::npos) {
+        locale.resize(ext);
+    }
+
+    return locale.empty() ? "root" : locale;
+}
+
+static bool i18n_catalog_qore_value_to_utf8(QoreValue value, std::string& out, ExceptionSink* xsink,
+        const char* field) {
+    if (value.getType() != NT_STRING) {
+        xsink->raiseException("I18N-CATALOG-ERROR", "%s must be a string; got type '%s'", field,
+            value.getTypeName());
+        return false;
+    }
+
+    QoreStringValueHelper str(value, QCS_UTF8, xsink);
+    if (*xsink) {
+        return false;
+    }
+
+    out = str->c_str();
+    return true;
+}
+
+static std::string i18n_catalog_qore_string_to_utf8(const QoreStringNode* str, ExceptionSink* xsink,
+        const char* field) {
+    TempEncodingHelper tmp(str, QCS_UTF8, xsink);
+    if (*xsink) {
+        return std::string();
+    }
+    if (!tmp) {
+        xsink->raiseException("I18N-CATALOG-ERROR", "%s could not be converted to UTF-8", field);
+        return std::string();
+    }
+    return tmp->c_str();
+}
+
+static bool i18n_catalog_collect_placeholders(const std::string& text, std::set<std::string>& placeholders,
+        ExceptionSink* xsink, const char* field) {
+    for (size_t i = 0; i < text.size(); ++i) {
+        if (i && !(i % 100) && qore_check_cancel(xsink, "validating i18n catalog placeholders")) {
+            return false;
+        }
+
+        if (text[i] == '}') {
+            xsink->raiseException("I18N-CATALOG-ERROR", "unmatched '}' in %s", field);
+            return false;
+        }
+        if (text[i] != '{') {
+            continue;
+        }
+
+        size_t end = i + 1;
+        while (end < text.size() && text[end] != '}') {
+            if (end && !(end % 100) && qore_check_cancel(xsink, "validating i18n catalog placeholders")) {
+                return false;
+            }
+            ++end;
+        }
+        if (end == text.size()) {
+            xsink->raiseException("I18N-CATALOG-ERROR", "unmatched '{' in %s", field);
+            return false;
+        }
+
+        std::string name = text.substr(i + 1, end - i - 1);
+        if (name.size() > 128) {
+            xsink->raiseException("I18N-CATALOG-ERROR", "placeholder name in %s is too long", field);
+            return false;
+        }
+        if (name.empty() || !i18n_catalog_is_ascii_ident_start(name[0])) {
+            xsink->raiseException("I18N-CATALOG-ERROR",
+                "invalid placeholder name '{%s}' in %s", name.c_str(), field);
+            return false;
+        }
+        for (size_t n = 1; n < name.size(); ++n) {
+            if (!i18n_catalog_is_ascii_ident_char(name[n])) {
+                xsink->raiseException("I18N-CATALOG-ERROR",
+                    "invalid placeholder name '{%s}' in %s", name.c_str(), field);
+                return false;
+            }
+        }
+
+        placeholders.insert(name);
+        i = end;
+    }
+
+    return true;
+}
+
+static bool i18n_catalog_validate_placeholders(const std::string& id, I18nCatalogMessage& msg,
+        ExceptionSink* xsink) {
+    std::set<std::string> source_placeholders;
+    std::set<std::string> message_placeholders;
+    if (!i18n_catalog_collect_placeholders(msg.source, source_placeholders, xsink, "message source")) {
+        return false;
+    }
+    if (!i18n_catalog_collect_placeholders(msg.message, message_placeholders, xsink, "message text")) {
+        return false;
+    }
+
+    if (source_placeholders != message_placeholders) {
+        xsink->raiseException("I18N-CATALOG-ERROR",
+            "message '%s' must preserve exactly the source placeholders", id.c_str());
+        return false;
+    }
+
+    msg.placeholders = std::move(message_placeholders);
+    return true;
+}
+
+static bool i18n_catalog_get_optional_string(const QoreHashNode* h, const char* key, std::string& out,
+        ExceptionSink* xsink) {
+    QoreValue value = h->getKeyValue(key);
+    if (value.isNullOrNothing()) {
+        return true;
+    }
+    return i18n_catalog_qore_value_to_utf8(value, out, xsink, key);
+}
+
+} // namespace
+
+class QoreMessageCatalog : public AbstractPrivateData {
+public:
+    DLLLOCAL explicit QoreMessageCatalog(bool use_unreviewed = false) : use_unreviewed(use_unreviewed) {
+    }
+
+    DLLLOCAL void loadCatalog(const QoreHashNode* catalog, ExceptionSink* xsink) {
+        QoreValue schema = catalog->getKeyValue("schema_version");
+        if (schema.isNullOrNothing() || schema.getAsBigInt() != I18N_CATALOG_SCHEMA_VERSION) {
+            xsink->raiseException("I18N-CATALOG-ERROR",
+                "catalog schema_version must be %d", (int)I18N_CATALOG_SCHEMA_VERSION);
+            return;
+        }
+
+        QoreValue locales_value = catalog->getKeyValue("locales");
+        if (locales_value.getType() != NT_HASH) {
+            xsink->raiseException("I18N-CATALOG-ERROR", "catalog.locales must be a hash");
+            return;
+        }
+
+        const QoreHashNode* locales = locales_value.get<const QoreHashNode>();
+        size_t i = 0;
+        ConstHashIterator li(locales);
+        while (li.next()) {
+            if (i && !(i % 100) && qore_check_cancel(xsink, "loading i18n catalog locales")) {
+                return;
+            }
+            ++i;
+
+            QoreValue locale_value = li.get();
+            if (locale_value.getType() != NT_HASH) {
+                xsink->raiseException("I18N-CATALOG-ERROR", "catalog locale '%s' must be a hash", li.getKey());
+                return;
+            }
+
+            std::string locale_name = li.getKey();
+            if (!i18n_catalog_check_locale_length(locale_name, xsink, "catalog locale")) {
+                return;
+            }
+            loadLocale(i18n_catalog_normalize_locale(locale_name), locale_value.get<const QoreHashNode>(), xsink);
+            if (*xsink) {
+                return;
+            }
+        }
+    }
+
+    DLLLOCAL QoreStringNode* translate(const QoreStringNode* id_arg, const QoreStringNode* source_arg,
+            const QoreStringNode* locale_arg, const QoreHashNode* args, ExceptionSink* xsink) const {
+        std::string id = i18n_catalog_qore_string_to_utf8(id_arg, xsink, "id");
+        if (*xsink) {
+            return nullptr;
+        }
+        std::string source = i18n_catalog_qore_string_to_utf8(source_arg, xsink, "source");
+        if (*xsink) {
+            return nullptr;
+        }
+        std::string locale = i18n_catalog_qore_string_to_utf8(locale_arg, xsink, "locale");
+        if (*xsink) {
+            return nullptr;
+        }
+        if (!i18n_catalog_check_locale_length(locale, xsink, "locale")) {
+            return nullptr;
+        }
+
+        const I18nCatalogMessage* msg = findMessage(id, locale);
+        if (!msg || (!use_unreviewed && msg->state != "translated")) {
+            I18nCatalogMessage fallback;
+            fallback.source = source;
+            fallback.message = source;
+            if (!i18n_catalog_validate_placeholders(id, fallback, xsink)) {
+                return nullptr;
+            }
+            return formatMessage(fallback, args, xsink);
+        }
+
+        return formatMessage(*msg, args, xsink);
+    }
+
+    DLLLOCAL QoreListNode* getFallbackChain(const QoreStringNode* locale_arg, ExceptionSink* xsink) const {
+        std::string locale = i18n_catalog_qore_string_to_utf8(locale_arg, xsink, "locale");
+        if (*xsink) {
+            return nullptr;
+        }
+        if (!i18n_catalog_check_locale_length(locale, xsink, "locale")) {
+            return nullptr;
+        }
+
+        ReferenceHolder<QoreListNode> rv(new QoreListNode(stringTypeInfo), xsink);
+        std::vector<std::string> chain = fallbackChain(locale);
+        for (size_t i = 0; i < chain.size(); ++i) {
+            rv->push(new QoreStringNode(chain[i], QCS_UTF8), xsink);
+            if (*xsink) {
+                return nullptr;
+            }
+        }
+        return rv.release();
+    }
+
+    DLLLOCAL QoreStringNode* getEffectiveLocale(const QoreStringNode* locale_arg, ExceptionSink* xsink) const {
+        std::string locale = i18n_catalog_qore_string_to_utf8(locale_arg, xsink, "locale");
+        if (*xsink) {
+            return nullptr;
+        }
+        if (!i18n_catalog_check_locale_length(locale, xsink, "locale")) {
+            return nullptr;
+        }
+
+        for (const std::string& entry : fallbackChain(locale)) {
+            if (locales.find(entry) != locales.end()) {
+                return new QoreStringNode(entry, QCS_UTF8);
+            }
+        }
+        return new QoreStringNode("root", QCS_UTF8);
+    }
+
+    DLLLOCAL QoreListNode* availableLocales(ExceptionSink* xsink) const {
+        ReferenceHolder<QoreListNode> rv(new QoreListNode(stringTypeInfo), xsink);
+        std::vector<std::string> names;
+        names.reserve(locales.size());
+        size_t collect_count = 0;
+        for (const auto& entry : locales) {
+            if (collect_count && !(collect_count % 100) && qore_check_cancel(xsink, "listing i18n catalog locales")) {
+                return nullptr;
+            }
+            ++collect_count;
+            names.push_back(entry.first);
+        }
+        std::sort(names.begin(), names.end());
+
+        for (size_t i = 0; i < names.size(); ++i) {
+            if (i && !(i % 100) && qore_check_cancel(xsink, "listing i18n catalog locales")) {
+                return nullptr;
+            }
+            rv->push(new QoreStringNode(names[i], QCS_UTF8), xsink);
+            if (*xsink) {
+                return nullptr;
+            }
+        }
+        return rv.release();
+    }
+
+    DLLLOCAL QoreHashNode* getStats(const QoreStringNode* locale_arg, ExceptionSink* xsink) const {
+        std::string locale = i18n_catalog_qore_string_to_utf8(locale_arg, xsink, "locale");
+        if (*xsink) {
+            return nullptr;
+        }
+        if (!i18n_catalog_check_locale_length(locale, xsink, "locale")) {
+            return nullptr;
+        }
+        locale = i18n_catalog_normalize_locale(locale);
+
+        int64 total = 0;
+        int64 translated = 0;
+        int64 fuzzy = 0;
+        int64 needs_review = 0;
+        int64 stale = 0;
+
+        auto li = locales.find(locale);
+        if (li != locales.end()) {
+            size_t i = 0;
+            for (const auto& entry : li->second) {
+                (void)entry;
+                if (i && !(i % 100) && qore_check_cancel(xsink, "computing i18n catalog stats")) {
+                    return nullptr;
+                }
+                ++i;
+                ++total;
+                const std::string& state = entry.second.state;
+                if (state == "translated") {
+                    ++translated;
+                } else if (state == "fuzzy") {
+                    ++fuzzy;
+                } else if (state == "needs-review") {
+                    ++needs_review;
+                } else if (state == "stale") {
+                    ++stale;
+                }
+            }
+        }
+
+        ReferenceHolder<QoreHashNode> h(new QoreHashNode(autoTypeInfo), xsink);
+        h->setKeyValue("locale", new QoreStringNode(locale, QCS_UTF8), xsink);
+        if (*xsink) return nullptr;
+        h->setKeyValue("total", total, xsink);
+        if (*xsink) return nullptr;
+        h->setKeyValue("translated", translated, xsink);
+        if (*xsink) return nullptr;
+        h->setKeyValue("fuzzy", fuzzy, xsink);
+        if (*xsink) return nullptr;
+        h->setKeyValue("needs_review", needs_review, xsink);
+        if (*xsink) return nullptr;
+        h->setKeyValue("stale", stale, xsink);
+        if (*xsink) return nullptr;
+        h->setKeyValue("usable", translated + (use_unreviewed ? fuzzy + needs_review + stale : 0), xsink);
+        if (*xsink) return nullptr;
+        return h.release();
+    }
+
+private:
+    I18nLocaleMap locales;
+    bool use_unreviewed = false;
+
+    DLLLOCAL void loadLocale(const std::string& locale, const QoreHashNode* locale_hash, ExceptionSink* xsink) {
+        QoreValue messages_value = locale_hash->getKeyValue("messages");
+        if (messages_value.getType() != NT_HASH) {
+            xsink->raiseException("I18N-CATALOG-ERROR", "catalog locale '%s' must contain a messages hash",
+                locale.c_str());
+            return;
+        }
+
+        const QoreHashNode* messages = messages_value.get<const QoreHashNode>();
+        I18nMessageMap& target = locales[locale];
+
+        size_t i = 0;
+        ConstHashIterator mi(messages);
+        while (mi.next()) {
+            if (i && !(i % 100) && qore_check_cancel(xsink, "loading i18n catalog messages")) {
+                return;
+            }
+            ++i;
+
+            std::string id = mi.getKey();
+            if (id.empty()) {
+                xsink->raiseException("I18N-CATALOG-ERROR", "catalog message ids cannot be empty");
+                return;
+            }
+
+            I18nCatalogMessage msg;
+            if (!parseMessageEntry(id, mi.get(), msg, xsink)) {
+                return;
+            }
+            target[id] = std::move(msg);
+        }
+    }
+
+    DLLLOCAL bool parseMessageEntry(const std::string& id, QoreValue value, I18nCatalogMessage& msg,
+            ExceptionSink* xsink) const {
+        if (value.getType() == NT_STRING) {
+            msg.source = id;
+            if (!i18n_catalog_qore_value_to_utf8(value, msg.message, xsink, id.c_str())) {
+                return false;
+            }
+        } else if (value.getType() == NT_HASH) {
+            const QoreHashNode* h = value.get<const QoreHashNode>();
+            msg.source = id;
+            if (!i18n_catalog_get_optional_string(h, "source", msg.source, xsink)) {
+                return false;
+            }
+
+            QoreValue message_value = h->getKeyValue("message");
+            if (message_value.isNullOrNothing()) {
+                xsink->raiseException("I18N-CATALOG-ERROR", "message '%s' must contain a message string",
+                    id.c_str());
+                return false;
+            }
+            if (!i18n_catalog_qore_value_to_utf8(message_value, msg.message, xsink, "message")) {
+                return false;
+            }
+
+            if (!i18n_catalog_get_optional_string(h, "state", msg.state, xsink)) {
+                return false;
+            }
+            if (!i18n_catalog_is_allowed_state(msg.state)) {
+                xsink->raiseException("I18N-CATALOG-ERROR",
+                    "message '%s' has unsupported state '%s'", id.c_str(), msg.state.c_str());
+                return false;
+            }
+        } else {
+            xsink->raiseException("I18N-CATALOG-ERROR",
+                "message '%s' must be a string or metadata hash; got type '%s'", id.c_str(), value.getTypeName());
+            return false;
+        }
+
+        return i18n_catalog_validate_placeholders(id, msg, xsink);
+    }
+
+    DLLLOCAL std::vector<std::string> fallbackChain(const std::string& raw_locale) const {
+        std::vector<std::string> chain;
+        std::string locale = i18n_catalog_normalize_locale(raw_locale);
+        if (locale != "root") {
+            chain.push_back(locale);
+            while (true) {
+                size_t pos = locale.rfind('-');
+                if (pos == std::string::npos) {
+                    break;
+                }
+                locale.resize(pos);
+                chain.push_back(locale);
+            }
+        }
+        chain.push_back("root");
+        return chain;
+    }
+
+    DLLLOCAL const I18nCatalogMessage* findMessage(const std::string& id, const std::string& locale) const {
+        for (const std::string& entry : fallbackChain(locale)) {
+            auto li = locales.find(entry);
+            if (li == locales.end()) {
+                continue;
+            }
+            auto mi = li->second.find(id);
+            if (mi != li->second.end()) {
+                return &mi->second;
+            }
+        }
+        return nullptr;
+    }
+
+    DLLLOCAL QoreStringNode* formatMessage(const I18nCatalogMessage& msg, const QoreHashNode* args,
+            ExceptionSink* xsink) const {
+        std::string out;
+        out.reserve(msg.message.size());
+
+        for (size_t i = 0; i < msg.message.size(); ++i) {
+            if (i && !(i % 100) && qore_check_cancel(xsink, "formatting i18n message")) {
+                return nullptr;
+            }
+
+            if (msg.message[i] != '{') {
+                out.push_back(msg.message[i]);
+                continue;
+            }
+
+            size_t end = i + 1;
+            while (end < msg.message.size() && msg.message[end] != '}') {
+                if (end && !(end % 100) && qore_check_cancel(xsink, "formatting i18n message")) {
+                    return nullptr;
+                }
+                ++end;
+            }
+            if (end == msg.message.size()) {
+                xsink->raiseException("I18N-FORMAT-ERROR", "unmatched '{' in catalog message");
+                return nullptr;
+            }
+
+            std::string name = msg.message.substr(i + 1, end - i - 1);
+            if (!args) {
+                xsink->raiseException("I18N-FORMAT-ERROR", "missing arguments for placeholder '{%s}'",
+                    name.c_str());
+                return nullptr;
+            }
+
+            QoreValue arg = args->getKeyValue(name.c_str());
+            if (arg.isNullOrNothing()) {
+                xsink->raiseException("I18N-FORMAT-ERROR", "missing argument for placeholder '{%s}'",
+                    name.c_str());
+                return nullptr;
+            }
+
+            QoreStringValueHelper str(arg, QCS_UTF8, xsink);
+            if (*xsink) {
+                return nullptr;
+            }
+            out += str->c_str();
+            i = end;
+        }
+
+        return new QoreStringNode(out, QCS_UTF8);
+    }
+};
+
+//! Message catalog for locale-aware text lookup and simple placeholder formatting.
+/** The class stores an immutable, schema-versioned native catalog passed as Qore data. Catalog file loading is
+    intentionally separate from this class so filesystem sandboxing can be applied by the future loader API.
+
+    Native catalog shape:
+    @code{.py}
+hash<auto> catalog = {
+    "schema_version": 1,
+    "locales": {
+        "root": {"messages": {"Hello, {name}": "Hello, {name}"}},
+        "cs": {"messages": {
+            "Hello, {name}": {"message": "Ahoj, {name}", "state": "translated"},
+        }},
+    },
+};
+    @endcode
+*/
+qclass MessageCatalog [arg=QoreMessageCatalog* catalog; ns=Qore::I18n; flags=final];
+
+//! Creates a message catalog from one native catalog hash.
+/** @param native_catalog schema-versioned native catalog hash
+
+    @throw I18N-CATALOG-ERROR if the catalog schema or placeholders are invalid
+*/
+MessageCatalog::constructor(hash<auto> native_catalog) {
+    std::unique_ptr<QoreMessageCatalog> holder(new QoreMessageCatalog());
+    holder->loadCatalog(native_catalog, xsink);
+    if (*xsink) {
+        return;
+    }
+    self->setPrivate(CID_MESSAGECATALOG, holder.release());
+}
+
+//! Creates a message catalog from one native catalog hash with options.
+/** @param native_catalog schema-versioned native catalog hash
+    @param opts options hash; \c "use_unreviewed" allows \c fuzzy, \c needs-review, and \c stale entries at runtime
+
+    @throw I18N-CATALOG-ERROR if the catalog schema or placeholders are invalid
+*/
+MessageCatalog::constructor(hash<auto> native_catalog, *hash<auto> opts) {
+    bool use_unreviewed = opts && opts->getKeyValue("use_unreviewed").getAsBool();
+    std::unique_ptr<QoreMessageCatalog> holder(new QoreMessageCatalog(use_unreviewed));
+    holder->loadCatalog(native_catalog, xsink);
+    if (*xsink) {
+        return;
+    }
+    self->setPrivate(CID_MESSAGECATALOG, holder.release());
+}
+
+//! Creates a message catalog by merging native catalog hashes in order.
+/** Later catalog hashes override earlier hashes per whole message id.
+
+    @param native_catalogs list of schema-versioned native catalog hashes
+
+    @throw I18N-CATALOG-ERROR if any catalog schema or placeholders are invalid
+*/
+MessageCatalog::constructor(list<hash<auto>> native_catalogs) {
+    std::unique_ptr<QoreMessageCatalog> holder(new QoreMessageCatalog());
+    for (size_t i = 0; i < native_catalogs->size(); ++i) {
+        if (i && !(i % 100) && qore_check_cancel(xsink, "loading i18n catalog layers")) {
+            return;
+        }
+        QoreValue value = native_catalogs->retrieveEntry(i);
+        holder->loadCatalog(value.get<const QoreHashNode>(), xsink);
+        if (*xsink) {
+            return;
+        }
+    }
+    self->setPrivate(CID_MESSAGECATALOG, holder.release());
+}
+
+//! Creates a message catalog by merging native catalog hashes in order with options.
+/** Later catalog hashes override earlier hashes per whole message id.
+
+    @param native_catalogs list of schema-versioned native catalog hashes
+    @param opts options hash; \c "use_unreviewed" allows \c fuzzy, \c needs-review, and \c stale entries at runtime
+
+    @throw I18N-CATALOG-ERROR if any catalog schema or placeholders are invalid
+*/
+MessageCatalog::constructor(list<hash<auto>> native_catalogs, *hash<auto> opts) {
+    bool use_unreviewed = opts && opts->getKeyValue("use_unreviewed").getAsBool();
+    std::unique_ptr<QoreMessageCatalog> holder(new QoreMessageCatalog(use_unreviewed));
+    for (size_t i = 0; i < native_catalogs->size(); ++i) {
+        if (i && !(i % 100) && qore_check_cancel(xsink, "loading i18n catalog layers")) {
+            return;
+        }
+        QoreValue value = native_catalogs->retrieveEntry(i);
+        holder->loadCatalog(value.get<const QoreHashNode>(), xsink);
+        if (*xsink) {
+            return;
+        }
+    }
+    self->setPrivate(CID_MESSAGECATALOG, holder.release());
+}
+
+//! MessageCatalog objects cannot be copied.
+/** @throw COPY-ERROR always thrown
+*/
+MessageCatalog::copy() {
+    xsink->raiseException("COPY-ERROR", "MessageCatalog objects cannot be copied");
+}
+
+//! Translates a source-string key for an explicit locale.
+/** @param source source string and lookup key
+    @param locale requested locale
+    @return translated string, or the source string if no translated runtime-usable entry is found
+
+    @throw I18N-FORMAT-ERROR if the selected message requires missing placeholder arguments
+*/
+string MessageCatalog::t(string source, string locale) [flags=RET_VALUE_ONLY] {
+    return catalog->translate(source, source, locale, nullptr, xsink);
+}
+
+//! Translates and formats a source-string key for an explicit locale.
+/** @param source source string and lookup key
+    @param locale requested locale
+    @param vars placeholder values
+    @return translated and formatted string, or the formatted source string if no runtime-usable entry is found
+
+    @throw I18N-FORMAT-ERROR if a required placeholder argument is missing
+*/
+string MessageCatalog::t(string source, string locale, *hash<auto> vars) [flags=RET_VALUE_ONLY] {
+    return catalog->translate(source, source, locale, vars, xsink);
+}
+
+//! Translates a symbolic-id message for an explicit locale.
+/** @param id stable symbolic message id
+    @param source source fallback text
+    @param locale requested locale
+    @return translated string, or \a source if no runtime-usable entry is found
+
+    @throw I18N-FORMAT-ERROR if the selected message requires missing placeholder arguments
+*/
+string MessageCatalog::tc(string id, string source, string locale) [flags=RET_VALUE_ONLY] {
+    return catalog->translate(id, source, locale, nullptr, xsink);
+}
+
+//! Translates and formats a symbolic-id message for an explicit locale.
+/** @param id stable symbolic message id
+    @param source source fallback text
+    @param locale requested locale
+    @param vars placeholder values
+    @return translated and formatted string, or formatted \a source if no runtime-usable entry is found
+
+    @throw I18N-FORMAT-ERROR if a required placeholder argument is missing
+*/
+string MessageCatalog::tc(string id, string source, string locale, *hash<auto> vars) [flags=RET_VALUE_ONLY] {
+    return catalog->translate(id, source, locale, vars, xsink);
+}
+
+//! Returns the locale fallback chain for a requested locale.
+/** Unicode formatting extensions are stripped from catalog identity.
+
+    @param locale requested locale
+    @return list such as \c ("fr-CA", "fr", "root")
+*/
+list<string> MessageCatalog::getFallbackChain(string locale) [flags=RET_VALUE_ONLY] {
+    return catalog->getFallbackChain(locale, xsink);
+}
+
+//! Returns the first catalog locale available in the fallback chain.
+/** @param locale requested locale
+    @return effective catalog locale, or \c "root" if no specific catalog is available
+*/
+string MessageCatalog::getEffectiveLocale(string locale) [flags=RET_VALUE_ONLY] {
+    return catalog->getEffectiveLocale(locale, xsink);
+}
+
+//! Returns available catalog locale names.
+/** @return sorted list of locales present in the catalog
+*/
+list<string> MessageCatalog::availableLocales() [flags=RET_VALUE_ONLY] {
+    return catalog->availableLocales(xsink);
+}
+
+//! Returns message-state statistics for one locale.
+/** @param locale locale to inspect after catalog-locale normalization
+    @return hash with \c total, \c translated, \c fuzzy, \c needs_review, \c stale, and \c usable counts
+*/
+hash<auto> MessageCatalog::getStats(string locale) [flags=RET_VALUE_ONLY] {
+    return catalog->getStats(locale, xsink);
+}

--- a/modules/i18n/src/QC_MessageCatalog.qpp
+++ b/modules/i18n/src/QC_MessageCatalog.qpp
@@ -27,6 +27,12 @@
 
 #include "i18n-module.h"
 
+#include <unicode/locid.h>
+#include <unicode/numberformatter.h>
+#include <unicode/plurrule.h>
+#include <unicode/stringpiece.h>
+#include <unicode/unistr.h>
+
 #include <algorithm>
 #include <cctype>
 #include <memory>
@@ -42,12 +48,25 @@ constexpr int64 I18N_CATALOG_SCHEMA_VERSION = 1;
 struct I18nCatalogMessage {
     std::string source;
     std::string message;
+    std::string plural_source;
+    std::unordered_map<std::string, std::string> plural_forms;
     std::string state = "translated";
     std::set<std::string> placeholders;
+    bool plural = false;
 };
 
 using I18nMessageMap = std::unordered_map<std::string, I18nCatalogMessage>;
 using I18nLocaleMap = std::unordered_map<std::string, I18nMessageMap>;
+
+struct I18nCatalogDecimalInfo {
+    std::string formatted;
+    std::string canonical;
+    int32_t fraction_digits = 0;
+};
+
+static const char* i18n_catalog_icu_error_name(UErrorCode status) {
+    return u_errorName(status);
+}
 
 static bool i18n_catalog_is_ascii_ident_start(char c) {
     return std::isalpha(static_cast<unsigned char>(c)) || c == '_';
@@ -67,6 +86,151 @@ static bool i18n_catalog_check_locale_length(const std::string& locale, Exceptio
         return false;
     }
     return true;
+}
+
+static bool i18n_catalog_trim_ascii(const std::string& s, std::string& out, ExceptionSink* xsink) {
+    size_t start = 0;
+    while (start < s.size() && std::isspace(static_cast<unsigned char>(s[start]))) {
+        if (start && !(start % 100) && qore_check_cancel(xsink, "trimming i18n catalog numeric string")) {
+            return false;
+        }
+        ++start;
+    }
+
+    size_t end = s.size();
+    while (end > start && std::isspace(static_cast<unsigned char>(s[end - 1]))) {
+        if ((s.size() - end) && !((s.size() - end) % 100)
+            && qore_check_cancel(xsink, "trimming i18n catalog numeric string")) {
+            return false;
+        }
+        --end;
+    }
+
+    out = s.substr(start, end - start);
+    return true;
+}
+
+static bool i18n_catalog_parse_decimal_string(const std::string& input, I18nCatalogDecimalInfo& info,
+        ExceptionSink* xsink, const char* field) {
+    std::string s;
+    if (!i18n_catalog_trim_ascii(input, s, xsink)) {
+        return false;
+    }
+    if (s.empty()) {
+        xsink->raiseException("I18N-NUMBER-ERROR", "%s cannot be empty", field);
+        return false;
+    }
+
+    size_t pos = 0;
+    bool negative = false;
+    if (s[pos] == '+' || s[pos] == '-') {
+        negative = s[pos] == '-';
+        ++pos;
+    }
+
+    std::string integer;
+    while (pos < s.size() && std::isdigit(static_cast<unsigned char>(s[pos]))) {
+        if (pos && !(pos % 100) && qore_check_cancel(xsink, "parsing i18n catalog numeric string")) {
+            return false;
+        }
+        integer.push_back(s[pos++]);
+    }
+
+    std::string fraction;
+    if (pos < s.size() && s[pos] == '.') {
+        ++pos;
+        while (pos < s.size() && std::isdigit(static_cast<unsigned char>(s[pos]))) {
+            if (pos && !(pos % 100) && qore_check_cancel(xsink, "parsing i18n catalog numeric string")) {
+                return false;
+            }
+            fraction.push_back(s[pos++]);
+        }
+    }
+
+    if (integer.empty() && fraction.empty()) {
+        xsink->raiseException("I18N-NUMBER-ERROR", "%s must contain at least one digit", field);
+        return false;
+    }
+    if (pos != s.size()) {
+        xsink->raiseException("I18N-NUMBER-ERROR",
+            "%s must be a base-10 integer or decimal string; got '%s'", field, input.c_str());
+        return false;
+    }
+    if (integer.empty()) {
+        integer = "0";
+    }
+    if (integer.size() > 1000) {
+        xsink->raiseException("I18N-NUMBER-ERROR",
+            "%s has too many integer digits; maximum supported is 1000", field);
+        return false;
+    }
+    if (fraction.size() > 100) {
+        xsink->raiseException("I18N-NUMBER-ERROR",
+            "%s has too many visible fraction digits; maximum supported is 100", field);
+        return false;
+    }
+
+    size_t first_non_zero = integer.find_first_not_of('0');
+    std::string canonical_integer = first_non_zero == std::string::npos ? "0" : integer.substr(first_non_zero);
+
+    std::string canonical_fraction = fraction;
+    size_t trim_pos = 0;
+    while (!canonical_fraction.empty() && canonical_fraction.back() == '0') {
+        if (trim_pos && !(trim_pos % 100) && qore_check_cancel(xsink, "normalizing i18n catalog numeric string")) {
+            return false;
+        }
+        canonical_fraction.pop_back();
+        ++trim_pos;
+    }
+
+    bool is_zero = canonical_integer == "0" && canonical_fraction.empty();
+    info.formatted.clear();
+    if (negative && !is_zero) {
+        info.formatted.push_back('-');
+    }
+    info.formatted += canonical_integer;
+    if (!fraction.empty()) {
+        info.formatted.push_back('.');
+        info.formatted += fraction;
+    }
+
+    info.canonical.clear();
+    if (negative && !is_zero) {
+        info.canonical.push_back('-');
+    }
+    info.canonical += canonical_integer;
+    if (!canonical_fraction.empty()) {
+        info.canonical.push_back('.');
+        info.canonical += canonical_fraction;
+    }
+    info.fraction_digits = static_cast<int32_t>(fraction.size());
+
+    return true;
+}
+
+static bool i18n_catalog_value_to_decimal_info(QoreValue value, I18nCatalogDecimalInfo& info,
+        ExceptionSink* xsink) {
+    switch (value.getType()) {
+        case NT_INT:
+            info.formatted = std::to_string(value.getAsBigInt());
+            info.canonical = info.formatted;
+            info.fraction_digits = 0;
+            return true;
+
+        case NT_NUMBER:
+        case NT_FLOAT:
+        case NT_STRING: {
+            QoreStringValueHelper str(value, QCS_UTF8, xsink);
+            if (*xsink) {
+                return false;
+            }
+            return i18n_catalog_parse_decimal_string(str->c_str(), info, xsink, "value");
+        }
+    }
+
+    xsink->raiseException("I18N-TYPE-ERROR", "value must be an int, float, number, or string; got type '%s'",
+        value.getTypeName());
+    return false;
 }
 
 static std::string i18n_catalog_normalize_locale(const std::string& raw) {
@@ -197,6 +361,78 @@ static bool i18n_catalog_get_optional_string(const QoreHashNode* h, const char* 
     return i18n_catalog_qore_value_to_utf8(value, out, xsink, key);
 }
 
+static bool i18n_catalog_is_valid_plural_category(const char* key) {
+    const char* valid_categories[] = {"zero", "one", "two", "few", "many", "other"};
+    for (const char* category : valid_categories) {
+        if (!strcmp(key, category)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool i18n_catalog_validate_plural_key(const char* key, ExceptionSink* xsink) {
+    if (!key || !key[0]) {
+        xsink->raiseException("I18N-CATALOG-ERROR", "plural form keys cannot be empty");
+        return false;
+    }
+    if (key[0] == '=') {
+        I18nCatalogDecimalInfo exact;
+        return i18n_catalog_parse_decimal_string(key + 1, exact, xsink, "plural exact-value key");
+    }
+    if (!i18n_catalog_is_valid_plural_category(key)) {
+        xsink->raiseException("I18N-CATALOG-ERROR",
+            "invalid plural form key '%s'; expected a CLDR category or exact key such as '=0'", key);
+        return false;
+    }
+    return true;
+}
+
+static std::string i18n_catalog_select_plural_category(const I18nCatalogDecimalInfo& decimal,
+        const std::string& locale_name, ExceptionSink* xsink) {
+    std::string tag = i18n_catalog_normalize_locale(locale_name);
+    UErrorCode status = U_ZERO_ERROR;
+    icu::Locale locale = icu::Locale::forLanguageTag(icu::StringPiece(tag), status);
+    if (U_FAILURE(status) || locale.isBogus()) {
+        xsink->raiseException("I18N-LOCALE-ERROR", "invalid locale '%s': %s", locale_name.c_str(),
+            i18n_catalog_icu_error_name(status));
+        return std::string();
+    }
+
+    std::unique_ptr<icu::PluralRules> rules(icu::PluralRules::forLocale(locale, UPLURAL_TYPE_CARDINAL, status));
+    if (U_FAILURE(status) || !rules) {
+        xsink->raiseException("I18N-ICU-ERROR", "cannot create plural rules for locale '%s': %s",
+            locale.getName(), i18n_catalog_icu_error_name(status));
+        return std::string();
+    }
+
+    icu::number::LocalizedNumberFormatter formatter = icu::number::NumberFormatter::with()
+        .precision(icu::number::Precision::fixedFraction(decimal.fraction_digits))
+        .locale(locale);
+    icu::number::FormattedNumber formatted = formatter.formatDecimal(icu::StringPiece(decimal.formatted), status);
+    if (U_FAILURE(status)) {
+        xsink->raiseException("I18N-ICU-ERROR", "cannot format plural operand '%s': %s",
+            decimal.formatted.c_str(), i18n_catalog_icu_error_name(status));
+        return std::string();
+    }
+
+    icu::UnicodeString keyword = rules->select(formatted, status);
+    if (U_FAILURE(status)) {
+        xsink->raiseException("I18N-ICU-ERROR", "cannot select plural category for '%s': %s",
+            decimal.formatted.c_str(), i18n_catalog_icu_error_name(status));
+        return std::string();
+    }
+
+    std::string rv;
+    keyword.toUTF8String(rv);
+    return rv;
+}
+
+static bool i18n_catalog_contains_placeholder(const std::set<std::string>& placeholders,
+        const std::string& name) {
+    return placeholders.find(name) != placeholders.end();
+}
+
 } // namespace
 
 class QoreMessageCatalog : public AbstractPrivateData {
@@ -262,7 +498,10 @@ public:
             return nullptr;
         }
 
-        const I18nCatalogMessage* msg = findMessage(id, locale);
+        const I18nCatalogMessage* msg = findMessage(id, locale, xsink);
+        if (*xsink) {
+            return nullptr;
+        }
         if (!msg || (!use_unreviewed && msg->state != "translated")) {
             I18nCatalogMessage fallback;
             fallback.source = source;
@@ -276,6 +515,55 @@ public:
         return formatMessage(*msg, args, xsink);
     }
 
+    DLLLOCAL QoreStringNode* translatePlural(const QoreStringNode* id_arg, const QoreStringNode* singular_arg,
+            const QoreStringNode* plural_arg, const QoreStringNode* locale_arg, QoreValue value,
+            const QoreHashNode* args, ExceptionSink* xsink) const {
+        std::string id = i18n_catalog_qore_string_to_utf8(id_arg, xsink, "id");
+        if (*xsink) {
+            return nullptr;
+        }
+        std::string singular = i18n_catalog_qore_string_to_utf8(singular_arg, xsink, "singular");
+        if (*xsink) {
+            return nullptr;
+        }
+        std::string plural = i18n_catalog_qore_string_to_utf8(plural_arg, xsink, "plural");
+        if (*xsink) {
+            return nullptr;
+        }
+        std::string locale = i18n_catalog_qore_string_to_utf8(locale_arg, xsink, "locale");
+        if (*xsink) {
+            return nullptr;
+        }
+        if (!i18n_catalog_check_locale_length(locale, xsink, "locale")) {
+            return nullptr;
+        }
+
+        const I18nCatalogMessage* msg = findMessage(id, locale, xsink);
+        if (*xsink) {
+            return nullptr;
+        }
+        if (!msg || (!use_unreviewed && msg->state != "translated")) {
+            I18nCatalogMessage fallback;
+            fallback.source = singular;
+            fallback.plural_source = plural;
+            fallback.plural = true;
+            fallback.plural_forms["one"] = singular;
+            fallback.plural_forms["other"] = plural;
+            if (!validatePluralPlaceholders(id, fallback, xsink)) {
+                return nullptr;
+            }
+            return formatPluralMessage(fallback, value, "en", args, xsink);
+        }
+
+        if (!msg->plural) {
+            xsink->raiseException("I18N-CATALOG-ERROR",
+                "message '%s' is not a plural message and cannot be used by tn()", id.c_str());
+            return nullptr;
+        }
+
+        return formatPluralMessage(*msg, value, locale, args, xsink);
+    }
+
     DLLLOCAL QoreListNode* getFallbackChain(const QoreStringNode* locale_arg, ExceptionSink* xsink) const {
         std::string locale = i18n_catalog_qore_string_to_utf8(locale_arg, xsink, "locale");
         if (*xsink) {
@@ -286,7 +574,10 @@ public:
         }
 
         ReferenceHolder<QoreListNode> rv(new QoreListNode(stringTypeInfo), xsink);
-        std::vector<std::string> chain = fallbackChain(locale);
+        std::vector<std::string> chain = fallbackChain(locale, xsink);
+        if (*xsink) {
+            return nullptr;
+        }
         for (size_t i = 0; i < chain.size(); ++i) {
             rv->push(new QoreStringNode(chain[i], QCS_UTF8), xsink);
             if (*xsink) {
@@ -305,7 +596,10 @@ public:
             return nullptr;
         }
 
-        for (const std::string& entry : fallbackChain(locale)) {
+        for (const std::string& entry : fallbackChain(locale, xsink)) {
+            if (*xsink) {
+                return nullptr;
+            }
             if (locales.find(entry) != locales.end()) {
                 return new QoreStringNode(entry, QCS_UTF8);
             }
@@ -447,6 +741,46 @@ private:
                 return false;
             }
 
+            QoreValue forms_value = h->getKeyValue("forms");
+            if (!forms_value.isNullOrNothing()) {
+                if (!h->getKeyValue("message").isNullOrNothing()) {
+                    xsink->raiseException("I18N-CATALOG-ERROR",
+                        "message '%s' cannot define both message and plural forms", id.c_str());
+                    return false;
+                }
+
+                QoreValue plural_source_value = h->getKeyValue("plural_source");
+                if (plural_source_value.isNullOrNothing()) {
+                    xsink->raiseException("I18N-CATALOG-ERROR",
+                        "plural message '%s' must contain a plural_source string", id.c_str());
+                    return false;
+                }
+                if (!i18n_catalog_qore_value_to_utf8(plural_source_value, msg.plural_source, xsink,
+                        "plural_source")) {
+                    return false;
+                }
+
+                if (forms_value.getType() != NT_HASH) {
+                    xsink->raiseException("I18N-CATALOG-ERROR",
+                        "plural message '%s' forms must be a hash", id.c_str());
+                    return false;
+                }
+                msg.plural = true;
+                if (!parsePluralForms(id, forms_value.get<const QoreHashNode>(), msg, xsink)) {
+                    return false;
+                }
+
+                if (!i18n_catalog_get_optional_string(h, "state", msg.state, xsink)) {
+                    return false;
+                }
+                if (!i18n_catalog_is_allowed_state(msg.state)) {
+                    xsink->raiseException("I18N-CATALOG-ERROR",
+                        "message '%s' has unsupported state '%s'", id.c_str(), msg.state.c_str());
+                    return false;
+                }
+                return validatePluralPlaceholders(id, msg, xsink);
+            }
+
             QoreValue message_value = h->getKeyValue("message");
             if (message_value.isNullOrNothing()) {
                 xsink->raiseException("I18N-CATALOG-ERROR", "message '%s' must contain a message string",
@@ -474,12 +808,100 @@ private:
         return i18n_catalog_validate_placeholders(id, msg, xsink);
     }
 
-    DLLLOCAL std::vector<std::string> fallbackChain(const std::string& raw_locale) const {
+    DLLLOCAL bool parsePluralForms(const std::string& id, const QoreHashNode* forms, I18nCatalogMessage& msg,
+            ExceptionSink* xsink) const {
+        bool has_other = false;
+        size_t i = 0;
+        ConstHashIterator fi(forms);
+        while (fi.next()) {
+            if (i && !(i % 100) && qore_check_cancel(xsink, "loading i18n catalog plural forms")) {
+                return false;
+            }
+            ++i;
+
+            const char* key = fi.getKey();
+            if (!i18n_catalog_validate_plural_key(key, xsink)) {
+                return false;
+            }
+            if (!strcmp(key, "other")) {
+                has_other = true;
+            }
+
+            std::string form;
+            if (!i18n_catalog_qore_value_to_utf8(fi.get(), form, xsink, key)) {
+                return false;
+            }
+            msg.plural_forms[key] = std::move(form);
+        }
+
+        if (!has_other) {
+            xsink->raiseException("I18N-CATALOG-ERROR",
+                "plural message '%s' must define an 'other' form", id.c_str());
+            return false;
+        }
+        return true;
+    }
+
+    DLLLOCAL bool validatePluralPlaceholders(const std::string& id, I18nCatalogMessage& msg,
+            ExceptionSink* xsink) const {
+        std::set<std::string> required;
+        if (!i18n_catalog_collect_placeholders(msg.source, required, xsink, "plural message source")) {
+            return false;
+        }
+        if (!i18n_catalog_collect_placeholders(msg.plural_source, required, xsink, "plural message plural_source")) {
+            return false;
+        }
+        required.erase("count");
+
+        std::set<std::string> allowed = required;
+        allowed.insert("count");
+
+        size_t i = 0;
+        for (const auto& entry : msg.plural_forms) {
+            if (i && !(i % 100) && qore_check_cancel(xsink, "validating i18n catalog plural placeholders")) {
+                return false;
+            }
+            ++i;
+
+            std::set<std::string> placeholders;
+            if (!i18n_catalog_collect_placeholders(entry.second, placeholders, xsink, "plural form text")) {
+                return false;
+            }
+
+            for (const std::string& placeholder : placeholders) {
+                if (!i18n_catalog_contains_placeholder(allowed, placeholder)) {
+                    xsink->raiseException("I18N-CATALOG-ERROR",
+                        "plural message '%s' form '%s' introduces unknown placeholder '{%s}'",
+                        id.c_str(), entry.first.c_str(), placeholder.c_str());
+                    return false;
+                }
+            }
+
+            for (const std::string& placeholder : required) {
+                if (!i18n_catalog_contains_placeholder(placeholders, placeholder)) {
+                    xsink->raiseException("I18N-CATALOG-ERROR",
+                        "plural message '%s' form '%s' must preserve placeholder '{%s}'",
+                        id.c_str(), entry.first.c_str(), placeholder.c_str());
+                    return false;
+                }
+            }
+        }
+
+        msg.placeholders = std::move(required);
+        return true;
+    }
+
+    DLLLOCAL std::vector<std::string> fallbackChain(const std::string& raw_locale, ExceptionSink* xsink) const {
         std::vector<std::string> chain;
         std::string locale = i18n_catalog_normalize_locale(raw_locale);
         if (locale != "root") {
             chain.push_back(locale);
+            size_t count = 0;
             while (true) {
+                if (count && !(count % 100) && qore_check_cancel(xsink, "building i18n catalog fallback chain")) {
+                    return chain;
+                }
+                ++count;
                 size_t pos = locale.rfind('-');
                 if (pos == std::string::npos) {
                     break;
@@ -492,8 +914,12 @@ private:
         return chain;
     }
 
-    DLLLOCAL const I18nCatalogMessage* findMessage(const std::string& id, const std::string& locale) const {
-        for (const std::string& entry : fallbackChain(locale)) {
+    DLLLOCAL const I18nCatalogMessage* findMessage(const std::string& id, const std::string& locale,
+            ExceptionSink* xsink) const {
+        for (const std::string& entry : fallbackChain(locale, xsink)) {
+            if (*xsink) {
+                return nullptr;
+            }
             auto li = locales.find(entry);
             if (li == locales.end()) {
                 continue;
@@ -506,34 +932,40 @@ private:
         return nullptr;
     }
 
-    DLLLOCAL QoreStringNode* formatMessage(const I18nCatalogMessage& msg, const QoreHashNode* args,
-            ExceptionSink* xsink) const {
+    DLLLOCAL QoreStringNode* formatText(const std::string& text, const QoreHashNode* args,
+            const I18nCatalogDecimalInfo* count, ExceptionSink* xsink) const {
         std::string out;
-        out.reserve(msg.message.size());
+        out.reserve(text.size());
 
-        for (size_t i = 0; i < msg.message.size(); ++i) {
+        for (size_t i = 0; i < text.size(); ++i) {
             if (i && !(i % 100) && qore_check_cancel(xsink, "formatting i18n message")) {
                 return nullptr;
             }
 
-            if (msg.message[i] != '{') {
-                out.push_back(msg.message[i]);
+            if (text[i] != '{') {
+                out.push_back(text[i]);
                 continue;
             }
 
             size_t end = i + 1;
-            while (end < msg.message.size() && msg.message[end] != '}') {
+            while (end < text.size() && text[end] != '}') {
                 if (end && !(end % 100) && qore_check_cancel(xsink, "formatting i18n message")) {
                     return nullptr;
                 }
                 ++end;
             }
-            if (end == msg.message.size()) {
+            if (end == text.size()) {
                 xsink->raiseException("I18N-FORMAT-ERROR", "unmatched '{' in catalog message");
                 return nullptr;
             }
 
-            std::string name = msg.message.substr(i + 1, end - i - 1);
+            std::string name = text.substr(i + 1, end - i - 1);
+            if (count && name == "count") {
+                out += count->formatted;
+                i = end;
+                continue;
+            }
+
             if (!args) {
                 xsink->raiseException("I18N-FORMAT-ERROR", "missing arguments for placeholder '{%s}'",
                     name.c_str());
@@ -557,6 +989,48 @@ private:
 
         return new QoreStringNode(out, QCS_UTF8);
     }
+
+    DLLLOCAL QoreStringNode* formatMessage(const I18nCatalogMessage& msg, const QoreHashNode* args,
+            ExceptionSink* xsink) const {
+        return formatText(msg.message, args, nullptr, xsink);
+    }
+
+    DLLLOCAL QoreStringNode* formatPluralMessage(const I18nCatalogMessage& msg, QoreValue value,
+            const std::string& locale, const QoreHashNode* args, ExceptionSink* xsink) const {
+        I18nCatalogDecimalInfo decimal;
+        if (!i18n_catalog_value_to_decimal_info(value, decimal, xsink)) {
+            return nullptr;
+        }
+
+        for (const auto& entry : msg.plural_forms) {
+            if (!entry.first.empty() && entry.first[0] == '=') {
+                I18nCatalogDecimalInfo exact;
+                if (!i18n_catalog_parse_decimal_string(entry.first.c_str() + 1, exact, xsink,
+                        "plural exact-value key")) {
+                    return nullptr;
+                }
+                if (exact.canonical == decimal.canonical) {
+                    return formatText(entry.second, args, &decimal, xsink);
+                }
+            }
+        }
+
+        std::string category = i18n_catalog_select_plural_category(decimal, locale, xsink);
+        if (*xsink) {
+            return nullptr;
+        }
+
+        auto form = msg.plural_forms.find(category);
+        if (form == msg.plural_forms.end()) {
+            form = msg.plural_forms.find("other");
+        }
+        if (form == msg.plural_forms.end()) {
+            xsink->raiseException("I18N-CATALOG-ERROR", "plural message is missing required 'other' form");
+            return nullptr;
+        }
+
+        return formatText(form->second, args, &decimal, xsink);
+    }
 };
 
 //! Message catalog for locale-aware text lookup and simple placeholder formatting.
@@ -571,6 +1045,15 @@ hash<auto> catalog = {
         "root": {"messages": {"Hello, {name}": "Hello, {name}"}},
         "cs": {"messages": {
             "Hello, {name}": {"message": "Ahoj, {name}", "state": "translated"},
+            "1 file": {
+                "plural_source": "{count} files",
+                "forms": {
+                    "one": "{count} soubor",
+                    "few": "{count} soubory",
+                    "other": "{count} souboru",
+                },
+                "state": "translated",
+            },
         }},
     },
 };
@@ -682,6 +1165,42 @@ string MessageCatalog::t(string source, string locale) [flags=RET_VALUE_ONLY] {
 */
 string MessageCatalog::t(string source, string locale, *hash<auto> vars) [flags=RET_VALUE_ONLY] {
     return catalog->translate(source, source, locale, vars, xsink);
+}
+
+//! Translates and formats a source-string plural message for an explicit locale.
+/** @param value numeric plural selector; strings preserve visible fraction digits
+    @param singular source-language singular fallback text and lookup key
+    @param plural source-language plural fallback text
+    @param locale requested locale
+    @return translated plural form, or the selected source fallback if no runtime-usable entry is found
+
+    @throw I18N-CATALOG-ERROR if the selected catalog entry is not plural-capable
+    @throw I18N-FORMAT-ERROR if a required placeholder argument is missing
+    @throw I18N-NUMBER-ERROR if \a value is a malformed decimal string
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+    @throw I18N-ICU-ERROR if ICU cannot select a plural category
+*/
+string MessageCatalog::tn(auto value, string singular, string plural, string locale) [flags=RET_VALUE_ONLY] {
+    return catalog->translatePlural(singular, singular, plural, locale, value, nullptr, xsink);
+}
+
+//! Translates and formats a source-string plural message for an explicit locale.
+/** @param value numeric plural selector; strings preserve visible fraction digits
+    @param singular source-language singular fallback text and lookup key
+    @param plural source-language plural fallback text
+    @param locale requested locale
+    @param vars placeholder values; \c count is supplied by \a value when used in the selected form
+    @return translated plural form, or the selected source fallback if no runtime-usable entry is found
+
+    @throw I18N-CATALOG-ERROR if the selected catalog entry is not plural-capable
+    @throw I18N-FORMAT-ERROR if a required placeholder argument is missing
+    @throw I18N-NUMBER-ERROR if \a value is a malformed decimal string
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+    @throw I18N-ICU-ERROR if ICU cannot select a plural category
+*/
+string MessageCatalog::tn(auto value, string singular, string plural, string locale, *hash<auto> vars)
+        [flags=RET_VALUE_ONLY] {
+    return catalog->translatePlural(singular, singular, plural, locale, value, vars, xsink);
 }
 
 //! Translates a symbolic-id message for an explicit locale.

--- a/modules/i18n/src/QC_MessageCatalog.qpp
+++ b/modules/i18n/src/QC_MessageCatalog.qpp
@@ -927,7 +927,14 @@ private:
                 return false;
             }
 
+            size_t placeholder_count = 0;
             for (const std::string& placeholder : placeholders) {
+                if (placeholder_count && !(placeholder_count % 100)
+                    && qore_check_cancel(xsink, "validating i18n catalog plural placeholder set")) {
+                    return false;
+                }
+                ++placeholder_count;
+
                 if (!i18n_catalog_contains_placeholder(allowed, placeholder)) {
                     xsink->raiseException("I18N-CATALOG-ERROR",
                         "plural message '%s' form '%s' introduces unknown placeholder '{%s}'",
@@ -936,7 +943,14 @@ private:
                 }
             }
 
+            size_t required_count = 0;
             for (const std::string& placeholder : required) {
+                if (required_count && !(required_count % 100)
+                    && qore_check_cancel(xsink, "validating i18n catalog required placeholder set")) {
+                    return false;
+                }
+                ++required_count;
+
                 if (!i18n_catalog_contains_placeholder(placeholders, placeholder)) {
                     xsink->raiseException("I18N-CATALOG-ERROR",
                         "plural message '%s' form '%s' must preserve placeholder '{%s}'",
@@ -1061,7 +1075,14 @@ private:
             return nullptr;
         }
 
+        size_t form_count = 0;
         for (const auto& entry : msg.plural_forms) {
+            if (form_count && !(form_count % 100)
+                && qore_check_cancel(xsink, "checking i18n catalog exact plural forms")) {
+                return nullptr;
+            }
+            ++form_count;
+
             if (!entry.first.empty() && entry.first[0] == '=') {
                 I18nCatalogDecimalInfo exact;
                 if (!i18n_catalog_parse_decimal_string(entry.first.c_str() + 1, exact, xsink,

--- a/modules/i18n/src/i18n-catalog-json.cpp
+++ b/modules/i18n/src/i18n-catalog-json.cpp
@@ -428,6 +428,10 @@ private:
             }
         } else if (data[pos] >= '1' && data[pos] <= '9') {
             while (pos < len && data[pos] >= '0' && data[pos] <= '9') {
+                if (pos != start && !((pos - start) % 100)
+                    && qore_check_cancel(xsink, "parsing i18n catalog JSON number")) {
+                    return QoreValue();
+                }
                 ++pos;
             }
         } else {
@@ -444,6 +448,10 @@ private:
                 return QoreValue();
             }
             while (pos < len && data[pos] >= '0' && data[pos] <= '9') {
+                if (pos != start && !((pos - start) % 100)
+                    && qore_check_cancel(xsink, "parsing i18n catalog JSON number fraction")) {
+                    return QoreValue();
+                }
                 ++pos;
             }
         }
@@ -459,6 +467,10 @@ private:
                 return QoreValue();
             }
             while (pos < len && data[pos] >= '0' && data[pos] <= '9') {
+                if (pos != start && !((pos - start) % 100)
+                    && qore_check_cancel(xsink, "parsing i18n catalog JSON number exponent")) {
+                    return QoreValue();
+                }
                 ++pos;
             }
         }

--- a/modules/i18n/src/i18n-catalog-json.cpp
+++ b/modules/i18n/src/i18n-catalog-json.cpp
@@ -35,6 +35,8 @@
 #include <cstring>
 #include <fcntl.h>
 #include <limits>
+#include <locale>
+#include <sstream>
 #include <string>
 #include <unordered_set>
 
@@ -58,6 +60,13 @@ static int i18n_json_hex_value(char c) {
         return c - 'A' + 10;
     }
     return -1;
+}
+
+static bool i18n_json_parse_classic_double(const std::string& text, double& value) {
+    std::istringstream stream(text);
+    stream.imbue(std::locale::classic());
+    stream >> value;
+    return !stream.fail() && stream.peek() == std::char_traits<char>::eof() && std::isfinite(value);
 }
 
 static bool i18n_json_append_utf8(std::string& out, uint32_t codepoint, ExceptionSink* xsink, size_t pos) {
@@ -493,8 +502,8 @@ private:
             return static_cast<int64>(value);
         }
 
-        double value = std::strtod(text.c_str(), &end);
-        if (errno == ERANGE || !end || *end || !std::isfinite(value)) {
+        double value = 0.0;
+        if (!i18n_json_parse_classic_double(text, value)) {
             xsink->raiseException("I18N-CATALOG-JSON-ERROR",
                 "floating-point JSON number out of range at byte offset %zu", start);
             return QoreValue();

--- a/modules/i18n/src/i18n-catalog-json.cpp
+++ b/modules/i18n/src/i18n-catalog-json.cpp
@@ -1,0 +1,597 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+  i18n-catalog-json.cpp
+
+  Qore i18n native catalog JSON loader
+
+  Copyright (C) 2026 Qore Technologies, s.r.o.
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+*/
+
+#include "i18n-module.h"
+
+#include "qore/QoreFile.h"
+
+#include <cerrno>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <limits>
+#include <string>
+#include <unordered_set>
+
+namespace {
+
+static constexpr int64 I18N_DEFAULT_MAX_CATALOG_FILE_LEN = 16 * 1024 * 1024;
+static constexpr int64 I18N_MAX_CATALOG_FILE_LEN = 256 * 1024 * 1024;
+
+static bool i18n_json_is_ws(char c) {
+    return c == ' ' || c == '\n' || c == '\r' || c == '\t';
+}
+
+static int i18n_json_hex_value(char c) {
+    if (c >= '0' && c <= '9') {
+        return c - '0';
+    }
+    if (c >= 'a' && c <= 'f') {
+        return c - 'a' + 10;
+    }
+    if (c >= 'A' && c <= 'F') {
+        return c - 'A' + 10;
+    }
+    return -1;
+}
+
+static bool i18n_json_append_utf8(std::string& out, uint32_t codepoint, ExceptionSink* xsink, size_t pos) {
+    if (codepoint > 0x10ffff || (codepoint >= 0xd800 && codepoint <= 0xdfff)) {
+        xsink->raiseException("I18N-CATALOG-JSON-ERROR",
+            "invalid Unicode code point in JSON string at byte offset %zu", pos);
+        return false;
+    }
+
+    if (codepoint <= 0x7f) {
+        out.push_back(static_cast<char>(codepoint));
+    } else if (codepoint <= 0x7ff) {
+        out.push_back(static_cast<char>(0xc0 | (codepoint >> 6)));
+        out.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
+    } else if (codepoint <= 0xffff) {
+        out.push_back(static_cast<char>(0xe0 | (codepoint >> 12)));
+        out.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3f)));
+        out.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
+    } else {
+        out.push_back(static_cast<char>(0xf0 | (codepoint >> 18)));
+        out.push_back(static_cast<char>(0x80 | ((codepoint >> 12) & 0x3f)));
+        out.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3f)));
+        out.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
+    }
+    return true;
+}
+
+static bool i18n_json_validate_utf8(const std::string& value, ExceptionSink* xsink, const char* context) {
+    for (size_t i = 0; i < value.size();) {
+        if (i && !(i % 100) && qore_check_cancel(xsink, "validating i18n catalog JSON UTF-8")) {
+            return false;
+        }
+
+        unsigned char c = static_cast<unsigned char>(value[i]);
+        if (c <= 0x7f) {
+            ++i;
+            continue;
+        }
+
+        uint32_t codepoint = 0;
+        size_t need = 0;
+        if (c >= 0xc2 && c <= 0xdf) {
+            codepoint = c & 0x1f;
+            need = 1;
+        } else if (c >= 0xe0 && c <= 0xef) {
+            codepoint = c & 0x0f;
+            need = 2;
+        } else if (c >= 0xf0 && c <= 0xf4) {
+            codepoint = c & 0x07;
+            need = 3;
+        } else {
+            xsink->raiseException("I18N-CATALOG-JSON-ERROR",
+                "%s contains invalid UTF-8 at byte offset %zu", context, i);
+            return false;
+        }
+
+        if (i + need >= value.size()) {
+            xsink->raiseException("I18N-CATALOG-JSON-ERROR",
+                "%s contains truncated UTF-8 at byte offset %zu", context, i);
+            return false;
+        }
+
+        for (size_t n = 1; n <= need; ++n) {
+            unsigned char cc = static_cast<unsigned char>(value[i + n]);
+            if ((cc & 0xc0) != 0x80) {
+                xsink->raiseException("I18N-CATALOG-JSON-ERROR",
+                    "%s contains invalid UTF-8 continuation byte at byte offset %zu", context, i + n);
+                return false;
+            }
+            codepoint = (codepoint << 6) | (cc & 0x3f);
+        }
+
+        if ((need == 2 && codepoint < 0x800) || (need == 3 && codepoint < 0x10000)
+            || codepoint > 0x10ffff || (codepoint >= 0xd800 && codepoint <= 0xdfff)) {
+            xsink->raiseException("I18N-CATALOG-JSON-ERROR",
+                "%s contains invalid UTF-8 sequence at byte offset %zu", context, i);
+            return false;
+        }
+        i += need + 1;
+    }
+    return true;
+}
+
+class I18nJsonParser {
+public:
+    DLLLOCAL I18nJsonParser(const char* data, size_t len, ExceptionSink* xsink) : data(data), len(len), xsink(xsink) {
+    }
+
+    DLLLOCAL QoreValue parse() {
+        skipWs();
+        ValueHolder value(parseValue(), xsink);
+        if (*xsink) {
+            return QoreValue();
+        }
+        skipWs();
+        if (pos != len) {
+            raise("unexpected trailing data");
+            return QoreValue();
+        }
+        return value.release();
+    }
+
+private:
+    const char* data = nullptr;
+    size_t len = 0;
+    size_t pos = 0;
+    ExceptionSink* xsink = nullptr;
+
+    DLLLOCAL void raise(const char* msg) {
+        xsink->raiseException("I18N-CATALOG-JSON-ERROR", "%s at byte offset %zu", msg, pos);
+    }
+
+    DLLLOCAL void skipWs() {
+        while (pos < len && i18n_json_is_ws(data[pos])) {
+            ++pos;
+        }
+    }
+
+    DLLLOCAL bool consume(char c) {
+        if (pos < len && data[pos] == c) {
+            ++pos;
+            return true;
+        }
+        return false;
+    }
+
+    DLLLOCAL bool expect(char c, const char* msg) {
+        if (consume(c)) {
+            return true;
+        }
+        raise(msg);
+        return false;
+    }
+
+    DLLLOCAL bool matchLiteral(const char* literal) {
+        size_t literal_len = strlen(literal);
+        if (pos + literal_len > len || memcmp(data + pos, literal, literal_len)) {
+            return false;
+        }
+        pos += literal_len;
+        return true;
+    }
+
+    DLLLOCAL bool parseHex4(uint32_t& out) {
+        if (pos + 4 > len) {
+            raise("truncated Unicode escape");
+            return false;
+        }
+
+        uint32_t value = 0;
+        for (size_t i = 0; i < 4; ++i) {
+            int hv = i18n_json_hex_value(data[pos + i]);
+            if (hv < 0) {
+                raise("invalid Unicode escape");
+                return false;
+            }
+            value = (value << 4) | static_cast<uint32_t>(hv);
+        }
+        pos += 4;
+        out = value;
+        return true;
+    }
+
+    DLLLOCAL QoreStringNode* parseString() {
+        if (!expect('"', "expected JSON string")) {
+            return nullptr;
+        }
+
+        std::string out;
+        while (pos < len) {
+            if (pos && !(pos % 100) && qore_check_cancel(xsink, "parsing i18n catalog JSON string")) {
+                return nullptr;
+            }
+
+            unsigned char c = static_cast<unsigned char>(data[pos++]);
+            if (c == '"') {
+                if (!i18n_json_validate_utf8(out, xsink, "JSON string")) {
+                    return nullptr;
+                }
+                return new QoreStringNode(out, QCS_UTF8);
+            }
+            if (c < 0x20) {
+                raise("unescaped control character in JSON string");
+                return nullptr;
+            }
+            if (c != '\\') {
+                out.push_back(static_cast<char>(c));
+                continue;
+            }
+            if (pos == len) {
+                raise("truncated JSON string escape");
+                return nullptr;
+            }
+
+            char esc = data[pos++];
+            switch (esc) {
+                case '"':
+                case '\\':
+                case '/':
+                    out.push_back(esc);
+                    break;
+                case 'b':
+                    out.push_back('\b');
+                    break;
+                case 'f':
+                    out.push_back('\f');
+                    break;
+                case 'n':
+                    out.push_back('\n');
+                    break;
+                case 'r':
+                    out.push_back('\r');
+                    break;
+                case 't':
+                    out.push_back('\t');
+                    break;
+                case 'u': {
+                    uint32_t codepoint = 0;
+                    if (!parseHex4(codepoint)) {
+                        return nullptr;
+                    }
+
+                    if (codepoint >= 0xd800 && codepoint <= 0xdbff) {
+                        if (pos + 2 > len || data[pos] != '\\' || data[pos + 1] != 'u') {
+                            raise("high surrogate must be followed by a low surrogate");
+                            return nullptr;
+                        }
+                        pos += 2;
+                        uint32_t low = 0;
+                        if (!parseHex4(low)) {
+                            return nullptr;
+                        }
+                        if (low < 0xdc00 || low > 0xdfff) {
+                            raise("high surrogate must be followed by a low surrogate");
+                            return nullptr;
+                        }
+                        codepoint = 0x10000 + ((codepoint - 0xd800) << 10) + (low - 0xdc00);
+                    } else if (codepoint >= 0xdc00 && codepoint <= 0xdfff) {
+                        raise("low surrogate without preceding high surrogate");
+                        return nullptr;
+                    }
+
+                    if (!i18n_json_append_utf8(out, codepoint, xsink, pos)) {
+                        return nullptr;
+                    }
+                    break;
+                }
+                default:
+                    raise("unsupported JSON string escape");
+                    return nullptr;
+            }
+        }
+
+        raise("unterminated JSON string");
+        return nullptr;
+    }
+
+    DLLLOCAL QoreValue parseObject() {
+        if (!expect('{', "expected JSON object")) {
+            return QoreValue();
+        }
+
+        ReferenceHolder<QoreHashNode> h(new QoreHashNode(autoTypeInfo), xsink);
+        std::unordered_set<std::string> keys;
+        skipWs();
+        if (consume('}')) {
+            return h.release();
+        }
+
+        while (pos < len) {
+            if (keys.size() && !(keys.size() % 100) && qore_check_cancel(xsink, "parsing i18n catalog JSON object")) {
+                return QoreValue();
+            }
+
+            SimpleRefHolder<QoreStringNode> key(parseString());
+            if (*xsink) {
+                return QoreValue();
+            }
+            std::string key_text = key->c_str();
+            if (!keys.insert(key_text).second) {
+                xsink->raiseException("I18N-CATALOG-JSON-ERROR",
+                    "duplicate object key '%s' at byte offset %zu", key_text.c_str(), pos);
+                return QoreValue();
+            }
+
+            skipWs();
+            if (!expect(':', "expected ':' after JSON object key")) {
+                return QoreValue();
+            }
+            skipWs();
+
+            ValueHolder value(parseValue(), xsink);
+            if (*xsink) {
+                return QoreValue();
+            }
+            h->setKeyValue(key_text.c_str(), value.release(), xsink);
+            if (*xsink) {
+                return QoreValue();
+            }
+
+            skipWs();
+            if (consume('}')) {
+                return h.release();
+            }
+            if (!expect(',', "expected ',' or '}' in JSON object")) {
+                return QoreValue();
+            }
+            skipWs();
+        }
+
+        raise("unterminated JSON object");
+        return QoreValue();
+    }
+
+    DLLLOCAL QoreValue parseArray() {
+        if (!expect('[', "expected JSON array")) {
+            return QoreValue();
+        }
+
+        ReferenceHolder<QoreListNode> list(new QoreListNode(autoTypeInfo), xsink);
+        skipWs();
+        if (consume(']')) {
+            return list.release();
+        }
+
+        while (pos < len) {
+            if (list->size() && !(list->size() % 100) && qore_check_cancel(xsink, "parsing i18n catalog JSON array")) {
+                return QoreValue();
+            }
+
+            ValueHolder value(parseValue(), xsink);
+            if (*xsink) {
+                return QoreValue();
+            }
+            list->push(value.release(), xsink);
+            if (*xsink) {
+                return QoreValue();
+            }
+
+            skipWs();
+            if (consume(']')) {
+                return list.release();
+            }
+            if (!expect(',', "expected ',' or ']' in JSON array")) {
+                return QoreValue();
+            }
+            skipWs();
+        }
+
+        raise("unterminated JSON array");
+        return QoreValue();
+    }
+
+    DLLLOCAL QoreValue parseNumber() {
+        size_t start = pos;
+        consume('-');
+
+        if (pos == len) {
+            raise("truncated JSON number");
+            return QoreValue();
+        }
+
+        if (data[pos] == '0') {
+            ++pos;
+            if (pos < len && data[pos] >= '0' && data[pos] <= '9') {
+                raise("JSON numbers cannot have leading zeroes");
+                return QoreValue();
+            }
+        } else if (data[pos] >= '1' && data[pos] <= '9') {
+            while (pos < len && data[pos] >= '0' && data[pos] <= '9') {
+                ++pos;
+            }
+        } else {
+            raise("expected JSON number");
+            return QoreValue();
+        }
+
+        bool integral = true;
+        if (pos < len && data[pos] == '.') {
+            integral = false;
+            ++pos;
+            if (pos == len || data[pos] < '0' || data[pos] > '9') {
+                raise("JSON number fraction must contain at least one digit");
+                return QoreValue();
+            }
+            while (pos < len && data[pos] >= '0' && data[pos] <= '9') {
+                ++pos;
+            }
+        }
+
+        if (pos < len && (data[pos] == 'e' || data[pos] == 'E')) {
+            integral = false;
+            ++pos;
+            if (pos < len && (data[pos] == '+' || data[pos] == '-')) {
+                ++pos;
+            }
+            if (pos == len || data[pos] < '0' || data[pos] > '9') {
+                raise("JSON number exponent must contain at least one digit");
+                return QoreValue();
+            }
+            while (pos < len && data[pos] >= '0' && data[pos] <= '9') {
+                ++pos;
+            }
+        }
+
+        if (pos - start > 128) {
+            raise("JSON number is too long");
+            return QoreValue();
+        }
+
+        std::string text(data + start, pos - start);
+        char* end = nullptr;
+        errno = 0;
+        if (integral) {
+            long long value = std::strtoll(text.c_str(), &end, 10);
+            if (errno == ERANGE || !end || *end) {
+                xsink->raiseException("I18N-CATALOG-JSON-ERROR",
+                    "integer JSON number out of range at byte offset %zu", start);
+                return QoreValue();
+            }
+            return static_cast<int64>(value);
+        }
+
+        double value = std::strtod(text.c_str(), &end);
+        if (errno == ERANGE || !end || *end || !std::isfinite(value)) {
+            xsink->raiseException("I18N-CATALOG-JSON-ERROR",
+                "floating-point JSON number out of range at byte offset %zu", start);
+            return QoreValue();
+        }
+        return value;
+    }
+
+    DLLLOCAL QoreValue parseValue() {
+        if (pos == len) {
+            raise("expected JSON value");
+            return QoreValue();
+        }
+
+        switch (data[pos]) {
+            case '{':
+                return parseObject();
+            case '[':
+                return parseArray();
+            case '"':
+                return parseString();
+            case 't':
+                if (matchLiteral("true")) {
+                    return true;
+                }
+                break;
+            case 'f':
+                if (matchLiteral("false")) {
+                    return false;
+                }
+                break;
+            case 'n':
+                if (matchLiteral("null")) {
+                    return QoreValue();
+                }
+                break;
+            default:
+                if (data[pos] == '-' || (data[pos] >= '0' && data[pos] <= '9')) {
+                    return parseNumber();
+                }
+                break;
+        }
+
+        raise("expected JSON value");
+        return QoreValue();
+    }
+};
+
+static int64 i18n_catalog_checked_max_file_len(int64 max_file_len, ExceptionSink* xsink) {
+    if (max_file_len < 1 || max_file_len > I18N_MAX_CATALOG_FILE_LEN) {
+        xsink->raiseException("I18N-CATALOG-ERROR",
+            "max_file_len must be between 1 and %lld bytes", I18N_MAX_CATALOG_FILE_LEN);
+        return 0;
+    }
+    return max_file_len;
+}
+
+} // namespace
+
+QoreHashNode* i18n_parse_native_catalog_json(const QoreStringNode* json, ExceptionSink* xsink) {
+    TempEncodingHelper tmp(json, QCS_UTF8, xsink);
+    if (*xsink) {
+        return nullptr;
+    }
+    if (!tmp) {
+        xsink->raiseException("I18N-CATALOG-JSON-ERROR", "JSON catalog data could not be converted to UTF-8");
+        return nullptr;
+    }
+
+    I18nJsonParser parser(tmp->c_str(), tmp->size(), xsink);
+    ValueHolder root(parser.parse(), xsink);
+    if (*xsink) {
+        return nullptr;
+    }
+    if (root->getType() != NT_HASH) {
+        xsink->raiseException("I18N-CATALOG-JSON-ERROR", "native catalog JSON root must be an object");
+        return nullptr;
+    }
+    return root.releaseAs<QoreHashNode>();
+}
+
+QoreHashNode* i18n_load_native_catalog_json(const QoreStringNode* path, int64 max_file_len, ExceptionSink* xsink) {
+    max_file_len = max_file_len < 0 ? I18N_DEFAULT_MAX_CATALOG_FILE_LEN
+        : i18n_catalog_checked_max_file_len(max_file_len, xsink);
+    if (*xsink) {
+        return nullptr;
+    }
+
+    TempEncodingHelper npath(path, QCS_DEFAULT, xsink);
+    if (*xsink) {
+        return nullptr;
+    }
+
+    QoreFile qf;
+    if (qf.open2(xsink, npath->c_str(), O_RDONLY, 0777, QCS_UTF8)) {
+        return nullptr;
+    }
+
+    ReferenceHolder<QoreStringNode> data(qf.read(max_file_len + 1, xsink), xsink);
+    if (*xsink) {
+        return nullptr;
+    }
+    if (!data) {
+        data = new QoreStringNode(QCS_UTF8);
+    }
+    if (data->size() > static_cast<size_t>(max_file_len)) {
+        xsink->raiseException("I18N-CATALOG-ERROR",
+            "native catalog file '%s' exceeds the maximum allowed size of %lld bytes", npath->c_str(), max_file_len);
+        return nullptr;
+    }
+
+    return i18n_parse_native_catalog_json(*data, xsink);
+}

--- a/modules/i18n/src/i18n-module.cpp
+++ b/modules/i18n/src/i18n-module.cpp
@@ -29,7 +29,13 @@
 
 QoreNamespace I18nNS("Qore::I18n");
 
+DLLLOCAL void preinitMessageCatalogClass();
+DLLLOCAL QoreClass* initMessageCatalogClass(QoreNamespace& ns);
+
 static void i18n_module_init(QoreModuleInitContext& ctx, ExceptionSink& xsink) {
+    preinitMessageCatalogClass();
+
+    I18nNS.addSystemClass(initMessageCatalogClass(I18nNS));
     init_i18n_functions(I18nNS);
 }
 

--- a/modules/i18n/src/i18n-module.cpp
+++ b/modules/i18n/src/i18n-module.cpp
@@ -1,0 +1,56 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+  i18n-module.cpp
+
+  Qore i18n module
+
+  Copyright (C) 2026 Qore Technologies, s.r.o.
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+*/
+
+#include "i18n-module.h"
+
+QoreNamespace I18nNS("Qore::I18n");
+
+static void i18n_module_init(QoreModuleInitContext& ctx, ExceptionSink& xsink) {
+    init_i18n_functions(I18nNS);
+}
+
+static void i18n_module_ns_init(QoreNamespace* rns, QoreNamespace* qns, ExceptionSink& xsink) {
+    qns->addNamespace(I18nNS.copy());
+}
+
+static void i18n_module_delete() {
+}
+
+extern "C" DLLEXPORT void i18n_qore_module_desc(QoreModuleInfo& mod_info) {
+    mod_info.name = "i18n";
+    mod_info.version = PACKAGE_VERSION;
+    mod_info.desc = "Internationalization module with ICU-backed locale data";
+    mod_info.author = "Qore Technologies, s.r.o.";
+    mod_info.url = "https://qore.org";
+    mod_info.api_major = QORE_MODULE_API_MAJOR;
+    mod_info.api_minor = QORE_MODULE_API_MINOR;
+    mod_info.init = i18n_module_init;
+    mod_info.ns_init = i18n_module_ns_init;
+    mod_info.del = i18n_module_delete;
+    mod_info.license = QL_MIT;
+    mod_info.license_str = "MIT";
+}

--- a/modules/i18n/src/i18n-module.h
+++ b/modules/i18n/src/i18n-module.h
@@ -33,5 +33,8 @@
 extern QoreNamespace I18nNS;
 
 DLLLOCAL void init_i18n_functions(QoreNamespace& ns);
+DLLLOCAL QoreHashNode* i18n_parse_native_catalog_json(const QoreStringNode* json, ExceptionSink* xsink);
+DLLLOCAL QoreHashNode* i18n_load_native_catalog_json(const QoreStringNode* path, int64 max_file_len,
+    ExceptionSink* xsink);
 
 #endif

--- a/modules/i18n/src/i18n-module.h
+++ b/modules/i18n/src/i18n-module.h
@@ -1,0 +1,37 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+  i18n-module.h
+
+  Qore i18n module
+
+  Copyright (C) 2026 Qore Technologies, s.r.o.
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef I18N_MODULE_H
+#define I18N_MODULE_H
+
+#include "qore/Qore.h"
+
+extern QoreNamespace I18nNS;
+
+DLLLOCAL void init_i18n_functions(QoreNamespace& ns);
+
+#endif

--- a/modules/i18n/src/ql_i18n.qpp
+++ b/modules/i18n/src/ql_i18n.qpp
@@ -27,13 +27,17 @@
 
 #include "i18n-module.h"
 
+#include "qore/intern/QoreTimeZoneManager.h"
+
 #include <unicode/bytestream.h>
 #include <unicode/coll.h>
 #include <unicode/currunit.h>
+#include <unicode/datefmt.h>
 #include <unicode/locid.h>
 #include <unicode/numberformatter.h>
 #include <unicode/plurrule.h>
 #include <unicode/stringpiece.h>
+#include <unicode/timezone.h>
 #include <unicode/ulocdata.h>
 #include <unicode/unistr.h>
 #include <unicode/uversion.h>
@@ -854,6 +858,101 @@ static QoreStringNode* i18n_format_currency_value(QoreValue value, const QoreStr
     return new QoreStringNode(rv, QCS_UTF8);
 }
 
+static bool i18n_get_datetime_style(const QoreHashNode* opts, const char* key, icu::DateFormat::EStyle def,
+        icu::DateFormat::EStyle& out, ExceptionSink* xsink) {
+    out = def;
+    if (!opts) {
+        return true;
+    }
+
+    QoreValue value = opts->getKeyValue(key);
+    if (value.isNullOrNothing()) {
+        return true;
+    }
+
+    std::string style;
+    if (!i18n_qore_value_to_utf8_string(value, style, xsink, key)) {
+        return false;
+    }
+
+    if (style == "none") {
+        out = icu::DateFormat::kNone;
+    } else if (style == "short") {
+        out = icu::DateFormat::kShort;
+    } else if (style == "medium") {
+        out = icu::DateFormat::kMedium;
+    } else if (style == "long") {
+        out = icu::DateFormat::kLong;
+    } else if (style == "full") {
+        out = icu::DateFormat::kFull;
+    } else {
+        xsink->raiseException("I18N-FORMAT-ERROR",
+            "opts.%s must be 'none', 'short', 'medium', 'long', or 'full'; got '%s'", key, style.c_str());
+        return false;
+    }
+    return true;
+}
+
+static std::string i18n_get_datetime_timezone_id(const DateTimeNode* dt) {
+    const AbstractQoreZoneInfo* zone = dt->getZone();
+    if (!zone) {
+        return "UTC";
+    }
+    const char* region = zone->getRegionName();
+    if (!region || !strcmp(region, "UTC")) {
+        return "UTC";
+    }
+    if (region[0] == '+' || region[0] == '-') {
+        return std::string("GMT") + region;
+    }
+    return region;
+}
+
+static QoreStringNode* i18n_format_datetime_value(const DateTimeNode* dt, const QoreStringNode* locale_arg,
+        const QoreHashNode* opts, ExceptionSink* xsink) {
+    if (dt->isRelative()) {
+        xsink->raiseException("I18N-DATETIME-ERROR", "relative date/time values cannot be formatted as instants");
+        return nullptr;
+    }
+
+    icu::DateFormat::EStyle date_style;
+    icu::DateFormat::EStyle time_style;
+    if (!i18n_get_datetime_style(opts, "date_style", icu::DateFormat::kMedium, date_style, xsink)
+        || !i18n_get_datetime_style(opts, "time_style", icu::DateFormat::kShort, time_style, xsink)) {
+        return nullptr;
+    }
+    if (date_style == icu::DateFormat::kNone && time_style == icu::DateFormat::kNone) {
+        xsink->raiseException("I18N-FORMAT-ERROR", "date_style and time_style cannot both be 'none'");
+        return nullptr;
+    }
+
+    icu::Locale locale = i18n_make_locale(locale_arg, xsink);
+    if (*xsink) {
+        return nullptr;
+    }
+
+    std::unique_ptr<icu::DateFormat> formatter(icu::DateFormat::createDateTimeInstance(date_style, time_style,
+        locale));
+    if (!formatter) {
+        xsink->raiseException("I18N-ICU-ERROR", "cannot create date/time formatter for locale '%s'",
+            locale.getName());
+        return nullptr;
+    }
+
+    std::string tzid = i18n_get_datetime_timezone_id(dt);
+    icu::UnicodeString tzid_u = icu::UnicodeString::fromUTF8(icu::StringPiece(tzid));
+    formatter->adoptTimeZone(icu::TimeZone::createTimeZone(tzid_u));
+
+    UDate udate = static_cast<UDate>(dt->getEpochSecondsUTC()) * 1000.0
+        + static_cast<UDate>(dt->getMicrosecond()) / 1000.0;
+    icu::UnicodeString formatted;
+    formatter->format(udate, formatted);
+
+    std::string rv;
+    formatted.toUTF8String(rv);
+    return new QoreStringNode(rv, QCS_UTF8);
+}
+
 static std::unique_ptr<icu::Collator> i18n_make_collator(const QoreStringNode* locale_arg, ExceptionSink* xsink) {
     icu::Locale locale = i18n_make_locale(locale_arg, xsink);
     if (*xsink) {
@@ -1302,6 +1401,36 @@ string format_currency(auto value, string currency, string locale) [flags=RET_VA
 */
 string format_currency(auto value, string currency, string locale, *hash<auto> opts) [flags=RET_VALUE_ONLY] {
     return i18n_format_currency_value(value, currency, locale, opts, xsink);
+}
+
+//! Formats an absolute date/time value with explicit locale data.
+/** @param dt absolute date/time value
+    @param locale BCP 47 locale tag, including supported calendar/hour-cycle extensions
+    @return locale-formatted date/time with medium date and short time styles
+
+    @throw I18N-DATETIME-ERROR if \a dt is relative
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+    @throw I18N-FORMAT-ERROR if formatting options are invalid
+    @throw I18N-ICU-ERROR if ICU cannot create a date/time formatter
+*/
+string format_datetime(date dt, string locale) [flags=RET_VALUE_ONLY] {
+    return i18n_format_datetime_value(dt, locale, nullptr, xsink);
+}
+
+//! Formats an absolute date/time value with explicit locale data and style options.
+/** @param dt absolute date/time value
+    @param locale BCP 47 locale tag, including supported calendar/hour-cycle extensions
+    @param opts optional hash; \c date_style and \c time_style may be \c "none", \c "short", \c "medium", \c "long",
+        or \c "full"
+    @return locale-formatted date/time
+
+    @throw I18N-DATETIME-ERROR if \a dt is relative
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+    @throw I18N-FORMAT-ERROR if \a opts is invalid
+    @throw I18N-ICU-ERROR if ICU cannot create a date/time formatter
+*/
+string format_datetime(date dt, string locale, *hash<auto> opts) [flags=RET_VALUE_ONLY] {
+    return i18n_format_datetime_value(dt, locale, opts, xsink);
 }
 
 //! Compares two strings using explicit locale collation.

--- a/modules/i18n/src/ql_i18n.qpp
+++ b/modules/i18n/src/ql_i18n.qpp
@@ -27,6 +27,7 @@
 
 #include "i18n-module.h"
 
+#include "qore/SystemEnvironment.h"
 #include "qore/intern/QoreTimeZoneManager.h"
 
 #include <unicode/bytestream.h>
@@ -49,7 +50,10 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
+
+#include <sys/stat.h>
 
 static constexpr int64 I18N_CATALOG_SCHEMA_VERSION = 1;
 
@@ -627,6 +631,206 @@ static bool i18n_qore_value_to_utf8_string(QoreValue value, std::string& out, Ex
 
     out = str->c_str();
     return true;
+}
+
+static bool i18n_validate_catalog_domain(const std::string& domain, ExceptionSink* xsink) {
+    if (domain.empty() || domain.size() > 128) {
+        xsink->raiseException("I18N-CATALOG-ERROR",
+            "catalog domain must be between 1 and 128 ASCII bytes");
+        return false;
+    }
+    if (domain == "." || domain == ".." || domain.find("..") != std::string::npos) {
+        xsink->raiseException("I18N-CATALOG-ERROR", "catalog domain cannot contain path traversal components");
+        return false;
+    }
+
+    for (size_t i = 0; i < domain.size(); ++i) {
+        if (i && !(i % 100) && qore_check_cancel(xsink, "validating i18n catalog domain")) {
+            return false;
+        }
+        unsigned char c = static_cast<unsigned char>(domain[i]);
+        if (!(std::isalnum(c) || c == '_' || c == '-' || c == '.')) {
+            xsink->raiseException("I18N-CATALOG-ERROR",
+                "catalog domain may only contain ASCII letters, digits, '.', '_', and '-'");
+            return false;
+        }
+    }
+    return true;
+}
+
+static void i18n_push_catalog_search_path(std::vector<std::string>& paths, const std::string& path) {
+    if (!path.empty() && std::find(paths.begin(), paths.end(), path) == paths.end()) {
+        paths.push_back(path);
+    }
+}
+
+static bool i18n_split_catalog_path_list(std::vector<std::string>& paths, const std::string& path_list,
+        ExceptionSink* xsink) {
+#ifdef _WIN32
+    static constexpr char path_sep = ';';
+#else
+    static constexpr char path_sep = ':';
+#endif
+
+    size_t start = 0;
+    while (start <= path_list.size()) {
+        if (start && !(start % 100) && qore_check_cancel(xsink, "parsing i18n catalog search path")) {
+            return false;
+        }
+
+        size_t sep = path_list.find(path_sep, start);
+        std::string entry = path_list.substr(start, sep == std::string::npos ? std::string::npos : sep - start);
+        i18n_push_catalog_search_path(paths, entry);
+        if (sep == std::string::npos) {
+            break;
+        }
+        start = sep + 1;
+    }
+    return true;
+}
+
+static bool i18n_append_catalog_paths_option(std::vector<std::string>& paths, const QoreHashNode* opts,
+        const char* key, ExceptionSink* xsink) {
+    if (!opts) {
+        return true;
+    }
+
+    QoreValue value = opts->getKeyValue(key);
+    if (value.isNullOrNothing()) {
+        return true;
+    }
+    if (value.getType() == NT_STRING) {
+        std::string path;
+        if (!i18n_qore_value_to_utf8_string(value, path, xsink, key)) {
+            return false;
+        }
+        i18n_push_catalog_search_path(paths, path);
+        return true;
+    }
+    if (value.getType() != NT_LIST) {
+        xsink->raiseException("I18N-CATALOG-ERROR", "opts.%s must be a string or list<string>; got type '%s'",
+            key, value.getTypeName());
+        return false;
+    }
+
+    const QoreListNode* list = value.get<const QoreListNode>();
+    for (size_t i = 0; i < list->size(); ++i) {
+        if (i && !(i % 100) && qore_check_cancel(xsink, "checking i18n catalog search path option")) {
+            return false;
+        }
+        QoreStringValueHelper str(list->retrieveEntry(i), QCS_UTF8, xsink);
+        if (*xsink) {
+            return false;
+        }
+        i18n_push_catalog_search_path(paths, str->c_str());
+    }
+    return true;
+}
+
+static bool i18n_append_env_catalog_search_path(std::vector<std::string>& paths, ExceptionSink* xsink) {
+    SimpleRefHolder<QoreStringNode> env_path(SystemEnvironment::getAsStringNode("QORE_CATALOG_DIR"));
+    if (!env_path) {
+        return true;
+    }
+
+    TempEncodingHelper tmp(*env_path, QCS_UTF8, xsink);
+    if (*xsink) {
+        return false;
+    }
+    return i18n_split_catalog_path_list(paths, tmp->c_str(), xsink);
+}
+
+static std::vector<std::string> i18n_get_catalog_search_paths(const QoreHashNode* opts, ExceptionSink* xsink) {
+    std::vector<std::string> paths;
+
+    if (opts && !opts->getKeyValue("search_path").isNullOrNothing()) {
+        if (!i18n_append_catalog_paths_option(paths, opts, "search_path", xsink)) {
+            return paths;
+        }
+    } else if (!i18n_append_env_catalog_search_path(paths, xsink)) {
+        return paths;
+    }
+
+    i18n_append_catalog_paths_option(paths, opts, "override_path", xsink);
+    return paths;
+}
+
+static std::string i18n_join_catalog_path(const std::string& dir, const std::string& rel) {
+    if (dir.empty()) {
+        return rel;
+    }
+
+    char last = dir[dir.size() - 1];
+    if (last == '/' || last == '\\') {
+        return dir + rel;
+    }
+    return dir + "/" + rel;
+}
+
+static bool i18n_regular_file_exists(const std::string& path) {
+    struct stat sbuf;
+    return !stat(path.c_str(), &sbuf) && S_ISREG(sbuf.st_mode);
+}
+
+static std::vector<std::string> i18n_discover_catalog_files(const std::string& domain, const std::string& locale,
+        const QoreHashNode* opts, ExceptionSink* xsink) {
+    std::vector<std::string> files;
+    if (!i18n_validate_catalog_domain(domain, xsink)) {
+        return files;
+    }
+
+    std::vector<std::string> paths = i18n_get_catalog_search_paths(opts, xsink);
+    if (*xsink) {
+        return files;
+    }
+
+    std::vector<std::string> locales = i18n_locale_fallback_chain(locale, xsink);
+    if (*xsink) {
+        return files;
+    }
+    std::reverse(locales.begin(), locales.end());
+
+    std::unordered_set<std::string> seen;
+    for (size_t p = 0; p < paths.size(); ++p) {
+        if (p && !(p % 100) && qore_check_cancel(xsink, "discovering i18n catalog files")) {
+            return files;
+        }
+
+        for (size_t l = 0; l < locales.size(); ++l) {
+            const std::string rels[] = {
+                domain + "/" + locales[l] + ".json",
+                domain + "." + locales[l] + ".json",
+            };
+
+            for (const std::string& rel : rels) {
+                std::string path = i18n_join_catalog_path(paths[p], rel);
+                if (seen.find(path) != seen.end()) {
+                    continue;
+                }
+                seen.insert(path);
+                if (i18n_regular_file_exists(path)) {
+                    files.push_back(std::move(path));
+                }
+            }
+        }
+    }
+
+    return files;
+}
+
+static QoreListNode* i18n_string_vector_to_list(const std::vector<std::string>& values, ExceptionSink* xsink,
+        const char* activity) {
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(stringTypeInfo), xsink);
+    for (size_t i = 0; i < values.size(); ++i) {
+        if (i && !(i % 100) && qore_check_cancel(xsink, activity)) {
+            return nullptr;
+        }
+        rv->push(new QoreStringNode(values[i], QCS_UTF8), xsink);
+        if (*xsink) {
+            return nullptr;
+        }
+    }
+    return rv.release();
 }
 
 static std::string i18n_string_arg_to_utf8(const QoreStringNode* str, ExceptionSink* xsink, const char* arg_name,
@@ -1437,6 +1641,57 @@ string negotiate_locale(string header, list<string> available) [flags=RET_VALUE_
 */
 string negotiate_locale(string header, list<string> available, string default_locale) [flags=RET_VALUE_ONLY] {
     return i18n_negotiate_locale(header, available, default_locale, xsink);
+}
+
+//! Returns the configured native catalog search path.
+/** If \c opts.search_path is present, it is returned instead of \c QORE_CATALOG_DIR. \c opts.override_path entries are
+    appended after the base search path and therefore have higher precedence for catalog composition.
+
+    @param opts optional hash with \c search_path and \c override_path string or list<string> entries
+    @return search path entries in low-to-high precedence order
+
+    @throw I18N-CATALOG-ERROR if options have invalid types
+*/
+list<string> get_catalog_search_path(*hash<auto> opts) [flags=RET_VALUE_ONLY;dom=EXTERNAL_INFO] {
+    std::vector<std::string> paths = i18n_get_catalog_search_paths(opts, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    return i18n_string_vector_to_list(paths, xsink, "returning i18n catalog search path");
+}
+
+//! Discovers native catalog JSON files for a domain and requested locale.
+/** Discovery checks \c QORE_CATALOG_DIR by default. Pass \c opts.search_path to use an explicit base path list, and
+    \c opts.override_path to append application/Qorus override paths. Returned files are ordered for direct
+    MessageCatalog construction: lower precedence first, with locale files ordered \c root before more-specific
+    locales.
+
+    For each search directory, both \c domain/locale.json and \c domain.locale.json are recognized. The domain is
+    restricted to ASCII letters, digits, \c '.', \c '_', and \c '-' to prevent path traversal.
+
+    @param domain catalog domain
+    @param locale requested locale
+    @param opts optional hash with \c search_path and \c override_path string or list<string> entries
+    @return existing native catalog JSON file paths in load order
+
+    @throw I18N-CATALOG-ERROR if \a domain or \a opts is invalid
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+*/
+list<string> discover_catalog_files(string domain, string locale, *hash<auto> opts) [flags=RET_VALUE_ONLY;dom=FILESYSTEM,EXTERNAL_INFO] {
+    std::string domain_str = i18n_string_arg_to_utf8(domain, xsink, "domain", 128);
+    if (*xsink) {
+        return QoreValue();
+    }
+    std::string locale_str = i18n_qore_string_to_utf8(locale, xsink, "locale");
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    std::vector<std::string> files = i18n_discover_catalog_files(domain_str, locale_str, opts, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    return i18n_string_vector_to_list(files, xsink, "returning discovered i18n catalog files");
 }
 
 //! Formats a decimal number with explicit locale data.

--- a/modules/i18n/src/ql_i18n.qpp
+++ b/modules/i18n/src/ql_i18n.qpp
@@ -333,6 +333,39 @@ static std::string i18n_canonicalize_locale_tag(const std::string& raw, Exceptio
     return strip_extensions ? i18n_strip_unicode_extensions(canonical) : canonical;
 }
 
+static QoreHashNode* i18n_make_locale_context_hash(const std::string& locale, ExceptionSink* xsink) {
+    ReferenceHolder<QoreHashNode> h(new QoreHashNode(autoTypeInfo), xsink);
+    h->setKeyValue("locale", new QoreStringNode(locale, QCS_UTF8), xsink);
+    if (*xsink) {
+        return nullptr;
+    }
+    return h.release();
+}
+
+static std::string i18n_get_locale_from_context(const QoreHashNode* context, ExceptionSink* xsink) {
+    QoreValue locale_value = context->getKeyValue("locale");
+    if (locale_value.getType() != NT_STRING) {
+        xsink->raiseException("I18N-LOCALE-CONTEXT-ERROR",
+            "locale context must contain a string 'locale' key; got type '%s'", locale_value.getTypeName());
+        return std::string();
+    }
+
+    QoreStringValueHelper str(locale_value, QCS_UTF8, xsink);
+    if (*xsink) {
+        return std::string();
+    }
+    if (!str->c_str()[0]) {
+        xsink->raiseException("I18N-LOCALE-CONTEXT-ERROR", "locale context locale cannot be empty");
+        return std::string();
+    }
+
+    std::string canonical = i18n_canonicalize_locale_tag(str->c_str(), xsink, true);
+    if (*xsink) {
+        return std::string();
+    }
+    return canonical;
+}
+
 static std::vector<std::string> i18n_locale_fallback_chain(const std::string& raw, ExceptionSink* xsink) {
     std::vector<std::string> chain;
     std::string locale = i18n_canonicalize_locale_tag(raw, xsink, true);
@@ -1664,6 +1697,52 @@ nothing set_thread_locale(string locale) [dom=LOCALE_CONTROL] {
 */
 string get_thread_locale() [flags=RET_VALUE_ONLY] {
     return new QoreStringNode(i18n_thread_locale.empty() ? "root" : i18n_thread_locale, QCS_UTF8);
+}
+
+//! Creates a locale context hash for explicit propagation across task boundaries.
+/** The returned hash has a canonical \c "locale" key and is data-only. Pass it explicitly to background work,
+    thread-pool tasks, or request dispatch code, then call I18n::apply_locale_context() in the destination thread.
+
+    @param locale BCP 47 locale tag
+    @return hash containing the canonical catalog locale
+
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+*/
+hash<auto> make_locale_context(string locale) [flags=RET_VALUE_ONLY] {
+    std::string tag = i18n_qore_string_to_utf8(locale, xsink, "locale");
+    if (*xsink) {
+        return QoreValue();
+    }
+    std::string canonical = i18n_canonicalize_locale_tag(tag, xsink, true);
+    if (*xsink) {
+        return QoreValue();
+    }
+    return i18n_make_locale_context_hash(canonical, xsink);
+}
+
+//! Captures the current thread's ambient locale as a locale context hash.
+/** @return hash containing the current thread locale, or \c "root" if none has been set
+*/
+hash<auto> capture_locale_context() [flags=RET_VALUE_ONLY] {
+    return i18n_make_locale_context_hash(i18n_thread_locale.empty() ? "root" : i18n_thread_locale, xsink);
+}
+
+//! Applies a previously captured or constructed locale context to the current thread.
+/** @param context hash returned by I18n::make_locale_context() or I18n::capture_locale_context()
+
+    @throw I18N-LOCALE-CONTEXT-ERROR if \a context is malformed
+    @throw I18N-LOCALE-ERROR if the context locale is invalid
+*/
+nothing apply_locale_context(hash<auto> context) [dom=LOCALE_CONTROL] {
+    std::string canonical = i18n_get_locale_from_context(context, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    if (canonical == "root") {
+        i18n_thread_locale.clear();
+    } else {
+        i18n_thread_locale = canonical;
+    }
 }
 
 //! Clears the current thread's ambient i18n locale.

--- a/modules/i18n/src/ql_i18n.qpp
+++ b/modules/i18n/src/ql_i18n.qpp
@@ -28,6 +28,8 @@
 #include "i18n-module.h"
 
 #include <unicode/bytestream.h>
+#include <unicode/coll.h>
+#include <unicode/currunit.h>
 #include <unicode/locid.h>
 #include <unicode/numberformatter.h>
 #include <unicode/plurrule.h>
@@ -38,6 +40,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <cstdlib>
 #include <memory>
 #include <string>
@@ -620,6 +623,24 @@ static bool i18n_qore_value_to_utf8_string(QoreValue value, std::string& out, Ex
     return true;
 }
 
+static std::string i18n_string_arg_to_utf8(const QoreStringNode* str, ExceptionSink* xsink, const char* arg_name,
+        size_t max_len = 1024 * 1024) {
+    TempEncodingHelper tmp(str, QCS_UTF8, xsink);
+    if (*xsink) {
+        return std::string();
+    }
+    if (!tmp) {
+        xsink->raiseException("I18N-STRING-ERROR", "%s could not be converted to UTF-8", arg_name);
+        return std::string();
+    }
+    if (tmp->strlen() > max_len) {
+        xsink->raiseException("I18N-STRING-ERROR", "%s is too long; maximum supported length is %zu bytes",
+            arg_name, max_len);
+        return std::string();
+    }
+    return tmp->c_str();
+}
+
 static icu::Locale i18n_make_locale(const QoreStringNode* locale_arg, ExceptionSink* xsink) {
     std::string tag = i18n_qore_string_to_utf8(locale_arg, xsink, "locale");
     if (*xsink) {
@@ -663,6 +684,194 @@ static UPluralType i18n_get_plural_type(const QoreHashNode* opts, ExceptionSink*
     xsink->raiseException("I18N-PLURAL-TYPE-ERROR",
         "unsupported plural type '%s'; expected 'cardinal' or 'ordinal'", type.c_str());
     return UPLURAL_TYPE_CARDINAL;
+}
+
+static bool i18n_get_optional_fraction_digits(const QoreHashNode* opts, const char* key, int32_t& out,
+        bool& present, ExceptionSink* xsink) {
+    present = false;
+    if (!opts) {
+        return true;
+    }
+
+    QoreValue value = opts->getKeyValue(key);
+    if (value.isNullOrNothing()) {
+        return true;
+    }
+    if (value.getType() != NT_INT) {
+        xsink->raiseException("I18N-FORMAT-ERROR", "opts.%s must be an int; got type '%s'", key,
+            value.getTypeName());
+        return false;
+    }
+
+    int64 i = value.getAsBigInt();
+    if (i < 0 || i > 100) {
+        xsink->raiseException("I18N-FORMAT-ERROR", "opts.%s must be between 0 and 100", key);
+        return false;
+    }
+
+    out = static_cast<int32_t>(i);
+    present = true;
+    return true;
+}
+
+static bool i18n_get_optional_bool(const QoreHashNode* opts, const char* key, bool& out, bool& present) {
+    present = false;
+    if (!opts) {
+        return true;
+    }
+
+    QoreValue value = opts->getKeyValue(key);
+    if (value.isNullOrNothing()) {
+        return true;
+    }
+
+    out = value.getAsBool();
+    present = true;
+    return true;
+}
+
+static bool i18n_apply_number_options(icu::number::UnlocalizedNumberFormatter& formatter,
+        const I18nDecimalInfo& decimal, const QoreHashNode* opts, bool currency, ExceptionSink* xsink) {
+    int32_t min_fraction = 0;
+    int32_t max_fraction = 0;
+    bool has_min_fraction = false;
+    bool has_max_fraction = false;
+    if (!i18n_get_optional_fraction_digits(opts, "min_fraction_digits", min_fraction, has_min_fraction, xsink)
+        || !i18n_get_optional_fraction_digits(opts, "max_fraction_digits", max_fraction, has_max_fraction, xsink)) {
+        return false;
+    }
+
+    if (has_min_fraction && has_max_fraction && min_fraction > max_fraction) {
+        xsink->raiseException("I18N-FORMAT-ERROR",
+            "opts.min_fraction_digits cannot be greater than opts.max_fraction_digits");
+        return false;
+    }
+
+    if (has_min_fraction && has_max_fraction) {
+        formatter = formatter.precision(icu::number::Precision::minMaxFraction(min_fraction, max_fraction));
+    } else if (has_min_fraction) {
+        formatter = formatter.precision(icu::number::Precision::minFraction(min_fraction));
+    } else if (has_max_fraction) {
+        formatter = formatter.precision(icu::number::Precision::maxFraction(max_fraction));
+    } else if (!currency) {
+        formatter = formatter.precision(icu::number::Precision::fixedFraction(decimal.fraction_digits));
+    }
+
+    bool grouping = false;
+    bool has_grouping = false;
+    i18n_get_optional_bool(opts, "grouping", grouping, has_grouping);
+    if (has_grouping && !grouping) {
+        formatter = formatter.grouping(UNUM_GROUPING_OFF);
+    }
+    return true;
+}
+
+static QoreStringNode* i18n_format_number_value(QoreValue value, const QoreStringNode* locale_arg,
+        const QoreHashNode* opts, ExceptionSink* xsink) {
+    I18nDecimalInfo decimal;
+    if (!i18n_value_to_decimal_info(value, decimal, xsink)) {
+        return nullptr;
+    }
+
+    icu::Locale locale = i18n_make_locale(locale_arg, xsink);
+    if (*xsink) {
+        return nullptr;
+    }
+
+    icu::number::UnlocalizedNumberFormatter formatter = icu::number::NumberFormatter::with();
+    if (!i18n_apply_number_options(formatter, decimal, opts, false, xsink)) {
+        return nullptr;
+    }
+
+    UErrorCode status = U_ZERO_ERROR;
+    icu::number::FormattedNumber formatted = formatter.locale(locale).formatDecimal(
+        icu::StringPiece(decimal.formatted), status);
+    if (U_FAILURE(status)) {
+        xsink->raiseException("I18N-ICU-ERROR", "cannot format number '%s': %s",
+            decimal.formatted.c_str(), i18n_icu_error_name(status));
+        return nullptr;
+    }
+
+    icu::UnicodeString formatted_text = formatted.toString(status);
+    if (U_FAILURE(status)) {
+        xsink->raiseException("I18N-ICU-ERROR", "cannot render formatted number '%s': %s",
+            decimal.formatted.c_str(), i18n_icu_error_name(status));
+        return nullptr;
+    }
+
+    std::string rv;
+    formatted_text.toUTF8String(rv);
+    return new QoreStringNode(rv, QCS_UTF8);
+}
+
+static QoreStringNode* i18n_format_currency_value(QoreValue value, const QoreStringNode* currency_arg,
+        const QoreStringNode* locale_arg, const QoreHashNode* opts, ExceptionSink* xsink) {
+    I18nDecimalInfo decimal;
+    if (!i18n_value_to_decimal_info(value, decimal, xsink)) {
+        return nullptr;
+    }
+
+    std::string currency_code = i18n_string_arg_to_utf8(currency_arg, xsink, "currency", 16);
+    if (*xsink) {
+        return nullptr;
+    }
+
+    UErrorCode status = U_ZERO_ERROR;
+    icu::CurrencyUnit currency(icu::StringPiece(currency_code), status);
+    if (U_FAILURE(status)) {
+        xsink->raiseException("I18N-CURRENCY-ERROR", "invalid currency code '%s': %s",
+            currency_code.c_str(), i18n_icu_error_name(status));
+        return nullptr;
+    }
+
+    icu::Locale locale = i18n_make_locale(locale_arg, xsink);
+    if (*xsink) {
+        return nullptr;
+    }
+
+    icu::number::UnlocalizedNumberFormatter formatter = icu::number::NumberFormatter::with().unit(currency);
+    if (!i18n_apply_number_options(formatter, decimal, opts, true, xsink)) {
+        return nullptr;
+    }
+
+    icu::number::FormattedNumber formatted = formatter.locale(locale).formatDecimal(
+        icu::StringPiece(decimal.formatted), status);
+    if (U_FAILURE(status)) {
+        xsink->raiseException("I18N-ICU-ERROR", "cannot format currency value '%s': %s",
+            decimal.formatted.c_str(), i18n_icu_error_name(status));
+        return nullptr;
+    }
+
+    icu::UnicodeString formatted_text = formatted.toString(status);
+    if (U_FAILURE(status)) {
+        xsink->raiseException("I18N-ICU-ERROR", "cannot render formatted currency value '%s': %s",
+            decimal.formatted.c_str(), i18n_icu_error_name(status));
+        return nullptr;
+    }
+
+    std::string rv;
+    formatted_text.toUTF8String(rv);
+    return new QoreStringNode(rv, QCS_UTF8);
+}
+
+static std::unique_ptr<icu::Collator> i18n_make_collator(const QoreStringNode* locale_arg, ExceptionSink* xsink) {
+    icu::Locale locale = i18n_make_locale(locale_arg, xsink);
+    if (*xsink) {
+        return nullptr;
+    }
+
+    UErrorCode status = U_ZERO_ERROR;
+    std::unique_ptr<icu::Collator> collator(icu::Collator::createInstance(locale, status));
+    if (U_FAILURE(status) || !collator) {
+        xsink->raiseException("I18N-ICU-ERROR", "cannot create collator for locale '%s': %s",
+            locale.getName(), i18n_icu_error_name(status));
+        return nullptr;
+    }
+    return collator;
+}
+
+static icu::UnicodeString i18n_utf8_to_unicode_string(const std::string& value) {
+    return icu::UnicodeString::fromUTF8(icu::StringPiece(value));
 }
 
 static std::string i18n_select_plural_category(QoreValue value, const QoreStringNode* locale_arg,
@@ -1026,6 +1235,163 @@ string negotiate_locale(string header, list<string> available) [flags=RET_VALUE_
 */
 string negotiate_locale(string header, list<string> available, string default_locale) [flags=RET_VALUE_ONLY] {
     return i18n_negotiate_locale(header, available, default_locale, xsink);
+}
+
+//! Formats a decimal number with explicit locale data.
+/** @param value integer, floating-point, number, or base-10 decimal string
+    @param locale BCP 47 locale tag, including supported Unicode numbering-system extensions
+    @return locale-formatted decimal number
+
+    @throw I18N-NUMBER-ERROR if \a value is a malformed decimal string
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+    @throw I18N-FORMAT-ERROR if formatting options are invalid
+    @throw I18N-ICU-ERROR if ICU cannot format the value
+
+    @par Example:
+    @code{.py}
+assertEq("1,234.50", I18n::format_number("1234.50", "en-US"));
+    @endcode
+*/
+string format_number(auto value, string locale) [flags=RET_VALUE_ONLY] {
+    return i18n_format_number_value(value, locale, nullptr, xsink);
+}
+
+//! Formats a decimal number with explicit locale data and options.
+/** @param value integer, floating-point, number, or base-10 decimal string
+    @param locale BCP 47 locale tag
+    @param opts optional hash; supported keys are \c min_fraction_digits, \c max_fraction_digits, and \c grouping
+    @return locale-formatted decimal number
+
+    @throw I18N-NUMBER-ERROR if \a value is a malformed decimal string
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+    @throw I18N-FORMAT-ERROR if \a opts is invalid
+    @throw I18N-ICU-ERROR if ICU cannot format the value
+*/
+string format_number(auto value, string locale, *hash<auto> opts) [flags=RET_VALUE_ONLY] {
+    return i18n_format_number_value(value, locale, opts, xsink);
+}
+
+//! Formats a currency value with explicit locale data.
+/** @param value integer, floating-point, number, or base-10 decimal string
+    @param currency ISO 4217 currency code such as \c "USD" or \c "EUR"
+    @param locale BCP 47 locale tag
+    @return locale-formatted currency value
+
+    @throw I18N-NUMBER-ERROR if \a value is a malformed decimal string
+    @throw I18N-CURRENCY-ERROR if \a currency is invalid
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+    @throw I18N-FORMAT-ERROR if formatting options are invalid
+    @throw I18N-ICU-ERROR if ICU cannot format the value
+*/
+string format_currency(auto value, string currency, string locale) [flags=RET_VALUE_ONLY] {
+    return i18n_format_currency_value(value, currency, locale, nullptr, xsink);
+}
+
+//! Formats a currency value with explicit locale data and options.
+/** @param value integer, floating-point, number, or base-10 decimal string
+    @param currency ISO 4217 currency code such as \c "USD" or \c "EUR"
+    @param locale BCP 47 locale tag
+    @param opts optional hash; supported keys are \c min_fraction_digits, \c max_fraction_digits, and \c grouping
+    @return locale-formatted currency value
+
+    @throw I18N-NUMBER-ERROR if \a value is a malformed decimal string
+    @throw I18N-CURRENCY-ERROR if \a currency is invalid
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+    @throw I18N-FORMAT-ERROR if \a opts is invalid
+    @throw I18N-ICU-ERROR if ICU cannot format the value
+*/
+string format_currency(auto value, string currency, string locale, *hash<auto> opts) [flags=RET_VALUE_ONLY] {
+    return i18n_format_currency_value(value, currency, locale, opts, xsink);
+}
+
+//! Compares two strings using explicit locale collation.
+/** @param left left string
+    @param right right string
+    @param locale BCP 47 locale tag, including supported Unicode collation extensions
+    @return \c -1 if \a left sorts before \a right, \c 1 if after, or \c 0 if equal under the collator
+
+    @throw I18N-STRING-ERROR if either string cannot be converted to UTF-8
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+    @throw I18N-ICU-ERROR if ICU cannot create a collator
+*/
+int compare_strings(string left, string right, string locale) [flags=RET_VALUE_ONLY] {
+    std::string left_str = i18n_string_arg_to_utf8(left, xsink, "left");
+    if (*xsink) {
+        return QoreValue();
+    }
+    std::string right_str = i18n_string_arg_to_utf8(right, xsink, "right");
+    if (*xsink) {
+        return QoreValue();
+    }
+    std::unique_ptr<icu::Collator> collator = i18n_make_collator(locale, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    icu::Collator::EComparisonResult result = collator->compare(i18n_utf8_to_unicode_string(left_str),
+        i18n_utf8_to_unicode_string(right_str));
+    return result == icu::Collator::LESS ? -1 : result == icu::Collator::GREATER ? 1 : 0;
+}
+
+//! Returns an ICU sort key for a string and explicit locale.
+/** Sort keys are binary data intended for cache-local ordering only.
+
+    @param value string to convert
+    @param locale BCP 47 locale tag, including supported Unicode collation extensions
+    @return binary ICU sort key
+
+    @throw I18N-STRING-ERROR if \a value cannot be converted to UTF-8 or the sort key is too large
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+    @throw I18N-ICU-ERROR if ICU cannot create a collator
+
+    @note Sort keys are not stable across ICU/CLDR versions, locales, or collation options. Persistent keys must be
+    tagged with the locale, options, backend, ICU/CLDR versions, and collation version.
+*/
+binary get_sort_key(string value, string locale) [flags=RET_VALUE_ONLY] {
+    std::string value_str = i18n_string_arg_to_utf8(value, xsink, "value");
+    if (*xsink) {
+        return QoreValue();
+    }
+    std::unique_ptr<icu::Collator> collator = i18n_make_collator(locale, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    icu::UnicodeString uvalue = i18n_utf8_to_unicode_string(value_str);
+    int32_t len = collator->getSortKey(uvalue, nullptr, 0);
+    if (len < 0 || len > 1024 * 1024) {
+        xsink->raiseException("I18N-STRING-ERROR", "generated sort key is too large");
+        return QoreValue();
+    }
+
+    std::vector<uint8_t> data(static_cast<size_t>(len));
+    int32_t actual = collator->getSortKey(uvalue, data.data(), len);
+    if (actual < 0 || actual > len) {
+        xsink->raiseException("I18N-ICU-ERROR", "cannot generate sort key");
+        return QoreValue();
+    }
+
+    BinaryNode* rv = new BinaryNode;
+    rv->append(data.data(), static_cast<size_t>(actual));
+    return rv;
+}
+
+//! Returns the ICU collation version for an explicit locale.
+/** @param locale BCP 47 locale tag
+    @return collation version string
+
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+    @throw I18N-ICU-ERROR if ICU cannot create a collator
+*/
+string get_collation_version(string locale) [flags=RET_VALUE_ONLY] {
+    std::unique_ptr<icu::Collator> collator = i18n_make_collator(locale, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    UVersionInfo version;
+    collator->getVersion(version);
+    return new QoreStringNode(i18n_version_to_string(version), QCS_UTF8);
 }
 
 //! Returns the CLDR plural category for a value and locale using cardinal rules.

--- a/modules/i18n/src/ql_i18n.qpp
+++ b/modules/i18n/src/ql_i18n.qpp
@@ -27,6 +27,7 @@
 
 #include "i18n-module.h"
 
+#include "qore/QoreSandboxManager.h"
 #include "qore/SystemEnvironment.h"
 #include "qore/intern/QoreTimeZoneManager.h"
 
@@ -807,7 +808,12 @@ static std::string i18n_join_catalog_path(const std::string& dir, const std::str
     return dir + "/" + rel;
 }
 
-static bool i18n_regular_file_exists(const std::string& path) {
+static bool i18n_regular_file_exists(const std::string& path, ExceptionSink* xsink) {
+    QoreSandboxManagerHelper smh;
+    if (smh && !smh->checkFilesystemAccess(path.c_str(), QSEC_READ, xsink)) {
+        return false;
+    }
+
     struct stat sbuf;
     return !stat(path.c_str(), &sbuf) && S_ISREG(sbuf.st_mode);
 }
@@ -852,7 +858,10 @@ static std::vector<std::string> i18n_discover_catalog_files(const std::string& d
                     continue;
                 }
                 seen.insert(path);
-                if (i18n_regular_file_exists(path)) {
+                if (i18n_regular_file_exists(path, xsink)) {
+                    if (*xsink) {
+                        return files;
+                    }
                     files.push_back(std::move(path));
                 }
             }

--- a/modules/i18n/src/ql_i18n.qpp
+++ b/modules/i18n/src/ql_i18n.qpp
@@ -35,10 +35,13 @@
 #include <unicode/currunit.h>
 #include <unicode/datefmt.h>
 #include <unicode/locid.h>
+#include <unicode/numfmt.h>
 #include <unicode/numberformatter.h>
+#include <unicode/parsepos.h>
 #include <unicode/plurrule.h>
 #include <unicode/stringpiece.h>
 #include <unicode/timezone.h>
+#include <unicode/uchar.h>
 #include <unicode/ulocdata.h>
 #include <unicode/unistr.h>
 #include <unicode/uversion.h>
@@ -1064,6 +1067,82 @@ static QoreStringNode* i18n_format_currency_value(QoreValue value, const QoreStr
     return new QoreStringNode(rv, QCS_UTF8);
 }
 
+static QoreValue i18n_parse_number_value(const QoreStringNode* text_arg, const QoreStringNode* locale_arg,
+        const QoreHashNode* opts, ExceptionSink* xsink) {
+    std::string text = i18n_string_arg_to_utf8(text_arg, xsink, "text", 4096);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    icu::Locale locale = i18n_make_locale(locale_arg, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    UErrorCode status = U_ZERO_ERROR;
+    std::unique_ptr<icu::NumberFormat> formatter(icu::NumberFormat::createInstance(locale, status));
+    if (U_FAILURE(status) || !formatter) {
+        xsink->raiseException("I18N-ICU-ERROR", "cannot create number parser for locale '%s': %s",
+            locale.getName(), i18n_icu_error_name(status));
+        return QoreValue();
+    }
+
+    bool integer_only = false;
+    bool has_integer_only = false;
+    i18n_get_optional_bool(opts, "integer_only", integer_only, has_integer_only);
+    if (has_integer_only) {
+        formatter->setParseIntegerOnly(integer_only);
+    }
+
+    icu::UnicodeString input = icu::UnicodeString::fromUTF8(icu::StringPiece(text));
+    icu::Formattable parsed;
+    icu::ParsePosition pos(0);
+    formatter->parse(input, parsed, pos);
+    if (pos.getIndex() == 0 || pos.getErrorIndex() >= 0) {
+        xsink->raiseException("I18N-PARSE-ERROR", "cannot parse number '%s' for locale '%s'",
+            text.c_str(), locale.getName());
+        return QoreValue();
+    }
+
+    int32_t i = pos.getIndex();
+    while (i < input.length()) {
+        if (i && !(i % 100) && qore_check_cancel(xsink, "checking parsed i18n number trailing text")) {
+            return QoreValue();
+        }
+        UChar32 ch = input.char32At(i);
+        if (!u_isUWhiteSpace(ch)) {
+            xsink->raiseException("I18N-PARSE-ERROR",
+                "unexpected trailing text while parsing number '%s' for locale '%s'", text.c_str(), locale.getName());
+            return QoreValue();
+        }
+        i += U16_LENGTH(ch);
+    }
+
+    status = U_ZERO_ERROR;
+    QoreValue rv;
+    switch (parsed.getType()) {
+        case icu::Formattable::kLong:
+            rv = static_cast<int64>(parsed.getLong(status));
+            break;
+        case icu::Formattable::kInt64:
+            rv = parsed.getInt64(status);
+            break;
+        case icu::Formattable::kDouble:
+            rv = new QoreNumberNode(parsed.getDouble(status));
+            break;
+        default:
+            xsink->raiseException("I18N-PARSE-ERROR",
+                "ICU returned an unsupported parsed number type for '%s'", text.c_str());
+            return QoreValue();
+    }
+    if (U_FAILURE(status)) {
+        xsink->raiseException("I18N-ICU-ERROR", "cannot convert parsed number '%s': %s",
+            text.c_str(), i18n_icu_error_name(status));
+        return QoreValue();
+    }
+    return rv;
+}
+
 static bool i18n_get_datetime_style(const QoreHashNode* opts, const char* key, icu::DateFormat::EStyle def,
         icu::DateFormat::EStyle& out, ExceptionSink* xsink) {
     out = def;
@@ -1772,6 +1851,38 @@ string format_number(auto value, string locale) [flags=RET_VALUE_ONLY] {
 */
 string format_number(auto value, string locale, *hash<auto> opts) [flags=RET_VALUE_ONLY] {
     return i18n_format_number_value(value, locale, opts, xsink);
+}
+
+//! Parses a locale-formatted decimal number with explicit locale data.
+/** @param text locale-formatted decimal number text
+    @param locale BCP 47 locale tag, including supported Unicode numbering-system extensions
+    @return parsed Qore integer or number value
+
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+    @throw I18N-PARSE-ERROR if \a text cannot be parsed completely as a number
+    @throw I18N-ICU-ERROR if ICU cannot parse or convert the value
+
+    @par Example:
+    @code{.py}
+assertEq(1234, I18n::parse_number("1,234", "en-US"));
+    @endcode
+*/
+auto parse_number(string text, string locale) [flags=RET_VALUE_ONLY] {
+    return i18n_parse_number_value(text, locale, nullptr, xsink);
+}
+
+//! Parses a locale-formatted decimal number with explicit locale data and options.
+/** @param text locale-formatted decimal number text
+    @param locale BCP 47 locale tag
+    @param opts optional hash; supported key: \c integer_only
+    @return parsed Qore integer or number value
+
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+    @throw I18N-PARSE-ERROR if \a text cannot be parsed completely as a number
+    @throw I18N-ICU-ERROR if ICU cannot parse or convert the value
+*/
+auto parse_number(string text, string locale, *hash<auto> opts) [flags=RET_VALUE_ONLY] {
+    return i18n_parse_number_value(text, locale, opts, xsink);
 }
 
 //! Formats a currency value with explicit locale data.

--- a/modules/i18n/src/ql_i18n.qpp
+++ b/modules/i18n/src/ql_i18n.qpp
@@ -1,0 +1,622 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+/*
+  ql_i18n.qpp
+
+  Qore i18n module functions
+
+  Copyright (C) 2026 Qore Technologies, s.r.o.
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+*/
+
+#include "i18n-module.h"
+
+#include <unicode/bytestream.h>
+#include <unicode/locid.h>
+#include <unicode/numberformatter.h>
+#include <unicode/plurrule.h>
+#include <unicode/stringpiece.h>
+#include <unicode/ulocdata.h>
+#include <unicode/unistr.h>
+#include <unicode/uversion.h>
+
+#include <algorithm>
+#include <cctype>
+#include <memory>
+#include <string>
+
+static const char* i18n_icu_error_name(UErrorCode status) {
+    return u_errorName(status);
+}
+
+static std::string i18n_version_to_string(const UVersionInfo version) {
+    char buf[U_MAX_VERSION_STRING_LENGTH] = {0};
+    u_versionToString(version, buf);
+    return buf;
+}
+
+static std::string i18n_get_icu_version_string() {
+    UVersionInfo version;
+    u_getVersion(version);
+    return i18n_version_to_string(version);
+}
+
+static std::string i18n_get_cldr_version_string(ExceptionSink* xsink) {
+    UVersionInfo version;
+    UErrorCode status = U_ZERO_ERROR;
+    ulocdata_getCLDRVersion(version, &status);
+    if (U_FAILURE(status)) {
+        xsink->raiseException("I18N-ICU-ERROR", "cannot read ICU CLDR version: %s", i18n_icu_error_name(status));
+        return std::string();
+    }
+    return i18n_version_to_string(version);
+}
+
+static bool i18n_is_ascii_space(char c) {
+    return std::isspace(static_cast<unsigned char>(c)) != 0;
+}
+
+static bool i18n_trim_ascii(const std::string& s, std::string& out, ExceptionSink* xsink) {
+    size_t start = 0;
+    while (start < s.size() && i18n_is_ascii_space(s[start])) {
+        if (start && !(start % 100) && qore_check_cancel(xsink, "trimming i18n numeric string")) {
+            return false;
+        }
+        ++start;
+    }
+
+    size_t end = s.size();
+    while (end > start && i18n_is_ascii_space(s[end - 1])) {
+        if ((s.size() - end) && !((s.size() - end) % 100)
+            && qore_check_cancel(xsink, "trimming i18n numeric string")) {
+            return false;
+        }
+        --end;
+    }
+
+    out = s.substr(start, end - start);
+    return true;
+}
+
+struct I18nDecimalInfo {
+    std::string formatted;
+    std::string canonical;
+    int32_t fraction_digits = 0;
+};
+
+static bool i18n_parse_decimal_string(const std::string& input, I18nDecimalInfo& info, ExceptionSink* xsink,
+        const char* arg_name) {
+    std::string s;
+    if (!i18n_trim_ascii(input, s, xsink)) {
+        return false;
+    }
+    if (s.empty()) {
+        xsink->raiseException("I18N-NUMBER-ERROR", "%s cannot be empty", arg_name);
+        return false;
+    }
+
+    size_t pos = 0;
+    bool negative = false;
+    if (s[pos] == '+' || s[pos] == '-') {
+        negative = s[pos] == '-';
+        ++pos;
+    }
+
+    std::string integer;
+    while (pos < s.size() && std::isdigit(static_cast<unsigned char>(s[pos]))) {
+        if (pos && !(pos % 100) && qore_check_cancel(xsink, "parsing i18n numeric string")) {
+            return false;
+        }
+        integer.push_back(s[pos++]);
+    }
+
+    std::string fraction;
+    if (pos < s.size() && s[pos] == '.') {
+        ++pos;
+        while (pos < s.size() && std::isdigit(static_cast<unsigned char>(s[pos]))) {
+            if (pos && !(pos % 100) && qore_check_cancel(xsink, "parsing i18n numeric string")) {
+                return false;
+            }
+            fraction.push_back(s[pos++]);
+        }
+    }
+
+    if (integer.empty() && fraction.empty()) {
+        xsink->raiseException("I18N-NUMBER-ERROR", "%s must contain at least one digit", arg_name);
+        return false;
+    }
+
+    if (pos != s.size()) {
+        xsink->raiseException("I18N-NUMBER-ERROR",
+            "%s must be a base-10 integer or decimal string; got '%s'", arg_name, input.c_str());
+        return false;
+    }
+
+    if (integer.empty()) {
+        integer = "0";
+    }
+
+    if (integer.size() > 1000) {
+        xsink->raiseException("I18N-NUMBER-ERROR",
+            "%s has too many integer digits; maximum supported is 1000", arg_name);
+        return false;
+    }
+
+    size_t first_non_zero = integer.find_first_not_of('0');
+    std::string canonical_integer = first_non_zero == std::string::npos ? "0" : integer.substr(first_non_zero);
+
+    std::string canonical_fraction = fraction;
+    size_t trim_pos = 0;
+    while (!canonical_fraction.empty() && canonical_fraction.back() == '0') {
+        if (trim_pos && !(trim_pos % 100) && qore_check_cancel(xsink, "normalizing i18n numeric string")) {
+            return false;
+        }
+        canonical_fraction.pop_back();
+        ++trim_pos;
+    }
+
+    if (fraction.size() > 100) {
+        xsink->raiseException("I18N-NUMBER-ERROR",
+            "%s has too many visible fraction digits; maximum supported is 100", arg_name);
+        return false;
+    }
+
+    bool is_zero = canonical_integer == "0" && canonical_fraction.empty();
+
+    info.formatted.clear();
+    if (negative && !is_zero) {
+        info.formatted.push_back('-');
+    }
+    info.formatted += canonical_integer;
+    if (!fraction.empty()) {
+        info.formatted.push_back('.');
+        info.formatted += fraction;
+    }
+
+    info.canonical.clear();
+    if (negative && !is_zero) {
+        info.canonical.push_back('-');
+    }
+    info.canonical += canonical_integer;
+    if (!canonical_fraction.empty()) {
+        info.canonical.push_back('.');
+        info.canonical += canonical_fraction;
+    }
+    info.fraction_digits = static_cast<int32_t>(fraction.size());
+
+    return true;
+}
+
+static bool i18n_value_to_decimal_info(QoreValue value, I18nDecimalInfo& info, ExceptionSink* xsink) {
+    switch (value.getType()) {
+        case NT_INT: {
+            int64 i = value.getAsBigInt();
+            info.formatted = std::to_string(i);
+            info.canonical = info.formatted;
+            info.fraction_digits = 0;
+            return true;
+        }
+        case NT_NUMBER:
+        case NT_FLOAT:
+        case NT_STRING: {
+            QoreStringValueHelper str(value, QCS_UTF8, xsink);
+            if (*xsink) {
+                return false;
+            }
+            return i18n_parse_decimal_string(str->c_str(), info, xsink, "value");
+        }
+    }
+
+    xsink->raiseException("I18N-TYPE-ERROR", "value must be an int, float, number, or string; got type '%s'",
+        value.getTypeName());
+    return false;
+}
+
+static std::string i18n_qore_string_to_utf8(const QoreStringNode* str, ExceptionSink* xsink, const char* arg_name) {
+    TempEncodingHelper tmp(str, QCS_UTF8, xsink);
+    if (*xsink) {
+        return std::string();
+    }
+
+    if (!tmp || !tmp->c_str()[0]) {
+        xsink->raiseException("I18N-LOCALE-ERROR", "%s cannot be empty", arg_name);
+        return std::string();
+    }
+
+    if (tmp->strlen() > 255) {
+        xsink->raiseException("I18N-LOCALE-ERROR", "%s is too long; maximum supported length is 255 bytes",
+            arg_name);
+        return std::string();
+    }
+
+    return tmp->c_str();
+}
+
+static bool i18n_qore_value_to_utf8_string(QoreValue value, std::string& out, ExceptionSink* xsink,
+        const char* arg_name) {
+    if (value.getType() != NT_STRING) {
+        xsink->raiseException("I18N-TYPE-ERROR", "%s must be a string; got type '%s'", arg_name, value.getTypeName());
+        return false;
+    }
+
+    QoreStringValueHelper str(value, QCS_UTF8, xsink);
+    if (*xsink) {
+        return false;
+    }
+
+    out = str->c_str();
+    return true;
+}
+
+static icu::Locale i18n_make_locale(const QoreStringNode* locale_arg, ExceptionSink* xsink) {
+    std::string tag = i18n_qore_string_to_utf8(locale_arg, xsink, "locale");
+    if (*xsink) {
+        return icu::Locale::getRoot();
+    }
+
+    std::replace(tag.begin(), tag.end(), '_', '-');
+    UErrorCode status = U_ZERO_ERROR;
+    icu::Locale locale = icu::Locale::forLanguageTag(icu::StringPiece(tag), status);
+    if (U_FAILURE(status) || locale.isBogus()) {
+        xsink->raiseException("I18N-LOCALE-ERROR", "invalid locale '%s': %s", tag.c_str(),
+            i18n_icu_error_name(status));
+        return icu::Locale::getRoot();
+    }
+
+    return locale;
+}
+
+static UPluralType i18n_get_plural_type(const QoreHashNode* opts, ExceptionSink* xsink) {
+    if (!opts) {
+        return UPLURAL_TYPE_CARDINAL;
+    }
+
+    QoreValue value = opts->getKeyValue("type");
+    if (value.isNullOrNothing()) {
+        return UPLURAL_TYPE_CARDINAL;
+    }
+
+    std::string type;
+    if (!i18n_qore_value_to_utf8_string(value, type, xsink, "opts.type")) {
+        return UPLURAL_TYPE_CARDINAL;
+    }
+
+    if (type == "cardinal") {
+        return UPLURAL_TYPE_CARDINAL;
+    }
+    if (type == "ordinal") {
+        return UPLURAL_TYPE_ORDINAL;
+    }
+
+    xsink->raiseException("I18N-PLURAL-TYPE-ERROR",
+        "unsupported plural type '%s'; expected 'cardinal' or 'ordinal'", type.c_str());
+    return UPLURAL_TYPE_CARDINAL;
+}
+
+static std::string i18n_select_plural_category(QoreValue value, const QoreStringNode* locale_arg,
+        const QoreHashNode* opts, ExceptionSink* xsink) {
+    I18nDecimalInfo decimal;
+    if (!i18n_value_to_decimal_info(value, decimal, xsink)) {
+        return std::string();
+    }
+
+    icu::Locale locale = i18n_make_locale(locale_arg, xsink);
+    if (*xsink) {
+        return std::string();
+    }
+
+    UPluralType type = i18n_get_plural_type(opts, xsink);
+    if (*xsink) {
+        return std::string();
+    }
+
+    UErrorCode status = U_ZERO_ERROR;
+    std::unique_ptr<icu::PluralRules> rules(icu::PluralRules::forLocale(locale, type, status));
+    if (U_FAILURE(status) || !rules) {
+        xsink->raiseException("I18N-ICU-ERROR", "cannot create plural rules for locale '%s': %s",
+            locale.getName(), i18n_icu_error_name(status));
+        return std::string();
+    }
+
+    icu::number::LocalizedNumberFormatter formatter = icu::number::NumberFormatter::with()
+        .precision(icu::number::Precision::fixedFraction(decimal.fraction_digits))
+        .locale(locale);
+    icu::number::FormattedNumber formatted = formatter.formatDecimal(icu::StringPiece(decimal.formatted), status);
+    if (U_FAILURE(status)) {
+        xsink->raiseException("I18N-ICU-ERROR", "cannot format plural operand '%s': %s",
+            decimal.formatted.c_str(), i18n_icu_error_name(status));
+        return std::string();
+    }
+
+    icu::UnicodeString keyword = rules->select(formatted, status);
+    if (U_FAILURE(status)) {
+        xsink->raiseException("I18N-ICU-ERROR", "cannot select plural category for '%s': %s",
+            decimal.formatted.c_str(), i18n_icu_error_name(status));
+        return std::string();
+    }
+
+    std::string rv;
+    keyword.toUTF8String(rv);
+    return rv;
+}
+
+static bool i18n_get_form_value(const QoreHashNode* forms, const char* key, std::string& out, ExceptionSink* xsink) {
+    QoreValue value = forms->getKeyValue(key);
+    if (value.isNullOrNothing()) {
+        return false;
+    }
+
+    return i18n_qore_value_to_utf8_string(value, out, xsink, key);
+}
+
+static QoreStringNode* i18n_select_plural_form(QoreValue value, const QoreStringNode* locale_arg,
+        const QoreHashNode* forms, const QoreHashNode* opts, ExceptionSink* xsink) {
+    if (!forms) {
+        xsink->raiseException("I18N-FORMS-ERROR", "forms cannot be NOTHING");
+        return nullptr;
+    }
+
+    I18nDecimalInfo decimal;
+    if (!i18n_value_to_decimal_info(value, decimal, xsink)) {
+        return nullptr;
+    }
+
+    size_t i = 0;
+    ConstHashIterator hi(forms);
+    while (hi.next()) {
+        if (i && !(i % 100) && qore_check_cancel(xsink, "checking plural forms")) {
+            return nullptr;
+        }
+        ++i;
+
+        const char* key = hi.getKey();
+        if (!key || !key[0]) {
+            xsink->raiseException("I18N-FORMS-ERROR", "forms cannot contain an empty key");
+            return nullptr;
+        }
+
+        std::string form_value;
+        if (!i18n_qore_value_to_utf8_string(hi.get(), form_value, xsink, key)) {
+            return nullptr;
+        }
+
+        if (key[0] == '=') {
+            I18nDecimalInfo exact;
+            if (!i18n_parse_decimal_string(key + 1, exact, xsink, "forms exact-value key")) {
+                return nullptr;
+            }
+            if (exact.canonical == decimal.canonical) {
+                return new QoreStringNode(form_value, QCS_UTF8);
+            }
+            continue;
+        }
+
+        const char* valid_categories[] = {"zero", "one", "two", "few", "many", "other"};
+        bool valid = false;
+        for (const char* category : valid_categories) {
+            if (!strcmp(key, category)) {
+                valid = true;
+                break;
+            }
+        }
+        if (!valid) {
+            xsink->raiseException("I18N-FORMS-ERROR",
+                "invalid plural form key '%s'; expected a CLDR category or exact key such as '=0'", key);
+            return nullptr;
+        }
+    }
+
+    std::string category = i18n_select_plural_category(value, locale_arg, opts, xsink);
+    if (*xsink) {
+        return nullptr;
+    }
+
+    std::string selected;
+    if (i18n_get_form_value(forms, category.c_str(), selected, xsink)) {
+        if (*xsink) {
+            return nullptr;
+        }
+        return new QoreStringNode(selected, QCS_UTF8);
+    }
+    if (*xsink) {
+        return nullptr;
+    }
+
+    if (!i18n_get_form_value(forms, "other", selected, xsink)) {
+        if (!*xsink) {
+            xsink->raiseException("I18N-FORMS-ERROR",
+                "forms must include an 'other' fallback when no exact-value key matches");
+        }
+        return nullptr;
+    }
+
+    return new QoreStringNode(selected, QCS_UTF8);
+}
+
+/** @defgroup i18n_functions I18n Functions
+ */
+///@{
+namespace Qore::I18n;
+
+//! Returns information about the locale-data backend used by the module.
+/** @return a hash with \c backend, \c icu_version, \c cldr_version, and \c catalog_schema_version keys
+
+    @par Example:
+    @code{.py}
+hash<auto> info = I18n::get_backend_info();
+printf("I18n backend: %s %s\n", info.backend, info.icu_version);
+    @endcode
+*/
+hash<auto> get_backend_info() [flags=CONSTANT] {
+    ReferenceHolder<QoreHashNode> h(new QoreHashNode(autoTypeInfo), xsink);
+    h->setKeyValue("backend", new QoreStringNode("icu", QCS_UTF8), xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    h->setKeyValue("icu_version", new QoreStringNode(i18n_get_icu_version_string(), QCS_UTF8), xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    UVersionInfo cldr_version;
+    UErrorCode status = U_ZERO_ERROR;
+    ulocdata_getCLDRVersion(cldr_version, &status);
+    h->setKeyValue("cldr_version",
+        new QoreStringNode(U_SUCCESS(status) ? i18n_version_to_string(cldr_version) : "unknown", QCS_UTF8), xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    h->setKeyValue("catalog_schema_version", 0, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    return h.release();
+}
+
+//! Returns the ICU library version used by the module.
+/** @return ICU version string, for example \c "78.2"
+
+    @par Example:
+    @code{.py}
+printf("ICU: %s\n", I18n::get_icu_version());
+    @endcode
+*/
+string get_icu_version() [flags=CONSTANT] {
+    return new QoreStringNode(i18n_get_icu_version_string(), QCS_UTF8);
+}
+
+//! Returns the CLDR data version used by ICU.
+/** @return CLDR version string
+
+    @throw I18N-ICU-ERROR if ICU does not expose the CLDR data version
+
+    @par Example:
+    @code{.py}
+printf("CLDR: %s\n", I18n::get_cldr_version());
+    @endcode
+*/
+string get_cldr_version() [flags=RET_VALUE_ONLY] {
+    std::string version = i18n_get_cldr_version_string(xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    return new QoreStringNode(version, QCS_UTF8);
+}
+
+//! Returns the CLDR plural category for a value and locale using cardinal rules.
+/** @param value integer, floating-point, number, or base-10 decimal string
+    @param locale BCP 47 locale tag, for example \c "en", \c "ru", or \c "ar"
+    @return one of \c "zero", \c "one", \c "two", \c "few", \c "many", or \c "other"
+
+    @throw I18N-NUMBER-ERROR if \a value is a malformed decimal string
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+    @throw I18N-ICU-ERROR if ICU cannot create or apply plural rules
+
+    @note String values preserve visible fraction digits, so \c "1", \c "1.0", and \c "1.00" can select different
+    categories in locales whose CLDR rules distinguish them.
+
+    @par Example:
+    @code{.py}
+assertEq("one", I18n::plural_category(1, "en"));
+assertEq("few", I18n::plural_category(2, "ru"));
+    @endcode
+*/
+string plural_category(auto value, string locale) [flags=RET_VALUE_ONLY] {
+    std::string category = i18n_select_plural_category(value, locale, nullptr, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    return new QoreStringNode(category, QCS_UTF8);
+}
+
+//! Returns the CLDR plural category for a value and locale.
+/** @param value integer, floating-point, number, or base-10 decimal string
+    @param locale BCP 47 locale tag, for example \c "en", \c "ru", or \c "ar"
+    @param opts optional hash; \c "type" may be \c "cardinal" or \c "ordinal"
+    @return one of \c "zero", \c "one", \c "two", \c "few", \c "many", or \c "other"
+
+    @throw I18N-NUMBER-ERROR if \a value is a malformed decimal string
+    @throw I18N-PLURAL-TYPE-ERROR if \c opts.type is unsupported
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+    @throw I18N-ICU-ERROR if ICU cannot create or apply plural rules
+
+    @par Example:
+    @code{.py}
+assertEq("one", I18n::plural_category(1, "en", {"type": "ordinal"}));
+assertEq("two", I18n::plural_category(2, "en", {"type": "ordinal"}));
+    @endcode
+*/
+string plural_category(auto value, string locale, *hash<auto> opts) [flags=RET_VALUE_ONLY] {
+    std::string category = i18n_select_plural_category(value, locale, opts, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    return new QoreStringNode(category, QCS_UTF8);
+}
+
+//! Selects a caller-supplied plural form using cardinal CLDR rules.
+/** @param value integer, floating-point, number, or base-10 decimal string
+    @param locale BCP 47 locale tag
+    @param forms hash keyed by CLDR plural category, with optional exact-value keys such as \c "=0" or \c "=1"
+    @return the selected form string; missing category keys fall back to \c "other"
+
+    @throw I18N-FORMS-ERROR if \a forms is invalid or does not include an \c "other" fallback
+    @throw I18N-NUMBER-ERROR if \a value or an exact-value key is malformed
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+    @throw I18N-ICU-ERROR if ICU cannot create or apply plural rules
+
+    @note This function only selects among forms supplied by the caller. A locale string alone cannot localize an
+    English two-form word pair into languages with more plural categories.
+
+    @par Example:
+    @code{.py}
+hash<auto> ru = {"one": "soubor", "few": "soubory", "many": "souboru", "other": "souboru"};
+printf("%d %s\n", n, I18n::plural_form(n, "cs", ru));
+    @endcode
+*/
+string plural_form(auto value, string locale, hash<auto> forms) [flags=RET_VALUE_ONLY] {
+    return i18n_select_plural_form(value, locale, forms, nullptr, xsink);
+}
+
+//! Selects a caller-supplied plural form using CLDR rules.
+/** @param value integer, floating-point, number, or base-10 decimal string
+    @param locale BCP 47 locale tag
+    @param forms hash keyed by CLDR plural category, with optional exact-value keys such as \c "=0" or \c "=1"
+    @param opts optional hash; \c "type" may be \c "cardinal" or \c "ordinal"
+    @return the selected form string; missing category keys fall back to \c "other"
+
+    @throw I18N-FORMS-ERROR if \a forms is invalid or does not include an \c "other" fallback
+    @throw I18N-NUMBER-ERROR if \a value or an exact-value key is malformed
+    @throw I18N-PLURAL-TYPE-ERROR if \c opts.type is unsupported
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+    @throw I18N-ICU-ERROR if ICU cannot create or apply plural rules
+
+    @note Exact-value keys take precedence over CLDR categories.
+
+    @par Example:
+    @code{.py}
+hash<auto> en_ordinal = {"one": "st", "two": "nd", "few": "rd", "other": "th"};
+printf("2%s\n", I18n::plural_form(2, "en", en_ordinal, {"type": "ordinal"}));
+    @endcode
+*/
+string plural_form(auto value, string locale, hash<auto> forms, *hash<auto> opts) [flags=RET_VALUE_ONLY] {
+    return i18n_select_plural_form(value, locale, forms, opts, xsink);
+}
+
+///@}

--- a/modules/i18n/src/ql_i18n.qpp
+++ b/modules/i18n/src/ql_i18n.qpp
@@ -326,7 +326,12 @@ static std::vector<std::string> i18n_locale_fallback_chain(const std::string& ra
 
     if (locale != "root") {
         chain.push_back(locale);
+        size_t count = 0;
         while (true) {
+            if (count && !(count % 100) && qore_check_cancel(xsink, "building locale fallback chain")) {
+                return chain;
+            }
+            ++count;
             size_t pos = locale.rfind('-');
             if (pos == std::string::npos) {
                 break;
@@ -337,6 +342,87 @@ static std::vector<std::string> i18n_locale_fallback_chain(const std::string& ra
     }
     chain.push_back("root");
     return chain;
+}
+
+static std::string i18n_add_likely_subtags_to_locale(const std::string& raw, ExceptionSink* xsink,
+        bool strip_extensions = false) {
+    std::string tag = i18n_canonicalize_locale_tag(raw, xsink, strip_extensions);
+    if (*xsink || tag == "root") {
+        return tag;
+    }
+
+    UErrorCode status = U_ZERO_ERROR;
+    icu::Locale locale = icu::Locale::forLanguageTag(icu::StringPiece(tag), status);
+    if (U_FAILURE(status) || locale.isBogus()) {
+        xsink->raiseException("I18N-LOCALE-ERROR", "invalid locale '%s': %s", raw.c_str(),
+            i18n_icu_error_name(status));
+        return std::string();
+    }
+
+    locale.addLikelySubtags(status);
+    if (U_FAILURE(status)) {
+        xsink->raiseException("I18N-LOCALE-ERROR", "cannot add likely subtags to locale '%s': %s", raw.c_str(),
+            i18n_icu_error_name(status));
+        return std::string();
+    }
+
+    std::string likely = locale.toLanguageTag<std::string>(status);
+    if (U_FAILURE(status)) {
+        xsink->raiseException("I18N-LOCALE-ERROR", "cannot canonicalize likely-subtag locale '%s': %s",
+            raw.c_str(), i18n_icu_error_name(status));
+        return std::string();
+    }
+    return strip_extensions ? i18n_strip_unicode_extensions(likely) : likely;
+}
+
+static void i18n_push_locale_candidate(std::vector<std::string>& candidates, const std::string& candidate,
+        bool include_root) {
+    if (candidate.empty() || (candidate == "root" && !include_root)
+        || std::find(candidates.begin(), candidates.end(), candidate) != candidates.end()) {
+        return;
+    }
+    candidates.push_back(candidate);
+}
+
+static std::vector<std::string> i18n_locale_lookup_candidates(const std::string& raw, ExceptionSink* xsink,
+        bool include_root) {
+    std::vector<std::string> candidates;
+    for (const std::string& candidate : i18n_locale_fallback_chain(raw, xsink)) {
+        if (*xsink) {
+            return candidates;
+        }
+        i18n_push_locale_candidate(candidates, candidate, include_root);
+    }
+
+    std::string likely = i18n_add_likely_subtags_to_locale(raw, xsink, true);
+    if (*xsink || likely == "root") {
+        return candidates;
+    }
+
+    UErrorCode status = U_ZERO_ERROR;
+    icu::Locale locale = icu::Locale::forLanguageTag(icu::StringPiece(likely), status);
+    if (U_FAILURE(status) || locale.isBogus()) {
+        xsink->raiseException("I18N-LOCALE-ERROR", "invalid likely-subtag locale '%s': %s", likely.c_str(),
+            i18n_icu_error_name(status));
+        return candidates;
+    }
+
+    const std::string language = locale.getLanguage();
+    const std::string script = locale.getScript();
+    const std::string region = locale.getCountry();
+
+    i18n_push_locale_candidate(candidates, likely, include_root);
+    if (!language.empty() && !region.empty()) {
+        i18n_push_locale_candidate(candidates, language + "-" + region, include_root);
+    }
+    if (!language.empty() && !script.empty()) {
+        i18n_push_locale_candidate(candidates, language + "-" + script, include_root);
+    }
+    if (!language.empty()) {
+        i18n_push_locale_candidate(candidates, language, include_root);
+    }
+
+    return candidates;
 }
 
 struct I18nLanguageRange {
@@ -499,12 +585,14 @@ static QoreStringNode* i18n_negotiate_locale(const QoreStringNode* header, const
             return new QoreStringNode(default_str, QCS_UTF8);
         }
 
-        for (const std::string& candidate : i18n_locale_fallback_chain(ranges[i].locale, xsink)) {
+        std::vector<std::string> candidates = i18n_locale_lookup_candidates(ranges[i].locale, xsink,
+            ranges[i].locale == "root");
+        if (*xsink) {
+            return nullptr;
+        }
+        for (const std::string& candidate : candidates) {
             if (*xsink) {
                 return nullptr;
-            }
-            if (candidate == "root" && ranges[i].locale != "root") {
-                continue;
             }
             auto match = available_map.find(candidate);
             if (match != available_map.end()) {
@@ -822,6 +910,29 @@ string canonicalize_locale(string locale) [flags=RET_VALUE_ONLY] {
     return new QoreStringNode(canonical, QCS_UTF8);
 }
 
+//! Returns the likely-subtag form of a locale tag.
+/** @param locale locale tag
+    @return canonical locale tag with likely language, script, and region subtags added
+
+    @throw I18N-LOCALE-ERROR if \a locale is invalid or ICU cannot maximize the locale
+
+    @par Example:
+    @code{.py}
+assertEq("sr-Cyrl-RS", I18n::add_likely_subtags("sr"));
+    @endcode
+*/
+string add_likely_subtags(string locale) [flags=RET_VALUE_ONLY] {
+    std::string tag = i18n_qore_string_to_utf8(locale, xsink, "locale");
+    if (*xsink) {
+        return QoreValue();
+    }
+    std::string likely = i18n_add_likely_subtags_to_locale(tag, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    return new QoreStringNode(likely, QCS_UTF8);
+}
+
 //! Returns the catalog fallback chain for a locale tag.
 /** Unicode formatting extensions are stripped from catalog identity.
 
@@ -843,6 +954,9 @@ list<string> get_locale_fallback_chain(string locale) [flags=RET_VALUE_ONLY] {
 
     ReferenceHolder<QoreListNode> rv(new QoreListNode(stringTypeInfo), xsink);
     for (size_t i = 0; i < chain.size(); ++i) {
+        if (i && !(i % 100) && qore_check_cancel(xsink, "returning locale fallback chain")) {
+            return QoreValue();
+        }
         rv->push(new QoreStringNode(chain[i], QCS_UTF8), xsink);
         if (*xsink) {
             return QoreValue();

--- a/modules/i18n/src/ql_i18n.qpp
+++ b/modules/i18n/src/ql_i18n.qpp
@@ -1155,6 +1155,70 @@ hash<auto> get_backend_info() [flags=CONSTANT] {
     return h.release();
 }
 
+//! Parses native catalog JSON data into a Qore catalog hash.
+/** The JSON data must be UTF-8 and must represent the schema-versioned native catalog shape consumed by
+    I18n::MessageCatalog. Catalog JSON is data only; it is parsed by this module and never evaluated as Qore code.
+
+    @param json UTF-8 JSON catalog data
+    @return native catalog hash suitable for I18n::MessageCatalog
+
+    @throw I18N-CATALOG-JSON-ERROR if \a json is malformed, not UTF-8, or does not contain a JSON object
+
+    @par Example:
+    @code{.py}
+hash<auto> catalog_data = I18n::parse_native_catalog_json(ReadOnlyFile::readTextFile("catalog.json"));
+I18n::MessageCatalog catalog(catalog_data);
+    @endcode
+*/
+hash<auto> parse_native_catalog_json(string json) [flags=RET_VALUE_ONLY] {
+    QoreHashNode* catalog = i18n_parse_native_catalog_json(json, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    return catalog;
+}
+
+//! Loads and parses a native catalog JSON file.
+/** Files are parsed as UTF-8 JSON and never evaluated as Qore code. The resulting hash is still validated by
+    I18n::MessageCatalog construction.
+
+    @param path catalog JSON file path
+    @return native catalog hash suitable for I18n::MessageCatalog
+
+    @throw FILE-READ-ERROR if the file cannot be read
+    @throw I18N-CATALOG-ERROR if the file exceeds the default size limit
+    @throw I18N-CATALOG-JSON-ERROR if the file is not valid native catalog JSON
+
+    @par Example:
+    @code{.py}
+I18n::MessageCatalog catalog(I18n::load_native_catalog("catalog.json"));
+    @endcode
+*/
+hash<auto> load_native_catalog(string path) [dom=FILESYSTEM] {
+    QoreHashNode* catalog = i18n_load_native_catalog_json(path, -1, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    return catalog;
+}
+
+//! Loads and parses a native catalog JSON file with an explicit maximum file size.
+/** @param path catalog JSON file path
+    @param max_file_len maximum accepted file size in bytes
+    @return native catalog hash suitable for I18n::MessageCatalog
+
+    @throw FILE-READ-ERROR if the file cannot be read
+    @throw I18N-CATALOG-ERROR if \a max_file_len is invalid or the file exceeds it
+    @throw I18N-CATALOG-JSON-ERROR if the file is not valid native catalog JSON
+*/
+hash<auto> load_native_catalog(string path, int max_file_len) [dom=FILESYSTEM] {
+    QoreHashNode* catalog = i18n_load_native_catalog_json(path, max_file_len, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    return catalog;
+}
+
 //! Returns the ICU library version used by the module.
 /** @return ICU version string, for example \c "78.2"
 

--- a/modules/i18n/src/ql_i18n.qpp
+++ b/modules/i18n/src/ql_i18n.qpp
@@ -537,6 +537,10 @@ static std::vector<I18nLanguageRange> i18n_parse_accept_language_header(const st
                 std::string params = item.substr(semi + 1);
                 size_t pstart = 0;
                 while (pstart <= params.size()) {
+                    if (pstart && !(pstart % 100) && qore_check_cancel(xsink,
+                            "parsing Accept-Language parameters")) {
+                        return ranges;
+                    }
                     size_t psemi = params.find(';', pstart);
                     std::string raw_param = params.substr(pstart,
                         psemi == std::string::npos ? std::string::npos : psemi - pstart);
@@ -833,6 +837,10 @@ static std::vector<std::string> i18n_discover_catalog_files(const std::string& d
         }
 
         for (size_t l = 0; l < locales.size(); ++l) {
+            if (l && !(l % 100) && qore_check_cancel(xsink, "checking i18n catalog locale candidates")) {
+                return files;
+            }
+
             const std::string rels[] = {
                 domain + "/" + locales[l] + ".json",
                 domain + "." + locales[l] + ".json",

--- a/modules/i18n/src/ql_i18n.qpp
+++ b/modules/i18n/src/ql_i18n.qpp
@@ -41,6 +41,8 @@
 #include <memory>
 #include <string>
 
+static constexpr int64 I18N_CATALOG_SCHEMA_VERSION = 1;
+
 static const char* i18n_icu_error_name(UErrorCode status) {
     return u_errorName(status);
 }
@@ -482,7 +484,7 @@ hash<auto> get_backend_info() [flags=CONSTANT] {
     if (*xsink) {
         return QoreValue();
     }
-    h->setKeyValue("catalog_schema_version", 0, xsink);
+    h->setKeyValue("catalog_schema_version", I18N_CATALOG_SCHEMA_VERSION, xsink);
     if (*xsink) {
         return QoreValue();
     }
@@ -517,6 +519,18 @@ string get_cldr_version() [flags=RET_VALUE_ONLY] {
         return QoreValue();
     }
     return new QoreStringNode(version, QCS_UTF8);
+}
+
+//! Returns the native message catalog schema version supported by this module.
+/** @return catalog schema version number
+
+    @par Example:
+    @code{.py}
+assertEq(1, I18n::get_catalog_schema_version());
+    @endcode
+*/
+int get_catalog_schema_version() [flags=CONSTANT] {
+    return I18N_CATALOG_SCHEMA_VERSION;
 }
 
 //! Returns the CLDR plural category for a value and locale using cardinal rules.

--- a/modules/i18n/src/ql_i18n.qpp
+++ b/modules/i18n/src/ql_i18n.qpp
@@ -94,6 +94,34 @@ static bool i18n_is_ascii_space(char c) {
     return std::isspace(static_cast<unsigned char>(c)) != 0;
 }
 
+static bool i18n_parse_accept_language_qvalue(const std::string& text, double& q) {
+    if (text.empty() || (text[0] != '0' && text[0] != '1')) {
+        return false;
+    }
+
+    size_t pos = 1;
+    if (pos < text.size()) {
+        if (text[pos] != '.') {
+            return false;
+        }
+        ++pos;
+        size_t digits = 0;
+        while (pos < text.size() && std::isdigit(static_cast<unsigned char>(text[pos]))) {
+            if (text[0] == '1' && text[pos] != '0') {
+                return false;
+            }
+            ++digits;
+            ++pos;
+        }
+        if (digits > 3 || pos != text.size()) {
+            return false;
+        }
+    }
+
+    q = q_strtod(text.c_str());
+    return q >= 0.0 && q <= 1.0;
+}
+
 static bool i18n_trim_ascii(const std::string& s, std::string& out, ExceptionSink* xsink) {
     size_t start = 0;
     while (start < s.size() && i18n_is_ascii_space(s[start])) {
@@ -550,11 +578,10 @@ static std::vector<I18nLanguageRange> i18n_parse_accept_language_header(const st
                         return ranges;
                     }
                     if (param.size() >= 2 && param[0] == 'q' && param[1] == '=') {
-                        char* end = nullptr;
-                        range.q = std::strtod(param.c_str() + 2, &end);
-                        if (!end || *end || range.q < 0.0 || range.q > 1.0) {
+                        std::string qtext = param.substr(2);
+                        if (!i18n_parse_accept_language_qvalue(qtext, range.q)) {
                             xsink->raiseException("I18N-ACCEPT-LANGUAGE-ERROR",
-                                "invalid q value '%s' in Accept-Language header", param.c_str() + 2);
+                                "invalid q value '%s' in Accept-Language header", qtext.c_str());
                             return ranges;
                         }
                     }

--- a/modules/i18n/src/ql_i18n.qpp
+++ b/modules/i18n/src/ql_i18n.qpp
@@ -53,6 +53,8 @@
 
 static constexpr int64 I18N_CATALOG_SCHEMA_VERSION = 1;
 
+static thread_local std::string i18n_thread_locale;
+
 static const char* i18n_icu_error_name(UErrorCode status) {
     return u_errorName(status);
 }
@@ -1239,6 +1241,43 @@ string add_likely_subtags(string locale) [flags=RET_VALUE_ONLY] {
         return QoreValue();
     }
     return new QoreStringNode(likely, QCS_UTF8);
+}
+
+//! Sets the current thread's ambient i18n locale.
+/** Explicit-locale APIs should be preferred for stable behavior. The ambient locale is intended for request or task
+    context integration and is not propagated through raw queue handoff by this module.
+
+    @param locale BCP 47 locale tag
+
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+*/
+nothing set_thread_locale(string locale) [dom=LOCALE_CONTROL] {
+    std::string tag = i18n_qore_string_to_utf8(locale, xsink, "locale");
+    if (*xsink) {
+        return QoreValue();
+    }
+    std::string canonical = i18n_canonicalize_locale_tag(tag, xsink, true);
+    if (*xsink) {
+        return QoreValue();
+    }
+    i18n_thread_locale = canonical;
+}
+
+//! Returns the current thread's ambient i18n locale.
+/** @return the current thread locale, or \c "root" if none has been set
+
+    @note Raw \c Queue handoff does not propagate this ambient locale; pass an explicit context object or locale string
+    across queue boundaries.
+*/
+string get_thread_locale() [flags=RET_VALUE_ONLY] {
+    return new QoreStringNode(i18n_thread_locale.empty() ? "root" : i18n_thread_locale, QCS_UTF8);
+}
+
+//! Clears the current thread's ambient i18n locale.
+/** After this call, I18n::get_thread_locale() returns \c "root".
+*/
+nothing clear_thread_locale() [dom=LOCALE_CONTROL] {
+    i18n_thread_locale.clear();
 }
 
 //! Returns the catalog fallback chain for a locale tag.

--- a/modules/i18n/src/ql_i18n.qpp
+++ b/modules/i18n/src/ql_i18n.qpp
@@ -38,8 +38,11 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdlib>
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 static constexpr int64 I18N_CATALOG_SCHEMA_VERSION = 1;
 
@@ -93,6 +96,15 @@ static bool i18n_trim_ascii(const std::string& s, std::string& out, ExceptionSin
     }
 
     out = s.substr(start, end - start);
+    return true;
+}
+
+static bool i18n_check_locale_length(const std::string& locale, ExceptionSink* xsink, const char* arg_name) {
+    if (locale.size() > 255) {
+        xsink->raiseException("I18N-LOCALE-ERROR", "%s is too long; maximum supported length is 255 bytes",
+            arg_name);
+        return false;
+    }
     return true;
 }
 
@@ -241,13 +253,267 @@ static std::string i18n_qore_string_to_utf8(const QoreStringNode* str, Exception
         return std::string();
     }
 
-    if (tmp->strlen() > 255) {
-        xsink->raiseException("I18N-LOCALE-ERROR", "%s is too long; maximum supported length is 255 bytes",
-            arg_name);
+    std::string rv = tmp->c_str();
+    if (!i18n_check_locale_length(rv, xsink, arg_name)) {
         return std::string();
     }
 
+    return rv;
+}
+
+static std::string i18n_accept_language_to_utf8(const QoreStringNode* str, ExceptionSink* xsink) {
+    TempEncodingHelper tmp(str, QCS_UTF8, xsink);
+    if (*xsink) {
+        return std::string();
+    }
+    if (!tmp) {
+        xsink->raiseException("I18N-ACCEPT-LANGUAGE-ERROR",
+            "Accept-Language header could not be converted to UTF-8");
+        return std::string();
+    }
+    if (tmp->strlen() > 8192) {
+        xsink->raiseException("I18N-ACCEPT-LANGUAGE-ERROR",
+            "Accept-Language header is too long; maximum supported length is 8192 bytes");
+        return std::string();
+    }
     return tmp->c_str();
+}
+
+static std::string i18n_strip_unicode_extensions(const std::string& locale) {
+    std::string lower = locale;
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    size_t ext = lower.find("-u-");
+    return ext == std::string::npos ? locale : locale.substr(0, ext);
+}
+
+static std::string i18n_canonicalize_locale_tag(const std::string& raw, ExceptionSink* xsink,
+        bool strip_extensions = false) {
+    std::string tag = raw.empty() ? "root" : raw;
+    if (tag == "root") {
+        return tag;
+    }
+    if (!i18n_check_locale_length(tag, xsink, "locale")) {
+        return std::string();
+    }
+
+    std::replace(tag.begin(), tag.end(), '_', '-');
+    UErrorCode status = U_ZERO_ERROR;
+    icu::Locale locale = icu::Locale::forLanguageTag(icu::StringPiece(tag), status);
+    if (U_FAILURE(status) || locale.isBogus()) {
+        xsink->raiseException("I18N-LOCALE-ERROR", "invalid locale '%s': %s", raw.c_str(),
+            i18n_icu_error_name(status));
+        return std::string();
+    }
+
+    std::string canonical = locale.toLanguageTag<std::string>(status);
+    if (U_FAILURE(status)) {
+        xsink->raiseException("I18N-LOCALE-ERROR", "cannot canonicalize locale '%s': %s", raw.c_str(),
+            i18n_icu_error_name(status));
+        return std::string();
+    }
+
+    return strip_extensions ? i18n_strip_unicode_extensions(canonical) : canonical;
+}
+
+static std::vector<std::string> i18n_locale_fallback_chain(const std::string& raw, ExceptionSink* xsink) {
+    std::vector<std::string> chain;
+    std::string locale = i18n_canonicalize_locale_tag(raw, xsink, true);
+    if (*xsink) {
+        return chain;
+    }
+
+    if (locale != "root") {
+        chain.push_back(locale);
+        while (true) {
+            size_t pos = locale.rfind('-');
+            if (pos == std::string::npos) {
+                break;
+            }
+            locale.resize(pos);
+            chain.push_back(locale);
+        }
+    }
+    chain.push_back("root");
+    return chain;
+}
+
+struct I18nLanguageRange {
+    std::string locale;
+    double q = 1.0;
+    int64 index = 0;
+    bool wildcard = false;
+};
+
+static std::vector<I18nLanguageRange> i18n_parse_accept_language_header(const std::string& header,
+        ExceptionSink* xsink) {
+    std::vector<I18nLanguageRange> ranges;
+    if (header.size() > 8192) {
+        xsink->raiseException("I18N-ACCEPT-LANGUAGE-ERROR",
+            "Accept-Language header is too long; maximum supported length is 8192 bytes");
+        return ranges;
+    }
+
+    size_t start = 0;
+    int64 index = 0;
+    while (start <= header.size()) {
+        if (start && !(start % 100) && qore_check_cancel(xsink, "parsing Accept-Language header")) {
+            return ranges;
+        }
+
+        size_t comma = header.find(',', start);
+        std::string raw_item = header.substr(start, comma == std::string::npos ? std::string::npos : comma - start);
+        std::string item;
+        if (!i18n_trim_ascii(raw_item, item, xsink)) {
+            return ranges;
+        }
+
+        if (!item.empty()) {
+            if (ranges.size() >= 100) {
+                xsink->raiseException("I18N-ACCEPT-LANGUAGE-ERROR",
+                    "Accept-Language header has too many language ranges; maximum supported count is 100");
+                return ranges;
+            }
+
+            size_t semi = item.find(';');
+            std::string range_text;
+            if (!i18n_trim_ascii(item.substr(0, semi), range_text, xsink)) {
+                return ranges;
+            }
+            if (range_text.empty()) {
+                xsink->raiseException("I18N-ACCEPT-LANGUAGE-ERROR", "empty language range in Accept-Language header");
+                return ranges;
+            }
+
+            I18nLanguageRange range;
+            range.index = index++;
+            range.wildcard = range_text == "*";
+            if (range.wildcard) {
+                range.locale = "*";
+            } else {
+                range.locale = i18n_canonicalize_locale_tag(range_text, xsink, true);
+                if (*xsink) {
+                    return ranges;
+                }
+            }
+
+            if (semi != std::string::npos) {
+                std::string params = item.substr(semi + 1);
+                size_t pstart = 0;
+                while (pstart <= params.size()) {
+                    size_t psemi = params.find(';', pstart);
+                    std::string raw_param = params.substr(pstart,
+                        psemi == std::string::npos ? std::string::npos : psemi - pstart);
+                    std::string param;
+                    if (!i18n_trim_ascii(raw_param, param, xsink)) {
+                        return ranges;
+                    }
+                    if (param.size() >= 2 && param[0] == 'q' && param[1] == '=') {
+                        char* end = nullptr;
+                        range.q = std::strtod(param.c_str() + 2, &end);
+                        if (!end || *end || range.q < 0.0 || range.q > 1.0) {
+                            xsink->raiseException("I18N-ACCEPT-LANGUAGE-ERROR",
+                                "invalid q value '%s' in Accept-Language header", param.c_str() + 2);
+                            return ranges;
+                        }
+                    }
+                    if (psemi == std::string::npos) {
+                        break;
+                    }
+                    pstart = psemi + 1;
+                }
+            }
+
+            if (range.q > 0.0) {
+                ranges.push_back(std::move(range));
+            }
+        }
+
+        if (comma == std::string::npos) {
+            break;
+        }
+        start = comma + 1;
+    }
+
+    std::stable_sort(ranges.begin(), ranges.end(), [](const I18nLanguageRange& a, const I18nLanguageRange& b) {
+        if (a.q == b.q) {
+            return a.index < b.index;
+        }
+        return a.q > b.q;
+    });
+
+    return ranges;
+}
+
+static QoreStringNode* i18n_negotiate_locale(const QoreStringNode* header, const QoreListNode* available,
+        const QoreStringNode* default_locale, ExceptionSink* xsink) {
+    std::string header_str = i18n_accept_language_to_utf8(header, xsink);
+    if (*xsink) {
+        return nullptr;
+    }
+
+    std::string default_str = "root";
+    if (default_locale) {
+        default_str = i18n_qore_string_to_utf8(default_locale, xsink, "default_locale");
+        if (*xsink) {
+            return nullptr;
+        }
+        default_str = i18n_canonicalize_locale_tag(default_str, xsink, true);
+        if (*xsink) {
+            return nullptr;
+        }
+    }
+
+    std::unordered_map<std::string, std::string> available_map;
+    for (size_t i = 0; i < available->size(); ++i) {
+        if (i && !(i % 100) && qore_check_cancel(xsink, "checking available locales")) {
+            return nullptr;
+        }
+        QoreStringValueHelper value(available->retrieveEntry(i), QCS_UTF8, xsink);
+        if (*xsink) {
+            return nullptr;
+        }
+        std::string locale = i18n_canonicalize_locale_tag(value->c_str(), xsink, true);
+        if (*xsink) {
+            return nullptr;
+        }
+        available_map.emplace(locale, locale);
+    }
+
+    std::vector<I18nLanguageRange> ranges = i18n_parse_accept_language_header(header_str, xsink);
+    if (*xsink) {
+        return nullptr;
+    }
+
+    for (size_t i = 0; i < ranges.size(); ++i) {
+        if (i && !(i % 100) && qore_check_cancel(xsink, "negotiating locale")) {
+            return nullptr;
+        }
+
+        if (ranges[i].wildcard) {
+            auto def = available_map.find(default_str);
+            if (def != available_map.end()) {
+                return new QoreStringNode(def->second, QCS_UTF8);
+            }
+            return new QoreStringNode(default_str, QCS_UTF8);
+        }
+
+        for (const std::string& candidate : i18n_locale_fallback_chain(ranges[i].locale, xsink)) {
+            if (*xsink) {
+                return nullptr;
+            }
+            if (candidate == "root" && ranges[i].locale != "root") {
+                continue;
+            }
+            auto match = available_map.find(candidate);
+            if (match != available_map.end()) {
+                return new QoreStringNode(match->second, QCS_UTF8);
+            }
+        }
+    }
+
+    return new QoreStringNode(default_str, QCS_UTF8);
 }
 
 static bool i18n_qore_value_to_utf8_string(QoreValue value, std::string& out, ExceptionSink* xsink,
@@ -531,6 +797,121 @@ assertEq(1, I18n::get_catalog_schema_version());
 */
 int get_catalog_schema_version() [flags=CONSTANT] {
     return I18N_CATALOG_SCHEMA_VERSION;
+}
+
+//! Returns the canonical BCP 47 form of a locale tag.
+/** @param locale locale tag such as \c "en_US" or \c "iw"
+    @return canonical BCP 47 locale tag
+
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+
+    @par Example:
+    @code{.py}
+assertEq("en-US", I18n::canonicalize_locale("en_US"));
+    @endcode
+*/
+string canonicalize_locale(string locale) [flags=RET_VALUE_ONLY] {
+    std::string tag = i18n_qore_string_to_utf8(locale, xsink, "locale");
+    if (*xsink) {
+        return QoreValue();
+    }
+    std::string canonical = i18n_canonicalize_locale_tag(tag, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    return new QoreStringNode(canonical, QCS_UTF8);
+}
+
+//! Returns the catalog fallback chain for a locale tag.
+/** Unicode formatting extensions are stripped from catalog identity.
+
+    @param locale locale tag
+    @return fallback chain such as \c ("fr-CA", "fr", "root")
+
+    @throw I18N-LOCALE-ERROR if \a locale is invalid
+*/
+list<string> get_locale_fallback_chain(string locale) [flags=RET_VALUE_ONLY] {
+    std::string tag = i18n_qore_string_to_utf8(locale, xsink, "locale");
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    std::vector<std::string> chain = i18n_locale_fallback_chain(tag, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(stringTypeInfo), xsink);
+    for (size_t i = 0; i < chain.size(); ++i) {
+        rv->push(new QoreStringNode(chain[i], QCS_UTF8), xsink);
+        if (*xsink) {
+            return QoreValue();
+        }
+    }
+    return rv.release();
+}
+
+//! Parses an HTTP Accept-Language header.
+/** @param header Accept-Language header value
+    @return list of hashes sorted by preference; each hash has \c locale, \c q, \c index, and \c wildcard keys
+
+    @throw I18N-ACCEPT-LANGUAGE-ERROR if \a header is malformed
+    @throw I18N-LOCALE-ERROR if a language range is invalid
+*/
+list<hash<auto>> parse_accept_language(string header) [flags=RET_VALUE_ONLY] {
+    std::string header_str = i18n_accept_language_to_utf8(header, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    std::vector<I18nLanguageRange> ranges = i18n_parse_accept_language_header(header_str, xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(autoTypeInfo), xsink);
+    for (size_t i = 0; i < ranges.size(); ++i) {
+        if (i && !(i % 100) && qore_check_cancel(xsink, "returning Accept-Language ranges")) {
+            return QoreValue();
+        }
+        ReferenceHolder<QoreHashNode> h(new QoreHashNode(autoTypeInfo), xsink);
+        h->setKeyValue("locale", new QoreStringNode(ranges[i].locale, QCS_UTF8), xsink);
+        if (*xsink) return QoreValue();
+        h->setKeyValue("q", ranges[i].q, xsink);
+        if (*xsink) return QoreValue();
+        h->setKeyValue("index", ranges[i].index, xsink);
+        if (*xsink) return QoreValue();
+        h->setKeyValue("wildcard", ranges[i].wildcard, xsink);
+        if (*xsink) return QoreValue();
+        rv->push(h.release(), xsink);
+        if (*xsink) return QoreValue();
+    }
+    return rv.release();
+}
+
+//! Negotiates an effective locale from an HTTP Accept-Language header.
+/** @param header Accept-Language header value
+    @param available available catalog locales
+    @return best matching locale, or \c "root" if no match is found
+
+    @throw I18N-ACCEPT-LANGUAGE-ERROR if \a header is malformed
+    @throw I18N-LOCALE-ERROR if a language range or available locale is invalid
+*/
+string negotiate_locale(string header, list<string> available) [flags=RET_VALUE_ONLY] {
+    return i18n_negotiate_locale(header, available, nullptr, xsink);
+}
+
+//! Negotiates an effective locale from an HTTP Accept-Language header.
+/** @param header Accept-Language header value
+    @param available available catalog locales
+    @param default_locale default locale returned when no language range matches
+    @return best matching locale, or \a default_locale if no match is found
+
+    @throw I18N-ACCEPT-LANGUAGE-ERROR if \a header is malformed
+    @throw I18N-LOCALE-ERROR if a language range, available locale, or default locale is invalid
+*/
+string negotiate_locale(string header, list<string> available, string default_locale) [flags=RET_VALUE_ONLY] {
+    return i18n_negotiate_locale(header, available, default_locale, xsink);
 }
 
 //! Returns the CLDR plural category for a value and locale using cardinal rules.

--- a/modules/i18n/src/ql_i18n.qpp
+++ b/modules/i18n/src/ql_i18n.qpp
@@ -1099,6 +1099,35 @@ static bool i18n_get_datetime_style(const QoreHashNode* opts, const char* key, i
     return true;
 }
 
+static bool i18n_get_optional_datetime_skeleton(const QoreHashNode* opts, std::string& skeleton, bool& present,
+        ExceptionSink* xsink) {
+    present = false;
+    if (!opts) {
+        return true;
+    }
+
+    QoreValue value = opts->getKeyValue("skeleton");
+    if (value.isNullOrNothing()) {
+        return true;
+    }
+    if (!i18n_qore_value_to_utf8_string(value, skeleton, xsink, "skeleton")) {
+        return false;
+    }
+    if (skeleton.empty() || skeleton.size() > 128) {
+        xsink->raiseException("I18N-FORMAT-ERROR",
+            "opts.skeleton must be between 1 and 128 bytes");
+        return false;
+    }
+    if (!opts->getKeyValue("date_style").isNullOrNothing() || !opts->getKeyValue("time_style").isNullOrNothing()) {
+        xsink->raiseException("I18N-FORMAT-ERROR",
+            "opts.skeleton cannot be combined with opts.date_style or opts.time_style");
+        return false;
+    }
+
+    present = true;
+    return true;
+}
+
 static std::string i18n_get_datetime_timezone_id(const DateTimeNode* dt) {
     const AbstractQoreZoneInfo* zone = dt->getZone();
     if (!zone) {
@@ -1121,24 +1150,41 @@ static QoreStringNode* i18n_format_datetime_value(const DateTimeNode* dt, const 
         return nullptr;
     }
 
-    icu::DateFormat::EStyle date_style;
-    icu::DateFormat::EStyle time_style;
-    if (!i18n_get_datetime_style(opts, "date_style", icu::DateFormat::kMedium, date_style, xsink)
-        || !i18n_get_datetime_style(opts, "time_style", icu::DateFormat::kShort, time_style, xsink)) {
-        return nullptr;
-    }
-    if (date_style == icu::DateFormat::kNone && time_style == icu::DateFormat::kNone) {
-        xsink->raiseException("I18N-FORMAT-ERROR", "date_style and time_style cannot both be 'none'");
-        return nullptr;
-    }
-
     icu::Locale locale = i18n_make_locale(locale_arg, xsink);
     if (*xsink) {
         return nullptr;
     }
 
-    std::unique_ptr<icu::DateFormat> formatter(icu::DateFormat::createDateTimeInstance(date_style, time_style,
-        locale));
+    std::unique_ptr<icu::DateFormat> formatter;
+    std::string skeleton;
+    bool has_skeleton = false;
+    if (!i18n_get_optional_datetime_skeleton(opts, skeleton, has_skeleton, xsink)) {
+        return nullptr;
+    }
+
+    if (has_skeleton) {
+        UErrorCode status = U_ZERO_ERROR;
+        icu::UnicodeString skeleton_u = icu::UnicodeString::fromUTF8(icu::StringPiece(skeleton));
+        formatter.reset(icu::DateFormat::createInstanceForSkeleton(skeleton_u, locale, status));
+        if (U_FAILURE(status)) {
+            xsink->raiseException("I18N-ICU-ERROR", "cannot create date/time skeleton formatter '%s' for locale '%s': %s",
+                skeleton.c_str(), locale.getName(), i18n_icu_error_name(status));
+            return nullptr;
+        }
+    } else {
+        icu::DateFormat::EStyle date_style;
+        icu::DateFormat::EStyle time_style;
+        if (!i18n_get_datetime_style(opts, "date_style", icu::DateFormat::kMedium, date_style, xsink)
+            || !i18n_get_datetime_style(opts, "time_style", icu::DateFormat::kShort, time_style, xsink)) {
+            return nullptr;
+        }
+        if (date_style == icu::DateFormat::kNone && time_style == icu::DateFormat::kNone) {
+            xsink->raiseException("I18N-FORMAT-ERROR", "date_style and time_style cannot both be 'none'");
+            return nullptr;
+        }
+
+        formatter.reset(icu::DateFormat::createDateTimeInstance(date_style, time_style, locale));
+    }
     if (!formatter) {
         xsink->raiseException("I18N-ICU-ERROR", "cannot create date/time formatter for locale '%s'",
             locale.getName());
@@ -1779,7 +1825,7 @@ string format_datetime(date dt, string locale) [flags=RET_VALUE_ONLY] {
 /** @param dt absolute date/time value
     @param locale BCP 47 locale tag, including supported calendar/hour-cycle extensions
     @param opts optional hash; \c date_style and \c time_style may be \c "none", \c "short", \c "medium", \c "long",
-        or \c "full"
+        or \c "full"; alternatively pass \c skeleton for CLDR skeleton formatting such as \c "yMMMd"
     @return locale-formatted date/time
 
     @throw I18N-DATETIME-ERROR if \a dt is relative

--- a/modules/i18n/test/i18n.qtest
+++ b/modules/i18n/test/i18n.qtest
@@ -33,6 +33,7 @@ class I18nTest inherits QUnit::Test {
         addTestCase("message catalog layer precedence", \messageCatalogLayerPrecedenceTest());
         addTestCase("message catalog JSON file loading", \messageCatalogJsonFileLoadingTest());
         addTestCase("message catalog JSON validation", \messageCatalogJsonValidationTest());
+        addTestCase("message catalog discovery", \messageCatalogDiscoveryTest());
         addTestCase("message catalog validation", \messageCatalogValidationTest());
 
         set_return_value(main());
@@ -313,6 +314,13 @@ class I18nTest inherits QUnit::Test {
             "}\n";
     }
 
+    private nothing writeTextFile(string path, string data) {
+        File f();
+        f.open2(path, O_CREAT | O_WRONLY | O_TRUNC);
+        f.write(data);
+        f.close();
+    }
+
     messageCatalogLookupTest() {
 %ifdef NoI18n
         testSkip("i18n module not available");
@@ -447,6 +455,45 @@ class I18nTest inherits QUnit::Test {
         bad.file.close();
         assertThrows("I18N-CATALOG-JSON-ERROR", auto sub() {
             return new I18n::MessageCatalog(bad.path);
+        });
+    }
+
+    messageCatalogDiscoveryTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        string base_dir = make_tmp_dir("qore-i18n-base-");
+        string override_dir = make_tmp_dir("qore-i18n-override-");
+        on_exit remove_tree(base_dir);
+        on_exit remove_tree(override_dir);
+
+        mkdir(base_dir + "/billing");
+        mkdir(override_dir + "/billing");
+
+        string base_root = base_dir + "/billing/root.json";
+        string base_cs = base_dir + "/billing/cs.json";
+        string override_cs = override_dir + "/billing/cs.json";
+        writeTextFile(base_root, createCatalogJson("Root"));
+        writeTextFile(base_cs, createCatalogJson("Ahoj"));
+        writeTextFile(override_cs, createCatalogJson("Cau"));
+
+        list<string> search_path = I18n::get_catalog_search_path({
+            "search_path": (base_dir,),
+            "override_path": override_dir,
+        });
+        assertEq((base_dir, override_dir), search_path);
+
+        list<string> files = I18n::discover_catalog_files("billing", "cs-CZ", {
+            "search_path": (base_dir,),
+            "override_path": override_dir,
+        });
+        assertEq((base_root, base_cs, override_cs), files);
+
+        I18n::MessageCatalog catalog(files);
+        assertEq("Cau, Eva", catalog.t("Hello, {name}", "cs", {"name": "Eva"}));
+
+        assertThrows("I18N-CATALOG-ERROR", auto sub() {
+            return I18n::discover_catalog_files("../billing", "cs", {"search_path": (base_dir,)});
         });
     }
 

--- a/modules/i18n/test/i18n.qtest
+++ b/modules/i18n/test/i18n.qtest
@@ -29,6 +29,7 @@ class I18nTest inherits QUnit::Test {
         addTestCase("plural validation errors", \validationErrorTest());
         addTestCase("message catalog lookup", \messageCatalogLookupTest());
         addTestCase("message catalog plural lookup", \messageCatalogPluralLookupTest());
+        addTestCase("message catalog bidi isolation", \messageCatalogBidiIsolationTest());
         addTestCase("message catalog state policy", \messageCatalogStatePolicyTest());
         addTestCase("message catalog layer precedence", \messageCatalogLayerPrecedenceTest());
         addTestCase("message catalog JSON file loading", \messageCatalogJsonFileLoadingTest());
@@ -369,6 +370,16 @@ class I18nTest inherits QUnit::Test {
         assertEq("2 files", catalog.tn(2, "1 file", "{count} files", "de"));
         assertEq("1 file", catalog.tn(1, "1 file", "{count} files", "de"));
         assertEq("1.0 files", catalog.tn("1.0", "1 file", "{count} files", "de"));
+    }
+
+    messageCatalogBidiIsolationTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        I18n::MessageCatalog catalog(createCatalog());
+
+        assertEq("Hello, \u2068Sam\u2069", catalog.t("Hello, {name}", "ar", {"name": "Sam"}));
+        assertEq("\u20682\u2069 files", catalog.tn(2, "1 file", "{count} files", "ar"));
     }
 
     messageCatalogStatePolicyTest() {

--- a/modules/i18n/test/i18n.qtest
+++ b/modules/i18n/test/i18n.qtest
@@ -1,0 +1,146 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+/*  i18n.qtest Copyright 2026 Qore Technologies, s.r.o.
+    MIT License
+*/
+
+%modern
+
+%requires ../../../qlib/QUnit.qm
+
+%try-module i18n
+%define NoI18n
+%endtry
+
+%exec-class I18nTest
+
+class I18nTest inherits QUnit::Test {
+    constructor() : Test("I18nTest", "1.0") {
+        addTestCase("backend version introspection", \backendInfoTest());
+        addTestCase("cardinal plural categories", \cardinalPluralCategoryTest());
+        addTestCase("visible fraction digits", \visibleFractionDigitsTest());
+        addTestCase("ordinal plural categories", \ordinalPluralCategoryTest());
+        addTestCase("plural form selection", \pluralFormTest());
+        addTestCase("plural validation errors", \validationErrorTest());
+
+        set_return_value(main());
+    }
+
+    backendInfoTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        hash<auto> info = I18n::get_backend_info();
+        assertEq("icu", info.backend);
+        assertRegex("^[0-9]+\\.[0-9]+", info.icu_version);
+        assertRegex("^[0-9]+\\.[0-9]+", I18n::get_icu_version());
+        assertRegex("^[0-9]+\\.[0-9]+", info.cldr_version);
+        assertEq(I18n::get_cldr_version(), info.cldr_version);
+        assertEq(0, info.catalog_schema_version);
+    }
+
+    cardinalPluralCategoryTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        assertEq("one", I18n::plural_category(1, "en"));
+        assertEq("other", I18n::plural_category(2, "en"));
+
+        assertEq("other", I18n::plural_category(1, "ja"));
+        assertEq("other", I18n::plural_category(2, "zh"));
+
+        assertEq("one", I18n::plural_category(1, "ru"));
+        assertEq("few", I18n::plural_category(2, "ru"));
+        assertEq("many", I18n::plural_category(5, "ru"));
+
+        assertEq("zero", I18n::plural_category(0, "ar"));
+        assertEq("one", I18n::plural_category(1, "ar"));
+        assertEq("two", I18n::plural_category(2, "ar"));
+        assertEq("few", I18n::plural_category(3, "ar"));
+        assertEq("many", I18n::plural_category(11, "ar"));
+        assertEq("other", I18n::plural_category(100, "ar"));
+
+        assertEq("few", I18n::plural_category(2, "cs"));
+        assertEq("many", I18n::plural_category(5, "pl"));
+        assertEq("zero", I18n::plural_category(0, "cy"));
+        assertEq("two", I18n::plural_category(2, "cy"));
+    }
+
+    visibleFractionDigitsTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        assertEq("one", I18n::plural_category("1", "ru"));
+        assertEq("other", I18n::plural_category("1.0", "ru"));
+        assertEq("other", I18n::plural_category("1.00", "ru"));
+
+        assertEq("one", I18n::plural_category("1", "cs"));
+        assertEq("many", I18n::plural_category("1.0", "cs"));
+        assertEq("many", I18n::plural_category("1.20", "cs"));
+    }
+
+    ordinalPluralCategoryTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        hash<auto> opts = {"type": "ordinal"};
+        assertEq("one", I18n::plural_category(1, "en", opts));
+        assertEq("two", I18n::plural_category(2, "en", opts));
+        assertEq("few", I18n::plural_category(3, "en", opts));
+        assertEq("other", I18n::plural_category(4, "en", opts));
+        assertEq("other", I18n::plural_category(11, "en", opts));
+        assertEq("one", I18n::plural_category(21, "en", opts));
+    }
+
+    pluralFormTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        hash<auto> ru_forms = {
+            "one": "file-one",
+            "few": "file-few",
+            "many": "file-many",
+            "other": "file-other",
+        };
+        assertEq("file-one", I18n::plural_form(1, "ru", ru_forms));
+        assertEq("file-few", I18n::plural_form(2, "ru", ru_forms));
+        assertEq("file-many", I18n::plural_form(5, "ru", ru_forms));
+        assertEq("file-other", I18n::plural_form("1.0", "ru", ru_forms));
+
+        hash<auto> exact_forms = {
+            "=0": "no files",
+            "=1": "one exact file",
+            "one": "one category file",
+            "other": "many files",
+        };
+        assertEq("no files", I18n::plural_form(0, "en", exact_forms));
+        assertEq("one exact file", I18n::plural_form("1.0", "en", exact_forms));
+        assertEq("many files", I18n::plural_form(2, "en", exact_forms));
+
+        hash<auto> suffixes = {"one": "st", "two": "nd", "few": "rd", "other": "th"};
+        assertEq("nd", I18n::plural_form(2, "en", suffixes, {"type": "ordinal"}));
+        assertEq("th", I18n::plural_form(4, "en", suffixes, {"type": "ordinal"}));
+    }
+
+    validationErrorTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        assertThrows("I18N-NUMBER-ERROR", auto sub() {
+            return I18n::plural_category("abc", "en");
+        });
+        assertThrows("I18N-PLURAL-TYPE-ERROR", auto sub() {
+            return I18n::plural_category(1, "en", {"type": "range"});
+        });
+        assertThrows("I18N-FORMS-ERROR", auto sub() {
+            return I18n::plural_form(2, "en", {"one": "one"});
+        });
+        assertThrows("I18N-FORMS-ERROR", auto sub() {
+            return I18n::plural_form(1, "en", {"bogus": "bad", "other": "other"});
+        });
+        assertThrows("I18N-NUMBER-ERROR", auto sub() {
+            return I18n::plural_form(1, "en", {"=abc": "bad", "other": "other"});
+        });
+    }
+}

--- a/modules/i18n/test/i18n.qtest
+++ b/modules/i18n/test/i18n.qtest
@@ -21,6 +21,7 @@ class I18nTest inherits QUnit::Test {
         addTestCase("cardinal plural categories", \cardinalPluralCategoryTest());
         addTestCase("visible fraction digits", \visibleFractionDigitsTest());
         addTestCase("ordinal plural categories", \ordinalPluralCategoryTest());
+        addTestCase("locale negotiation utilities", \localeNegotiationTest());
         addTestCase("plural form selection", \pluralFormTest());
         addTestCase("plural validation errors", \validationErrorTest());
         addTestCase("message catalog lookup", \messageCatalogLookupTest());
@@ -96,6 +97,32 @@ class I18nTest inherits QUnit::Test {
         assertEq("other", I18n::plural_category(4, "en", opts));
         assertEq("other", I18n::plural_category(11, "en", opts));
         assertEq("one", I18n::plural_category(21, "en", opts));
+    }
+
+    localeNegotiationTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        assertEq("en-US", I18n::canonicalize_locale("en_US"));
+        assertEq("he", I18n::canonicalize_locale("iw"));
+        assertEq(("fr-CA", "fr", "root"), I18n::get_locale_fallback_chain("fr-CA-u-nu-latn"));
+
+        list<hash<auto>> ranges = I18n::parse_accept_language("da, en-gb;q=0.8, en;q=0.7");
+        assertEq(3, ranges.size());
+        assertEq("da", ranges[0].locale);
+        assertEq("en-GB", ranges[1].locale);
+        assertEq("en", ranges[2].locale);
+        assertEq(0.8, ranges[1].q);
+
+        assertEq("fr", I18n::negotiate_locale("fr-CA, fr;q=0.8, en;q=0.5", ("en", "fr", "root")));
+        assertEq("en", I18n::negotiate_locale("de-AT, en;q=0.9", ("en", "fr", "root")));
+        assertEq("root", I18n::negotiate_locale("de-AT", ("en", "fr", "root")));
+        assertEq("fr", I18n::negotiate_locale("de-AT", ("en", "fr"), "fr"));
+        assertEq("fr", I18n::negotiate_locale("*, en;q=0.5", ("en", "fr"), "fr"));
+
+        assertThrows("I18N-ACCEPT-LANGUAGE-ERROR", auto sub() {
+            return I18n::parse_accept_language("en;q=1.5");
+        });
     }
 
     pluralFormTest() {

--- a/modules/i18n/test/i18n.qtest
+++ b/modules/i18n/test/i18n.qtest
@@ -138,6 +138,11 @@ class I18nTest inherits QUnit::Test {
         assertEq("1234.50", I18n::format_number("1234.50", "en-US", {"grouping": False}));
         assertEq("1.00", I18n::format_number(1, "en-US", {"min_fraction_digits": 2}));
         assertRegex("^\\$12\\.50$", I18n::format_currency("12.5", "USD", "en-US"));
+        date instant = 2020-05-04T15:06:07Z;
+        assertEq("May 4, 2020",
+            I18n::format_datetime(instant, "en-US", {"date_style": "medium", "time_style": "none"}));
+        assertRegex("^3:06.*PM$",
+            I18n::format_datetime(instant, "en-US", {"date_style": "none", "time_style": "short"}));
 
         assertLt(0, I18n::compare_strings("a", "b", "en-US"));
         assertEq(0, I18n::compare_strings("a", "a", "en-US"));

--- a/modules/i18n/test/i18n.qtest
+++ b/modules/i18n/test/i18n.qtest
@@ -144,8 +144,17 @@ class I18nTest inherits QUnit::Test {
         assertEq("root", I18n::get_thread_locale());
         I18n::set_thread_locale("cs_CZ-u-nu-latn");
         assertEq("cs-CZ", I18n::get_thread_locale());
+        hash<auto> locale_context = I18n::capture_locale_context();
+        assertEq("cs-CZ", locale_context.locale);
         I18n::clear_thread_locale();
         assertEq("root", I18n::get_thread_locale());
+        I18n::apply_locale_context(locale_context);
+        assertEq("cs-CZ", I18n::get_thread_locale());
+        I18n::apply_locale_context(I18n::make_locale_context("root"));
+        assertEq("root", I18n::get_thread_locale());
+        assertThrows("I18N-LOCALE-CONTEXT-ERROR", sub() {
+            I18n::apply_locale_context({});
+        });
     }
 
     localeFormattingAndCollationTest() {

--- a/modules/i18n/test/i18n.qtest
+++ b/modules/i18n/test/i18n.qtest
@@ -22,6 +22,7 @@ class I18nTest inherits QUnit::Test {
         addTestCase("visible fraction digits", \visibleFractionDigitsTest());
         addTestCase("ordinal plural categories", \ordinalPluralCategoryTest());
         addTestCase("locale negotiation utilities", \localeNegotiationTest());
+        addTestCase("thread locale control", \threadLocaleControlTest());
         addTestCase("locale formatting and collation", \localeFormattingAndCollationTest());
         addTestCase("plural form selection", \pluralFormTest());
         addTestCase("plural validation errors", \validationErrorTest());
@@ -128,6 +129,18 @@ class I18nTest inherits QUnit::Test {
         assertThrows("I18N-ACCEPT-LANGUAGE-ERROR", auto sub() {
             return I18n::parse_accept_language("en;q=1.5");
         });
+    }
+
+    threadLocaleControlTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        I18n::clear_thread_locale();
+        assertEq("root", I18n::get_thread_locale());
+        I18n::set_thread_locale("cs_CZ-u-nu-latn");
+        assertEq("cs-CZ", I18n::get_thread_locale());
+        I18n::clear_thread_locale();
+        assertEq("root", I18n::get_thread_locale());
     }
 
     localeFormattingAndCollationTest() {

--- a/modules/i18n/test/i18n.qtest
+++ b/modules/i18n/test/i18n.qtest
@@ -10,9 +10,7 @@
 %requires ../../../qlib/FsUtil.qm
 %requires ../../../qlib/QUnit.qm
 
-%try-module i18n
-%define NoI18n
-%endtry
+%requires i18n
 
 %exec-class I18nTest
 
@@ -42,9 +40,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     backendInfoTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         hash<auto> info = I18n::get_backend_info();
         assertEq("icu", info.backend);
         assertRegex("^[0-9]+\\.[0-9]+", info.icu_version);
@@ -56,9 +51,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     cardinalPluralCategoryTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         assertEq("one", I18n::plural_category(1, "en"));
         assertEq("other", I18n::plural_category(2, "en"));
 
@@ -83,9 +75,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     visibleFractionDigitsTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         assertEq("one", I18n::plural_category("1", "ru"));
         assertEq("other", I18n::plural_category("1.0", "ru"));
         assertEq("other", I18n::plural_category("1.00", "ru"));
@@ -96,9 +85,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     ordinalPluralCategoryTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         hash<auto> opts = {"type": "ordinal"};
         assertEq("one", I18n::plural_category(1, "en", opts));
         assertEq("two", I18n::plural_category(2, "en", opts));
@@ -109,9 +95,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     localeNegotiationTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         assertEq("en-US", I18n::canonicalize_locale("en_US"));
         assertEq("he", I18n::canonicalize_locale("iw"));
         assertEq("sr-Cyrl-RS", I18n::add_likely_subtags("sr"));
@@ -138,9 +121,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     threadLocaleControlTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         I18n::clear_thread_locale();
         assertEq("root", I18n::get_thread_locale());
         I18n::set_thread_locale("cs_CZ-u-nu-latn");
@@ -159,9 +139,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     localeFormattingAndCollationTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         assertEq("1,234.50", I18n::format_number("1234.50", "en-US"));
         assertEq("1234.50", I18n::format_number("1234.50", "en-US", {"grouping": False}));
         assertEq("1.00", I18n::format_number(1, "en-US", {"min_fraction_digits": 2}));
@@ -193,9 +170,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     pluralFormTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         hash<auto> ru_forms = {
             "one": "file-one",
             "few": "file-few",
@@ -223,9 +197,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     validationErrorTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         assertThrows("I18N-NUMBER-ERROR", auto sub() {
             return I18n::plural_category("abc", "en");
         });
@@ -343,9 +314,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     messageCatalogLookupTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         I18n::MessageCatalog catalog(createCatalog());
 
         assertEq("Ahoj, Petr", catalog.t("Hello, {name}", "cs-CZ", {"name": "Petr"}));
@@ -364,9 +332,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     messageCatalogPluralLookupTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         I18n::MessageCatalog catalog(createCatalog());
 
         assertEq("1 soubor", catalog.tn(1, "1 file", "{count} files", "cs"));
@@ -383,9 +348,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     messageCatalogBidiIsolationTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         I18n::MessageCatalog catalog(createCatalog());
 
         assertEq("Hello, \u2068Sam\u2069", catalog.t("Hello, {name}", "ar", {"name": "Sam"}));
@@ -393,9 +355,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     messageCatalogStatePolicyTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         hash<auto> data = {
             "schema_version": 1,
             "locales": {
@@ -417,9 +376,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     messageCatalogLayerPrecedenceTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         hash<auto> base = {
             "schema_version": 1,
             "locales": {
@@ -440,9 +396,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     messageCatalogJsonFileLoadingTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         TmpFile base("qore-i18n-", ".json");
         base.file.write(createCatalogJson("Ahoj"));
         base.file.close();
@@ -464,9 +417,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     messageCatalogJsonValidationTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         assertThrows("I18N-CATALOG-JSON-ERROR", auto sub() {
             return I18n::parse_native_catalog_json("{\"a\": 1, \"a\": 2}");
         });
@@ -490,9 +440,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     messageCatalogDiscoveryTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         string base_dir = make_tmp_dir("qore-i18n-base-");
         string override_dir = make_tmp_dir("qore-i18n-override-");
         on_exit remove_tree(base_dir);
@@ -529,9 +476,6 @@ class I18nTest inherits QUnit::Test {
     }
 
     messageCatalogDiscoverySandboxTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         string base_dir = make_tmp_dir("qore-i18n-sandbox-");
         on_exit remove_tree(base_dir);
 
@@ -560,9 +504,6 @@ list<string> sub discover_catalogs(string domain, string locale, string path) {
     }
 
     messageCatalogValidationTest() {
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
         assertThrows("I18N-FORMAT-ERROR", auto sub() {
             I18n::MessageCatalog catalog(createCatalog());
             return catalog.t("Hello, {name}", "cs");

--- a/modules/i18n/test/i18n.qtest
+++ b/modules/i18n/test/i18n.qtest
@@ -107,6 +107,11 @@ class I18nTest inherits QUnit::Test {
         assertEq("en", ranges[2].locale);
         assertEq(0.8, ranges[1].q);
 
+        ranges = I18n::parse_accept_language("en;q=1.000, fr;q=0.125");
+        assertEq(2, ranges.size());
+        assertEq(1.0, ranges[0].q);
+        assertEq(0.125, ranges[1].q);
+
         assertEq("fr", I18n::negotiate_locale("fr-CA, fr;q=0.8, en;q=0.5", ("en", "fr", "root")));
         assertEq("en", I18n::negotiate_locale("de-AT, en;q=0.9", ("en", "fr", "root")));
         assertEq("root", I18n::negotiate_locale("de-AT", ("en", "fr", "root")));
@@ -117,6 +122,9 @@ class I18nTest inherits QUnit::Test {
 
         assertThrows("I18N-ACCEPT-LANGUAGE-ERROR", auto sub() {
             return I18n::parse_accept_language("en;q=1.5");
+        });
+        assertThrows("I18N-ACCEPT-LANGUAGE-ERROR", auto sub() {
+            return I18n::parse_accept_language("en;q=0.8x");
         });
     }
 
@@ -423,6 +431,9 @@ class I18nTest inherits QUnit::Test {
         assertThrows("I18N-CATALOG-JSON-ERROR", auto sub() {
             return I18n::parse_native_catalog_json("[1, 2, 3]");
         });
+        hash<auto> parsed = I18n::parse_native_catalog_json("{\"schema_version\":1,\"score\":0.8,\"small\":1e-2}");
+        assertEq(0.8, parsed.score);
+        assertEq(0.01, parsed.small);
 
         TmpFile tmp("qore-i18n-", ".json");
         tmp.file.write(createCatalogJson("Ahoj"));

--- a/modules/i18n/test/i18n.qtest
+++ b/modules/i18n/test/i18n.qtest
@@ -154,6 +154,12 @@ class I18nTest inherits QUnit::Test {
         assertEq("1,234.50", I18n::format_number("1234.50", "en-US"));
         assertEq("1234.50", I18n::format_number("1234.50", "en-US", {"grouping": False}));
         assertEq("1.00", I18n::format_number(1, "en-US", {"min_fraction_digits": 2}));
+        assertEq(1234, I18n::parse_number("1,234", "en-US"));
+        assertEq(1234, I18n::parse_number("1.234", "de-DE"));
+        assertEq("1234.5", string(I18n::parse_number("1,234.50", "en-US")));
+        assertThrows("I18N-PARSE-ERROR", auto sub() {
+            return I18n::parse_number("1,234.50 trailing", "en-US");
+        });
         assertRegex("^\\$12\\.50$", I18n::format_currency("12.5", "USD", "en-US"));
         date instant = 2020-05-04T15:06:07Z;
         assertEq("May 4, 2020",

--- a/modules/i18n/test/i18n.qtest
+++ b/modules/i18n/test/i18n.qtest
@@ -23,6 +23,10 @@ class I18nTest inherits QUnit::Test {
         addTestCase("ordinal plural categories", \ordinalPluralCategoryTest());
         addTestCase("plural form selection", \pluralFormTest());
         addTestCase("plural validation errors", \validationErrorTest());
+        addTestCase("message catalog lookup", \messageCatalogLookupTest());
+        addTestCase("message catalog state policy", \messageCatalogStatePolicyTest());
+        addTestCase("message catalog layer precedence", \messageCatalogLayerPrecedenceTest());
+        addTestCase("message catalog validation", \messageCatalogValidationTest());
 
         set_return_value(main());
     }
@@ -37,7 +41,8 @@ class I18nTest inherits QUnit::Test {
         assertRegex("^[0-9]+\\.[0-9]+", I18n::get_icu_version());
         assertRegex("^[0-9]+\\.[0-9]+", info.cldr_version);
         assertEq(I18n::get_cldr_version(), info.cldr_version);
-        assertEq(0, info.catalog_schema_version);
+        assertEq(1, info.catalog_schema_version);
+        assertEq(1, I18n::get_catalog_schema_version());
     }
 
     cardinalPluralCategoryTest() {
@@ -141,6 +146,160 @@ class I18nTest inherits QUnit::Test {
         });
         assertThrows("I18N-NUMBER-ERROR", auto sub() {
             return I18n::plural_form(1, "en", {"=abc": "bad", "other": "other"});
+        });
+    }
+
+    private hash<auto> createCatalog() {
+        return {
+            "schema_version": 1,
+            "locales": {
+                "root": {
+                    "messages": {
+                        "Hello, {name}": "Hello, {name}",
+                        "workflow.greeting": {
+                            "source": "Hello, {name}",
+                            "message": "Hello, {name}",
+                            "state": "translated",
+                        },
+                    },
+                },
+                "cs": {
+                    "messages": {
+                        "Hello, {name}": {
+                            "message": "Ahoj, {name}",
+                            "state": "translated",
+                        },
+                        "workflow.greeting": {
+                            "source": "Hello, {name}",
+                            "message": "Nazdar, {name}",
+                            "state": "translated",
+                        },
+                    },
+                },
+                "fr": {
+                    "messages": {
+                        "Hello, {name}": {
+                            "message": "Bonjour, {name}",
+                            "state": "translated",
+                        },
+                    },
+                },
+            },
+        };
+    }
+
+    messageCatalogLookupTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        I18n::MessageCatalog catalog(createCatalog());
+
+        assertEq("Ahoj, Petr", catalog.t("Hello, {name}", "cs-CZ", {"name": "Petr"}));
+        assertEq("Nazdar, Eva", catalog.tc("workflow.greeting", "Hello, {name}", "cs", {"name": "Eva"}));
+        assertEq("Bonjour, Jean", catalog.t("Hello, {name}", "fr-CA", {"name": "Jean"}));
+        assertEq("Hello, Sam", catalog.t("Hello, {name}", "de", {"name": "Sam"}));
+
+        assertEq(("cs-CZ", "cs", "root"), catalog.getFallbackChain("cs-CZ-u-nu-latn"));
+        assertEq("cs", catalog.getEffectiveLocale("cs-CZ"));
+        assertEq(("cs", "fr", "root"), catalog.availableLocales());
+
+        hash<auto> stats = catalog.getStats("cs");
+        assertEq(2, stats.total);
+        assertEq(2, stats.translated);
+        assertEq(2, stats.usable);
+    }
+
+    messageCatalogStatePolicyTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        hash<auto> data = {
+            "schema_version": 1,
+            "locales": {
+                "root": {"messages": {"Hello": "Hello"}},
+                "cs": {"messages": {"Hello": {"message": "Ahoj", "state": "fuzzy"}}},
+            },
+        };
+
+        I18n::MessageCatalog strict(data);
+        I18n::MessageCatalog preview(data, {"use_unreviewed": True});
+
+        assertEq("Hello", strict.t("Hello", "cs"));
+        assertEq("Ahoj", preview.t("Hello", "cs"));
+
+        hash<auto> strict_stats = strict.getStats("cs");
+        hash<auto> preview_stats = preview.getStats("cs");
+        assertEq(0, strict_stats.usable);
+        assertEq(1, preview_stats.usable);
+    }
+
+    messageCatalogLayerPrecedenceTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        hash<auto> base = {
+            "schema_version": 1,
+            "locales": {
+                "root": {"messages": {"Hello": "Hello"}},
+                "cs": {"messages": {"Hello": "Ahoj"}},
+            },
+        };
+        hash<auto> override = {
+            "schema_version": 1,
+            "locales": {
+                "cs": {"messages": {"Hello": "Cau"}},
+            },
+        };
+
+        I18n::MessageCatalog catalog((base, override));
+        assertEq("Cau", catalog.t("Hello", "cs"));
+        assertEq("Hello", catalog.t("Hello", "de"));
+    }
+
+    messageCatalogValidationTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        assertThrows("I18N-FORMAT-ERROR", auto sub() {
+            I18n::MessageCatalog catalog(createCatalog());
+            return catalog.t("Hello, {name}", "cs");
+        });
+
+        assertThrows("I18N-CATALOG-ERROR", auto sub() {
+            return new I18n::MessageCatalog({"schema_version": 2, "locales": {}});
+        });
+
+        assertThrows("I18N-CATALOG-ERROR", auto sub() {
+            return new I18n::MessageCatalog({
+                "schema_version": 1,
+                "locales": {
+                    "cs": {"messages": {
+                        "Hello, {name}": {"message": "Ahoj", "state": "translated"},
+                    }},
+                },
+            });
+        });
+
+        assertThrows("I18N-CATALOG-ERROR", auto sub() {
+            return new I18n::MessageCatalog({
+                "schema_version": 1,
+                "locales": {
+                    "cs": {"messages": {
+                        "Hello": {"message": "Ahoj, {name}", "state": "translated"},
+                    }},
+                },
+            });
+        });
+
+        assertThrows("I18N-CATALOG-ERROR", auto sub() {
+            return new I18n::MessageCatalog({
+                "schema_version": 1,
+                "locales": {
+                    "cs": {"messages": {
+                        "Hello": {"message": "Ahoj", "state": "reviewed"},
+                    }},
+                },
+            });
         });
     }
 }

--- a/modules/i18n/test/i18n.qtest
+++ b/modules/i18n/test/i18n.qtest
@@ -105,6 +105,7 @@ class I18nTest inherits QUnit::Test {
 %endif
         assertEq("en-US", I18n::canonicalize_locale("en_US"));
         assertEq("he", I18n::canonicalize_locale("iw"));
+        assertEq("sr-Cyrl-RS", I18n::add_likely_subtags("sr"));
         assertEq(("fr-CA", "fr", "root"), I18n::get_locale_fallback_chain("fr-CA-u-nu-latn"));
 
         list<hash<auto>> ranges = I18n::parse_accept_language("da, en-gb;q=0.8, en;q=0.7");
@@ -119,6 +120,8 @@ class I18nTest inherits QUnit::Test {
         assertEq("root", I18n::negotiate_locale("de-AT", ("en", "fr", "root")));
         assertEq("fr", I18n::negotiate_locale("de-AT", ("en", "fr"), "fr"));
         assertEq("fr", I18n::negotiate_locale("*, en;q=0.5", ("en", "fr"), "fr"));
+        assertEq("sr-Cyrl", I18n::negotiate_locale("sr", ("sr-Cyrl", "en"), "en"));
+        assertEq("zh-Hant", I18n::negotiate_locale("zh-TW", ("zh-Hant", "en"), "en"));
 
         assertThrows("I18N-ACCEPT-LANGUAGE-ERROR", auto sub() {
             return I18n::parse_accept_language("en;q=1.5");

--- a/modules/i18n/test/i18n.qtest
+++ b/modules/i18n/test/i18n.qtest
@@ -7,6 +7,7 @@
 
 %modern
 
+%requires ../../../qlib/FsUtil.qm
 %requires ../../../qlib/QUnit.qm
 
 %try-module i18n
@@ -30,6 +31,8 @@ class I18nTest inherits QUnit::Test {
         addTestCase("message catalog plural lookup", \messageCatalogPluralLookupTest());
         addTestCase("message catalog state policy", \messageCatalogStatePolicyTest());
         addTestCase("message catalog layer precedence", \messageCatalogLayerPrecedenceTest());
+        addTestCase("message catalog JSON file loading", \messageCatalogJsonFileLoadingTest());
+        addTestCase("message catalog JSON validation", \messageCatalogJsonValidationTest());
         addTestCase("message catalog validation", \messageCatalogValidationTest());
 
         set_return_value(main());
@@ -293,6 +296,23 @@ class I18nTest inherits QUnit::Test {
         };
     }
 
+    private string createCatalogJson(string cs_message) {
+        return "{\n"
+            "  \"schema_version\": 1,\n"
+            "  \"locales\": {\n"
+            "    \"root\": {\"messages\": {\"Hello, {name}\": \"Hello, {name}\"}},\n"
+            "    \"cs\": {\"messages\": {\n"
+            "      \"Hello, {name}\": {\"message\": \"" + cs_message + ", {name}\", \"state\": \"translated\"},\n"
+            "      \"1 file\": {\n"
+            "        \"plural_source\": \"{count} files\",\n"
+            "        \"forms\": {\"one\": \"{count} soubor\", \"few\": \"{count} soubory\", \"other\": \"{count} souboru\"},\n"
+            "        \"state\": \"translated\"\n"
+            "      }\n"
+            "    }}\n"
+            "  }\n"
+            "}\n";
+    }
+
     messageCatalogLookupTest() {
 %ifdef NoI18n
         testSkip("i18n module not available");
@@ -378,6 +398,56 @@ class I18nTest inherits QUnit::Test {
         I18n::MessageCatalog catalog((base, override));
         assertEq("Cau", catalog.t("Hello", "cs"));
         assertEq("Hello", catalog.t("Hello", "de"));
+    }
+
+    messageCatalogJsonFileLoadingTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        TmpFile base("qore-i18n-", ".json");
+        base.file.write(createCatalogJson("Ahoj"));
+        base.file.close();
+
+        hash<auto> loaded = I18n::load_native_catalog(base.path);
+        assertEq(1, loaded.schema_version);
+        assertEq("Ahoj, {name}", loaded.locales.cs.messages."Hello, {name}".message);
+
+        I18n::MessageCatalog catalog(base.path);
+        assertEq("Ahoj, Petr", catalog.t("Hello, {name}", "cs", {"name": "Petr"}));
+        assertEq("2 soubory", catalog.tn(2, "1 file", "{count} files", "cs"));
+
+        TmpFile override("qore-i18n-", ".json");
+        override.file.write(createCatalogJson("Cau"));
+        override.file.close();
+
+        I18n::MessageCatalog layered((base.path, override.path));
+        assertEq("Cau, Eva", layered.t("Hello, {name}", "cs", {"name": "Eva"}));
+    }
+
+    messageCatalogJsonValidationTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        assertThrows("I18N-CATALOG-JSON-ERROR", auto sub() {
+            return I18n::parse_native_catalog_json("{\"a\": 1, \"a\": 2}");
+        });
+        assertThrows("I18N-CATALOG-JSON-ERROR", auto sub() {
+            return I18n::parse_native_catalog_json("[1, 2, 3]");
+        });
+
+        TmpFile tmp("qore-i18n-", ".json");
+        tmp.file.write(createCatalogJson("Ahoj"));
+        tmp.file.close();
+        assertThrows("I18N-CATALOG-ERROR", auto sub() {
+            return I18n::load_native_catalog(tmp.path, 8);
+        });
+
+        TmpFile bad("qore-i18n-", ".json");
+        bad.file.write("{\"schema_version\": 1,");
+        bad.file.close();
+        assertThrows("I18N-CATALOG-JSON-ERROR", auto sub() {
+            return new I18n::MessageCatalog(bad.path);
+        });
     }
 
     messageCatalogValidationTest() {

--- a/modules/i18n/test/i18n.qtest
+++ b/modules/i18n/test/i18n.qtest
@@ -158,8 +158,12 @@ class I18nTest inherits QUnit::Test {
         date instant = 2020-05-04T15:06:07Z;
         assertEq("May 4, 2020",
             I18n::format_datetime(instant, "en-US", {"date_style": "medium", "time_style": "none"}));
+        assertEq("May 4, 2020", I18n::format_datetime(instant, "en-US", {"skeleton": "yMMMd"}));
         assertRegex("^3:06.*PM$",
             I18n::format_datetime(instant, "en-US", {"date_style": "none", "time_style": "short"}));
+        assertThrows("I18N-FORMAT-ERROR", auto sub() {
+            return I18n::format_datetime(instant, "en-US", {"skeleton": "yMMMd", "date_style": "medium"});
+        });
 
         assertLt(0, I18n::compare_strings("a", "b", "en-US"));
         assertEq(0, I18n::compare_strings("a", "a", "en-US"));

--- a/modules/i18n/test/i18n.qtest
+++ b/modules/i18n/test/i18n.qtest
@@ -35,6 +35,7 @@ class I18nTest inherits QUnit::Test {
         addTestCase("message catalog JSON file loading", \messageCatalogJsonFileLoadingTest());
         addTestCase("message catalog JSON validation", \messageCatalogJsonValidationTest());
         addTestCase("message catalog discovery", \messageCatalogDiscoveryTest());
+        addTestCase("message catalog discovery sandbox", \messageCatalogDiscoverySandboxTest());
         addTestCase("message catalog validation", \messageCatalogValidationTest());
 
         set_return_value(main());
@@ -524,6 +525,37 @@ class I18nTest inherits QUnit::Test {
 
         assertThrows("I18N-CATALOG-ERROR", auto sub() {
             return I18n::discover_catalog_files("../billing", "cs", {"search_path": (base_dir,)});
+        });
+    }
+
+    messageCatalogDiscoverySandboxTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        string base_dir = make_tmp_dir("qore-i18n-sandbox-");
+        on_exit remove_tree(base_dir);
+
+        mkdir(base_dir + "/billing");
+        string base_root = base_dir + "/billing/root.json";
+        writeTextFile(base_root, createCatalogJson("Root"));
+
+        Program p(PO_NO_CHILD_PO_RESTRICTIONS);
+        p.parse("
+%modern
+%requires i18n
+
+list<string> sub discover_catalogs(string domain, string locale, string path) {
+    return I18n::discover_catalog_files(domain, locale, {\"search_path\": (path,)});
+}
+        ", "i18n_sandbox_discovery");
+
+        SandboxManager sm();
+        sm.setFilesystemSandboxRoot(base_dir);
+        p.setSandboxManager(sm);
+
+        assertEq((base_root,), p.callFunction("discover_catalogs", "billing", "root", base_dir));
+        assertThrows("FILESYSTEM-ACCESS-DENIED", auto sub() {
+            return p.callFunction("discover_catalogs", "billing", "root", "/etc");
         });
     }
 

--- a/modules/i18n/test/i18n.qtest
+++ b/modules/i18n/test/i18n.qtest
@@ -22,6 +22,7 @@ class I18nTest inherits QUnit::Test {
         addTestCase("visible fraction digits", \visibleFractionDigitsTest());
         addTestCase("ordinal plural categories", \ordinalPluralCategoryTest());
         addTestCase("locale negotiation utilities", \localeNegotiationTest());
+        addTestCase("locale formatting and collation", \localeFormattingAndCollationTest());
         addTestCase("plural form selection", \pluralFormTest());
         addTestCase("plural validation errors", \validationErrorTest());
         addTestCase("message catalog lookup", \messageCatalogLookupTest());
@@ -127,6 +128,25 @@ class I18nTest inherits QUnit::Test {
         assertThrows("I18N-ACCEPT-LANGUAGE-ERROR", auto sub() {
             return I18n::parse_accept_language("en;q=1.5");
         });
+    }
+
+    localeFormattingAndCollationTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        assertEq("1,234.50", I18n::format_number("1234.50", "en-US"));
+        assertEq("1234.50", I18n::format_number("1234.50", "en-US", {"grouping": False}));
+        assertEq("1.00", I18n::format_number(1, "en-US", {"min_fraction_digits": 2}));
+        assertRegex("^\\$12\\.50$", I18n::format_currency("12.5", "USD", "en-US"));
+
+        assertLt(0, I18n::compare_strings("a", "b", "en-US"));
+        assertEq(0, I18n::compare_strings("a", "a", "en-US"));
+        assertRegex("^[0-9]+\\.[0-9]+", I18n::get_collation_version("en-US"));
+
+        binary a_key = I18n::get_sort_key("a", "en-US");
+        binary b_key = I18n::get_sort_key("b", "en-US");
+        assertTrue(a_key.size() > 0);
+        assertNeq(a_key, b_key);
     }
 
     pluralFormTest() {

--- a/modules/i18n/test/i18n.qtest
+++ b/modules/i18n/test/i18n.qtest
@@ -25,6 +25,7 @@ class I18nTest inherits QUnit::Test {
         addTestCase("plural form selection", \pluralFormTest());
         addTestCase("plural validation errors", \validationErrorTest());
         addTestCase("message catalog lookup", \messageCatalogLookupTest());
+        addTestCase("message catalog plural lookup", \messageCatalogPluralLookupTest());
         addTestCase("message catalog state policy", \messageCatalogStatePolicyTest());
         addTestCase("message catalog layer precedence", \messageCatalogLayerPrecedenceTest());
         addTestCase("message catalog validation", \messageCatalogValidationTest());
@@ -191,6 +192,22 @@ class I18nTest inherits QUnit::Test {
                             "message": "Hello, {name}",
                             "state": "translated",
                         },
+                        "1 file": {
+                            "plural_source": "{count} files",
+                            "forms": {
+                                "one": "1 file",
+                                "other": "{count} files",
+                            },
+                            "state": "translated",
+                        },
+                        "{name} has 1 file": {
+                            "plural_source": "{name} has {count} files",
+                            "forms": {
+                                "one": "{name} has 1 file",
+                                "other": "{name} has {count} files",
+                            },
+                            "state": "translated",
+                        },
                     },
                 },
                 "cs": {
@@ -202,6 +219,26 @@ class I18nTest inherits QUnit::Test {
                         "workflow.greeting": {
                             "source": "Hello, {name}",
                             "message": "Nazdar, {name}",
+                            "state": "translated",
+                        },
+                        "1 file": {
+                            "plural_source": "{count} files",
+                            "forms": {
+                                "one": "{count} soubor",
+                                "few": "{count} soubory",
+                                "many": "{count} souboru",
+                                "other": "{count} souboru",
+                            },
+                            "state": "translated",
+                        },
+                        "{name} has 1 file": {
+                            "plural_source": "{name} has {count} files",
+                            "forms": {
+                                "one": "{name} ma {count} soubor",
+                                "few": "{name} ma {count} soubory",
+                                "many": "{name} ma {count} souboru",
+                                "other": "{name} ma {count} souboru",
+                            },
                             "state": "translated",
                         },
                     },
@@ -234,9 +271,28 @@ class I18nTest inherits QUnit::Test {
         assertEq(("cs", "fr", "root"), catalog.availableLocales());
 
         hash<auto> stats = catalog.getStats("cs");
-        assertEq(2, stats.total);
-        assertEq(2, stats.translated);
-        assertEq(2, stats.usable);
+        assertEq(4, stats.total);
+        assertEq(4, stats.translated);
+        assertEq(4, stats.usable);
+    }
+
+    messageCatalogPluralLookupTest() {
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+        I18n::MessageCatalog catalog(createCatalog());
+
+        assertEq("1 soubor", catalog.tn(1, "1 file", "{count} files", "cs"));
+        assertEq("2 soubory", catalog.tn(2, "1 file", "{count} files", "cs"));
+        assertEq("5 souboru", catalog.tn(5, "1 file", "{count} files", "cs"));
+        assertEq("1.0 souboru", catalog.tn("1.0", "1 file", "{count} files", "cs"));
+
+        assertEq("Petr ma 2 soubory",
+            catalog.tn(2, "{name} has 1 file", "{name} has {count} files", "cs", {"name": "Petr"}));
+
+        assertEq("2 files", catalog.tn(2, "1 file", "{count} files", "de"));
+        assertEq("1 file", catalog.tn(1, "1 file", "{count} files", "de"));
+        assertEq("1.0 files", catalog.tn("1.0", "1 file", "{count} files", "de"));
     }
 
     messageCatalogStatePolicyTest() {
@@ -327,6 +383,34 @@ class I18nTest inherits QUnit::Test {
                 "locales": {
                     "cs": {"messages": {
                         "Hello": {"message": "Ahoj", "state": "reviewed"},
+                    }},
+                },
+            });
+        });
+
+        assertThrows("I18N-CATALOG-ERROR", auto sub() {
+            return new I18n::MessageCatalog({
+                "schema_version": 1,
+                "locales": {
+                    "cs": {"messages": {
+                        "1 file": {
+                            "plural_source": "{count} files",
+                            "forms": {"one": "{count} soubor"},
+                        },
+                    }},
+                },
+            });
+        });
+
+        assertThrows("I18N-CATALOG-ERROR", auto sub() {
+            return new I18n::MessageCatalog({
+                "schema_version": 1,
+                "locales": {
+                    "cs": {"messages": {
+                        "{name} has 1 file": {
+                            "plural_source": "{name} has {count} files",
+                            "forms": {"other": "{count} souboru"},
+                        },
                     }},
                 },
             });

--- a/modules/i18n/test/qore-i18n-cli.qtest
+++ b/modules/i18n/test/qore-i18n-cli.qtest
@@ -1,0 +1,126 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+/*  qore-i18n-cli.qtest Copyright 2026 Qore Technologies, s.r.o.
+    MIT License
+*/
+
+%modern
+
+%requires ../../../qlib/QUnit.qm
+%requires ../../../qlib/Util.qm
+
+%try-module astparser
+%define NoAstParser
+%endtry
+
+%try-module i18n
+%define NoI18n
+%endtry
+
+%try-module json
+%define NoJson
+%endtry
+
+%exec-class QoreI18nCliTest
+
+class QoreI18nCliTest inherits QUnit::Test {
+    private {
+        string tool = get_script_dir() + "/../../../bin/qore-i18n";
+    }
+
+    constructor() : Test("qore-i18n CLI", "1.0") {
+        addTestCase("extract, stats, pseudo, and PO round trip", \cliWorkflowTest());
+        set_return_value(main());
+    }
+
+    cliWorkflowTest() {
+%ifdef NoAstParser
+        testSkip("astparser module not available");
+%endif
+%ifdef NoI18n
+        testSkip("i18n module not available");
+%endif
+%ifdef NoJson
+        testSkip("json module not available");
+%endif
+        string root = normalize_dir(dirname(get_script_path()) + DirSep + "../../..");
+        string qore_bin = root + DirSep + "build/qore";
+        if (!is_executable(qore_bin)) {
+            qore_bin = root + DirSep + "build-ci/qore";
+        }
+        if (!is_executable(qore_bin)) {
+            testSkip("built qore executable not available");
+            return;
+        }
+
+        string source = tmp_location() + "/qore-i18n-cli-source-" + getpid() + ".q";
+        string catalog = tmp_location() + "/qore-i18n-cli-catalog-" + getpid() + ".json";
+        string pseudo = tmp_location() + "/qore-i18n-cli-pseudo-" + getpid() + ".json";
+        string po = tmp_location() + "/qore-i18n-cli-catalog-" + getpid() + ".po";
+        string imported = tmp_location() + "/qore-i18n-cli-imported-" + getpid() + ".json";
+        on_exit {
+            unlink(source);
+            unlink(catalog);
+            unlink(pseudo);
+            unlink(po);
+            unlink(imported);
+        }
+
+        writeTextFile(source,
+            "%modern\n"
+            "# i18n: greeting shown on dashboard\n"
+            "sub main() { t(\"Hello, {name}\"); tn(count, \"1 file\", \"{count} files\"); }\n");
+
+        runTool(qore_bin, sprintf("extract -o %s %s", shellQuote(catalog), shellQuote(source)));
+        hash<auto> extracted = parse_json(ReadOnlyFile::readTextFile(catalog));
+        assertEq(1, extracted.schema_version);
+        assertEq("Hello, {name}", extracted.locales.root.messages."Hello, {name}".message);
+        assertEq("{count} files", extracted.locales.root.messages."1 file".plural_source);
+
+        I18n::MessageCatalog runtime(catalog);
+        assertEq("Hello, Eva", runtime.t("Hello, {name}", "root", {"name": "Eva"}));
+        assertEq("2 files", runtime.tn(2, "1 file", "{count} files", "root"));
+
+        string stats = runTool(qore_bin, sprintf("stats --format=json %s", shellQuote(catalog)));
+        list<hash<auto>> rows = parse_json(stats);
+        assertEq(1, rows.size());
+        assertEq(2, rows[0].total);
+        assertEq(100, rows[0].coverage);
+
+        runTool(qore_bin, sprintf("pseudo -o %s %s", shellQuote(pseudo), shellQuote(catalog)));
+        hash<auto> pseudo_catalog = parse_json(ReadOnlyFile::readTextFile(pseudo));
+        assertEq("[!! Heelloo, {name} !!]", pseudo_catalog.locales."qps-ploc".messages."Hello, {name}".message);
+
+        runTool(qore_bin, sprintf("export-po -o %s %s", shellQuote(po), shellQuote(catalog)));
+        string po_text = ReadOnlyFile::readTextFile(po);
+        assertTrue(po_text.find("msgid \"Hello, {name}\"") >= 0);
+        assertTrue(po_text.find("msgid_plural \"{count} files\"") >= 0);
+
+        runTool(qore_bin, sprintf("import-po -l cs -o %s %s", shellQuote(imported), shellQuote(po)));
+        hash<auto> imported_catalog = parse_json(ReadOnlyFile::readTextFile(imported));
+        assertEq("Hello, {name}", imported_catalog.locales.cs.messages."Hello, {name}".message);
+        assertEq("{count} files", imported_catalog.locales.cs.messages."1 file".forms.other);
+    }
+
+    private string runTool(string qore_bin, string args) {
+        string module_dir = "build/modules/astparser:build/modules/i18n";
+        if (exists ENV.QORE_MODULE_DIR) {
+            module_dir += ":" + ENV.QORE_MODULE_DIR;
+        }
+        string lib_path = ENV.LD_LIBRARY_PATH ?? "build";
+        return backquote(sprintf("QORE_MODULE_DIR=%s LD_LIBRARY_PATH=%s %s %s %s 2>&1",
+            shellQuote(module_dir), shellQuote(lib_path), shellQuote(qore_bin), shellQuote(tool), args));
+    }
+
+    private string shellQuote(string value) {
+        return "'" + replace(value, "'", "'\"'\"'") + "'";
+    }
+
+    private writeTextFile(string path, string data) {
+        File f();
+        f.open2(path, O_CREAT | O_WRONLY | O_TRUNC);
+        f.write(data);
+        f.close();
+    }
+}

--- a/modules/i18n/test/qore-i18n-cli.qtest
+++ b/modules/i18n/test/qore-i18n-cli.qtest
@@ -26,20 +26,38 @@ class QoreI18nCliTest inherits QUnit::Test {
     }
 
     constructor() : Test("qore-i18n CLI", "1.0") {
+        addTestCase("help output and color controls", \cliHelpTest());
         addTestCase("extract, stats, pseudo, and PO round trip", \cliWorkflowTest());
         set_return_value(main());
+    }
+
+    cliHelpTest() {
+%ifdef NoJson
+        testSkip("json module not available");
+%endif
+        *string qore_bin = getQoreBin();
+        if (!exists qore_bin) {
+            testSkip("built qore executable not available");
+            return;
+        }
+
+        string help = runTool(qore_bin, "--no-color --help");
+        assertTrue(help.find("GLOBAL OPTIONS") >= 0);
+        assertTrue(help.find("-C, --no-color") >= 0);
+        assertEq(help, Util::TerminalColor::stripAnsi(help));
+
+        string extract_help = runTool(qore_bin, "extract --no-color --help");
+        assertTrue(extract_help.find("qore-i18n extract [options] <source-files...>") >= 0);
+        assertTrue(extract_help.find("--fail-dynamic") >= 0);
+        assertEq(extract_help, Util::TerminalColor::stripAnsi(extract_help));
     }
 
     cliWorkflowTest() {
 %ifdef NoJson
         testSkip("json module not available");
 %endif
-        string root = normalize_dir(dirname(get_script_path()) + DirSep + "../../..");
-        string qore_bin = root + DirSep + "build/qore";
-        if (!is_executable(qore_bin)) {
-            qore_bin = root + DirSep + "build-ci/qore";
-        }
-        if (!is_executable(qore_bin)) {
+        *string qore_bin = getQoreBin();
+        if (!exists qore_bin) {
             testSkip("built qore executable not available");
             return;
         }
@@ -91,6 +109,16 @@ class QoreI18nCliTest inherits QUnit::Test {
         hash<auto> imported_catalog = parse_json(ReadOnlyFile::readTextFile(imported));
         assertEq("Hello, {name}", imported_catalog.locales.cs.messages."Hello, {name}".message);
         assertEq("{count} files", imported_catalog.locales.cs.messages."1 file".forms.other);
+    }
+
+    private *string getQoreBin() {
+        string root = normalize_dir(dirname(get_script_path()) + DirSep + "../../..");
+        string qore_bin = root + DirSep + "build/qore";
+        if (is_executable(qore_bin)) {
+            return qore_bin;
+        }
+        qore_bin = root + DirSep + "build-ci/qore";
+        return is_executable(qore_bin) ? qore_bin : NOTHING;
     }
 
     private string runTool(string qore_bin, string args) {

--- a/modules/i18n/test/qore-i18n-cli.qtest
+++ b/modules/i18n/test/qore-i18n-cli.qtest
@@ -10,13 +10,9 @@
 %requires ../../../qlib/QUnit.qm
 %requires ../../../qlib/Util.qm
 
-%try-module astparser
-%define NoAstParser
-%endtry
+%requires astparser
 
-%try-module i18n
-%define NoI18n
-%endtry
+%requires i18n
 
 %try-module json
 %define NoJson
@@ -35,12 +31,6 @@ class QoreI18nCliTest inherits QUnit::Test {
     }
 
     cliWorkflowTest() {
-%ifdef NoAstParser
-        testSkip("astparser module not available");
-%endif
-%ifdef NoI18n
-        testSkip("i18n module not available");
-%endif
 %ifdef NoJson
         testSkip("json module not available");
 %endif


### PR DESCRIPTION
## Summary
- add required ICU-backed i18n binary module with CLDR plural rules, locale negotiation, formatting, collation, and message catalog runtime
- add qore-i18n catalog CLI, docs, release notes, and module test coverage
- require bundled i18n and astparser modules in tests while keeping external json optional

## Verification
- cmake -S . -B build
- cmake --build build --target i18n
- cmake --build build --target docs-i18n
- QORE_MODULE_DIR=build/modules/i18n LD_LIBRARY_PATH=build modules/i18n/test/i18n.qtest
- QORE_MODULE_DIR=build/modules/astparser:build/modules/i18n LD_LIBRARY_PATH=build modules/i18n/test/qore-i18n-cli.qtest
- QORE_MODULE_DIR=build/modules/astparser LD_LIBRARY_PATH=build modules/astparser/test/astparser.qtest
- git diff --check

Closes #5334