### PR TITLE
fix(DataProvider): auto-load make-api-call builder for REST apps on index startup

### DIFF
--- a/examples/test/qlib/AnthropicDataProvider/AnthropicDataProvider.qtest
+++ b/examples/test/qlib/AnthropicDataProvider/AnthropicDataProvider.qtest
@@ -286,8 +286,12 @@ public class AnthropicDataProviderTest inherits QUnit::Test {
         FakeAnthropicRestClientIo rest();
         AnthropicDataProvider prov(rest);
         assertEq("anthropic", prov.getName());
+        # filter out the framework-injected __call__ child (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider); this test asserts the
+        # app's own child surface only
         assertEq(("batches", "count-tokens", "files", "messages", "models", "skills"),
-            sort(prov.getChildProviderNames()));
+            sort(select prov.getChildProviderNames(),
+                $1 != AbstractDataProvider::GenericApiCallChildName));
 %endif
     }
 
@@ -388,21 +392,35 @@ public class AnthropicDataProviderTest inherits QUnit::Test {
         FakeAnthropicRestClientIo rest();
         AnthropicDataProvider prov(rest);
 
+        # NOTE on the `select ... != GenericApiCallChildName` filter below: every provider with
+        # a discoverable rest client (including these intermediate containers) gets __call__
+        # auto-injected by the framework. These assertions are about each container's own
+        # children, not the framework's auto-injection (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider).
+
         # verify batches children
         AbstractDataProvider batches = prov.getChildProvider("batches");
-        assertEq(("cancel", "create", "get", "list"), sort(batches.getChildProviderNames()));
+        assertEq(("cancel", "create", "get", "list"),
+            sort(select batches.getChildProviderNames(),
+                $1 != AbstractDataProvider::GenericApiCallChildName));
 
         # verify files children
         AbstractDataProvider files = prov.getChildProvider("files");
-        assertEq(("delete", "get", "get-content", "list", "upload"), sort(files.getChildProviderNames()));
+        assertEq(("delete", "get", "get-content", "list", "upload"),
+            sort(select files.getChildProviderNames(),
+                $1 != AbstractDataProvider::GenericApiCallChildName));
 
         # verify skills children
         AbstractDataProvider skills = prov.getChildProvider("skills");
-        assertEq(("create", "delete", "get", "list", "update"), sort(skills.getChildProviderNames()));
+        assertEq(("create", "delete", "get", "list", "update"),
+            sort(select skills.getChildProviderNames(),
+                $1 != AbstractDataProvider::GenericApiCallChildName));
 
         # verify models children (now a container)
         AbstractDataProvider models = prov.getChildProvider("models");
-        assertEq(("get", "list"), sort(models.getChildProviderNames()));
+        assertEq(("get", "list"),
+            sort(select models.getChildProviderNames(),
+                $1 != AbstractDataProvider::GenericApiCallChildName));
 %endif
     }
 

--- a/examples/test/qlib/AssemblyAiDataProvider/AssemblyAiDataProvider.qtest
+++ b/examples/test/qlib/AssemblyAiDataProvider/AssemblyAiDataProvider.qtest
@@ -115,8 +115,12 @@ public class AssemblyAiDataProviderTest inherits QUnit::Test {
         assertEq("AssemblyAI", app.name);
         assertEq("assemblyai", app.scheme);
 
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("AssemblyAI");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider); this test asserts the
+        # provider's own action surface only
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("AssemblyAI"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(1, actions.size());
         assertEq("transcribe", actions[0].action);
     }

--- a/examples/test/qlib/AwsTextractDataProvider/AwsTextractDataProvider.qtest
+++ b/examples/test/qlib/AwsTextractDataProvider/AwsTextractDataProvider.qtest
@@ -101,8 +101,11 @@ public class AwsTextractDataProviderTest inherits QUnit::Test {
         assertEq("AwsTextract", app.name);
         assertEq("aws-textract", app.scheme);
 
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("AwsTextract");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("AwsTextract"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(2, actions.size());
 
         list<string> action_codes = sort(map $1.action, actions);

--- a/examples/test/qlib/AzureDocumentIntelligenceDataProvider/AzureDocumentIntelligenceDataProvider.qtest
+++ b/examples/test/qlib/AzureDocumentIntelligenceDataProvider/AzureDocumentIntelligenceDataProvider.qtest
@@ -106,8 +106,11 @@ public class AzureDocumentIntelligenceDataProviderTest inherits QUnit::Test {
         assertEq("AzureDocumentIntelligence", app.name);
         assertEq("azure-documentintelligence", app.scheme);
 
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("AzureDocumentIntelligence");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("AzureDocumentIntelligence"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(1, actions.size());
         assertEq("analyze-document", actions[0].action);
     }

--- a/examples/test/qlib/BflDataProvider/BflDataProvider.qtest
+++ b/examples/test/qlib/BflDataProvider/BflDataProvider.qtest
@@ -96,8 +96,11 @@ public class BflDataProviderTest inherits QUnit::Test {
         assertEq("BlackForestLabs", app.name);
         assertEq("bfl", app.scheme);
 
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("BlackForestLabs");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("BlackForestLabs"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(1, actions.size());
         assertEq("generate-image", actions[0].action);
     }

--- a/examples/test/qlib/BgeM3FastApiDataProvider/BgeM3FastApiDataProvider.qtest
+++ b/examples/test/qlib/BgeM3FastApiDataProvider/BgeM3FastApiDataProvider.qtest
@@ -132,8 +132,11 @@ public class BgeM3FastApiDataProviderTest inherits QUnit::Test {
         installHandler({});
         BgeM3FastApiDataProvider::BgeM3FastApiDataProvider prov(makeRest());
         assertEq("bge-m3-fastapi", prov.getName());
+        # filter out the framework-injected __call__ child (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
         assertEq(("create-embeddings", "health", "metrics"),
-            sort(prov.getChildProviderNames()));
+            sort(select prov.getChildProviderNames(),
+                $1 != AbstractDataProvider::GenericApiCallChildName));
     }
 
     testChildMapPathResolution() {

--- a/examples/test/qlib/CdsRestDataProvider/CdsRestDataProvider.qtest
+++ b/examples/test/qlib/CdsRestDataProvider/CdsRestDataProvider.qtest
@@ -732,7 +732,12 @@ class CdsRestDataProviderTest inherits QUnit::Test {
 
             BcCompaniesDataProvider companies_dp(mock_client);
 
-            list<string> names = companies_dp.getChildProviderNames();
+            # filter out the framework-injected __call__ child from `names` so it lines up with
+            # `summary` (getChildProviderSummaryInfo does not include framework-injected children);
+            # the framework's auto-injection has dedicated coverage in
+            # GenericApiCallAutoInjection.qtest in RestClientDataProvider
+            list<string> names = select companies_dp.getChildProviderNames(),
+                $1 != AbstractDataProvider::GenericApiCallChildName;
             *list<hash<DataProviderSummaryInfo>> summary = companies_dp.getChildProviderSummaryInfo();
 
             assertEq(names.size(), summary.size(), "names and summary should have same count");

--- a/examples/test/qlib/ChromaDataProvider/ChromaDataProvider.qtest
+++ b/examples/test/qlib/ChromaDataProvider/ChromaDataProvider.qtest
@@ -92,8 +92,11 @@ public class ChromaDataProviderTest inherits QUnit::Test {
             DataProvider::DataProviderActionCatalog::getApp("Chroma");
         assertEq("Chroma", app.name);
         assertEq("chroma", app.scheme);
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("Chroma");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("Chroma"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(1, actions.size());
         assertEq("vector-search", actions[0].action);
     }

--- a/examples/test/qlib/CohereDataProvider/CohereDataProvider.qtest
+++ b/examples/test/qlib/CohereDataProvider/CohereDataProvider.qtest
@@ -103,8 +103,11 @@ public class CohereDataProviderTest inherits QUnit::Test {
         assertEq("Cohere", app.name);
         assertEq("cohere", app.scheme);
 
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("Cohere");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("Cohere"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(4, actions.size());
         list<string> action_names = sort(map $1.action, actions);
         assertEq(("chat", "classify", "embed", "rerank"), action_names);
@@ -113,7 +116,10 @@ public class CohereDataProviderTest inherits QUnit::Test {
     private rootProviderTest() {
         FakeCohereRestClientIo fake();
         CohereDataProvider::CohereDataProvider prov(fake);
-        list<string> children = sort(prov.getChildProviderNames());
+        # filter out the framework-injected __call__ child (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<string> children = sort(select prov.getChildProviderNames(),
+            $1 != AbstractDataProvider::GenericApiCallChildName);
         assertEq(("chat", "classify", "embed", "rerank"), children);
     }
 

--- a/examples/test/qlib/CustomerIoDataProvider/CustomerIoDataProvider.qtest
+++ b/examples/test/qlib/CustomerIoDataProvider/CustomerIoDataProvider.qtest
@@ -317,8 +317,11 @@ public class CustomerIoDataProviderTest inherits QUnit::Test {
         assertTrue(events.getInfo().supports_children);
         assertTrue(events.getInfo().children_can_support_observers);
 
-        # Verify all 21 event children
-        list<string> eventChildren = events.getChildProviderNames();
+        # Verify all 21 event children — filter out the framework-injected __call__ child
+        # (covered by GenericApiCallAutoInjection.qtest in RestClientDataProvider); every
+        # provider with a discoverable rest client picks it up, including this sub-container
+        list<string> eventChildren = select events.getChildProviderNames(),
+            $1 != AbstractDataProvider::GenericApiCallChildName;
         assertTrue(eventChildren.contains(CustomerIoDataProvider::EVENT_EMAIL_SENT));
         assertTrue(eventChildren.contains(CustomerIoDataProvider::EVENT_EMAIL_DELIVERED));
         assertTrue(eventChildren.contains(CustomerIoDataProvider::EVENT_EMAIL_OPENED));

--- a/examples/test/qlib/DeepSeekDataProvider/DeepSeekDataProvider.qtest
+++ b/examples/test/qlib/DeepSeekDataProvider/DeepSeekDataProvider.qtest
@@ -112,8 +112,11 @@ public class DeepSeekDataProviderTest inherits QUnit::Test {
         assertEq("deepseek-logo.svg", app.logo_file_name);
         assertTrue(app.logo.size() > 0);
 
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("DeepSeek");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("DeepSeek"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(1, actions.size());
         assertEq("chat-completion", actions[0].action);
         assertEq("/chat-completion", actions[0].path);
@@ -129,7 +132,10 @@ public class DeepSeekDataProviderTest inherits QUnit::Test {
         FakeDeepSeekRestClientIo fake();
         DeepSeekDataProvider::DeepSeekDataProvider prov(fake);
         assertEq("deepseek", prov.getName());
-        list<string> children = prov.getChildProviderNames();
+        # filter out the framework-injected __call__ child (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<string> children = select prov.getChildProviderNames(),
+            $1 != AbstractDataProvider::GenericApiCallChildName;
         assertEq(("chat-completion",), children);
         AbstractDataProvider chat = prov.getChildProvider("chat-completion");
         assertTrue(chat instanceof

--- a/examples/test/qlib/DeepgramDataProvider/DeepgramDataProvider.qtest
+++ b/examples/test/qlib/DeepgramDataProvider/DeepgramDataProvider.qtest
@@ -94,8 +94,11 @@ public class DeepgramDataProviderTest inherits QUnit::Test {
         assertEq("Deepgram", app.name);
         assertEq("deepgram", app.scheme);
 
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("Deepgram");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("Deepgram"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(2, actions.size());
 
         list<string> action_codes = sort(map $1.action, actions);

--- a/examples/test/qlib/ExaDataProvider/ExaDataProvider.qtest
+++ b/examples/test/qlib/ExaDataProvider/ExaDataProvider.qtest
@@ -89,8 +89,11 @@ public class ExaDataProviderTest inherits QUnit::Test {
         assertEq("exa", app.scheme);
         assertEq("exa-logo.svg", app.logo_file_name);
 
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("Exa");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("Exa"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(3, actions.size());
         list<string> action_names = sort(map $1.action, actions);
         assertEq(("contents", "find-similar", "search"), action_names);
@@ -99,7 +102,10 @@ public class ExaDataProviderTest inherits QUnit::Test {
     private rootProviderTest() {
         FakeExaRestClientIo fake();
         ExaDataProvider::ExaDataProvider prov(fake);
-        list<string> children = sort(prov.getChildProviderNames());
+        # filter out the framework-injected __call__ child (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<string> children = sort(select prov.getChildProviderNames(),
+            $1 != AbstractDataProvider::GenericApiCallChildName);
         assertEq(("contents", "find-similar", "search"), children);
     }
 

--- a/examples/test/qlib/FirecrawlDataProvider/FirecrawlDataProvider.qtest
+++ b/examples/test/qlib/FirecrawlDataProvider/FirecrawlDataProvider.qtest
@@ -208,8 +208,10 @@ public class FirecrawlDataProviderTest inherits QUnit::Test {
             return;
         }
 
-        # Check all expected child providers exist
-        list<string> children = prov.getChildProviderNames();
+        # Check all expected child providers exist — filter out the framework-injected
+        # __call__ child (covered by GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<string> children = select prov.getChildProviderNames(),
+            $1 != AbstractDataProvider::GenericApiCallChildName;
         assertEq(15, children.size());
 
         foreach string childName in (ExpectedChildren) {
@@ -574,8 +576,12 @@ public class FirecrawlDataProviderTest inherits QUnit::Test {
         assertEq("Firecrawl", appInfo.name);
         assertEq("firecrawlrest", appInfo.scheme);
 
-        # Verify all 15 actions are registered
-        *list<hash<DataProviderActionInfo>> actions = DataProviderActionCatalog::getActions("Firecrawl");
+        # Verify all 15 actions are registered — filter out the framework-injected
+        # make-api-call action (covered by GenericApiCallAutoInjection.qtest in
+        # RestClientDataProvider)
+        *list<hash<DataProviderActionInfo>> actions = select
+            DataProviderActionCatalog::getActions("Firecrawl"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         hash<string, bool> actionMap;
         map actionMap{$1.action} = True, actions;
 

--- a/examples/test/qlib/FireworksDataProvider/FireworksDataProvider.qtest
+++ b/examples/test/qlib/FireworksDataProvider/FireworksDataProvider.qtest
@@ -103,8 +103,11 @@ public class FireworksDataProviderTest inherits QUnit::Test {
         assertEq("fireworks-ai-logo.svg", app.logo_file_name);
         assertTrue(app.logo.size() > 0);
 
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("FireworksAi");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("FireworksAi"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(2, actions.size());
         list<string> action_names = sort(map $1.action, actions);
         assertEq(("chat-completion", "create-embeddings"), action_names);
@@ -114,7 +117,10 @@ public class FireworksDataProviderTest inherits QUnit::Test {
         FakeFireworksRestClientIo fake();
         FireworksDataProvider::FireworksDataProvider prov(fake);
         assertEq("fireworks", prov.getName());
-        list<string> children = sort(prov.getChildProviderNames());
+        # filter out the framework-injected __call__ child (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<string> children = sort(select prov.getChildProviderNames(),
+            $1 != AbstractDataProvider::GenericApiCallChildName);
         assertEq(("chat-completion", "create-embeddings"), children);
     }
 

--- a/examples/test/qlib/GeminiDataProvider/GeminiDataProvider.qtest
+++ b/examples/test/qlib/GeminiDataProvider/GeminiDataProvider.qtest
@@ -316,7 +316,11 @@ class GeminiDataProviderTest inherits QUnit::Test {
         };
 
         AbstractDataProvider child = dp.getChildProviderEx("models");
-        *list<string> names = child.getChildProviderNames();
+        # filter out the framework-injected __call__ child (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider); every sub-container
+        # with a discoverable rest member picks it up too
+        *list<string> names = select child.getChildProviderNames(),
+            $1 != AbstractDataProvider::GenericApiCallChildName;
         assertEq("GET", fake.last_method);
         assertTrue(fake.last_path.find("models") >= 0);
         assertEq(2, names.size());
@@ -333,7 +337,10 @@ class GeminiDataProviderTest inherits QUnit::Test {
         };
 
         AbstractDataProvider child = dp.getChildProviderEx("files");
-        *list<string> names = child.getChildProviderNames();
+        # filter out the framework-injected __call__ child (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        *list<string> names = select child.getChildProviderNames(),
+            $1 != AbstractDataProvider::GenericApiCallChildName;
         assertEq("GET", fake.last_method);
         assertTrue(fake.last_path.find("files") >= 0);
         assertEq(1, names.size());

--- a/examples/test/qlib/GoogleDocumentAiDataProvider/GoogleDocumentAiDataProvider.qtest
+++ b/examples/test/qlib/GoogleDocumentAiDataProvider/GoogleDocumentAiDataProvider.qtest
@@ -78,8 +78,11 @@ public class GoogleDocumentAiDataProviderTest inherits QUnit::Test {
         assertEq("GoogleDocumentAi", app.name);
         assertEq("google-documentai", app.scheme);
 
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("GoogleDocumentAi");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("GoogleDocumentAi"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(1, actions.size());
         assertEq("process-document", actions[0].action);
     }

--- a/examples/test/qlib/GroqDataProvider/GroqDataProvider.qtest
+++ b/examples/test/qlib/GroqDataProvider/GroqDataProvider.qtest
@@ -113,8 +113,11 @@ public class GroqDataProviderTest inherits QUnit::Test {
         assertEq("groq-logo.svg", app.logo_file_name);
         assertTrue(app.logo.size() > 0);
 
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("Groq");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("Groq"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(1, actions.size());
         assertEq("chat-completion", actions[0].action);
         assertEq("/chat-completion", actions[0].path);
@@ -129,7 +132,10 @@ public class GroqDataProviderTest inherits QUnit::Test {
         FakeGroqRestClientIo fake();
         GroqDataProvider::GroqDataProvider prov(fake);
         assertEq("groq", prov.getName());
-        list<string> children = prov.getChildProviderNames();
+        # filter out the framework-injected __call__ child (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<string> children = select prov.getChildProviderNames(),
+            $1 != AbstractDataProvider::GenericApiCallChildName;
         assertEq(("chat-completion",), children);
         AbstractDataProvider chat = prov.getChildProvider("chat-completion");
         assertTrue(chat instanceof

--- a/examples/test/qlib/InstantlyDataProvider/InstantlyDataProvider.qtest
+++ b/examples/test/qlib/InstantlyDataProvider/InstantlyDataProvider.qtest
@@ -358,9 +358,12 @@ public class InstantlyDataProviderTest inherits QUnit::Test {
         assertEq("Instantly", app.display_name);
         assertEq("instantly", app.scheme);
 
-        # Verify actions exist
-        list<hash<auto>> actions = DataProviderActionCatalog::getActionsEx(
-            InstantlyDataProvider::AppName);
+        # Verify actions exist — filter out the framework-injected make-api-call action
+        # (covered by GenericApiCallAutoInjection.qtest in RestClientDataProvider) so the
+        # count assertion below reflects only the provider's own actions
+        list<hash<auto>> actions = select
+            DataProviderActionCatalog::getActionsEx(InstantlyDataProvider::AppName),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertTrue(actions.size() > 0, "Instantly has registered actions");
 
         # Build action name map

--- a/examples/test/qlib/JinaDataProvider/JinaDataProvider.qtest
+++ b/examples/test/qlib/JinaDataProvider/JinaDataProvider.qtest
@@ -102,8 +102,11 @@ public class JinaDataProviderTest inherits QUnit::Test {
         assertEq("Jina AI", app.display_name);
         assertEq("jina", app.scheme);
 
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("JinaAi");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("JinaAi"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(2, actions.size());
         list<string> action_names = sort(map $1.action, actions);
         assertEq(("create-embeddings", "rerank"), action_names);
@@ -112,7 +115,10 @@ public class JinaDataProviderTest inherits QUnit::Test {
     private rootProviderTest() {
         FakeJinaRestClientIo fake();
         JinaDataProvider::JinaDataProvider prov(fake);
-        list<string> children = sort(prov.getChildProviderNames());
+        # filter out the framework-injected __call__ child (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<string> children = sort(select prov.getChildProviderNames(),
+            $1 != AbstractDataProvider::GenericApiCallChildName);
         assertEq(("create-embeddings", "rerank"), children);
     }
 

--- a/examples/test/qlib/KatanaDataProvider/KatanaDataProvider.qtest
+++ b/examples/test/qlib/KatanaDataProvider/KatanaDataProvider.qtest
@@ -321,7 +321,10 @@ public class KatanaDataProviderTest inherits QUnit::Test {
 
         assertEq("katana", provider.getName(), "root provider name is 'katana'");
 
-        *list<string> names = provider.getChildProviderNames();
+        # filter out the framework-injected __call__ child (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        *list<string> names = select provider.getChildProviderNames(),
+            $1 != AbstractDataProvider::GenericApiCallChildName;
         assertTrue(exists names, "child names list is non-empty");
         assertEq(ExpectedChildCount, names.size(),
             sprintf("provider exposes %d children (got %d)",
@@ -373,7 +376,11 @@ public class KatanaDataProviderTest inherits QUnit::Test {
         } catch (hash<ExceptionInfo> ex) {
             testSkip(sprintf("events container not available: %s", ex.err));
         }
-        *list<string> event_names = events.getChildProviderNames();
+        # filter out the framework-injected __call__ child — it's not observable, so
+        # iterating it through getExampleEventData() would throw INVALID-OPERATION
+        # (covered by GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        *list<string> event_names = select events.getChildProviderNames(),
+            $1 != AbstractDataProvider::GenericApiCallChildName;
         assertTrue(exists event_names && event_names.size() > 0,
             "events container exposes children");
 

--- a/examples/test/qlib/LlamaParseDataProvider/LlamaParseDataProvider.qtest
+++ b/examples/test/qlib/LlamaParseDataProvider/LlamaParseDataProvider.qtest
@@ -83,8 +83,11 @@ public class LlamaParseDataProviderTest inherits QUnit::Test {
             DataProvider::DataProviderActionCatalog::getApp("LlamaParse");
         assertEq("LlamaParse", app.name);
         assertEq("llamaparse", app.scheme);
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("LlamaParse");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("LlamaParse"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(1, actions.size());
         assertEq("parse-document", actions[0].action);
     }

--- a/examples/test/qlib/MilvusDataProvider/MilvusDataProvider.qtest
+++ b/examples/test/qlib/MilvusDataProvider/MilvusDataProvider.qtest
@@ -81,8 +81,11 @@ public class MilvusDataProviderTest inherits QUnit::Test {
             DataProvider::DataProviderActionCatalog::getApp("Milvus");
         assertEq("Milvus", app.name);
         assertEq("milvus", app.scheme);
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("Milvus");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("Milvus"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(1, actions.size());
         assertEq("list-collections", actions[0].action);
     }

--- a/examples/test/qlib/MistralDataProvider/MistralDataProvider.qtest
+++ b/examples/test/qlib/MistralDataProvider/MistralDataProvider.qtest
@@ -103,8 +103,11 @@ public class MistralDataProviderTest inherits QUnit::Test {
         assertEq("mistral", app.scheme);
         assertEq("mistral-ai-logo.svg", app.logo_file_name);
 
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("MistralAi");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("MistralAi"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(3, actions.size());
         list<string> action_names = sort(map $1.action, actions);
         assertEq(("chat-completion", "create-embeddings", "ocr"), action_names);
@@ -113,7 +116,10 @@ public class MistralDataProviderTest inherits QUnit::Test {
     private rootProviderTest() {
         FakeMistralRestClientIo fake();
         MistralDataProvider::MistralDataProvider prov(fake);
-        list<string> children = sort(prov.getChildProviderNames());
+        # filter out the framework-injected __call__ child (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<string> children = sort(select prov.getChildProviderNames(),
+            $1 != AbstractDataProvider::GenericApiCallChildName);
         assertEq(("chat-completion", "create-embeddings", "ocr"), children);
     }
 

--- a/examples/test/qlib/OllamaDataProvider/OllamaDataProvider.qtest
+++ b/examples/test/qlib/OllamaDataProvider/OllamaDataProvider.qtest
@@ -105,8 +105,11 @@ public class OllamaDataProviderTest inherits QUnit::Test {
         assertEq("ollama-logo.svg", app.logo_file_name);
         assertTrue(app.logo.size() > 0);
 
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("Ollama");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("Ollama"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(3, actions.size());
         list<string> action_names = sort(map $1.action, actions);
         assertEq(("chat-completion", "create-embeddings", "list-models"),
@@ -117,7 +120,10 @@ public class OllamaDataProviderTest inherits QUnit::Test {
         FakeOllamaRestClientIo fake();
         OllamaDataProvider::OllamaDataProvider prov(fake);
         assertEq("ollama", prov.getName());
-        list<string> children = sort(prov.getChildProviderNames());
+        # filter out the framework-injected __call__ child (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<string> children = sort(select prov.getChildProviderNames(),
+            $1 != AbstractDataProvider::GenericApiCallChildName);
         assertEq(("chat-completion", "create-embeddings", "list-models"), children);
     }
 

--- a/examples/test/qlib/PdfCoDataProvider/PdfCoDataProvider.qtest
+++ b/examples/test/qlib/PdfCoDataProvider/PdfCoDataProvider.qtest
@@ -221,8 +221,10 @@ public class PdfCoDataProviderTest inherits QUnit::Test {
             return;
         }
 
-        # Check all expected child providers exist
-        list<string> children = prov.getChildProviderNames();
+        # Check all expected child providers exist — filter out the framework-injected __call__
+        # child (covered by GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<string> children = select prov.getChildProviderNames(),
+            $1 != AbstractDataProvider::GenericApiCallChildName;
         assertEq(26, children.size());
 
         foreach string childName in (ExpectedChildren) {
@@ -480,8 +482,11 @@ public class PdfCoDataProviderTest inherits QUnit::Test {
         assertEq("PdfCo", appInfo.name);
         assertEq("pdfco", appInfo.scheme);
 
-        # Verify all 26 actions are registered
-        *list<hash<DataProviderActionInfo>> actions = DataProviderActionCatalog::getActions("PdfCo");
+        # Verify all 26 actions are registered — filter out the framework-injected make-api-call
+        # action (covered by GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        *list<hash<DataProviderActionInfo>> actions = select
+            DataProviderActionCatalog::getActions("PdfCo"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         hash<string, bool> actionMap;
         map actionMap{$1.action} = True, actions;
 

--- a/examples/test/qlib/PineconeDataProvider/PineconeDataProvider.qtest
+++ b/examples/test/qlib/PineconeDataProvider/PineconeDataProvider.qtest
@@ -80,8 +80,11 @@ public class PineconeDataProviderTest inherits QUnit::Test {
             DataProvider::DataProviderActionCatalog::getApp("Pinecone");
         assertEq("Pinecone", app.name);
         assertEq("pinecone", app.scheme);
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("Pinecone");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("Pinecone"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(1, actions.size());
         assertEq("list-indexes", actions[0].action);
     }

--- a/examples/test/qlib/StabilityAiDataProvider/StabilityAiDataProvider.qtest
+++ b/examples/test/qlib/StabilityAiDataProvider/StabilityAiDataProvider.qtest
@@ -94,8 +94,11 @@ public class StabilityAiDataProviderTest inherits QUnit::Test {
         assertEq("StabilityAi", app.name);
         assertEq("stability-ai", app.scheme);
 
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("StabilityAi");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("StabilityAi"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(1, actions.size());
         assertEq("generate-image", actions[0].action);
     }

--- a/examples/test/qlib/TavilyDataProvider/TavilyDataProvider.qtest
+++ b/examples/test/qlib/TavilyDataProvider/TavilyDataProvider.qtest
@@ -97,8 +97,11 @@ public class TavilyDataProviderTest inherits QUnit::Test {
         assertEq("tavily-logo.svg", app.logo_file_name);
         assertTrue(app.logo.size() > 0);
 
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("Tavily");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("Tavily"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(4, actions.size());
         list<string> action_names = sort(map $1.action, actions);
         assertEq(("crawl", "extract", "map", "search"), action_names);
@@ -108,7 +111,10 @@ public class TavilyDataProviderTest inherits QUnit::Test {
         FakeTavilyRestClientIo fake();
         TavilyDataProvider::TavilyDataProvider prov(fake);
         assertEq("tavily", prov.getName());
-        list<string> children = sort(prov.getChildProviderNames());
+        # filter out the framework-injected __call__ child (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<string> children = sort(select prov.getChildProviderNames(),
+            $1 != AbstractDataProvider::GenericApiCallChildName);
         assertEq(("crawl", "extract", "map", "search"), children);
         AbstractDataProvider s = prov.getChildProvider("search");
         assertTrue(s instanceof TavilyDataProvider::TavilySearchDataProvider);

--- a/examples/test/qlib/TogetherDataProvider/TogetherDataProvider.qtest
+++ b/examples/test/qlib/TogetherDataProvider/TogetherDataProvider.qtest
@@ -106,8 +106,11 @@ public class TogetherDataProviderTest inherits QUnit::Test {
         assertEq("together-ai-logo.svg", app.logo_file_name);
         assertTrue(app.logo.size() > 0);
 
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("TogetherAi");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("TogetherAi"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(3, actions.size());
         list<string> action_names = sort(map $1.action, actions);
         assertEq(("chat-completion", "create-embeddings", "generate-image"),
@@ -118,7 +121,10 @@ public class TogetherDataProviderTest inherits QUnit::Test {
         FakeTogetherRestClientIo fake();
         TogetherDataProvider::TogetherDataProvider prov(fake);
         assertEq("together", prov.getName());
-        list<string> children = sort(prov.getChildProviderNames());
+        # filter out the framework-injected __call__ child (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<string> children = sort(select prov.getChildProviderNames(),
+            $1 != AbstractDataProvider::GenericApiCallChildName);
         assertEq(("chat-completion", "create-embeddings", "generate-image"),
             children);
         AbstractDataProvider chat = prov.getChildProvider("chat-completion");

--- a/examples/test/qlib/UnstructuredDataProvider/UnstructuredDataProvider.qtest
+++ b/examples/test/qlib/UnstructuredDataProvider/UnstructuredDataProvider.qtest
@@ -77,8 +77,11 @@ public class UnstructuredDataProviderTest inherits QUnit::Test {
             DataProvider::DataProviderActionCatalog::getApp("UnstructuredIo");
         assertEq("UnstructuredIo", app.name);
         assertEq("unstructured", app.scheme);
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("UnstructuredIo");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("UnstructuredIo"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(1, actions.size());
         assertEq("partition-text", actions[0].action);
     }

--- a/examples/test/qlib/VoyageDataProvider/VoyageDataProvider.qtest
+++ b/examples/test/qlib/VoyageDataProvider/VoyageDataProvider.qtest
@@ -92,7 +92,11 @@ public class VoyageDataProviderTest inherits QUnit::Test {
         FakeVoyageRestClientIo rest();
         VoyageDataProvider::VoyageDataProvider prov(rest);
         assertEq("voyage", prov.getName());
-        assertEq(("create-embeddings", "rerank"), sort(prov.getChildProviderNames()));
+        # filter out the framework-injected __call__ child (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        assertEq(("create-embeddings", "rerank"),
+            sort(select prov.getChildProviderNames(),
+                $1 != AbstractDataProvider::GenericApiCallChildName));
 %endif
     }
 

--- a/examples/test/qlib/WaveDataProvider/WaveDataProvider.qtest
+++ b/examples/test/qlib/WaveDataProvider/WaveDataProvider.qtest
@@ -473,8 +473,11 @@ public class WaveDataProviderTest inherits QUnit::Test {
         assertEq("Wave", app.name);
         assertEq("Wave", app.display_name);
 
-        # Get all actions for the Wave app
-        *list<hash<DataProviderActionInfo>> actions = DataProviderActionCatalog::getActions("Wave");
+        # Get all actions for the Wave app — filter out the framework-injected make-api-call
+        # action (covered by GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        *list<hash<DataProviderActionInfo>> actions = select
+            DataProviderActionCatalog::getActions("Wave"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertTrue(actions.size() > 0, "Wave app should have actions");
         assertEq(22, actions.size(), "Wave app should have exactly 22 actions");
 

--- a/examples/test/qlib/WeaviateDataProvider/WeaviateDataProvider.qtest
+++ b/examples/test/qlib/WeaviateDataProvider/WeaviateDataProvider.qtest
@@ -79,8 +79,11 @@ public class WeaviateDataProviderTest inherits QUnit::Test {
             DataProvider::DataProviderActionCatalog::getApp("Weaviate");
         assertEq("Weaviate", app.name);
         assertEq("weaviate", app.scheme);
-        list<hash<DataProviderActionInfo>> actions =
-            DataProvider::DataProviderActionCatalog::getActions("Weaviate");
+        # filter out the framework-injected make-api-call action (covered by
+        # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
+        list<hash<DataProviderActionInfo>> actions = select
+            DataProvider::DataProviderActionCatalog::getActions("Weaviate"),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertEq(1, actions.size());
         assertEq("list-classes", actions[0].action);
     }

--- a/examples/test/qlib/ZohoBooksDataProvider/ZohoBooksDataProvider.qtest
+++ b/examples/test/qlib/ZohoBooksDataProvider/ZohoBooksDataProvider.qtest
@@ -643,9 +643,13 @@ public class ZohoBooksDataProviderTest inherits QUnit::Test {
     #! Action catalog tests - verify all actions are registered
     actionCatalogTests() {
         checkJson();
-        # Get all actions for the Zoho Books app
-        *list<hash<DataProviderActionInfo>> actions = DataProviderActionCatalog::getActions(
-            ZohoBooksDataProvider::AppName);
+        # Get all actions for the Zoho Books app — filter out the framework-injected
+        # make-api-call action (covered by GenericApiCallAutoInjection.qtest in
+        # RestClientDataProvider) so the count assertion below reflects only this
+        # provider's own actions
+        *list<hash<DataProviderActionInfo>> actions = select
+            DataProviderActionCatalog::getActions(ZohoBooksDataProvider::AppName),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertTrue(actions.size() > 0);
 
         # Verify action count (38 CRUD + 10 triggers = 48)

--- a/examples/test/qlib/ZohoInventoryDataProvider/ZohoInventoryDataProvider.qtest
+++ b/examples/test/qlib/ZohoInventoryDataProvider/ZohoInventoryDataProvider.qtest
@@ -579,9 +579,12 @@ public class ZohoInventoryDataProviderTest inherits QUnit::Test {
     #! Action catalog tests - verify all actions are registered
     actionCatalogTests() {
         checkJson();
-        # Get all actions for the Zoho Inventory app
-        *list<hash<DataProviderActionInfo>> actions = DataProviderActionCatalog::getActions(
-            ZohoInventoryDataProvider::AppName);
+        # Get all actions for the Zoho Inventory app — filter out the framework-injected
+        # make-api-call action (covered by GenericApiCallAutoInjection.qtest in
+        # RestClientDataProvider) so the count assertion reflects only this provider's own actions
+        *list<hash<DataProviderActionInfo>> actions = select
+            DataProviderActionCatalog::getActions(ZohoInventoryDataProvider::AppName),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertTrue(actions.size() > 0);
 
         # Verify action count (10 DPAT_FIND + 44 DPAT_API + 8 DPAT_EVENT = 62)

--- a/examples/test/qlib/ZohoInvoiceDataProvider/ZohoInvoiceDataProvider.qtest
+++ b/examples/test/qlib/ZohoInvoiceDataProvider/ZohoInvoiceDataProvider.qtest
@@ -645,9 +645,13 @@ public class ZohoInvoiceDataProviderTest inherits QUnit::Test {
     #! Action catalog tests - verify all actions are registered
     actionCatalogTests() {
         checkJson();
-        # Get all actions for the Zoho Invoice app
-        *list<hash<DataProviderActionInfo>> actions = DataProviderActionCatalog::getActions(
-            ZohoInvoiceDataProvider::AppName);
+        # Get all actions for the Zoho Invoice app — filter out the framework-injected
+        # make-api-call action (covered by GenericApiCallAutoInjection.qtest in
+        # RestClientDataProvider) so the count assertion below reflects only this
+        # provider's own actions
+        *list<hash<DataProviderActionInfo>> actions = select
+            DataProviderActionCatalog::getActions(ZohoInvoiceDataProvider::AppName),
+            $1.action != AbstractDataProvider::GenericApiCallActionName;
         assertTrue(actions.size() > 0);
 
         # Verify action count (50 CRUD/actions + 6 triggers = 56)

--- a/qlib/DataProvider/DataProviderActionCatalog.qc
+++ b/qlib/DataProvider/DataProviderActionCatalog.qc
@@ -557,6 +557,22 @@ public class DataProviderActionCatalog {
         */
         static *code<hash<DataProviderActionInfo>(hash<DataProviderAppInfo>)> cb_build_generic_api_call_action;
 
+        #! Name of the module that registers the generic @c make-api-call action builder
+        /** Loaded on demand by @ref registerApp() when a REST-capable app is registered before the
+            builder has been set — i.e. when the embedding application skipped
+            @ref DataProvider::registerKnownFactories() (typically because it loaded the data-provider
+            index from disk, so the persisted index advertises @c make-api-call but the live catalog
+            never receives it). Loading this module runs its init block, which calls
+            @ref setGenericApiCallActionBuilder() and drains the pending-app backlog.
+
+            This is a runtime (string) load, not a @c %requires dependency, so it does not create a
+            module cycle (@c RestClientDataProvider already @c %requires(reexport) @c DataProvider). The
+            same name-based indirection to this module is used by @c DataProvider::FactoryMap.
+
+            @since DataProvider 3.5
+        */
+        const GenericApiCallBuilderModule = "RestClientDataProvider";
+
         #! Late-bound scheme lookup hook — set by @c ConnectionProvider at init time
         /** Signature: <tt>*hash<auto> sub (string scheme)</tt>. Returns the
             @c ConnectionSchemeInfo hash (with @c cls) for the given scheme, or @ref NOTHING /
@@ -693,6 +709,7 @@ public class DataProviderActionCatalog {
         }
 
         bool should_auto_register_generic_call = False;
+        bool should_load_generic_api_call_builder = False;
         {
             bool needs_lock = !lck.lockOwner();
             if (needs_lock) {
@@ -791,16 +808,32 @@ public class DataProviderActionCatalog {
                     should_auto_register_generic_call = True;
                 } else {
                     # builder is not yet set — queue the app for retroactive registration when
-                    # setGenericApiCallActionBuilder() is eventually called
+                    # setGenericApiCallActionBuilder() is eventually called, and arrange (after the
+                    # lock is released) to load the module that provides the builder, so the backlog is
+                    # drained promptly instead of waiting for an external trigger that may never come
                     pending_generic_api_call_apps{app.name} = True;
+                    should_load_generic_api_call_builder = True;
                 }
             }
         }
 
-        # auto-register the framework-injected "Make an API call" action outside the lock; registerAction()
-        # will re-acquire the lock cleanly. Swallow errors via the helper to avoid breaking app registration
-        # when the builder produces invalid action info.
+        # register the framework-injected "Make an API call" action outside the lock; registerAction()
+        # (and the builder-provider module load below) re-acquire the lock cleanly, so this must run
+        # unlocked. Errors are swallowed by the helpers to avoid breaking app registration.
         if (should_auto_register_generic_call) {
+            # the builder was already available when this app was registered
+            DataProviderActionCatalog::registerGenericApiCallActionForApp(app);
+        } else if (should_load_generic_api_call_builder) {
+            # the app qualifies for the make-api-call action but the builder has not been registered,
+            # which means the module that provides it (GenericApiCallBuilderModule) is not loaded in
+            # this process. This is the normal case when the embedding application loaded the
+            # data-provider index from disk and therefore skipped DataProvider::registerKnownFactories()
+            # at startup: the persisted index still advertises make-api-call, but the live catalog would
+            # never receive it and action lookups would 404. Load the builder-provider module
+            # (idempotent); its init registers the builder and drains the pending backlog. Then register
+            # this app explicitly: it is a no-op if the drain already covered it, and it closes the race
+            # where a concurrent registration drained the backlog before this app was queued.
+            DataProviderActionCatalog::loadGenericApiCallBuilder(app);
             DataProviderActionCatalog::registerGenericApiCallActionForApp(app);
         }
     }
@@ -892,6 +925,39 @@ public class DataProviderActionCatalog {
             # log but do not fail the surrounding registration
             stderr.printf("DataProviderActionCatalog: failed to auto-register generic API call action for "
                 "app %y: %s: %s\n", app.name, ex.err, ex.desc);
+        }
+    }
+
+    #! Loads the module that provides the generic @c make-api-call action builder, on demand
+    /** Called from @ref registerApp() when a REST-capable app is registered before the builder has been
+        set — e.g. the embedding application loaded the provider index from disk and skipped
+        @ref DataProvider::registerKnownFactories(), so @ref GenericApiCallBuilderModule was never
+        loaded. Loading it runs its init block, which calls @ref setGenericApiCallActionBuilder() and
+        drains the pending-app backlog, so the live catalog gains the @c make-api-call action for the
+        queued REST apps and stops diverging from the persisted index.
+
+        The load is idempotent (so it runs effectively once per process — only apps registered before
+        the first load reach this path) and is bracketed in a module-init savepoint so a failed or
+        partial load rolls back cleanly, mirroring @ref DataProvider::tryLoad(). Must be called with no
+        catalog lock held, because draining the backlog re-acquires the lock through registerAction().
+
+        @param app the REST-capable app whose registration triggered the load (used for diagnostics)
+
+        @since DataProvider 3.5
+    */
+    private:internal static loadGenericApiCallBuilder(hash<DataProviderAppInfo> app) {
+        int sp = ImplicitModuleTransaction::savepoint();
+        try {
+            load_module(GenericApiCallBuilderModule);
+            ImplicitModuleTransaction::commit(sp);
+        } catch (hash<ExceptionInfo> ex) {
+            # roll back any partial registrations from the failed load, then warn loudly: a REST app
+            # will silently lack its make-api-call action otherwise
+            ImplicitModuleTransaction::rollback(sp);
+            stderr.printf("DataProviderActionCatalog: REST app %y qualifies for the framework-injected "
+                "%y action, but the builder-provider module %y could not be loaded; the action will be "
+                "missing from this app: %s: %s\n", app.name, AbstractDataProvider::GenericApiCallActionName,
+                GenericApiCallBuilderModule, ex.err, ex.desc);
         }
     }
 


### PR DESCRIPTION
## What

Fixes the framework-injected generic **"Make an API call"** action (`make-api-call`) being silently missing from the live `DataProviderActionCatalog` for REST-capable apps after an embedding application starts from a persisted provider index.

Symptom (as seen in Qorus after a restart where a provider index already exists):

```
PUT /api/latest/dataprovider/apps/<App>/actions/make-api-call/getOptions
→ 404 Not Found: class "actions" has no subclass "make-api-call"
```

The persisted index still advertises the action (so the UI shows it), but the live catalog never received it → the lookup 404s.

## Why

`make-api-call`'s builder is registered as a side effect of loading `RestClientDataProvider` (`setGenericApiCallActionBuilder()`), which is normally pulled in by `DataProvider::registerKnownFactories()`. Applications that load the data-provider **index from disk** skip `registerKnownFactories()` for fast startup, so the builder is never set, the `pending_generic_api_call_apps` backlog never drains, and the live catalog diverges from the index.

## Fix

When `registerApp()` encounters a REST-capable app with no builder set, lazily load the builder-provider module. Its init sets the builder and drains the backlog, so the live catalog matches the index.

- Runtime string-load, not a `%requires` dependency → no module cycle; mirrors the existing `FactoryMap` indirection.
- Demand-driven (only when a REST app is registered), idempotent, effectively once per process.
- Savepoint-bracketed so a failed/partial load rolls back cleanly (mirrors `DataProvider::tryLoad()`).
- Respects the per-app `disable_generic_api_call` opt-out.
- Warns loudly to `stderr` on load failure, replacing the previous silent-backlog failure mode.

## Verification

Standalone repro: load only `RestClient` (builder unset, `RestClientDataProvider` unloaded — the index fast-path state), then register a REST-capable app.

| | before | after |
|---|---|---|
| `make-api-call` in live catalog | ❌ absent → 404 | ✅ present |
| builder-provider auto-loaded | ❌ no | ✅ yes |
| 2nd app (builder already set) | ❌ absent | ✅ present (normal path) |
| `disable_generic_api_call` app | ✅ excluded | ✅ excluded |

Closes #5341

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Follow-up: test-side filter for off-by-one CI failures (`6cf4dd9dc`, `4632f3f46`)

After PR #5338 landed `make-api-call` auto-injection on `develop`, pre-existing per-provider tests that hardcode action counts and child-name lists started failing across the board with consistent off-by-one shapes:

- `assertEq(N, actions.size())` — actual `N+1` (the framework-injected `make-api-call` counts)
- `assertEq((<list>), sort(prov.getChildProviderNames()))` — actual list contains the framework-injected `__call__`
- One special shape: CdsRest's `assertEq(names.size(), summary.size())` parity, where `getChildProviderNames()` carries `__call__` but `getChildProviderSummaryInfo()` doesn't

Two commits in this PR fix this across **37 test files** (17 in `6cf4dd9dc`, 20 in `4632f3f46`) by filtering the framework-injected entries at the assertion site using the reserved constants `AbstractDataProvider::GenericApiCallActionName` and `AbstractDataProvider::GenericApiCallChildName`. Zero production-code changes.

### Why the test-side filter instead of a framework-side fix

I considered three "smaller-touch" alternatives and rejected each for the reasons below. They all live within reach as future cleanups — see [Possible follow-up](#possible-framework-side-follow-up) — but they're not safe to combine with this bugfix.

1. **Change `DataProviderActionCatalog::getActions()` / `getActionHash()` defaults to exclude framework-injected entries** — would have meant zero test edits.

   **Killed by dispatch coupling.** `DpqlActionSession.qc:595` calls `getActionHash(app_name)` and looks up the action by name to dispatch it:

   ```qore
   *hash<string, hash<DataProviderActionInfo>> actions =
       DataProviderActionCatalog::getActionHash(app_name);
   *hash<DataProviderActionInfo> action = actions{action_name};
   if (!action) { throw "CONTEXT-ERROR", ... }
   ```

   If we exclude framework-injected from the default view, any `@App/make-api-call` invocation throws `CONTEXT-ERROR` at dispatch time. That's a runtime regression for every UI/cron/script that dispatches `make-api-call`. Not a tradeoff worth taking inside a bugfix PR.

2. **Stop auto-injecting `__call__` into nested sub-containers** (Anthropic's `batches`/`files`/`skills`/`models`, Katana's event children, Gemini's `models`/`files`, CustomerIo/ZohoBooks/ZohoInvoice event sub-containers, etc.). Idea: `__call__` only at per-app root.

   **Killed by missing framework concept.** The framework has no notion of "this provider is an app root." Reflective discovery walks the class hierarchy looking for a `rest` member; that member is inherited at every level. Threading a `is_app_root` flag through every provider constructor (or adding a parent-pointer model, or a class-name registry check on every `getChildProviderNames()` call) would be a much larger architectural change than the test breakage warrants. And it doesn't fix the *root-level* child-list assertions (Voyage, Tavily, Anthropic root, Cohere root, etc.) — they'd still need filtering.

3. **Add a tag (`framework_injected: True`) on injected entries and provide convenience getters (`getOwnActions`, `getOwnChildProviderNames`)** that filter by the tag.

   **Same footprint, no behavioral win.** Tests still need touching in the same 37 files — just renaming `getActions(app)` to `getOwnActions(app)` instead of wrapping in `select … != GenericApiCallActionName`. The framework gains a clearer "own vs framework-injected" concept, which is real value, but it doesn't *reduce* the test churn we're paying here.

### Why the current pattern is OK

- **Zero production-code risk.** All filtering happens locally in the test's own variables after the framework method returns. Production callers see identical behavior.
- **Uses framework constants, not magic strings.** If `GenericApiCallChildName` / `GenericApiCallActionName` ever rename, the filters follow.
- **The framework's auto-injection has dedicated coverage.** `GenericApiCallAutoInjection.qtest` asserts `make-api-call` is present in the catalog and `__call__` resolves through the runtime for REST apps. Per-provider tests asserting the provider's own surface is correct test intent.
- **The pattern composes.** If the framework later auto-injects more, the same filter generalises by reading more constants.

### Possible framework-side follow-up

If we decide the test-side discipline is too easy for new test authors to forget, a clean follow-up PR could land *G-safe-A*:

- Add `framework_injected: *bool` on `DataProviderActionInfo`; tag at the injection site (`registerGenericApiCallActionForApp`).
- Add new convenience getters: `getOwnActions(app)`, `getOwnActionHash(app)`, `AbstractDataProvider::getOwnChildProviderNames()`.
- Existing getters keep their current behavior — dispatch and provider-index serialization unchanged.
- Sweep the 37 test files to switch from the inline filter to the new `getOwn*` calls.

This would be a pure cleanup, not a bugfix, and is safe to defer.
