### PR TITLE
SqlUtil: add PostgreSQL schema physical size measurement

### DIFF
--- a/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
@@ -412,20 +412,31 @@ class PgsqlTest inherits SqlTestBase {
         ds.exec(sprintf("create table %s.other_payloads as select * from %s.payloads", OtherSchema, SizeSchema));
         ds.commit();
 
+        # independent decomposition of the physical storage rooted in a single namespace
+        code<int(string)> decompose = int sub (string schema) {
+            return ds.selectRow("select "
+                "coalesce((select sum(pg_catalog.pg_table_size(c.oid) + pg_catalog.pg_indexes_size(c.oid)) "
+                "from pg_catalog.pg_class c join pg_catalog.pg_namespace n on n.oid = c.relnamespace "
+                "where n.nspname = %v and c.relkind in ('r', 'm')), 0) "
+                "+ coalesce((select sum(pg_catalog.pg_relation_size(c.oid)) "
+                "from pg_catalog.pg_class c join pg_catalog.pg_namespace n on n.oid = c.relnamespace "
+                "where n.nspname = %v and c.relkind = 'S'), 0) as size_bytes",
+                schema, schema).size_bytes;
+        };
+
         int measured = db.getSchemaPhysicalSize(SizeSchema);
-        int expected = ds.selectRow("select "
-            "coalesce((select sum(pg_catalog.pg_table_size(c.oid) + pg_catalog.pg_indexes_size(c.oid)) "
-            "from pg_catalog.pg_class c join pg_catalog.pg_namespace n on n.oid = c.relnamespace "
-            "where n.nspname = %v and c.relkind in ('r', 'm')), 0) "
-            "+ coalesce((select sum(pg_catalog.pg_relation_size(c.oid)) "
-            "from pg_catalog.pg_class c join pg_catalog.pg_namespace n on n.oid = c.relnamespace "
-            "where n.nspname = %v and c.relkind = 'S'), 0) as size_bytes",
-            SizeSchema, SizeSchema).size_bytes;
-        assertEq(expected, measured,
+        assertEq(decompose(SizeSchema), measured,
             "schema size equals independent table/index/TOAST/sequence decomposition");
         assertGt(0, measured, "populated schema reports allocated bytes");
         assertEq(0, db.getSchemaPhysicalSize(EmptySchema), "empty schema reports zero bytes");
-        assertGt(db.getSchemaPhysicalSize(OtherSchema), measured,
+
+        # Isolation: the other schema holds a copy of the payload data, so a measurement that ignored the
+        # requested namespace would return more than this schema's own decomposition.  Each schema must
+        # report exactly its own storage; ordering between the two totals is deliberately not asserted, as
+        # it is not required to prove isolation.
+        int other_measured = db.getSchemaPhysicalSize(OtherSchema);
+        assertGt(0, other_measured, "cross-schema fixture data has physical storage of its own");
+        assertEq(decompose(OtherSchema), other_measured,
             "measurement is isolated to the requested schema");
 
         hash<auto> storage = ds.selectRow("select "

--- a/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
@@ -352,6 +352,7 @@ class PgsqlTest inherits SqlTestBase {
             addTestCase("partition child not listed as table", \partitionChildExclusionTest());
             addTestCase("PK not backed by non-unique index", \pkNonUniqueIndexTest());
             addTestCase("drop PK constraint without backing index", \dropPkConstraintNoBackingIndexTest());
+            addTestCase("schema physical size", \schemaPhysicalSizeTest());
         }
 
         set_return_value(main());
@@ -361,6 +362,90 @@ class PgsqlTest inherits SqlTestBase {
         on_error printf("alignment: %y\n", map {AbstractDatabase::ActionMap{$1.key}: $1.value},
             schema_info.change_map.pairIterator());
         assertTrue(schema_info.created);
+    }
+
+    #! Schema physical measurement counts every PostgreSQL storage family once
+    private schemaPhysicalSizeTest() {
+        AbstractDatasource ds = getDatasource();
+        Database db(ds);
+        const string SizeSchema = "sqlutil_schema_size_test";
+        const string OtherSchema = "sqlutil_schema_size_other";
+        const string EmptySchema = "sqlutil_schema_size_empty";
+
+        code cleanup = sub () {
+            on_error ds.rollback();
+            ds.exec(sprintf("drop schema if exists %s cascade", SizeSchema));
+            ds.exec(sprintf("drop schema if exists %s cascade", OtherSchema));
+            ds.exec(sprintf("drop schema if exists %s cascade", EmptySchema));
+            ds.commit();
+        };
+        cleanup();
+        on_exit cleanup();
+
+        on_error ds.rollback();
+        ds.exec(sprintf("create schema %s", SizeSchema));
+        ds.exec(sprintf("create schema %s", OtherSchema));
+        ds.exec(sprintf("create schema %s", EmptySchema));
+        ds.exec(sprintf("create table %s.payloads (id bigint primary key, tag text not null, payload text)",
+            SizeSchema));
+        ds.exec(sprintf("create index payloads_tag_idx on %s.payloads (tag)", SizeSchema));
+        # The correlated digest stream is deliberately incompressible enough to force external TOAST storage.
+        ds.exec(sprintf("insert into %s.payloads "
+            "select g, 'tag-' || mod(g, 17), (select string_agg(md5((g * 1000 + x)::text), '') "
+            "from generate_series(1, 400) x) from generate_series(1, 128) g", SizeSchema));
+        ds.exec(sprintf("create table %s.events (id bigint, event_day date, payload text) "
+            "partition by range (event_day)", SizeSchema));
+        ds.exec(sprintf("create table %s.events_2026_01 partition of %s.events "
+            "for values from ('2026-01-01') to ('2026-02-01')", SizeSchema, SizeSchema));
+        ds.exec(sprintf("create table %s.events_2026_02 partition of %s.events "
+            "for values from ('2026-02-01') to ('2026-03-01')", SizeSchema, SizeSchema));
+        ds.exec(sprintf("create index events_payload_idx on %s.events (payload)", SizeSchema));
+        ds.exec(sprintf("insert into %s.events values "
+            "(1, '2026-01-15', 'one'), (2, '2026-02-15', 'two')", SizeSchema));
+        ds.exec(sprintf("create materialized view %s.tag_counts as "
+            "select tag, count(*) as count from %s.payloads group by tag", SizeSchema, SizeSchema));
+        ds.exec(sprintf("create unique index tag_counts_idx on %s.tag_counts (tag)", SizeSchema));
+        ds.exec(sprintf("create sequence %s.standalone_seq", SizeSchema));
+        ds.exec(sprintf("create view %s.payload_view as select id, tag from %s.payloads", SizeSchema, SizeSchema));
+
+        # Cross-schema data must not leak into the requested namespace total.
+        ds.exec(sprintf("create table %s.other_payloads as select * from %s.payloads", OtherSchema, SizeSchema));
+        ds.commit();
+
+        int measured = db.getSchemaPhysicalSize(SizeSchema);
+        int expected = ds.selectRow("select "
+            "coalesce((select sum(pg_catalog.pg_table_size(c.oid) + pg_catalog.pg_indexes_size(c.oid)) "
+            "from pg_catalog.pg_class c join pg_catalog.pg_namespace n on n.oid = c.relnamespace "
+            "where n.nspname = %v and c.relkind in ('r', 'm')), 0) "
+            "+ coalesce((select sum(pg_catalog.pg_relation_size(c.oid)) "
+            "from pg_catalog.pg_class c join pg_catalog.pg_namespace n on n.oid = c.relnamespace "
+            "where n.nspname = %v and c.relkind = 'S'), 0) as size_bytes",
+            SizeSchema, SizeSchema).size_bytes;
+        assertEq(expected, measured,
+            "schema size equals independent table/index/TOAST/sequence decomposition");
+        assertGt(0, measured, "populated schema reports allocated bytes");
+        assertEq(0, db.getSchemaPhysicalSize(EmptySchema), "empty schema reports zero bytes");
+        assertGt(db.getSchemaPhysicalSize(OtherSchema), measured,
+            "measurement is isolated to the requested schema");
+
+        hash<auto> storage = ds.selectRow("select "
+            "pg_catalog.pg_total_relation_size(%v::regclass) as table_bytes, "
+            "pg_catalog.pg_indexes_size(%v::regclass) as index_bytes, "
+            "pg_catalog.pg_total_relation_size(c.reltoastrelid) as toast_bytes "
+            "from pg_catalog.pg_class c where c.oid = %v::regclass",
+            SizeSchema + ".payloads", SizeSchema + ".payloads", SizeSchema + ".payloads");
+        assertGt(0, storage.index_bytes, "secondary and primary indexes have physical storage");
+        assertGt(0, storage.toast_bytes, "fixture has physical TOAST storage");
+        assertGt(storage.index_bytes + storage.toast_bytes, storage.table_bytes,
+            "table total includes index and TOAST storage without adding either twice");
+
+        assertThrows("SCHEMA-NOT-FOUND", "PostgreSQL schema \"sqlutil_schema_size_missing\" does not exist",
+            sub () {
+                db.getSchemaPhysicalSize("sqlutil_schema_size_missing");
+            });
+        assertThrows("SCHEMA-NOT-FOUND", "the schema name cannot be empty", sub () {
+            db.getSchemaPhysicalSize("");
+        });
     }
 
     #! a primary key must only be backed by a unique index

--- a/qlib/PgsqlSqlUtilBase.qm
+++ b/qlib/PgsqlSqlUtilBase.qm
@@ -1784,6 +1784,26 @@ public class PgsqlDatabase inherits SqlUtil::AbstractDatabase {
         return ds.selectRow("select pg_database_size(%v) as val", dbname).val ?? GET_PHYSICAL_DB_SIZE_NOVAL;
     }
 
+    #! @ref SqlUtil::AbstractDatabase.getSchemaPhysicalSize()
+    private int getSchemaPhysicalSizeImpl(string schema) {
+        # Enumerate only storage roots in the requested namespace.  pg_total_relation_size() already includes
+        # every table/materialized-view index and its TOAST relation and index.  Enumerating relkind 'i', 'I',
+        # or the pg_toast namespace separately would therefore double count storage.  Partitioned roots have no
+        # storage; each physical leaf is relkind 'r' and is counted independently.
+        *hash<auto> row = ds.selectRow("select coalesce(sum(case "
+            "when c.relkind in ('r', 'm') then pg_catalog.pg_total_relation_size(c.oid) "
+            "when c.relkind = 'S' then pg_catalog.pg_relation_size(c.oid) "
+            "else 0 end), 0)::bigint as size_bytes "
+            "from pg_catalog.pg_namespace n "
+            "left join pg_catalog.pg_class c on c.relnamespace = n.oid "
+            "and c.relkind in ('r', 'm', 'S') "
+            "where n.nspname = %v group by n.oid", schema);
+        if (!row) {
+            throw "SCHEMA-NOT-FOUND", sprintf("PostgreSQL schema %y does not exist", schema);
+        }
+        return row.size_bytes;
+    }
+
     #! tries to execute a command so that if an error occurs the current transaction status is not lost
     private auto tryExecArgsImpl(string sql, *softlist<auto> args) {
         return PgsqlDatabase::tryExecArgs(ds, sql, args);

--- a/qlib/SqlUtil/AbstractDatabase.qc
+++ b/qlib/SqlUtil/AbstractDatabase.qc
@@ -1457,6 +1457,38 @@ string sql = t.getSqlFromList(list);
         return getPhysicalSizeImpl();
     }
 
+    #! Get the physical size of a database schema in bytes.
+    /** The result includes physical table, partition, materialized-view, index,
+        TOAST/overflow, and sequence storage according to the driver-specific
+        implementation. Logical objects without physical storage, such as
+        ordinary views, are not included.
+
+        @param schema the database schema to measure
+
+        @return the schema size in bytes, or \c -1 when the driver does not
+            implement schema-level physical measurement
+
+        @throw SCHEMA-NOT-FOUND if @p schema does not exist
+
+        @note Each physical object is counted once. In particular, driver
+            implementations must not add index or overflow storage separately
+            when it is already included in a table total.
+
+        @par Example
+        @code
+        Database db(datasource);
+        int tenant_bytes = db.getSchemaPhysicalSize("tenant_42");
+        @endcode
+
+        @since %SqlUtil 3.2.0
+    */
+    int getSchemaPhysicalSize(string schema) {
+        if (!schema) {
+            throw "SCHEMA-NOT-FOUND", "the schema name cannot be empty";
+        }
+        return getSchemaPhysicalSizeImpl(schema);
+    }
+
     #! Returns @ref True if the driver requires a scale to support decimal values in numeric or decimal columns
     /** @return @ref True if the driver requires a scale to support decimal values in numeric or decimal columns
 
@@ -1652,6 +1684,17 @@ string sql = t.getSqlFromList(list);
     #! tries to execute a command so that if an error occurs the current transaction status is not lost
     private auto tryExecRawImpl(string sql) {
         return ds.execRaw(sql);
+    }
+
+    #! returns the physical size of the given schema; reimplement in drivers with equivalent catalog metadata
+    /** the default implementation returns \c -1
+
+        @param schema the database schema to measure
+
+        @since %SqlUtil 3.2.0
+    */
+    private int getSchemaPhysicalSizeImpl(string schema) {
+        return GET_PHYSICAL_DB_SIZE_NOVAL;
     }
 
     private abstract string getCreateSqlImpl(list l);

--- a/qlib/SqlUtil/AbstractDatabase.qc
+++ b/qlib/SqlUtil/AbstractDatabase.qc
@@ -1468,7 +1468,10 @@ string sql = t.getSqlFromList(list);
         @return the schema size in bytes, or \c -1 when the driver does not
             implement schema-level physical measurement
 
-        @throw SCHEMA-NOT-FOUND if @p schema does not exist
+        @throw SCHEMA-NOT-FOUND @p schema is empty, or, when the driver implements
+            schema-level physical measurement, @p schema does not exist; drivers
+            without an implementation return \c -1 without checking whether the
+            schema exists
 
         @note Each physical object is counted once. In particular, driver
             implementations must not add index or overflow storage separately

--- a/qlib/SqlUtil/SqlUtil.qm
+++ b/qlib/SqlUtil/SqlUtil.qm
@@ -121,6 +121,11 @@ module SqlUtil {
     - added @ref SqlUtil::RestartableTransaction "RestartableTransaction" for
       bounded, driver-independent recovery of complete idempotent transaction
       bodies after database failover and datasource-pool timeout errors
+    - added @ref SqlUtil::AbstractDatabase::getSchemaPhysicalSize()
+      "AbstractDatabase::getSchemaPhysicalSize()" for portable schema-level
+      physical storage measurement; PostgreSQL includes tables, partitions,
+      materialized views, indexes, TOAST storage, and sequences without
+      double counting
     - fixed @ref SqlUtil::AbstractColumn::equal() "AbstractColumn::equal()" to compare the column scale; a change
       to the scale alone (for example \c numeric(15,0) to \c numeric(15,2)) compared equal, so table alignment
       silently ignored the schema upgrade


### PR DESCRIPTION
## Summary
- add portable `AbstractDatabase::getSchemaPhysicalSize()` API with an unsupported-driver fallback
- implement PostgreSQL measurement for ordinary and partition tables, materialized views, indexes, TOAST, and sequences without double counting
- cover relation families, schema isolation, empty schemas, and error handling

This is the policy-neutral physical-schema measurement slice for qoretechnologies/qorus#377. qorus-api remains responsible for deduplicating registered components by physical `(database, schema_name)` before producing allocation totals.

## Validation
- `cmake --build build -j25`
- `qore examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest --verbose` (56/56 cases; 1,014 assertions, 1 expected skip)