### PR TITLE
Fix copied class reclamation on Program teardown

### DIFF
--- a/examples/test/qore/classes/Program/program-memory.qtest
+++ b/examples/test/qore/classes/Program/program-memory.qtest
@@ -1,0 +1,53 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%modern
+%no-child-restrictions
+
+%prepend-module-path "${SCRIPT_DIR}/../../../../../qlib"
+%requires QUnit
+%exec-class ProgramMemoryTest
+
+class ProgramMemoryImportedBaseClass {
+}
+
+class ProgramMemoryImportedClass inherits ProgramMemoryImportedBaseClass {
+}
+
+class ProgramMemoryTest inherits QUnit::Test {
+    constructor() : QUnit::Test("ProgramMemoryTest", "1.0", \ARGV) {
+        addTestCase("child Program class handles are reclaimed", \classHandleReclamationTest());
+    }
+
+    classHandleReclamationTest() {
+        bool tracking = True;
+        try {
+            call_function("start_alloc_tracking");
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.err == "NO-FUNCTION" || ex.err == "UNDEFINED-FUNCTION-CALL") {
+                tracking = False;
+            } else {
+                rethrow;
+            }
+        }
+
+        for (int i = 0; i < 1000; ++i) {
+            Program pgm();
+            pgm.importClass("ProgramMemoryImportedClass");
+            delete pgm;
+        }
+
+        if (!tracking) {
+            testSkip("allocation-tracking build required for leak-byte assertion");
+        }
+
+        hash<auto> result = call_function("stop_alloc_tracking");
+        int live_bytes = 0;
+        foreach string key in (keys result) {
+            if (key != "_objects") {
+                live_bytes += result{key}.leak_bytes;
+            }
+        }
+        assertEq(0, live_bytes, "child Program teardown must release all tracked allocations");
+    }
+}

--- a/include/qore/intern/QoreClassIntern.h
+++ b/include/qore/intern/QoreClassIntern.h
@@ -1971,9 +1971,8 @@ public:
 #define QCCM_NORMAL (1 << 0)
 #define QCCM_STATIC (1 << 1)
 
-// set of QoreClass pointers associated to a qore_class_private object
-typedef vector_set_t<QoreClass*> qc_set_t;
-//typedef std::set<QoreClass*> qc_set_t;
+// QoreClass pointers associated with a qore_class_private object and their pointer reference counts
+typedef vector_map_t<QoreClass*, unsigned> qc_ref_map_t;
 
 // private QoreClass implementation
 // only dynamically allocated; reference counter managed in "refs"
@@ -1985,7 +1984,7 @@ public:
     QoreClass* cls;                 // parent class
     qore_ns_private* ns = nullptr;  // parent namespace
     BCList* scl = nullptr;          // base class list
-    qc_set_t qcset;                 // set of QoreClass pointers associated with this private object (besides cls)
+    qc_ref_map_t qcrefs;            // QoreClass pointers associated with this private object (besides cls)
 
     mutable VRMutex gate;           // for synchronized static methods
 
@@ -2217,15 +2216,47 @@ public:
             }
 
             // delete all linked QoreClass objects
-            for (auto& i : qcset) {
-                i->priv = nullptr;
-                delete i;
+            for (auto& i : qcrefs) {
+                i.first->priv = nullptr;
+                delete i.first;
             }
 
             delete this;
             return true;
         }
         return false;
+    }
+
+    DLLLOCAL static void refClass(QoreClass& qc) {
+        qore_class_private* priv = qc.priv;
+        priv->ref();
+        if (&qc != priv->cls) {
+            AutoLocker al(priv->gate.asl_lock);
+            qc_ref_map_t::iterator i = priv->qcrefs.find(&qc);
+            assert(i != priv->qcrefs.end());
+            ++i->second;
+        }
+    }
+
+    DLLLOCAL static void derefClass(QoreClass& qc, bool ns_const, bool ns_vars) {
+        qore_class_private* priv = qc.priv;
+        bool del = false;
+        if (&qc != priv->cls) {
+            AutoLocker al(priv->gate.asl_lock);
+            qc_ref_map_t::iterator i = priv->qcrefs.find(&qc);
+            assert(i != priv->qcrefs.end());
+            assert(i->second);
+            if (!--i->second) {
+                priv->qcrefs.erase(i);
+                qc.priv = nullptr;
+                del = true;
+            }
+        }
+
+        priv->deref(ns_const, ns_vars);
+        if (del) {
+            delete &qc;
+        }
     }
 
     DLLLOCAL bool hasAbstract() const {

--- a/lib/QoreClass.cpp
+++ b/lib/QoreClass.cpp
@@ -3727,13 +3727,13 @@ BCSMList::BCSMList(const BCSMList& old) {
     reserve(old.size());
     for (auto& i : old) {
         push_back(i);
-        i.first->priv->ref();
+        qore_class_private::refClass(*i.first);
     }
 }
 
 BCSMList::~BCSMList() {
     for (auto& i : *this) {
-        i.first->priv->deref(false, false);
+        qore_class_private::derefClass(*i.first, false, false);
     }
 }
 
@@ -3793,7 +3793,7 @@ void BCSMList::align(QoreClass* thisclass, QoreClass* qc, bool is_virtual) {
         }
         assert(i.first->getID() != thisclass->getID());
     }
-    qc->priv->ref();
+    qore_class_private::refClass(*qc);
 
     // append to the end of the vector
     push_back(std::make_pair(qc, is_virtual));
@@ -3845,7 +3845,7 @@ int BCSMList::add(QoreClass* thisclass, QoreClass* qc, bool is_virtual) {
         }
         ++i;
     }
-    qc->priv->ref();
+    qore_class_private::refClass(*qc);
 
     // append to the end of the list
     push_back(std::make_pair(qc, is_virtual));
@@ -3890,7 +3890,10 @@ const QoreClass* BCSMList::getClass(qore_classid_t cid) const {
 void BCSMList::resolveCopy() {
     for (class_list_t::iterator i = begin(), e = end(); i != e; ++i) {
         assert(i->first->priv->new_copy);
-        i->first = i->first->priv->new_copy;
+        QoreClass* old = i->first;
+        i->first = old->priv->new_copy;
+        qore_class_private::refClass(*i->first);
+        qore_class_private::derefClass(*old, false, false);
     }
 }
 
@@ -3903,9 +3906,9 @@ QoreClass::QoreClass(const QoreClass& old) : priv(old.priv) {
 
     priv->pgmRef();
 
-    // ensure atomicity when writing to qcset
+    // ensure atomicity when writing to qcrefs
     AutoLocker al(priv->gate.asl_lock);
-    priv->qcset.insert(this);
+    priv->qcrefs[this] = 1;
 }
 
 QoreClass::QoreClass(std::string&& nme, std::string&& ns_path, int64 dom)
@@ -3939,11 +3942,11 @@ QoreClass::~QoreClass() {
     // dereference the private data if still present
     if (priv) {
         {
-            // ensure atomicity when writing to qcset
+            // ensure atomicity when writing to qcrefs
             AutoLocker al(priv->gate.asl_lock);
-            qc_set_t::iterator i = priv->qcset.find(this);
-            if (i != priv->qcset.end()) {
-                priv->qcset.erase(i);
+            qc_ref_map_t::iterator i = priv->qcrefs.find(this);
+            if (i != priv->qcrefs.end()) {
+                priv->qcrefs.erase(i);
             }
         }
 

--- a/lib/QoreClassList.cpp
+++ b/lib/QoreClassList.cpp
@@ -66,7 +66,7 @@ void QoreClassList::deleteAll() {
     for (auto& i : hm) {
         //printd(5, "QoreClassList::deleteAll() this: %p cls: '%s' %p priv: %p ns_const: %d ns_vars: %d\n", this,
         //  i.second.cls->getName(), i.second.cls, qore_class_private::get(*i.second.cls), ns_const, ns_vars);
-        qore_class_private::get(*i.second.cls)->deref(!ns_const, !ns_vars);
+        qore_class_private::derefClass(*i.second.cls, !ns_const, !ns_vars);
     }
     hm.clear();
     ns_const = false;
@@ -199,7 +199,7 @@ void QoreClassList::parseRemove(const char* name, ExceptionSink* xsink) {
         // Roll back any pending variants first
         qore_class_private::parseRollback(*(i->second.cls));
         // Then delete the class
-        qore_class_private::get(*i->second.cls)->deref(!ns_const, !ns_vars);
+        qore_class_private::derefClass(*i->second.cls, !ns_const, !ns_vars);
         hm.erase(i);
     }
 }
@@ -228,7 +228,7 @@ void QoreClassList::assimilate(QoreClassList& n, qore_ns_private& ns,
         if (ns.hashDeclList.find(i.first)) {
             parse_error(*qore_class_private::get(*i.second.cls)->loc, "hashdecl '%s' has already been defined in " \
                 "namespace '%s'", i.first, ns.name.c_str());
-            qore_class_private::get(*i.second.cls)->deref(!ns_const, !ns_vars);
+            qore_class_private::derefClass(*i.second.cls, !ns_const, !ns_vars);
         } else if (QoreClass* existing = ns.classList.find(i.first)) {
             if (ns.imported && qore_class_private::isPublic(*existing)
                 && qore_class_private::isPublic(*i.second.cls)) {
@@ -238,16 +238,16 @@ void QoreClassList::assimilate(QoreClassList& n, qore_ns_private& ns,
                 parse_error(*qore_class_private::get(*i.second.cls)->loc,
                     "class '%s' has already been defined in namespace '%s'", i.first, ns.name.c_str());
             }
-            qore_class_private::get(*i.second.cls)->deref(!ns_const, !ns_vars);
+            qore_class_private::derefClass(*i.second.cls, !ns_const, !ns_vars);
         } else if (find(i.first)) {
             parse_error(*qore_class_private::get(*i.second.cls)->loc, "class '%s' is already pending in namespace " \
                 "'%s'", i.first, ns.name.c_str());
-            qore_class_private::get(*i.second.cls)->deref(!ns_const, !ns_vars);
+            qore_class_private::derefClass(*i.second.cls, !ns_const, !ns_vars);
         } else if (ns.nsl.find(i.first)) {
             parse_error(*qore_class_private::get(*i.second.cls)->loc, "cannot add class '%s' to existing " \
                 "namespace '%s' because a subnamespace has already been defined with this name", i.first,
                 ns.name.c_str());
-            qore_class_private::get(*i.second.cls)->deref(!ns_const, !ns_vars);
+            qore_class_private::derefClass(*i.second.cls, !ns_const, !ns_vars);
         } else {
             printd(5, "QoreClassList::assimilate() this: %p adding: %p '%s::%s'\n", this, i.second,
                 ns.name.c_str(), i.second.cls->getName());

--- a/lib/QoreNamespace.cpp
+++ b/lib/QoreNamespace.cpp
@@ -87,7 +87,7 @@
 #include "qore/intern/ql_time.h"
 #include "qore/intern/ql_lib.h"
 #ifdef QORE_HAVE_ALLOC_TRACKING
-#include "qore/intern/ql_alloc_tracking.h"
+DLLLOCAL void init_alloc_tracking_functions(QoreNamespace& ns);
 #endif
 #include "qore/intern/ql_math.h"
 #include "qore/intern/ql_type.h"


### PR DESCRIPTION
## Summary

- track copied `QoreClass` pointer references separately from shared private-data references
- release copied handles when child `Program` and inheritance owners are gone
- fix clean allocation-tracking builds without the ignored generated-header dependency
- add repeated inherited-class import regression coverage

This is the core fix for qoretechnologies/qorus#391. Before the fix, 10,000 child Program import/delete cycles retained 1,380,139 `QoreClass` objects; after the fix the process returns to the 139-object baseline.

## Local validation

- release and allocation-tracking builds
- allocation tracker: 0 live bytes after 1,000 inherited-class Program cycles
- focused Program suite: 7/7
- full non-performance suite: all 16 shards, 788 tests
- AddressSanitizer focused Program tests
- Qorus in-core service: class count returns exactly to baseline after unload
- 10 load/unload cycles: no cumulative RSS slope