### PR TITLE
Fix PostgreSQL index introspection schema fanout

### DIFF
--- a/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
+++ b/examples/test/qlib/SqlUtil/PgsqlSqlUtil.qtest
@@ -124,6 +124,22 @@ class Bug2963Schema inherits SqlUtilTestSchema {
 class DatasourceProxy inherits AbstractDatasource {
     private {
         AbstractDatasource real_ds;
+
+        *int primary_key_introspection_rows;
+
+        *int index_introspection_rows;
+    }
+
+    private recordIntrospectionRows(string sql, auto result) {
+        if (result.typeCode() != NT_HASH) {
+            return;
+        }
+        int rows = result.index_name ? result.index_name.size() : 0;
+        if (sql =~ /i\.indisprimary/) {
+            primary_key_introspection_rows = rows;
+        } else if (sql =~ /am\.amname access_method/) {
+            index_introspection_rows = rows;
+        }
     }
 
     constructor(AbstractDatasource ds) {
@@ -135,12 +151,20 @@ class DatasourceProxy inherits AbstractDatasource {
     auto exec(string sql, ...) { return call_function_args(\real_ds.vexec(), (sql, argv)); }
     auto vexec(string sql, *softlist<auto> vargs) { return real_ds.vexec(sql, vargs); }
     auto execRaw(string sql) { return real_ds.execRaw(sql); }
-    auto select(string sql, ...) { return call_function_args(\real_ds.vselect(), (sql, argv)); }
+    auto select(string sql, ...) {
+        auto result = call_function_args(\real_ds.vselect(), (sql, argv));
+        recordIntrospectionRows(sql, result);
+        return result;
+    }
     auto selectRow(string sql, ...) { return call_function_args(\real_ds.vselectRow(), (sql, argv)); }
     auto selectRows(string sql, ...) { return call_function_args(\real_ds.vselectRows(), (sql, argv)); }
     auto selectTyped(string sql, ...) { return call_function_args(\real_ds.vselectTyped(), (sql, argv)); }
     auto selectRowsTyped(string sql, ...) { return call_function_args(\real_ds.vselectRowsTyped(), (sql, argv)); }
-    auto vselect(string sql, *softlist<auto> vargs) { return real_ds.vselect(sql, vargs); }
+    auto vselect(string sql, *softlist<auto> vargs) {
+        auto result = real_ds.vselect(sql, vargs);
+        recordIntrospectionRows(sql, result);
+        return result;
+    }
     auto vselectRow(string sql, *softlist<auto> vargs) { return real_ds.vselectRow(sql, vargs); }
     auto vselectRows(string sql, *softlist<auto> vargs) { return real_ds.vselectRows(sql, vargs); }
     auto vselectTyped(string sql, *softlist<auto> vargs) { return real_ds.vselectTyped(sql, vargs); }
@@ -160,6 +184,14 @@ class DatasourceProxy inherits AbstractDatasource {
     hash<auto> getConfigHash() { return real_ds.getConfigHash(); }
     string getConfigString() { return real_ds.getConfigString(); }
     int getCapabilities() { return real_ds.getCapabilities(); }
+
+    *int getPrimaryKeyIntrospectionRows() {
+        return primary_key_introspection_rows;
+    }
+
+    *int getIndexIntrospectionRows() {
+        return index_introspection_rows;
+    }
 }
 
 #! Schema with pgvector columns for testing vector type support
@@ -341,6 +373,7 @@ class PgsqlTest inherits SqlTestBase {
             addTestCase("temporary table resolution", \temporaryTableResolutionTest());
             addTestCase("search_path schema resolution", \searchPathSchemaResolutionTest());
             addTestCase("sequence schema resolution", \sequenceSchemaResolutionTest());
+            addTestCase("index introspection schema isolation", \indexSchemaIsolationTest());
             addTestCase("partition schema coercion and validation", \partitionSchemaCoercionAndValidationTest());
             addTestCase("range partition lifecycle", \rangePartitionLifecycleTest());
             addTestCase("concurrent partition detach", \concurrentPartitionDetachTest());
@@ -817,6 +850,50 @@ class PgsqlTest inherits SqlTestBase {
         # an explicit schema must still reach the other schema's sequence
         assertTrue(exists db.getSequence(other + "." + other_only),
             "an explicitly qualified sequence in another schema is found");
+    }
+
+    #! Index introspection must not join identically named indexes from other schemas
+    /** Per-tenant schemas repeat table, primary-key, and index names. Introspection of one table must
+        consume only that table's catalog rows; joining pg_indexes by index name alone multiplies every
+        target index column by the number of schemas carrying the same name.
+    */
+    private indexSchemaIsolationTest() {
+        if (!table) {
+            testSkip("no DB connection");
+        }
+
+        AbstractDatasource ds = getDatasource();
+        on_exit ds.rollback();
+
+        string mine = ("qore_pgsql_ixm_" + get_random_string()).lwr();
+        string other = ("qore_pgsql_ixo_" + get_random_string()).lwr();
+        string tname = ("qore_pgsql_ixt_" + get_random_string()).lwr();
+        string iname = ("qore_pgsql_ix_" + get_random_string()).lwr();
+        ds.exec(sprintf("create schema %s", mine));
+        ds.exec(sprintf("create schema %s", other));
+        on_exit {
+            ds.exec(sprintf("drop schema if exists %s cascade", mine));
+            ds.exec(sprintf("drop schema if exists %s cascade", other));
+            ds.commit();
+        }
+
+        ds.exec(sprintf("create table %s.%s (id int primary key, a int, b text)", mine, tname));
+        ds.exec(sprintf("create table %s.%s (id int primary key, a int, b text)", other, tname));
+        ds.exec(sprintf("create unique index %s on %s.%s (a, b)", iname, mine, tname));
+        ds.exec(sprintf("create unique index %s on %s.%s (a)", iname, other, tname));
+        ds.commit();
+
+        DatasourceProxy proxy(ds);
+        PgsqlTable target(proxy, mine + "." + tname);
+        Indexes indexes = target.getIndexes();
+
+        assertEq(1, proxy.getPrimaryKeyIntrospectionRows(),
+            "primary-key introspection returns one row for the target key column");
+        assertEq(3, proxy.getIndexIntrospectionRows(),
+            "index introspection returns the target primary-key row plus two target index-column rows");
+        assertTrue(indexes.hasKey(iname), "the target secondary index is described");
+        assertEq(2, indexes.memberGate(iname).columns.size(),
+            "the target secondary index retains its two columns");
     }
 
     private searchPathSchemaResolutionTest() {

--- a/qlib/PgsqlSqlUtilBase.qm
+++ b/qlib/PgsqlSqlUtilBase.qm
@@ -3551,10 +3551,14 @@ public class PgsqlTable inherits SqlUtil::AbstractTable {
         # get primary key description
         *hash<auto> qh = ds.select("select c1.relname index_name, a.attname, "
             "pg_catalog.pg_get_indexdef(a.attrelid, a.attnum, TRUE) AS column_name, "
-            "pg_catalog.format_type(a.atttypid, a.atttypmod), tablespace from pg_class c, pg_index i, "
-            "pg_attribute a, pg_class c1, pg_indexes ix where c.oid = %v::regclass and c.oid = i.indrelid and "
-            "i.indisprimary and i.indexrelid = a.attrelid and c1.oid = i.indexrelid and c1.relname = "
-            "ix.indexname and i.indisvalid and not a.attisdropped order by a.attnum", schema + "." + name);
+            "pg_catalog.format_type(a.atttypid, a.atttypmod), ts.spcname tablespace "
+            "from pg_catalog.pg_class c "
+            "join pg_catalog.pg_index i on (c.oid = i.indrelid) "
+            "join pg_catalog.pg_attribute a on (i.indexrelid = a.attrelid) "
+            "join pg_catalog.pg_class c1 on (c1.oid = i.indexrelid) "
+            "left join pg_catalog.pg_tablespace ts on (ts.oid = c1.reltablespace) "
+            "where c.oid = %v::regclass and i.indisprimary and i.indisvalid and not a.attisdropped "
+            "order by a.attnum", schema + "." + name);
         if (!qh.index_name) {
             return new PgsqlPrimaryKey();
         }
@@ -3577,17 +3581,20 @@ public class PgsqlTable inherits SqlUtil::AbstractTable {
         # recover the non-default opclass and WITH (storage option) clauses so that indexes using
         # pgvector access methods (ivfflat / hnsw) round-trip correctly through align / diff
         *hash<auto> qh = ds.select("SELECT i.relname index_name, d.indisunique, d.indisprimary, "
-            "pg_get_indexdef(i.oid, a.attnum, false) column_name, xs.tablespace, "
-            "am.amname access_method, pg_get_indexdef(i.oid, 0, false) indexdef "
-            "FROM pg_class t, pg_class i, pg_index d, pg_attribute a, pg_indexes xs, pg_am am "
+            "pg_catalog.pg_get_indexdef(i.oid, a.attnum, false) column_name, ts.spcname tablespace, "
+            "am.amname access_method, pg_catalog.pg_get_indexdef(i.oid, 0, false) indexdef "
+            "FROM pg_catalog.pg_class t "
+            "join pg_catalog.pg_index d on (t.oid = d.indrelid) "
+            "join pg_catalog.pg_class i on (d.indexrelid = i.oid) "
+            "join pg_catalog.pg_attribute a on (a.attrelid = i.oid) "
+            "join pg_catalog.pg_am am on (i.relam = am.oid) "
+            "join pg_catalog.pg_namespace n on (n.oid = i.relnamespace) "
+            "left join pg_catalog.pg_tablespace ts on (ts.oid = i.reltablespace) "
             # PostgreSQL uses relkind 'I' for partitioned parent indexes and
             # 'i' for ordinary indexes. Both are logical indexes on the table
             # and must round-trip through the portable SqlUtil API.
-            "WHERE i.relkind in ('i', 'I') and i.relname = xs.indexname AND "
-            "d.indexrelid = i.oid and t.oid = d.indrelid AND i.relam = am.oid AND "
-            "i.relnamespace IN (SELECT oid FROM pg_namespace "
-            "WHERE nspname IN (%v)) AND a.attrelid = i.oid AND t.relname = %v ORDER BY i.relname, attnum", schema,
-            name);
+            "WHERE i.relkind in ('i', 'I') and n.nspname = %v and t.relnamespace = i.relnamespace "
+            "and t.relname = %v ORDER BY i.relname, a.attnum", schema, name);
 
         if (qh.index_name) {
             hash<auto> ih;


### PR DESCRIPTION
## Summary

- join PostgreSQL index catalogs by relation OID instead of index name
- constrain index introspection to the target schema
- preserve tablespace reporting through `pg_tablespace`
- add a repeated-schema regression for primary and secondary indexes

## Validation

- `PgsqlSqlUtil.qtest`: 58/58 cases, 1,039 assertions (one pre-existing skip)
- `BulkPgsqlSqlUtil.qtest`: 7/7 cases, 56 assertions
- `PgsqlSqlUtilExpressions.qtest`: 24/24 cases, 106 assertions
- Qorus build/install and dense-catalog restart: 41.98 seconds
- Qorus `db-stored-options.qtest`: 91/91 cases, 315 assertions

On a Qorus catalog with the same index name in 26 schemas, secondary-index introspection changed from 130 rows / 69.595 ms to 5 rows / 1.270 ms; primary-key introspection changed from 26 rows / 16.832 ms to 1 row / 0.446 ms.

Closes #5375