### PR TITLE
scope cancel_thread() to the target's program-context chain

### DIFF
--- a/design/cooperative-cancellation.md
+++ b/design/cooperative-cancellation.md
@@ -7,7 +7,7 @@ Qore provides cooperative cancellation at two levels:
 | Level | Scope | Requested by | Exception |
 |-------|-------|-------------|-----------|
 | **Program interrupt** | All threads in a program | Sandbox controller via `SandboxManager::requestInterrupt()` | `PROGRAM-INTERRUPTED` |
-| **Thread cancellation** | One specific thread | Any thread (same program) via `cancel_thread(tid)` | `THREAD-CANCELLED` |
+| **Thread cancellation** | One specific thread | Any thread in scope (see [Program Scope](#program-scope-who-can-cancel-whom)) via `cancel_thread(tid)` | `THREAD-CANCELLED` |
 
 Both levels are checked at the same **cancellation points** through a single C++ function. This document covers the architecture, the C++ and Qore APIs, and the implementation guide for binary modules.
 
@@ -47,8 +47,8 @@ exported as a deprecated binary-compatibility wrapper that delegates to
 ### Thread Cancellation Control
 
 ```cpp
-// Request cancellation of a specific thread (same program only).
-// Returns 0 on success, -1 if thread not found/not active/wrong program.
+// Request cancellation of a specific thread; see "Program Scope" below.
+// Returns 0 if the request was delivered, -1 if the thread was not found or not active.
 DLLEXPORT int qore_cancel_thread(int tid, const char* reason = nullptr);
 
 // Clear the cancellation flag for the current thread.
@@ -494,17 +494,12 @@ bool qore_check_cancel(ExceptionSink* xsink, const char* operation) {
 ### `qore_cancel_thread()` Implementation
 
 ```cpp
-int QoreThreadList::cancelThread(int tid, const char* reason) {
+int QoreThreadList::cancelThread(int tid, const char* reason, unsigned scope_pgm_id) {
     AutoLocker al(lck);
     if (tid <= 0 || tid >= MAX_QORE_THREADS) {
         return -1;
     }
     if (!entry[tid].active()) {
-        return -1;
-    }
-    // Security: same-program only
-    ThreadData* td = entry[tid].thread_data;
-    if (td && td->current_pgm != getProgram()) {
         return -1;
     }
     if (reason) {
@@ -513,6 +508,8 @@ int QoreThreadList::cancelThread(int tid, const char* reason) {
         }
         entry[tid].cancel_reason = new QoreStringNode(reason);
     }
+    // publish the scope before the flag; the target reads it only after observing the flag
+    entry[tid].cancel_scope_pgm_id.store(scope_pgm_id, std::memory_order_release);
     // seq_cst pairs with seq_cst on the waiter side (see Broadcast-on-Cancel)
     entry[tid].cancel_requested.store(true, std::memory_order_seq_cst);
     QoreCondition* cond = entry[tid].waiting_on.load(std::memory_order_seq_cst);
@@ -622,13 +619,53 @@ the existing cleanup path handles everything — no special cleanup path is need
 - `xsink.handleExceptions()` — logs unhandled exception
 - `thread_list.deleteDataRelease()` — releases TID slot (clears cancel flag)
 
-### Security: Who Can Cancel Whom?
-
-`qore_cancel_thread()` verifies `td->current_pgm == getProgram()`. This prevents:
-- Sandboxed code from cancelling host threads
-- One program's threads from cancelling another program's threads
+### Program Scope: Who Can Cancel Whom?
 
 Self-cancellation (cancelling the current thread) is an error — use `throw "THREAD-CANCELLED"` directly.
+
+Otherwise a request carries a **scope**, computed on the requesting thread by
+`get_cancel_scope_pgm_id()`:
+
+| Requesting context | Scope | Effect |
+|---|---|---|
+| host (C++) code with no `Program` context | `0` (unscoped) | applies to any thread |
+| an unrestricted `Program` — no `SandboxManager` on it or any enclosing caller `Program` | `0` (unscoped) | applies to any thread |
+| a sandboxed `Program` | that program's ID | applies only to threads executing in it or under a call that originated in it |
+
+The scope is evaluated by the **target** thread at its next cancellation point
+(`check_cancel_in_scope()`), against its current `Program` and its chain of enclosing caller
+`Program`s (`ThreadData::current_pgm_ctx` → `ProgramThreadCountContextHelper::getOldProgram()`),
+using the same resolution order as `qore_find_thread_sandbox_manager_ref()`.
+
+Two consequences of evaluating on the target:
+
+- **It is safe.** The chain consists of stack-allocated `ProgramThreadCountContextHelper`
+  objects in the target's own frames; walking it from the requesting thread would be a
+  use-after-free hazard.
+- **Delivery is not the same as effect.** `cancel_thread()` returning `True` means the request
+  was delivered; an out-of-scope request is dropped by the target when it observes it
+  (`dropCancelRequest()`), which keeps the steady-state cost of a cancellation point at a single
+  atomic load. The drop is conditional on the scope being unchanged, so a request that arrives
+  while the target is evaluating an older one is never lost.
+
+Rationale for the scope rule:
+
+- An unrestricted `Program` can already terminate the process outright, so scoping its
+  cancellation requests protects nothing while breaking the legitimate case — a host cancelling
+  a thread that is running the host's own request inside a `Program` the host called into.
+- A sandboxed `Program` gains nothing it did not already have: it can cancel threads that entered
+  it (which the previous same-program rule also allowed), but cannot reach threads that never did.
+- The primary control against untrusted code remains the `THREAD_CONTROL` functional domain:
+  a `Program` created with `PO_NO_THREAD_CONTROL` cannot call `cancel_thread()` at all.
+
+**Superseded rule (Qore 2.2).** `cancelThread()` originally required
+`td->current_pgm == getProgram()` — the target had to be executing in the requesting `Program` at
+the instant of the call. Because `current_pgm` tracks the innermost frame and changes on every
+cross-`Program` call, the outcome depended on where the target happened to be at that moment: the
+same thread was cancellable or not depending on timing, and a denial was indistinguishable from
+"no such thread" (both returned `-1`/`False`). It also blocked the one direction that is
+unambiguously legitimate, while a `Program`-wide `SandboxManager::requestInterrupt()` — which
+stops *every* thread in the target program — remained unrestricted.
 
 ## Performance
 
@@ -698,9 +735,15 @@ int tid = background sub() {
 sleep(100ms);
 cancel_thread(tid);
 
-# Same-program security
-Program pgm(PO_NEW_STYLE);
-# pgm should NOT be able to cancel threads in the parent program
+# Program scope
+Program child(PO_NEW_STYLE);
+# a thread blocked inside child IS cancellable from the parent
+
+SandboxManager sm();
+Program sandboxed(PO_NEW_STYLE);
+sandboxed.setSandboxManager(sm);
+# sandboxed CAN cancel a thread that called into it, wherever that thread is now;
+# sandboxed CANNOT cancel a thread that never entered it — the request is dropped
 
 # Both program interrupt and thread cancel active simultaneously
 # Thread cancel is detected first (more specific)
@@ -767,7 +810,8 @@ do_io_operation();  # Works normally, no overhead
 ### Phase 4: Tests
 - Thread cancellation tests (loop, sleep, queue, counter, I/O)
 - `clear_thread_cancel()` continuation test
-- Same-program security test
+- Program scope tests (child program, nested child program, sandboxed requester in and out of scope,
+  dropped request followed by an in-scope request, `thread_cancelled()` ignoring an out-of-scope request)
 - Program interrupt + thread cancel interaction test
 - ThreadPool task cancellation test
 - Per-module cancellation tests
@@ -794,4 +838,4 @@ do_io_operation();  # Works normally, no overhead
 
 - **Qore 2.0**: Initial implementation of program interrupt infrastructure
 - **Qore 2.1**: Added `QoreSandboxManagerHelper` RAII class for safe access; removed raw `QoreSandboxManager*` from public API to prevent use-after-free; modules audited and updated for interruptible I/O and sandboxing
-- **Qore 3.0**: Unified cancellation API (`qore_check_cancel`); added per-thread cancellation (`cancel_thread`, `thread_cancelled`, `clear_thread_cancel`); replaced 500ms polling in `QoreCondition::waitWithInterrupt` with broadcast-on-cancel (`ThreadEntry::waiting_on`), eliminating O(N) wakeup contention when many threads share a single condition variable
+- **Qore 3.0**: Unified cancellation API (`qore_check_cancel`); added per-thread cancellation (`cancel_thread`, `thread_cancelled`, `clear_thread_cancel`); replaced 500ms polling in `QoreCondition::waitWithInterrupt` with broadcast-on-cancel (`ThreadEntry::waiting_on`), eliminating O(N) wakeup contention when many threads share a single condition variable; replaced the same-program restriction on `cancel_thread()` with the target-evaluated program scope rule (see [Program Scope](#program-scope-who-can-cancel-whom)), making a thread blocked inside a child program cancellable by the program that called into it

--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -1011,6 +1011,15 @@ cargo install tree-sitter-cli@0.26.5
       - cancelling an already-cancelled thread updates the reason string
       - cancelling a thread that has already exited returns @ref False
       - attempting to cancel the current thread raises \c THREAD-CANCEL-ERROR
+      - requests from an unrestricted @ref Qore::Program "Program" — one with no
+        @ref Qore::SandboxManager "SandboxManager" governing it or any enclosing caller \c Program —
+        apply to any thread, including threads blocked inside child Programs; requests from a
+        sandboxed \c Program apply only to threads executing in it or in a call that originated in it,
+        so sandboxed code can cancel threads running its own code but cannot reach threads that never
+        entered it
+      - the scope is evaluated by the target thread at its next check point, so a @ref True return from
+        @ref Qore::cancel_thread() "cancel_thread()" means the request was delivered; an out-of-scope
+        request is dropped by the target and has no effect
     - <b>Modern threading primitives</b>
       - new @ref Qore::Thread::Future "Future" / @ref Qore::Thread::Promise "Promise" classes for cross-thread
         result delivery: @ref Qore::Thread::Promise "Promise" is the producer side (set a value or error),

--- a/examples/test/qore/threads/thread-cancel.qtest
+++ b/examples/test/qore/threads/thread-cancel.qtest
@@ -56,6 +56,16 @@ public class ThreadCancelTest inherits QUnit::Test {
         addTestCase("program interrupt still works", \testProgramInterrupt());
         addTestCase("cancel_thread cross-program security", \testCrossProgramSecurity());
 
+        # Program scope rules for cancel_thread()
+        addTestCase("cancel thread in child program", \testCancelThreadInChildProgram());
+        addTestCase("cancel thread in nested child program", \testCancelThreadInNestedChildProgram());
+        addTestCase("sandboxed program cancels its own callers", \testSandboxedProgramCanCancelItsOwnCallers());
+        addTestCase("sandboxed program cannot cancel unrelated thread",
+            \testSandboxedProgramCannotCancelUnrelatedThread());
+        addTestCase("cancel after dropped out-of-scope request", \testCancelAfterDroppedRequest());
+        addTestCase("thread_cancelled ignores out-of-scope request",
+            \testThreadCancelledIgnoresOutOfScopeRequest());
+
         # Pipe stream cancel test
         addTestCase("cancel pipe read", \testCancelPipeRead());
 
@@ -510,6 +520,312 @@ sub loop_forever() {
 
         assertTrue(got_interrupt, "program interrupt should work on child program threads");
         sm.clearInterrupt();
+    }
+
+    #------------------------------------------------------------------
+    # Program scope tests
+    #
+    # A request from an unrestricted program (no SandboxManager) is unscoped and applies to any
+    # thread; a request from a sandboxed program only applies to threads executing in it or in a
+    # call that originated in it.
+    #------------------------------------------------------------------
+
+    #! returns a program that blocks in a Condition wait when "block_forever" is called
+    /** the release Counter is used instead of a reference so that the rescue path in
+        waitForBlocker() does not depend on writes propagating across program boundaries
+    */
+    private Program getBlockerProgram(string label) {
+        Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+        p.parse("
+%modern
+
+sub block_forever(Counter ready, Mutex m, Condition c, Counter release) {
+    AutoLock al(m);
+    ready.dec();
+    while (release.getCount()) {
+        c.wait(m);
+    }
+}
+", label);
+        return p;
+    }
+
+    #! blocks the current thread until the release Counter is decremented
+    private blockUntilReleased(Counter ready, Mutex m, Condition c, Counter release) {
+        AutoLock al(m);
+        ready.dec();
+        while (release.getCount()) {
+            c.wait(m);
+        }
+    }
+
+    #! waits for a blocker thread to exit, releasing it if it is still blocked
+    /** without the release, a regression in the scope rule would hang the test run instead of
+        failing it, since the blocker only exits when cancelled or released
+
+        @return 0 if the thread exited on its own (i.e. it was cancelled), -1 if it had to be
+        released
+    */
+    private int waitForBlocker(Counter done, Mutex m, Condition c, Counter release) {
+        int rc = done.waitForZero(20s);
+        if (rc) {
+            releaseBlocker(m, c, release);
+            done.waitForZero(20s);
+        }
+        return rc;
+    }
+
+    #! releases a blocked thread; the release is decremented under the mutex to avoid a lost wakeup
+    private releaseBlocker(Mutex m, Condition c, Counter release) {
+        AutoLock al(m);
+        if (release.getCount()) {
+            release.dec();
+        }
+        c.broadcast();
+    }
+
+    testCancelThreadInChildProgram() {
+        # the target blocks inside a child program; the request is issued from the parent, which
+        # is not the program the target is executing in
+        Program child = getBlockerProgram("child_program_cancel_test");
+
+        Counter ready(1);
+        Counter done(1);
+        Counter release(1);
+        Mutex m();
+        Condition c();
+        *hash<ExceptionInfo> ex_info;
+        int child_tid;
+
+        background sub() {
+            child_tid = gettid();
+            try {
+                child.callFunction("block_forever", ready, m, c, release);
+            } catch (hash<ExceptionInfo> ex) {
+                ex_info = ex;
+            }
+            done.dec();
+        }();
+
+        ready.waitForZero();
+        bool delivered = cancel_thread(child_tid, "child program cancel");
+        int rc = waitForBlocker(done, m, c, release);
+        assertTrue(delivered, "the request must be delivered");
+        assertEq(0, rc, "the cancelled thread must exit");
+        assertEq("THREAD-CANCELLED", ex_info.err, "a thread blocked in a child program must be cancellable");
+        assertRegex("child program cancel", ex_info.desc);
+    }
+
+    testCancelThreadInNestedChildProgram() {
+        # two program boundaries between the requesting program and where the target is blocked
+        Program grandchild = getBlockerProgram("nested_grandchild_cancel_test");
+
+        Program child(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+        child.parse("
+%modern
+
+sub call_blocker(Program p, Counter ready, Mutex m, Condition c, Counter release) {
+    p.callFunction(\"block_forever\", ready, m, c, release);
+}
+", "nested_child_cancel_test");
+
+        Counter ready(1);
+        Counter done(1);
+        Counter release(1);
+        Mutex m();
+        Condition c();
+        *hash<ExceptionInfo> ex_info;
+        int child_tid;
+
+        background sub() {
+            child_tid = gettid();
+            try {
+                child.callFunction("call_blocker", grandchild, ready, m, c, release);
+            } catch (hash<ExceptionInfo> ex) {
+                ex_info = ex;
+            }
+            done.dec();
+        }();
+
+        ready.waitForZero();
+        bool delivered = cancel_thread(child_tid);
+        int rc = waitForBlocker(done, m, c, release);
+        assertTrue(delivered, "the request must be delivered");
+        assertEq(0, rc, "the cancelled thread must exit");
+        assertEq("THREAD-CANCELLED", ex_info.err, "nesting must not make a thread uncancellable");
+    }
+
+    testSandboxedProgramCanCancelItsOwnCallers() {
+        # a sandboxed program cancels a thread that entered it and then blocked one program deeper;
+        # the requesting program is not where the target is executing, but it is on the target's
+        # chain of enclosing caller programs
+        Program grandchild = getBlockerProgram("sandboxed_grandchild_cancel_test");
+
+        SandboxManager sm();
+        Program sandboxed(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+        sandboxed.setSandboxManager(sm);
+        sandboxed.parse("
+%modern
+
+sub call_blocker(Program p, Counter ready, Mutex m, Condition c, Counter release) {
+    p.callFunction(\"block_forever\", ready, m, c, release);
+}
+
+bool sub do_cancel(int tid) {
+    return cancel_thread(tid, \"sandboxed scope cancel\");
+}
+", "sandboxed_program_cancel_test");
+
+        Counter ready(1);
+        Counter done(1);
+        Counter release(1);
+        Mutex m();
+        Condition c();
+        *hash<ExceptionInfo> ex_info;
+        int child_tid;
+
+        background sub() {
+            child_tid = gettid();
+            try {
+                sandboxed.callFunction("call_blocker", grandchild, ready, m, c, release);
+            } catch (hash<ExceptionInfo> ex) {
+                ex_info = ex;
+            }
+            done.dec();
+        }();
+
+        ready.waitForZero();
+        bool delivered = sandboxed.callFunction("do_cancel", child_tid);
+        int rc = waitForBlocker(done, m, c, release);
+        assertTrue(delivered, "the request must be delivered");
+        assertEq(0, rc, "the cancelled thread must exit");
+        assertEq("THREAD-CANCELLED", ex_info.err,
+            "a sandboxed program must be able to cancel a thread running its own code");
+        assertRegex("sandboxed scope cancel", ex_info.desc);
+    }
+
+    testSandboxedProgramCannotCancelUnrelatedThread() {
+        # the target never entered the requesting program, so the request must be dropped
+        SandboxManager sm();
+        Program sandboxed(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+        sandboxed.setSandboxManager(sm);
+        sandboxed.parse("
+%modern
+
+bool sub do_cancel(int tid) {
+    return cancel_thread(tid, \"out of scope\");
+}
+", "unrelated_program_cancel_test");
+
+        Counter ready(1);
+        Counter done(1);
+        Counter release(1);
+        Mutex m();
+        Condition c();
+        *hash<ExceptionInfo> ex_info;
+        int child_tid;
+
+        background sub() {
+            child_tid = gettid();
+            try {
+                blockUntilReleased(ready, m, c, release);
+            } catch (hash<ExceptionInfo> ex) {
+                ex_info = ex;
+            }
+            done.dec();
+        }();
+
+        ready.waitForZero();
+        # delivery succeeds; the scope is evaluated by the target, which drops the request
+        bool delivered = sandboxed.callFunction("do_cancel", child_tid);
+
+        # the target must still be running normal code: release it and check that it returned
+        # without an exception.  An honored request would have thrown at the wait's check point
+        # before or immediately after this release.
+        releaseBlocker(m, c, release);
+        int rc = done.waitForZero(20s);
+        assertTrue(delivered, "the request is delivered");
+        assertEq(0, rc, "the thread must exit normally");
+        assertNothing(ex_info, "an out-of-scope request must not cancel the thread");
+    }
+
+    testCancelAfterDroppedRequest() {
+        # a dropped out-of-scope request must not leave stale state that swallows a later,
+        # legitimate request
+        SandboxManager sm();
+        Program sandboxed(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+        sandboxed.setSandboxManager(sm);
+        sandboxed.parse("
+%modern
+
+bool sub do_cancel(int tid) {
+    return cancel_thread(tid, \"out of scope\");
+}
+", "dropped_request_cancel_test");
+
+        Counter ready(1);
+        Counter done(1);
+        Counter release(1);
+        Mutex m();
+        Condition c();
+        *hash<ExceptionInfo> ex_info;
+        int child_tid;
+
+        background sub() {
+            child_tid = gettid();
+            try {
+                blockUntilReleased(ready, m, c, release);
+            } catch (hash<ExceptionInfo> ex) {
+                ex_info = ex;
+            }
+            done.dec();
+        }();
+
+        ready.waitForZero();
+        bool dropped_delivered = sandboxed.callFunction("do_cancel", child_tid);
+        bool delivered = cancel_thread(child_tid, "in scope");
+        int rc = waitForBlocker(done, m, c, release);
+        assertTrue(dropped_delivered, "the out-of-scope request is delivered");
+        assertTrue(delivered, "the in-scope request is delivered");
+        assertEq(0, rc, "the cancelled thread must exit");
+        assertEq("THREAD-CANCELLED", ex_info.err, "the in-scope request must still be honored");
+        assertRegex("in scope", ex_info.desc);
+    }
+
+    testThreadCancelledIgnoresOutOfScopeRequest() {
+        # thread_cancelled() must not report a request that will never be honored
+        SandboxManager sm();
+        Program sandboxed(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
+        sandboxed.setSandboxManager(sm);
+        sandboxed.parse("
+%modern
+
+bool sub do_cancel(int tid) {
+    return cancel_thread(tid, \"out of scope\");
+}
+", "thread_cancelled_scope_test");
+
+        Counter ready(1);
+        Counter cancelled(1);
+        Counter done(1);
+        bool reported_cancelled = True;
+        int child_tid;
+
+        background sub() {
+            child_tid = gettid();
+            ready.dec();
+            cancelled.waitForZero();
+            reported_cancelled = thread_cancelled();
+            done.dec();
+        }();
+
+        ready.waitForZero();
+        bool delivered = sandboxed.callFunction("do_cancel", child_tid);
+        cancelled.dec();
+        int rc = done.waitForZero(20s);
+        assertTrue(delivered, "the request is delivered");
+        assertEq(0, rc, "the thread must exit");
+        assertFalse(reported_cancelled, "thread_cancelled() must ignore an out-of-scope request");
     }
 
     #------------------------------------------------------------------

--- a/include/qore/intern/QoreThreadList.h
+++ b/include/qore/intern/QoreThreadList.h
@@ -104,6 +104,17 @@ public:
     //! optional cancellation reason string
     QoreStringNode* cancel_reason = nullptr;
 
+    //! program ID scoping a pending cancellation request, or 0 if the request is unscoped
+    /** Set by cancelThread() from the requesting thread's Program context; a scoped request is
+        only honored if the target thread is executing in that Program or in a call that
+        originated in it (see qore_check_cancel()).
+
+        The scope is evaluated by the target thread itself, because the target's Program-context
+        chain is made of stack-allocated ProgramThreadCountContextHelper objects in the target's
+        own frames and therefore cannot be walked safely from another thread.
+    */
+    std::atomic<unsigned> cancel_scope_pgm_id{0};
+
     //! the condition the thread is currently blocked on, or nullptr if not blocked
     /** Set by QoreCondition::waitWithInterrupt() before sleeping and cleared after waking,
         so that cancelThread() / SandboxManager::requestInterrupt() can wake the thread directly
@@ -309,9 +320,28 @@ public:
     */
     DLLLOCAL void wakeAllWaiters();
 
-    //! Get the cancel reason for the given thread (caller must hold lck or be the owning thread)
-    DLLLOCAL QoreStringNode* getCancelReason(int tid) const {
-        return (tid >= 0 && tid < MAX_QORE_THREADS) ? entry[tid].cancel_reason : nullptr;
+    //! Get a reference to the cancel reason for the given thread, or nullptr if there is none
+    /** The reference is acquired under the lock, so the string cannot be replaced and freed by a
+        concurrent cancelThread() call while the caller is using it; the caller owns the reference
+        returned.
+    */
+    DLLLOCAL QoreStringNode* getCancelReasonRef(int tid) {
+        AutoLocker al(lck);
+        QoreStringNode* rv = (tid >= 0 && tid < MAX_QORE_THREADS) ? entry[tid].cancel_reason : nullptr;
+        return rv ? rv->stringRefSelf() : nullptr;
+    }
+
+    //! Get the program ID scoping the pending cancellation request for the given thread
+    /** @return the program ID that the target must be executing in (or under) for the request to
+        be honored, or 0 if the request is unscoped
+
+        Acquire pairs with the release store in cancelThread(), which publishes the scope before
+        the request flag; a thread that has observed the flag therefore observes the scope.
+    */
+    DLLLOCAL unsigned getCancelScopeProgramId(int tid) const {
+        return (tid >= 0 && tid < MAX_QORE_THREADS)
+            ? entry[tid].cancel_scope_pgm_id.load(std::memory_order_acquire)
+            : 0;
     }
 
     //! Mark a thread entry so that pthread_detach() is not called on exit
@@ -324,12 +354,39 @@ public:
     }
 
     //! Request cancellation of a thread; acquires lock internally
-    DLLLOCAL int cancelThread(int tid, const char* reason);
+    /** @param tid the thread to cancel
+        @param reason optional reason string included in the \c THREAD-CANCELLED exception
+        @param scope_pgm_id the program ID scoping the request, or 0 for an unscoped request
 
-    //! Clear cancellation for the given thread
+        @return 0 if the request was delivered, -1 if the thread is not active
+    */
+    DLLLOCAL int cancelThread(int tid, const char* reason, unsigned scope_pgm_id);
+
+    //! Clear cancellation for the given thread; acquires lock internally
     DLLLOCAL void clearCancel(int tid);
 
+    //! Drop a cancellation request that the target found to be out of scope; acquires lock internally
+    /** The request is only cleared if its scope is unchanged, so that a request delivered after the
+        scope was evaluated is left pending for the next cancellation check point instead of being
+        silently lost.  A new request with the same scope would be evaluated identically, so
+        clearing it is harmless.
+
+        @param tid the thread whose request should be dropped
+        @param scope_pgm_id the scope that was evaluated and found not to apply
+    */
+    DLLLOCAL void dropCancelRequest(int tid, unsigned scope_pgm_id);
+
 protected:
+    //! Clears all cancellation state for the given thread; lck must be held
+    DLLLOCAL void clearCancelIntern(int tid) {
+        entry[tid].cancel_requested.store(false, std::memory_order_release);
+        entry[tid].cancel_scope_pgm_id.store(0, std::memory_order_release);
+        if (entry[tid].cancel_reason) {
+            entry[tid].cancel_reason->deref();
+            entry[tid].cancel_reason = nullptr;
+        }
+    }
+
     // lock for reading the thread list
     mutable QoreThreadLock lck;
     unsigned num_threads = 0;

--- a/include/qore/qore_thread.h
+++ b/include/qore/qore_thread.h
@@ -454,12 +454,27 @@ DLLEXPORT bool qore_check_io_interrupt(ExceptionSink* xsink, const char* operati
 
 //! Requests cooperative cancellation of a specific thread
 /** The target thread will receive a \c THREAD-CANCELLED exception at the next cancellation
-    point. Only threads in the same program context can be cancelled.
+    point.
+
+    @par Scope
+    A request issued from an unrestricted %Program — one with no sandbox manager governing it or
+    any enclosing caller %Program — or from host code with no %Program context is unscoped and
+    always applies; such a caller can already terminate the process outright.
+
+    A request issued from a sandboxed %Program is scoped to that %Program: it is only honored if
+    the target thread is executing in it or in a call that originated in it. This allows a
+    %Program to cancel threads running its own code wherever they currently are — including
+    inside child Programs it called into — while preventing it from reaching threads that never
+    entered it.
+
+    The scope is evaluated by the target thread at its next cancellation point, so a return
+    value of 0 means the request was delivered, not that it was necessarily honored; an
+    out-of-scope request is dropped by the target.
 
     @param tid the Qore thread ID to cancel
     @param reason optional reason string (will be included in the exception message)
 
-    @return 0 on success, -1 if the thread was not found, not active, or in a different program
+    @return 0 if the request was delivered, -1 if the thread was not found or not active
 
     @since %Qore 2.2
 */

--- a/lib/ql_thread.qpp
+++ b/lib/ql_thread.qpp
@@ -1012,6 +1012,22 @@ bool active_exception() [dom=PROCESS] {
     no blocking calls) will not be interrupted, but such code is inherently finite and
     will complete on its own.
 
+    @par Which Threads Can Be Cancelled
+    A request issued from an unrestricted @ref Qore::Program "Program" — one with no
+    @ref Qore::SandboxManager "SandboxManager" governing it or any enclosing caller
+    \c Program — applies to any thread. Such a program can already terminate the entire
+    process, so restricting it protects nothing.
+
+    A request issued from a sandboxed \c Program is scoped to that program: it is only honored
+    if the target thread is executing in that program, or in a call that originated in it.
+    Sandboxed code can therefore cancel threads that are running its own code — wherever they
+    currently are, including inside child programs it called into — but cannot reach threads
+    that never entered it.
+
+    The scope is evaluated by the target thread at its next cancellation check point, so a
+    return value of @ref True means the request was delivered, not that it was necessarily
+    honored; an out-of-scope request is dropped by the target thread and has no effect.
+
     @return @ref True if the cancellation request was delivered, @ref False if the thread
     was not found or not active
 
@@ -1031,6 +1047,15 @@ bool active_exception() [dom=PROCESS] {
     # Wait up to 30 seconds, then cancel
     if (!done.waitForZero(30000)) {
         cancel_thread(tid, "processing timeout after 30s");
+    }
+    @endcode
+
+    @par Example: Unwedge a thread blocked in a child Program
+    @code{.py}
+    # a request handler that called into user code in a child Program and blocked there;
+    # the handler thread is cancelled even though it is not currently executing in this program
+    if (!handlers_done.waitForZero(grace_period)) {
+        map cancel_thread($1, "shutdown drain timeout"), stuck_handler_tids;
     }
     @endcode
 
@@ -1061,6 +1086,9 @@ bool cancel_thread(int thread_id, *string reason) [flags=NAMED_ARGS;dom=THREAD_C
     clear_thread_cancel() or the thread exits. After catching a \c THREAD-CANCELLED
     exception, the flag is still set, so any subsequent cancellation check point
     will throw again unless clear_thread_cancel() is called first.
+
+    @note Returns @ref False for a pending request that is out of scope for this thread (see
+    cancel_thread()); such a request is dropped when observed and never takes effect
 
     @return @ref True if cancellation has been requested, @ref False otherwise
 

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -739,6 +739,7 @@ void ThreadEntry::cleanup() {
 
     // clear per-thread cancellation state
     cancel_requested.store(false, std::memory_order_relaxed);
+    cancel_scope_pgm_id.store(0, std::memory_order_relaxed);
     if (cancel_reason) {
         cancel_reason->deref();
         cancel_reason = nullptr;
@@ -3932,17 +3933,12 @@ int q_remove_thread_local_data(int key, q_user_tld& data, bool run_destructor) {
 
 // --- Thread Cancellation API ---
 
-int QoreThreadList::cancelThread(int tid, const char* reason) {
+int QoreThreadList::cancelThread(int tid, const char* reason, unsigned scope_pgm_id) {
     AutoLocker al(lck);
     if (tid <= 0 || tid >= MAX_QORE_THREADS) {
         return -1;
     }
     if (!entry[tid].active()) {
-        return -1;
-    }
-    // security: only allow cancellation within the same program context
-    ThreadData* td = entry[tid].thread_data;
-    if (td && td->current_pgm != getProgram()) {
         return -1;
     }
     if (reason) {
@@ -3951,6 +3947,9 @@ int QoreThreadList::cancelThread(int tid, const char* reason) {
         }
         entry[tid].cancel_reason = new QoreStringNode(reason);
     }
+    // publish the scope before the request flag; the target only reads the scope after observing
+    // the flag, so this release store pairs with the acquire load in getCancelScopeProgramId()
+    entry[tid].cancel_scope_pgm_id.store(scope_pgm_id, std::memory_order_release);
     // seq_cst pairs with seq_cst on the waiter side (register waiting_on, then check flag) to
     // defeat the lost-wakeup race in QoreCondition::waitWithInterrupt
     entry[tid].cancel_requested.store(true, std::memory_order_seq_cst);
@@ -3983,21 +3982,96 @@ void QoreThreadList::wakeAllWaiters() {
 }
 
 void QoreThreadList::clearCancel(int tid) {
+    // the lock serializes cancel_reason handling against a concurrent cancelThread() call, which
+    // would otherwise be able to replace (and deref) the string between our read and our deref
+    AutoLocker al(lck);
     if (tid >= 0 && tid < MAX_QORE_THREADS) {
-        entry[tid].cancel_requested.store(false, std::memory_order_release);
-        if (entry[tid].cancel_reason) {
-            entry[tid].cancel_reason->deref();
-            entry[tid].cancel_reason = nullptr;
-        }
+        clearCancelIntern(tid);
     }
 }
 
+void QoreThreadList::dropCancelRequest(int tid, unsigned scope_pgm_id) {
+    AutoLocker al(lck);
+    if (tid < 0 || tid >= MAX_QORE_THREADS) {
+        return;
+    }
+    if (entry[tid].cancel_scope_pgm_id.load(std::memory_order_acquire) != scope_pgm_id) {
+        // a different request was delivered after we evaluated the scope; leave it pending
+        return;
+    }
+    clearCancelIntern(tid);
+}
+
+//! Returns the scope to apply to a cancellation request issued by the current thread
+/** Returns 0 for an unscoped request: the caller has no Program context (i.e. it is host code
+    embedding the library), or it runs in an unrestricted Program — one with no sandbox manager
+    governing it or any of its enclosing caller Programs.  An unrestricted Program can already
+    terminate the process outright, so scoping its cancellation requests would protect nothing.
+
+    Otherwise the current Program's ID is returned, and the request is only honored if the target
+    thread is executing in that Program or in a call that originated in it (see
+    check_cancel_in_scope()).  This is what prevents sandboxed code from reaching threads that
+    never entered it, while still allowing it to cancel threads running its own code.
+*/
+static unsigned get_cancel_scope_pgm_id() {
+    QoreProgram* pgm = getProgram();
+    if (!pgm) {
+        return 0;
+    }
+    QoreSandboxManagerHelper smh;
+    if (!smh) {
+        return 0;
+    }
+    return pgm->getProgramId();
+}
+
+//! Evaluates a pending cancellation request for the current thread against its Program context
+/** Must be called by the target thread itself: the Program-context chain consists of
+    stack-allocated ProgramThreadCountContextHelper objects in this thread's own frames.
+
+    An out-of-scope request is dropped, so that the steady-state cost of a cancellation check
+    point remains a single atomic load.
+
+    @return true if the request applies to this thread, false if there was no request in scope
+*/
+static bool check_cancel_in_scope(int tid) {
+    unsigned scope = thread_list.getCancelScopeProgramId(tid);
+    if (!scope) {
+        return true;
+    }
+    ThreadData* td = thread_data.get();
+    if (td) {
+        // 1) the current program context
+        if (td->current_pgm && td->current_pgm->getProgramId() == scope) {
+            return true;
+        }
+        // 2) enclosing caller programs via the program-context (call) stack, innermost first; a
+        // thread executing a call that originated in the requesting Program is in scope wherever
+        // it currently is
+        for (const ProgramThreadCountContextHelper* ch = td->current_pgm_ctx; ch; ch = ch->getOldContext()) {
+            const QoreProgram* pgm = ch->getOldProgram();
+            if (pgm && pgm->getProgramId() == scope) {
+                return true;
+            }
+        }
+        // 3) call program context fallback; matches qore_find_thread_sandbox_manager_ref()
+        if (td->call_program_context && td->call_program_context->getProgramId() == scope) {
+            return true;
+        }
+    }
+    thread_list.dropCancelRequest(tid, scope);
+    return false;
+}
+
 bool qore_check_cancel(ExceptionSink* xsink, const char* operation) {
-    // check thread-level cancellation first (cheap: one atomic load)
+    // check thread-level cancellation first (cheap: one atomic load); the scope of a pending
+    // request is only evaluated in the rare case that a request is actually pending
     int tid = q_gettid();
-    if (thread_list.isCancelRequested(tid)) {
+    if (thread_list.isCancelRequested(tid) && check_cancel_in_scope(tid)) {
         if (xsink) {
-            QoreStringNode* reason = thread_list.getCancelReason(tid);
+            // hold a reference while formatting; a concurrent cancelThread() call would otherwise
+            // be able to replace and free the string between the read and its use
+            ReferenceHolder<QoreStringNode> reason(thread_list.getCancelReasonRef(tid), nullptr);
             if (reason) {
                 xsink->raiseException("THREAD-CANCELLED",
                     new QoreStringNodeMaker("%s: thread %d cancelled: %s", operation, tid, reason->c_str()));
@@ -4029,7 +4103,7 @@ bool qore_check_io_interrupt(ExceptionSink* xsink, const char* operation) {
 }
 
 int qore_cancel_thread(int tid, const char* reason) {
-    return thread_list.cancelThread(tid, reason);
+    return thread_list.cancelThread(tid, reason, get_cancel_scope_pgm_id());
 }
 
 void qore_clear_thread_cancel() {
@@ -4037,5 +4111,6 @@ void qore_clear_thread_cancel() {
 }
 
 bool qore_is_thread_cancel_requested() {
-    return thread_list.isCancelRequested(q_gettid());
+    int tid = q_gettid();
+    return thread_list.isCancelRequested(tid) && check_cancel_in_scope(tid);
 }


### PR DESCRIPTION
## Problem

`cancel_thread()` required the target thread to be executing in the caller's `Program` at the instant of the call:

```cpp
// security: only allow cancellation within the same program context
ThreadData* td = entry[tid].thread_data;
if (td && td->current_pgm != getProgram()) {
    return -1;
}
```

Three problems with that rule:

1. **It is not stable.** `current_pgm` tracks the innermost frame and changes on every cross-`Program` call, so the same target thread is cancellable or not depending on where it happens to be at that moment.
2. **A denial is indistinguishable from "no such thread"** — both return `-1` / `False`, and the restriction was not documented.
3. **It denies the one case that is unambiguously legitimate**: cancelling a thread that is running the caller's own request inside a `Program` the caller called into. Meanwhile `SandboxManager::requestInterrupt()`, which stops *every* thread in a program, has no such restriction — so the precise tool was arbitrarily unavailable while the blunt one always worked.

The primary control against untrusted code is unaffected either way: `PO_NO_THREAD_CONTROL` programs cannot call `cancel_thread()` at all.

## Change

A request now carries a **scope**, computed on the requesting thread:

| Requesting context | Scope | Effect |
|---|---|---|
| host (C++) code with no `Program` context | unscoped | applies to any thread |
| an unrestricted `Program` — no `SandboxManager` on it or any enclosing caller `Program` | unscoped | applies to any thread |
| a sandboxed `Program` | that program | applies only to threads executing in it or under a call that originated in it |

An unrestricted `Program` can already terminate the process outright, so scoping its requests protects nothing. A sandboxed `Program` gains nothing it did not already have — it could always cancel threads that had entered it — but still cannot reach threads that never did.

The scope is evaluated **by the target thread** at its next cancellation check point, against its current `Program` and its chain of enclosing caller `Program`s, using the same resolution order as `qore_find_thread_sandbox_manager_ref()`. Evaluating on the target is what makes this safe: the chain is made of stack-allocated `ProgramThreadCountContextHelper` objects in the target's own frames and cannot be walked from another thread.

An out-of-scope request is dropped when observed, so a cancellation check point still costs a single atomic load in the steady state. The drop is conditional on the scope being unchanged, so a request that arrives while the target is evaluating an older one is not lost.

Also in this change: hold a reference to the cancel reason string while formatting the `THREAD-CANCELLED` message, and take the thread-list lock in `clearCancel()` — a concurrent `cancelThread()` call could otherwise replace and free the string between the read and its use.

`cancel_thread()` was added after the `release-2.2.0` tag, so this is a rule for unreleased functionality; it is documented as part of the feature rather than as a behavior change.

## Motivation

A wedged HTTP request handler in Qorus blocks shutdown indefinitely: the handler thread is blocked inside an interface's `Program`, so the shutdown thread could not cancel it, and the only remaining option was to interrupt the whole interface `Program` (killing unrelated in-flight work in it). With this rule, `cancel_thread(tid)` covers that case directly.

## Tests

6 new cases in `examples/test/qore/threads/thread-cancel.qtest`:

- cancelling a thread blocked in a child `Program`
- cancelling a thread blocked in a nested (grandchild) `Program`
- a sandboxed `Program` cancelling a thread that called into it and blocked one `Program` deeper
- a sandboxed `Program` failing to reach a thread that never entered it (request delivered, then dropped)
- an in-scope request still honored after a dropped out-of-scope one
- `thread_cancelled()` ignoring an out-of-scope request

The blockers are released on the failure path so a regression fails the run rather than hanging it.

## Verification

- `thread-cancel.qtest`: 45/45 (75 assertions)
- against the unpatched library the same file fails exactly the 6 new cases and no others
- all `examples/test/qore/threads/` and `examples/test/qore/classes/Program/` tests pass
- full sweep of all 794 qtests: the only failures (DbDataProvider upsert, QoreOcrUtils, an at-exit kill in HttpServerQuicDeadPeer) reproduce identically on the unpatched build — missing DB/OCR environment
- valgrind (`qore -b`): 0 errors, 0 bytes definitely lost, 45/45

## Docs

- `design/cooperative-cancellation.md`: new "Program Scope" section, including the superseded rule and why it was replaced
- `include/qore/qore_thread.h`, `lib/ql_thread.qpp`: scope documented, including that a `True` return means delivered, not necessarily honored
- release notes bullet under the existing cooperative-cancellation entry