### PR TITLE
feat: add SQL partition support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -552,6 +552,21 @@ endif()
 # (/usr/lib/llvm-<major>/lib/libLLVM.so) to avoid leaking the development
 # directory into installed RUNPATHs and confusing dpkg-shlibdeps.
 string(REGEX MATCH "^[0-9]+" QORE_LLVM_MAJOR_VERSION "${LLVM_PACKAGE_VERSION}")
+# find_library() below caches QORE_LLVM_SYSTEM_LIBRARY / LLVM_LIBRARIES and will
+# not re-search once they are set.  When LLVM_DIR is repointed at a different
+# LLVM in an existing build tree (e.g. switching llvm-20 -> llvm-21), the cached
+# library would stay pinned to the previous version, silently mixing the new
+# headers with the old runtime library (an ABI mismatch).  Invalidate the cached
+# results whenever the resolved LLVM (cmake dir + version) differs from what they
+# were last resolved for, so find_library re-runs.
+set(_qore_llvm_lib_fingerprint "${LLVM_DIR}|${LLVM_PACKAGE_VERSION}")
+if(DEFINED QORE_LLVM_LIBRARY_FINGERPRINT AND
+        NOT QORE_LLVM_LIBRARY_FINGERPRINT STREQUAL "${_qore_llvm_lib_fingerprint}")
+    unset(QORE_LLVM_SYSTEM_LIBRARY CACHE)
+    unset(LLVM_LIBRARIES CACHE)
+endif()
+set(QORE_LLVM_LIBRARY_FINGERPRINT "${_qore_llvm_lib_fingerprint}"
+    CACHE INTERNAL "LLVM dir+version the cached LLVM library was resolved for")
 set(QORE_LLVM_LIBRARY_NAMES)
 if(QORE_LLVM_MAJOR_VERSION)
     list(APPEND QORE_LLVM_LIBRARY_NAMES LLVM-${QORE_LLVM_MAJOR_VERSION})

--- a/bin/qschema
+++ b/bin/qschema
@@ -54,6 +54,7 @@ const Opts = {
     "verbose":       "v,verbose:i+",
     "output":        "o,output=s",
     "format":        "format=s",
+    "with_partitions": "with-partitions",
     "help":          "h,help",
     "version":       "V,version",
 };
@@ -187,6 +188,7 @@ class QSchemaMain {
         printf("  %s        Output file (for export)\n", color.key("-o, --output <file>"));
         printf("  %s     Output format for export %s\n", color.key("    --format yaml|json"),
             color.dim("(default: yaml)"));
+        printf("  %s     Include physical partitions in export\n", color.key("    --with-partitions"));
         printf("  %s                 Show this help\n", color.key("-h, --help"));
         printf("  %s              Show version\n", color.key("-V, --version"));
 
@@ -574,7 +576,11 @@ class QSchemaMain {
         }
 
         string class_name = "ExportedSchema";
-        SchemaReverse::SchemaReverse rev(ds, class_name);
+        hash<auto!> rev_opts;
+        if (opts.with_partitions) {
+            rev_opts.with_partitions = True;
+        }
+        SchemaReverse::SchemaReverse rev(ds, class_name, rev_opts);
 
         string output;
         if (format == "yaml") {

--- a/design-pending/sqlutil-partitions.md
+++ b/design-pending/sqlutil-partitions.md
@@ -1,0 +1,778 @@
+# Generic Partition Support in SqlUtil
+
+## Status
+
+Draft / proposal. No partition lifecycle API exists in SqlUtil today; this document
+specifies a portable one.
+
+Phase 1 is deliberately limited to **range partitions**. The data model leaves room for
+list/hash/sub-partitioning later, but those methods are not part of the initial contract
+because their DDL, naming, and drop semantics are not yet uniformly specified across the
+target drivers.
+
+## Motivation
+
+Qorus archiving needs **time-range (monthly) partitions** so that retiring old data is a
+near-instant catalog operation (drop a partition) instead of a row-by-row `DELETE` over a
+large table. The same primitive — "roll a new period forward, drop the oldest period" — must
+work uniformly across the database backends Qorus runs on (PostgreSQL, Oracle, MySQL).
+
+## Current state
+
+Partition handling in SqlUtil today is fragmentary and read-only:
+
+- **PostgreSQL** — partitioned parent tables (`pg_class.relkind = 'p'`) are now visible to
+  `checkExistenceImpl()` / `describeImpl()` (they query `pg_class`/`pg_namespace` instead of
+  `pg_statio_all_tables`, which omits relations with no physical storage). This is the
+  prerequisite that lets SqlUtil *see* a partitioned table at all; there is no DDL.
+- **Oracle** — a SELECT-time `"partition"` qualifier only
+  (`OracleSqlUtilBase.qm`, `OracleSelectOptions`): `selectRows({"partition": "p1"})`.
+- **MySQL / SQLite / Firebird / MSSQL** — `partition` is at most a reserved word.
+- **No driver** generates add / drop / truncate / detach / exchange-partition DDL.
+
+## Design principles
+
+1. **`dropPartition()` is uniform.** It removes the named partition *and its data*, with
+   identical observable semantics on every supported driver. Drivers must not weaken or
+   strengthen this (for example, PostgreSQL must not silently leave the data behind as a
+   standalone table).
+2. **Driver-unique capabilities are exposed through their own API, never overloaded onto a
+   generic method.** PostgreSQL can *detach* a partition into a standalone table without
+   dropping it — that is surfaced as a separate, capability-gated `detachPartition()`, not as
+   a flag on `dropPartition()`.
+3. **No imposed creation model.** Some databases auto-create partitions on insert (Oracle
+   interval partitioning); others require explicit pre-creation (PostgreSQL declarative).
+   The API supports **both** and forces neither: explicit `addPartition()`, an optional
+   declared auto-strategy, and an idempotent `ensurePartition()` that the archiving job can
+   call regardless of how partitions come into existence.
+4. **Lifecycle ops are imperative, not part of `align()`.** Schema alignment must never
+   create or drop partitions as a side effect — dropping a partition destroys data and must
+   always be an explicit, intentional call.
+5. **Capability-gated with clear failures.** Unsupported backends throw a well-defined
+   exception rather than silently no-op'ing or emulating with non-equivalent semantics.
+6. **Names are identifiers, not SQL fragments.** Public methods accept driver partition
+   identifiers. Implementations must quote identifiers through existing driver helpers and
+   must never concatenate a caller-provided name into SQL unescaped.
+
+## Phase-1 scope
+
+Phase 1 supports only range partitions:
+
+- one partitioning method: `"range"`;
+- one or more key columns;
+- inclusive lower and exclusive upper bounds;
+- optional default / catch-all range partition where the driver supports it;
+- optional auto-create strategy for drivers with native interval partitioning.
+
+List partitions, hash partitions, composite sub-partitioning, partition exchange, and
+non-equivalent detach emulations are deferred. Future work should add method-specific spec
+hashdecls rather than overloading the range-oriented fields below.
+
+## Capability flags
+
+Mirrors the existing `supportsTablespacesImpl()` pattern. Default implementations on
+`AbstractTable` return `False`; drivers override. In phase 1, `supportsPartitions()` means
+that the driver/server supports range-partition DDL through this API.
+
+```qore
+#! True if the driver/server supports range partitioning DDL through SqlUtil
+bool supportsPartitions();
+
+#! True if a partition can be detached into a standalone table without dropping its data
+bool supportsPartitionDetach();
+
+#! True if the backend can auto-create range partitions on insert (for example Oracle interval)
+bool supportsAutoPartitioning();
+```
+
+| Capability            | PostgreSQL 10+ | Oracle 12c+ | MySQL 5.7+ | SQLite | Firebird | MSSQL (later) |
+|-----------------------|:--------------:|:-----------:|:----------:|:------:|:--------:|:-------------:|
+| `supportsPartitions`        | yes      | yes         | yes        | no     | no       | yes (phase 2) |
+| `supportsPartitionDetach`   | yes      | no¹         | no         | no     | no       | no            |
+| `supportsAutoPartitioning`  | no²      | yes         | no         | no     | no       | no            |
+
+¹ Oracle can approximate detach via `EXCHANGE PARTITION`, but it requires a pre-existing
+target table with an identical shape, so the semantics are not equivalent; left unsupported
+in phase 1 rather than emulated.
+² Native declarative partitioning has no built-in interval auto-create (pre-`pg_partman`).
+
+## Data model
+
+> **Implementation convention:** every hash in the implementation (hashdecl members, method
+> parameters, return types, locals) must be a typed hash — `hash<auto>`, a templated
+> `hash<string, T>`, or a `hash<SomeHashdecl>` — and never a bare `hash`. A bare `hash`
+> forces expensive runtime type-stripping on every assignment; the typed forms avoid it. All
+> hashdecls and signatures in this document already follow this rule.
+
+### Bound values
+
+`bound_from` and `bound_to` use typed Qore values when the bound can be represented
+portably. For multi-column range partitioning, the value is a list whose cardinality must
+match the table's partition key. For driver-native expressions or sentinels such as
+`MINVALUE` / `MAXVALUE`, use `bound_from_sql` / `bound_to_sql`; portable callers should
+prefer typed values.
+
+For `PartitionSpec` input, typed and native SQL values are mutually exclusive per bound side:
+callers must not provide both `bound_from` and `bound_from_sql`, or both `bound_to` and
+`bound_to_sql`. This prevents ambiguous DDL generation. `PartitionInfo` introspection may
+include both typed values and native SQL text when the driver can provide both.
+
+When introspecting, drivers should return both the typed values they can parse and the native
+SQL text used by the database. The native text is required for diagnostics and round-trip
+visibility because parsing partition bounds is not equally reliable on every backend.
+
+### Schema-file bound coercion
+
+Qore source schema descriptions may use native Qore values such as date literals. `.ysm` /
+`.jsm` data-schema files cannot represent Qore date literals directly, so
+`DataSchemaLoader` must define deterministic coercion for partition bounds:
+
+- table/column driver overrides and column shorthand normalization run before partition bound
+  coercion; `PartitionStrategy.columns` is resolved against the normalized column map first;
+- JSON/YAML strings matching ISO date or datetime syntax are converted to Qore `date` values
+  when the corresponding partition column is declared as a Qore/date-like column;
+- otherwise JSON/YAML strings remain strings and are quoted as string values by the driver;
+- numeric and boolean values retain their native JSON/YAML scalar type;
+- composite bounds are coerced element by element against `PartitionStrategy.columns`;
+- `bound_from_sql` / `bound_to_sql` are never coerced and are passed through as native SQL
+  expressions.
+
+If the loader cannot infer the target partition column type, it must leave the value unchanged
+rather than guessing.
+
+### `PartitionInfo` — one row per existing partition (introspection result)
+
+```qore
+public hashdecl PartitionInfo {
+    string name;                  #! canonical public partition identifier for lifecycle calls
+    string method = "range";      #! phase 1 only: "range"
+    softlist<string> columns;     #! partition key column(s)
+    int ordinal;                  #! stable lifecycle order; lower ranges first, default last
+
+    *auto bound_from;             #! inclusive lower bound; scalar or list for composite keys
+    *auto bound_to;               #! exclusive upper bound; scalar or list for composite keys
+    *string bound_from_sql;       #! native lower-bound expression if available
+    *string bound_to_sql;         #! native upper-bound expression if available
+    *string bound_sql;            #! native complete bound clause for diagnostics / round-trip
+
+    bool is_default = False;      #! catch-all / default partition
+
+    *string schema;               #! schema that owns the partition object/relation, if exposed
+    *string relation_name;        #! physical relation/table name, if distinct from name
+    *string sql_name;             #! fully quoted SQL identifier for diagnostics only
+
+    *hash<auto> driver;           #! driver-specific metadata, keyed by driver name
+}
+```
+
+For PostgreSQL, `name` is the child table identifier used by lifecycle calls; `relation_name`
+is also set to the child table name. For Oracle/MySQL, `name` is the database partition name
+and `relation_name` is normally unset.
+
+`method` and `columns` are convenience copies of the table-level `PartitionStrategy` facts
+(constant across every partition of a table); they are denormalized into `PartitionInfo` so a
+single partition descriptor is self-contained, not because they vary per partition.
+
+`ordinal` is assigned by the driver during introspection and is the stable ordering key for
+`listPartitions()`. When typed lower bounds are available, ordinal follows ascending lower
+bound order with the default/catch-all partition last. When only native `bound_sql` is
+available, the driver must still assign a deterministic ordinal from database metadata rather
+than forcing callers to parse native SQL text.
+
+`ordinal` is a position **within a single `listPartitions()` result**, recomputed on every
+introspection — it shifts when partitions are added or dropped. It is an ordering aid, **not a
+durable identity**: use `name` (or `schema`/`relation_name`) to refer to a partition across
+calls, and never persist `ordinal` across structural changes.
+
+### `PartitionSpec` — input to create / lookup operations
+
+`PartitionSpec` intentionally does **not** repeat the partition method or key columns. Those
+are table-level facts from `PartitionStrategy`. `addPartition()` and `ensurePartition()` must
+validate each spec against the table's strategy.
+
+```qore
+public hashdecl PartitionSpec {
+    *auto bound_from;             #! range lower bound (inclusive); scalar or composite list
+    *auto bound_to;               #! range upper bound (exclusive); scalar or composite list
+    *string bound_from_sql;       #! native lower-bound expression, if a typed value is not usable
+    *string bound_to_sql;         #! native upper-bound expression, if a typed value is not usable
+    bool is_default = False;      #! create / find the default catch-all partition
+                                  #! (note: `default` is a Qore keyword and cannot be a hashdecl member)
+    *hash<auto> driver;           #! driver-specific options (tablespace, PG child schema, etc.)
+}
+```
+
+Validation rules:
+
+- `PartitionStrategy.columns` must reference columns that are actually declared on the table;
+  an unknown partition key column is a `DESCRIPTION-ERROR`, validated at `setupTable()` before
+  any bound coercion or DDL generation (the PK-includes-partition-key rule and the schema-file
+  bound coercion both depend on this resolving first);
+- non-default range partitions require `bound_from`/`bound_from_sql` and
+  `bound_to`/`bound_to_sql`;
+- `is_default` partitions must not provide regular bounds;
+- `bound_from` and `bound_from_sql` are mutually exclusive, as are `bound_to` and
+  `bound_to_sql`;
+- composite bounds must have the same number of values as `PartitionStrategy.columns`;
+- drivers whose DDL only names an upper bound (Oracle/MySQL range partitioning) still use
+  `bound_from` for validation, lookup, and overlap detection;
+- implementations must reject overlapping ranges, duplicate names, and specs incompatible
+  with the table strategy;
+- implementations must surface driver restrictions on unique/primary keys for partitioned
+  tables as `PARTITION-ERROR` or `DESCRIPTION-ERROR`, not as late SQL surprises where the
+  restriction can be validated earlier. In particular, both PostgreSQL and MySQL **require
+  every primary-key and unique constraint to include all `PartitionStrategy.columns`**; this
+  must be validated at `setupTable()` (description time), not deferred to `CREATE`.
+
+### Table-level partition strategy
+
+Added as an optional `partition_strategy` key in the table-description hash so a partitioned
+table can be created and re-described round-trip. Absent for non-partitioned tables.
+
+```qore
+public hashdecl PartitionStrategy {
+    string method = "range";       #! phase 1 only: "range"
+    softlist<string> columns;      #! partition key column(s)
+    *hash<auto> auto;              #! declared auto-create policy where supported
+                                   #! portable example: {"interval_months": 1}
+    *hash<auto> driver;            #! driver-specific strategy options
+}
+```
+
+The `auto` member is how principle 3 is honoured declaratively: a table may declare an
+auto-create policy (Oracle interval) *or* leave it unset and have partitions created
+explicitly. `supportsAutoPartitioning()` gates whether `auto` is meaningful for the driver.
+
+Initial partitions are represented by an optional top-level `partitions` key in the table
+description:
+
+```qore
+"partition_strategy": <PartitionStrategy>{
+    "method": "range",
+    "columns": "created",
+},
+"partitions": {
+    "y2026m07": <PartitionSpec>{
+        "bound_from": 2026-07-01,
+        "bound_to": 2026-08-01,
+    },
+},
+```
+
+`partitions` is used when creating a table and when describing an existing table. It is not
+processed by `align()` as a lifecycle delta; creating, dropping, or truncating partitions
+remains an explicit lifecycle operation.
+
+**`align()` and `partition_strategy`.** While the `partitions` *list* is never an alignment
+delta, the `partition_strategy` itself participates in comparison. Converting a table's
+partitioning — non-partitioned ↔ partitioned, or a changed method/key columns — cannot be done
+by in-place `ALTER` on any target driver (it is a table rebuild plus data migration). Therefore
+`getAlignSql()` must **compare `partition_strategy` and, on any mismatch, throw a clear
+`PARTITION-ERROR`** (with both the existing and desired strategy in the message) rather than
+emit DDL or silently ignore the difference. Re-partitioning is an explicit, out-of-band
+operation, not an alignment step. Two partitioned tables with identical `partition_strategy`
+align normally on their non-partition structure (columns, indexes, etc.).
+
+### Table-description integration
+
+Implementation must add the following top-level table-description keys:
+
+- `partition_strategy`: `PartitionStrategy`;
+- `partitions`: `hash<string, PartitionSpec>`.
+
+The keys must be added to `AbstractTable::TableDescriptionHashOptions`; otherwise
+`setupTable()` will reject table descriptions before any driver-specific code can run.
+Driver-specific option merging must also apply to `partition_strategy`, `partitions`, and
+each individual `PartitionSpec`, following the existing `driver` sub-hash pattern.
+
+`AbstractTable::getDescriptionHash()` is extended from its current argumentless form to:
+
+```qore
+hash<auto> getDescriptionHash(*hash<auto> opt);
+```
+
+The new option hash is backward-compatible: callers that pass no options get the existing
+description shape plus `partition_strategy` for partitioned tables. The first generic option
+is `with_partitions` (`bool`, default `False`). When `with_partitions` is `False`,
+`getDescriptionHash()` omits the `partitions` list; when `True`, it materializes the current
+partition list as `hash<string, PartitionSpec>`.
+
+Implementation should add a small `GetDescriptionOptions` option map, initially containing
+only `with_partitions`, and validate it with the same `OPTION-ERROR` behavior used by other
+SqlUtil option-taking methods. The name is intentionally distinct from the existing
+`TableDescriptionHashOptions` const (which lists the allowed description *content* keys) to
+avoid confusion: `GetDescriptionOptions` governs the `getDescriptionHash()` *method* options.
+Existing subclasses that do not override description behavior remain source-compatible because
+the argument is optional.
+
+An archive table can have thousands of monthly partitions, so embedding every `PartitionSpec`
+in the default description would make routine `describe()` / round-trip calls large and slow.
+`partition_strategy` alone is enough to re-create a correctly partitioned but empty parent on
+drivers that support parent-only partitioned-table creation (PostgreSQL phase 1). Drivers that
+require at least one partition definition at create time, or require an auto strategy to
+bootstrap the table, must document and validate that requirement during `setupTable()` /
+`getCreateTableSql()`. `SchemaReverse`'s `with_partitions` toggle (below) mirrors this same
+default-off behaviour, so description-level and reverse-engineering output stay consistent.
+
+## API
+
+All DDL-producing methods follow the established SqlUtil shape: a public method takes the
+table lock, delegates to a driver `…Impl()`, and wraps generated SQL through
+`AbstractDatabase::doCallback()`.
+
+### Transaction management
+
+SqlUtil's established convention is a **method pair**: the bare verb executes with no
+transaction management (e.g. `AbstractTable::drop()`), and a `…Commit()` companion wraps it
+with `on_exit ds.commit(); on_error ds.rollback()` (e.g. `dropCommit()`, `truncateCommit()`,
+`createCommit()`). The partition lifecycle methods follow the same convention:
+
+- the bare executors (`addPartition()`, `dropPartition()`, `truncatePartition()`,
+  `detachPartition()`, `ensurePartition()`) execute within the **caller's** transaction and do
+  **not** commit, exactly like `drop()`;
+- committing companions `addPartitionCommit()`, `dropPartitionCommit()`,
+  `truncatePartitionCommit()`, `detachPartitionCommit()`, and `ensurePartitionCommit()` provide
+  the managed form.
+
+Two driver realities must be documented on these methods rather than smoothed over: Oracle and
+MySQL DDL commits implicitly (so the bare form cannot truly stay uncommitted there), and
+PostgreSQL `DETACH … CONCURRENTLY` cannot run inside a transaction at all (see Open items).
+The methods do not promise identical rollback semantics across drivers; they promise the same
+naming/contract split as the rest of SqlUtil.
+
+### Caching
+
+`listPartitions()` / `getPartitionStrategy()` cache their results like `getIndexes()` /
+`describe()` do today. Every lifecycle public method that mutates partition structure
+(`addPartition`, `dropPartition`, `detachPartition`, and `ensurePartition` when it creates)
+must, after a successful execution, invalidate the table's cached partition list (and, where
+partition changes affect it, the table's describe/`getDescriptionHash()` cache).
+`truncatePartition()` mutates data, not structure; it does not need to invalidate the
+structural partition list unless future `PartitionInfo` metadata includes row counts,
+statistics, or other data-dependent fields. Drivers must not leave stale partition metadata
+visible after a successful lifecycle call; this is asserted by the cache-invalidation tests
+below.
+
+### Name and identifier semantics
+
+Portable API methods accept the canonical partition identifier exposed as `PartitionInfo.name`,
+not a raw SQL fragment:
+
+- PostgreSQL: canonical relation identity encoded as `schema.relation_name` when a schema is
+  needed, otherwise `relation_name`;
+- Oracle/MySQL: partition identifier.
+
+Driver-specific physical placement (for example a PostgreSQL child schema) belongs in
+`PartitionSpec.driver.<driver>` or `PartitionStrategy.driver.<driver>`. Implementations must
+quote all generated identifiers through existing driver helpers and must verify PostgreSQL
+child relations through the parent relationship before generating destructive SQL.
+
+For PostgreSQL, `PartitionInfo.schema` and `PartitionInfo.relation_name` are the authoritative
+identity fields. `PartitionInfo.name` is a convenience canonical key for hashes and lifecycle
+calls. It must be generated from those fields, never from already quoted SQL text, and must be
+parsed back through the same SqlUtil identifier parser used for table names. If either
+component contains characters that make a dotted string ambiguous, the implementation must
+require the caller to use the introspected `PartitionInfo.name` or a driver option carrying
+separate `schema` / `relation_name` values; SQL-quoted strings are not accepted as API names.
+
+Callers that receive a `PartitionInfo` from `listPartitions()` or `findPartitionBySpec()`
+must be able to pass `PartitionInfo.name` directly to `dropPartition()`,
+`truncatePartition()`, and `detachPartition()`. For manually named PostgreSQL partitions,
+`addPartition(name, spec, opt)` accepts the desired child relation name; if the child schema
+is not the parent schema, it must be supplied through a driver option and reflected back in
+`PartitionInfo.schema` / `PartitionInfo.name` after introspection.
+
+For PostgreSQL in particular, `getDropPartitionSql()` must confirm that `name` is a partition
+of `self` before returning `DROP TABLE child`; a standalone table with the same name must not
+be droppable through `dropPartition()`.
+
+### Introspection and lookup
+
+```qore
+public enum PartitionLookupStatus : string {
+    Found = "found",
+    NotFound = "not_found",
+    Uncomparable = "uncomparable",
+}
+
+public enum PartitionVerifiedBy : string {
+    Bounds = "bounds",   #! verified by matching typed bounds
+    Name = "name",       #! verified by canonical partition name only
+    Auto = "auto",       #! covered by a declared auto-create strategy
+}
+
+public hashdecl PartitionLookupResult {
+    PartitionLookupStatus status;
+    *PartitionInfo partition;
+    *string reason;
+}
+
+#! Returns the partitions of this table keyed by PartitionInfo.name, inserted in
+#! PartitionInfo.ordinal order; empty hash if not partitioned
+hash<string, PartitionInfo> listPartitions();      # -> getPartitionsImpl()
+
+#! Returns the table's partition strategy, or NOTHING if the table is not partitioned
+*PartitionStrategy getPartitionStrategy();
+
+#! Finds a materialized partition by normalized bounds/default status, not by name
+PartitionLookupResult findPartitionBySpec(hash<PartitionSpec> spec);
+```
+
+`PartitionLookupStatus::Found` requires `partition`; `NotFound` must not set `partition`;
+`Uncomparable` should set `reason` with the missing capability or unparsed bound that made a
+deterministic comparison impossible.
+
+`listPartitions()` returns range partitions in `PartitionInfo.ordinal` order. Qore hashes
+preserve insertion order, so this is a stable contract drivers must honour: it makes
+"oldest = first" reliable and lets archiving sweep "drop every partition with
+`bound_to <= cutoff`" deterministically without re-sorting. Ordinal normally follows typed
+lower-bound order (default/catch-all partition last); when typed bounds are unavailable, the
+driver still supplies a deterministic ordinal from database metadata.
+
+On PostgreSQL, `getPartitionsImpl()` walks `pg_inherits` → `pg_class` from the parent (now
+discoverable thanks to the `relkind 'p'` fix) and reads each child's bounds via
+`pg_get_expr(relpartbound, …)`. The implementation should expose the native bound clause in
+`bound_sql` even if typed parsing is incomplete.
+
+`findPartitionBySpec()` exists because auto-created partitions may have driver-generated
+names. Qorus archiving code finds the partition for a month by bounds, then — on a `Found`
+result — drops it by `result.partition.name`.
+
+Matching semantics: `findPartitionBySpec()` compares **typed** bounds when both the spec and
+the candidate partition expose them (`bound_from`/`bound_to`), plus `is_default` status. When
+a partition exposes only native bound text (`bound_sql` and no parsed typed bounds — possible
+on backends where bound parsing is incomplete), it cannot be reliably compared: the method must
+return `PartitionLookupStatus::Uncomparable` rather than guess. `NotFound` is reserved for a
+successful comparison that found no matching partition. Callers that need determinism when
+lookup is uncomparable should fall back to a deterministic partition naming scheme and drop by
+known canonical name.
+
+### Lifecycle — SQL generators (for batching / preview) + convenience executors
+
+```qore
+public hashdecl PartitionEnsureResult {
+    bool created;              #! True if SqlUtil executed DDL to create a partition
+    bool materialized;         #! True if a concrete partition exists after the call
+    bool deferred_auto = False;#! True if no DDL was needed because an auto policy covers it
+    PartitionVerifiedBy verified_by;  #! how the result was verified
+    bool bounds_verified;             #! convenience alias: == (verified_by == PartitionVerifiedBy::Bounds)
+    *PartitionInfo partition;  #! existing or newly-created partition when materialized
+}
+
+# --- SQL generators (return softlist<auto> of DDL statements) ---
+softlist<auto> getAddPartitionSql(string name, hash<PartitionSpec> spec, *hash<auto> opt);
+softlist<auto> getDropPartitionSql(string name, *hash<auto> opt);
+softlist<auto> getTruncatePartitionSql(string name, *hash<auto> opt);
+softlist<auto> getDetachPartitionSql(string name, *hash<auto> opt);   # detach-capable only
+
+# --- imperative executors: bare form runs in the caller's transaction (no commit), like drop() ---
+#! create a partition; throws PARTITION-ERROR if it already exists
+addPartition(string name, hash<PartitionSpec> spec, *hash<auto> opt);
+
+#! create the partition only if needed; returns whether DDL ran and/or a partition exists
+PartitionEnsureResult ensurePartition(string name, hash<PartitionSpec> spec, *hash<auto> opt);
+
+#! remove the partition AND its data — identical semantics on every supported driver
+dropPartition(string name, *hash<auto> opt);
+
+#! empty the partition, keeping the partition object
+truncatePartition(string name, *hash<auto> opt);
+
+#! PostgreSQL-style: detach into a standalone table without dropping data.
+#! Returns the resulting standalone AbstractTable. Throws PARTITION-NOT-SUPPORTED where
+#! supportsPartitionDetach() is False. The returned table is constructed against the same
+#! datasource with the detached relation's name/schema; it is NOT implicitly added to the
+#! parent's Tables cache (the caller owns its lifecycle).
+AbstractTable detachPartition(string name, *hash<auto> opt);
+
+# --- committing companions: wrap the bare form with on_exit commit / on_error rollback ---
+addPartitionCommit(string name, hash<PartitionSpec> spec, *hash<auto> opt);
+PartitionEnsureResult ensurePartitionCommit(string name, hash<PartitionSpec> spec, *hash<auto> opt);
+dropPartitionCommit(string name, *hash<auto> opt);
+truncatePartitionCommit(string name, *hash<auto> opt);
+AbstractTable detachPartitionCommit(string name, *hash<auto> opt);
+```
+
+`verified_by` is a `PartitionVerifiedBy` enum value. `bounds_verified` is a derived convenience
+alias — it is `True` exactly when `verified_by == PartitionVerifiedBy::Bounds`, never set
+independently — so callers may test either; they must always agree.
+
+`ensurePartition()` is the method the Qorus monthly job should call to "roll forward":
+
+1. call `findPartitionBySpec(spec)`;
+2. if lookup returns `Found`, return the matched partition with `created = False`,
+   `materialized = True`, `bounds_verified = True`, `verified_by = PartitionVerifiedBy::Bounds`;
+3. if lookup returns `Uncomparable`, fall back to the canonical name: `ensurePartition()` is
+   given `name`, so check `listPartitions(){name}` — if a partition with that exact name
+   exists, return it with `created = False`, `materialized = True`,
+   `bounds_verified = False`, `verified_by = PartitionVerifiedBy::Name`; only if the name is also absent (and the
+   auto strategy in step 4 does not cover it) proceed to create. Name fallback is deterministic
+   identity resolution, not a bound match; callers that require bound proof can reject
+   `bounds_verified = False`. Throw `PARTITION-ERROR` only if neither bounds nor name can be
+   resolved deterministically;
+4. if the backend has an auto-create strategy that covers the requested range and no
+   materialized partition exists yet, return `created = False`, `materialized = False`,
+   `deferred_auto = True`, `bounds_verified = False`, `verified_by = PartitionVerifiedBy::Auto`;
+5. otherwise create the partition and return it with `created = True`,
+   `materialized = True`, `bounds_verified = True`, `verified_by = PartitionVerifiedBy::Bounds` when the created
+   partition can be resolved by bounds, or `bounds_verified = False`, `verified_by = PartitionVerifiedBy::Name`
+   when only canonical-name verification is possible.
+
+**Concurrency (TOCTOU).** Qorus archiving may run the roll-forward concurrently on multiple
+instances, so the existence check and the `CREATE` race. `ensurePartition()`
+must be deterministic, not check-then-hope: if the `CREATE` fails because the partition already
+exists (driver "relation/partition already exists" error), it must **treat that as success** —
+re-resolve via `findPartitionBySpec()`, and if that is still `Uncomparable`, via the canonical
+name in `listPartitions(){name}` — and return `created = False`, `materialized = True` when
+either resolves. The returned `verified_by` / `bounds_verified` fields must reflect which
+resolution path succeeded. Only if neither bounds nor name resolve does it throw
+`PARTITION-ERROR`. It must distinguish the specific duplicate error from other failures (which
+still propagate). This is the deterministic resolution; no retry loop or polling is used.
+
+### Per-driver mapping of the uniform operations
+
+| Operation                | PostgreSQL                                   | Oracle                              | MySQL                              |
+|--------------------------|----------------------------------------------|-------------------------------------|------------------------------------|
+| `addPartition`           | `CREATE TABLE child PARTITION OF parent FOR VALUES FROM … TO …` | `ALTER TABLE … ADD PARTITION … VALUES LESS THAN …` | `ALTER TABLE … ADD PARTITION (…)` |
+| `dropPartition` (uniform)| verify child belongs to parent, then `DROP TABLE child` | `ALTER TABLE … DROP PARTITION p`    | `ALTER TABLE … DROP PARTITION p`  |
+| `truncatePartition`      | `TRUNCATE TABLE child`                        | `ALTER TABLE … TRUNCATE PARTITION p`| `ALTER TABLE … TRUNCATE PARTITION p` |
+| `detachPartition`        | `ALTER TABLE … DETACH PARTITION child` → standalone table | unsupported (throws)    | unsupported (throws)               |
+
+This is what principle 1 buys: on PostgreSQL `dropPartition()` deliberately uses
+`DROP TABLE child` (data gone), matching Oracle/MySQL `DROP PARTITION`. The detach-and-keep
+behaviour is only reachable through the explicit, capability-gated `detachPartition()`.
+
+For Oracle/MySQL range partitioning, DDL often declares only the upper bound. The portable
+spec still carries both lower and upper bounds so SqlUtil can identify the partition
+unambiguously, verify that the intended range is contiguous with existing partitions, and
+avoid dropping the wrong driver-generated partition.
+
+Default-partition caveat: when a default/catch-all partition exists, `addPartition()` is not a
+pure metadata operation on every backend. PostgreSQL must scan the default partition for rows
+that would belong in the new range and takes a strong lock while doing so; Oracle/MySQL behave
+differently again. In MySQL, a catch-all `MAXVALUE` range partition generally means adding a
+new upper range requires `ALTER TABLE … REORGANIZE PARTITION …` rather than plain
+`ADD PARTITION`. Implementations should document this per driver and surface row-conflicts or
+unsupported catch-all reshaping as `PARTITION-ERROR` rather than letting raw DDL errors escape.
+
+### Action codes
+
+No new `AC_*` constants are required for phase 1. Use the existing integer action codes from
+`AbstractDatabase` with object type `"partition"`:
+
+```qore
+getAddPartitionSql()      -> AC_Add,      type "partition"
+getDropPartitionSql()     -> AC_Drop,     type "partition"
+getTruncatePartitionSql() -> AC_Truncate, type "partition"
+getDetachPartitionSql()   -> AC_Modify,   type "partition"
+```
+
+If a future callback consumer needs to distinguish detach from other modifications without
+looking at the object type/name/table context, add a new integer action code and update
+`ActionMap`, `ActionDescMap`, and `ActionLetterMap` together.
+
+## Exceptions
+
+- `PARTITION-NOT-SUPPORTED` — operation requested on a driver/server without the capability
+  (for example `detachPartition()` on Oracle, any partition op on SQLite).
+- `PARTITION-ERROR` — semantic error (for example `addPartition()` for a name that already
+  exists, dropping a non-existent partition, a spec with invalid range bounds, or a range that
+  overlaps an existing partition).
+- `DESCRIPTION-ERROR` — invalid partition metadata in a table-description hash.
+- `OPTION-ERROR` — invalid partition lifecycle option.
+
+## Abstract `…Impl()` methods drivers override
+
+Defaults on `AbstractTable` throw `PARTITION-NOT-SUPPORTED` for lifecycle SQL generation and
+return `False` for capabilities. Partition-capable drivers override:
+
+```qore
+private *PartitionStrategy getPartitionStrategyImpl();
+private hash<string, PartitionInfo> getPartitionsImpl();
+private PartitionLookupResult findPartitionBySpecImpl(hash<PartitionSpec> spec);
+private bool partitionAutoStrategyCoversSpecImpl(hash<PartitionSpec> spec);
+
+private softlist<auto> getAddPartitionSqlImpl(string name, hash<PartitionSpec> spec, *hash<auto> opt);
+private softlist<auto> getDropPartitionSqlImpl(string name, *hash<auto> opt);
+private softlist<auto> getTruncatePartitionSqlImpl(string name, *hash<auto> opt);
+private softlist<auto> getDetachPartitionSqlImpl(string name, *hash<auto> opt);
+
+private bool supportsPartitionsImpl();
+private bool supportsPartitionDetachImpl();
+private bool supportsAutoPartitioningImpl();
+```
+
+`findPartitionBySpecImpl()` may be implemented generically by scanning `listPartitions()` if
+the driver returns canonical typed bounds. Drivers with lossy or native-only bound metadata
+should override it so they can return `Uncomparable` with a useful reason instead of silently
+missing a partition.
+
+`partitionAutoStrategyCoversSpecImpl()` answers `ensurePartition()` step 4: it returns `True`
+when the table's declared auto-create strategy (e.g. Oracle interval) will materialize a
+partition covering the requested spec on insert, so no explicit `CREATE` is needed. Drivers
+without auto-partitioning inherit the default `False`.
+
+The table-create path (`getCreateTableSqlImpl()` and, where needed, create-misc SQL) is
+extended in partition-capable drivers to emit `PARTITION BY …` and initial partition clauses
+when the description carries `partition_strategy` and `partitions`, mirroring how
+`data_tablespace` is appended today.
+
+## Qorus archiving usage
+
+```qore
+# one-time: create the partitioned table (or describe an existing one)
+# monthly roll-forward job — correct whether the backend auto-creates or not:
+PartitionEnsureResult ensured = table.ensurePartition("y2026m07", <PartitionSpec>{
+    "bound_from": 2026-07-01,
+    "bound_to": 2026-08-01,
+});
+
+# archive the oldest month by bounds so driver-generated names are handled correctly:
+PartitionLookupResult oldest = table.findPartitionBySpec(<PartitionSpec>{
+    "bound_from": 2026-01-01,
+    "bound_to": 2026-02-01,
+});
+if (oldest.status == PartitionLookupStatus::Found) {
+    table.dropPartition(oldest.partition.name);
+} else if (oldest.status == PartitionLookupStatus::Uncomparable) {
+    throw "PARTITION-ERROR", oldest.reason ?? "partition bounds could not be compared";
+}
+
+# PostgreSQL only, when the data must be preserved to cold storage first:
+if (table.supportsPartitionDetach()) {
+    AbstractTable archived = table.detachPartition("y2026m01");
+    # ... export `archived`, then archived.drop()
+}
+```
+
+For PostgreSQL deployments with deterministic partition names, dropping by known name is
+also valid:
+
+```qore
+table.dropPartition("y2026m01");
+```
+
+## Schema / SchemaReverse round-trip
+
+Qorus schemas are frequently defined as `Schema`-module table descriptions (including `.ysm` /
+`.jsm` data-schema files) and reverse-engineered from live databases with `SchemaReverse`. For
+a partitioned archive table to round-trip — *define → align → reverse-engineer → re-align* —
+the schema tooling must be partition-aware. Two of these modules **do not pass new
+table-description keys through transparently** (verified in source), so they need explicit
+changes; the rest are pass-through.
+
+| Module | File | Behavior today | Change required |
+|--------|------|----------------|-----------------|
+| `AbstractSchema` | `qlib/Schema/AbstractSchema.qc` | passes the whole table hash to `db.getAlignSql()` | none (transparent once SqlUtil whitelists the keys) |
+| `DataSchema` | `qlib/Schema/DataSchema.qc` | delegates to loader/parent | none |
+| `DataSchemaLoader` | `qlib/Schema/DataSchemaLoader.qc` (`normalizeTable()`, ~L202) | rebuilds into a fresh `hash<auto!>` with an **explicit per-key allow-list**; unlisted keys are silently dropped | **add** `partition_strategy` and `partitions` pass-through |
+| `DataSchemaMetaSchema` | `qlib/Schema/DataSchemaMetaSchema.qc` (`tableDefinition`, ~L259) | JSON-Schema (Draft 2020-12) validation of `.ysm`/`.jsm`; unknown table keys are currently allowed by JSON Schema defaults | **add** `partitionStrategy` / `partitionSpec` `$defs` and `partition_strategy` / `partitions` table properties for validation, documentation, and future strictness |
+| `SchemaReverse` | `qlib/SchemaReverse.qm` (`TableReverse.toQore()`, ~L508) | **explicitly enumerates** columns/indexes/primary_key/triggers/foreign_constraints | **add** extraction via `getPartitionStrategy()` / `listPartitions()` |
+
+Requirements for the changes:
+
+- **`DataSchemaLoader::normalizeTable()`** — add pass-through of `partition_strategy` and
+  `partitions` (the latter keyed by partition name → `PartitionSpec`), and apply the same
+  shorthand/normalization conventions used for columns where applicable. Without this, a schema
+  file's partition definitions are dropped before they ever reach SqlUtil.
+- **`DataSchemaMetaSchema`** — add `partitionStrategy` and `partitionSpec` definitions matching
+  the hashdecls in this document (note: `is_default`, not `default`; range-only `method` enum
+  for phase 1) and reference them from `tableDefinition` properties named
+  `partition_strategy` and `partitions`. The current meta-schema does not reject unknown table
+  keys because it does not set `additionalProperties: false`, but explicit definitions are
+  still required for schema documentation, editor validation, and any future strict mode.
+- **`SchemaReverse::TableReverse`** — extract partitioning into the emitted description. Because
+  reverse-engineering an archive table can surface thousands of monthly partitions, gate the
+  per-partition emission behind a **`with_partitions` Qore option (default off)**: by default
+  emit `partition_strategy` only (enough to re-create a correctly partitioned but empty parent
+  only on drivers that support parent-only creation, such as PostgreSQL in phase 1) and emit
+  the individual `partitions` list only when explicitly requested. Bounds that cannot be
+  represented portably must be emitted as `bound_from_sql` / `bound_to_sql` (with `bound_sql`
+  retained for diagnostics), consistent with the introspection contract above.
+  Implementation must add option plumbing because SchemaReverse constructors currently do not
+  carry per-table reverse options: add an optional options hash to `TableReverse`,
+  `TablesReverse`, top-level `SchemaReverse`, and `get_object()` / CLI creation paths; the CLI
+  spelling should be `--with-partitions`, mapped to Qore option `with_partitions`.
+
+`SqlUtilDataProvider` and other consumers that round-trip descriptions inherit partition
+awareness automatically once `partition_strategy` / `partitions` are in
+`TableDescriptionHashOptions` and `getDescriptionHash()` — they do not maintain their own
+key allow-lists.
+
+## Phasing
+
+1. **Phase 1 — abstraction + PostgreSQL range partitions.** Capability flags, hashdecls,
+   table-description keys, abstract methods, `listPartitions()`, `findPartitionBySpec()`,
+   `addPartition`/`ensurePartition`/`dropPartition`/`truncatePartition`/`detachPartition`
+   (plus their `…Commit()` companions), `PARTITION BY` in create DDL, and
+   `getDescriptionHash()` round-trip support. **Schema tooling (same phase, since it gates
+   defining partitioned tables from schema files):** `DataSchemaLoader::normalizeTable()`
+   pass-through, `DataSchemaMetaSchema` definitions, and `SchemaReverse::TableReverse`
+   extraction with the `with_partitions` / `--with-partitions` toggle.
+2. **Phase 2 — Oracle + MySQL range partitions.** Implement uniform ops; Oracle adds interval
+   `auto` strategy (`supportsAutoPartitioning`); both throw `PARTITION-NOT-SUPPORTED` for
+   `detachPartition`.
+3. **Phase 3 — MSSQL / others as needed**, plus optional unification of the existing Oracle
+   read-side `"partition"` select qualifier into a generic select option.
+4. **Future method support.** Add list/hash partitioning only after method-specific
+   `PartitionSpec` fields, validation rules, and drop/truncate semantics are specified.
+
+## Tests
+
+Phase 1 tests should cover:
+
+- creating a range-partitioned PostgreSQL table from a table-description hash;
+- describing a partitioned parent and round-tripping `partition_strategy` / `partitions`
+  through `getDescriptionHash()`, including that `partitions` is omitted by default and
+  included only when the `with_partitions` option is set on
+  `getDescriptionHash({"with_partitions": True})`;
+- `getDescriptionHash()` remains backward-compatible when called without options and rejects
+  unknown description options with `OPTION-ERROR`;
+- `listPartitions()` returns range partitions in `PartitionInfo.ordinal` order (default
+  partition last), including a native-bound case where ordinal is available but typed bounds
+  are not;
+- `listPartitions()` and `findPartitionBySpec()` with typed bounds, raw `bound_sql`, and all
+  `PartitionLookupStatus` outcomes (`Found`, `NotFound`, `Uncomparable`);
+- `ensurePartition()` idempotence for an existing partition, creation of a missing one, and
+  correct `PartitionEnsureResult` flags, including `bounds_verified` and `verified_by`;
+- dropping the oldest partition and verifying data removal;
+- truncating a partition while retaining the partition object;
+- detach round-trip on PostgreSQL, including the returned standalone `AbstractTable`;
+- negative tests for unsupported drivers, duplicate names, missing partitions, invalid bounds,
+  overlapping ranges, default partition misuse, composite-bound cardinality mismatch, a
+  `partition_strategy.columns` entry that is not a declared column, and a PK/UNIQUE constraint
+  that omits a partition key column (both `DESCRIPTION-ERROR` at `setupTable()`);
+- `ensurePartition()` with an `Uncomparable` bound lookup resolving by canonical name via
+  `listPartitions(){name}` and returning `verified_by = PartitionVerifiedBy::Name`, `bounds_verified = False`;
+- quoted identifiers and schema-qualified parent tables;
+- PostgreSQL refusal to drop a standalone table that is not a child partition of `self`;
+- callback SQL generation/action metadata for add/drop/truncate/detach;
+- cache invalidation after add/drop/detach and after `ensurePartition()` creates (stale
+  partition structure must not survive a successful lifecycle call);
+- `truncatePartition()` retains the partition object and does not invalidate structural
+  partition metadata unless data-dependent partition metadata is later added;
+- bare-vs-`…Commit()` transaction behavior (bare executor leaves the change uncommitted in the
+  caller's transaction where the driver allows it; `…Commit()` commits/rolls back);
+- `ensurePartition()` concurrent-create race: a second caller racing the `CREATE` resolves to
+  `created = False`, `materialized = True` rather than throwing;
+- driver restrictions around primary/unique keys on partitioned tables, validated at
+  `setupTable()` (PK/UNIQUE must include the partition key);
+- **Schema round-trip:** a `.ysm`/`.jsm` file declaring `partition_strategy` + `partitions`
+  validates against `DataSchemaMetaSchema` and survives `DataSchemaLoader::normalizeTable()`
+  (keys not dropped); a partitioned table created through a `Schema` aligns correctly;
+- **Schema bound coercion:** ISO date/datetime strings in `.ysm`/`.jsm` partition bounds are
+  coerced according to the target partition column type, native SQL bounds are not coerced,
+  and ambiguous typed-plus-SQL bound input is rejected;
+- **SchemaReverse:** reverse-engineering a partitioned table emits `partition_strategy` by
+  default and the full `partitions` list only with Qore option `with_partitions` / CLI flag
+  `--with-partitions`, with non-portable bounds emitted as `bound_*_sql`;
+- **SchemaReverse option plumbing:** `TableReverse`, `TablesReverse`, top-level
+  `SchemaReverse`, `get_object()`, and CLI construction all pass the reverse options through
+  consistently.
+
+## Open items
+
+- Whether `detachPartition()` should expose PostgreSQL `DETACH … CONCURRENTLY` (cannot run in
+  a transaction) as an option — deferred; phase 1 uses the transactional form.
+- Whether future list/hash support should use separate hashdecls or a discriminated
+  `PartitionSpec` family.

--- a/design/data-schema-format.md
+++ b/design/data-schema-format.md
@@ -185,6 +185,82 @@ tables:
           data: {type: clob, comment: "Oracle-specific"}
 ```
 
+## Table Partitioning
+
+Tables can declare range partitioning with `partition_strategy` and optional initial physical
+partitions with `partitions`. Phase 1 partition support covers range partitioning.
+
+```yaml
+tables:
+  archive_events:
+    columns:
+      id: {type: int, notnull: true}
+      event_ts:
+        type: date
+        notnull: true
+        driver:
+          mysql: {native_type: datetime}
+      payload: {type: text}
+
+    primary_key:
+      name: pk_archive_events
+      columns: [id, event_ts]
+
+    partition_strategy:
+      method: range
+      columns: [event_ts]
+
+    partitions:
+      archive_events_202601:
+        bound_from: "2026-01-01"
+        bound_to: "2026-02-01"
+
+      archive_events_202602:
+        bound_from_sql: "date '2026-02-01'"
+        bound_to_sql: "date '2026-03-01'"
+
+      archive_events_default:
+        is_default: true
+```
+
+`partition_strategy.columns` defines the partition key. `partitions` is keyed by partition name;
+each partition can also set `name`, but it must match the hash key. `bound_from` is inclusive and
+`bound_to` is exclusive. Use scalar bounds for single-column keys and lists for multi-column keys.
+When the partition key column has type `date` or `timestamp`, string `bound_from` and `bound_to`
+values are normalized to typed dates by `DataSchemaLoader`; SQL expressions are not parsed and must
+use `bound_from_sql`, `bound_to_sql`, or `bound_sql`.
+
+Partition metadata supports the same `driver` override pattern used elsewhere in schema hashes:
+
+```yaml
+partition_strategy:
+  method: range
+  columns: [event_ts]
+  driver:
+    mysql:
+      columns: [event_ts]
+
+partitions:
+  archive_events_202601:
+    bound_to: "2026-02-01"
+    driver:
+      oracle:
+        bound_to_sql: "timestamp '2026-02-01 00:00:00'"
+```
+
+Database-specific restrictions still apply. For MySQL and MariaDB, every primary key or unique key
+on a partitioned table must include the partition key, and `timestamp` columns are not allowed in
+`RANGE COLUMNS` partition keys; use a `date` column or set the MySQL/MariaDB native type to
+`datetime` when the partition key needs date/time values.
+
+Schema alignment creates declared initial partitions with the table and can reverse-engineer
+partitioned tables. Partition lifecycle operations such as adding, dropping, truncating, detaching,
+or comparing physical partitions are exposed by `SqlUtil`; schema diff/alignment does not currently
+treat changes under `partitions` as an automatic partition lifecycle migration. By default
+reverse-engineering exports only `partition_strategy`; use `SchemaReverse` option
+`with_partitions: true` or `qschema export --with-partitions` to include the physical `partitions`
+hash.
+
 ## Auto-Triggers
 
 Auto-triggers generate standard database triggers for common patterns:
@@ -329,6 +405,7 @@ qschema diff <connection> <file>            # Compare schema to database
 qschema validate <file>                     # Validate schema file
 qschema info [-v] <file>                    # Show schema summary
 qschema export <connection> -o <file>       # Reverse-engineer database
+qschema export --with-partitions <connection> -o <file>
 ```
 
 ### Color Output

--- a/examples/test/ir/JITSmoke.qtest
+++ b/examples/test/ir/JITSmoke.qtest
@@ -1264,11 +1264,13 @@ printf(\"%d\\n\", no_arg_func());
         string code = "%modern
 int i = 5;
 int r = i++;
-printf(\"%d:%d\\n\", r, i);
+int j;
+int s = j++;
+printf(\"%d:%d:%d:%d\\n\", r, i, s, j);
 ";
-        foreach string mode in ("ast", "ir", "jit") {
+        foreach string mode in ("ast", "ir", "jit", "tiered") {
             string result = trim(runScript(code, mode));
-            assertEq("5:6", result, sprintf("int post-increment %s", mode));
+            assertEq("5:6:0:1", result, sprintf("int post-increment %s", mode));
         }
     }
 
@@ -1278,11 +1280,13 @@ printf(\"%d:%d\\n\", r, i);
         string code = "%modern
 int i = 5;
 int r = i--;
-printf(\"%d:%d\\n\", r, i);
+int j;
+int s = j--;
+printf(\"%d:%d:%d:%d\\n\", r, i, s, j);
 ";
-        foreach string mode in ("ast", "ir", "jit") {
+        foreach string mode in ("ast", "ir", "jit", "tiered") {
             string result = trim(runScript(code, mode));
-            assertEq("5:4", result, sprintf("int post-decrement %s", mode));
+            assertEq("5:4:0:-1", result, sprintf("int post-decrement %s", mode));
         }
     }
 

--- a/examples/test/ir/JITSmoke_49d3.qtest
+++ b/examples/test/ir/JITSmoke_49d3.qtest
@@ -846,11 +846,13 @@ printf(\"%d\\n\", no_arg_func());
         string code = "%modern
 int i = 5;
 int r = i++;
-printf(\"%d:%d\\n\", r, i);
+int j;
+int s = j++;
+printf(\"%d:%d:%d:%d\\n\", r, i, s, j);
 ";
-        foreach string mode in ("ast", "ir", "jit") {
+        foreach string mode in ("ast", "ir", "jit", "tiered") {
             string result = trim(runScript(code, mode));
-            assertEq("5:6", result, sprintf("int post-increment %s", mode));
+            assertEq("5:6:0:1", result, sprintf("int post-increment %s", mode));
         }
     }
 
@@ -860,11 +862,13 @@ printf(\"%d:%d\\n\", r, i);
         string code = "%modern
 int i = 5;
 int r = i--;
-printf(\"%d:%d\\n\", r, i);
+int j;
+int s = j--;
+printf(\"%d:%d:%d:%d\\n\", r, i, s, j);
 ";
-        foreach string mode in ("ast", "ir", "jit") {
+        foreach string mode in ("ast", "ir", "jit", "tiered") {
             string result = trim(runScript(code, mode));
-            assertEq("5:4", result, sprintf("int post-decrement %s", mode));
+            assertEq("5:4:0:-1", result, sprintf("int post-decrement %s", mode));
         }
     }
 

--- a/examples/test/qlib/QoreLlmUtils/QoreLlmUtils.qtest
+++ b/examples/test/qlib/QoreLlmUtils/QoreLlmUtils.qtest
@@ -185,6 +185,12 @@ public class QoreLlmUtilsTest inherits QUnit::Test {
             \geminiOpenAiMalformedForcedToolRetryContentTest());
         addTestCase("LlmBackend OpenAI chat facade retries required empty "
             "tool responses", \geminiOpenAiRequiredToolEmptyRetryTest());
+        addTestCase("LlmBackend OpenAI chat facade retries single required "
+            "empty tool responses as JSON",
+            \geminiOpenAiSingleRequiredToolEmptyJsonRetryTest());
+        addTestCase("LlmBackend OpenAI streaming facade retries single "
+            "required empty tool responses as JSON",
+            \callbackOpenAiStreamSingleRequiredToolEmptyJsonRetryTest());
         addTestCase("LlmBackend OpenAI chat facade retries malformed "
             "required tool responses", \geminiOpenAiRequiredToolMalformedRetryTest());
         addTestCase("LlmBackend OpenAI chat facade converts tool turns",
@@ -2181,6 +2187,212 @@ public class QoreLlmUtilsTest inherits QUnit::Test {
             "retry function arguments are serialized");
         assertEq("STOP", rv.provider_diagnostics.finish_reason,
             "OpenAI facade exposes provider finish diagnostics");
+    }
+
+    geminiOpenAiSingleRequiredToolEmptyJsonRetryTest() {
+        checkGeminiModule();
+        installGeminiHandler({
+            "/v1beta/models/gemini-2.5-flash:generateContent": {
+                "sequence": (
+                    {
+                        "code": 200,
+                        "body": {
+                            "responseId": "gemini-single-required-empty-1",
+                            "candidates": ({
+                                "finishReason": "STOP",
+                                "content": {"parts": ()},
+                            },),
+                            "usageMetadata": {
+                                "promptTokenCount": 120,
+                                "candidatesTokenCount": 0,
+                                "totalTokenCount": 120,
+                            },
+                        },
+                    },
+                    {
+                        "code": 200,
+                        "body": {
+                            "responseId": "gemini-single-required-json-1",
+                            "candidates": ({
+                                "finishReason": "STOP",
+                                "content": {
+                                    "parts": ({
+                                        "text": make_json({
+                                            "operation": "revise",
+                                            "reason": "single tool JSON retry",
+                                        }),
+                                    },),
+                                },
+                            },),
+                            "usageMetadata": {
+                                "promptTokenCount": 135,
+                                "candidatesTokenCount": 7,
+                                "totalTokenCount": 142,
+                            },
+                        },
+                    },
+                ),
+            },
+        });
+
+        LlmBackend llm = makeGeminiBackend();
+        hash<auto> rv = llm.chatCompletions({
+            "model": "gemini-2.5-flash",
+            "messages": (
+                {"role": "system", "content": "Choose one action."},
+                {"role": "user", "content": "Continue design mode."},
+            ),
+            "tools": ({
+                "type": "function",
+                "function": {
+                    "name": "select_action",
+                    "description": "Select the next design action",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "operation": {"type": "string"},
+                            "reason": {"type": "string"},
+                        },
+                        "required": ("operation",),
+                    },
+                },
+            },),
+            "tool_choice": "required",
+        });
+
+        assertEq(2, gemini_handler.requests.size(),
+            "single required-tool empty response is retried once");
+        assertEq("ANY", gemini_handler.requests[0]
+                .body.toolConfig.functionCallingConfig.mode,
+            "initial request requires the single available tool");
+        assertFalse(gemini_handler.requests[1].body.hasKey("toolConfig"),
+            "single-tool required retry removes native tool choice");
+        assertFalse(gemini_handler.requests[1].body.hasKey("tools"),
+            "single-tool required retry uses JSON schema mode");
+        assertEq("application/json",
+            gemini_handler.requests[1].body.generationConfig.responseMimeType,
+            "single-tool required retry requests structured JSON");
+        assertEq("tool_calls", rv.choices[0].finish_reason,
+            "JSON retry response is synthesized to a tool call");
+        assertEq("required_tool_no_output",
+            rv.provider_diagnostics.forced_tool_retry.reason,
+            "diagnostics record why the JSON retry was attempted");
+        assertEq(True,
+            rv.provider_diagnostics.forced_tool_retry.recovered_tool_call,
+            "diagnostics record successful single-tool recovery");
+        hash<auto> args = parse_json(
+            rv.choices[0].message.tool_calls[0].function.arguments);
+        assertEq("revise", args.operation,
+            "JSON retry arguments are serialized as the required tool call");
+    }
+
+    callbackOpenAiStreamSingleRequiredToolEmptyJsonRetryTest() {
+        int stream_calls = 0;
+        int sync_calls = 0;
+        list<hash<auto>> stream_bodies = ();
+        list<hash<auto>> sync_bodies = ();
+
+        LlmBackend llm(<LlmBackendConfig>{
+            "mode": "callback",
+            "model": "callback-model",
+            "api_callback": hash<auto> sub (string m, string p,
+                    hash<auto> body) {
+                ++sync_calls;
+                push sync_bodies, body;
+                return {
+                    "id": "callback-required-json-retry-1",
+                    "model": "callback-model",
+                    "choices": ({
+                        "message": {
+                            "role": "assistant",
+                            "content": make_json({
+                                "operation": "revise",
+                                "reason": "stream JSON retry",
+                            }),
+                        },
+                        "finish_reason": "stop",
+                    },),
+                    "usage": {
+                        "prompt_tokens": 20,
+                        "completion_tokens": 5,
+                        "total_tokens": 25,
+                    },
+                };
+            },
+            "api_stream_callback": sub (string m, string p, hash<auto> body,
+                    code<nothing(hash<auto>)> dcb) {
+                ++stream_calls;
+                push stream_bodies, body;
+                dcb({
+                    "id": "callback-required-empty-stream-1",
+                    "object": "chat.completion.chunk",
+                    "model": "callback-model",
+                    "choices": ({
+                        "index": 0,
+                        "delta": {},
+                        "finish_reason": "stop",
+                    },),
+                    "usage": {
+                        "prompt_tokens": 10,
+                        "completion_tokens": 0,
+                        "total_tokens": 10,
+                    },
+                });
+            },
+        });
+
+        list<hash<auto>> chunks = ();
+        hash<auto> rv = llm.chatCompletionsStream({
+            "model": "callback-model",
+            "messages": (
+                {"role": "system", "content": "Choose one action."},
+                {"role": "user", "content": "Continue design mode."},
+            ),
+            "tools": ({
+                "type": "function",
+                "function": {
+                    "name": "select_action",
+                    "description": "Select the next design action",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "operation": {"type": "string"},
+                            "reason": {"type": "string"},
+                        },
+                        "required": ("operation",),
+                    },
+                },
+            },),
+            "tool_choice": "required",
+        }, sub (hash<auto> chunk) {
+            push chunks, chunk;
+        });
+
+        assertEq(1, stream_calls,
+            "streaming facade uses the streaming callback first");
+        assertEq(1, sync_calls,
+            "empty required streaming result is retried once synchronously");
+        assertEq("required", stream_bodies[0].tool_choice,
+            "initial stream request preserves required tool mode");
+        assertEq(1, stream_bodies[0].tools.size(),
+            "initial stream request includes the single tool");
+        assertFalse(sync_bodies[0].hasKey("tool_choice"),
+            "JSON retry removes callback tool choice");
+        assertFalse(sync_bodies[0].hasKey("tools"),
+            "JSON retry removes callback tools");
+        assertEq("json_schema", sync_bodies[0].response_format.type,
+            "callback chat retry receives the output schema");
+        assertEq(1, chunks.size(),
+            "only the original streamed terminal chunk is forwarded");
+        assertEq("tool_calls", rv.choices[0].finish_reason,
+            "streaming JSON retry is synthesized to a tool call");
+        assertEq("required_tool_no_output",
+            rv.provider_diagnostics.forced_tool_retry.reason,
+            "streaming diagnostics record required-tool retry");
+        hash<auto> args = parse_json(
+            rv.choices[0].message.tool_calls[0].function.arguments);
+        assertEq("stream JSON retry", args.reason,
+            "streaming JSON retry arguments are serialized");
     }
 
     geminiOpenAiRequiredToolMalformedRetryTest() {

--- a/examples/test/qlib/Schema/DataSchema.qtest
+++ b/examples/test/qlib/Schema/DataSchema.qtest
@@ -250,6 +250,10 @@ class DataSchemaTest inherits QUnit::Test {
             "foreign_constraints": {
                 "fk_role": {"columns": ("role_id",), "table": "roles"},
             },
+            "partition_strategy": {"method": "range", "columns": ("id",)},
+            "partitions": {
+                "test_p1": {"bound_from": 0, "bound_to": 100},
+            },
             "auto_triggers": {"created": True},
         };
 
@@ -264,6 +268,8 @@ class DataSchemaTest inherits QUnit::Test {
         assertTrue(result.indexes.hasKey("idx_name"));
         assertTrue(result.foreign_constraints.hasKey("fk_role"));
         assertEq("roles", result.foreign_constraints.fk_role.table);
+        assertEq(("id",), result.partition_strategy.columns);
+        assertEq(100, result.partitions.test_p1.bound_to);
 
         # Auto triggers preserved (expanded later)
         assertTrue(result.auto_triggers.created);

--- a/examples/test/qlib/Schema/DataSchema.qtest
+++ b/examples/test/qlib/Schema/DataSchema.qtest
@@ -17,6 +17,7 @@ class DataSchemaTest inherits QUnit::Test {
         addTestCase("meta-schema migration action fields", \metaSchemaMigrationFieldTests());
         addTestCase("column normalization", \columnNormalizationTests());
         addTestCase("table normalization", \tableNormalizationTests());
+        addTestCase("partition normalization", \partitionNormalizationTests());
         addTestCase("reference data normalization", \referenceDataTests());
         addTestCase("auto-trigger expansion", \autoTriggerExpansionTests());
         addTestCase("DPQL expression evaluation in reference data", \dpqlExpressionTests());
@@ -112,7 +113,11 @@ class DataSchemaTest inherits QUnit::Test {
         assertTrue(ms."$defs".hasKey("migration"));
         assertTrue(ms."$defs".hasKey("migrationAction"));
         assertTrue(ms."$defs".hasKey("autoTriggerConfig"));
+        assertTrue(ms."$defs".hasKey("partitionStrategy"));
+        assertTrue(ms."$defs".hasKey("partitionSpec"));
         assertTrue(ms."$defs".hasKey("referenceData"));
+        assertTrue(ms."$defs".tableDefinition.properties.hasKey("partition_strategy"));
+        assertTrue(ms."$defs".tableDefinition.properties.hasKey("partitions"));
     }
 
     columnNormalizationTests() {
@@ -273,6 +278,65 @@ class DataSchemaTest inherits QUnit::Test {
 
         # Auto triggers preserved (expanded later)
         assertTrue(result.auto_triggers.created);
+    }
+
+    partitionNormalizationTests() {
+        hash<auto> table_def = {
+            "columns": {
+                "id": {"type": "int", "notnull": True},
+                "created": {"type": "date", "notnull": True},
+            },
+            "primary_key": {"name": "pk_events", "columns": ("id", "created")},
+            "partition_strategy": {"method": "range", "columns": ("created",)},
+            "partitions": {
+                "events_p202601": {"bound_from": "2026-01-01", "bound_to": "2026-02-01"},
+                "events_psql": {"bound_from_sql": "date '2026-03-01'",
+                    "bound_to_sql": "date '2026-04-01'"},
+                "events_default": {"is_default": True},
+            },
+        };
+
+        hash<auto> result = Schema::DataSchemaLoader::normalizeTable("events", table_def);
+        assertEq(Type::Date, result.partitions.events_p202601.bound_from.type());
+        assertEq(Type::Date, result.partitions.events_p202601.bound_to.type());
+        assertEq("2026-01-01", format_date("YYYY-MM-DD", result.partitions.events_p202601.bound_from));
+        assertEq("2026-02-01", format_date("YYYY-MM-DD", result.partitions.events_p202601.bound_to));
+        assertEq("date '2026-03-01'", result.partitions.events_psql.bound_from_sql);
+        assertEq("date '2026-04-01'", result.partitions.events_psql.bound_to_sql);
+        assertTrue(result.partitions.events_default.is_default);
+
+        table_def.partition_strategy.columns = ("id", "created");
+        table_def.partitions = {
+            "events_p202601": {"bound_from": (1, "2026-01-01"), "bound_to": (2, "2026-02-01")},
+        };
+        result = Schema::DataSchemaLoader::normalizeTable("events", table_def);
+        assertEq(1, result.partitions.events_p202601.bound_from[0]);
+        assertEq(Type::Date, result.partitions.events_p202601.bound_from[1].type());
+        assertEq("2026-01-01", format_date("YYYY-MM-DD", result.partitions.events_p202601.bound_from[1]));
+
+        assertThrows("DATA-SCHEMA-ERROR", "cannot be parsed as a date", sub () {
+            Schema::DataSchemaLoader::normalizeTable("events", {
+                "columns": {"created": {"type": "date"}},
+                "partition_strategy": {"method": "range", "columns": ("created",)},
+                "partitions": {"bad": {"bound_from": "not-a-date", "bound_to": "2026-02-01"}},
+            });
+        });
+
+        assertThrows("DATA-SCHEMA-ERROR", "has 1 values for 2 partition columns", sub () {
+            Schema::DataSchemaLoader::normalizeTable("events", {
+                "columns": {"id": {"type": "int"}, "created": {"type": "date"}},
+                "partition_strategy": {"method": "range", "columns": ("id", "created")},
+                "partitions": {"bad": {"bound_from": (1,), "bound_to": (2,)}},
+            });
+        });
+
+        assertThrows("DATA-SCHEMA-ERROR", "must be a list", sub () {
+            Schema::DataSchemaLoader::normalizeTable("events", {
+                "columns": {"id": {"type": "int"}, "created": {"type": "date"}},
+                "partition_strategy": {"method": "range", "columns": ("id", "created")},
+                "partitions": {"bad": {"bound_from": 1, "bound_to": 2}},
+            });
+        });
     }
 
     referenceDataTests() {

--- a/examples/test/qlib/SqlUtil/MysqlSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/MysqlSqlUtil.qtest
@@ -4,11 +4,11 @@
 %modern
 
 %prepend-module-path "${SCRIPT_DIR}/../../../../qlib"
-%requires Util
-%requires Logger
-%requires DataProvider
-%requires SqlUtil
-%requires MysqlSqlUtil
+%requires ../../../../qlib/Util.qm
+%requires ../../../../qlib/Logger.qm
+%requires ../../../../qlib/DataProvider
+%requires ../../../../qlib/SqlUtil
+%requires ../../../../qlib/MysqlSqlUtil.qm
 
 %requires ./SqlUtilTestBase.qm
 
@@ -210,6 +210,7 @@ class MysqlTest inherits SqlTestBase {
 
             addTestCase("test create table with auto increment - negative", \testCreateTableWithAutoIncrementNegative());
             addTestCase("test create table with auto increment - positive", \testCreateTableWithAutoIncrementPositive());
+            addTestCase("range partition lifecycle", \rangePartitionLifecycleTest());
         }
 
         set_return_value(main());
@@ -231,6 +232,105 @@ class MysqlTest inherits SqlTestBase {
         MysqlTestAutoIncrementPositiveSchema schema(table.getDatasource());
         schema.align(False, m_options.verbose, m_options.verbose > 0);
         assertEq(True, True, "schema alignment works");
+    }
+
+    private rangePartitionLifecycleTest() {
+        if (!table) {
+            testSkip("no DB connection");
+        }
+
+        AbstractDatasource ds = table.getDatasource();
+        ds.execRaw("drop table if exists mysql_partition_test");
+        ds.commit();
+
+        on_exit {
+            try {
+                ds.execRaw("drop table if exists mysql_partition_test");
+                ds.commit();
+            } catch (hash<ExceptionInfo> ex) {
+            }
+        }
+
+        MysqlTable t(ds, "mysql_partition_test");
+        t.setupTable({
+            "columns": {
+                "id": {"qore_type": Type::Int, "notnull": True},
+                "d": {"native_type": "datetime", "notnull": True},
+                "v": {"qore_type": Type::String, "size": 20},
+            },
+            "primary_key": {"name": "mysql_partition_test_pk", "columns": ("id", "d")},
+            "partition_strategy": {"method": "range", "columns": "d"},
+            "partitions": {
+                "p1": {"name": "p1", "bound_from": 2026-01-01, "bound_to": 2026-02-01},
+                "p2": {"name": "p2", "bound_from": 2026-02-01, "bound_to": 2026-03-01},
+            },
+        });
+        t.createCommit();
+
+        MysqlTable rt(ds, "mysql_partition_test");
+        assertEq(True, rt.supportsPartitions());
+        assertEq(False, rt.supportsPartitionDetach());
+
+        hash<PartitionStrategy> strategy = rt.getPartitionStrategy();
+        assertEq("range", strategy.method);
+        assertEq(1, strategy.columns.size());
+        assertEq("d", strategy.columns[0]);
+
+        hash<string, PartitionInfo> parts = rt.listPartitions();
+        assertEq(2, parts.size());
+        assertEq(2026-02-01, parts.p2.bound_from);
+        assertEq(2026-03-01, parts.p2.bound_to);
+
+        hash<auto> desc = rt.getDescriptionHash({"with_partitions": True});
+        assertEq(2, desc.partitions.size());
+        assertTrue(rt.getCreateSql()[0] =~ /partition by range columns/i);
+
+        hash<PartitionLookupResult> lookup = rt.findPartitionBySpec({
+            "bound_from": 2026-02-01,
+            "bound_to": 2026-03-01,
+        });
+        assertEq(PartitionLookupStatus::Found, lookup.status);
+        assertEq("p2", lookup.partition.name);
+
+        hash<PartitionEnsureResult> ensure = rt.ensurePartitionCommit({
+            "name": "p3",
+            "bound_from": 2026-03-01,
+            "bound_to": 2026-04-01,
+        });
+        assertEq(True, ensure.created);
+        assertEq(True, ensure.materialized);
+        assertEq(PartitionVerifiedBy::Bounds, ensure.verified_by);
+        assertEq(True, rt.listPartitions().hasKey("p3"));
+
+        ds.execRaw("insert into mysql_partition_test values (3, '2026-03-15 00:00:00', 'x')");
+        ds.commit();
+        assertEq(1, ds.selectRow("select count(*) c from mysql_partition_test partition (p3)").c);
+        rt.truncatePartitionCommit("p3");
+        assertEq(0, ds.selectRow("select count(*) c from mysql_partition_test partition (p3)").c);
+
+        rt.dropPartitionCommit("p3");
+        assertEq(False, rt.listPartitions().hasKey("p3"));
+        assertThrows("PARTITION-ERROR", "does not support detaching partitions",
+            sub() {
+                rt.detachPartition("p2");
+            });
+
+        MysqlTable bad(ds, "mysql_partition_test_bad");
+        bad.setupTable({
+            "columns": {
+                "id": {"qore_type": Type::Int, "notnull": True},
+                "d": {"qore_type": Type::Date, "notnull": True},
+            },
+            "primary_key": {"name": "mysql_partition_test_bad_pk", "columns": ("id", "d")},
+            "partition_strategy": {"method": "range", "columns": "d"},
+            "partitions": {
+                "p1": {"name": "p1", "bound_from": 2026-01-01, "bound_to": 2026-02-01},
+            },
+        });
+        assertThrows("PARTITION-ERROR", "does not allow \"timestamp\" columns in RANGE COLUMNS partition keys",
+            sub() {
+                bad.getCreateSql();
+            });
     }
 
     private usageIntern() {

--- a/examples/test/qlib/SqlUtil/OracleSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/OracleSqlUtil.qtest
@@ -4,11 +4,11 @@
 %modern
 
 %prepend-module-path "${SCRIPT_DIR}/../../../../qlib"
-%requires Util
-%requires Logger
-%requires DataProvider
-%requires SqlUtil
-%requires OracleSqlUtil
+%requires ../../../../qlib/Util.qm
+%requires ../../../../qlib/Logger.qm
+%requires ../../../../qlib/DataProvider
+%requires ../../../../qlib/SqlUtil
+%requires ../../../../qlib/OracleSqlUtil.qm
 
 %requires ./SqlUtilTestBase.qm
 
@@ -262,6 +262,7 @@ class OracleTest inherits SqlTestBase {
             addTestCase("analytic/window functions", \testAnalyticFunctions());
             addTestCase("custom column operators #2314", \testCustomColumnOperators());
             addTestCase("chained synonyms #2408", \testChainedSynonyms());
+            addTestCase("range partition lifecycle", \rangePartitionLifecycleTest());
         }
 
         set_return_value(main());
@@ -532,6 +533,90 @@ class OracleTest inherits SqlTestBase {
 
         Table t(ds, "oracle_test_syn3");
         assertEq("X", t.selectRow().dummy, "dummy must be resolved, returning X");
+    }
+
+    private rangePartitionLifecycleTest() {
+        if (!table) {
+            testSkip("no DB connection");
+        }
+
+        AbstractDatasource ds = table.getDatasource();
+        ds.execRaw("begin execute immediate 'drop table oracle_partition_test purge'; exception when others then "
+            "null; end;");
+        ds.commit();
+
+        on_exit {
+            try {
+                ds.execRaw("begin execute immediate 'drop table oracle_partition_test purge'; exception when others "
+                    "then null; end;");
+                ds.commit();
+            } catch (hash<ExceptionInfo> ex) {
+            }
+        }
+
+        OracleTable t(ds, "oracle_partition_test");
+        t.setupTable({
+            "columns": {
+                "id": {"qore_type": Type::Int, "notnull": True},
+                "d": {"qore_type": Type::Date, "notnull": True},
+                "v": {"qore_type": Type::String, "size": 20},
+            },
+            "primary_key": {"name": "oracle_partition_test_pk", "columns": ("id", "d")},
+            "partition_strategy": {"method": "range", "columns": "d"},
+            "partitions": {
+                "p1": {"name": "p1", "bound_from": 2026-01-01, "bound_to": 2026-02-01},
+                "p2": {"name": "p2", "bound_from": 2026-02-01, "bound_to": 2026-03-01},
+            },
+        });
+        t.createCommit();
+
+        OracleTable rt(ds, "oracle_partition_test");
+        assertEq(True, rt.supportsPartitions());
+        assertEq(False, rt.supportsPartitionDetach());
+
+        hash<PartitionStrategy> strategy = rt.getPartitionStrategy();
+        assertEq("range", strategy.method);
+        assertEq(1, strategy.columns.size());
+        assertEq("d", strategy.columns[0]);
+
+        hash<string, PartitionInfo> parts = rt.listPartitions();
+        assertEq(2, parts.size());
+        assertEq(2026-02-01, parts.p2.bound_from);
+        assertEq(2026-03-01, parts.p2.bound_to);
+
+        hash<auto> desc = rt.getDescriptionHash({"with_partitions": True});
+        assertEq(2, desc.partitions.size());
+        assertTrue(rt.getCreateSql()[0] =~ /partition by range/i);
+
+        hash<PartitionLookupResult> lookup = rt.findPartitionBySpec({
+            "bound_from": 2026-02-01,
+            "bound_to": 2026-03-01,
+        });
+        assertEq(PartitionLookupStatus::Found, lookup.status);
+        assertEq("p2", lookup.partition.name);
+
+        hash<PartitionEnsureResult> ensure = rt.ensurePartitionCommit({
+            "name": "p3",
+            "bound_from": 2026-03-01,
+            "bound_to": 2026-04-01,
+        });
+        assertEq(True, ensure.created);
+        assertEq(True, ensure.materialized);
+        assertEq(PartitionVerifiedBy::Bounds, ensure.verified_by);
+        assertEq(True, rt.listPartitions().hasKey("p3"));
+
+        ds.execRaw("insert into oracle_partition_test values (3, timestamp '2026-03-15 00:00:00', 'x')");
+        ds.commit();
+        assertEq(1, ds.selectRow("select count(*) c from oracle_partition_test partition (p3)").c);
+        rt.truncatePartitionCommit("p3");
+        assertEq(0, ds.selectRow("select count(*) c from oracle_partition_test partition (p3)").c);
+
+        rt.dropPartitionCommit("p3");
+        assertEq(False, rt.listPartitions().hasKey("p3"));
+        assertThrows("PARTITION-ERROR", "does not support detaching partitions",
+            sub() {
+                rt.detachPartition("p2");
+            });
     }
 
     private string getResultSetSql() {

--- a/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
@@ -336,6 +336,7 @@ class PgsqlTest inherits SqlTestBase {
             addTestCase("populate column backfill", \populateColumnTest());
             addTestCase("tables populate FK ordering", \tablesPopulateFkOrderingTest());
             addTestCase("temporary table resolution", \temporaryTableResolutionTest());
+            addTestCase("range partition lifecycle", \rangePartitionLifecycleTest());
         }
 
         set_return_value(main());
@@ -1026,6 +1027,121 @@ class PgsqlTest inherits SqlTestBase {
             assertTrue(joined =~ /legacy/i, "alignment SQL drops legacy column on parent");
             assertTrue(joined =~ /display/i, "alignment SQL adds display column on parent");
         }
+    }
+
+    rangePartitionLifecycleTest() {
+        if (!table) {
+            testSkip("no DB connection");
+        }
+
+        AbstractDatasource ds = schema.getDatasource();
+        on_exit ds.rollback();
+
+        string parent = "pgsql_partition_test";
+        string p1 = parent + "_p1";
+        string p2 = parent + "_p2";
+        string p3 = parent + "_p3";
+
+        code drop_if_exists = sub (string n) {
+            PgsqlTable t(ds, n);
+            if (t.checkExistence()) {
+                t.dropCommit();
+            }
+        };
+
+        drop_if_exists(p3);
+        drop_if_exists(parent);
+        on_exit {
+            drop_if_exists(p3);
+            drop_if_exists(parent);
+        }
+
+        hash<auto> desc = {
+            "columns": {
+                "id": {"qore_type": Type::Int, "notnull": True},
+                "name": {"qore_type": SqlUtil::VARCHAR, "size": 80},
+            },
+            "primary_key": {"name": "pk_" + parent, "columns": ("id",)},
+            "partition_strategy": {"method": "range", "columns": ("id",)},
+            "partitions": {
+                (p1): {"bound_from": 0, "bound_to": 10},
+                (p2): {"bound_from": 10, "bound_to": 20},
+            },
+        };
+
+        PgsqlTable tmpl(ds, parent);
+        tmpl.setupTable(desc);
+        string create_sql = tmpl.getCreateSqlString();
+        assertTrue(create_sql =~ /partition by range \(id\)/i, "parent DDL contains partition strategy");
+        assertTrue(create_sql =~ /partition of public\.pgsql_partition_test/i, "child DDL references parent");
+        tmpl.createCommit();
+
+        PgsqlTable t(ds, parent);
+        assertTrue(t.supportsPartitions(), "pgsql supports partitions");
+        assertTrue(t.supportsPartitionDetach(), "pgsql supports partition detach");
+
+        *hash<PartitionStrategy> strategy = t.getPartitionStrategy();
+        assertTrue(exists strategy, "partition strategy introspected");
+        assertEq("range", strategy.method, "partition method");
+        assertEq(("id",), strategy.columns, "partition key columns");
+
+        hash<string, PartitionInfo> partitions = t.listPartitions();
+        assertEq(2, partitions.size(), "initial partition count");
+        assertTrue(partitions.hasKey(p1), "partition p1 introspected");
+        assertEq(0, partitions{p1}.bound_from, "p1 lower bound parsed");
+        assertEq(10, partitions{p1}.bound_to, "p1 upper bound parsed");
+
+        hash<auto> desc_no_parts = t.getDescriptionHash();
+        assertTrue(desc_no_parts.hasKey("partition_strategy"), "description includes strategy");
+        assertFalse(desc_no_parts.hasKey("partitions"), "description omits partitions by default");
+        hash<auto> desc_parts = t.getDescriptionHash({"with_partitions": True});
+        assertTrue(desc_parts.partitions.hasKey(p1), "description includes partitions when requested");
+
+        hash<PartitionLookupResult> lookup = t.findPartitionBySpec({"bound_from": 0, "bound_to": 10});
+        assertEq(PartitionLookupStatus::Found, lookup.status, "find partition by typed bounds");
+        assertEq(p1, lookup.partition.name, "lookup returned p1");
+
+        hash<PartitionEnsureResult> ensure_existing = t.ensurePartition({
+            "name": p1,
+            "bound_from": 0,
+            "bound_to": 10,
+        });
+        assertFalse(ensure_existing.created, "ensure existing does not create");
+        assertTrue(ensure_existing.materialized, "ensure existing is materialized");
+        assertTrue(ensure_existing.bounds_verified, "ensure existing verified by bounds");
+
+        hash<PartitionEnsureResult> ensure_created = t.ensurePartition({
+            "name": p3,
+            "bound_from": 20,
+            "bound_to": 30,
+        });
+        assertTrue(ensure_created.created, "ensure new creates");
+        assertTrue(ensure_created.materialized, "ensure new is materialized");
+        ds.commit();
+
+        t.clear();
+        partitions = t.listPartitions();
+        assertTrue(partitions.hasKey(p3), "new partition introspected after cache clear");
+
+        t.insert({"id": 21, "name": "to truncate"});
+        assertEq(1, ds.selectRow("select count(*) c from " + p3).c, "row routed to p3");
+        t.truncatePartition(p3);
+        assertEq(0, ds.selectRow("select count(*) c from " + p3).c, "partition truncate removes rows");
+
+        t.detachPartition(p3);
+        ds.commit();
+        t.clear();
+        assertFalse(t.listPartitions().hasKey(p3), "detached partition removed from parent list");
+        drop_if_exists(p3);
+
+        t.dropPartition(p2);
+        ds.commit();
+        t.clear();
+        assertFalse(t.listPartitions().hasKey(p2), "dropped partition removed from parent list");
+
+        hash<auto> reversed = (new SchemaReverse::TableReverse(ds, parent, {"with_partitions": True})).toQore();
+        assertTrue(reversed.hasKey("partition_strategy"), "SchemaReverse includes partition strategy");
+        assertTrue(reversed.partitions.hasKey(p1), "SchemaReverse includes partitions with option");
     }
 
     private string getResultSetSql() {

--- a/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
@@ -1062,10 +1062,13 @@ class PgsqlTest inherits SqlTestBase {
                 "name": {"qore_type": SqlUtil::VARCHAR, "size": 80},
             },
             "primary_key": {"name": "pk_" + parent, "columns": ("id",)},
-            "partition_strategy": {"method": "range", "columns": ("id",)},
+            "partition_strategy": {"method": "range", "columns": ("name",),
+                "driver": {"pgsql": {"columns": ("id",)}}},
             "partitions": {
-                (p1): {"bound_from": 0, "bound_to": 10},
-                (p2): {"bound_from": 10, "bound_to": 20},
+                (p1): {"bound_from": -10, "bound_to": -1,
+                    "driver": {"pgsql": {"bound_from": 0, "bound_to": 10}}},
+                (p2): {"bound_from": 10, "bound_to": 999,
+                    "driver": {"pgsql": {"bound_to": 20}}},
             },
         };
 
@@ -1090,6 +1093,7 @@ class PgsqlTest inherits SqlTestBase {
         assertTrue(partitions.hasKey(p1), "partition p1 introspected");
         assertEq(0, partitions{p1}.bound_from, "p1 lower bound parsed");
         assertEq(10, partitions{p1}.bound_to, "p1 upper bound parsed");
+        assertEq(20, partitions{p2}.bound_to, "partition driver override applied");
 
         hash<auto> desc_no_parts = t.getDescriptionHash();
         assertTrue(desc_no_parts.hasKey("partition_strategy"), "description includes strategy");

--- a/lib/QoreIRLowering.cpp
+++ b/lib/QoreIRLowering.cpp
@@ -6979,16 +6979,22 @@ QoreIRValue QoreIRLowering::lowerPostIncrement(const QoreValue& expr, std::strin
             if (!old_value.isValid()) {
                 return QoreIRValue();
             }
+            QoreIRValue zero = builder.createConstInt(0, base_op->loc)->result;
+            QoreIRValue old_result = lowerBinaryOpOrInvoke(
+                QoreIROpcode::AddInt, expr, old_value, zero, base_op->loc, error);
+            if (!old_result.isValid()) {
+                return QoreIRValue();
+            }
             QoreIRValue one = builder.createConstInt(1, base_op->loc)->result;
             QoreIRValue new_value = lowerBinaryOpOrInvoke(
-                QoreIROpcode::AddAssignInt, expr, old_value, one, base_op->loc, error);
+                QoreIROpcode::AddAssignInt, expr, old_result, one, base_op->loc, error);
             if (!new_value.isValid()) {
                 return QoreIRValue();
             }
             if (!storeVarRef(var, new_value, error, "post-increment-int")) {
                 return QoreIRValue();
             }
-            return old_value;  // post-increment returns old value
+            return old_result;  // post-increment returns old value coerced to int
         }
     }
     // Range lvalue (e.g., list[0..2]++) - delegate entire expression to AST
@@ -7151,16 +7157,22 @@ QoreIRValue QoreIRLowering::lowerPostDecrement(const QoreValue& expr, std::strin
             if (!old_value.isValid()) {
                 return QoreIRValue();
             }
+            QoreIRValue zero = builder.createConstInt(0, base_op->loc)->result;
+            QoreIRValue old_result = lowerBinaryOpOrInvoke(
+                QoreIROpcode::AddInt, expr, old_value, zero, base_op->loc, error);
+            if (!old_result.isValid()) {
+                return QoreIRValue();
+            }
             QoreIRValue one = builder.createConstInt(1, base_op->loc)->result;
             QoreIRValue new_value = lowerBinaryOpOrInvoke(
-                QoreIROpcode::SubAssignInt, expr, old_value, one, base_op->loc, error);
+                QoreIROpcode::SubAssignInt, expr, old_result, one, base_op->loc, error);
             if (!new_value.isValid()) {
                 return QoreIRValue();
             }
             if (!storeVarRef(var, new_value, error, "post-decrement-int")) {
                 return QoreIRValue();
             }
-            return old_value;  // post-decrement returns old value
+            return old_result;  // post-decrement returns old value coerced to int
         }
     }
     // Range lvalue (e.g., list[0..2]--) - delegate entire expression to AST

--- a/man/qschema.1
+++ b/man/qschema.1
@@ -2,7 +2,7 @@
 .\"
 .\" Copyright (C) 2019 - 2026 Qore Technologies, s.r.o.
 .\"
-.TH QSCHEMA 1 "2026 April 02" "Qore 2.3" "Qore Programming Language"
+.TH QSCHEMA 1 "2026 June 04" "Qore 2.3" "Qore Programming Language"
 .SH NAME
 qschema \- database schema management tool
 .SH SYNOPSIS
@@ -71,6 +71,9 @@ Output file (for export).
 .B \-\-format =\fIformat\fP
 Export format: \fByaml\fP (default) or \fBjson\fP.
 .TP
+.B \-\-with\-partitions
+Include physical table partitions in exported schema files.
+.TP
 .BR \-h ", " \-\-help
 Show help text and exit.
 .TP
@@ -95,6 +98,11 @@ Dry-run alignment:
 Export a database schema:
 .RS
 .B qschema export mydb \-o exported.ysm
+.RE
+.PP
+Export a database schema including physical partitions:
+.RS
+.B qschema export mydb \-o exported.ysm \-\-with\-partitions
 .RE
 .PP
 Validate a schema file:

--- a/qlib/DbDataProvider/DbTableBulkRecordInterface.qc
+++ b/qlib/DbDataProvider/DbTableBulkRecordInterface.qc
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! Qore DbTableBulkRecordInterface class definition
 
-/** DbTableBulkRecordInterface.qc Copyright 2019 - 2024 Qore Technologies, s.r.o.
+/** DbTableBulkRecordInterface.qc Copyright 2019 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -35,6 +35,9 @@ public class DbTableBulkRecordInterface inherits AbstractDataProviderBulkRecordI
 
         #! release the transaction with a rollback in the destructor?
         bool release_transaction;
+
+        #! use the native buffer-column shape
+        bool use_columnar = True;
     }
 
     #! creates the iterator
@@ -50,6 +53,13 @@ public class DbTableBulkRecordInterface inherits AbstractDataProviderBulkRecordI
         # release the transaction with a rollback in the destructor if we do not already have a transaction lock
         release_transaction = !table.getDatasource().currentThreadInTransaction();
         stmt = table.getStatement({"where": where_cond});
+
+        foreach AbstractColumn col in (table.describe().iterator()) {
+            if (col.qore_type == Type::Binary) {
+                use_columnar = False;
+                break;
+            }
+        }
     }
 
     #! Rolls back the transaction if applicable
@@ -87,12 +97,12 @@ public class DbTableBulkRecordInterface inherits AbstractDataProviderBulkRecordI
           transaction
     */
     private *auto getShapedValueImpl() {
-        return stmt.fetchColumnar(block_size);
+        return use_columnar ? stmt.fetchColumnar(block_size) : stmt.fetchColumns(block_size);
     }
 
     #! Returns the native pipeline shape produced by getShapedValueImpl()
     private DataProviderShape getValueShapeImpl() {
-        return DataProviderShape::BufferColumns;
+        return use_columnar ? DataProviderShape::BufferColumns : DataProviderShape::HashOfLists;
     }
 
     #! Returns a hash of lists according to the block size

--- a/qlib/MysqlSqlUtil.qm
+++ b/qlib/MysqlSqlUtil.qm
@@ -90,6 +90,8 @@ module MysqlSqlUtil {
     @section mysql_relnotes Release Notes
 
     @subsection mysqlsqlutilv15 MysqlSqlUtil v1.5
+    - implemented MySQL/MariaDB range-partitioned table DDL, introspection, and lifecycle operations through the
+      generic @ref SqlUtil::AbstractTable "AbstractTable" partition APIs
     - fixed the prepend and append column operators
       (<a href="https://github.com/qoretechnologies/qore/issues/4548">issue 4548</a>)
     - implemented support for generating queries based on generic expressions using the DataProvider module's generic
@@ -2352,7 +2354,45 @@ end";
                 }
             }
 
+            sql += getMysqlPartitionCreateClause();
+
             return sql;
+        }
+
+        private string getMysqlPartitionCreateClause() {
+            if (!partitionStrategy) {
+                return "";
+            }
+            if (partitionStrategy.method != "range") {
+                throw "PARTITION-ERROR", sprintf("%s: unsupported MySQL/MariaDB partition method %y", getDesc(),
+                    partitionStrategy.method);
+            }
+
+            getPartitionsUnlocked();
+            if (partitions.empty()) {
+                throw "PARTITION-ERROR", sprintf("%s: MySQL/MariaDB range-partitioned tables require at least one "
+                    "partition definition in the table description", getDesc());
+            }
+            validateMysqlPartitionColumnsUnlocked();
+
+            list<string> defs = ();
+            foreach hash<PartitionInfo> pi in (partitions.iterator()) {
+                defs += "  " + getMysqlPartitionDefinitionSql(pi);
+            }
+
+            return sprintf(" partition by range columns (%s) (\n%s\n)",
+                (foldl $1 + ", " + $2, getColumnSqlNames(partitionStrategy.columns)),
+                (foldl $1 + ",\n" + $2, defs));
+        }
+
+        private validateMysqlPartitionColumnsUnlocked() {
+            foreach string col in (partitionStrategy.columns) {
+                if (columns{col}.native_type == "timestamp") {
+                    throw "PARTITION-ERROR", sprintf("%s: MySQL/MariaDB does not allow %y columns in "
+                        "RANGE COLUMNS partition keys; use a partitionable native type such as %y or %y",
+                        getDesc(), "timestamp", "datetime", "date");
+                }
+            }
         }
 
         #! returns @ref False "False" because the mysql driver does not support array binds / bulk DML operations
@@ -2560,6 +2600,254 @@ end";
         #! returns a list of column names for use in SQL strings; subclasses can process the argument list in case a column name is a reserved word
         list getColumnSqlNames(softlist cols) {
             return map getColumnSqlName($1), cols;
+        }
+
+        private bool supportsPartitionsImpl() {
+            return True;
+        }
+
+        private bool createPartitionsInCreateTableImpl() {
+            return True;
+        }
+
+        private *hash<PartitionStrategy> getPartitionStrategyImpl() {
+            *hash<auto> row = ds.selectRow("select partition_method, partition_expression from "
+                "information_schema.partitions where table_schema = %v and table_name = %v "
+                "and partition_name is not null order by partition_ordinal_position limit 1", schema, name);
+            if (!row) {
+                return;
+            }
+            if (!(row.partition_method =~ /^RANGE/i)) {
+                return;
+            }
+
+            hash<PartitionStrategy> rv({
+                "method": "range",
+                "columns": parseMysqlPartitionColumns(row.partition_expression),
+            });
+            return rv;
+        }
+
+        private hash<string, PartitionInfo> getPartitionsImpl() {
+            hash<string, PartitionInfo> rv();
+
+            *PartitionStrategy strategy = getPartitionStrategyUnlocked();
+            if (!strategy) {
+                return rv;
+            }
+            getColumnsUnlocked();
+
+            *hash<auto> qh = ds.select("select partition_name, partition_description, "
+                "partition_ordinal_position from information_schema.partitions where table_schema = %v "
+                "and table_name = %v and partition_name is not null order by partition_ordinal_position",
+                schema, name);
+
+            *string prev_bound_sql;
+            *auto prev_bound;
+            foreach hash<auto> row in (qh.contextIterator()) {
+                string pname = row.partition_name;
+                string pdesc = row.partition_description;
+                trim pdesc;
+
+                hash<PartitionInfo> info({
+                    "name": pname,
+                    "method": strategy.method,
+                    "columns": strategy.columns,
+                    "ordinal": row.partition_ordinal_position - 1,
+                    "schema": schema,
+                    "relation_name": pname,
+                    "sql_name": sprintf("%s partition (%s)", getSqlName(), pname),
+                    "is_default": pdesc =~ /^MAXVALUE$/i,
+                });
+
+                if (!info.is_default) {
+                    info.bound_to_sql = pdesc;
+                    if (exists prev_bound_sql) {
+                        info.bound_from_sql = prev_bound_sql;
+                    }
+
+                    *auto bound_to = parseMysqlPartitionBoundValues(pdesc, info.columns);
+                    if (exists bound_to) {
+                        info.bound_to = bound_to;
+                    }
+                    if (exists prev_bound) {
+                        info.bound_from = prev_bound;
+                    }
+
+                    prev_bound_sql = pdesc;
+                    if (exists bound_to) {
+                        prev_bound = bound_to;
+                    } else {
+                        delete prev_bound;
+                    }
+                }
+
+                rv{info.name} = info;
+            }
+
+            return rv;
+        }
+
+        private hash<PartitionInfo> resolveMysqlPartitionInfoUnlocked(string partition_name) {
+            hash<string, PartitionInfo> ph = getPartitionsUnlocked();
+            if (!ph.hasKey(partition_name)) {
+                throw "PARTITION-ERROR", sprintf("%s: partition %y does not exist", getDesc(), partition_name);
+            }
+            return ph{partition_name};
+        }
+
+        private string getAddPartitionSqlImpl(hash<PartitionSpec> spec) {
+            assertNoMysqlDefaultPartitionForAddUnlocked(spec);
+            return sprintf("alter table %s add partition (%s)", getSqlName(), getMysqlPartitionDefinitionSql(spec));
+        }
+
+        private string getDropPartitionSqlImpl(string partition_name) {
+            hash<PartitionInfo> info = resolveMysqlPartitionInfoUnlocked(partition_name);
+            return sprintf("alter table %s drop partition %s", getSqlName(), info.name);
+        }
+
+        private string getTruncatePartitionSqlImpl(string partition_name) {
+            hash<PartitionInfo> info = resolveMysqlPartitionInfoUnlocked(partition_name);
+            return sprintf("alter table %s truncate partition %s", getSqlName(), info.name);
+        }
+
+        private assertNoMysqlDefaultPartitionForAddUnlocked(hash<PartitionSpec> spec) {
+            if (spec.is_default) {
+                return;
+            }
+            foreach hash<PartitionInfo> pi in (getPartitionsUnlocked().iterator()) {
+                if (pi.is_default) {
+                    throw "PARTITION-ERROR", sprintf("%s: cannot add partition %y after catch-all partition %y; "
+                        "reorganize the catch-all partition explicitly", getDesc(), spec.name, pi.name);
+                }
+            }
+        }
+
+        private string getMysqlPartitionDefinitionSql(hash<PartitionSpec> spec) {
+            if (!spec.name) {
+                throw "PARTITION-ERROR", sprintf("%s: MySQL/MariaDB partition name is required", getDesc());
+            }
+            return sprintf("partition %s %s", spec.name, getMysqlPartitionBoundSql(spec));
+        }
+
+        private string getMysqlPartitionBoundSql(hash<PartitionSpec> spec) {
+            if (spec.is_default) {
+                return "values less than (maxvalue)";
+            }
+            if (spec.bound_sql) {
+                string sql = spec.bound_sql;
+                trim sql;
+                if (sql =~ x/^values\s+less\s+than\b/i) {
+                    return sql;
+                }
+                return "values less than (" + sql + ")";
+            }
+            if (spec.bound_to_sql) {
+                return sprintf("values less than (%s)", spec.bound_to_sql);
+            }
+            return sprintf("values less than (%s)", getMysqlPartitionBoundValuesSql(spec.bound_to));
+        }
+
+        private string getMysqlPartitionBoundValuesSql(auto value) {
+            if (value.typeCode() != NT_LIST) {
+                return getMysqlPartitionBoundValueSql(value);
+            }
+            return foldl $1 + ", " + $2, (map getMysqlPartitionBoundValueSql($1), value);
+        }
+
+        private string getMysqlPartitionBoundValueSql(auto value) {
+            if (value.typeCode() == NT_DATE) {
+                TimeZone tz = TimeZone::get();
+                value = tz.date(value);
+                return value.format("'YYYY-MM-DD HH:mm:SS.us'");
+            }
+            return getSqlValue(value);
+        }
+
+        private list<string> parseMysqlPartitionColumns(string expr) {
+            list<string> cols = ();
+            foreach string col in (expr.split(",")) {
+                trim col;
+                col =~ s/^`//;
+                col =~ s/`$//;
+                cols += col;
+            }
+            return cols;
+        }
+
+        private *auto parseMysqlPartitionBoundValues(string sql, softlist<string> pcols) {
+            if (pcols.size() == 1) {
+                return parseMysqlPartitionBoundValue(sql, columns{pcols[0]});
+            }
+
+            list<string> parts = sql.split(",");
+            if (parts.size() != pcols.size()) {
+                return;
+            }
+
+            list<auto> values = ();
+            foreach string part in (parts) {
+                *auto value = parseMysqlPartitionBoundValue(part, columns{pcols[$#]});
+                if (!exists value) {
+                    return;
+                }
+                values += value;
+            }
+            return values;
+        }
+
+        private *auto parseMysqlPartitionBoundValue(string sql, *AbstractColumn col) {
+            trim sql;
+            if (sql =~ /^MAXVALUE$/i) {
+                return;
+            }
+
+            *string value = (sql =~ x/^'(.*)'$/)[0];
+            if (exists value) {
+                value =~ s/''/'/g;
+                return parseMysqlPartitionTypedLiteral(value, col) ?? value;
+            }
+            if (*auto typed = parseMysqlPartitionTypedLiteral(sql, col)) {
+                return typed;
+            }
+            if (sql =~ /^-?\d+$/) {
+                return sql.toInt();
+            }
+            if (sql =~ /^-?\d+\.\d+$/) {
+                return number(sql);
+            }
+        }
+
+        private *auto parseMysqlPartitionTypedLiteral(string value, *AbstractColumn col) {
+            if (!col || !col.qore_type) {
+                return;
+            }
+            try {
+                switch (col.qore_type) {
+                    case Type::Int: {
+                        if (value =~ /^-?\d+$/) {
+                            return value.toInt();
+                        }
+                        break;
+                    }
+                    case Type::Float: {
+                        if (value =~ /^-?\d+(\.\d+)?$/) {
+                            return value.toFloat();
+                        }
+                        break;
+                    }
+                    case Type::Number: {
+                        if (value =~ /^-?\d+(\.\d+)?$/) {
+                            return number(value);
+                        }
+                        break;
+                    }
+                    case Type::Date: {
+                        return date(value);
+                    }
+                }
+            } catch (hash<ExceptionInfo> ex) {
+            }
         }
 
         #! returns a string for use in SQL queries representing the DB-specific value of the argument

--- a/qlib/OracleSqlUtil.qm
+++ b/qlib/OracleSqlUtil.qm
@@ -32,7 +32,7 @@
 %requires Util >= 1.0
 
 # the implementation is in OracleSqlUtilBase
-%requires(reexport) OracleSqlUtilBase.qm
+%requires(reexport) OracleSqlUtilBase
 
 # for bindOracleCollection
 %try-module oracle

--- a/qlib/OracleSqlUtil.qm
+++ b/qlib/OracleSqlUtil.qm
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! @file OracleSqlUtil.qm Qore user module for working with Oracle SQL data
 
-/*  OracleSqlUtil.qm Copyright 2013 - 2024 Qore Technologies, s.r.o.
+/*  OracleSqlUtil.qm Copyright 2013 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -32,7 +32,7 @@
 %requires Util >= 1.0
 
 # the implementation is in OracleSqlUtilBase
-%requires(reexport) OracleSqlUtilBase
+%requires(reexport) OracleSqlUtilBase.qm
 
 # for bindOracleCollection
 %try-module oracle
@@ -79,6 +79,8 @@ module OracleSqlUtil {
 
     @subsection oraclesqlutil_v1_6 OracleSqlUtil v1.6
     - updated to use the @ref oraclesqlutilbaseintro module for the base implementation
+    - load the base implementation by module-path source filename so source-tree tests use the local
+      @ref oraclesqlutilbaseintro implementation
 
     @subsection oraclesqlutil_v1_5 OracleSqlUtil v1.5
     - implemented support for generating queries based on generic expressions using the DataProvider module's generic

--- a/qlib/OracleSqlUtilBase.qm
+++ b/qlib/OracleSqlUtilBase.qm
@@ -274,6 +274,8 @@ hash schema = (
     @section ora_relnotes Release Notes
 
     @subsection oracle16 OracleSqlUtilBase v1.6
+    - implemented range-partitioned table DDL, introspection, and lifecycle operations through the generic
+      @ref SqlUtil::AbstractTable "AbstractTable" partition APIs
     - fixed a bug in the IN operator
       (<a href="https://github.com/qoretechnologies/qore/issues/4901">issue 4901</a>)
     - fixed space management on Oracle
@@ -2973,10 +2975,13 @@ public class OracleTable inherits SqlUtil::AbstractTable {
             "dba_ind_expressions"   : "all_ind_expressions",
             "dba_indexes"           : "all_indexes",
             "dba_objects"           : "all_objects",
+            "dba_part_key_columns"  : "all_part_key_columns",
+            "dba_part_tables"       : "all_part_tables",
             "dba_sequences"         : "all_sequences",
             "dba_synonyms"          : "all_synonyms",
             "dba_tab_columns"       : "all_tab_columns",
             "dba_tab_comments"      : "all_tab_comments",
+            "dba_tab_partitions"    : "all_tab_partitions",
             "dba_tables"            : "all_tables",
             "dba_triggers"          : "all_triggers",
             "dba_views"             : "all_views",
@@ -3690,7 +3695,40 @@ where i.owner = %v and i.table_name = %v", schema.upr(), name.upr());
             sql += sprintf(" tablespace %s", ts);
         }
 
+        sql += getOraclePartitionCreateClause();
+
         return sql;
+    }
+
+    private string getOraclePartitionCreateClause() {
+        if (!partitionStrategy) {
+            return "";
+        }
+        if (partitionStrategy.method != "range") {
+            throw "PARTITION-ERROR", sprintf("%s: unsupported Oracle partition method %y", getDesc(),
+                partitionStrategy.method);
+        }
+
+        getPartitionsUnlocked();
+        if (partitions.empty()) {
+            throw "PARTITION-ERROR", sprintf("%s: Oracle range-partitioned tables require at least one partition "
+                "definition in the table description", getDesc());
+        }
+
+        string sql = sprintf(" partition by range (%s)", (foldl $1 + ", " + $2,
+            getColumnSqlNames(partitionStrategy.columns)));
+        if (partitionStrategy.auto) {
+            *string expr = partitionStrategy.auto.expression ?? partitionStrategy.auto.interval;
+            if (expr) {
+                sql += sprintf(" interval (%s)", expr);
+            }
+        }
+
+        list<string> defs = ();
+        foreach hash<PartitionInfo> pi in (partitions.iterator()) {
+            defs += "  " + getOraclePartitionDefinitionSql(pi);
+        }
+        return sql + " (\n" + (foldl $1 + ",\n" + $2, defs) + "\n)";
     }
 
     #! Returns the expression map for Oracle
@@ -3852,6 +3890,286 @@ where i.owner = %v and i.table_name = %v", schema.upr(), name.upr());
     #! returns a list of column names for use in SQL strings; subclasses can process the argument list in case a column name is a reserved word
     list getColumnSqlNames(softlist cols) {
         return map (OracleDatabase::OracleReservedWords{$1.lwr()} ? ("\"" + $1 + "\"") : $1), cols;
+    }
+
+    private bool supportsPartitionsImpl() {
+        return True;
+    }
+
+    private bool supportsAutoPartitioningImpl() {
+        return True;
+    }
+
+    private bool createPartitionsInCreateTableImpl() {
+        return True;
+    }
+
+    private *hash<PartitionStrategy> getPartitionStrategyImpl() {
+        *hash<auto> row = ds.selectRow("select partitioning_type, interval from "
+            + systemView("dba_part_tables") + (dblink ? "@" + dblink : "")
+            + " where owner = %v and table_name = %v", schema.upr(), name.upr());
+        if (!row) {
+            return;
+        }
+        if (row.partitioning_type != "RANGE") {
+            return;
+        }
+
+        *hash<auto> qh = ds.select("select column_name from " + systemView("dba_part_key_columns")
+            + (dblink ? "@" + dblink : "")
+            + " where owner = %v and name = %v and object_type = %v order by column_position",
+            schema.upr(), name.upr(), "TABLE");
+        if (!qh.column_name) {
+            return;
+        }
+
+        list<string> cols = ();
+        foreach string col in (qh.column_name) {
+            cols += native_case ? col : col.lwr();
+        }
+
+        hash<PartitionStrategy> rv({
+            "method": "range",
+            "columns": cols,
+        });
+        if (row.interval) {
+            rv.auto = {
+                "type": "interval",
+                "expression": row.interval,
+            };
+        }
+        return rv;
+    }
+
+    private hash<string, PartitionInfo> getPartitionsImpl() {
+        hash<string, PartitionInfo> rv();
+
+        *PartitionStrategy strategy = getPartitionStrategyUnlocked();
+        if (!strategy) {
+            return rv;
+        }
+        getColumnsUnlocked();
+
+        *hash<auto> qh = ds.select("select partition_name, partition_position, high_value from "
+            + systemView("dba_tab_partitions") + (dblink ? "@" + dblink : "")
+            + " where table_owner = %v and table_name = %v order by partition_position",
+            schema.upr(), name.upr());
+
+        *string prev_bound_sql;
+        *auto prev_bound;
+        foreach hash<auto> row in (qh.contextIterator()) {
+            string pname = native_case ? row.partition_name : row.partition_name.lwr();
+            string high_value = row.high_value;
+            trim high_value;
+
+            hash<PartitionInfo> info({
+                "name": pname,
+                "method": strategy.method,
+                "columns": strategy.columns,
+                "ordinal": row.partition_position - 1,
+                "schema": schema,
+                "relation_name": pname,
+                "sql_name": sprintf("%s partition (%s)", getSqlName(), pname),
+                "is_default": high_value =~ /^MAXVALUE$/i,
+            });
+
+            if (!info.is_default) {
+                info.bound_to_sql = high_value;
+                if (exists prev_bound_sql) {
+                    info.bound_from_sql = prev_bound_sql;
+                }
+
+                *auto bound_to = parseOraclePartitionBoundValues(high_value, info.columns);
+                if (exists bound_to) {
+                    info.bound_to = bound_to;
+                }
+                if (exists prev_bound) {
+                    info.bound_from = prev_bound;
+                }
+
+                prev_bound_sql = high_value;
+                if (exists bound_to) {
+                    prev_bound = bound_to;
+                } else {
+                    delete prev_bound;
+                }
+            }
+
+            rv{info.name} = info;
+        }
+
+        return rv;
+    }
+
+    private hash<PartitionInfo> resolveOraclePartitionInfoUnlocked(string partition_name) {
+        string pname = native_case ? partition_name : partition_name.lwr();
+        hash<string, PartitionInfo> ph = getPartitionsUnlocked();
+        if (!ph.hasKey(pname)) {
+            throw "PARTITION-ERROR", sprintf("%s: partition %y does not exist", getDesc(), partition_name);
+        }
+        return ph{pname};
+    }
+
+    private string getAddPartitionSqlImpl(hash<PartitionSpec> spec) {
+        assertNoOracleDefaultPartitionForAddUnlocked(spec);
+        return sprintf("alter table %s add %s", getSqlName(), getOraclePartitionDefinitionSql(spec));
+    }
+
+    private string getDropPartitionSqlImpl(string partition_name) {
+        hash<PartitionInfo> info = resolveOraclePartitionInfoUnlocked(partition_name);
+        return sprintf("alter table %s drop partition %s", getSqlName(), info.name);
+    }
+
+    private string getTruncatePartitionSqlImpl(string partition_name) {
+        hash<PartitionInfo> info = resolveOraclePartitionInfoUnlocked(partition_name);
+        return sprintf("alter table %s truncate partition %s", getSqlName(), info.name);
+    }
+
+    private bool partitionAutoStrategyCoversSpecImpl(hash<PartitionSpec> spec) {
+        *PartitionStrategy strategy = getPartitionStrategyUnlocked();
+        if (!strategy || !strategy.auto || spec.is_default || !partitionSpecsHaveComparableBounds(spec)) {
+            return False;
+        }
+
+        *auto upper;
+        foreach hash<PartitionInfo> pi in (getPartitionsUnlocked().iterator()) {
+            if (pi.is_default || !exists pi.bound_to) {
+                continue;
+            }
+            if (!exists upper || upper < pi.bound_to) {
+                upper = pi.bound_to;
+            }
+        }
+        return !exists upper || upper < spec.bound_to;
+    }
+
+    private assertNoOracleDefaultPartitionForAddUnlocked(hash<PartitionSpec> spec) {
+        if (spec.is_default) {
+            return;
+        }
+        foreach hash<PartitionInfo> pi in (getPartitionsUnlocked().iterator()) {
+            if (pi.is_default) {
+                throw "PARTITION-ERROR", sprintf("%s: cannot add partition %y after catch-all partition %y; "
+                    "split the catch-all partition explicitly", getDesc(), spec.name, pi.name);
+            }
+        }
+    }
+
+    private string getOraclePartitionDefinitionSql(hash<PartitionSpec> spec) {
+        if (!spec.name) {
+            throw "PARTITION-ERROR", sprintf("%s: Oracle partition name is required", getDesc());
+        }
+        return sprintf("partition %s %s", spec.name, getOraclePartitionBoundSql(spec));
+    }
+
+    private string getOraclePartitionBoundSql(hash<PartitionSpec> spec) {
+        if (spec.is_default) {
+            return "values less than (maxvalue)";
+        }
+        if (spec.bound_sql) {
+            string sql = spec.bound_sql;
+            trim sql;
+            if (sql =~ x/^values\s+less\s+than\b/i) {
+                return sql;
+            }
+            return "values less than (" + sql + ")";
+        }
+        if (spec.bound_to_sql) {
+            return sprintf("values less than (%s)", spec.bound_to_sql);
+        }
+        return sprintf("values less than (%s)", getOraclePartitionBoundValuesSql(spec.bound_to));
+    }
+
+    private string getOraclePartitionBoundValuesSql(auto value) {
+        if (value.typeCode() != NT_LIST) {
+            return getSqlValue(value);
+        }
+        return foldl $1 + ", " + $2, (map getSqlValue($1), value);
+    }
+
+    private *auto parseOraclePartitionBoundValues(string sql, softlist<string> pcols) {
+        if (pcols.size() == 1) {
+            return parseOraclePartitionBoundValue(sql, columns{pcols[0]});
+        }
+
+        list<string> parts = sql.split(",");
+        if (parts.size() != pcols.size()) {
+            return;
+        }
+
+        list<auto> values = ();
+        foreach string part in (parts) {
+            *auto value = parseOraclePartitionBoundValue(part, columns{pcols[$#]});
+            if (!exists value) {
+                return;
+            }
+            values += value;
+        }
+        return values;
+    }
+
+    private *auto parseOraclePartitionBoundValue(string sql, *AbstractColumn col) {
+        trim sql;
+        if (sql =~ /^MAXVALUE$/i) {
+            return;
+        }
+
+        *string value = (sql =~ x/^TIMESTAMP'\s*(.*)'$/i)[0];
+        if (!exists value) {
+            value = (sql =~ x/^TO_DATE\('\s*([^']+)'.*$/i)[0];
+        }
+        if (!exists value) {
+            value = (sql =~ x/^TO_TIMESTAMP\('\s*([^']+)'.*$/i)[0];
+        }
+        if (!exists value) {
+            value = (sql =~ x/^'(.*)'$/)[0];
+        }
+
+        if (exists value) {
+            value =~ s/''/'/g;
+            return parseOraclePartitionTypedLiteral(value, col) ?? value;
+        }
+        if (*auto typed = parseOraclePartitionTypedLiteral(sql, col)) {
+            return typed;
+        }
+        if (sql =~ /^-?\d+$/) {
+            return sql.toInt();
+        }
+        if (sql =~ /^-?\d+\.\d+$/) {
+            return number(sql);
+        }
+    }
+
+    private *auto parseOraclePartitionTypedLiteral(string value, *AbstractColumn col) {
+        if (!col || !col.qore_type) {
+            return;
+        }
+        try {
+            switch (col.qore_type) {
+                case Type::Int: {
+                    if (value =~ /^-?\d+$/) {
+                        return value.toInt();
+                    }
+                    break;
+                }
+                case Type::Float: {
+                    if (value =~ /^-?\d+(\.\d+)?$/) {
+                        return value.toFloat();
+                    }
+                    break;
+                }
+                case Type::Number: {
+                    if (value =~ /^-?\d+(\.\d+)?$/) {
+                        return number(value);
+                    }
+                    break;
+                }
+                case Type::Date: {
+                    return date(value);
+                }
+            }
+        } catch (hash<ExceptionInfo> ex) {
+        }
     }
 
     #! returns the base type of the underlying object (either \"table\" or \c "view")

--- a/qlib/PgsqlSqlUtilBase.qm
+++ b/qlib/PgsqlSqlUtilBase.qm
@@ -177,6 +177,8 @@ $function$
       results (base class only returns the first row)
     - fixed \c PgsqlTable handling of session temporary tables so unqualified table names and the
       \c pg_temp schema alias resolve to the backend's active temporary schema
+    - implemented PostgreSQL range partition support for %SqlUtil table creation, introspection, lookup, ensure,
+      add, drop, truncate, and detach operations
 
     @subsection pgsqlsqlutilbasev18 PgsqlSqlUtilBase v1.8
     - updated to support \c jdbc and \c odbc drivers as well as the native \c pgsql driver
@@ -3746,6 +3748,15 @@ public class PgsqlTable inherits SqlUtil::AbstractTable {
         sql += foldl $1 + ",\n" + $2, (map "  " + $1.getCreateSql(self), columns.iterator());
         sql += "\n)";
 
+        if (partitionStrategy) {
+            if (partitionStrategy.method != "range") {
+                throw "PARTITION-ERROR", sprintf("%s: unsupported PostgreSQL partition method %y", getDesc(),
+                    partitionStrategy.method);
+            }
+            sql += sprintf(" partition by range (%s)", (foldl $1 + ", " + $2,
+                getColumnSqlNames(partitionStrategy.columns)));
+        }
+
         *string ts = opt.data_tablespace ? opt.data_tablespace : tablespace;
         if (ts)
             sql += sprintf(" tablespace %s", ts);
@@ -3915,6 +3926,280 @@ public class PgsqlTable inherits SqlUtil::AbstractTable {
 
     private bool emptyImpl() {
         return triggerFunctions.empty();
+    }
+
+    private bool supportsPartitionsImpl() {
+        return True;
+    }
+
+    private bool supportsPartitionDetachImpl() {
+        return True;
+    }
+
+    private *hash<PartitionStrategy> getPartitionStrategyImpl() {
+        *hash<auto> row = ds.selectRow("select case pt.partstrat when 'r' then 'range' else pt.partstrat::text end "
+            "method, string_agg(a.attname, ',' order by k.ord) columns from pg_catalog.pg_partitioned_table pt "
+            "join pg_catalog.pg_class c on c.oid = pt.partrelid "
+            "join pg_catalog.pg_namespace n on n.oid = c.relnamespace "
+            "join unnest(pt.partattrs) with ordinality as k(attnum, ord) on true "
+            "join pg_catalog.pg_attribute a on a.attrelid = c.oid and a.attnum = k.attnum "
+            "where n.nspname = %v and c.relname = %v group by pt.partstrat", schema, name);
+        if (!row) {
+            return;
+        }
+
+        list<string> cols = row.columns.split(",");
+        hash<PartitionStrategy> rv({
+            "method": row.method,
+            "columns": cols,
+        });
+        return rv;
+    }
+
+    private hash<string, PartitionInfo> getPartitionsImpl() {
+        hash<string, PartitionInfo> rv();
+
+        *PartitionStrategy strategy = getPartitionStrategyUnlocked();
+        if (!strategy) {
+            return rv;
+        }
+        getColumnsUnlocked();
+
+        *hash<auto> qh = ds.select("select cn.nspname as schema, c.relname as relation_name, "
+            "pg_catalog.pg_get_expr(c.relpartbound, c.oid, true) as bound_sql "
+            "from pg_catalog.pg_inherits i "
+            "join pg_catalog.pg_class p on p.oid = i.inhparent "
+            "join pg_catalog.pg_namespace pn on pn.oid = p.relnamespace "
+            "join pg_catalog.pg_class c on c.oid = i.inhrelid "
+            "join pg_catalog.pg_namespace cn on cn.oid = c.relnamespace "
+            "where pn.nspname = %v and p.relname = %v order by i.inhseqno, cn.nspname, c.relname", schema, name);
+
+        int ordinal;
+        foreach hash<auto> row in (qh.contextIterator()) {
+            string pname = getCanonicalPartitionName(row.schema, row.relation_name);
+            hash<PartitionInfo> info({
+                "name": pname,
+                "method": strategy.method,
+                "columns": strategy.columns,
+                "ordinal": ordinal++,
+                "schema": row.schema,
+                "relation_name": row.relation_name,
+                "sql_name": sprintf("%s.%s", row.schema, row.relation_name),
+                "bound_sql": row.bound_sql,
+                "is_default": False,
+            });
+            populatePgPartitionBounds(\info);
+            rv{info.name} = info;
+        }
+
+        return rv;
+    }
+
+    private string getCanonicalPartitionName(string pschema, string pname) {
+        return pschema == "public" ? pname : sprintf("%s.%s", pschema, pname);
+    }
+
+    private hash<auto> parsePartitionRelationName(string partition_name) {
+        hash<auto> rv;
+        bool explicit_schema = (partition_name =~ x/^(\w+)\.\w+/)[0] ? True : False;
+        parse_schema_name(partition_name, \rv.schema, \rv.name);
+        if (!explicit_schema) {
+            rv.schema = schema;
+        }
+        return rv;
+    }
+
+    private string getPartitionSqlName(hash<PartitionSpec> spec) {
+        if (spec.sql_name) {
+            return spec.sql_name;
+        }
+        if (spec.schema && spec.relation_name) {
+            return sprintf("%s.%s", spec.schema, spec.relation_name);
+        }
+
+        hash<auto> rel = parsePartitionRelationName(spec.name);
+        return sprintf("%s.%s", rel.schema, rel.name);
+    }
+
+    private hash<PartitionInfo> resolvePartitionInfoUnlocked(string partition_name) {
+        hash<auto> rel = parsePartitionRelationName(partition_name);
+        *hash<auto> row = ds.selectRow("select cn.nspname as schema, c.relname as relation_name "
+            "from pg_catalog.pg_inherits i "
+            "join pg_catalog.pg_class p on p.oid = i.inhparent "
+            "join pg_catalog.pg_namespace pn on pn.oid = p.relnamespace "
+            "join pg_catalog.pg_class c on c.oid = i.inhrelid "
+            "join pg_catalog.pg_namespace cn on cn.oid = c.relnamespace "
+            "where pn.nspname = %v and p.relname = %v and cn.nspname = %v and c.relname = %v",
+            schema, name, rel.schema, rel.name);
+        if (!row) {
+            throw "PARTITION-ERROR", sprintf("%s: relation %y is not a partition of this table", getDesc(),
+                partition_name);
+        }
+
+        *PartitionStrategy strategy = getPartitionStrategyUnlocked();
+        hash<PartitionInfo> info({
+            "name": getCanonicalPartitionName(row.schema, row.relation_name),
+            "method": strategy ? strategy.method : "range",
+            "columns": strategy ? strategy.columns : (),
+            "ordinal": 0,
+            "schema": row.schema,
+            "relation_name": row.relation_name,
+            "sql_name": sprintf("%s.%s", row.schema, row.relation_name),
+        });
+        return info;
+    }
+
+    private string getAddPartitionSqlImpl(hash<PartitionSpec> spec) {
+        return sprintf("create table %s partition of %s %s", getPartitionSqlName(spec), getSqlName(),
+            getPgPartitionBoundSql(spec));
+    }
+
+    private string getDropPartitionSqlImpl(string partition_name) {
+        hash<PartitionInfo> info = resolvePartitionInfoUnlocked(partition_name);
+        return sprintf("drop table %s", info.sql_name);
+    }
+
+    private string getTruncatePartitionSqlImpl(string partition_name) {
+        hash<PartitionInfo> info = resolvePartitionInfoUnlocked(partition_name);
+        return sprintf("truncate table %s", info.sql_name);
+    }
+
+    private string getDetachPartitionSqlImpl(string partition_name) {
+        hash<PartitionInfo> info = resolvePartitionInfoUnlocked(partition_name);
+        return sprintf("alter table %s detach partition %s", getSqlName(), info.sql_name);
+    }
+
+    private string getPgPartitionBoundSql(hash<PartitionSpec> spec) {
+        if (spec.is_default) {
+            return "default";
+        }
+        if (spec.bound_sql) {
+            string sql = spec.bound_sql;
+            trim sql;
+            if (sql =~ x/^(for\s+values|default)\b/i) {
+                return sql;
+            }
+            return "for values " + sql;
+        }
+        if (spec.bound_from_sql) {
+            return sprintf("for values from (%s) to (%s)", spec.bound_from_sql, spec.bound_to_sql);
+        }
+
+        return sprintf("for values from (%s) to (%s)", getPgPartitionBoundValuesSql(spec.bound_from),
+            getPgPartitionBoundValuesSql(spec.bound_to));
+    }
+
+    private string getPgPartitionBoundValuesSql(auto value) {
+        if (value.typeCode() != NT_LIST) {
+            return getSqlValue(value);
+        }
+        return foldl $1 + ", " + $2, (map getSqlValue($1), value);
+    }
+
+    private populatePgPartitionBounds(reference<hash<PartitionInfo>> info) {
+        string bound_sql = info.bound_sql;
+        if (bound_sql =~ x/^default$/i) {
+            info.is_default = True;
+            return;
+        }
+
+        (*string bound_from_sql, *string bound_to_sql) = (bound_sql =~ x/^for\s+values\s+from\s*\((.*)\)\s+to\s*\((.*)\)$/i);
+        if (!bound_from_sql || !bound_to_sql) {
+            return;
+        }
+
+        info.bound_from_sql = bound_from_sql;
+        info.bound_to_sql = bound_to_sql;
+
+        *auto bound_from = parsePgPartitionBoundValues(bound_from_sql, info.columns);
+        *auto bound_to = parsePgPartitionBoundValues(bound_to_sql, info.columns);
+        if (exists bound_from && exists bound_to) {
+            info.bound_from = bound_from;
+            info.bound_to = bound_to;
+        }
+    }
+
+    private *auto parsePgPartitionBoundValues(string sql, softlist<string> pcols) {
+        if (pcols.size() == 1) {
+            return parsePgPartitionBoundValue(sql, columns{pcols[0]});
+        }
+
+        list<string> parts = sql.split(",");
+        if (parts.size() != pcols.size()) {
+            return;
+        }
+
+        list<auto> values = ();
+        foreach string part in (parts) {
+            *auto value = parsePgPartitionBoundValue(part, columns{pcols[$#]});
+            if (!exists value) {
+                return;
+            }
+            values += value;
+        }
+        return values;
+    }
+
+    private *auto parsePgPartitionBoundValue(string sql, *AbstractColumn col) {
+        trim sql;
+        sql =~ s/::.*$//;
+        trim sql;
+
+        *string str = (sql =~ x/^'(.*)'$/)[0];
+        if (exists str) {
+            str =~ s/''/'/g;
+            return parsePgPartitionTypedLiteral(str, col) ?? str;
+        }
+        if (*auto typed = parsePgPartitionTypedLiteral(sql, col)) {
+            return typed;
+        }
+        if (sql =~ /^-?\d+$/) {
+            return sql.toInt();
+        }
+        if (sql =~ /^-?\d+\.\d+$/) {
+            return number(sql);
+        }
+        if (sql =~ /^true$/i) {
+            return True;
+        }
+        if (sql =~ /^false$/i) {
+            return False;
+        }
+    }
+
+    private *auto parsePgPartitionTypedLiteral(string value, *AbstractColumn col) {
+        if (!col || !col.qore_type) {
+            return;
+        }
+        switch (col.qore_type) {
+            case Type::Int: {
+                if (value =~ /^-?\d+$/) {
+                    return value.toInt();
+                }
+                break;
+            }
+            case Type::Number: {
+                if (value =~ /^-?\d+(?:\.\d+)?$/) {
+                    return number(value);
+                }
+                break;
+            }
+            case Type::Float: {
+                if (value =~ /^-?\d+(?:\.\d+)?$/) {
+                    return value.toFloat();
+                }
+                break;
+            }
+            case Type::Boolean: {
+                if (value =~ /^true$/i) {
+                    return True;
+                }
+                if (value =~ /^false$/i) {
+                    return False;
+                }
+                break;
+            }
+        }
     }
 
     #! clears PostgreSQL-specific table information

--- a/qlib/PgsqlSqlUtilBase.qm
+++ b/qlib/PgsqlSqlUtilBase.qm
@@ -3276,14 +3276,19 @@ public class PgsqlTable inherits SqlUtil::AbstractTable {
     }
 
     private bool checkExistenceImpl() {
-        *hash<auto> qh = ds.selectRow("select * from pg_catalog.pg_statio_all_tables where schemaname = %v and "
-            "relname = %v", schema, name);
+        # note: cannot use pg_catalog.pg_statio_all_tables here, as it lists only relations with
+        # physical storage and therefore excludes partitioned parent tables (relkind 'p'); query
+        # pg_class directly so that partitioned tables are recognized as well
+        *hash<auto> qh = ds.selectRow("select 1 as v from pg_catalog.pg_class c "
+            "join pg_catalog.pg_namespace n on (n.oid = c.relnamespace) where n.nspname = %v and "
+            "c.relname = %v and c.relkind in ('r', 'p', 'm', 'f')", schema, name);
         if (qh) {
             return inDb = True;
         }
         if (resolveTemporaryTableSchema(True)) {
-            qh = ds.selectRow("select * from pg_catalog.pg_statio_all_tables where schemaname = %v and "
-                "relname = %v", schema, name);
+            qh = ds.selectRow("select 1 as v from pg_catalog.pg_class c "
+                "join pg_catalog.pg_namespace n on (n.oid = c.relnamespace) where n.nspname = %v and "
+                "c.relname = %v and c.relkind in ('r', 'p', 'm', 'f')", schema, name);
             if (qh) {
                 return inDb = True;
             }
@@ -3310,15 +3315,19 @@ public class PgsqlTable inherits SqlUtil::AbstractTable {
     }
 
     private Columns describeImpl() {
-        # get column descriptions
+        # get column descriptions; the relation join uses pg_class/pg_namespace (not
+        # pg_statio_all_tables, which omits partitioned parent tables - relkind 'p' - because
+        # they have no physical storage) so that partitioned tables can be described too
         *hash<auto> qh = ds.select("select column_name, data_type, c.udt_name, "
             "character_maximum_length, "
             "character_octet_length, numeric_precision, numeric_scale, datetime_precision, "
             "pa.atttypmod, is_nullable, "
             "column_default, description from information_schema.columns c "
-            "join pg_catalog.pg_statio_all_tables st on (c.table_schema = st.schemaname and c.table_name = "
-            "st.relname) left join pg_catalog.pg_description pgd on (st.relid = pgd.objoid and pgd.objsubid = "
-            "c.ordinal_position) left join pg_catalog.pg_attribute pa on (st.relid = pa.attrelid and "
+            "join (select rc.oid as relid, rn.nspname as schemaname, rc.relname as relname "
+            "from pg_catalog.pg_class rc join pg_catalog.pg_namespace rn on (rn.oid = rc.relnamespace) "
+            "where rc.relkind in ('r', 'p', 'm', 'f')) st on (c.table_schema = st.schemaname and "
+            "c.table_name = st.relname) left join pg_catalog.pg_description pgd on (st.relid = pgd.objoid "
+            "and pgd.objsubid = c.ordinal_position) left join pg_catalog.pg_attribute pa on (st.relid = pa.attrelid and "
             "pa.attnum = c.ordinal_position and not pa.attisdropped) "
             "where table_schema = %v and table_name = %v order by ordinal_position", schema,
             name);

--- a/qlib/PgsqlSqlUtilBase.qm
+++ b/qlib/PgsqlSqlUtilBase.qm
@@ -3974,7 +3974,7 @@ public class PgsqlTable inherits SqlUtil::AbstractTable {
             "join pg_catalog.pg_namespace cn on cn.oid = c.relnamespace "
             "where pn.nspname = %v and p.relname = %v order by i.inhseqno, cn.nspname, c.relname", schema, name);
 
-        int ordinal;
+        int ordinal = 0;
         foreach hash<auto> row in (qh.contextIterator()) {
             string pname = getCanonicalPartitionName(row.schema, row.relation_name);
             hash<PartitionInfo> info({

--- a/qlib/QoreLlmUtils/CallbackLlmProvider.qc
+++ b/qlib/QoreLlmUtils/CallbackLlmProvider.qc
@@ -348,6 +348,16 @@ backend.chatStream(history,
         if (request_model.val()) {
             body.model = request_model;
         }
+        if (opts.output_schema) {
+            body.response_format = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": opts.output_schema.name ?? "output",
+                    "strict": True,
+                    "schema": opts.output_schema,
+                },
+            };
+        }
         if (tools) {
             list<auto> tool_defs = ();
             foreach hash<ToolDefinition> td in (tools) {

--- a/qlib/QoreLlmUtils/LlmBackend.qc
+++ b/qlib/QoreLlmUtils/LlmBackend.qc
@@ -887,25 +887,30 @@ llm.chatStream(
             forced_tool_name, tools);
         if (shouldRetryForcedToolAsJson(rv, forced_tool_name)) {
             *hash<auto> retry = retryForcedToolAsJson(messages, tools, options,
-                forced_tool_name);
+                forced_tool_name,
+                "The previous forced function-call response was malformed.");
             if (retry) {
                 if (openAiResponseHasToolCall(retry)) {
                     return attachForcedToolRetryDiagnostics(retry, rv, retry,
-                        True, True);
+                        True, True, "malformed_function_call");
                 }
                 if (openAiResponseHasMessageContent(retry)) {
                     return attachForcedToolRetryDiagnostics(retry, rv, retry,
-                        True, False);
+                        True, False, "malformed_function_call");
                 }
                 rv = attachForcedToolRetryDiagnostics(rv, rv, retry, False,
-                    False);
+                    False, "malformed_function_call");
             }
         }
         if (shouldRetryRequiredToolNoOutput(rv, body, tools)) {
             *hash<auto> retry = retryRequiredToolNoOutput(messages, tools,
-                options, forced_tool_name);
-            if (retry && openAiResponseHasToolCall(retry)) {
-                return retry;
+                options, forced_tool_name, rv);
+            if (retry) {
+                if (openAiResponseHasToolCall(retry)
+                        || openAiResponseHasMessageContent(retry)) {
+                    return retry;
+                }
+                rv = retry;
             }
         }
         # Never return NOTHING (see chatCompletionsStream): coalesce to an
@@ -948,16 +953,30 @@ llm.chatStream(
         *string forced_tool_name = getForcedOpenAiToolName(body, tools);
         if (shouldRetryForcedToolAsJson(rv, forced_tool_name)) {
             *hash<auto> retry = retryForcedToolAsJson(messages, tools, options,
-                forced_tool_name);
-            if (retry && openAiResponseHasToolCall(retry)) {
-                return retry;
+                forced_tool_name,
+                "The previous forced function-call response was malformed.");
+            if (retry) {
+                if (openAiResponseHasToolCall(retry)) {
+                    return attachForcedToolRetryDiagnostics(retry, rv, retry,
+                        True, True, "malformed_function_call");
+                }
+                if (openAiResponseHasMessageContent(retry)) {
+                    return attachForcedToolRetryDiagnostics(retry, rv, retry,
+                        True, False, "malformed_function_call");
+                }
+                rv = attachForcedToolRetryDiagnostics(rv, rv, retry, False,
+                    False, "malformed_function_call");
             }
         }
         if (shouldRetryRequiredToolNoOutput(rv, body, tools)) {
             *hash<auto> retry = retryRequiredToolNoOutput(messages, tools,
-                options, forced_tool_name);
-            if (retry && openAiResponseHasToolCall(retry)) {
-                return retry;
+                options, forced_tool_name, rv);
+            if (retry) {
+                if (openAiResponseHasToolCall(retry)
+                        || openAiResponseHasMessageContent(retry)) {
+                    return retry;
+                }
+                rv = retry;
             }
         }
         # Never return NOTHING: if the upstream produced no usable response
@@ -1360,7 +1379,8 @@ llm.chatStream(
     private *hash<auto> retryForcedToolAsJson(
             list<hash<ChatMessage>> messages,
             *list<hash<ToolDefinition>> tools,
-            hash<LlmRequestOptions> options, *string forced_tool_name) {
+            hash<LlmRequestOptions> options, *string forced_tool_name,
+            string failure_description) {
         if (!forced_tool_name.val()) {
             return NOTHING;
         }
@@ -1373,15 +1393,13 @@ llm.chatStream(
         list<hash<ChatMessage>> retry_messages = messages;
         push retry_messages, <ChatMessage>{
             "role": "system",
-            "content": "The previous forced function-call response was "
-                "malformed. Return only a JSON object matching the requested "
-                "function arguments schema; do not call a tool.",
+            "content": failure_description + " Return only a JSON object "
+                "matching the requested function arguments schema; do not "
+                "call a tool.",
         };
 
-        hash<LlmRequestOptions> retry_options = options;
-        retry_options.output_schema = forced_tool.parameters;
-        retry_options.body_options = stripForcedToolBodyOptions(
-            options.body_options);
+        hash<LlmRequestOptions> retry_options =
+            makeForcedToolJsonRetryOptions(options, forced_tool.parameters);
 
         hash<ChatResponse> retry_response = chat(retry_messages, NOTHING,
             retry_options);
@@ -1393,9 +1411,31 @@ llm.chatStream(
     private *hash<auto> retryRequiredToolNoOutput(
             list<hash<ChatMessage>> messages,
             *list<hash<ToolDefinition>> tools,
-            hash<LlmRequestOptions> options, *string forced_tool_name) {
+            hash<LlmRequestOptions> options, *string forced_tool_name,
+            hash<auto> original_response) {
         if (!tools) {
             return NOTHING;
+        }
+        if (forced_tool_name.val()) {
+            *hash<auto> retry = retryForcedToolAsJson(messages, tools,
+                options, forced_tool_name,
+                "The previous response returned no content and no function "
+                    "call even though a tool call was required.");
+            if (retry) {
+                if (openAiResponseHasToolCall(retry)) {
+                    return attachForcedToolRetryDiagnostics(retry,
+                        original_response, retry, True, True,
+                        "required_tool_no_output");
+                }
+                if (openAiResponseHasMessageContent(retry)) {
+                    return attachForcedToolRetryDiagnostics(retry,
+                        original_response, retry, True, False,
+                        "required_tool_no_output");
+                }
+                return attachForcedToolRetryDiagnostics(original_response,
+                    original_response, retry, False, False,
+                    "required_tool_no_output");
+            }
         }
         list<hash<ChatMessage>> retry_messages = messages;
         push retry_messages, <ChatMessage>{
@@ -1435,6 +1475,27 @@ llm.chatStream(
         hash<LlmStructuredRepairResult> result =
             LlmStructuredRepair::coerceBySchema(args, tool.parameters);
         return result.valid ? cast<hash<auto>>(result.value) : args;
+    }
+
+    private static hash<LlmRequestOptions> makeForcedToolJsonRetryOptions(
+            hash<LlmRequestOptions> options, hash<auto> output_schema) {
+        hash<LlmRequestOptions> retry_options = <LlmRequestOptions>{};
+        foreach string key in (("model", "max_tokens",
+                "max_output_tokens", "reasoning_token_budget",
+                "temperature", "telemetry_observer",
+                "telemetry_context")) {
+            if (exists options{key}
+                    && options{key}.typeCode() != NT_NOTHING) {
+                retry_options{key} = options{key};
+            }
+        }
+        retry_options.output_schema = output_schema;
+        *hash<auto> retry_body_options = stripForcedToolBodyOptions(
+            options.body_options);
+        if (retry_body_options) {
+            retry_options.body_options = retry_body_options;
+        }
+        return retry_options;
     }
 
     private static *hash<auto> stripForcedToolBodyOptions(
@@ -1526,7 +1587,7 @@ llm.chatStream(
     private static hash<auto> attachForcedToolRetryDiagnostics(
             hash<auto> response, hash<auto> original_response,
             hash<auto> retry_response, bool returned_retry_response,
-            bool recovered_tool_call) {
+            bool recovered_tool_call, string reason) {
         hash<auto!> rv;
         rv += response;
 
@@ -1537,7 +1598,7 @@ llm.chatStream(
 
         hash<auto!> retry_diagnostics = {
             "attempted": True,
-            "reason": "malformed_function_call",
+            "reason": reason,
             "returned_retry_response": returned_retry_response,
             "recovered_tool_call": recovered_tool_call,
         };

--- a/qlib/Schema/DataSchemaLoader.qc
+++ b/qlib/Schema/DataSchemaLoader.qc
@@ -222,6 +222,12 @@ public class DataSchemaLoader {
         if (table_def.foreign_constraints) {
             result.foreign_constraints = table_def.foreign_constraints;
         }
+        if (table_def.partition_strategy) {
+            result.partition_strategy = table_def.partition_strategy;
+        }
+        if (table_def.partitions) {
+            result.partitions = table_def.partitions;
+        }
 
         # Store auto_triggers for expansion at alignment time (driver-dependent)
         if (table_def.auto_triggers) {

--- a/qlib/Schema/DataSchemaLoader.qc
+++ b/qlib/Schema/DataSchemaLoader.qc
@@ -222,11 +222,16 @@ public class DataSchemaLoader {
         if (table_def.foreign_constraints) {
             result.foreign_constraints = table_def.foreign_constraints;
         }
+        *hash<auto> partition_strategy;
         if (table_def.partition_strategy) {
             result.partition_strategy = table_def.partition_strategy;
+            if (table_def.partition_strategy.typeCode() == NT_HASH) {
+                partition_strategy = table_def.partition_strategy;
+            }
         }
         if (table_def.partitions) {
-            result.partitions = table_def.partitions;
+            result.partitions = DataSchemaLoader::normalizePartitions(table_name, table_def.partitions,
+                partition_strategy, columns);
         }
 
         # Store auto_triggers for expansion at alignment time (driver-dependent)
@@ -367,6 +372,124 @@ public class DataSchemaLoader {
         }
 
         return result;
+    }
+
+    #! Normalizes partition definitions after column shorthand has been expanded
+    /** Converts string bounds for date partition columns to typed dates so JSON and YAML schemas
+        produce the same typed partition specifications as Qore schema modules.
+    */
+    private static auto normalizePartitions(string table_name, auto partitions, *hash<auto> partition_strategy,
+            hash<auto> columns) {
+        if (partitions.typeCode() != NT_HASH) {
+            return partitions;
+        }
+
+        hash<auto!> result();
+        foreach hash<auto> pair in (partitions.pairIterator()) {
+            if (pair.value.typeCode() != NT_HASH) {
+                result{pair.key} = pair.value;
+                continue;
+            }
+
+            hash<auto!> spec(pair.value);
+            list<string> pcols = DataSchemaLoader::getPartitionColumns(table_name, pair.key, spec,
+                partition_strategy);
+            foreach string key in (("bound_from", "bound_to")) {
+                if (exists spec{key}) {
+                    spec{key} = DataSchemaLoader::normalizePartitionBound(table_name, pair.key, key, spec{key},
+                        pcols, columns);
+                }
+            }
+            result{pair.key} = spec;
+        }
+
+        return result;
+    }
+
+    #! Returns the effective partition key columns for a partition specification
+    private static list<string> getPartitionColumns(string table_name, string partition_name, hash<auto> spec,
+            *hash<auto> partition_strategy) {
+        auto cols;
+        if (spec.columns) {
+            cols = spec.columns;
+        } else if (partition_strategy) {
+            cols = partition_strategy.columns;
+        }
+
+        list<string> result();
+        if (!cols) {
+            return result;
+        }
+
+        if (cols.typeCode() == NT_STRING) {
+            push result, cols;
+            return result;
+        }
+
+        if (cols.typeCode() != NT_LIST) {
+            throw "DATA-SCHEMA-ERROR", sprintf("table %y partition %y: columns must be a string or a list of "
+                "strings, got %y", table_name, partition_name, cols.type());
+        }
+
+        foreach auto col in (cols) {
+            if (col.typeCode() != NT_STRING) {
+                throw "DATA-SCHEMA-ERROR", sprintf("table %y partition %y: columns must contain only strings, "
+                    "got %y", table_name, partition_name, col.type());
+            }
+            push result, col;
+        }
+
+        return result;
+    }
+
+    #! Normalizes one range bound against the effective partition key columns
+    private static auto normalizePartitionBound(string table_name, string partition_name, string key, auto value,
+            list<string> pcols, hash<auto> columns) {
+        if (!pcols.size()) {
+            return value;
+        }
+
+        if (value.typeCode() == NT_LIST) {
+            if (value.size() != pcols.size()) {
+                throw "DATA-SCHEMA-ERROR", sprintf("table %y partition %y: %s has %d values for %d partition "
+                    "columns", table_name, partition_name, key, value.size(), pcols.size());
+            }
+
+            list<auto> result();
+            for (int i = 0; i < value.size(); ++i) {
+                push result, DataSchemaLoader::normalizePartitionScalarBound(table_name, partition_name, key,
+                    value[i], pcols[i], columns);
+            }
+            return result;
+        }
+
+        if (pcols.size() != 1) {
+            throw "DATA-SCHEMA-ERROR", sprintf("table %y partition %y: %s must be a list because the partition "
+                "key has %d columns", table_name, partition_name, key, pcols.size());
+        }
+
+        return DataSchemaLoader::normalizePartitionScalarBound(table_name, partition_name, key, value, pcols[0],
+            columns);
+    }
+
+    #! Converts scalar bounds that can be inferred safely from the normalized column definition
+    private static auto normalizePartitionScalarBound(string table_name, string partition_name, string key, auto value,
+            string col_name, hash<auto> columns) {
+        if (value.typeCode() != NT_STRING) {
+            return value;
+        }
+
+        *hash<auto> col = columns{col_name};
+        if (!col || col.qore_type != Type::Date) {
+            return value;
+        }
+
+        try {
+            return date(value);
+        } catch (hash<ExceptionInfo> ex) {
+            throw "DATA-SCHEMA-ERROR", sprintf("table %y partition %y: %s value %y cannot be parsed as a date "
+                "for partition column %y", table_name, partition_name, key, value, col_name);
+        }
     }
 
     #! Normalizes reference data from .ysm/.jsm format to Schema.qm format

--- a/qlib/Schema/DataSchemaMetaSchema.qc
+++ b/qlib/Schema/DataSchemaMetaSchema.qc
@@ -256,6 +256,86 @@ public const DataSchemaJsonSchema = {
                 },
             },
         },
+        "partitionStrategy": {
+            "type": "object",
+            "required": ("columns",),
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "enum": ("range",),
+                    "default": "range",
+                    "description": "Partitioning method; Phase 1 supports range partitioning",
+                },
+                "columns": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                    "description": "Partition key columns in declaration order",
+                },
+                "auto": {
+                    "type": "object",
+                    "description": "Driver-specific automatic partitioning strategy",
+                },
+                "driver": {
+                    "type": "object",
+                    "description": "Driver-specific partition strategy overrides",
+                },
+            },
+        },
+        "partitionSpec": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Canonical partition name",
+                },
+                "method": {
+                    "type": "string",
+                    "enum": ("range",),
+                    "default": "range",
+                },
+                "columns": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                },
+                "bound_from": {
+                    "description": "Inclusive lower range bound as a typed value",
+                },
+                "bound_to": {
+                    "description": "Exclusive upper range bound as a typed value",
+                },
+                "bound_from_sql": {
+                    "type": "string",
+                    "description": "Inclusive lower range bound as a SQL expression",
+                },
+                "bound_to_sql": {
+                    "type": "string",
+                    "description": "Exclusive upper range bound as a SQL expression",
+                },
+                "bound_sql": {
+                    "type": "string",
+                    "description": "Complete driver-native partition bound SQL",
+                },
+                "is_default": {
+                    "type": "boolean",
+                    "default": False,
+                },
+                "schema": {
+                    "type": "string",
+                },
+                "relation_name": {
+                    "type": "string",
+                },
+                "sql_name": {
+                    "type": "string",
+                },
+                "driver": {
+                    "type": "object",
+                    "description": "Driver-specific partition overrides",
+                },
+            },
+        },
         "tableDefinition": {
             "type": "object",
             "required": ("columns",),
@@ -296,6 +376,15 @@ public const DataSchemaJsonSchema = {
                     "type": "object",
                     "additionalProperties": {
                         "$ref": "#/$defs/foreignConstraintDefinition",
+                    },
+                },
+                "partition_strategy": {
+                    "$ref": "#/$defs/partitionStrategy",
+                },
+                "partitions": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/partitionSpec",
                     },
                 },
                 "auto_triggers": {

--- a/qlib/SchemaReverse.qm
+++ b/qlib/SchemaReverse.qm
@@ -345,9 +345,7 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
         constructor(AbstractDatasource ds, string name, *hash<auto> opts) {
             m_ds = ds;
             m_name = name;
-            if (opts) {
-                m_options = opts;
-            }
+            m_options = opts ?? {};
         }
 
         #! @return current AbstractDatasource
@@ -935,9 +933,7 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
         constructor(AbstractDatasource ds, string class_name, *hash<auto> opts) {
             m_ds = ds;
             m_class_name = class_name;
-            if (opts) {
-                m_options = opts;
-            }
+            m_options = opts ?? {};
         }
 
         string toString() {

--- a/qlib/SchemaReverse.qm
+++ b/qlib/SchemaReverse.qm
@@ -183,6 +183,8 @@ The output will be:
       structured hash output suitable for use with @ref Schema::DataSchema "DataSchema"
     - added @ref SchemaReverse::SchemaReverse::toYaml() "SchemaReverse::toYaml()" and
       @ref SchemaReverse::SchemaReverse::toJson() "SchemaReverse::toJson()" for full schema export
+    - added partition strategy output for partitioned tables and optional physical partition output with the
+      \c with_partitions option
 
     @subsection schemareverse_v1_1 SchemaReverse Module v1.1
     - initial release
@@ -333,15 +335,19 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
             AbstractDatasource m_ds;
             Database m_db;
             string m_name;
+            hash<auto> m_options;
         }
 
         /*! Setup basic shared attributes.
             @param ds a AbstractDatasource with DB connection
             @param name a string with exact name or regex to match names of DB objects
          */
-        constructor(AbstractDatasource ds, string name) {
+        constructor(AbstractDatasource ds, string name, *hash<auto> opts) {
             m_ds = ds;
             m_name = name;
+            if (opts) {
+                m_options = opts;
+            }
         }
 
         #! @return current AbstractDatasource
@@ -360,6 +366,16 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
         #! @return a string with exact name or regex to match names
         string name() {
             return m_name;
+        }
+
+        #! @return option hash for reverse-engineering behavior
+        hash<auto> options() {
+            return m_options;
+        }
+
+        #! @return True if physical partitions should be included in table output
+        bool withPartitions() {
+            return m_options.with_partitions ? True : False;
         }
 
         #! Dedicated functionlity to get DB object info into the internal structure is done here.
@@ -415,8 +431,8 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
         /*! @param ds an AbstractDatasource object
             @param name a string with exact object name
          */
-        constructor(AbstractDatasource ds, string name)
-            : AbstractReverseObject(ds, name)
+        constructor(AbstractDatasource ds, string name, *hash<auto> opts)
+            : AbstractReverseObject(ds, name, opts)
         {
         }
 
@@ -455,8 +471,8 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
         /*! @param ds an AbstractDatasource object
             @param name a string with exact object name
          */
-        constructor(AbstractDatasource ds, string name)
-            : AbstractReverseObject(ds, name)
+        constructor(AbstractDatasource ds, string name, *hash<auto> opts)
+            : AbstractReverseObject(ds, name, opts)
         {
         }
 
@@ -500,8 +516,8 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
         /*! @param ds an AbstractDatasource object
             @param name a string with exact object name
          */
-        constructor(AbstractDatasource ds, string name)
-            : AbstractReverseObject(ds, name)
+        constructor(AbstractDatasource ds, string name, *hash<auto> opts)
+            : AbstractReverseObject(ds, name, opts)
         {
         }
 
@@ -558,6 +574,19 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
                     };
                 }
                 ret.foreign_constraints = fk_hash;
+            }
+
+            if (t.supportsPartitions()) {
+                *hash<PartitionStrategy> strategy = t.getPartitionStrategy();
+                if (strategy) {
+                    ret.partition_strategy = strategy;
+                }
+                if (withPartitions()) {
+                    hash<string, PartitionInfo> partitions = t.listPartitions();
+                    if (partitions) {
+                        ret.partitions = partitions;
+                    }
+                }
             }
 
             return ret;
@@ -639,8 +668,8 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
         /*! @param ds an AbstractDatasource object
             @param mask a regexp mask used to specify what objects of this type are fetched
          */
-        constructor(AbstractDatasource ds, string mask = ".*")
-            : AbstractReverseObject(ds, mask)
+        constructor(AbstractDatasource ds, string mask = ".*", *hash<auto> opts)
+            : AbstractReverseObject(ds, mask, opts)
         {
         }
 
@@ -650,7 +679,7 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
             while (it.next()) {
                 string s = it.getValue();
                 if (s.regex(name())) {
-                    ret{s} = new TableReverse(datasource(), s).toQore();
+                    ret{s} = new TableReverse(datasource(), s, options()).toQore();
                 }
             }
             return ret;
@@ -896,14 +925,19 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
         private {
             AbstractDatasource m_ds;
             string m_class_name;
+            hash<auto> m_options;
         }
 
         /*! @param ds an AbstractDatasource object
             @param class_name a string with name of the resulting schema class
+            @param opts optional reverse-engineering options; \c with_partitions includes physical partitions
          */
-        constructor(AbstractDatasource ds, string class_name) {
+        constructor(AbstractDatasource ds, string class_name, *hash<auto> opts) {
             m_ds = ds;
             m_class_name = class_name;
+            if (opts) {
+                m_options = opts;
+            }
         }
 
         string toString() {
@@ -914,7 +948,9 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
             ListIterator<string> it(toReplace);
             while (it.next()) {
                 string key = regex_extract(it.getValue(), "<SCHEMA_(.*)>")[0];
-                AbstractReverseObject o = get_object(key.lwr(), m_ds);
+                AbstractReverseObject o = key.lwr() == "tables"
+                    ? get_object(key.lwr(), m_ds, ".*", m_options)
+                    : get_object(key.lwr(), m_ds);
                 string out = o.toString();
                 # HACK: let's guess that SchemaDescriptionOptions contains
                 #       objects supported in all DB servers/dialects.
@@ -940,7 +976,7 @@ class <X_SCHEMA_NAME> inherits AbstractSchema {
                     "name": m_class_name,
                     "version": "1.0",
                 },
-                "tables": new TablesReverse(m_ds).toQore(),
+                "tables": new TablesReverse(m_ds, ".*", m_options).toQore(),
                 "sequences": new SequencesReverse(m_ds).toQore(),
             };
 

--- a/qlib/SqlUtil/AbstractTable.qc
+++ b/qlib/SqlUtil/AbstractTable.qc
@@ -8551,6 +8551,9 @@ on_exit printf("SQL> %s\n", sql);
             getPartitionStrategyUnlocked();
             getPartitionsUnlocked();
         }
+        if (createPartitionsInCreateTableImpl()) {
+            return;
+        }
         if (!partitionStrategy || partitions.empty()) {
             return;
         }
@@ -8572,6 +8575,10 @@ on_exit printf("SQL> %s\n", sql);
 
         # mark in options that the entire table is being created
         opt.create_table_all = True;
+        if (createPartitionsInCreateTableImpl()) {
+            getPartitionStrategyUnlocked();
+            getPartitionsUnlocked();
+        }
         list<auto> l += getCreateTableSqlUnlocked(opt);
         *list tl;
         tl = getCreatePartitionsSqlUnlocked(opt, cache); if (tl) l += tl;
@@ -8818,6 +8825,11 @@ on_exit printf("SQL> %s\n", sql);
 
     #! returns @ref True "True" if the database supports automatic partitioning
     private bool supportsAutoPartitioningImpl() {
+        return False;
+    }
+
+    #! returns @ref True "True" if initial partitions are emitted inline in \c CREATE \c TABLE
+    private bool createPartitionsInCreateTableImpl() {
         return False;
     }
 

--- a/qlib/SqlUtil/AbstractTable.qc
+++ b/qlib/SqlUtil/AbstractTable.qc
@@ -966,6 +966,7 @@ bool b = table.empty();
         AbstractDatabase::checkDriverOptions(\desc.unique_constraints, drv);
         AbstractDatabase::checkDriverOptions(\desc.foreign_constraints, drv);
         AbstractDatabase::checkDriverOptions(\desc.triggers, drv);
+        AbstractDatabase::checkDriverOptions(\desc.partition_strategy, drv);
 
         # process column definitions
         foreach string cn in (desc.columns.keyIterator()) {
@@ -973,6 +974,14 @@ bool b = table.empty();
                 throw "DESCRIPTION-ERROR", sprintf("%s: value assigned to column key %y is not a hash, got type %y "
                     "instead (%y)", getDesc(), cn, desc.columns{cn}.type(), desc.columns{cn});
             AbstractDatabase::checkDriverOptions(\desc.columns{cn}, drv);
+        }
+
+        foreach string pn in (desc.partitions.keyIterator()) {
+            if (desc.partitions{pn}.typeCode() == NT_HASH) {
+                hash<auto> part = desc.partitions{pn};
+                AbstractDatabase::checkDriverOptions(\part, drv);
+                desc.partitions{pn} = part;
+            }
         }
 
         preSetupTableImpl(\desc, opt);

--- a/qlib/SqlUtil/AbstractTable.qc
+++ b/qlib/SqlUtil/AbstractTable.qc
@@ -153,6 +153,10 @@ public class AbstractTable inherits AbstractSqlUtilBase {
             - \c triggers: a hash of trigger information keyed by trigger name; the values are the trigger source code; since triggers are driver-dependent, a driver-independent table description would include trigger hashes under the \c drivers key and the driver key name under that
             - \c foreign_constraints: (@ref fk_desc_hash "foreign constraint hashes") a hash<auto> describing the foreign constraints on the table
             - \c unique_constraints: (@ref uk_desc_hash "unique constraint hashes") a hash<auto> describing the unique constraints on the table
+            - \c partition_strategy: (@ref SqlUtil::PartitionStrategy "partition strategy hash") a hash<auto>
+              describing the table's partitioning strategy
+            - \c partitions: a hash of @ref SqlUtil::PartitionSpec "partition specification hashes" keyed by
+              partition name
             - \c table_cache: (@ref SqlUtil::Tables "Tables") an optional table cache for maintaining cached tables and foreign key relationships between tables
 
             @see @ref table_desc_hash
@@ -164,8 +168,46 @@ public class AbstractTable inherits AbstractSqlUtilBase {
             "triggers": Type::Hash,
             "foreign_constraints": Type::Hash,
             "unique_constraints": Type::Hash,
+            "partition_strategy": Type::Hash,
+            "partitions": Type::Hash,
             #"check_constraints": Type::Hash,
             "table_cache": "Tables",
+        };
+
+        #! partition strategy options
+        /** @since SqlUtil 2.4
+        */
+        const PartitionStrategyOptions = {
+            "method": Type::String,
+            "columns": "softstringlist",
+            "auto": Type::Hash,
+            "driver": Type::Hash,
+        };
+
+        #! partition specification options
+        /** @since SqlUtil 2.4
+        */
+        const PartitionSpecOptions = {
+            "name": Type::String,
+            "method": Type::String,
+            "columns": "softstringlist",
+            "bound_from": Type::NothingType,
+            "bound_to": Type::NothingType,
+            "bound_from_sql": Type::String,
+            "bound_to_sql": Type::String,
+            "bound_sql": Type::String,
+            "is_default": Type::Boolean,
+            "schema": Type::String,
+            "relation_name": Type::String,
+            "sql_name": Type::String,
+            "driver": Type::Hash,
+        };
+
+        #! options for getDescriptionHash()
+        /** @since SqlUtil 2.4
+        */
+        const GetDescriptionOptions = {
+            "with_partitions": Type::Boolean,
         };
 
         #! Column description options
@@ -416,6 +458,14 @@ public class AbstractTable inherits AbstractSqlUtilBase {
         Constraints constraints;
         #! trigger descriptions
         Triggers triggers;
+        #! partitioning strategy
+        *PartitionStrategy partitionStrategy;
+        #! partition descriptions keyed by canonical partition name
+        hash<string, PartitionInfo> partitions;
+        #! True if the partition strategy cache has been loaded
+        bool partitionStrategyLoaded = False;
+        #! True if the partition list cache has been loaded
+        bool partitionsLoaded = False;
         #! native case option
         bool native_case = False;
         #! in database
@@ -455,6 +505,16 @@ public class AbstractTable inherits AbstractSqlUtilBase {
             constraints = constraints.copy();
         if (triggers)
             triggers = triggers.copy();
+        if (partitionStrategy) {
+            hash<PartitionStrategy> ps(partitionStrategy);
+            partitionStrategy = ps;
+        }
+        if (partitions) {
+            hash<string, PartitionInfo> ph(partitions);
+            partitions = ph;
+        }
+        partitionStrategyLoaded = old.partitionStrategyLoaded;
+        partitionsLoaded = old.partitionsLoaded;
 
         copyImpl(old);
     }
@@ -836,7 +896,9 @@ bool b = table.empty();
             || !indexes.empty()
             || !foreignConstraints.empty()
             || !constraints.empty()
-            || !triggers.empty())
+            || !triggers.empty()
+            || partitionStrategy
+            || !partitions.empty())
             return False;
 
         return emptyImpl();
@@ -1021,6 +1083,26 @@ bool b = table.empty();
             string src = desc.triggers{tn};
 
             addTriggerUnlocked(tn, src, opt.(getTriggerOptions().keys()));
+        }
+
+        if (desc.partition_strategy) {
+            setupPartitionStrategyUnlocked(desc.partition_strategy);
+        }
+
+        foreach string pn in (desc.partitions.keyIterator()) {
+            if (desc.partitions{pn}.typeCode() != NT_HASH) {
+                throw "DESCRIPTION-ERROR", sprintf("%s: value assigned to partition key %y is not a hash, got type "
+                    "%y instead (%y)", getDesc(), pn, desc.partitions{pn}.type(), desc.partitions{pn});
+            }
+
+            hash<auto!> ps(desc.partitions{pn});
+            if (!ps.name) {
+                ps.name = pn;
+            } else if (ps.name != pn) {
+                throw "DESCRIPTION-ERROR", sprintf("%s: partition key %y has mismatched name %y", getDesc(), pn,
+                    ps.name);
+            }
+            addPartitionToCacheUnlocked(normalizePartitionSpecUnlocked(ps, "DESCRIPTION-ERROR"));
         }
 
         setupTableImpl(desc, opt);
@@ -6188,8 +6270,317 @@ table.clear();
         delete constraints;
         delete indexes;
         delete triggers;
+        delete partitionStrategy;
+        delete partitions;
+        partitionStrategyLoaded = False;
+        partitionsLoaded = False;
 
         clearImpl();
+    }
+
+    #! returns @ref True "True" if this table supports table partitioning
+    /** @since SqlUtil 2.4
+    */
+    bool supportsPartitions() {
+        return supportsPartitionsImpl();
+    }
+
+    #! returns @ref True "True" if this table supports partition detach operations
+    /** @since SqlUtil 2.4
+    */
+    bool supportsPartitionDetach() {
+        return supportsPartitions() && supportsPartitionDetachImpl();
+    }
+
+    #! returns @ref True "True" if this table supports automatic partition materialization
+    /** @since SqlUtil 2.4
+    */
+    bool supportsAutoPartitioning() {
+        return supportsPartitions() && supportsAutoPartitioningImpl();
+    }
+
+    #! returns this table's partitioning strategy or @ref nothing if the table is not partitioned
+    /** @since SqlUtil 2.4
+    */
+    *hash<PartitionStrategy> getPartitionStrategy() {
+        l.lock();
+        on_exit l.unlock();
+
+        return getPartitionStrategyUnlocked();
+    }
+
+    #! returns partition descriptions keyed by canonical partition name
+    /** @since SqlUtil 2.4
+    */
+    hash<string, PartitionInfo> listPartitions() {
+        l.lock();
+        on_exit l.unlock();
+
+        return getPartitionsUnlocked();
+    }
+
+    #! finds a partition matching the given specification
+    /** @since SqlUtil 2.4
+    */
+    hash<PartitionLookupResult> findPartitionBySpec(hash<auto> spec) {
+        l.lock();
+        on_exit l.unlock();
+
+        assertPartitionSupportUnlocked();
+        return findPartitionBySpecImpl(normalizePartitionSpecUnlocked(spec, "PARTITION-ERROR"));
+    }
+
+    #! returns SQL to add a partition
+    /** @since SqlUtil 2.4
+    */
+    string getAddPartitionSql(hash<auto> spec, *hash<auto> opt) {
+        validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
+
+        l.lock();
+        on_exit l.unlock();
+
+        assertPartitionSupportUnlocked();
+        hash<PartitionSpec> ps = normalizePartitionSpecUnlocked(spec, "PARTITION-ERROR");
+        if (!ps.name) {
+            throw "PARTITION-ERROR", sprintf("%s: partition name is required", getDesc());
+        }
+        on_success if (opt.sql_callback_executed) {
+            addPartitionToCacheUnlocked(ps);
+        }
+        return AbstractDatabase::doCallback(opt, getAddPartitionSqlImpl(ps), AbstractDatabase::AC_Add,
+            "partition", ps.name, name);
+    }
+
+    #! adds a partition without transaction management
+    /** @since SqlUtil 2.4
+    */
+    hash<PartitionInfo> addPartition(hash<auto> spec, *hash<auto> opt) {
+        string sql;
+        hash<PartitionInfo> info;
+
+        {
+            l.lock();
+            on_exit l.unlock();
+
+            assertPartitionSupportUnlocked();
+            hash<PartitionSpec> ps = normalizePartitionSpecUnlocked(spec, "PARTITION-ERROR");
+            if (!ps.name) {
+                throw "PARTITION-ERROR", sprintf("%s: partition name is required", getDesc());
+            }
+            sql = getAddPartitionSqlImpl(ps);
+            info = makePartitionInfoUnlocked(ps);
+
+            if (!inDb) {
+                addPartitionToCacheUnlocked(ps);
+                manual = True;
+                return info;
+            }
+        }
+
+        ds.execRaw(sql);
+
+        l.lock();
+        on_exit l.unlock();
+        clearPartitionsUnlocked();
+
+        return info;
+    }
+
+    #! adds a partition and commits the transaction
+    /** @since SqlUtil 2.4
+    */
+    hash<PartitionInfo> addPartitionCommit(hash<auto> spec, *hash<auto> opt) {
+        on_exit ds.commit();
+        on_error ds.rollback();
+        return addPartition(spec, opt);
+    }
+
+    #! returns SQL to drop a partition
+    /** @since SqlUtil 2.4
+    */
+    string getDropPartitionSql(string partition_name, *hash<auto> opt) {
+        validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
+
+        l.lock();
+        on_exit l.unlock();
+
+        assertPartitionSupportUnlocked();
+        on_success if (opt.sql_callback_executed) {
+            clearPartitionsUnlocked();
+        }
+        return AbstractDatabase::doCallback(opt, getDropPartitionSqlImpl(partition_name), AbstractDatabase::AC_Drop,
+            "partition", partition_name, name);
+    }
+
+    #! drops a partition without transaction management
+    /** @since SqlUtil 2.4
+    */
+    dropPartition(string partition_name, *hash<auto> opt) {
+        validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
+
+        string sql;
+        bool execute;
+
+        {
+            l.lock();
+            on_exit l.unlock();
+
+            assertPartitionSupportUnlocked();
+            execute = inDb;
+            if (execute) {
+                sql = getDropPartitionSqlImpl(partition_name);
+            } else {
+                clearPartitionsUnlocked();
+                manual = True;
+            }
+        }
+
+        if (execute) {
+            ds.execRaw(sql);
+            l.lock();
+            on_exit l.unlock();
+            clearPartitionsUnlocked();
+        }
+    }
+
+    #! drops a partition and commits the transaction
+    /** @since SqlUtil 2.4
+    */
+    dropPartitionCommit(string partition_name, *hash<auto> opt) {
+        on_exit ds.commit();
+        on_error ds.rollback();
+        dropPartition(partition_name, opt);
+    }
+
+    #! returns SQL to truncate a partition
+    /** @since SqlUtil 2.4
+    */
+    string getTruncatePartitionSql(string partition_name, *hash<auto> opt) {
+        validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
+
+        l.lock();
+        on_exit l.unlock();
+
+        assertPartitionSupportUnlocked();
+        return AbstractDatabase::doCallback(opt, getTruncatePartitionSqlImpl(partition_name),
+            AbstractDatabase::AC_Truncate, "partition", partition_name, name);
+    }
+
+    #! truncates a partition without transaction management
+    /** @since SqlUtil 2.4
+    */
+    truncatePartition(string partition_name, *hash<auto> opt) {
+        string sql = getTruncatePartitionSql(partition_name, opt);
+        ds.execRaw(sql);
+    }
+
+    #! truncates a partition and commits the transaction
+    /** @since SqlUtil 2.4
+    */
+    truncatePartitionCommit(string partition_name, *hash<auto> opt) {
+        on_exit ds.commit();
+        on_error ds.rollback();
+        truncatePartition(partition_name, opt);
+    }
+
+    #! returns SQL to detach a partition
+    /** @since SqlUtil 2.4
+    */
+    string getDetachPartitionSql(string partition_name, *hash<auto> opt) {
+        validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
+
+        l.lock();
+        on_exit l.unlock();
+
+        assertPartitionDetachSupportUnlocked();
+        on_success if (opt.sql_callback_executed) {
+            clearPartitionsUnlocked();
+        }
+        return AbstractDatabase::doCallback(opt, getDetachPartitionSqlImpl(partition_name),
+            AbstractDatabase::AC_Drop, "partition", partition_name, name);
+    }
+
+    #! detaches a partition without transaction management
+    /** @since SqlUtil 2.4
+    */
+    detachPartition(string partition_name, *hash<auto> opt) {
+        validateOptionsIntern("OPTION-ERROR", getAlignTableOptions(), \opt);
+
+        string sql;
+        bool execute;
+
+        {
+            l.lock();
+            on_exit l.unlock();
+
+            assertPartitionDetachSupportUnlocked();
+            execute = inDb;
+            if (execute) {
+                sql = getDetachPartitionSqlImpl(partition_name);
+            } else {
+                clearPartitionsUnlocked();
+                manual = True;
+            }
+        }
+
+        if (execute) {
+            ds.execRaw(sql);
+            l.lock();
+            on_exit l.unlock();
+            clearPartitionsUnlocked();
+        }
+    }
+
+    #! detaches a partition and commits the transaction
+    /** @since SqlUtil 2.4
+    */
+    detachPartitionCommit(string partition_name, *hash<auto> opt) {
+        on_exit ds.commit();
+        on_error ds.rollback();
+        detachPartition(partition_name, opt);
+    }
+
+    #! ensures that a partition matching the given specification exists
+    /** @since SqlUtil 2.4
+    */
+    hash<PartitionEnsureResult> ensurePartition(hash<auto> spec, *hash<auto> opt) {
+        hash<PartitionSpec> ps;
+
+        {
+            l.lock();
+            on_exit l.unlock();
+
+            assertPartitionSupportUnlocked();
+            ps = normalizePartitionSpecUnlocked(spec, "PARTITION-ERROR");
+
+            hash<PartitionLookupResult> lookup = findPartitionBySpecImpl(ps);
+            if (lookup.status == PartitionLookupStatus::Found) {
+                return makePartitionEnsureResult(False, True, False, PartitionVerifiedBy::Bounds, lookup.partition);
+            }
+
+            if (lookup.status == PartitionLookupStatus::Uncomparable && ps.name) {
+                hash<string, PartitionInfo> ph = getPartitionsUnlocked();
+                if (ph.hasKey(ps.name)) {
+                    return makePartitionEnsureResult(False, True, False, PartitionVerifiedBy::Name, ph{ps.name});
+                }
+            }
+
+            if (supportsAutoPartitioningImpl() && partitionAutoStrategyCoversSpecImpl(ps)) {
+                return makePartitionEnsureResult(False, False, True, PartitionVerifiedBy::Auto);
+            }
+        }
+
+        hash<PartitionInfo> info = addPartition(ps, opt);
+        return makePartitionEnsureResult(True, True, False, PartitionVerifiedBy::Bounds, info);
+    }
+
+    #! ensures that a partition matching the given specification exists and commits the transaction if it was created
+    /** @since SqlUtil 2.4
+    */
+    hash<PartitionEnsureResult> ensurePartitionCommit(hash<auto> spec, *hash<auto> opt) {
+        on_exit ds.commit();
+        on_error ds.rollback();
+        return ensurePartition(spec, opt);
     }
 
     #! Returns a description hash of the table
@@ -6203,7 +6594,9 @@ table.clear();
 
         @since %SqlUtil 1.7.5
     */
-    hash<auto> getDescriptionHash() {
+    hash<auto> getDescriptionHash(*hash<auto> opt) {
+        validateOptionsIntern("OPTION-ERROR", GetDescriptionOptions, \opt);
+
         hash<auto> rv = {};
 
         l.lock();
@@ -6245,6 +6638,18 @@ table.clear();
                     "target_columns": i.value.target.columns.keys(),
                 };
                 rv.foreign_constraints{i.key} = fc;
+            }
+        }
+
+        *PartitionStrategy strategy = getPartitionStrategyUnlocked();
+        if (strategy) {
+            rv.partition_strategy = strategy;
+        }
+
+        if (opt.with_partitions) {
+            hash<string, PartitionInfo> ph = getPartitionsUnlocked();
+            if (ph) {
+                rv.partitions = ph;
             }
         }
 
@@ -6522,6 +6927,338 @@ string sql = table.getCreateTableSql();
         return oh;
     }
 
+    private assertPartitionSupportUnlocked() {
+        if (!supportsPartitionsImpl()) {
+            throw "PARTITION-ERROR", sprintf("%s: database driver %y does not support table partitioning", getDesc(),
+                ds.getDriverName());
+        }
+    }
+
+    private assertPartitionDetachSupportUnlocked() {
+        assertPartitionSupportUnlocked();
+        if (!supportsPartitionDetachImpl()) {
+            throw "PARTITION-ERROR", sprintf("%s: database driver %y does not support detaching partitions",
+                getDesc(), ds.getDriverName());
+        }
+    }
+
+    private setupPartitionStrategyUnlocked(hash<auto> strategy) {
+        if (!supportsPartitionsImpl()) {
+            throw "DESCRIPTION-ERROR", sprintf("%s: database driver %y does not support table partitioning",
+                getDesc(), ds.getDriverName());
+        }
+        partitionStrategy = normalizePartitionStrategyUnlocked(strategy, "DESCRIPTION-ERROR");
+        partitionStrategyLoaded = True;
+        validatePartitionUniqueKeysUnlocked(partitionStrategy.columns, "DESCRIPTION-ERROR");
+    }
+
+    private hash<PartitionStrategy> normalizePartitionStrategyUnlocked(hash<auto> strategy, string err) {
+        validateOptionsIntern(err, PartitionStrategyOptions, \strategy);
+
+        if (!strategy.method) {
+            strategy.method = "range";
+        }
+        if (strategy.method != "range") {
+            throw err, sprintf("%s: partition method %y is not supported; Phase 1 supports only %y", getDesc(),
+                strategy.method, "range");
+        }
+        if (!strategy.columns) {
+            throw err, sprintf("%s: partition strategy is missing the required %y key", getDesc(), "columns");
+        }
+
+        softlist<string> pcols = strategy.columns;
+        if (!pcols) {
+            throw err, sprintf("%s: partition strategy must reference at least one column", getDesc());
+        }
+
+        validatePartitionColumnsUnlocked(pcols, err);
+        hash<PartitionStrategy> rv(strategy);
+        return rv;
+    }
+
+    private validatePartitionColumnsUnlocked(softlist<string> pcols, string err) {
+        if (!columns) {
+            getColumnsUnlocked();
+        }
+
+        hash<string, bool> pch = map {$1: True}, pcols;
+        *hash<string, bool> invalid = pch - columns.keys();
+        if (invalid) {
+            throw err, sprintf("%s: partition key references unknown column(s): %y; known columns: %y", getDesc(),
+                invalid.keys(), columns.keys());
+        }
+    }
+
+    private validatePartitionUniqueKeysUnlocked(softlist<string> pcols, string err) {
+        hash<string, bool> pch = map {$1: True}, pcols;
+
+        if (!primaryKey.empty()) {
+            *hash<string, bool> missing = pch - primaryKey.keys();
+            if (missing) {
+                throw err, sprintf("%s: primary key %y must include partition key column(s): %y", getDesc(),
+                    primaryKey.getName(), missing.keys());
+            }
+        }
+
+        foreach AbstractIndex ix in (indexes.iterator()) {
+            if (!ix.unique) {
+                continue;
+            }
+            *hash<string, bool> missing = pch - ix.columns.keys();
+            if (missing) {
+                throw err, sprintf("%s: unique index %y must include partition key column(s): %y", getDesc(),
+                    ix.name, missing.keys());
+            }
+        }
+
+        foreach AbstractConstraint c in (constraints.iterator()) {
+            if (!(c instanceof AbstractUniqueConstraint)) {
+                continue;
+            }
+            AbstractUniqueConstraint uk = cast<AbstractUniqueConstraint>(c);
+            *hash<string, bool> missing = pch - uk.keys();
+            if (missing) {
+                throw err, sprintf("%s: unique constraint %y must include partition key column(s): %y", getDesc(),
+                    uk.getName(), missing.keys());
+            }
+        }
+    }
+
+    private hash<PartitionSpec> normalizePartitionSpecUnlocked(hash<auto> spec, string err) {
+        hash<auto> ps = {} + spec;
+        validateOptionsIntern(err, PartitionSpecOptions, \ps);
+
+        *PartitionStrategy strategy = getPartitionStrategyUnlocked();
+        if (!strategy) {
+            throw err, sprintf("%s: table has no partition strategy", getDesc());
+        }
+
+        if (!ps.method) {
+            ps.method = strategy.method;
+        }
+        if (ps.method != strategy.method) {
+            throw err, sprintf("%s: partition method %y does not match table partition method %y", getDesc(),
+                ps.method, strategy.method);
+        }
+        if (ps.method != "range") {
+            throw err, sprintf("%s: partition method %y is not supported; Phase 1 supports only %y", getDesc(),
+                ps.method, "range");
+        }
+
+        if (!ps.columns) {
+            ps.columns = strategy.columns;
+        } else if (ps.columns != strategy.columns) {
+            throw err, sprintf("%s: partition columns %y do not match table partition columns %y", getDesc(),
+                ps.columns, strategy.columns);
+        }
+
+        if (!exists ps.is_default) {
+            ps.is_default = False;
+        }
+
+        bool has_typed_from = exists ps.bound_from;
+        bool has_typed_to = exists ps.bound_to;
+        bool has_sql_from = exists ps.bound_from_sql;
+        bool has_sql_to = exists ps.bound_to_sql;
+        bool has_bound_sql = exists ps.bound_sql;
+        bool has_typed = has_typed_from || has_typed_to;
+        bool has_sql_pair = has_sql_from || has_sql_to;
+
+        if (ps.is_default) {
+            if (has_typed || has_sql_pair || has_bound_sql) {
+                throw err, sprintf("%s: default partition %y cannot have range bounds", getDesc(), ps.name);
+            }
+            hash<PartitionSpec> rv(ps);
+            return rv;
+        }
+
+        if (has_bound_sql && (has_typed || has_sql_pair)) {
+            throw err, sprintf("%s: partition %y cannot combine %y with typed or paired SQL bounds", getDesc(),
+                ps.name, "bound_sql");
+        }
+        if (has_typed && has_sql_pair) {
+            throw err, sprintf("%s: partition %y cannot combine typed bounds with SQL bounds", getDesc(), ps.name);
+        }
+        if (has_typed_from != has_typed_to) {
+            throw err, sprintf("%s: partition %y must define both %y and %y", getDesc(), ps.name, "bound_from",
+                "bound_to");
+        }
+        if (has_sql_from != has_sql_to) {
+            throw err, sprintf("%s: partition %y must define both %y and %y", getDesc(), ps.name, "bound_from_sql",
+                "bound_to_sql");
+        }
+        if (!has_bound_sql && !has_typed && !has_sql_pair) {
+            throw err, sprintf("%s: partition %y must define range bounds", getDesc(), ps.name);
+        }
+
+        if (has_typed) {
+            validatePartitionBoundCardinalityUnlocked(ps.bound_from, ps.columns, err, "bound_from");
+            validatePartitionBoundCardinalityUnlocked(ps.bound_to, ps.columns, err, "bound_to");
+            validatePartitionTypedBoundsUnlocked(ps, err);
+        }
+
+        hash<PartitionSpec> rv(ps);
+        return rv;
+    }
+
+    private validatePartitionBoundCardinalityUnlocked(auto value, softlist<string> pcols, string err, string key) {
+        if (value.typeCode() == NT_LIST) {
+            if (value.size() != pcols.size()) {
+                throw err, sprintf("%s: partition %y has %d value(s) in %y but partition key has %d column(s): %y",
+                    getDesc(), key, value.size(), key, pcols.size(), pcols);
+            }
+        } else if (pcols.size() != 1) {
+            throw err, sprintf("%s: partition %y must be a list with %d value(s) for composite partition key %y",
+                getDesc(), key, pcols.size(), pcols);
+        }
+    }
+
+    private validatePartitionTypedBoundsUnlocked(hash<auto> ps, string err) {
+        if (!partitionBoundLess(ps.bound_from, ps.bound_to)) {
+            throw err, sprintf("%s: partition %y lower bound must be less than upper bound", getDesc(), ps.name);
+        }
+
+        foreach hash<PartitionInfo> pi in (getPartitionsUnlocked().iterator()) {
+            if (pi.is_default || exists pi.bound_sql || exists pi.bound_from_sql || !exists pi.bound_from) {
+                continue;
+            }
+            if (partitionBoundsOverlap(ps.bound_from, ps.bound_to, pi.bound_from, pi.bound_to)) {
+                throw err, sprintf("%s: partition %y bounds overlap existing partition %y", getDesc(), ps.name,
+                    pi.name);
+            }
+        }
+    }
+
+    private static bool partitionBoundLess(auto left, auto right) {
+        return left < right;
+    }
+
+    private static bool partitionBoundsOverlap(auto left_from, auto left_to, auto right_from, auto right_to) {
+        return partitionBoundLess(left_from, right_to) && partitionBoundLess(right_from, left_to);
+    }
+
+    private hash<PartitionInfo> makePartitionInfoUnlocked(hash<PartitionSpec> ps) {
+        if (!ps.name) {
+            throw "PARTITION-ERROR", sprintf("%s: partition name is required", getDesc());
+        }
+        ensurePartitionsHashUnlocked();
+
+        hash<PartitionInfo> info({
+            "name": ps.name,
+            "method": ps.method,
+            "columns": ps.columns,
+            "ordinal": partitions.size(),
+            "is_default": ps.is_default,
+        });
+
+        if (exists ps.bound_from) info.bound_from = ps.bound_from;
+        if (exists ps.bound_to) info.bound_to = ps.bound_to;
+        if (exists ps.bound_from_sql) info.bound_from_sql = ps.bound_from_sql;
+        if (exists ps.bound_to_sql) info.bound_to_sql = ps.bound_to_sql;
+        if (exists ps.bound_sql) info.bound_sql = ps.bound_sql;
+        if (exists ps.schema) info.schema = ps.schema;
+        if (exists ps.relation_name) info.relation_name = ps.relation_name;
+        if (exists ps.sql_name) info.sql_name = ps.sql_name;
+        if (exists ps.driver) info.driver = ps.driver;
+
+        return info;
+    }
+
+    private hash<PartitionInfo> addPartitionToCacheUnlocked(hash<PartitionSpec> ps) {
+        hash<PartitionInfo> info = makePartitionInfoUnlocked(ps);
+        if (partitions.hasKey(info.name)) {
+            throw "PARTITION-ERROR", sprintf("%s: partition %y already exists", getDesc(), info.name);
+        }
+        if (info.is_default) {
+            foreach hash<PartitionInfo> pi in (partitions.iterator()) {
+                if (pi.is_default) {
+                    throw "PARTITION-ERROR", sprintf("%s: default partition %y already exists", getDesc(), pi.name);
+                }
+            }
+        }
+        partitions{info.name} = info;
+        partitionsLoaded = True;
+        return info;
+    }
+
+    private hash<PartitionEnsureResult> makePartitionEnsureResult(bool created, bool materialized,
+            bool deferred_auto, PartitionVerifiedBy verified_by, *hash<PartitionInfo> partition) {
+        hash<PartitionEnsureResult> rv({
+            "created": created,
+            "materialized": materialized,
+            "deferred_auto": deferred_auto,
+            "verified_by": verified_by,
+            "bounds_verified": verified_by == PartitionVerifiedBy::Bounds,
+            "partition": partition,
+        });
+        return rv;
+    }
+
+    private *hash<PartitionStrategy> getPartitionStrategyUnlocked() {
+        if (partitionStrategyLoaded) {
+            return partitionStrategy;
+        }
+        if (manual || !supportsPartitionsImpl()) {
+            partitionStrategyLoaded = True;
+            return partitionStrategy;
+        }
+
+        partitionStrategy = getPartitionStrategyImpl();
+        partitionStrategyLoaded = True;
+        if (partitionStrategy) {
+            inDb = True;
+        }
+        return partitionStrategy;
+    }
+
+    private hash<string, PartitionInfo> getPartitionsUnlocked() {
+        ensurePartitionsHashUnlocked();
+        if (partitionsLoaded) {
+            return partitions;
+        }
+        if (manual || !supportsPartitionsImpl()) {
+            partitionsLoaded = True;
+            return partitions;
+        }
+
+        partitions = getPartitionsImpl();
+        partitionsLoaded = True;
+        if (partitions) {
+            inDb = True;
+        }
+        return partitions;
+    }
+
+    private ensurePartitionsHashUnlocked() {
+        if (!partitions) {
+            hash<string, PartitionInfo> ph();
+            partitions = ph;
+        }
+    }
+
+    private clearPartitionsUnlocked() {
+        delete partitions;
+        partitionsLoaded = False;
+    }
+
+    private bool partitionSpecsHaveComparableBounds(hash<PartitionSpec> ps) {
+        return !ps.is_default && exists ps.bound_from && exists ps.bound_to;
+    }
+
+    private validatePartitionStrategyAlignmentUnlocked(AbstractTable t) {
+        *PartitionStrategy source = getPartitionStrategyUnlocked();
+        *PartitionStrategy target = t.getPartitionStrategyUnlocked();
+
+        if (!source && !target) {
+            return;
+        }
+        if (!source || !target || source.method != target.method || source.columns != target.columns
+            || source.auto != target.auto || source.driver != target.driver) {
+            throw "PARTITION-ERROR", sprintf("cannot align partition strategy for %s to %s; existing: %y; "
+                "template: %y", getDesc(), t.getDesc(), source, target);
+        }
+    }
+
     #! returns a list of SQL strings required to align the table to the table given as an argument
     /** if the tables are identical then an empty list is returned
 
@@ -6589,6 +7326,7 @@ list<auto> l = table.getAlignSql(table2);
         }
 
         AbstractTable this = opt.sql_callback_executed ? self : self.copy();
+        this.validatePartitionStrategyAlignmentUnlocked(t);
 
         return this.getAlignSqlUnlocked(t, opt);
     }
@@ -7808,6 +8546,23 @@ on_exit printf("SQL> %s\n", sql);
         return l;
     }
 
+    private *list<auto> getCreatePartitionsSqlUnlocked(*hash<auto> opt, bool cache = True) {
+        if (cache) {
+            getPartitionStrategyUnlocked();
+            getPartitionsUnlocked();
+        }
+        if (!partitionStrategy || partitions.empty()) {
+            return;
+        }
+
+        list<auto> l = ();
+        foreach hash<PartitionInfo> pi in (partitions.iterator()) {
+            l += AbstractDatabase::doCallback(opt, getAddPartitionSqlImpl(pi), AbstractDatabase::AC_Add,
+                "partition", pi.name, name);
+        }
+        return l;
+    }
+
     private list<auto> getCreateSqlUnlocked(*hash<auto> opt, bool cache = True) {
         # make sure driver options take precedence over generic options
         if (opt) {
@@ -7819,6 +8574,7 @@ on_exit printf("SQL> %s\n", sql);
         opt.create_table_all = True;
         list<auto> l += getCreateTableSqlUnlocked(opt);
         *list tl;
+        tl = getCreatePartitionsSqlUnlocked(opt, cache); if (tl) l += tl;
         if (!opt.omit.indexes) {
             tl = getCreateIndexesSqlUnlocked(opt, cache);
             if (tl) l += tl;
@@ -7846,6 +8602,8 @@ on_exit printf("SQL> %s\n", sql);
         getForeignConstraintsUnlocked(opt);
         getConstraintsUnlocked();
         getTriggersUnlocked();
+        getPartitionStrategyUnlocked();
+        getPartitionsUnlocked();
     }
 
     private auto execData(*hash<auto> opt, string sql, *list<auto> args) {
@@ -8046,6 +8804,111 @@ on_exit printf("SQL> %s\n", sql);
     }
 
     private preSetupTableImpl(reference desc, *hash<auto> opt) {
+    }
+
+    #! returns @ref True "True" if the database supports table partitioning
+    private bool supportsPartitionsImpl() {
+        return False;
+    }
+
+    #! returns @ref True "True" if the database supports detaching partitions
+    private bool supportsPartitionDetachImpl() {
+        return False;
+    }
+
+    #! returns @ref True "True" if the database supports automatic partitioning
+    private bool supportsAutoPartitioningImpl() {
+        return False;
+    }
+
+    #! returns the table partitioning strategy or @ref nothing if the table is not partitioned
+    private *hash<PartitionStrategy> getPartitionStrategyImpl() {
+    }
+
+    #! returns partition descriptions keyed by canonical partition name
+    private hash<string, PartitionInfo> getPartitionsImpl() {
+        hash<string, PartitionInfo> rv();
+        return rv;
+    }
+
+    #! finds a partition matching the given specification
+    private hash<PartitionLookupResult> findPartitionBySpecImpl(hash<PartitionSpec> spec) {
+        if (spec.is_default) {
+            foreach hash<PartitionInfo> pi in (getPartitionsUnlocked().iterator()) {
+                if (pi.is_default) {
+                    hash<PartitionLookupResult> rv({
+                        "status": PartitionLookupStatus::Found,
+                        "partition": pi,
+                    });
+                    return rv;
+                }
+            }
+            hash<PartitionLookupResult> rv({
+                "status": PartitionLookupStatus::NotFound,
+            });
+            return rv;
+        }
+
+        if (!partitionSpecsHaveComparableBounds(spec)) {
+            hash<PartitionLookupResult> rv({
+                "status": PartitionLookupStatus::Uncomparable,
+                "reason": "partition specification does not have typed comparable bounds",
+            });
+            return rv;
+        }
+
+        bool uncomparable;
+        foreach hash<PartitionInfo> pi in (getPartitionsUnlocked().iterator()) {
+            if (pi.is_default) {
+                continue;
+            }
+            if (!exists pi.bound_from || !exists pi.bound_to) {
+                uncomparable = True;
+                continue;
+            }
+            if (pi.bound_from == spec.bound_from && pi.bound_to == spec.bound_to) {
+                hash<PartitionLookupResult> rv({
+                    "status": PartitionLookupStatus::Found,
+                    "partition": pi,
+                });
+                return rv;
+            }
+        }
+
+        hash<PartitionLookupResult> rv({
+            "status": uncomparable ? PartitionLookupStatus::Uncomparable : PartitionLookupStatus::NotFound,
+            "reason": uncomparable ? "one or more existing partitions have SQL-only bounds" : NOTHING,
+        });
+        return rv;
+    }
+
+    #! returns @ref True "True" if automatic partitioning covers the given spec
+    private bool partitionAutoStrategyCoversSpecImpl(hash<PartitionSpec> spec) {
+        return False;
+    }
+
+    #! returns SQL to add a partition
+    private string getAddPartitionSqlImpl(hash<PartitionSpec> spec) {
+        throw "PARTITION-ERROR", sprintf("%s: database driver %y does not support adding partitions", getDesc(),
+            ds.getDriverName());
+    }
+
+    #! returns SQL to drop a partition
+    private string getDropPartitionSqlImpl(string partition_name) {
+        throw "PARTITION-ERROR", sprintf("%s: database driver %y does not support dropping partitions", getDesc(),
+            ds.getDriverName());
+    }
+
+    #! returns SQL to truncate a partition
+    private string getTruncatePartitionSqlImpl(string partition_name) {
+        throw "PARTITION-ERROR", sprintf("%s: database driver %y does not support truncating partitions", getDesc(),
+            ds.getDriverName());
+    }
+
+    #! returns SQL to detach a partition
+    private string getDetachPartitionSqlImpl(string partition_name) {
+        throw "PARTITION-ERROR", sprintf("%s: database driver %y does not support detaching partitions", getDesc(),
+            ds.getDriverName());
     }
 
     #! returns the type for number / numeric columns for the database so that data conversions can be handled properly

--- a/qlib/SqlUtil/SqlUtil.qm
+++ b/qlib/SqlUtil/SqlUtil.qm
@@ -124,6 +124,9 @@ module SqlUtil {
       the referenced primary key order
     - added @ref SqlUtil::AbstractTable::bulkInsert() "AbstractTable::bulkInsert()" as a generic bulk insert
       hook for driver-specific high-throughput implementations
+    - added generic partition metadata hashdecls and @ref SqlUtil::AbstractTable "AbstractTable" partition
+      lifecycle APIs for range-partitioned tables; driver support is advertised by
+      @ref SqlUtil::AbstractTable::supportsPartitions() "supportsPartitions()"
 
     @subsection sqlutilv1_9_3 SqlUtil v1.9.3
     - fixed support for orderby with a matching unique index
@@ -1725,6 +1728,10 @@ db_table.getAlignSql(template_table, callback_opts);
       are @ref fk_desc_hash "foreign constraint hashes"
     - \c unique_constraints: (optional) a hash of unique constraint information keyed by constraint name; the values
       are @ref uk_desc_hash "unique constraint hashes"
+    - \c partition_strategy: (optional) a @ref SqlUtil::PartitionStrategy "partition strategy hash"; Phase 1
+      supports range partitioning
+    - \c partitions: (optional) a hash of @ref SqlUtil::PartitionSpec "partition specification hashes" keyed by
+      partition name; this key is used for table creation and description only, not for alignment deltas
     - \c driver: this key can optionally contain a hash keyed by driver name which contains a hash of values that will
       be added to the table description hash before processing; this way a table description hash can contain all the
       information required for the table including driver-specific options; any driver-specific options will overwrite
@@ -2219,6 +2226,114 @@ public namespace SqlUtil {
         hash<string, hash> driver;
         #! @ref True "True" for DBs that support an auto-increment column
         *bool auto_increment;
+    }
+
+    #! Partition lookup status codes
+    /** @since SqlUtil 2.4
+    */
+    public enum PartitionLookupStatus : string {
+        #! The partition was found
+        Found = "found",
+        #! No matching partition was found
+        NotFound = "not_found",
+        #! The partition bounds could not be compared generically
+        Uncomparable = "uncomparable",
+    }
+
+    #! Indicates how an ensurePartition() result was verified
+    /** @since SqlUtil 2.4
+    */
+    public enum PartitionVerifiedBy : string {
+        #! The partition was verified by comparing partition bounds
+        Bounds = "bounds",
+        #! The partition was verified by canonical partition name
+        Name = "name",
+        #! The partition was covered by automatic partitioning
+        Auto = "auto",
+    }
+
+    #! Partitioning strategy hash
+    /** @since SqlUtil 2.4
+    */
+    public hashdecl PartitionStrategy {
+        #! Partitioning method; Phase 1 supports \c "range"
+        string method = "range";
+        #! Partition key columns in declaration order
+        softlist<string> columns;
+        #! Optional automatic partitioning strategy
+        *hash<auto> auto;
+        #! Optional driver-specific configuration
+        *hash<auto> driver;
+    }
+
+    #! Partition definition or lookup specification hash
+    /** @since SqlUtil 2.4
+    */
+    public hashdecl PartitionSpec {
+        #! Canonical partition name
+        *string name;
+        #! Partitioning method; Phase 1 supports \c "range"
+        string method = "range";
+        #! Optional partition key columns; defaults to the table strategy columns
+        *softlist<string> columns;
+        #! Inclusive lower bound as a typed Qore value
+        *auto bound_from;
+        #! Exclusive upper bound as a typed Qore value
+        *auto bound_to;
+        #! Inclusive lower bound as a driver-native SQL expression
+        *string bound_from_sql;
+        #! Exclusive upper bound as a driver-native SQL expression
+        *string bound_to_sql;
+        #! Complete driver-native bound SQL expression
+        *string bound_sql;
+        #! True if this is the default partition
+        bool is_default = False;
+        #! Schema name when available
+        *string schema;
+        #! Unqualified relation name when available
+        *string relation_name;
+        #! SQL-ready relation name when available
+        *string sql_name;
+        #! Optional driver-specific configuration
+        *hash<auto> driver;
+    }
+
+    #! Partition introspection hash
+    /** @since SqlUtil 2.4
+    */
+    public hashdecl PartitionInfo inherits PartitionSpec {
+        #! Ordinal in the listPartitions() result
+        int ordinal;
+    }
+
+    #! Partition lookup result hash
+    /** @since SqlUtil 2.4
+    */
+    public hashdecl PartitionLookupResult {
+        #! Lookup status
+        PartitionLookupStatus status;
+        #! Matching partition when \c status is @ref PartitionLookupStatus::Found
+        *PartitionInfo partition;
+        #! Optional explanation for failed or uncomparable lookup results
+        *string reason;
+    }
+
+    #! Partition ensure result hash
+    /** @since SqlUtil 2.4
+    */
+    public hashdecl PartitionEnsureResult {
+        #! True if a physical partition was created
+        bool created = False;
+        #! True if a physical partition exists after the call
+        bool materialized = False;
+        #! True if the request is covered by automatic partitioning and no physical partition was created
+        bool deferred_auto = False;
+        #! How the result was verified
+        PartitionVerifiedBy verified_by = PartitionVerifiedBy::Bounds;
+        #! Backwards-friendly alias for \c verified_by == @ref PartitionVerifiedBy::Bounds
+        bool bounds_verified = False;
+        #! Matching or newly-created partition when available
+        *PartitionInfo partition;
     }
 
     #! SQL operator info hash as returned by all @ref sql_op_funcs "operator functions"


### PR DESCRIPTION
## Summary
- add generic SqlUtil range partition support and PostgreSQL partition handling
- add Oracle and MySQL/MariaDB range partition support
- complete Schema/DataSchema/SchemaReverse/qschema partition integration
- include existing local-only fixes carried on develop

## Tests
- qore --enable-debug examples/test/qlib/Schema/DataSchema.qtest
- QORE_MODULE_DIR=qlib qore --enable-debug bin/qschema --help
- qore --enable-debug examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
- qore --enable-debug examples/test/qlib/SqlUtil/OracleSqlUtil.qtest -c <local oracle>
- qore --enable-debug examples/test/qlib/SqlUtil/MysqlSqlUtil.qtest -c <local mariadb>
- qore --enable-debug examples/test/qlib/SchemaReverse/schema-reverse.qtest -c <local pgsql>
- git diff --check