### PR TITLE
feat(SqlUtil): add portable deferrable foreign keys

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -1864,6 +1864,9 @@ foreach string module_name in (registry.getProcessModules()) {
         pending-state introspection and deterministic \c FINALIZE recovery without retries or polling
       - added a generic named-partition select qualifier for primary and joined Oracle/MySQL table references,
         with explicit capability checks and unsupported errors for non-equivalent backend mechanisms
+      - added portable deferrable foreign-key options, capability discovery, schema-description round-trip, and
+        alignment support for PostgreSQL and Oracle
+        (<a href="https://github.com/qoretechnologies/qore/issues/5373">issue 5373</a>)
       - added targeted canonical-name partition metadata lookup for PostgreSQL, Oracle, MySQL/MariaDB, and SQL
         Server without loading complete high-cardinality partition catalogs
       - added portable list partitions on PostgreSQL, Oracle, and MySQL/MariaDB, explicit modulus/remainder hash

--- a/examples/test/qlib/SqlUtil/SqlUtilTestBase.qm
+++ b/examples/test/qlib/SqlUtil/SqlUtilTestBase.qm
@@ -122,6 +122,7 @@ public class SqlTestBase inherits QUnit::Test {
         addTestCase("Delete", \deleteTest());
         addTestCase("result set placeholder", \resultSetPlaceholderTest());
         addTestCase("Serialization", \serializationTest());
+        addTestCase("deferrable foreign constraints", \deferrableForeignConstraintsTest());
         addTestCase("implicit composite foreign key join", \implicitCompositeForeignKeyJoinTest());
         addTestCase("Temp Tables", \tempTableTest());
         addTestCase("wrong schema", \test2358SqlutilSchema());
@@ -150,6 +151,172 @@ public class SqlTestBase inherits QUnit::Test {
         # test that the table object works
         string sql = t.getSelectSql(("columns": "id", "limit": 1));
         assertEq(Type::String, sql.type());
+    }
+
+    deferrableForeignConstraintsTest() {
+        if (!table) {
+            testSkip("no DB connection");
+        }
+
+        AbstractDatasource ds = table.getDatasource();
+        AbstractDatabase db = (new Database(ds)).getDatabase();
+
+        if (!table.supportsDeferrableForeignConstraints()) {
+            AbstractTable probe = db.makeTable("sqlutil_dfk_probe", {
+                "columns": {
+                    "id": c_number(14, True),
+                    "parent_id": c_number(14),
+                },
+            });
+            assertFalse(probe.supportsDeferrableForeignConstraints(),
+                "driver does not advertise deferrable foreign constraints");
+            assertThrows("FOREIGN-CONSTRAINT-ERROR", "does not support deferrable foreign constraints", sub () {
+                probe.getAddForeignConstraintSql("fk_dfk_probe", "parent_id", "sqlutil_dfk_probe", "id",
+                    {"deferrable": True});
+            });
+            assertThrows("FOREIGN-CONSTRAINT-ERROR", "initially_deferred requires deferrable", sub () {
+                probe.getAddForeignConstraintSql("fk_dfk_probe", "parent_id", "sqlutil_dfk_probe", "id",
+                    {"initially_deferred": True});
+            });
+            assertFalse(probe.getAddForeignConstraintSql("fk_dfk_probe", "parent_id", "sqlutil_dfk_probe", "id",
+                {"deferrable": False}) =~ /deferrable/i,
+                "explicit portable defaults preserve existing SQL");
+            return;
+        }
+
+        assertTrue(table.supportsDeferrableForeignConstraints(),
+            "driver advertises deferrable foreign constraints");
+
+        const string ParentName = "sqlutil_dfk_p";
+        const string ChildName = "sqlutil_dfk_c";
+        const string NonDeferrableName = "fk_dfk_nd";
+        const string ImmediateName = "fk_dfk_imm";
+        const string DeferredName = "fk_dfk_def";
+
+        code<nothing()> cleanup = sub () {
+            ds.rollback();
+            db.dropTableIfExists(ChildName);
+            db.dropTableIfExists(ParentName);
+            ds.commit();
+        };
+        cleanup();
+        on_exit cleanup();
+
+        hash<auto> parent_desc = {
+            "columns": {
+                "tenant_id": c_number(14, True),
+                "entity_id": c_number(14, True),
+            },
+            "primary_key": {
+                "name": "pk_sqlutil_dfk_p",
+                "columns": ("tenant_id", "entity_id"),
+            },
+        };
+        hash<auto> child_desc = {
+            "columns": {
+                "id": c_number(14, True),
+                "nd_tenant": c_number(14),
+                "nd_entity": c_number(14),
+                "imm_tenant": c_number(14),
+                "imm_entity": c_number(14),
+                "def_tenant": c_number(14),
+                "def_entity": c_number(14),
+            },
+            "primary_key": {
+                "name": "pk_sqlutil_dfk_c",
+                "columns": "id",
+            },
+            "foreign_constraints": {
+                (NonDeferrableName): {
+                    "columns": ("nd_tenant", "nd_entity"),
+                    "table": ParentName,
+                    "target_columns": ("tenant_id", "entity_id"),
+                },
+                (ImmediateName): {
+                    "columns": ("imm_tenant", "imm_entity"),
+                    "table": ParentName,
+                    "target_columns": ("tenant_id", "entity_id"),
+                    "deferrable": True,
+                    "initially_deferred": False,
+                },
+                (DeferredName): {
+                    "columns": ("def_tenant", "def_entity"),
+                    "table": ParentName,
+                    "target_columns": ("tenant_id", "entity_id"),
+                    "deferrable": True,
+                    "initially_deferred": True,
+                },
+            },
+        };
+
+        AbstractTable parent = db.makeTable(ParentName, parent_desc);
+        parent.createCommit();
+        AbstractTable child = db.makeTable(ChildName, child_desc);
+
+        ForeignConstraints template_fks = child.getForeignConstraints();
+        assertFalse(template_fks.memberGate(NonDeferrableName).getCreateSql(ChildName) =~ /deferrable/i,
+            "default foreign constraint SQL remains non-deferrable");
+        assertTrue(template_fks.memberGate(ImmediateName).getCreateSql(ChildName)
+            =~ /deferrable initially immediate/i,
+            "initially-immediate SQL is generated");
+        assertTrue(template_fks.memberGate(DeferredName).getCreateSql(ChildName)
+            =~ /deferrable initially deferred/i,
+            "initially-deferred SQL is generated");
+        child.createCommit();
+
+        AbstractTable actual = db.getTable(ChildName);
+        ForeignConstraints actual_fks = actual.getForeignConstraints();
+        assertFalse(actual_fks.memberGate(NonDeferrableName).deferrable,
+            "non-deferrable mode is introspected");
+        assertTrue(actual_fks.memberGate(ImmediateName).deferrable,
+            "deferrable mode is introspected");
+        assertFalse(actual_fks.memberGate(ImmediateName).initially_deferred,
+            "initially-immediate mode is introspected");
+        assertTrue(actual_fks.memberGate(DeferredName).deferrable,
+            "deferred constraint is introspected as deferrable");
+        assertTrue(actual_fks.memberGate(DeferredName).initially_deferred,
+            "initially-deferred mode is introspected");
+
+        hash<auto> reverse_desc = actual.getDescriptionHash();
+        assertFalse(exists reverse_desc.foreign_constraints{NonDeferrableName}.deferrable,
+            "portable defaults are omitted from reverse descriptions");
+        assertEq(True, reverse_desc.foreign_constraints{ImmediateName}.deferrable,
+            "reverse description preserves deferrability");
+        assertEq(False, reverse_desc.foreign_constraints{ImmediateName}.initially_deferred,
+            "reverse description preserves initially-immediate mode");
+        assertEq(True, reverse_desc.foreign_constraints{DeferredName}.initially_deferred,
+            "reverse description preserves initially-deferred mode");
+        assertEq((), actual.getAlignSql(child), "the creation template aligns without drift");
+
+        AbstractTable reverse_template = db.makeTable(ChildName, reverse_desc);
+        assertEq((), actual.getAlignSql(reverse_template),
+            "the reverse-engineered template aligns without drift");
+
+        parent.insert({"tenant_id": 1, "entity_id": 10});
+        child.insert({"id": 1, "def_tenant": 1, "def_entity": 10});
+        ds.commit();
+
+        assertEq(1, parent.update({"tenant_id": 2, "entity_id": 20},
+            {"tenant_id": 1, "entity_id": 10}),
+            "the parent key can move before the deferred child key");
+        assertEq(1, child.update({"def_tenant": 2, "def_entity": 20}, {"id": 1}),
+            "the child key completes the bounded move");
+        ds.commit();
+
+        assertEq(1, parent.update({"tenant_id": 3, "entity_id": 30},
+            {"tenant_id": 2, "entity_id": 20}),
+            "an unresolved deferred move is accepted before commit");
+        *hash<ExceptionInfo> commit_error;
+        try {
+            ds.commit();
+        } catch (hash<ExceptionInfo> ex) {
+            commit_error = ex;
+        }
+        assertTrue(commit_error ? True : False, "an unresolved deferred move fails at commit");
+        if (commit_error) {
+            assertTrue(commit_error.err =~ /^DBI(:[^:]+)?:ERROR$/, commit_error.err);
+        }
+        ds.rollback();
     }
 
     implicitCompositeForeignKeyJoinTest() {

--- a/examples/test/qlib/SqlUtil/Sqlite3SqlUtilExpressions.qtest
+++ b/examples/test/qlib/SqlUtil/Sqlite3SqlUtilExpressions.qtest
@@ -117,6 +117,7 @@ class Sqlite3ExpressionTest inherits QUnit::Test {
         addTestCase("drop table options", \testDropTableOptions());
         addTestCase("stats preferences unsupported", \testStatsPreferencesUnsupported());
         addTestCase("create constraints SQL", \testCreateConstraintsSql());
+        addTestCase("deferrable foreign constraints unsupported", \testDeferrableForeignConstraintsUnsupported());
         addTestCase("temporary tables", \testTempTable());
 
         set_return_value(main());
@@ -402,6 +403,31 @@ class Sqlite3ExpressionTest inherits QUnit::Test {
 
         *list<auto> sql = table.getCreateConstraintsSql();
         assertEq(NOTHING, sql);
+    }
+
+    testDeferrableForeignConstraintsUnsupported() {
+        if (!table) { testSkip("no DB connection"); }
+
+        Sqlite3Table probe(ds, "sqlite3_dfk_probe");
+        probe.setupTable({
+            "columns": {
+                "id": {"qore_type": "integer", "notnull": True},
+                "parent_id": {"qore_type": "integer"},
+            },
+        });
+        assertFalse(probe.supportsDeferrableForeignConstraints(),
+            "SQLite does not advertise ALTER-based deferrable foreign constraints");
+        assertThrows("FOREIGN-CONSTRAINT-ERROR", "does not support deferrable foreign constraints", sub () {
+            probe.getAddForeignConstraintSql("fk_dfk_probe", "parent_id", "sqlite3_dfk_probe", "id",
+                {"deferrable": True});
+        });
+        assertThrows("FOREIGN-CONSTRAINT-ERROR", "initially_deferred requires deferrable", sub () {
+            probe.getAddForeignConstraintSql("fk_dfk_probe", "parent_id", "sqlite3_dfk_probe", "id",
+                {"initially_deferred": True});
+        });
+        assertFalse(probe.getAddForeignConstraintSql("fk_dfk_probe", "parent_id", "sqlite3_dfk_probe", "id",
+            {"deferrable": False}) =~ /deferrable/i,
+            "explicit portable defaults preserve existing SQL");
     }
 
     # --- Pattern matching tests ---

--- a/qlib/OracleSqlUtilBase.qm
+++ b/qlib/OracleSqlUtilBase.qm
@@ -776,13 +776,16 @@ public class OracleForeignConstraint inherits SqlUtil::AbstractForeignConstraint
         bool enabled;
     }
 
-    constructor(string n, Columns c, ForeignConstraintTarget t, bool e) : AbstractForeignConstraint(n, c, t) {
+    constructor(string n, Columns c, ForeignConstraintTarget t, bool e, bool deferrable = False,
+            bool initially_deferred = False)
+            : AbstractForeignConstraint(n, c, t, deferrable, initially_deferred) {
         enabled = e;
     }
 
     string getCreateSql(string table_name, *hash opt) {
-        return sprintf("alter table %s add constraint %s foreign key (%s) references %s (%s)", table_name, name,
-            (foldl $1 + ", " + $2, h.keys()), target.table, (foldl $1 + ", " + $2, target.columns.keys()));
+        return sprintf("alter table %s add constraint %s foreign key (%s) references %s (%s)%s", table_name, name,
+            (foldl $1 + ", " + $2, h.keys()), target.table, (foldl $1 + ", " + $2, target.columns.keys()),
+            getDeferrabilitySql());
     }
 
     softlist getRenameSql(string table_name, string new_name) {
@@ -3977,7 +3980,9 @@ group by p.index_name", schema.upr(), name.upr());
         hash ch;
 
         # get foreign referential constraints
-        *hash qh = ds.select("select constraint_name, status from user_constraints" + (dblink ? "@" + dblink : "") + " where owner = %v and table_name = %v and constraint_type = 'R'", schema.upr(), name.upr());
+        *hash qh = ds.select("select constraint_name, status, deferrable, deferred from user_constraints"
+            + (dblink ? "@" + dblink : "") + " where owner = %v and table_name = %v and constraint_type = 'R'",
+            schema.upr(), name.upr());
         if (qh.status) {
             hash rv;
             foreach hash<auto> row in (qh.contextIterator()) {
@@ -3985,6 +3990,8 @@ group by p.index_name", schema.upr(), name.upr());
                     row.constraint_name = row.constraint_name.lwr();
                 rv.(row.constraint_name) = (
                     "enabled": row.status == "ENABLED",
+                    "deferrable": row.deferrable == "DEFERRABLE",
+                    "initially_deferred": row.deferred == "DEFERRED",
                     );
             }
             qh = ds.select("select c.constraint_name, status, cols1.column_name source_column, cols1.position, cols2.table_name target_table, cols2.column_name target_column from " + systemView("dba_constraints") + (dblink ? "@" + dblink : "") + " c, " + systemView("dba_cons_columns") + (dblink ? "@" + dblink : "") + " cols1, " + systemView("dba_cons_columns") + (dblink ? "@" + dblink : "") + " cols2 where c.owner = %v and c.table_name = %v and c.constraint_name = cols1.constraint_name and constraint_type = 'R' and c.r_constraint_name = cols2.constraint_name and cols1.position = cols2.position and cols1.owner = c.owner and cols2.owner = c.owner order by cols1.position", schema.upr(), name.upr());
@@ -4007,7 +4014,8 @@ group by p.index_name", schema.upr(), name.upr());
                 # get a description of the target table's columns
                 Columns targ_columns = getReferencedTableColumnsUnlocked(c.value.target.table, opts.table_cache);
                 ForeignConstraintTarget fct(c.value.target.table, targ_columns.subset(c.value.target.columns.keys()));
-                ch.(c.key) = new OracleForeignConstraint(c.key, new Columns(c.value.columns), fct, c.value.enabled);
+                ch.(c.key) = new OracleForeignConstraint(c.key, new Columns(c.value.columns), fct, c.value.enabled,
+                    c.value.deferrable, c.value.initially_deferred);
             }
         }
 
@@ -4230,7 +4238,8 @@ group by p.index_name", schema.upr(), name.upr());
 
     private AbstractForeignConstraint addForeignConstraintImpl(string cname, hash ch, string table, hash tch, *hash opt) {
         ForeignConstraintTarget fct(table, new Columns(tch));
-        return new OracleForeignConstraint(cname, new Columns(ch), fct, True);
+        return new OracleForeignConstraint(cname, new Columns(ch), fct, True, opt.deferrable,
+            opt.initially_deferred);
     }
 
     private AbstractCheckConstraint addCheckConstraintImpl(string cname, string src, *hash opt) {
@@ -4444,6 +4453,10 @@ group by p.index_name", schema.upr(), name.upr());
     private bool supportsPartitionsImpl() {
         # Oracle table partitioning is enabled from 12c onwards (per the SqlUtil partition design)
         return getOracleServerMajorVersion() >= 12;
+    }
+
+    private bool supportsDeferrableForeignConstraintsImpl() {
+        return True;
     }
 
     private bool supportsPartitionMethodImpl(string method, bool subpartition) {

--- a/qlib/PgsqlSqlUtilBase.qm
+++ b/qlib/PgsqlSqlUtilBase.qm
@@ -568,7 +568,9 @@ public class PgsqlIndex inherits SqlUtil::AbstractIndex {
 #! represents a PostgreSQL-specific foreign constraint
 public class PgsqlForeignConstraint inherits SqlUtil::AbstractForeignConstraint {
     #! creates the constraint from the supplied arguments
-    constructor(string n, Columns c, ForeignConstraintTarget t) : AbstractForeignConstraint(n, c, t) {
+    constructor(string n, Columns c, ForeignConstraintTarget t, bool deferrable = False,
+            bool initially_deferred = False)
+            : AbstractForeignConstraint(n, c, t, deferrable, initially_deferred) {
     }
 
     #! returns a string that can be used to create the constraint in the database
@@ -591,8 +593,9 @@ public class PgsqlForeignConstraint inherits SqlUtil::AbstractForeignConstraint 
 
     #! returns a string that can be used to create the constraint in the database
     string getCreateSql(string name, string table_name, *hash<auto> opt) {
-        return sprintf("alter table %s add constraint %s foreign key (%s) references %s (%s)", table_name, name,
-            (foldl $1 + ", " + $2, h.keys()), target.table, (foldl $1 + ", " + $2, target.columns.keys()));
+        return sprintf("alter table %s add constraint %s foreign key (%s) references %s (%s)%s", table_name, name,
+            (foldl $1 + ", " + $2, h.keys()), target.table, (foldl $1 + ", " + $2, target.columns.keys()),
+            getDeferrabilitySql());
     }
 }
 
@@ -3736,8 +3739,10 @@ public class PgsqlTable inherits SqlUtil::AbstractTable {
     private ForeignConstraints getForeignConstraintsImpl(*hash<auto> opts) {
         hash<string, PgsqlForeignConstraint> rv;
         # get foreign referential constraints
-        *hash<auto> qh = ds.select("select constraint_name, att2.attname source_column, ns.nspname \"schema\", "
-            "cl.relname target_table, att.attname target_column from (select con1.conname constraint_name, "
+        *hash<auto> qh = ds.select("select constraint_name, condeferrable, condeferred, "
+            "att2.attname source_column, ns.nspname \"schema\", cl.relname target_table, "
+            "att.attname target_column from (select con1.conname constraint_name, con1.condeferrable, "
+            "con1.condeferred, "
             "generate_subscripts(con1.conkey, 1) AS rn, unnest(con1.conkey) parent, unnest(con1.confkey) child, "
             "con1.confrelid, con1.conrelid from pg_class cl join pg_namespace ns on cl.relnamespace = ns.oid "
             "join pg_constraint con1 on con1.conrelid = cl.oid where cl.relname = %v and ns.nspname = %v "
@@ -3761,13 +3766,16 @@ public class PgsqlTable inherits SqlUtil::AbstractTable {
                     ? row.target_table
                     : sprintf("%s.%s", row.schema, row.target_table);
                 c.target.columns.(row.target_column) = True;
+                c.deferrable = row.condeferrable;
+                c.initially_deferred = row.condeferred;
             }
 
             foreach hash<auto> c in (ch.pairIterator()) {
                 # get a description of the target table's columns
                 Columns targ_columns = getReferencedTableColumnsUnlocked(c.value.target.table, opts.table_cache);
                 ForeignConstraintTarget fct(c.value.target.table, targ_columns.subset(c.value.target.columns.keys()));
-                rv{c.key} = new PgsqlForeignConstraint(c.key, new Columns(c.value.columns), fct);
+                rv{c.key} = new PgsqlForeignConstraint(c.key, new Columns(c.value.columns), fct,
+                    c.value.deferrable, c.value.initially_deferred);
             }
         }
         return new ForeignConstraints(rv);
@@ -4042,7 +4050,7 @@ public class PgsqlTable inherits SqlUtil::AbstractTable {
     private AbstractForeignConstraint addForeignConstraintImpl(string cname, hash<auto> ch, string table,
             hash<auto> tch, *hash<auto> opt) {
         ForeignConstraintTarget fct(table, new Columns(tch));
-        return new PgsqlForeignConstraint(cname, new Columns(ch), fct);
+        return new PgsqlForeignConstraint(cname, new Columns(ch), fct, opt.deferrable, opt.initially_deferred);
     }
 
     private AbstractCheckConstraint addCheckConstraintImpl(string cname, string src, *hash opt) {
@@ -4137,6 +4145,10 @@ public class PgsqlTable inherits SqlUtil::AbstractTable {
         # declarative table partitioning was introduced in PostgreSQL 10
         getServerVersion();
         return server_version_major >= 10;
+    }
+
+    private bool supportsDeferrableForeignConstraintsImpl() {
+        return True;
     }
 
     private bool supportsPartitionMethodImpl(string method, bool subpartition) {

--- a/qlib/SqlUtil/AbstractTable.qc
+++ b/qlib/SqlUtil/AbstractTable.qc
@@ -88,9 +88,15 @@ public class AbstractTable inherits AbstractSqlUtilBase {
         /** The following keys can be set for this option:
             - \c table_cache: (@ref SqlUtil::Tables "Tables") an optional table cache for maintaining cached tables
               and foreign key relationships between tables
+            - \c deferrable: (@ref bool_type) if @ref True "True", constraint checks can be deferred until
+              transaction commit; unsupported drivers reject this option
+            - \c initially_deferred: (@ref bool_type) if @ref True "True", constraint checks are deferred by
+              default; requires \c deferrable to be @ref True "True"
         */
         const ForeignConstraintOptions = ConstraintOptions + {
             "table_cache": "Tables",
+            "deferrable": Type::Boolean,
+            "initially_deferred": Type::Boolean,
         };
 
         #! default trigger options
@@ -1488,8 +1494,10 @@ bool b = table.empty();
                 ch.target_columns = ch.columns;
 
             try {
+                hash<auto> fk_opt = opt.(getForeignConstraintOptions().keys())
+                    + (ch - ("columns", "table", "target_columns"));
                 addForeignConstraintUnlocked(cn, ch.columns, ch.table, ch.target_columns,
-                    opt.(getForeignConstraintOptions().keys()));
+                    fk_opt);
             } catch (hash<ExceptionInfo> ex) {
                 rethrow ex.err, sprintf("error setting up %s: %s", getDesc(), ex.desc), ex.arg;
             }
@@ -2600,6 +2608,15 @@ printf("%s;\n", sql);
         getColumnsUnlocked();
         # load constraints if needed, verify unique constraint name, validate/process options
         checkUniqueConstraintNameValidateOptions("FOREIGN-CONSTRAINT-ERROR", cname, getForeignConstraintOptions(), \opt);
+
+        if (opt.initially_deferred && !opt.deferrable) {
+            throw "FOREIGN-CONSTRAINT-ERROR", sprintf("%s: foreign constraint %y: initially_deferred requires "
+                "deferrable", getDesc(), cname);
+        }
+        if (opt.deferrable && !supportsDeferrableForeignConstraintsImpl()) {
+            throw "FOREIGN-CONSTRAINT-ERROR", sprintf("%s: database driver %y does not support deferrable foreign "
+                "constraints", getDesc(), ds.getDriverName());
+        }
 
         if (!cols)
             throw "FOREIGN-CONSTRAINT-ERROR", sprintf("%y: no column names passed to %s::addForeignConstraint()", getDesc(), self.className());
@@ -7414,6 +7431,24 @@ table.clear();
         return supportsPartitionsImpl();
     }
 
+    #! returns @ref True "True" if this table supports deferrable foreign constraints
+    /** @par Example:
+        @code{.py}
+if (table.supportsDeferrableForeignConstraints()) {
+    table.addForeignConstraint("fk_orders_accounts", "account_id", "accounts", "id",
+        {"deferrable": True, "initially_deferred": True});
+}
+        @endcode
+
+        @return @ref True "True" when the driver can create and introspect deferrable foreign constraints,
+            @ref False "False" otherwise
+
+        @since SqlUtil 3.0.0
+    */
+    bool supportsDeferrableForeignConstraints() {
+        return supportsDeferrableForeignConstraintsImpl();
+    }
+
     #! returns @ref True "True" if the driver supports the given portable partition method
     /** @param method \c "range", \c "list", or \c "hash"
         @param subpartition set to @ref True "True" to query support for the method below a parent partition
@@ -8799,6 +8834,10 @@ AbstractTable archived = table.finalizePartitionDetach({"bound_from": 2026-06-01
                     "columns": i.value.keys(),
                     "target_columns": i.value.target.columns.keys(),
                 };
+                if (i.value.deferrable) {
+                    fc.deferrable = True;
+                    fc.initially_deferred = i.value.initially_deferred;
+                }
                 rv.foreign_constraints{i.key} = fc;
             }
         }
@@ -11757,6 +11796,11 @@ on_exit printf("SQL> %s\n", sql);
 
     #! returns @ref True "True" if the database supports table partitioning
     private bool supportsPartitionsImpl() {
+        return False;
+    }
+
+    #! returns @ref True "True" if the database supports deferrable foreign constraints
+    private bool supportsDeferrableForeignConstraintsImpl() {
         return False;
     }
 

--- a/qlib/SqlUtil/SqlUtil.qm
+++ b/qlib/SqlUtil/SqlUtil.qm
@@ -9175,7 +9175,9 @@ uk.addSourceConstraint(table_name, constraint_name);
         *AbstractForeignConstraint findEqual(AbstractForeignConstraint fk) {
             foreach AbstractForeignConstraint fk2 in (h.iterator()) {
                 if (fk2.matchKeys(fk) && fk2.target.table == fk.target.table
-                    && fk2.target.columns.matchKeys(fk.target.columns))
+                    && fk2.target.columns.matchKeys(fk.target.columns)
+                    && fk2.deferrable == fk.deferrable
+                    && fk2.initially_deferred == fk.initially_deferred)
                     return fk2;
             }
         }
@@ -9255,10 +9257,55 @@ AbstractForeignConstraint ix = fcs.fk_jobs_job_defs;
         public {
             #! a ForeignConstraintTarget object to describe the target table and columns
             ForeignConstraintTarget target;
+
+            #! @ref True "True" if constraint checks can be deferred until transaction commit
+            bool deferrable;
+
+            #! @ref True "True" if constraint checks are deferred by default; only valid when \c deferrable is
+            #! @ref True "True"
+            bool initially_deferred;
         }
 
-        constructor(string name, Columns cols, ForeignConstraintTarget t) : AbstractColumnConstraint(name, cols) {
+        #! creates a foreign constraint
+        /** @param name the constraint name
+            @param cols the source columns
+            @param t the target table and columns
+            @param deferrable @ref True "True" if checks can be deferred until transaction commit
+            @param initially_deferred @ref True "True" if checks are deferred by default; requires \a deferrable
+                to be @ref True "True"
+
+            @throw FOREIGN-CONSTRAINT-ERROR \a initially_deferred is @ref True "True" and \a deferrable is
+                @ref False "False"
+        */
+        constructor(string name, Columns cols, ForeignConstraintTarget t, bool deferrable = False,
+                bool initially_deferred = False) : AbstractColumnConstraint(name, cols) {
+            if (initially_deferred && !deferrable) {
+                throw "FOREIGN-CONSTRAINT-ERROR", sprintf("foreign constraint %y: initially_deferred requires "
+                    "deferrable", name);
+            }
             target = t;
+            self.deferrable = deferrable;
+            self.initially_deferred = initially_deferred;
+        }
+
+        #! returns the portable SQL clause representing the constraint's deferrability
+        /** @par Example:
+            @code{.py}
+string sql = constraint.getDeferrabilitySql();
+            @endcode
+
+            @return an empty string for a non-deferrable constraint, or a leading-space SQL clause for a
+            deferrable constraint
+
+            @since SqlUtil 3.0.0
+        */
+        string getDeferrabilitySql() {
+            if (!deferrable) {
+                return "";
+            }
+            return initially_deferred
+                ? " deferrable initially deferred"
+                : " deferrable initially immediate";
         }
 
         #! Returns @ref True "True" if the constraint refers to the given target column
@@ -9307,6 +9354,8 @@ AbstractForeignConstraint ix = fcs.fk_jobs_job_defs;
             AbstractForeignConstraint c = cast<AbstractForeignConstraint>(con);
             return (h.keys() != c.h.keys())
                 || !target.equal(c.target)
+                || deferrable != c.deferrable
+                || initially_deferred != c.initially_deferred
                 ? False : True;
         }
     }


### PR DESCRIPTION
## Summary
- add portable `deferrable` and `initially_deferred` foreign-key options plus capability discovery
- preserve deferrability through PostgreSQL and Oracle SQL generation, catalog introspection, descriptions, equality, reverse engineering, and alignment
- reject non-default requests explicitly on unsupported drivers
- cover composite FK creation, no-drift round trips, bounded key moves, commit-time violations, and unsupported drivers

## Local validation
- all SqlUtil driver qmod targets compile (PostgreSQL, Oracle, MySQL, SQL Server, Firebird, JDBC, SQLite)
- `PgsqlSqlUtil.qtest`: 57/57 cases, 1,035 assertions (1 expected skip)
- `Sqlite3SqlUtilExpressions.qtest`: 30/30 cases, 156 assertions
- Oracle DB-backed test path is included but the configured local Oracle endpoint was unreachable; Oracle qmods compile successfully

Closes #5373