### PR TITLE
feat: shared ordered watch-processing template with durable cursors (#5377, #5378)

### DIFF
--- a/examples/test/qlib/DataProvider/OrderedWatchDataProvider.qtest
+++ b/examples/test/qlib/DataProvider/OrderedWatchDataProvider.qtest
@@ -1,0 +1,532 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%modern
+
+%prepend-module-path "${SCRIPT_DIR}/../../../../qlib"
+%requires QUnit
+%requires DataProvider
+
+%exec-class OrderedWatchDataProviderTest
+
+#! Records the events raised by a watch provider
+class RecordingObserver inherits DataProvider::Observer {
+    public {
+        list<hash<auto>> events = ();
+    }
+
+    update(string event_id, hash<auto> data_) {
+        push events, data_ + {"event_id": event_id};
+    }
+
+    list<auto> getIds() {
+        return map $1.id, events;
+    }
+}
+
+#! Watch provider driving the shared template with a scripted feed
+class MockOrderedWatchProvider inherits DataProvider::AbstractOrderedWatchDataProvider {
+    public {
+        #! the feed returned by fetchWatchItems(), deliberately newest-first
+        list<hash<auto>> feed = ();
+
+        #! the cursor: the order key of the newest item delivered
+        int cursor = 0;
+
+        #! dispatch fails for this item ID
+        *string fail_on;
+
+        #! the superseded action fails when it covers this item ID
+        *string supersede_fail_on;
+
+        #! payload retrievals performed
+        int payload_calls = 0;
+
+        #! IDs passed to the post-success hook, in order
+        list<string> post_success = ();
+
+        #! superseded ID lists passed to the superseded action, in order
+        list<auto> superseded_calls = ();
+
+        #! errors reported through logPollError()
+        list<string> errors = ();
+
+        #! messages reported through logWatchInfo()
+        list<string> infos = ();
+
+        #! checkpoints persisted, in order
+        list<hash<auto>> checkpoints = ();
+    }
+
+    constructor(*bool snapshot, *string action, *int budget) : AbstractOrderedWatchDataProvider(30) {
+        setWatchPolicy(snapshot ?? False, action, budget);
+    }
+
+    string getSourceOrdering() {
+        return WSO_DESCENDING;
+    }
+
+    #! Runs one cycle and returns its outcome
+    hash<WatchCycleInfo> runCycle() {
+        return runWatchCycle(fetchWatchItems());
+    }
+
+    private list<hash<WatchItemInfo>> fetchWatchItems() {
+        list<hash<WatchItemInfo>> items = ();
+        foreach hash<auto> entry in (feed) {
+            push items, <WatchItemInfo>{
+                "id": entry.id,
+                "order_key": entry.order_key,
+                "group_key": entry.group_key,
+                "data": entry,
+            };
+        }
+        return items;
+    }
+
+    private bool isNewWatchItem(hash<WatchItemInfo> item) {
+        return item.order_key > cursor;
+    }
+
+    private auto fetchWatchItemPayload(hash<WatchItemInfo> item) {
+        ++payload_calls;
+        return item.data;
+    }
+
+    private dispatchWatchItem(hash<WatchItemInfo> item, auto payload, list<hash<WatchItemInfo>> superseded) {
+        if (fail_on == item.id) {
+            throw "MOCK-DISPATCH-ERROR", sprintf("dispatch of item %y failed", item.id);
+        }
+        notifyObservers("MOCK-EVENT", payload + {
+            "superseded_count": superseded.size(),
+            "superseded_ids": map $1.id, superseded,
+        });
+    }
+
+    private advanceWatchCursor(hash<WatchItemInfo> item) {
+        hash<auto> checkpoint = {
+            "version": 1,
+            "cursor": item.order_key,
+            "id": item.id,
+        };
+        persistCheckpoint(checkpoint);
+        push checkpoints, checkpoint;
+        cursor = item.order_key;
+    }
+
+    private afterWatchItemDispatched(hash<WatchItemInfo> item, auto payload) {
+        push post_success, item.id;
+    }
+
+    private applySupersededAction(list<hash<WatchItemInfo>> superseded) {
+        list<auto> ids = map $1.id, superseded;
+        if (supersede_fail_on.val()) {
+            foreach auto id in (ids) {
+                if (id == supersede_fail_on) {
+                    throw "MOCK-SUPERSEDE-ERROR", sprintf("could not remove %y", supersede_fail_on);
+                }
+            }
+        }
+        push superseded_calls, ids;
+    }
+
+    private restoreCheckpoint(hash<auto> checkpoint) {
+        cursor = checkpoint.cursor;
+    }
+
+    private logPollError(hash<ExceptionInfo> ex) {
+        push errors, sprintf("%s: %s", ex.err, ex.desc);
+    }
+
+    private logWatchInfo(string fmt, ...) {
+        push infos, vsprintf(fmt, argv);
+    }
+}
+
+#! Snapshot-mode provider that does not implement a superseded action
+class MockNoSupersededActionProvider inherits DataProvider::AbstractOrderedWatchDataProvider {
+    public {
+        list<hash<auto>> feed = ();
+        list<string> errors = ();
+    }
+
+    constructor() : AbstractOrderedWatchDataProvider(30) {
+        setWatchPolicy(True, WSA_DELETE);
+    }
+
+    hash<WatchCycleInfo> runCycle() {
+        return runWatchCycle(fetchWatchItems());
+    }
+
+    private list<hash<WatchItemInfo>> fetchWatchItems() {
+        return map <WatchItemInfo>{"id": $1.id, "order_key": $1.order_key, "data": $1}, feed;
+    }
+
+    private bool isNewWatchItem(hash<WatchItemInfo> item) {
+        return True;
+    }
+
+    private dispatchWatchItem(hash<WatchItemInfo> item, auto payload, list<hash<WatchItemInfo>> superseded) {
+        notifyObservers("MOCK-EVENT", payload);
+    }
+
+    private advanceWatchCursor(hash<WatchItemInfo> item) {
+    }
+
+    private logPollError(hash<ExceptionInfo> ex) {
+        push errors, sprintf("%s: %s", ex.err, ex.desc);
+    }
+}
+
+#! Timestamp watch provider with a scripted record feed
+class MockTimestampWatchProvider inherits DataProvider::AbstractTimestampWatchDataProvider {
+    public {
+        list<hash<auto>> records = ();
+        list<hash<auto>> fetch_args = ();
+        list<string> infos = ();
+        *string fail_on;
+    }
+
+    constructor(*date start_date) : AbstractTimestampWatchDataProvider(30, start_date) {
+    }
+
+    string getSourceOrdering() {
+        return WSO_DESCENDING;
+    }
+
+    hash<WatchCycleInfo> runCycle() {
+        return runWatchCycle(fetchWatchItems());
+    }
+
+    private list<hash<auto>> fetchRecords(date since) {
+        push fetch_args, {"since": since};
+        return records;
+    }
+
+    private string getEventName() {
+        return "MOCK-RECORD";
+    }
+
+    private dispatchWatchItem(hash<WatchItemInfo> item, auto payload, list<hash<WatchItemInfo>> superseded) {
+        if (fail_on == item.id) {
+            throw "MOCK-DISPATCH-ERROR", sprintf("dispatch of record %y failed", item.id);
+        }
+        AbstractTimestampWatchDataProvider::dispatchWatchItem(item, payload, superseded);
+    }
+
+    private logPollError(hash<ExceptionInfo> ex) {
+    }
+
+    private logWatchInfo(string fmt, ...) {
+        push infos, vsprintf(fmt, argv);
+    }
+}
+
+public class OrderedWatchDataProviderTest inherits QUnit::Test {
+    constructor() : Test("OrderedWatchDataProviderTest", "1.0") {
+        addTestCase("descending input dispatches ascending", \ascendingDispatchTest());
+        addTestCase("items sharing an ordering key dispatch deterministically", \ascendingDispatchTiesTest());
+        addTestCase("a failed dispatch stops the cycle", \failedDispatchStopsCycleTest());
+        addTestCase("a failed checkpoint write does not advance the cursor", \failedCheckpointTest());
+        addTestCase("snapshot mode collapses a backlog", \snapshotCollapseTest());
+        addTestCase("snapshot mode groups by key", \snapshotGroupKeyTest());
+        addTestCase("a superseded action failure does not cost the event", \supersededActionFailureTest());
+        addTestCase("watch policy validation", \watchPolicyValidationTest());
+        addTestCase("the dispatch budget defers from the newest end", \dispatchBudgetTest());
+        addTestCase("ordering declarations", \orderingDeclarationTest());
+        addTestCase("timestamp cursor ordering and checkpoints", \timestampWatchTest());
+        addTestCase("timestamp checkpoint validation", \timestampCheckpointValidationTest());
+
+        set_return_value(main());
+    }
+
+    #! The template must dispatch oldest-first however the upstream API ordered its response
+    ascendingDispatchTest() {
+        MockOrderedWatchProvider provider();
+        RecordingObserver obs();
+        provider.registerObserver(obs);
+        # newest first, as a "latest N" API returns
+        provider.feed = ({"id": "c", "order_key": 30}, {"id": "b", "order_key": 20}, {"id": "a", "order_key": 10});
+
+        hash<WatchCycleInfo> info = provider.runCycle();
+        assertEq(3, info.dispatched, "every new item was dispatched");
+        assertEq(0, info.failed);
+        assertEq(("a", "b", "c"), obs.getIds(), "descending input is dispatched oldest-first");
+        assertEq(("a", "b", "c"), provider.post_success, "the post-success hook runs in dispatch order");
+        assertEq(30, provider.cursor, "the cursor identifies the newest item");
+        assertEq((10, 20, 30), (map $1.cursor, provider.checkpoints),
+            "the cursor is persisted once per item, ascending");
+
+        # items at or before the cursor are discarded on the next cycle
+        assertEq(0, provider.runCycle().dispatched, "already delivered items are not dispatched again");
+        assertEq(3, obs.events.size());
+    }
+
+    #! Items sharing an ordering key must still dispatch deterministically and advance the cursor
+    ascendingDispatchTiesTest() {
+        MockOrderedWatchProvider provider();
+        RecordingObserver obs();
+        provider.registerObserver(obs);
+        provider.feed = ({"id": "z", "order_key": 10}, {"id": "a", "order_key": 10});
+        provider.runCycle();
+        assertEq(("a", "z"), obs.getIds(), "ties break on identity");
+    }
+
+    #! Continuing past a failure would advance a monotonic cursor past an undelivered item
+    failedDispatchStopsCycleTest() {
+        MockOrderedWatchProvider provider();
+        RecordingObserver obs();
+        provider.registerObserver(obs);
+        provider.feed = ({"id": "c", "order_key": 30}, {"id": "b", "order_key": 20}, {"id": "a", "order_key": 10});
+        provider.fail_on = "b";
+
+        hash<WatchCycleInfo> info = provider.runCycle();
+        assertEq(1, info.dispatched, "only the item before the failure was dispatched");
+        assertEq(1, info.failed);
+        assertEq(("a",), obs.getIds());
+        assertEq(10, provider.cursor, "the cursor stops at the last successfully delivered item");
+        assertEq(1, provider.errors.size(), "the failure was reported");
+        assertEq(("a",), provider.post_success, "the post-success hook did not run for the failed item");
+
+        # the failed item and everything after it is retried once the failure clears
+        provider.fail_on = NOTHING;
+        assertEq(2, provider.runCycle().dispatched, "the failed item and its successors are retried");
+        assertEq(("a", "b", "c"), obs.getIds(), "the retry preserves ascending order");
+        assertEq(30, provider.cursor);
+    }
+
+    #! A checkpoint that was not stored must not advance the in-memory cursor
+    failedCheckpointTest() {
+        MockOrderedWatchProvider provider();
+        RecordingObserver obs();
+        provider.registerObserver(obs);
+        provider.setCheckpointPersistence(NOTHING, sub (hash<auto> checkpoint) {
+            throw "TEST-PERSISTENCE-ERROR", "checkpoint was not stored";
+        });
+        provider.feed = ({"id": "a", "order_key": 10}, {"id": "b", "order_key": 20});
+
+        hash<WatchCycleInfo> info = provider.runCycle();
+        assertEq(0, info.dispatched, "a checkpoint that was not stored fails the item");
+        assertEq(1, info.failed);
+        assertEq(0, provider.cursor, "the in-memory cursor did not advance");
+        assertEq(1, obs.events.size(), "the event was raised before the checkpoint failed");
+        assertEq((), provider.post_success, "the post-success hook did not run");
+
+        # the item is retried, so delivery is at-least-once and never at-most-once
+        assertEq(1, provider.runCycle().failed);
+        assertEq(2, obs.events.size(), "the undelivered item is retried");
+    }
+
+    #! A backlog must collapse to the latest item without fetching the payloads it discards
+    snapshotCollapseTest() {
+        MockOrderedWatchProvider provider(True, WSA_TRASH);
+        RecordingObserver obs();
+        provider.registerObserver(obs);
+        provider.feed = (
+            {"id": "c", "order_key": 30},
+            {"id": "a", "order_key": 10},
+            {"id": "b", "order_key": 20},
+        );
+
+        hash<WatchCycleInfo> info = provider.runCycle();
+        assertEq(1, info.dispatched, "only the latest item is dispatched");
+        assertEq(2, info.superseded, "the older items were collapsed away");
+        assertEq(("c",), obs.getIds());
+        assertEq(1, provider.payload_calls, "no payload is fetched for a superseded item");
+        assertEq(30, provider.cursor, "the cursor covers the whole collapsed backlog");
+        assertEq(2, obs.events[0].superseded_count, "the event reports how many items it superseded");
+        assertEq(("a", "b"), obs.events[0].superseded_ids, "the event identifies the superseded items");
+        assertEq((("a", "b"),), provider.superseded_calls, "the superseded action ran once for the group");
+    }
+
+    #! Grouping must retain the latest item per key, not one item overall
+    snapshotGroupKeyTest() {
+        MockOrderedWatchProvider provider(True, WSA_IGNORE);
+        RecordingObserver obs();
+        provider.registerObserver(obs);
+        provider.feed = (
+            {"id": "t1-new", "order_key": 40, "group_key": "t1"},
+            {"id": "t2-old", "order_key": 15, "group_key": "t2"},
+            {"id": "t1-old", "order_key": 10, "group_key": "t1"},
+            {"id": "t2-new", "order_key": 30, "group_key": "t2"},
+        );
+
+        hash<WatchCycleInfo> info = provider.runCycle();
+        assertEq(2, info.dispatched, "one item per group is retained");
+        assertEq(2, info.superseded);
+        assertEq(("t2-new", "t1-new"), obs.getIds(),
+            "retained items are still dispatched ascending across groups");
+        assertEq(40, provider.cursor);
+        # a superseded item of a later group (t1-old at 10) precedes the retained item of an earlier
+        # group (t2-new at 30), and is still covered once the newest retained item commits
+        assertEq(2, obs.events.size());
+        assertEq(("t2-old",), obs.events[0].superseded_ids);
+        assertEq(("t1-old",), obs.events[1].superseded_ids);
+    }
+
+    #! Removing a superseded item is cleanup; failing at it must not cost the delivered event
+    supersededActionFailureTest() {
+        MockOrderedWatchProvider provider(True, WSA_DELETE);
+        RecordingObserver obs();
+        provider.registerObserver(obs);
+        provider.feed = ({"id": "a", "order_key": 10}, {"id": "b", "order_key": 20});
+        provider.supersede_fail_on = "a";
+
+        hash<WatchCycleInfo> info = provider.runCycle();
+        assertEq(1, info.dispatched, "the retained event was delivered");
+        assertEq(0, info.failed, "a cleanup failure is not a delivery failure");
+        assertEq(("b",), obs.getIds());
+        assertEq(20, provider.cursor, "the cursor is durable regardless of the cleanup outcome");
+        assertEq(1, provider.errors.size(), "the cleanup failure was reported rather than swallowed");
+        assertEq(0, provider.runCycle().dispatched, "the item left behind is not re-delivered");
+    }
+
+    #! An unusable removal policy must be rejected when it is configured, not when it fires
+    watchPolicyValidationTest() {
+        assertThrows("WATCH-POLICY-ERROR", "unknown", sub () {
+            MockOrderedWatchProvider p(True, "shred");
+        });
+        assertThrows("WATCH-POLICY-ERROR", "requires snapshot mode", sub () {
+            MockOrderedWatchProvider p(False, WSA_DELETE);
+        });
+        assertThrows("WATCH-POLICY-ERROR", "negative", sub () {
+            MockOrderedWatchProvider p(False, NOTHING, -1);
+        });
+
+        # a provider that does not implement removal must say so instead of quietly keeping the items
+        MockNoSupersededActionProvider silent();
+        RecordingObserver obs();
+        silent.registerObserver(obs);
+        silent.feed = ({"id": "a", "order_key": 10}, {"id": "b", "order_key": 20});
+        hash<WatchCycleInfo> info = silent.runCycle();
+        assertEq(1, info.dispatched);
+        assertEq(1, silent.errors.size(), "the unimplemented removal action was reported");
+        assertTrue(silent.errors[0].find("WATCH-POLICY-ERROR") >= 0);
+    }
+
+    #! A bounded batch must be taken from the oldest end so that the cursor stays contiguous
+    dispatchBudgetTest() {
+        MockOrderedWatchProvider provider(False, NOTHING, 2);
+        RecordingObserver obs();
+        provider.registerObserver(obs);
+        provider.feed = (
+            {"id": "d", "order_key": 40},
+            {"id": "c", "order_key": 30},
+            {"id": "b", "order_key": 20},
+            {"id": "a", "order_key": 10},
+        );
+
+        hash<WatchCycleInfo> info = provider.runCycle();
+        assertEq(2, info.dispatched);
+        assertEq(2, info.deferred, "the remainder is deferred, not dropped");
+        assertEq(("a", "b"), obs.getIds(), "the budget takes the oldest items");
+        assertEq(20, provider.cursor);
+        assertEq(1, provider.infos.size(), "the deferral is logged rather than applied silently");
+
+        assertEq(2, provider.runCycle().dispatched, "the next cycle takes the rest");
+        assertEq(("a", "b", "c", "d"), obs.getIds());
+        assertEq(40, provider.cursor);
+    }
+
+    #! Every watch provider must declare whether its feed is ordered
+    orderingDeclarationTest() {
+        MockOrderedWatchProvider provider();
+        assertEq(WSO_DESCENDING, provider.getSourceOrdering(), "the upstream ordering is declared");
+        assertTrue(provider.hasAscendingDispatch(),
+            "a descending upstream feed is still dispatched ascending by the template");
+        assertEq(WSA_IGNORE, provider.getSupersededAction());
+        assertFalse(provider.hasSnapshotMode());
+        assertEq(0, provider.getMaxItemsPerCycle());
+
+        MockOrderedWatchProvider snap(True, WSA_TRASH, 5);
+        assertTrue(snap.hasSnapshotMode());
+        assertEq(WSA_TRASH, snap.getSupersededAction());
+        assertEq(5, snap.getMaxItemsPerCycle());
+    }
+
+    #! The timestamp cursor must order by record time and survive a restart
+    timestampWatchTest() {
+        date base = 2026-07-29T10:00:00Z;
+        MockTimestampWatchProvider provider(base);
+        RecordingObserver obs();
+        provider.registerObserver(obs);
+        list<hash<auto>> saved = ();
+        provider.setCheckpointPersistence(NOTHING, sub (hash<auto> checkpoint) {
+            push saved, checkpoint;
+        });
+        assertEq(base, provider.getLastCheck(), "the cursor starts at the configured start date");
+
+        # returned newest-first, and one record shares the newest timestamp
+        provider.records = (
+            {"id": "r3", "created_at": base + 20s},
+            {"id": "r4", "created_at": base + 20s},
+            {"id": "r1", "created_at": base + 5s},
+            {"id": "r0", "created_at": base},
+            {"id": "r2", "created_at": (base + 10s).format("YYYY-MM-DDTHH:mm:SSZ")},
+        );
+
+        hash<WatchCycleInfo> info = provider.runCycle();
+        assertEq(5, info.dispatched, "every record from the start date on was delivered");
+        assertEq(("r0", "r1", "r2", "r3", "r4"), obs.getIds(),
+            "records are delivered oldest-first, including one landing exactly on the start date");
+        assertEq(base + 20s, provider.getLastCheck());
+        assertEq(("r3", "r4"), sort(provider.getLastIds()),
+            "both records sharing the newest timestamp are remembered");
+        assertEq(base, provider.fetch_args[0].since, "the fetch is bounded by the cursor");
+
+        assertEq(0, provider.runCycle().dispatched, "nothing is delivered twice");
+
+        # a restart restores the cursor from the last checkpoint written
+        MockTimestampWatchProvider restarted(base);
+        RecordingObserver obs2();
+        restarted.registerObserver(obs2);
+        restarted.setCheckpointPersistence(saved.last(), sub (hash<auto> checkpoint) {});
+        assertEq(base + 20s, restarted.getLastCheck(), "the cursor was restored");
+        assertEq(("r3", "r4"), sort(restarted.getLastIds()));
+        restarted.records = provider.records + {"id": "r5", "created_at": base + 30s};
+        assertEq(1, restarted.runCycle().dispatched, "only the record after the restored cursor is delivered");
+        assertEq(("r5",), obs2.getIds());
+
+        # a record with no usable position is reported rather than delivered out of order
+        MockTimestampWatchProvider unpositioned(base);
+        RecordingObserver obs3();
+        unpositioned.registerObserver(obs3);
+        unpositioned.records = ({"id": "no-ts"}, {"created_at": base + 5s}, {"id": "ok", "created_at": base + 5s});
+        assertEq(1, unpositioned.runCycle().dispatched);
+        assertEq(("ok",), obs3.getIds());
+        assertEq(2, unpositioned.infos.size(), "the skipped records were reported");
+    }
+
+    #! A checkpoint in an unknown shape must be rejected instead of silently ignored
+    timestampCheckpointValidationTest() {
+        date base = 2026-07-29T10:00:00Z;
+        code noop = sub (hash<auto> checkpoint) {};
+
+        assertThrows("WATCH-CHECKPOINT-ERROR", "version 1", sub () {
+            MockTimestampWatchProvider p(base);
+            p.setCheckpointPersistence({"version": 2, "last_check": base, "last_ids": ()}, noop);
+        });
+        assertThrows("WATCH-CHECKPOINT-ERROR", "absolute", sub () {
+            MockTimestampWatchProvider p(base);
+            p.setCheckpointPersistence({"version": 1, "last_check": 5s, "last_ids": ()}, noop);
+        });
+        assertThrows("WATCH-CHECKPOINT-ERROR", "non-empty", sub () {
+            MockTimestampWatchProvider p(base);
+            p.setCheckpointPersistence({"version": 1, "last_check": base, "last_ids": ("",)}, noop);
+        });
+        assertThrows("WATCH-CHECKPOINT-ERROR", "absolute", sub () {
+            MockTimestampWatchProvider p(5s);
+        });
+
+        # the cursor may not move backwards
+        MockTimestampWatchProvider p(base);
+        p.setCheckpointPersistence({"version": 1, "last_check": base + 10s, "last_ids": ()}, noop);
+        assertEq(base + 10s, p.getLastCheck());
+
+        # a provider that has not been given a checkpoint format must reject one
+        MockNoSupersededActionProvider plain();
+        assertThrows("WATCH-CHECKPOINT-ERROR", "does not support checkpoints", sub () {
+            plain.setCheckpointPersistence({"anything": 1}, noop);
+        });
+    }
+}

--- a/examples/test/qlib/DataProvider/WatchProviderOrderingAudit.qtest
+++ b/examples/test/qlib/DataProvider/WatchProviderOrderingAudit.qtest
@@ -1,0 +1,175 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%modern
+
+%prepend-module-path "${SCRIPT_DIR}/../../../../qlib"
+%requires QUnit
+%requires reflection
+%requires DataProvider
+%requires AftershipDataProvider
+%requires ApolloDataProvider
+%requires BaseLinkerDataProvider
+%requires BigCommerceDataProvider
+%requires BitlyDataProvider
+%requires Cin7CoreDataProvider
+%requires CircleDataProvider
+%requires ClickFunnelsDataProvider
+%requires CloseDataProvider
+%requires ConstantContactDataProvider
+%requires DeelDataProvider
+%requires EmpathicBuildingDataProvider
+%requires FreshBooksDataProvider
+%requires FreshsalesDataProvider
+%requires GmailDataProvider
+%requires GoHighLevelDataProvider
+%requires GorgiasDataProvider
+%requires ImapClientDataProvider
+%requires InsightlyDataProvider
+%requires KatanaDataProvider
+%requires KeapDataProvider
+%requires KitDataProvider
+%requires OneDriveDataProvider
+%requires SendCloudDataProvider
+%requires ShippoDataProvider
+%requires SmartSheetDataProvider
+%requires SquareDataProvider
+%requires SquarespaceDataProvider
+%requires SystemeIoDataProvider
+%requires TableauDataProvider
+%requires TallyDataProvider
+%requires UnbounceDataProvider
+%requires UnleashedDataProvider
+%requires ZohoBooksDataProvider
+%requires ZohoInventoryDataProvider
+%requires ZohoInvoiceDataProvider
+
+%exec-class WatchProviderOrderingAuditTest
+
+#! Verifies the ordering and durability contract across every watch data provider in the library
+/** A watch provider that quietly inherits the "ordering unknown" default gives a consumer no way to
+    tell an ordered feed from an unordered one, which is exactly the ambiguity the contract exists to
+    remove. This test walks every loaded watch provider class and fails on any that has not made a
+    declaration, so a new provider cannot be added without classifying its feed.
+*/
+public class WatchProviderOrderingAuditTest inherits QUnit::Test {
+    private {
+        #! The base every watch provider derives from
+        const WatchBase = "DataProvider::AbstractWatchDataProviderBase";
+
+        #! The abstract bases that deliberately leave the declaration to their subclasses
+        const DeclarationExempt = {
+            "DataProvider::AbstractOrderedWatchDataProvider": True,
+            "DataProvider::AbstractTimestampWatchDataProvider": True,
+        };
+
+        #! The valid ordering classifications
+        const ValidOrderings = {
+            WSO_ASCENDING: True,
+            WSO_DESCENDING: True,
+            WSO_UNORDERED: True,
+            WSO_UNKNOWN: True,
+        };
+    }
+
+    constructor() : Test("WatchProviderOrderingAuditTest", "1.0") {
+        addTestCase("every watch provider declares its feed ordering", \orderingDeclaredTest());
+        addTestCase("no concrete watch provider is left abstract", \concreteProvidersTest());
+        addTestCase("the ordering classifications are exhaustive", \orderingValuesTest());
+
+        set_return_value(main());
+    }
+
+    #! Returns every loaded class deriving from the watch provider base
+    private list<Class> getWatchClasses() {
+        list<Class> all = ();
+        code walk = sub (Namespace ns) {
+            all += ns.getClasses();
+            map walk($1), ns.getNamespaces();
+        };
+        walk(Namespace::forName("::"));
+
+        list<Class> watch = ();
+        foreach Class c in (all) {
+            if (c.getPathName() == WatchBase) {
+                continue;
+            }
+            foreach auto parent in (c.getClassHierarchy().iterator()) {
+                if (parent.getPathName() == WatchBase) {
+                    push watch, c;
+                    break;
+                }
+            }
+        }
+        return watch;
+    }
+
+    #! Returns @ref True if some class other than the base declares getSourceOrdering()
+    private bool declaresOrdering(Class c) {
+        foreach auto parent in (c.getClassHierarchy().iterator()) {
+            if (parent.getPathName() == WatchBase) {
+                continue;
+            }
+            try {
+                parent.getNormalMethod("getSourceOrdering");
+                return True;
+            } catch (hash<ExceptionInfo> ex) {
+                # this class does not declare it; keep looking up the hierarchy
+            }
+        }
+        return False;
+    }
+
+    private bool isAbstract(Class c) {
+        foreach string mod in (c.getModifierList()) {
+            if (mod == "abstract") {
+                return True;
+            }
+        }
+        return False;
+    }
+
+    #! Every watch provider must classify its upstream feed rather than inherit "unknown"
+    orderingDeclaredTest() {
+        list<Class> watch = getWatchClasses();
+        assertGt(200, watch.size(), "the library's watch providers were found");
+
+        list<string> undeclared = ();
+        foreach Class c in (watch) {
+            if (DeclarationExempt{c.getPathName()}) {
+                continue;
+            }
+            if (!declaresOrdering(c)) {
+                push undeclared, c.getPathName();
+            }
+        }
+        assertEq((), undeclared, "every watch provider declares the ordering of its feed");
+    }
+
+    #! A provider left abstract by an incomplete migration cannot be instantiated at all
+    concreteProvidersTest() {
+        list<string> broken = ();
+        foreach Class c in (getWatchClasses()) {
+            string name = c.getPathName();
+            # bases are abstract on purpose; everything else must be instantiable
+            if (name =~ /Base$/ || name =~ /::Abstract/) {
+                continue;
+            }
+            if (isAbstract(c)) {
+                push broken, name;
+            }
+        }
+        assertEq((), broken, "no concrete watch provider has unimplemented abstract methods");
+    }
+
+    #! The declared classifications must be values the contract defines
+    orderingValuesTest() {
+        assertEq(4, ValidOrderings.size(), "the contract defines four classifications");
+        assertTrue(ValidOrderings{WSO_ASCENDING});
+        assertTrue(ValidOrderings{WSO_DESCENDING});
+        assertTrue(ValidOrderings{WSO_UNORDERED});
+        assertTrue(ValidOrderings{WSO_UNKNOWN});
+        # ascending and descending feeds both dispatch ascending; an unordered feed cannot
+        assertNeq(WSO_ASCENDING, WSO_DESCENDING);
+    }
+}

--- a/examples/test/qlib/GmailDataProvider/GmailWatchOrdering.qtest
+++ b/examples/test/qlib/GmailDataProvider/GmailWatchOrdering.qtest
@@ -1,0 +1,460 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%modern
+%allow-injection
+
+%prepend-module-path "${SCRIPT_DIR}/../../../../qlib"
+%requires QUnit
+%requires Logger
+%requires DataProvider
+%requires RestClient
+%requires RestClientIo
+%requires GoogleRestClient
+%requires GoogleDataProvider
+%requires GmailDataProvider
+
+%exec-class GmailWatchOrderingTest
+
+#! Records the events raised by a watch provider
+class RecordingObserver inherits DataProvider::Observer {
+    public {
+        list<hash<auto>> events = ();
+    }
+
+    update(string event_id, hash<auto> data_) {
+        push events, data_;
+    }
+
+    list<auto> getIds() {
+        return map $1.id, events;
+    }
+}
+
+#! A Gmail REST client that answers from a scripted mailbox instead of the network
+class MockGmailRestClient inherits GoogleRestClient::GoogleRestClientIo {
+    public {
+        #! list pages: page token ("" for the first page) -> (message ID, ...)
+        hash<auto> pages = {"": ()};
+
+        #! next page token by page token
+        hash<auto> next_tokens = {};
+
+        #! message ID -> internalDate in milliseconds
+        hash<auto> internal_dates = {};
+
+        #! message ID -> thread ID
+        hash<auto> thread_ids = {};
+
+        #! request paths seen, by method
+        list<string> gets = ();
+        list<string> dels = ();
+        list<string> posts = ();
+
+        #! fail requests for these message IDs
+        hash<string, bool> fail_get = {};
+        hash<string, bool> fail_remove = {};
+    }
+
+    constructor() : GoogleRestClientIo(MockGmailRestClient::getRestOptions()) {
+    }
+
+    #! Returns REST options that do not narrow when the client copies them
+    static hash<auto!> getRestOptions() {
+        hash<auto!> opts = {
+            "api_profile": "gmail",
+            "url": "https://example.com",
+            "oauth2_client_id": "test",
+            "oauth2_client_secret": "test",
+            "oauth2_redirect_url": "https://localhost",
+            "token": "test",
+        };
+        return opts;
+    }
+
+    #! Loads a mailbox where message N has internalDate base + N seconds
+    setMailbox(list<hash<auto>> messages, *int page_size) {
+        pages = {};
+        next_tokens = {};
+        internal_dates = {};
+        thread_ids = {};
+        list<string> ids = map $1.id, messages;
+        map internal_dates{$1.id} = $1.internal_date, messages;
+        map thread_ids{$1.id} = $1.thread_id ?? ("t-" + $1.id), messages;
+
+        int size = page_size ?? ids.size();
+        if (!size) {
+            pages{""} = ();
+            return;
+        }
+        int page = 0;
+        for (int i = 0; i < ids.size(); i += size) {
+            string token = page ? sprintf("page%d", page) : "";
+            int last = min(i + size, ids.size()) - 1;
+            pages{token} = ids[i..last];
+            if (last < ids.size() - 1) {
+                next_tokens{token} = sprintf("page%d", page + 1);
+            }
+            ++page;
+        }
+    }
+
+    hash<RestClient::RestResponseInfo> restGet(string path, *hash<auto> hdr) {
+        push gets, path;
+        if (path =~ /users\/me\/messages\?/) {
+            *string token = (path =~ x/pageToken=([^&]+)/)[0];
+            string key = token ?? "";
+            hash<auto!> body = {
+                "messages": map ("id": $1, "threadId": thread_ids{$1}), pages{key},
+            };
+            if (next_tokens{key}) {
+                body += {"nextPageToken": next_tokens{key}};
+            }
+            return makeResponse(body);
+        }
+        *string id = (path =~ x/messages\/([^\/\?]+)/)[0];
+        if (!id.val()) {
+            throw "MOCK-ERROR", sprintf("unexpected GET %y", path);
+        }
+        if (fail_get{id}) {
+            throw "MOCK-GET-ERROR", sprintf("retrieval of message %y failed", id);
+        }
+        return makeResponse(makeMessage(id));
+    }
+
+    hash<RestClient::RestResponseInfo> restDel(string path, auto body, *hash<auto> hdr) {
+        push dels, path;
+        checkRemoval(path);
+        return makeResponse(NOTHING);
+    }
+
+    hash<RestClient::RestResponseInfo> restPost(string path, auto body, *hash<auto> hdr) {
+        push posts, path;
+        checkRemoval(path);
+        return makeResponse({});
+    }
+
+    private checkRemoval(string path) {
+        *string id = (path =~ x/messages\/([^\/\?]+)/)[0];
+        if (id.val() && fail_remove{id}) {
+            throw "MOCK-REMOVE-ERROR", sprintf("removal of message %y failed", id);
+        }
+    }
+
+    #! Returns a Gmail message with the minimum structure the watch provider needs
+    private hash<auto> makeMessage(string id) {
+        return {
+            "id": id,
+            "threadId": thread_ids{id},
+            "internalDate": string(internal_dates{id}),
+            "labelIds": ("INBOX",),
+            "snippet": sprintf("message %s", id),
+            "payload": {
+                "mimeType": "text/plain",
+                "headers": (
+                    {"name": "Subject", "value": sprintf("subject %s", id)},
+                    {"name": "From", "value": "sender@example.com"},
+                    {"name": "Date", "value": "Wed, 29 Jul 2026 10:00:00 +0000"},
+                    {"name": "Content-Type", "value": "text/plain"},
+                ),
+                "body": {"size": 0},
+            },
+        };
+    }
+
+    private hash<RestClient::RestResponseInfo> makeResponse(auto body) {
+        return <RestClient::RestResponseInfo>{
+            "status_code": 200,
+            "headers": {},
+            "body": body,
+        };
+    }
+}
+
+#! Gmail watch provider exposing its cursor and a single polling cycle
+class TestGmailWatch inherits GmailMessageWatchDataProvider {
+    constructor(GoogleRestClient::GoogleRestClientIo rest, *hash<auto> options)
+            : GmailMessageWatchDataProvider(rest, options) {
+    }
+
+    int getPollEpoch() { return poll_epoch; }
+    list<string> getLastMessageIds() { return keys last_msg; }
+    hash<WatchCycleInfo> runCycle() { return runWatchCycle(fetchWatchItems()); }
+    bool usesOrdering() { return usesOrderingPass(); }
+}
+
+public class GmailWatchOrderingTest inherits QUnit::Test {
+    private {
+        #! 2026-07-29T10:00:00Z in milliseconds
+        const BaseMs = 1785664800000;
+    }
+
+    constructor() : Test("GmailWatchOrderingTest", "1.0") {
+        addTestCase("newest-first listings dispatch oldest-first", \orderingRegressionTest());
+        addTestCase("messages sharing a second are all delivered", \sameSecondTest());
+        addTestCase("pagination walks every page", \paginationTest());
+        addTestCase("a failed retrieval does not advance past the message", \failedMessageTest());
+        addTestCase("snapshot mode collapses to the latest message", \snapshotModeTest());
+        addTestCase("snapshot mode groups by thread", \snapshotThreadTest());
+        addTestCase("snapshot mode trashes superseded messages", \supersededTrashTest());
+        addTestCase("a failed superseded removal does not cost the event", \supersededFailureTest());
+        addTestCase("the per-cycle budget delivers the oldest messages first", \messageBudgetTest());
+        addTestCase("watch option validation", \optionValidationTest());
+
+        set_return_value(main());
+    }
+
+    private MockGmailRestClient getRest() {
+        return new MockGmailRestClient();
+    }
+
+    #! Gmail lists newest-first; the watch must deliver oldest-first and end on the newest message
+    orderingRegressionTest() {
+        MockGmailRestClient rest = getRest();
+        # deliberately newest first, as users.messages.list returns
+        rest.setMailbox((
+            {"id": "m3", "internal_date": BaseMs + 30000},
+            {"id": "m2", "internal_date": BaseMs + 20000},
+            {"id": "m1", "internal_date": BaseMs + 10000},
+        ));
+        TestGmailWatch watch(rest, {"q": "in:inbox"});
+        RecordingObserver obs();
+        watch.registerObserver(obs);
+        list<hash<auto>> saved = ();
+        watch.setCheckpointPersistence(NOTHING, sub (hash<auto> checkpoint) {
+            push saved, checkpoint;
+        });
+
+        hash<WatchCycleInfo> info = watch.runCycle();
+        assertEq(3, info.dispatched);
+        assertEq(("m1", "m2", "m3"), obs.getIds(), "a newest-first listing is delivered oldest-first");
+        assertEq((BaseMs + 10000) / 1000, saved[0].poll_epoch, "the first checkpoint is the oldest message");
+        assertEq((BaseMs + 30000) / 1000, saved.last().poll_epoch,
+            "the final checkpoint identifies the newest message");
+        assertEq(("m3",), saved.last().last_message_ids);
+        assertEq((BaseMs + 30000) / 1000, watch.getPollEpoch());
+
+        assertEq(0, watch.runCycle().dispatched, "nothing is delivered twice");
+        assertEq(3, obs.events.size());
+    }
+
+    #! Messages sharing one second must all be delivered and all be remembered at the cursor
+    sameSecondTest() {
+        MockGmailRestClient rest = getRest();
+        rest.setMailbox((
+            {"id": "b", "internal_date": BaseMs + 10000},
+            {"id": "a", "internal_date": BaseMs + 10000},
+            {"id": "older", "internal_date": BaseMs},
+        ));
+        TestGmailWatch watch(rest, {"q": "in:inbox"});
+        RecordingObserver obs();
+        watch.registerObserver(obs);
+        list<hash<auto>> saved = ();
+        watch.setCheckpointPersistence(NOTHING, sub (hash<auto> checkpoint) {
+            push saved, checkpoint;
+        });
+
+        assertEq(3, watch.runCycle().dispatched);
+        assertEq(("older", "a", "b"), obs.getIds(),
+            "messages sharing a second are delivered together, ordered by ID");
+        assertEq(("a", "b"), sort(watch.getLastMessageIds()),
+            "both messages at the cursor second are remembered");
+        assertEq(("a", "b"), sort(saved.last().last_message_ids), "and both are persisted");
+
+        # the next poll includes the preceding second, so both must be filtered out by ID
+        assertEq(0, watch.runCycle().dispatched, "neither message at the cursor second is re-delivered");
+    }
+
+    #! A backlog spanning several list pages must be delivered in full and in order
+    paginationTest() {
+        MockGmailRestClient rest = getRest();
+        list<hash<auto>> mailbox = ();
+        # newest first across 5 pages of 2
+        for (int i = 10; i > 0; --i) {
+            push mailbox, {"id": sprintf("m%02d", i), "internal_date": BaseMs + i * 1000};
+        }
+        rest.setMailbox(mailbox, 2);
+        TestGmailWatch watch(rest, {"q": "in:inbox"});
+        RecordingObserver obs();
+        watch.registerObserver(obs);
+
+        assertEq(10, watch.runCycle().dispatched, "every page is walked in one cycle");
+        assertEq((map sprintf("m%02d", $1), (1..10)), obs.getIds(),
+            "messages from every page are delivered oldest-first");
+        assertEq(5, (select rest.gets, $1 =~ /users\/me\/messages\?/).size(), "all 5 list pages were fetched");
+        assertEq((BaseMs + 10000) / 1000, watch.getPollEpoch());
+    }
+
+    #! A message that cannot be retrieved must block the cursor, not be skipped over
+    failedMessageTest() {
+        MockGmailRestClient rest = getRest();
+        rest.setMailbox((
+            {"id": "m3", "internal_date": BaseMs + 30000},
+            {"id": "m2", "internal_date": BaseMs + 20000},
+            {"id": "m1", "internal_date": BaseMs + 10000},
+        ));
+        rest.fail_get{"m2"} = True;
+        TestGmailWatch watch(rest, {"q": "in:inbox"});
+        RecordingObserver obs();
+        watch.registerObserver(obs);
+
+        # the cycle cannot deliver anything: the failed message has no position, so delivering the
+        # messages around it could only advance the cursor past a message that was never delivered
+        assertThrows("MOCK-GET-ERROR", sub () {
+            watch.runCycle();
+        });
+        assertEq((), obs.getIds(), "nothing is delivered while the feed has a hole in it");
+        assertEq(0, watch.getPollEpoch(), "the cursor did not move");
+
+        remove rest.fail_get{"m2"};
+        assertEq(3, watch.runCycle().dispatched, "the whole cycle is retried once the failure clears");
+        assertEq(("m1", "m2", "m3"), obs.getIds(), "the retry delivers everything in order");
+        assertEq((BaseMs + 30000) / 1000, watch.getPollEpoch());
+    }
+
+    #! A snapshot feed must raise one event for the newest message and report the rest
+    snapshotModeTest() {
+        MockGmailRestClient rest = getRest();
+        rest.setMailbox((
+            {"id": "m3", "internal_date": BaseMs + 30000},
+            {"id": "m2", "internal_date": BaseMs + 20000},
+            {"id": "m1", "internal_date": BaseMs + 10000},
+        ));
+        TestGmailWatch watch(rest, {"q": "in:inbox", "snapshot_mode": True});
+        RecordingObserver obs();
+        watch.registerObserver(obs);
+
+        hash<WatchCycleInfo> info = watch.runCycle();
+        assertEq(1, info.dispatched, "only the latest message is delivered");
+        assertEq(2, info.superseded);
+        assertEq(("m3",), obs.getIds());
+        assertEq(2, obs.events[0].superseded_count, "the event says how much backlog it stood in for");
+        assertEq(("m1", "m2"), obs.events[0].superseded_ids, "and identifies the collapsed messages");
+        assertEq((BaseMs + 30000) / 1000, watch.getPollEpoch(), "the cursor covers the whole backlog");
+
+        # the collapsed messages were never retrieved in full
+        assertEq(3, (select rest.gets, $1 =~ /format=minimal/).size(),
+            "each candidate costs only a metadata retrieval");
+        assertEq(1, (select rest.gets, $1 =~ /messages\/[^\/\?]+$/).size(),
+            "only the retained message is retrieved in full");
+        assertEq((), rest.dels, "the default superseded action leaves the messages in place");
+        assertEq(0, watch.runCycle().dispatched, "the collapsed messages are not raised again");
+    }
+
+    #! Grouping by thread must retain the newest message of each thread
+    snapshotThreadTest() {
+        MockGmailRestClient rest = getRest();
+        rest.setMailbox((
+            {"id": "a2", "internal_date": BaseMs + 40000, "thread_id": "ta"},
+            {"id": "b2", "internal_date": BaseMs + 30000, "thread_id": "tb"},
+            {"id": "b1", "internal_date": BaseMs + 20000, "thread_id": "tb"},
+            {"id": "a1", "internal_date": BaseMs + 10000, "thread_id": "ta"},
+        ));
+        TestGmailWatch watch(rest, {"q": "in:inbox", "snapshot_mode": True, "snapshot_key": "thread"});
+        RecordingObserver obs();
+        watch.registerObserver(obs);
+
+        hash<WatchCycleInfo> info = watch.runCycle();
+        assertEq(2, info.dispatched, "one event per thread");
+        assertEq(2, info.superseded);
+        assertEq(("b2", "a2"), obs.getIds(), "retained messages are still delivered oldest-first");
+        assertEq(("b1",), obs.events[0].superseded_ids);
+        assertEq(("a1",), obs.events[1].superseded_ids);
+        assertEq((BaseMs + 40000) / 1000, watch.getPollEpoch());
+    }
+
+    #! A configured removal action must actually run against the collapsed messages
+    supersededTrashTest() {
+        MockGmailRestClient rest = getRest();
+        rest.setMailbox((
+            {"id": "m3", "internal_date": BaseMs + 30000},
+            {"id": "m2", "internal_date": BaseMs + 20000},
+            {"id": "m1", "internal_date": BaseMs + 10000},
+        ));
+        TestGmailWatch watch(rest, {"q": "in:inbox", "snapshot_mode": True, "superseded_action": "trash"});
+        RecordingObserver obs();
+        watch.registerObserver(obs);
+
+        assertEq(1, watch.runCycle().dispatched);
+        assertEq(2, rest.posts.size(), "both superseded messages were trashed");
+        assertTrue(rest.posts[0] =~ /messages\/m1\/trash/);
+        assertTrue(rest.posts[1] =~ /messages\/m2\/trash/);
+        assertEq((), rest.dels, "trashing does not delete permanently");
+
+        # "delete" removes permanently instead
+        MockGmailRestClient rest2 = getRest();
+        rest2.setMailbox((
+            {"id": "n2", "internal_date": BaseMs + 20000},
+            {"id": "n1", "internal_date": BaseMs + 10000},
+        ));
+        TestGmailWatch del(rest2, {"q": "in:inbox", "snapshot_mode": True, "superseded_action": "delete"});
+        RecordingObserver obs2();
+        del.registerObserver(obs2);
+        assertEq(1, del.runCycle().dispatched);
+        assertEq(1, rest2.dels.size(), "the superseded message was deleted");
+        assertTrue(rest2.dels[0] =~ /messages\/n1$/);
+    }
+
+    #! Cleanup is not delivery: a removal failure must not undo a delivered event
+    supersededFailureTest() {
+        MockGmailRestClient rest = getRest();
+        rest.setMailbox((
+            {"id": "m3", "internal_date": BaseMs + 30000},
+            {"id": "m2", "internal_date": BaseMs + 20000},
+            {"id": "m1", "internal_date": BaseMs + 10000},
+        ));
+        rest.fail_remove{"m1"} = True;
+        TestGmailWatch watch(rest, {"q": "in:inbox", "snapshot_mode": True, "superseded_action": "delete"});
+        RecordingObserver obs();
+        watch.registerObserver(obs);
+
+        hash<WatchCycleInfo> info = watch.runCycle();
+        assertEq(1, info.dispatched, "the retained event was delivered");
+        assertEq(0, info.failed, "a removal failure is not a delivery failure");
+        assertEq((BaseMs + 30000) / 1000, watch.getPollEpoch(), "the cursor is durable regardless");
+        assertEq(2, rest.dels.size(), "the failure did not stop the other removal");
+        assertEq(0, watch.runCycle().dispatched, "the message left behind is not raised as an event");
+    }
+
+    #! A bounded batch must start at the oldest message so the cursor stays contiguous
+    messageBudgetTest() {
+        MockGmailRestClient rest = getRest();
+        rest.setMailbox((
+            {"id": "m4", "internal_date": BaseMs + 40000},
+            {"id": "m3", "internal_date": BaseMs + 30000},
+            {"id": "m2", "internal_date": BaseMs + 20000},
+            {"id": "m1", "internal_date": BaseMs + 10000},
+        ));
+        TestGmailWatch watch(rest, {"q": "in:inbox", "max_messages_per_cycle": 2});
+        RecordingObserver obs();
+        watch.registerObserver(obs);
+        assertTrue(watch.usesOrdering(), "a bounded batch needs the cheap ordering pass");
+
+        assertEq(2, watch.runCycle().dispatched);
+        assertEq(("m1", "m2"), obs.getIds(), "the oldest messages are delivered first");
+        assertEq((BaseMs + 20000) / 1000, watch.getPollEpoch());
+
+        assertEq(2, watch.runCycle().dispatched, "the deferred messages follow on the next cycle");
+        assertEq(("m1", "m2", "m3", "m4"), obs.getIds());
+        assertEq((BaseMs + 40000) / 1000, watch.getPollEpoch());
+    }
+
+    #! An unusable backlog policy must be rejected when the watch is created
+    optionValidationTest() {
+        MockGmailRestClient rest = getRest();
+        assertThrows("OPTION-VALUE-ERROR", "snapshot_key", sub () {
+            new TestGmailWatch(rest, {"q": "in:inbox", "snapshot_mode": True, "snapshot_key": "sender"});
+        });
+        assertThrows("WATCH-POLICY-ERROR", "requires snapshot mode", sub () {
+            new TestGmailWatch(rest, {"q": "in:inbox", "superseded_action": "delete"});
+        });
+        assertThrows("OPTION-VALUE-ERROR", "superseded_action", sub () {
+            new TestGmailWatch(rest, {"q": "in:inbox", "snapshot_mode": True, "superseded_action": "shred"});
+        });
+
+        TestGmailWatch plain(rest, {"q": "in:inbox"});
+        assertEq(WSO_DESCENDING, plain.getSourceOrdering(), "Gmail lists newest-first");
+        assertTrue(plain.hasAscendingDispatch(), "and the watch reverses that before delivery");
+        assertFalse(plain.usesOrdering(), "a plain watch does not pay for a separate ordering pass");
+    }
+}

--- a/examples/test/qlib/ImapClientDataProvider/ImapClientDataProvider.qtest
+++ b/examples/test/qlib/ImapClientDataProvider/ImapClientDataProvider.qtest
@@ -221,6 +221,40 @@ class MockImapDpServer {
     }
 }
 
+#! Watch provider that fails for one UID only, to prove that a sweep stops rather than skips
+class SelectiveFailWatchDataProvider inherits ImapClientDataProvider::ImapWatchDataProviderBase {
+    public {
+        #! reportMessage() throws for this UID
+        int fail_uid;
+
+        #! the UIDs reported, in order
+        list<int> reported = ();
+    }
+
+    constructor(int fail_uid, *hash<auto> options) : ImapWatchDataProviderBase(options) {
+        self.fail_uid = fail_uid;
+    }
+
+    string getName() {
+        return "selective-fail-watch";
+    }
+
+    private hash<DataProviderInfo> getStaticInfoImpl() {
+        return <DataProviderInfo>{"type": "SelectiveFailWatchDataProvider", "supports_observable": True};
+    }
+
+    private reportMessage(int uid) {
+        if (uid == fail_uid) {
+            throw "TEST-DELIVERY-ERROR", sprintf("simulated delivery failure for UID %d", uid);
+        }
+        push reported, uid;
+    }
+
+    runPoll() { pollOnce(); }
+    int runProcess() { return sweep(); }
+    forceBaseline(int uid) { last_uid = uid; }
+}
+
 #! Watch provider whose reportMessage() always fails, to exercise the failure path
 class FailingWatchDataProvider inherits ImapClientDataProvider::ImapWatchDataProviderBase {
     private {
@@ -253,7 +287,7 @@ class FailingWatchDataProvider inherits ImapClientDataProvider::ImapWatchDataPro
         commitCheckpoint(new_uidvalidity, new_last_uid);
     }
     runPoll() { pollOnce(); }
-    int runProcess() { return processNewMessages(); }
+    int runProcess() { return sweep(); }
 
     #! Calls each log helper with format arguments
     exerciseLogging() {
@@ -302,6 +336,7 @@ public class ImapClientDataProviderTest inherits QUnit::Test {
         addTestCase("event provider contract", \eventProviderTests());
         addTestCase("watch failure and logging semantics", \watchSemanticsTests());
         addTestCase("watch checkpoint semantics", \watchCheckpointTests());
+        addTestCase("a failed sweep stops instead of skipping", \watchOrderingTests());
         set_return_value(main());
     }
 
@@ -674,6 +709,42 @@ public class ImapClientDataProviderTest inherits QUnit::Test {
     }
 
     #! A failed report must not advance the baseline, and log helpers must accept format args
+    #! A monotonic UID cursor must never step over a message whose delivery failed
+    watchOrderingTests() {
+        MockImapDpServer server(binary(TestBody));
+        server.start();
+        on_exit server.wait();
+
+        # the mock mailbox holds UIDs 101 and 102; fail the first one
+        SelectiveFailWatchDataProvider w(101, {
+            "url": server.getUrl(),
+            "username": "u",
+            "password": "p",
+            "mailbox": "INBOX",
+        });
+        on_exit w.getImapClient().disconnect();
+
+        w.runPoll();
+        w.forceBaseline(100);
+        assertEq(0, w.runProcess(), "the sweep reported nothing");
+        assertEq((), w.reported, "no message was delivered");
+        assertEq(100, w.getLastUid(),
+            "the cursor stayed below the failed UID rather than stepping over it");
+
+        # UID 102 must not have been delivered either: delivering it would have advanced the
+        # cursor past UID 101, dropping it permanently on what may be a transient error
+        assertEq(0, w.reported.size(), "the message after the failure was not delivered");
+
+        # once the failure clears, both messages are delivered in ascending UID order
+        w.fail_uid = 0;
+        assertEq(2, w.runProcess(), "both messages are delivered once the failure clears");
+        assertEq((101, 102), w.reported, "delivery is in ascending UID order");
+        assertEq(102, w.getLastUid());
+        assertEq(WSO_ASCENDING, w.getSourceOrdering(), "IMAP UID SEARCH returns ascending UIDs");
+        assertTrue(w.hasAscendingDispatch());
+        assertNothing(server.getServerError(), "no server errors");
+    }
+
     watchSemanticsTests() {
         MockImapDpServer server(binary(TestBody));
         server.start();

--- a/qlib/AftershipDataProvider/AftershipWatchDataProviderBase.qc
+++ b/qlib/AftershipDataProvider/AftershipWatchDataProviderBase.qc
@@ -26,7 +26,7 @@
 public namespace AftershipDataProvider {
 #! Base class for Aftership polling watch providers
 public class AftershipWatchDataProviderBase inherits AftershipDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Watch constructor options
         const WatchConstructorOptions = ConstructorOptions + {
@@ -44,28 +44,20 @@ public class AftershipWatchDataProviderBase inherits AftershipDataProviderBase,
         const MaxSeenIds = 10000;
     }
 
-    private {
-        #! Last check timestamp
-        date last_check;
-
-        #! Set of seen record IDs for deduplication
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object from a RestClientIo client
     constructor(RestClientIo::RestClientIo rest, *hash<auto> options)
             : AftershipDataProviderBase(rest),
-              AbstractWatchDataProviderBase(
-                  max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = now_us();
+              AbstractTimestampWatchDataProvider(
+                  max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Creates the object from constructor options
     constructor(*hash<auto> options)
             : AftershipDataProviderBase(options),
-              AbstractWatchDataProviderBase(
-                  max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = now_us();
+              AbstractTimestampWatchDataProvider(
+                  max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Cancels in-flight REST operations for graceful shutdown
@@ -73,41 +65,27 @@ public class AftershipWatchDataProviderBase inherits AftershipDataProviderBase,
         rest.close();
     }
 
-    #! Polls for new/changed records
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date newest = last_check;
-            foreach hash<auto> record in (records) {
-                string record_id = getRecordId(record);
-                # skip already-seen records
-                if (seen_ids{record_id}) {
-                    continue;
-                }
-                # check timestamp
-                *string ts_str = record{getTimestampField()};
-                if (ts_str.val()) {
-                    date ts = date(ts_str);
-                    if (ts <= last_check) {
-                        continue;
-                    }
-                    if (ts > newest) {
-                        newest = ts;
-                    }
-                }
-                seen_ids{record_id} = True;
-                notifyObservers(getEventName(), record);
-            }
-            if (newest > last_check) {
-                last_check = newest;
-            }
-            # prune seen_ids if too large
-            if (seen_ids.size() > MaxSeenIds) {
-                seen_ids = {};
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            error("Error polling for %s events: %s: %s", getEventName(), ex.err, ex.desc);
-        }
+    #! The upstream ordering is not relied on; records are ordered by timestamp before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
+
+    #! Returns the record's identity using the provider's own accessor
+    private *string getWatchRecordId(hash<auto> record) {
+        return getRecordId(record);
+    }
+
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        error("Error polling for %s events: %s: %s", getEventName(), ex.err, ex.desc);
+    }
+
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        info(vsprintf(fmt, argv));
     }
 
     #! Returns example event data

--- a/qlib/AftershipDataProvider/AftershipWatchDataProviderBase.qc
+++ b/qlib/AftershipDataProvider/AftershipWatchDataProviderBase.qc
@@ -85,7 +85,7 @@ public class AftershipWatchDataProviderBase inherits AftershipDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        info(vsprintf(fmt, argv));
+        info("%s", vsprintf(fmt, argv));
     }
 
     #! Returns example event data

--- a/qlib/ApolloDataProvider/ApolloWatchDataProviderBase.qc
+++ b/qlib/ApolloDataProvider/ApolloWatchDataProviderBase.qc
@@ -89,7 +89,7 @@ public class ApolloWatchDataProviderBase inherits ApolloDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/ApolloDataProvider/ApolloWatchDataProviderBase.qc
+++ b/qlib/ApolloDataProvider/ApolloWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace ApolloDataProvider {
 
 #! Base class for Apollo polling watch data providers
 public class ApolloWatchDataProviderBase inherits ApolloDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -47,19 +47,11 @@ public class ApolloWatchDataProviderBase inherits ApolloDataProviderBase,
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client
     constructor(ApolloRestClient::ApolloRestClient rest, *hash<auto> options)
             : ApolloDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -72,51 +64,32 @@ public class ApolloWatchDataProviderBase inherits ApolloDataProviderBase,
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                # check for shutdown between iterations
-                if (isStopping()) {
-                    break;
-                }
-                string id = getRecordId(record);
+    #! Returns the record's identity using the provider's own accessor
+    private *string getWatchRecordId(hash<auto> record) {
+        return getRecordId(record);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
+    #! Returns the record's position in the feed using the provider's own accessor
+    private *date getWatchRecordTimestamp(hash<auto> record) {
+        return getRecordTimestamp(record);
+    }
 
-                # Check timestamp to avoid old records
-                *date record_time = getRecordTimestamp(record);
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Mark as seen
-                seen_ids{id} = True;
-
-                # Notify observers
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune seen_ids if it gets too large
-            if (seen_ids.size() > MaxSeenIds) {
-                seen_ids = {};
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/BaseLinkerDataProvider/BaseLinkerWatchDataProviderBase.qc
+++ b/qlib/BaseLinkerDataProvider/BaseLinkerWatchDataProviderBase.qc
@@ -59,7 +59,7 @@ public const WatchConstructorOptions = BaseLinkerDataProviderBase::BaseConstruct
     (polling loop, cursor tracking, deduplication) is handled here.
 */
 public class BaseLinkerWatchDataProviderBase inherits BaseLinkerDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractOrderedWatchDataProvider {
     private {
         #! Last journal `log_id` seen; BaseLinker returns entries strictly after this value
         softint last_log_id = 0;
@@ -71,7 +71,7 @@ public class BaseLinkerWatchDataProviderBase inherits BaseLinkerDataProviderBase
     #! Creates the object with an async REST client
     constructor(*RestClientIo::RestClientIo rest, *hash<auto> options)
             : BaseLinkerDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval,
+              AbstractOrderedWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval,
                   MinPollInterval)) {
         since = options.since;
     }
@@ -79,7 +79,7 @@ public class BaseLinkerWatchDataProviderBase inherits BaseLinkerDataProviderBase
     #! Creates the object with a connection
     constructor(BaseLinkerRestClient::BaseLinkerRestConnection conn, *hash<auto> options)
             : BaseLinkerDataProviderBase(conn),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval,
+              AbstractOrderedWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval,
                   MinPollInterval)) {
         since = options.since;
     }
@@ -87,7 +87,7 @@ public class BaseLinkerWatchDataProviderBase inherits BaseLinkerDataProviderBase
     #! Creates the object with options
     constructor(*hash<auto> options)
             : BaseLinkerDataProviderBase(options),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval,
+              AbstractOrderedWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval,
                   MinPollInterval)) {
         since = options.since;
     }
@@ -102,33 +102,85 @@ public class BaseLinkerWatchDataProviderBase inherits BaseLinkerDataProviderBase
         rest.close();
     }
 
-    #! Performs a single polling operation
-    private pollOnce() {
-        try {
-            hash<auto> params = cast<hash>({
-                "logs_types": (getLogType(),),
-            });
-            if (last_log_id > 0) {
-                params.last_log_id = last_log_id;
-            } else if (exists since) {
-                params.date_from = int(get_epoch_seconds(since));
-            }
-            hash<auto> response = callMethod("getJournalList", params);
-            list<auto> logs = response.logs ?? ();
-            foreach hash<auto> entry in (logs) {
-                if (isStopping()) {
-                    break;
-                }
-                softint lid = int(entry.log_id);
-                if (lid > last_log_id) {
-                    last_log_id = lid;
-                }
-                notifyObservers(getEventName(), convertEpochFields(entry));
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "BaseLinker watch %s: poll failed: %s: %s",
-                getEventName(), ex.err, ex.desc);
+    #! The BaseLinker journal is returned in ascending `log_id` order
+    string getSourceOrdering() {
+        return WSO_ASCENDING;
+    }
+
+    #! Returns the highest journal `log_id` delivered so far
+    /** @since BaseLinkerDataProvider 1.0
+    */
+    softint getLastLogId() {
+        return last_log_id;
+    }
+
+    #! Restores the journal cursor
+    private restoreCheckpoint(hash<auto> checkpoint) {
+        if (checkpoint.version.typeCode() != NT_INT || checkpoint.version != 1
+                || checkpoint.last_log_id.typeCode() != NT_INT || checkpoint.last_log_id < 0) {
+            throw "WATCH-CHECKPOINT-ERROR", "invalid BaseLinker watch checkpoint; expecting version 1 and a "
+                "non-negative last_log_id";
         }
+        last_log_id = checkpoint.last_log_id;
+    }
+
+    #! Durably advances the journal cursor
+    private commitCheckpoint(softint log_id) {
+        if (log_id < 0) {
+            throw "WATCH-CHECKPOINT-ERROR", "cannot persist a negative BaseLinker journal log_id";
+        }
+        persistCheckpoint({
+            "version": 1,
+            "last_log_id": int(log_id),
+        });
+        last_log_id = log_id;
+    }
+
+    #! Fetches the journal entries after the current cursor
+    private list<hash<WatchItemInfo>> fetchWatchItems() {
+        hash<auto> params = cast<hash>({
+            "logs_types": (getLogType(),),
+        });
+        if (last_log_id > 0) {
+            params.last_log_id = last_log_id;
+        } else if (exists since) {
+            params.date_from = int(get_epoch_seconds(since));
+        }
+        hash<auto> response = callMethod("getJournalList", params);
+        list<hash<WatchItemInfo>> items = ();
+        foreach hash<auto> entry in (response.logs ?? ()) {
+            push items, <WatchItemInfo>{
+                "id": string(entry.log_id),
+                "order_key": int(entry.log_id),
+                "data": entry,
+            };
+        }
+        return items;
+    }
+
+    #! Returns @ref True if the journal entry lies beyond the cursor
+    private bool isNewWatchItem(hash<WatchItemInfo> item) {
+        return item.order_key > last_log_id;
+    }
+
+    #! Raises the event for one journal entry
+    private dispatchWatchItem(hash<WatchItemInfo> item, auto payload, list<hash<WatchItemInfo>> superseded) {
+        notifyObservers(getEventName(), convertEpochFields(payload));
+    }
+
+    #! Durably advances the cursor to the given journal entry
+    private advanceWatchCursor(hash<WatchItemInfo> item) {
+        commitCheckpoint(item.order_key);
+    }
+
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "BaseLinker watch %s: poll failed: %s: %s", getEventName(), ex.err, ex.desc);
+    }
+
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/BaseLinkerDataProvider/BaseLinkerWatchDataProviderBase.qc
+++ b/qlib/BaseLinkerDataProvider/BaseLinkerWatchDataProviderBase.qc
@@ -180,7 +180,7 @@ public class BaseLinkerWatchDataProviderBase inherits BaseLinkerDataProviderBase
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/BigCommerceDataProvider/BigCommerceWatchDataProviderBase.qc
+++ b/qlib/BigCommerceDataProvider/BigCommerceWatchDataProviderBase.qc
@@ -89,7 +89,7 @@ public class BigCommerceWatchDataProviderBase inherits BigCommerceDataProviderBa
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/BigCommerceDataProvider/BigCommerceWatchDataProviderBase.qc
+++ b/qlib/BigCommerceDataProvider/BigCommerceWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace BigCommerceDataProvider {
 
 #! Base class for BigCommerce polling watch data providers
 public class BigCommerceWatchDataProviderBase inherits BigCommerceDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -47,19 +47,11 @@ public class BigCommerceWatchDataProviderBase inherits BigCommerceDataProviderBa
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client
     constructor(BigCommerceRestClient::BigCommerceRestClient rest, *hash<auto> options)
             : BigCommerceDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -72,52 +64,32 @@ public class BigCommerceWatchDataProviderBase inherits BigCommerceDataProviderBa
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                # check for shutdown between iterations
-                if (isStopping()) {
-                    break;
-                }
-                string id = getRecordId(record);
+    #! Returns the record's identity using the provider's own accessor
+    private *string getWatchRecordId(hash<auto> record) {
+        return getRecordId(record);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
+    #! Returns the record's position in the feed using the provider's own accessor
+    private *date getWatchRecordTimestamp(hash<auto> record) {
+        return getRecordTimestamp(record);
+    }
 
-                # Check timestamp to avoid old records
-                *date record_time = getRecordTimestamp(record);
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Mark as seen
-                seen_ids{id} = True;
-
-                # Notify observers
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune seen_ids if it gets too large
-            if (seen_ids.size() > MaxSeenIds) {
-                seen_ids = {};
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s",
-                getEventName(), ex.err, ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/BitlyDataProvider/BitlyWatchDataProviderBase.qc
+++ b/qlib/BitlyDataProvider/BitlyWatchDataProviderBase.qc
@@ -74,7 +74,7 @@ public class BitlyWatchDataProviderBase inherits BitlyDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/BitlyDataProvider/BitlyWatchDataProviderBase.qc
+++ b/qlib/BitlyDataProvider/BitlyWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace BitlyDataProvider {
 
 #! Base class for Bitly polling watch data providers
 public class BitlyWatchDataProviderBase inherits BitlyDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -41,20 +41,12 @@ public class BitlyWatchDataProviderBase inherits BitlyDataProviderBase,
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client (async)
     constructor(RestClientIo::RestClientIo rest, *hash<auto> options)
             : BitlyDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval,
-                  MinPollInterval)) {
-        last_check = now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval,
+                  MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -67,56 +59,22 @@ public class BitlyWatchDataProviderBase inherits BitlyDataProviderBase,
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                if (isStopping()) {
-                    break;
-                }
-                string id = string(record.id);
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
-
-                # Check timestamp to avoid old records
-                *date record_time;
-                *string ts = record{getTimestampField()};
-                if (ts) {
-                    record_time = date(ts);
-                }
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
-
-                seen_ids{id} = True;
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune oldest half of seen_ids if it gets too large
-            if (seen_ids.size() > 10000) {
-                list<string> all_keys = keys seen_ids;
-                int half = all_keys.size() / 2;
-                foreach string k in (all_keys[0..half-1]) {
-                    delete seen_ids{k};
-                }
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err,
-                ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/Cin7CoreDataProvider/Cin7CoreWatchDataProviderBase.qc
+++ b/qlib/Cin7CoreDataProvider/Cin7CoreWatchDataProviderBase.qc
@@ -90,36 +90,84 @@ public class Cin7CoreWatchDataProviderBase inherits Cin7CoreDataProviderBase,
     }
 
     #! Performs a single polling operation
+    #! The upstream feed carries no reliable per-record ordering key
+    /** Records are deduplicated by ID and the cursor is a wall-clock poll boundary, so no ordering
+        guarantee can be offered; consumers must not assume that events arrive in source order.
+
+        This provider is a documented exemption from the shared ordered template
+        (@ref DataProvider::AbstractOrderedWatchDataProvider) because its API exposes no monotonic
+        per-record position to order or checkpoint against. Its cursor is nonetheless durable.
+    */
+    string getSourceOrdering() {
+        return WSO_UNORDERED;
+    }
+
+    #! Restores the poll-boundary cursor
+    private restoreCheckpoint(hash<auto> checkpoint) {
+        if (checkpoint.version.typeCode() != NT_INT || checkpoint.version != 1
+                || checkpoint.since.typeCode() != NT_DATE || !checkpoint.since.absolute()
+                || checkpoint.seen_ids.typeCode() != NT_LIST) {
+            throw "WATCH-CHECKPOINT-ERROR", "invalid watch checkpoint; expecting version 1, an absolute since "
+                "date/time value, and a seen_ids list";
+        }
+        hash<string, bool> restored = {};
+        foreach auto id in (checkpoint.seen_ids) {
+            if (id.typeCode() != NT_STRING || !id.val()) {
+                throw "WATCH-CHECKPOINT-ERROR", "invalid watch checkpoint; record IDs must be non-empty strings";
+            }
+            restored{id} = True;
+        }
+        since = checkpoint.since;
+        seen_ids = restored;
+    }
+
+    #! Durably advances the poll-boundary cursor
+    /** The IDs delivered are stored with the boundary, because a wall-clock cursor alone cannot tell
+        a record that has already been delivered from one that arrived in the same instant.
+    */
+    private commitCheckpoint(date poll_start, hash<string, bool> delivered) {
+        if (!poll_start.absolute()) {
+            throw "WATCH-CHECKPOINT-ERROR", "cannot persist a relative date/time value as a watch cursor";
+        }
+        persistCheckpoint({
+            "version": 1,
+            "since": poll_start,
+            "seen_ids": keys delivered,
+        });
+        since = poll_start;
+        seen_ids = delivered;
+    }
+
+    #! Polls once, advancing the cursor only after every record has been delivered
+    /** @note The cursor is advanced only once the whole sweep has succeeded. Advancing it after a
+        partial sweep would move the poll boundary past records that were never delivered.
+    */
     private pollOnce() {
         date poll_start = now_us();
         list<hash<auto>> records = pollOnceImpl();
 
+        hash<string, bool> delivered = seen_ids;
         foreach hash<auto> record in (records) {
             if (isStopping()) {
-                break;
+                # the cursor stays where it is, so the remaining records are swept again
+                return;
             }
             string id = getRecordId(record);
-            if (!seen_ids{id}) {
-                seen_ids{id} = True;
+            if (!delivered{id}) {
                 notifyObservers(getEventName(), record);
+                delivered{id} = True;
             }
         }
 
-        # Update since time for next poll
-        since = poll_start;
-
-        # Clean up old seen_ids periodically (keep last 10000)
-        if (seen_ids.size() > 10000) {
-            # Remove oldest half
-            int count = 0;
-            foreach string key in (keys seen_ids) {
-                if (count++ < 5000) {
-                    remove seen_ids{key};
-                } else {
-                    break;
-                }
+        # Clean up old IDs periodically (keep the most recent 5000)
+        if (delivered.size() > 10000) {
+            list<string> all_keys = keys delivered;
+            foreach string key in (all_keys[0..4999]) {
+                remove delivered{key};
             }
         }
+
+        commitCheckpoint(poll_start, delivered);
     }
 
     #! Called when a polling error occurs

--- a/qlib/CircleDataProvider/CircleWatchDataProviderBase.qc
+++ b/qlib/CircleDataProvider/CircleWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace CircleDataProvider {
 
 #! Base class for Circle polling watch data providers
 public class CircleWatchDataProviderBase inherits CircleDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -41,20 +41,12 @@ public class CircleWatchDataProviderBase inherits CircleDataProviderBase,
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client (async)
     constructor(RestClientIo::RestClientIo rest, *hash<auto> options)
             : CircleDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval,
-                  MinPollInterval)) {
-        last_check = now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval,
+                  MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -67,56 +59,22 @@ public class CircleWatchDataProviderBase inherits CircleDataProviderBase,
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                if (isStopping()) {
-                    break;
-                }
-                string id = string(record.id);
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
-
-                # Check timestamp to avoid old records
-                *date record_time;
-                *string ts = record{getTimestampField()};
-                if (ts) {
-                    record_time = date(ts);
-                }
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
-
-                seen_ids{id} = True;
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune oldest half of seen_ids if it gets too large
-            if (seen_ids.size() > 10000) {
-                list<string> all_keys = keys seen_ids;
-                int half = all_keys.size() / 2;
-                foreach string k in (all_keys[0..half-1]) {
-                    delete seen_ids{k};
-                }
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err,
-                ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/CircleDataProvider/CircleWatchDataProviderBase.qc
+++ b/qlib/CircleDataProvider/CircleWatchDataProviderBase.qc
@@ -74,7 +74,7 @@ public class CircleWatchDataProviderBase inherits CircleDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/ClickFunnelsDataProvider/ClickFunnelsWatchDataProviderBase.qc
+++ b/qlib/ClickFunnelsDataProvider/ClickFunnelsWatchDataProviderBase.qc
@@ -93,7 +93,7 @@ public class ClickFunnelsWatchDataProviderBase inherits ClickFunnelsDataProvider
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/ClickFunnelsDataProvider/ClickFunnelsWatchDataProviderBase.qc
+++ b/qlib/ClickFunnelsDataProvider/ClickFunnelsWatchDataProviderBase.qc
@@ -26,7 +26,7 @@ public namespace ClickFunnelsDataProvider {
 
 #! Base class for ClickFunnels polling watch data providers
 public class ClickFunnelsWatchDataProviderBase inherits ClickFunnelsDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions
@@ -47,23 +47,15 @@ public class ClickFunnelsWatchDataProviderBase inherits ClickFunnelsDataProvider
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client
     constructor(ClickFunnelsRestClient::ClickFunnelsRestClientIo rest, *hash<auto> options)
             : ClickFunnelsDataProviderBase(rest),
-              AbstractWatchDataProviderBase(
-                  max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
+              AbstractTimestampWatchDataProvider(
+                  max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
         if (options.workspace_id) {
             setWorkspaceId(options.workspace_id);
         }
-        last_check = options.start_date ?? now_us();
     }
 
     #! Destructor - stops the polling thread
@@ -76,45 +68,32 @@ public class ClickFunnelsWatchDataProviderBase inherits ClickFunnelsDataProvider
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                if (isStopping()) {
-                    break;
-                }
-                string id = getRecordId(record);
+    #! Returns the record's identity using the provider's own accessor
+    private *string getWatchRecordId(hash<auto> record) {
+        return getRecordId(record);
+    }
 
-                if (seen_ids{id}) {
-                    continue;
-                }
+    #! Returns the record's position in the feed using the provider's own accessor
+    private *date getWatchRecordTimestamp(hash<auto> record) {
+        return getRecordTimestamp(record);
+    }
 
-                *date record_time = getRecordTimestamp(record);
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                seen_ids{id} = True;
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            if (seen_ids.size() > MaxSeenIds) {
-                seen_ids = {};
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s",
-                getEventName(), ex.err, ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/CloseDataProvider/CloseWatchDataProviderBase.qc
+++ b/qlib/CloseDataProvider/CloseWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace CloseDataProvider {
 
 #! Base class for Close polling watch data providers using the Event Log API
 public class CloseWatchDataProviderBase inherits CloseDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -47,19 +47,11 @@ public class CloseWatchDataProviderBase inherits CloseDataProviderBase,
         };
     }
 
-    private {
-        #! Last check time for high-water mark
-        date last_check;
-
-        #! Set of seen event IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client
     constructor(CloseRestClient::CloseRestClient rest, *hash<auto> options)
             : CloseDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -72,66 +64,38 @@ public class CloseWatchDataProviderBase inherits CloseDataProviderBase,
         rest.close();
     }
 
-    #! Polls for new events once
-    private pollOnce() {
-        try {
-            # Fetch events from Close Event Log API
-            string since_str = CloseDataProviderBase::formatDateTime(last_check);
-            hash<auto> params = {
-                "object_type": getObjectType(),
-                "action": getAction(),
-                "date_updated__gte": since_str,
-                "_limit": 50,
-            };
-            list<hash<auto>> events = fetchEventPages(params, 1000);
+    #! The upstream ordering is not relied on; records are ordered by timestamp before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_DESCENDING;
+    }
 
-            # Close returns latest-first; reverse for correct watermark advancement
-            events = reverse(events);
+    #! Fetches every record changed at or after the given timestamp
+    private list<hash<auto>> fetchRecords(date since) {
+        hash<auto> params = {
+            "object_type": getObjectType(),
+            "action": getAction(),
+            "date_updated__gte": CloseDataProviderBase::formatDateTime(since),
+            "_limit": 50,
+        };
+        return fetchEventPages(params, 1000);
+    }
 
-            date new_last_check = last_check;
+    #! Returns the record field holding the record's position in the feed
+    private string getTimestampField() {
+        return "date_updated";
+    }
 
-            foreach hash<auto> event in (events) {
-                # Check for shutdown between iterations
-                if (isStopping()) {
-                    break;
-                }
-                string id = string(event.id);
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
-
-                # Check timestamp to avoid old events
-                *date event_time;
-                if (event.date_updated) {
-                    event_time = date(event.date_updated);
-                }
-                if (event_time) {
-                    if (event_time <= last_check) {
-                        continue;
-                    }
-                    if (event_time > new_last_check) {
-                        new_last_check = event_time;
-                    }
-                }
-
-                # Mark as seen
-                seen_ids{id} = True;
-
-                # Notify observers
-                notifyObservers(getEventName(), event);
-            }
-
-            last_check = new_last_check;
-
-            # Prune seen_ids if it gets too large
-            if (seen_ids.size() > MaxSeenIds) {
-                seen_ids = {};
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/CloseDataProvider/CloseWatchDataProviderBase.qc
+++ b/qlib/CloseDataProvider/CloseWatchDataProviderBase.qc
@@ -95,7 +95,7 @@ public class CloseWatchDataProviderBase inherits CloseDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/ConstantContactDataProvider/ConstantContactWatchDataProviderBase.qc
+++ b/qlib/ConstantContactDataProvider/ConstantContactWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace ConstantContactDataProvider {
 
 #! Base class for Constant Contact polling watch data providers
 public class ConstantContactWatchDataProviderBase inherits ConstantContactDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -47,20 +47,12 @@ public class ConstantContactWatchDataProviderBase inherits ConstantContactDataPr
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client
     constructor(RestClientIo::RestClientIo rest, *hash<auto> options)
             : ConstantContactDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval,
-                  MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval,
+                  MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -73,51 +65,32 @@ public class ConstantContactWatchDataProviderBase inherits ConstantContactDataPr
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                # check for shutdown between iterations
-                if (isStopping()) {
-                    break;
-                }
-                string id = getRecordId(record);
+    #! Returns the record's identity using the provider's own accessor
+    private *string getWatchRecordId(hash<auto> record) {
+        return getRecordId(record);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
+    #! Returns the record's position in the feed using the provider's own accessor
+    private *date getWatchRecordTimestamp(hash<auto> record) {
+        return getRecordTimestamp(record);
+    }
 
-                # Check timestamp to avoid old records
-                *date record_time = getRecordTimestamp(record);
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Mark as seen
-                seen_ids{id} = True;
-
-                # Notify observers
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune seen_ids if it gets too large
-            if (seen_ids.size() > MaxSeenIds) {
-                seen_ids = {};
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/ConstantContactDataProvider/ConstantContactWatchDataProviderBase.qc
+++ b/qlib/ConstantContactDataProvider/ConstantContactWatchDataProviderBase.qc
@@ -90,7 +90,7 @@ public class ConstantContactWatchDataProviderBase inherits ConstantContactDataPr
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/DataProvider/AbstractOrderedWatchDataProvider.qc
+++ b/qlib/DataProvider/AbstractOrderedWatchDataProvider.qc
@@ -1,0 +1,446 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! @file AbstractOrderedWatchDataProvider.qc shared ordered polling template for Watch data providers
+
+/*  DataProvider Copyright 2019 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the DataProvider module
+public namespace DataProvider {
+
+#! Describes how a watch data provider's upstream feed is ordered
+/** Every event-producing watch data provider declares this so that a consumer can tell an ordered
+    feed from an unordered one instead of having to infer it from the implementation.
+
+    @since DataProvider 3.6
+*/
+public enum WatchSourceOrdering : string {
+    #! the upstream API returns items in ascending source order, and they are dispatched as received
+    WSO_ASCENDING = "ascending",
+
+    #! the upstream API returns items in descending source order; they are reversed before dispatch
+    WSO_DESCENDING = "descending",
+
+    #! the feed has no comparable source order; each item is dispatched independently
+    WSO_UNORDERED = "unordered",
+
+    #! the upstream ordering has not been verified, so no ordering guarantee can be offered
+    WSO_UNKNOWN = "unknown",
+}
+
+#! What to do with items that snapshot mode collapsed away
+/** @since DataProvider 3.6
+*/
+public enum WatchSupersededAction : string {
+    #! leave superseded items untouched in the source system
+    WSA_IGNORE = "ignore",
+
+    #! move superseded items to the source system's trash / recycle bin, where recovery is possible
+    WSA_TRASH = "trash",
+
+    #! remove superseded items permanently; unrecoverable
+    WSA_DELETE = "delete",
+}
+
+#! One candidate item in a watch polling cycle
+/** An item is a cheap descriptor, not a payload: the shared template sorts, filters, and collapses
+    items before any payload is fetched, so a backlog that is going to be collapsed away never costs
+    a payload retrieval.
+
+    @since DataProvider 3.6
+*/
+public hashdecl WatchItemInfo {
+    #! The item's stable identity; unique in the provider's feed
+    string id;
+
+    #! The item's monotonic ordering key
+    /** Items are dispatched in ascending order of this value; ties are broken by @ref id so that
+        the dispatch order of a given set of items is deterministic
+    */
+    auto order_key;
+
+    #! Optional grouping key for snapshot collapse
+    /** When not set, all items in a cycle belong to one global group, so snapshot mode retains a
+        single latest item. Providers that can group (ex: by mail thread) set this to the group's
+        key, and snapshot mode then retains the latest item per key.
+    */
+    *string group_key;
+
+    #! Opaque provider-defined data carried through the cycle
+    auto data;
+}
+
+#! The outcome of one watch polling cycle
+/** @since DataProvider 3.6
+*/
+public hashdecl WatchCycleInfo {
+    #! the number of items dispatched to observers
+    int dispatched = 0;
+
+    #! the number of items collapsed away by snapshot mode
+    int superseded = 0;
+
+    #! the number of items left for the next cycle by the per-cycle dispatch budget
+    int deferred = 0;
+
+    #! the number of items whose dispatch failed; the cycle stops at the first failure
+    int failed = 0;
+}
+
+#! Watch data provider base class implementing the shared ordered polling sequence
+/** Watch providers that expose an ordered feed all have to solve the same problems: upstream
+    pagination, upstream ordering that does not match delivery order, a durable cursor that must not
+    advance past an item that was never delivered, and follow-up actions that must not run for an
+    item observers never received. This class implements that sequence once:
+
+    @code
+    fetch
+      -> discard items at or before the durable cursor
+      -> sort ascending by the provider-defined ordering key
+      -> optionally collapse superseded items (snapshot mode)
+      -> optionally bound the batch from the oldest end (dispatch budget)
+      -> for each item: fetch payload -> dispatch -> persist and advance the cursor
+                        -> run the post-success hook -> apply the superseded action
+    @endcode
+
+    Subclasses supply the provider-specific pieces as typed hooks:
+    - @ref fetchWatchItems() "fetchWatchItems()": the cycle's candidate items
+    - @ref isNewWatchItem() "isNewWatchItem()": whether an item is beyond the durable cursor
+    - @ref fetchWatchItemPayload() "fetchWatchItemPayload()": the item's full payload
+    - @ref dispatchWatchItem() "dispatchWatchItem()": raising the event
+    - @ref advanceWatchCursor() "advanceWatchCursor()": persisting and advancing the cursor
+    - @ref afterWatchItemDispatched() "afterWatchItemDispatched()": the optional post-success action
+    - @ref applySupersededAction() "applySupersededAction()": the optional collapse action
+    - @ref restoreCheckpoint() "restoreCheckpoint()": cursor restoration
+
+    @par Ordering
+    Items are always dispatched in ascending order of their ordering key, whatever order the upstream
+    API returned them in. This is not cosmetic: the durable cursor is monotonic, so dispatching a
+    newer item first would advance the cursor past an older item that had not been delivered yet, and
+    a failure at that point would drop the older item permanently.
+
+    @par Advance on success only
+    The cursor is advanced only after an item has been dispatched successfully, and the cycle
+    <b>stops at the first failure</b> rather than continuing with later items. Continuing would
+    advance the monotonic cursor past the failed item and lose it; stopping leaves it in place to be
+    retried on the next cycle. Delivery is therefore at-least-once, never at-most-once.
+
+    @par Durability
+    With @ref AbstractWatchDataProviderBase::setCheckpointPersistence() "checkpoint persistence"
+    configured, the cursor survives a host restart, so an item that was never dispatched is still
+    dispatched after a reload. Without it, the cursor lives only in memory and the provider's
+    behavior after a restart is provider-specific.
+
+    @see @ref AbstractWatchDataProviderBase for the lifecycle and checkpoint machinery
+
+    @since DataProvider 3.6
+*/
+public class AbstractOrderedWatchDataProvider inherits AbstractWatchDataProviderBase {
+    private {
+        #! collapse a backlog to the latest item per group?
+        bool snapshot_mode = False;
+
+        #! what to do with items collapsed away by snapshot mode
+        string superseded_action = WSA_IGNORE;
+
+        #! maximum number of items dispatched per cycle; 0 means unlimited
+        int max_items_per_cycle = 0;
+    }
+
+    #! Creates the object
+    /** @param poll_interval_secs the polling interval in seconds
+    */
+    constructor(int poll_interval_secs) : AbstractWatchDataProviderBase(poll_interval_secs) {
+    }
+
+    #! Returns @ref True if the provider collapses a backlog to the latest item per group
+    /** @since DataProvider 3.6
+    */
+    bool hasSnapshotMode() {
+        return snapshot_mode;
+    }
+
+    #! Returns the action applied to items that snapshot mode collapsed away
+    /** @since DataProvider 3.6
+    */
+    string getSupersededAction() {
+        return superseded_action;
+    }
+
+    #! Returns the maximum number of items dispatched per cycle; 0 means unlimited
+    /** @since DataProvider 3.6
+    */
+    int getMaxItemsPerCycle() {
+        return max_items_per_cycle;
+    }
+
+    #! Returns @ref True if this provider dispatches events in ascending source order
+    /** The template sorts every cycle's items by their ordering key before dispatching them, so the
+        guarantee holds whatever order the upstream API used; it is only withheld for a feed that
+        declares itself @ref WSO_UNORDERED, where there is no source order to ascend.
+
+        @since DataProvider 3.6
+    */
+    bool hasAscendingDispatch() {
+        return getSourceOrdering() != WSO_UNORDERED;
+    }
+
+    #! @cond nodoc
+    #! Sets the snapshot-collapse and dispatch-budget policy for the provider
+    /** @param snapshot the backlog is collapsed to the latest item per group when @ref True
+        @param action the action applied to collapsed items; one of @ref WatchSupersededAction
+        @param max_items the maximum number of items dispatched per cycle; 0 or unset means unlimited
+
+        @throw WATCH-POLICY-ERROR the superseded action is unknown, the item budget is negative, or a
+        superseded action other than @ref WSA_IGNORE was requested without snapshot mode
+    */
+    private setWatchPolicy(bool snapshot, *string action, *int max_items) {
+        if (action.val() && action != WSA_IGNORE && action != WSA_TRASH && action != WSA_DELETE) {
+            throw "WATCH-POLICY-ERROR", sprintf("superseded action %y is unknown; expecting one of %y", action,
+                (WSA_IGNORE, WSA_TRASH, WSA_DELETE));
+        }
+        if (max_items && max_items < 0) {
+            throw "WATCH-POLICY-ERROR", sprintf("the per-cycle item budget cannot be negative (got %d)", max_items);
+        }
+        string new_action = action ?? WSA_IGNORE;
+        if (!snapshot && new_action != WSA_IGNORE) {
+            throw "WATCH-POLICY-ERROR", sprintf("superseded action %y requires snapshot mode; without it no item "
+                "is superseded, so the action could only remove items that were delivered", new_action);
+        }
+        snapshot_mode = snapshot;
+        superseded_action = new_action;
+        max_items_per_cycle = max_items ?? 0;
+    }
+
+    #! Performs a single polling operation using the shared sequence
+    private pollOnce() {
+        runWatchCycle(fetchWatchItems());
+    }
+
+    #! Runs the shared ordered processing sequence over a cycle's candidate items
+    /** @param items the cycle's candidate items in any order
+
+        @return a summary of what the cycle did
+
+        @note this method never throws for a dispatch failure; the failure is logged through
+        @ref AbstractWatchDataProviderBase::logPollError() "logPollError()" and reported in the
+        return value, because the polling thread must keep running
+    */
+    private hash<WatchCycleInfo> runWatchCycle(list<hash<WatchItemInfo>> items) {
+        hash<WatchCycleInfo> info();
+
+        # discard everything at or before the durable cursor before doing any other work
+        items = map $1, items, isNewWatchItem($1);
+        if (!items) {
+            return info;
+        }
+
+        # dispatch order is ascending in the provider's ordering key whatever order the upstream
+        # API used; ties break on identity so that a given set of items always dispatches the same way
+        items = sort(items, int sub (hash<WatchItemInfo> l, hash<WatchItemInfo> r) {
+            int rv = compareWatchOrderKeys(l.order_key, r.order_key);
+            return rv ? rv : (l.id <=> r.id);
+        });
+
+        # each batch entry is a retained item plus the items it superseded
+        list<hash<auto>> batch;
+        if (snapshot_mode) {
+            batch = collapseWatchItems(items);
+        } else {
+            batch = map ("item": $1, "superseded": ()), items;
+        }
+
+        # bound the batch from the oldest end so that the cursor still advances contiguously; the
+        # remainder is dispatched by later cycles rather than skipped
+        if (max_items_per_cycle > 0 && batch.size() > max_items_per_cycle) {
+            info.deferred = batch.size() - max_items_per_cycle;
+            batch = batch[0..(max_items_per_cycle - 1)];
+            logWatchInfo("watch dispatch budget of %d item(s) reached; %d item(s) deferred to the next cycle",
+                max_items_per_cycle, info.deferred);
+        }
+
+        foreach hash<auto> entry in (batch) {
+            if (isStopping()) {
+                break;
+            }
+            hash<WatchItemInfo> item = entry.item;
+            list<hash<WatchItemInfo>> superseded = entry.superseded;
+            try {
+                auto payload = fetchWatchItemPayload(item);
+                dispatchWatchItem(item, payload, superseded);
+                # persist before advancing: a persistence failure must retry, not skip
+                advanceWatchCursor(item);
+                afterWatchItemDispatched(item, payload);
+            } catch (hash<ExceptionInfo> ex) {
+                ++info.failed;
+                logPollError(ex);
+                # stop here: dispatching a later item would advance the monotonic cursor past this
+                # one and drop it permanently on what may well be a transient error
+                break;
+            }
+            ++info.dispatched;
+            if (superseded) {
+                info.superseded += superseded.size();
+                # the retained event is already delivered and its cursor is durable, so a failure
+                # here cannot cost an event; it only leaves the superseded items in place
+                try {
+                    applySupersededAction(superseded);
+                } catch (hash<ExceptionInfo> ex) {
+                    logPollError(ex);
+                }
+            }
+        }
+        return info;
+    }
+
+    #! Collapses items to the latest item per group, preserving ascending dispatch order
+    /** @param items the cycle's new items, already sorted ascending
+
+        @return a list of hashes with an \c "item" key holding the retained item and a
+        \c "superseded" key holding the items it collapsed away, ordered ascending by the retained
+        item's ordering key
+
+        @note the retained item of each group is the group's newest item, so every superseded item
+        precedes it; the cursor therefore covers a superseded item as soon as the item that
+        superseded it has been committed
+    */
+    private list<hash<auto>> collapseWatchItems(list<hash<WatchItemInfo>> items) {
+        hash<string, list<hash<WatchItemInfo>>> groups();
+        foreach hash<WatchItemInfo> item in (items) {
+            string key = item.group_key ?? "";
+            if (!exists groups{key}) {
+                groups{key} = ();
+            }
+            push groups{key}, item;
+        }
+        list<hash<auto>> batch = ();
+        foreach string key in (keys groups) {
+            list<hash<WatchItemInfo>> members = groups{key};
+            hash<WatchItemInfo> retained = members.last();
+            push batch, {
+                "item": retained,
+                "superseded": members.size() > 1 ? members[0..(members.size() - 2)] : (),
+            };
+        }
+        return sort(batch, int sub (hash<auto> l, hash<auto> r) {
+            int rv = compareWatchOrderKeys(l.item.order_key, r.item.order_key);
+            return rv ? rv : (l.item.id <=> r.item.id);
+        });
+    }
+    #! @endcond
+
+    #! Returns the cycle's candidate items
+    /** Implementations must return every item in scope for the cycle, following upstream pagination
+        as needed: an item that is not returned cannot be dispatched, and snapshot mode can only
+        collapse over the items it is given.
+
+        The order of the returned items does not matter; the template sorts them.
+    */
+    abstract private list<hash<WatchItemInfo>> fetchWatchItems();
+
+    #! Returns @ref True if the item lies beyond the durable cursor
+    /** Called before any payload is fetched, so this must be answerable from the item descriptor
+        alone.
+    */
+    abstract private bool isNewWatchItem(hash<WatchItemInfo> item);
+
+    #! Dispatches one item to observers
+    /** @param item the item being dispatched
+        @param payload the value returned by @ref fetchWatchItemPayload()
+        @param superseded the items snapshot mode collapsed into this one; empty when snapshot mode
+        is not enabled
+
+        Implementations raise the provider's event here. When @a superseded is not empty the event
+        should carry the collapse metadata so a consumer can tell a collapsed event from a plain one.
+
+        An exception stops the cycle without advancing the cursor, so the item is retried.
+    */
+    abstract private dispatchWatchItem(hash<WatchItemInfo> item, auto payload,
+            list<hash<WatchItemInfo>> superseded);
+
+    #! Durably advances the cursor to the given item
+    /** Implementations must call
+        @ref AbstractWatchDataProviderBase::persistCheckpoint() "persistCheckpoint()" <b>before</b>
+        mutating the in-memory cursor, so that a persistence failure retries the item instead of
+        silently advancing past it.
+
+        An exception stops the cycle; the item is dispatched again on the next cycle, which is why
+        delivery is at-least-once.
+    */
+    abstract private advanceWatchCursor(hash<WatchItemInfo> item);
+
+    #! Returns the item's payload
+    /** Called only for items that are actually going to be dispatched, so a collapsed backlog costs
+        no payload retrievals.
+
+        The default implementation returns the item's @ref WatchItemInfo::data "data" value.
+    */
+    private auto fetchWatchItemPayload(hash<WatchItemInfo> item) {
+        return item.data;
+    }
+
+    #! Compares two ordering keys
+    /** @return -1 if @a l sorts before @a r, 0 if they sort equally, 1 if @a l sorts after @a r
+
+        The default implementation uses the \c <=> operator, which covers the usual integer, date,
+        and string keys.
+    */
+    private int compareWatchOrderKeys(auto l, auto r) {
+        return l <=> r;
+    }
+
+    #! Runs the provider's post-success action for a dispatched item
+    /** Called after the item has been dispatched and its cursor committed, so an exception here
+        cannot cost an event; it stops the cycle and the item is dispatched again on the next cycle.
+
+        @note This hook runs when the <b>event has been raised</b>, which is not the same as the
+        consumer having <b>processed</b> it; see @ref watch_removal_semantics.
+
+        The default implementation does nothing.
+    */
+    private afterWatchItemDispatched(hash<WatchItemInfo> item, auto payload) {
+        # default: no post-success action
+    }
+
+    #! Applies the configured action to items that snapshot mode collapsed away
+    /** Called after the retained item's event has been raised and its cursor committed.
+
+        The default implementation does nothing for @ref WSA_IGNORE and throws for any other action,
+        because silently ignoring a request to remove superseded items would leave a caller believing
+        that mail or records were being cleaned up when they were not.
+
+        @throw WATCH-POLICY-ERROR a removal action was configured but the provider does not implement
+        one
+    */
+    private applySupersededAction(list<hash<WatchItemInfo>> superseded) {
+        if (superseded_action != WSA_IGNORE) {
+            throw "WATCH-POLICY-ERROR", sprintf("watch provider %y was configured with superseded action %y but "
+                "does not implement one", self.className(), superseded_action);
+        }
+    }
+
+    #! Logs an informational message about a polling cycle
+    /** Overridden by providers that have a logger; the default implementation discards the message.
+    */
+    private logWatchInfo(string fmt, ...) {
+        # default: ignore; subclasses should override for proper logging
+    }
+}
+}

--- a/qlib/DataProvider/AbstractTimestampWatchDataProvider.qc
+++ b/qlib/DataProvider/AbstractTimestampWatchDataProvider.qc
@@ -1,0 +1,252 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! @file AbstractTimestampWatchDataProvider.qc timestamp-cursor Watch data provider base class
+
+/*  DataProvider Copyright 2019 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the DataProvider module
+public namespace DataProvider {
+
+#! Watch data provider base class for feeds positioned by a record timestamp
+/** Most polling watch providers track their position in an upstream feed with a "records changed
+    since <i>t</i>" query. This class implements that cursor once on top of the
+    @ref AbstractOrderedWatchDataProvider "shared ordered polling template", so a provider only has to
+    say how to fetch records and what event to raise.
+
+    The cursor is a timestamp plus the set of record IDs already delivered <b>at exactly that
+    timestamp</b>: a record is new when its timestamp is later than the cursor, or equal to it and
+    not in the delivered set. The ID set is what makes the cursor safe at its own boundary: a timestamp-only
+    cursor either re-delivers every record sharing the boundary timestamp (if the query is
+    inclusive) or drops them (if it is exclusive). The ID set is reset whenever the cursor moves to a
+    newer timestamp, so it stays small.
+
+    @par Ordering
+    Records are dispatched in ascending timestamp order whatever order the upstream API returned
+    them in, and the cursor advances only after a record has been dispatched successfully. See
+    @ref AbstractOrderedWatchDataProvider for the full sequence.
+
+    @par Records without a usable timestamp
+    A record whose timestamp field is missing or unparseable has no position in the feed, so it
+    cannot be ordered against the cursor and is not dispatched; the fact is logged rather than
+    passed over silently. A provider whose feed carries its timestamp somewhere else overrides
+    @ref getRecordTimestamp().
+
+    @par Durability
+    The checkpoint format is
+    @code{.py}
+{
+    "version": 1,
+    "last_check": <the timestamp of the newest record delivered>,
+    "last_ids": (<the IDs delivered at that timestamp>,),
+}
+    @endcode
+
+    Without @ref AbstractWatchDataProviderBase::setCheckpointPersistence() "checkpoint persistence"
+    the cursor lives only in memory, and a restart resumes from the provider's start date, or from
+    the restart time when no start date was given.
+
+    @since DataProvider 3.6
+*/
+public class AbstractTimestampWatchDataProvider inherits AbstractOrderedWatchDataProvider {
+    private {
+        #! the timestamp of the newest record delivered
+        date last_check;
+
+        #! the IDs of the records delivered at exactly @ref last_check
+        hash<string, bool> last_ids = {};
+    }
+
+    #! Creates the object
+    /** @param poll_interval_secs the polling interval in seconds
+        @param start_date do not deliver records earlier than this timestamp; a record at exactly
+        this timestamp <i>is</i> delivered, because nothing has been delivered at that position yet.
+        When not given, the cursor starts at the current time, so only records that arrive after the
+        provider starts are delivered
+
+        @throw WATCH-CHECKPOINT-ERROR the start date is a relative date/time value
+    */
+    constructor(int poll_interval_secs, *date start_date) : AbstractOrderedWatchDataProvider(poll_interval_secs) {
+        if (exists start_date && !start_date.absolute()) {
+            throw "WATCH-CHECKPOINT-ERROR", sprintf("the watch start date must be an absolute date/time value; got "
+                "%y", start_date);
+        }
+        last_check = start_date ?? now_us();
+    }
+
+    #! Returns the timestamp of the newest record delivered
+    /** @since DataProvider 3.6
+    */
+    date getLastCheck() {
+        return last_check;
+    }
+
+    #! Returns the IDs of the records delivered at exactly @ref getLastCheck()
+    /** @since DataProvider 3.6
+    */
+    list<string> getLastIds() {
+        return keys last_ids;
+    }
+
+    #! @cond nodoc
+    #! Restores a timestamp cursor
+    private restoreCheckpoint(hash<auto> checkpoint) {
+        if (checkpoint.version.typeCode() != NT_INT || checkpoint.version != 1
+                || checkpoint.last_check.typeCode() != NT_DATE || !checkpoint.last_check.absolute()
+                || checkpoint.last_ids.typeCode() != NT_LIST) {
+            throw "WATCH-CHECKPOINT-ERROR", "invalid timestamp watch checkpoint; expecting version 1, an absolute "
+                "last_check date/time value, and a last_ids list";
+        }
+        hash<string, bool> restored = {};
+        foreach auto id in (checkpoint.last_ids) {
+            if (id.typeCode() != NT_STRING || !id.val()) {
+                throw "WATCH-CHECKPOINT-ERROR", "invalid timestamp watch checkpoint; record IDs must be non-empty "
+                    "strings";
+            }
+            restored{id} = True;
+        }
+        last_check = checkpoint.last_check;
+        last_ids = restored;
+    }
+
+    #! Durably advances the timestamp cursor
+    /** The replacement checkpoint is stored before the in-memory cursor changes, so a persistence
+        failure retries the record instead of advancing past it.
+    */
+    private commitCheckpoint(date record_date, string id) {
+        if (!record_date.absolute() || !id.val()) {
+            throw "WATCH-CHECKPOINT-ERROR", "cannot persist a timestamp checkpoint with a relative date/time value "
+                "or an empty record ID";
+        }
+        if (record_date < last_check) {
+            throw "WATCH-CHECKPOINT-ERROR", sprintf("cannot move the watch cursor backwards from %y to %y",
+                last_check, record_date);
+        }
+        hash<string, bool> next_ids = record_date == last_check ? last_ids : {};
+        next_ids{id} = True;
+        persistCheckpoint({
+            "version": 1,
+            "last_check": record_date,
+            "last_ids": keys next_ids,
+        });
+        last_check = record_date;
+        last_ids = next_ids;
+    }
+
+    #! Returns the cycle's candidate records as watch items
+    private list<hash<WatchItemInfo>> fetchWatchItems() {
+        string ts_field = getTimestampField();
+        string id_field = getIdField();
+        list<hash<WatchItemInfo>> items = ();
+        foreach hash<auto> record in (fetchRecords(last_check)) {
+            if (isStopping()) {
+                break;
+            }
+            *string id = exists record{id_field} ? string(record{id_field}) : NOTHING;
+            if (!id.val()) {
+                logWatchInfo("watch record without a usable %y identity ignored", id_field);
+                continue;
+            }
+            *date record_date = getRecordTimestamp(record, ts_field);
+            if (!exists record_date) {
+                logWatchInfo("watch record %y has no usable %y timestamp, so it has no position in the feed and "
+                    "cannot be delivered in order; ignored", id, ts_field);
+                continue;
+            }
+            push items, <WatchItemInfo>{
+                "id": id,
+                "order_key": record_date,
+                "data": record,
+            };
+        }
+        return items;
+    }
+
+    #! Returns @ref True if the record lies beyond the durable cursor
+    private bool isNewWatchItem(hash<WatchItemInfo> item) {
+        date record_date = item.order_key;
+        if (record_date > last_check) {
+            return True;
+        }
+        if (record_date == last_check) {
+            return !last_ids{item.id};
+        }
+        return False;
+    }
+
+    #! Raises the provider's event for one record
+    private dispatchWatchItem(hash<WatchItemInfo> item, auto payload, list<hash<WatchItemInfo>> superseded) {
+        notifyObservers(getEventName(), payload);
+    }
+
+    #! Durably advances the cursor to the given record
+    private advanceWatchCursor(hash<WatchItemInfo> item) {
+        commitCheckpoint(item.order_key, item.id);
+    }
+    #! @endcond
+
+    #! Returns the record's position in the feed
+    /** The default implementation reads @ref getTimestampField() from the record and accepts a
+        date/time value or a string that can be converted to one.
+
+        @param record the record as returned by @ref fetchRecords()
+        @param field the timestamp field name
+
+        @return the record's timestamp, or @ref nothing if the record has no usable timestamp, in
+        which case the record is not delivered
+    */
+    private *date getRecordTimestamp(hash<auto> record, string field) {
+        auto val = record{field};
+        switch (val.typeCode()) {
+            case NT_DATE:
+                return val.absolute() ? val : NOTHING;
+            case NT_STRING:
+                return val.val() ? date(val) : NOTHING;
+        }
+    }
+
+    #! Returns the record field holding the record's position in the feed
+    /** The default is \c "created_at"; override in providers whose feed is positioned by a different
+        field (ex: \c "updated_at")
+    */
+    private string getTimestampField() {
+        return "created_at";
+    }
+
+    #! Returns the record field holding the record's stable identity
+    /** The default is \c "id"
+    */
+    private string getIdField() {
+        return "id";
+    }
+
+    #! Fetches every record changed at or after the given timestamp
+    /** Implementations must follow upstream pagination: a record that is not returned cannot be
+        delivered. The order of the returned records does not matter.
+
+        @param since the cursor timestamp; returning records at or before it is harmless because the
+        template discards them
+    */
+    abstract private list<hash<auto>> fetchRecords(date since);
+
+    #! Returns the name of the event raised for each new record
+    abstract private string getEventName();
+}
+}

--- a/qlib/DataProvider/AbstractTimestampWatchDataProvider.qc
+++ b/qlib/DataProvider/AbstractTimestampWatchDataProvider.qc
@@ -46,8 +46,8 @@ public namespace DataProvider {
     @par Records without a usable timestamp
     A record whose timestamp field is missing or unparseable has no position in the feed, so it
     cannot be ordered against the cursor and is not dispatched; the fact is logged rather than
-    passed over silently. A provider whose feed carries its timestamp somewhere else overrides
-    @ref getRecordTimestamp().
+    passed over silently. A provider whose feed carries its timestamp or identity somewhere else
+    overrides @ref getWatchRecordTimestamp() or @ref getWatchRecordId().
 
     @par Durability
     The checkpoint format is
@@ -154,17 +154,18 @@ public class AbstractTimestampWatchDataProvider inherits AbstractOrderedWatchDat
     private list<hash<WatchItemInfo>> fetchWatchItems() {
         string ts_field = getTimestampField();
         string id_field = getIdField();
+        # both are read once for the log messages below; the values themselves come from the hooks
         list<hash<WatchItemInfo>> items = ();
         foreach hash<auto> record in (fetchRecords(last_check)) {
             if (isStopping()) {
                 break;
             }
-            *string id = exists record{id_field} ? string(record{id_field}) : NOTHING;
+            *string id = getWatchRecordId(record);
             if (!id.val()) {
                 logWatchInfo("watch record without a usable %y identity ignored", id_field);
                 continue;
             }
-            *date record_date = getRecordTimestamp(record, ts_field);
+            *date record_date = getWatchRecordTimestamp(record);
             if (!exists record_date) {
                 logWatchInfo("watch record %y has no usable %y timestamp, so it has no position in the feed and "
                     "cannot be delivered in order; ignored", id, ts_field);
@@ -202,18 +203,31 @@ public class AbstractTimestampWatchDataProvider inherits AbstractOrderedWatchDat
     }
     #! @endcond
 
+    #! Returns the record's stable identity
+    /** The default implementation reads @ref getIdField() from the record and converts it to a
+        string.
+
+        @param record the record as returned by @ref fetchRecords()
+
+        @return the record's identity, or @ref nothing if the record has none, in which case the
+        record is not delivered
+    */
+    private *string getWatchRecordId(hash<auto> record) {
+        auto val = record{getIdField()};
+        return exists val ? string(val) : NOTHING;
+    }
+
     #! Returns the record's position in the feed
     /** The default implementation reads @ref getTimestampField() from the record and accepts a
         date/time value or a string that can be converted to one.
 
         @param record the record as returned by @ref fetchRecords()
-        @param field the timestamp field name
 
         @return the record's timestamp, or @ref nothing if the record has no usable timestamp, in
         which case the record is not delivered
     */
-    private *date getRecordTimestamp(hash<auto> record, string field) {
-        auto val = record{field};
+    private *date getWatchRecordTimestamp(hash<auto> record) {
+        auto val = record{getTimestampField()};
         switch (val.typeCode()) {
             case NT_DATE:
                 return val.absolute() ? val : NOTHING;

--- a/qlib/DataProvider/AbstractWatchDataProviderBase.qc
+++ b/qlib/DataProvider/AbstractWatchDataProviderBase.qc
@@ -35,6 +35,40 @@ public namespace DataProvider {
     - WaitGroup-based thread lifecycle management
     - Condition-based sleep for instant wakeup on stop (no busy-wait polling)
     - Clean shutdown with @ref stopEventsIntern()
+
+    @par Dispatch order
+    A provider whose events represent an <b>ordered feed</b> must dispatch them in ascending source
+    order, and must declare that it does so with @ref getSourceOrdering() and
+    @ref hasAscendingDispatch(). Order is not a presentation detail: a watch cursor is monotonic, so
+    dispatching a newer item before an older one advances the cursor past an item that has not been
+    delivered, and a failure at that point drops the older item permanently. A provider whose feed
+    has no comparable order declares @ref WSO_UNORDERED; a provider whose upstream ordering has not
+    been established declares @ref WSO_UNKNOWN and therefore offers no ordering guarantee at all.
+
+    @ref DataProvider::AbstractOrderedWatchDataProvider "AbstractOrderedWatchDataProvider" implements
+    the whole ordered sequence — fetch, sort, cursor filtering, optional collapse, in-order dispatch,
+    and advance-on-success — so a provider should only implement @ref pollOnce() directly when its
+    feed does not fit that shape.
+
+    @par Durability
+    Checkpoint persistence is optional at this layer because %Qore does not own a database:
+    - <b>with</b> a persistence callback configured through @ref setCheckpointPersistence(): the
+      cursor is durable, so delivery is at-least-once across host reloads and restarts;
+    - <b>without</b> one: the cursor lives only in memory and behavior after a restart is
+      provider-specific — typically the provider resumes from its configured start position, or from
+      the restart time when it has none.
+
+    @anchor watch_removal_semantics
+    @par Removal is dispatch-aware, not processing-aware
+    A watch provider observes one thing: that raising an event returned without an exception. It does
+    not, and at this layer cannot, observe whether the consumer went on to process the event
+    successfully. Any option that removes the source item after its event has been raised
+    (ex: deleting mail) therefore acts on <b>dispatch</b>, not on <b>completion</b>: a consumer that
+    receives the event and then fails, times out, or is restarted mid-processing has already lost the
+    source item. Providers must document such options in those terms and must not describe them as
+    processing-aware. Workloads that must not lose the source item leave those options unset and act
+    from the consumer once processing has succeeded, using the item identity that every event carries.
+
     @since DataProvider 3.4
 */
 public class AbstractWatchDataProviderBase inherits DataProvider::DelayedObservable {
@@ -171,9 +205,45 @@ public class AbstractWatchDataProviderBase inherits DataProvider::DelayedObserva
         }
     }
 
+    #! Returns the ordering of this provider's upstream feed
+    /** Used to tell an ordered feed from an unordered one without having to read the implementation.
+
+        The default is @ref WSO_UNKNOWN, which declares that the upstream ordering has not been
+        established and that the provider therefore offers no ordering guarantee; every provider
+        that raises events representing an ordered feed must override this.
+
+        @since DataProvider 3.6
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
+
+    #! Returns @ref True if this provider dispatches events in ascending source order
+    /** The default is @ref False, because a provider that implements @ref pollOnce() itself
+        dispatches in whatever order its upstream API returned. Providers using
+        @ref DataProvider::AbstractOrderedWatchDataProvider "AbstractOrderedWatchDataProvider" get an
+        ascending guarantee from the shared template.
+
+        @since DataProvider 3.6
+    */
+    bool hasAscendingDispatch() {
+        return False;
+    }
+
     #! Performs a single polling operation
     /** Subclasses must implement this method to fetch records and call
         @ref notifyObservers() for each new record.
+
+        @par Ordering obligation
+        An implementation whose events represent an ordered feed must dispatch them in ascending
+        source order and must advance its cursor only after a successful dispatch, stopping the cycle
+        at the first failure rather than continuing with later items — continuing advances a
+        monotonic cursor past the failed item and drops it. An implementation that cannot meet that
+        obligation must declare @ref WSO_UNORDERED (its events have no comparable order) or
+        @ref WSO_UNKNOWN (its ordering is unverified, so consumers must not assume one).
+
+        @ref DataProvider::AbstractOrderedWatchDataProvider "AbstractOrderedWatchDataProvider"
+        implements these obligations once; prefer it over implementing this method directly.
     */
     abstract private pollOnce();
 

--- a/qlib/DataProvider/DataProvider.qm
+++ b/qlib/DataProvider/DataProvider.qm
@@ -1210,9 +1210,143 @@ if (errors) {
 }
     @endcode
 
+    @section dataprovider_watch Watch Data Providers
+
+    A <b>watch data provider</b> polls an external system and raises an event for each new item it
+    finds. Getting that right is mostly about one question: what happens to an item when something
+    fails? The answers are contracts, not implementation details, so they are stated here.
+
+    @subsection dataprovider_watch_template The Shared Processing Sequence
+
+    @ref DataProvider::AbstractOrderedWatchDataProvider "AbstractOrderedWatchDataProvider" implements
+    the sequence every ordered watch provider needs:
+
+    @code
+fetch
+  -> discard items at or before the durable cursor
+  -> sort ascending by the provider-defined ordering key
+  -> optionally collapse superseded items (snapshot mode)
+  -> optionally bound the batch from the oldest end (dispatch budget)
+  -> for each item: fetch payload -> dispatch -> persist and advance the cursor
+                    -> run the post-success hook -> apply the superseded action
+    @endcode
+
+    A provider supplies only the provider-specific pieces as typed hooks over
+    @ref DataProvider::WatchItemInfo "WatchItemInfo" descriptors. Items are cheap descriptors, not
+    payloads, so ordering and collapse decisions are made before anything expensive is retrieved.
+
+    @ref DataProvider::AbstractTimestampWatchDataProvider "AbstractTimestampWatchDataProvider"
+    implements the common "records changed since <i>t</i>" cursor on top of it: a timestamp plus the
+    IDs already delivered at exactly that timestamp, which is what makes the cursor safe at its own
+    boundary.
+
+    @subsection dataprovider_watch_ordering Dispatch Order
+
+    Events representing an ordered feed are dispatched in ascending source order. This is a
+    correctness property, not a presentation one: a watch cursor is monotonic, so dispatching a newer
+    item before an older one advances the cursor past an item that has not been delivered, and a
+    failure at that point drops the older item permanently.
+
+    Every provider declares how its upstream feed is ordered with
+    @ref DataProvider::AbstractWatchDataProviderBase::getSourceOrdering() "getSourceOrdering()":
+
+    |!Classification|!Meaning
+    |@ref WSO_ASCENDING|the upstream API returns items in ascending source order
+    |@ref WSO_DESCENDING|the upstream API returns items newest-first; the provider reverses them
+    |@ref WSO_UNORDERED|the feed has no comparable source order, so no ordering can be guaranteed
+    |@ref WSO_UNKNOWN|the upstream ordering has not been established; the provider orders items \
+        itself before delivery, but makes no claim about the API
+
+    @ref DataProvider::AbstractWatchDataProviderBase::hasAscendingDispatch() "hasAscendingDispatch()"
+    answers the question a consumer actually cares about: whether events arrive oldest-first. Both
+    ascending and descending upstream feeds do; an unordered feed does not.
+
+    @subsection dataprovider_watch_failure Advance On Success Only
+
+    The cursor advances only after an item has been dispatched successfully, and a cycle <b>stops at
+    the first failure</b> rather than continuing with later items. Continuing would advance the
+    monotonic cursor past the failed item and lose it. The failed item and everything after it is
+    retried on the next cycle, so delivery is <b>at-least-once</b> and never at-most-once.
+
+    The same rule applies to the checkpoint write itself: the replacement checkpoint is stored before
+    the in-memory cursor changes, so a storage failure retries the item instead of silently advancing
+    past it.
+
+    @subsection dataprovider_watch_durability Durability
+
+    Checkpoint persistence is optional at this layer because %Qore does not own a database:
+    - <b>with</b> a callback configured through
+      @ref DataProvider::AbstractWatchDataProviderBase::setCheckpointPersistence() "setCheckpointPersistence()":
+      the cursor survives a host reload or restart, so an item that was never delivered is still
+      delivered afterwards;
+    - <b>without</b> one: the cursor lives only in memory, and behavior after a restart is
+      provider-specific — typically the provider resumes from its configured start position, or from
+      the restart time when it has none, which means items that arrived while it was down are never
+      reported.
+
+    The checkpoint value is opaque to the base class; each provider validates and restores its own
+    format and rejects one it does not recognize, so a stored checkpoint from a different provider or
+    an older format cannot be silently ignored.
+
+    @subsection dataprovider_watch_snapshot Snapshot Collapse
+
+    Some feeds are snapshots rather than logs: each item restates the current state, so after an
+    outage only the last one is worth processing. A provider that supports snapshot mode raises one
+    event per group carrying the newest item, reports what it collapsed away in the event metadata,
+    and can optionally remove the superseded items — see
+    @ref DataProvider::WatchSupersededAction "WatchSupersededAction". Superseded items are identified
+    before their payloads are retrieved, so a large backlog costs one payload retrieval per group
+    rather than one per item.
+
+    A superseded-item removal that fails is logged and the item is left in place; it is not retried,
+    because the retained event has already been raised and the cursor has already moved past it. The
+    item is therefore never raised as an event again, but it is also never lost silently.
+
+    @subsection dataprovider_watch_removal Removal Is Dispatch-Aware, Not Processing-Aware
+
+    A watch provider observes exactly one thing: that raising an event returned without an exception.
+    It does not — and at this layer cannot — observe whether the consumer went on to process the
+    event successfully.
+
+    Any option that removes the source item after its event has been raised (deleting mail, flagging
+    a message, emptying a queue) therefore acts on <b>dispatch</b>, not on <b>completion</b>. A
+    consumer that receives the event and then fails, times out, or is restarted mid-processing has
+    already lost the source item. Providers document such options in exactly those terms and must not
+    describe them as processing-aware.
+
+    For a workload that must not lose the source item, leave those options unset and act from the
+    consumer once processing has succeeded: every event carries the identity of its source item, and
+    providers expose first-class actions that take it.
+
     @section dataprovider_relnotes Release Notes
 
     @subsection dataprovider_v3_6 DataProvider v3.6
+    - added @ref DataProvider::AbstractOrderedWatchDataProvider "AbstractOrderedWatchDataProvider", which
+      implements the shared watch processing sequence — fetch, cursor filtering, ascending sort, optional
+      snapshot collapse, optional dispatch budget, in-order dispatch, advance-on-success, and the post-success
+      hook — with typed @ref DataProvider::WatchItemInfo "WatchItemInfo" item and cursor contracts; see
+      @ref dataprovider_watch
+    - added @ref DataProvider::AbstractTimestampWatchDataProvider "AbstractTimestampWatchDataProvider", which
+      implements the common "records changed since <i>t</i>" cursor on top of the shared template, using a
+      durable timestamp plus the record IDs delivered at that timestamp so the cursor is safe at its own
+      boundary
+    - a watch cycle now <b>stops at the first dispatch failure</b> instead of continuing with later items;
+      continuing advanced the monotonic cursor past the failed item and dropped it permanently on what may
+      well have been a transient error
+    - added an explicit dispatch-order contract: every watch provider declares how its upstream feed is
+      ordered with @ref DataProvider::AbstractWatchDataProviderBase::getSourceOrdering() "getSourceOrdering()"
+      and whether its events arrive oldest-first with
+      @ref DataProvider::AbstractWatchDataProviderBase::hasAscendingDispatch() "hasAscendingDispatch()", so a
+      consumer no longer has to infer either from the implementation
+    - added optional snapshot collapse to the shared template: a backlog can be reduced to the latest item per
+      group, with the collapsed items reported in the event metadata and optionally removed according to
+      @ref DataProvider::WatchSupersededAction "WatchSupersededAction"; superseded items are identified before
+      their payloads are retrieved
+    - added an optional per-cycle dispatch budget, applied from the oldest end so that the durable cursor still
+      advances contiguously and the remainder is delivered by later cycles rather than skipped
+    - documented that checkpoint persistence is what makes delivery at-least-once across host reloads, that
+      without it a provider's restart behavior is provider-specific, and that watch options which remove the
+      source item act on event <b>dispatch</b> and not on consumer <b>processing</b>
     - @ref DataProvider::AbstractDataField::getDisplayName() "AbstractDataField::getDisplayName()" now case-folds
       words in all upper case, so that technical names in upper case produce readable display names (ex:
       \c "PAYMENT-DISPUTE-ADJUDICATE-28" -> \c "Payment Dispute Adjudicate 28"); acronyms are preserved, and an

--- a/qlib/DeelDataProvider/DeelWatchDataProviderBase.qc
+++ b/qlib/DeelDataProvider/DeelWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace DeelDataProvider {
 
 #! Base class for Deel polling watch data providers
 public class DeelWatchDataProviderBase inherits DeelDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -47,22 +47,11 @@ public class DeelWatchDataProviderBase inherits DeelDataProviderBase,
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Primary set of seen IDs for deduplication (current bucket)
-        hash<string, bool> seen_ids;
-
-        #! Previous bucket of seen IDs (for 2-bucket rotation)
-        hash<string, bool> old_seen_ids;
-    }
-
     #! Creates the object with a REST client
     constructor(DeelRestClient::DeelRestClient rest, *hash<auto> options)
             : DeelDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -75,53 +64,32 @@ public class DeelWatchDataProviderBase inherits DeelDataProviderBase,
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                if (isStopping()) {
-                    break;
-                }
-                string id = getRecordId(record);
+    #! Returns the record's identity using the provider's own accessor
+    private *string getWatchRecordId(hash<auto> record) {
+        return getRecordId(record);
+    }
 
-                # Skip if already seen (check both current and previous buckets)
-                if (seen_ids{id} || old_seen_ids{id}) {
-                    continue;
-                }
+    #! Returns the record's position in the feed using the provider's own accessor
+    private *date getWatchRecordTimestamp(hash<auto> record) {
+        return getRecordTimestamp(record);
+    }
 
-                # Check timestamp to avoid old records
-                *date record_time = getRecordTimestamp(record);
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Mark as seen
-                seen_ids{id} = True;
-
-                # Notify observers
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Rotate seen_ids buckets when current bucket exceeds half capacity;
-            # keeps the previous bucket so recently-seen IDs are still checked
-            if (seen_ids.size() > MaxSeenIds / 2) {
-                old_seen_ids = seen_ids;
-                seen_ids = {};
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            # Log only ex.err (not ex.desc) to avoid leaking Bearer token from HTTP error details
-            log(LoggerLevel::ERROR, "Error polling %s: %s", getEventName(), ex.err);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/DeelDataProvider/DeelWatchDataProviderBase.qc
+++ b/qlib/DeelDataProvider/DeelWatchDataProviderBase.qc
@@ -89,7 +89,7 @@ public class DeelWatchDataProviderBase inherits DeelDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/EmpathicBuildingDataProvider/EmpathicBuildingWatchSensorDataProvider.qc
+++ b/qlib/EmpathicBuildingDataProvider/EmpathicBuildingWatchSensorDataProvider.qc
@@ -109,6 +109,16 @@ public class EmpathicBuildingWatchSensorDataProvider inherits EmpathicBuildingDa
     }
 
     #! Performs a single polling operation
+    #! Sensor readings are a level, not an ordered feed
+    /** This provider reports the sensor's current state whenever it changes, so there is no feed to
+        order and no cursor to make durable: a restart simply reports the next reading that differs
+        from the one it then reads. It is a documented exemption from the shared ordered template
+        (@ref DataProvider::AbstractOrderedWatchDataProvider) and from durable checkpoints.
+    */
+    string getSourceOrdering() {
+        return WSO_UNORDERED;
+    }
+
     private pollOnce() {
         hash<auto> event = getEvent();
         if (event != last_event) {

--- a/qlib/FreshBooksDataProvider/FreshBooksWatchDataProviderBase.qc
+++ b/qlib/FreshBooksDataProvider/FreshBooksWatchDataProviderBase.qc
@@ -96,7 +96,7 @@ public class FreshBooksWatchDataProviderBase inherits FreshBooksDataProviderBase
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns query parameters for the poll request

--- a/qlib/FreshBooksDataProvider/FreshBooksWatchDataProviderBase.qc
+++ b/qlib/FreshBooksDataProvider/FreshBooksWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace FreshBooksDataProvider {
 
 #! Base class for FreshBooks polling watch data providers
 public class FreshBooksWatchDataProviderBase inherits FreshBooksDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Maximum number of seen IDs to track before pruning
         const MaxSeenIds = 10000;
@@ -50,22 +50,14 @@ public class FreshBooksWatchDataProviderBase inherits FreshBooksDataProviderBase
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client
     constructor(FreshBooksRestClient::FreshBooksRestClient rest, *hash<auto> options)
             : FreshBooksDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
         if (options.account_id) {
             rest.setAccountId(options.account_id);
         }
-        last_check = options.start_date ?? now_us();
     }
 
     #! Destructor - stops the polling thread
@@ -78,58 +70,33 @@ public class FreshBooksWatchDataProviderBase inherits FreshBooksDataProviderBase
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            # Get records modified since last check
-            hash<auto> params = getQueryParams();
+    #! The upstream ordering is not relied on; records are ordered by timestamp before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            hash<auto> response = doGet(getResourcePath(), params);
-            list<auto> records = response{getResourceKey()} ?? ();
+    #! Fetches every record changed at or after the given timestamp
+    private list<hash<auto>> fetchRecords(date since) {
+        hash<auto> response = doGet(getResourcePath(), getQueryParams());
+        return response{getResourceKey()} ?? ();
+    }
 
-            date new_last_check = last_check;
+    #! Returns the record's identity using the provider's own accessor
+    private *string getWatchRecordId(hash<auto> record) {
+        return getRecordId(record);
+    }
 
-            foreach hash<auto> record in (records) {
-                # check for shutdown between iterations
-                if (isStopping()) {
-                    break;
-                }
-                string id = getRecordId(record);
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
-
-                # Check if this is a new record (created after last check)
-                *string created_date = record.created_at ?? record.create_date;
-                if (created_date) {
-                    date record_time = date(created_date);
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
-
-                # Mark as seen
-                seen_ids{id} = True;
-
-                # Notify observers
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune seen_ids if it gets too large (time-based filtering is primary dedup)
-            if (seen_ids.size() > MaxSeenIds) {
-                seen_ids = {};
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            # Log error but continue polling
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getResourcePath(), ex.err, ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns query parameters for the poll request

--- a/qlib/FreshsalesDataProvider/FreshsalesWatchDataProviderBase.qc
+++ b/qlib/FreshsalesDataProvider/FreshsalesWatchDataProviderBase.qc
@@ -74,7 +74,7 @@ public class FreshsalesWatchDataProviderBase inherits FreshsalesDataProviderBase
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/FreshsalesDataProvider/FreshsalesWatchDataProviderBase.qc
+++ b/qlib/FreshsalesDataProvider/FreshsalesWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace FreshsalesDataProvider {
 
 #! Base class for Freshsales polling watch data providers
 public class FreshsalesWatchDataProviderBase inherits FreshsalesDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -41,20 +41,12 @@ public class FreshsalesWatchDataProviderBase inherits FreshsalesDataProviderBase
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client (async)
     constructor(RestClientIo::RestClientIo rest, *hash<auto> options)
             : FreshsalesDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval,
-                  MinPollInterval)) {
-        last_check = now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval,
+                  MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -67,56 +59,22 @@ public class FreshsalesWatchDataProviderBase inherits FreshsalesDataProviderBase
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                if (isStopping()) {
-                    break;
-                }
-                string id = string(record.id);
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
-
-                # Check timestamp to avoid old records
-                *date record_time;
-                *string ts = record{getTimestampField()};
-                if (ts) {
-                    record_time = date(ts);
-                }
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
-
-                seen_ids{id} = True;
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune oldest half of seen_ids if it gets too large
-            if (seen_ids.size() > 10000) {
-                list<string> all_keys = keys seen_ids;
-                int half = all_keys.size() / 2;
-                foreach string k in (all_keys[0..half-1]) {
-                    delete seen_ids{k};
-                }
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err,
-                ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/GmailDataProvider/GmailAttachmentWatchDataProvider.qc
+++ b/qlib/GmailDataProvider/GmailAttachmentWatchDataProvider.qc
@@ -166,8 +166,7 @@ public class GmailAttachmentWatchDataProvider inherits GmailMessageWatchDataProv
         @since DataProvider 3.0
     */
     private auto getExampleEventDataImpl(string event_id) {
-        hash<auto> info = setup() + {"test_mode": True};
-        *hash<auto> msg = pollOnceIntern(\info);
+        *hash<auto> msg = getExampleMessage();
         if (msg.attachments) {
             # must match the shape raised by messageReceived(), including the source message ID
             return msg.attachments[0] + {"message_id": msg.id};

--- a/qlib/GmailDataProvider/GmailDataProvider.qm
+++ b/qlib/GmailDataProvider/GmailDataProvider.qm
@@ -227,7 +227,7 @@ module GmailDataProvider {
                     "desc": "Sets the start date and time for matching messages",
                     "type": AbstractDataProviderTypeMap."date",
                 },
-            },
+            } + WatchBacklogOptions,
             "get_output_type": AbstractDataProviderType sub () {
                 return create_object("GmailMessageEventDataType");
             },
@@ -298,7 +298,7 @@ module GmailDataProvider {
                     "desc": "Sets the start date and time for matching messages",
                     "type": AbstractDataProviderTypeMap."date",
                 },
-            },
+            } + WatchBacklogOptions,
             "output_type": GmailAttachmentEventDataType,
         });
         DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
@@ -424,4 +424,88 @@ public const GoogleDiscoveryGmailApiName = "gmail";
 
 #! used in accordance with: https://about.google/brand-resource-center/brand-elements/
 public const GmailLogo = File::readTextFile(get_script_dir() + "/gmail-logo.svg");
+
+#! Backlog-handling options shared by the Gmail watch actions
+/** @since GmailDataProvider 1.1
+*/
+public const WatchBacklogOptions = {
+    "snapshot_mode": <ActionOptionInfo>{
+        "display_name": "Latest Message Only?",
+        "short_desc": "Collapse a backlog to its latest message instead of replaying it?",
+        "desc": "Collapse a backlog to its latest message instead of replaying it.\n\n"
+            "Some feeds are snapshots rather than a log: each message restates the current state, so after "
+            "an outage only the last one is worth processing. With this option set, each polling cycle "
+            "raises one event per group (see `snapshot_key`) carrying the newest matching message, and "
+            "reports the messages it collapsed away in the event's `superseded_count` and `superseded_ids` "
+            "fields. The collapsed messages are never retrieved in full, so a large backlog costs one "
+            "message retrieval, not one per message.\n\n"
+            "Leave this unset for a feed where every message must be processed",
+        "type": AbstractDataProviderTypeMap."bool",
+    },
+    "snapshot_key": <ActionOptionInfo>{
+        "display_name": "Snapshot Grouping",
+        "short_desc": "How messages are grouped before the latest one is selected",
+        "desc": "How matching messages are grouped before the latest one in each group is selected; ignored "
+            "unless `snapshot_mode` is set.\n\n"
+            "- `all`: one global group, so each cycle raises a single event carrying the newest matching "
+            "message\n"
+            "- `thread`: group by Gmail thread, so each cycle raises one event per thread carrying that "
+            "thread's newest message",
+        "type": AbstractDataProviderTypeMap."string",
+        "default_value": "all",
+        "allowed_values": (
+            <AllowedValueInfo>{
+                "value": "all",
+                "display_name": "Latest Overall",
+                "desc": "Retain the single newest matching message",
+            },
+            <AllowedValueInfo>{
+                "value": "thread",
+                "display_name": "Latest Per Thread",
+                "desc": "Retain the newest message in each Gmail thread",
+            },
+        ),
+    },
+    "superseded_action": <ActionOptionInfo>{
+        "display_name": "Superseded Message Action",
+        "short_desc": "What to do with messages that were collapsed away",
+        "desc": "What to do with the messages that `snapshot_mode` collapsed away; ignored unless "
+            "`snapshot_mode` is set.\n\n"
+            "- `ignore`: leave them in the mailbox, so they remain available for audit; they are not raised "
+            "as events again because the watch cursor has moved past them\n"
+            "- `trash`: move them to the Gmail trash, where they can still be recovered\n"
+            "- `delete`: delete them permanently; **this cannot be undone**\n\n"
+            "A removal that fails is logged and the message is left in place; it is not retried, because "
+            "its event has already been raised and the watch cursor has already moved past it",
+        "type": AbstractDataProviderTypeMap."string",
+        "default_value": "ignore",
+        "allowed_values": (
+            <AllowedValueInfo>{
+                "value": "ignore",
+                "display_name": "Keep",
+                "desc": "Leave superseded messages in the mailbox",
+            },
+            <AllowedValueInfo>{
+                "value": "trash",
+                "display_name": "Move to Trash",
+                "desc": "Move superseded messages to the Gmail trash",
+            },
+            <AllowedValueInfo>{
+                "value": "delete",
+                "display_name": "Delete Permanently",
+                "desc": "Delete superseded messages permanently",
+            },
+        ),
+    },
+    "max_messages_per_cycle": <ActionOptionInfo>{
+        "display_name": "Maximum Messages Per Cycle",
+        "short_desc": "The maximum number of messages delivered in one polling cycle",
+        "desc": "The maximum number of messages delivered in one polling cycle; unset or `0` means no "
+            "limit.\n\n"
+            "The limit is applied from the **oldest** end of the backlog, so the watch cursor still advances "
+            "contiguously and the remaining messages are delivered by the following cycles rather than "
+            "skipped. Use it to bound the work a single cycle can do when a large backlog may accumulate",
+        "type": AbstractDataProviderTypeMap."int",
+    },
+};
 }

--- a/qlib/GmailDataProvider/GmailDataProvider.qm
+++ b/qlib/GmailDataProvider/GmailDataProvider.qm
@@ -409,6 +409,24 @@ module GmailDataProvider {
     - attachment watch events carry the \c message_id of the source message, so a consumer can address it
     - documented that the \c delete_messages watch option deletes each matched message as soon as its
       event has been raised, whatever the consumer then does with it
+    - the watch now follows \c nextPageToken and processes every page of matching messages in one polling
+      cycle; previously only the first page was ever seen, so a backlog larger than one page was never
+      fully delivered
+    - the watch delivers messages oldest-first and advances its durable cursor only after a message has
+      been delivered successfully, stopping the cycle at the first failure; Gmail lists messages
+      newest-first, so delivering in that order advanced the cursor past older messages that had not been
+      delivered
+    - added the \c snapshot_mode watch option for feeds where each message restates the current state
+      rather than adding to a log: a backlog is collapsed to the newest message overall or, with
+      \c snapshot_key set to \c "thread", to the newest message in each thread. The event reports what it
+      stood in for in its \c superseded_count and \c superseded_ids fields, and the collapsed messages are
+      never retrieved in full, so a large backlog costs one message retrieval rather than one per message
+    - added the \c superseded_action watch option to leave collapsed messages in place (the default), move
+      them to the trash, or delete them permanently; a removal that fails is logged and the message is left
+      in place
+    - added the \c max_messages_per_cycle watch option to bound the work one cycle can do; the limit is
+      applied from the oldest end of the backlog, so the cursor still advances contiguously and the
+      remaining messages are delivered by the following cycles rather than skipped
 
     @subsection gmaildataprovider_v1_0 GmailDataProvider v1.0
     - initial release of the module

--- a/qlib/GmailDataProvider/GmailMessageWatchDataProvider.qc
+++ b/qlib/GmailDataProvider/GmailMessageWatchDataProvider.qc
@@ -104,8 +104,7 @@ public class GmailMessageWatchDataProvider inherits GmailMessageWatchDataProvide
         @since DataProvider 3.0
     */
     private auto getExampleEventDataImpl(string event_id) {
-        hash<auto> info = setup() + {"test_mode": True};
-        if (*hash<auto> msg = pollOnceIntern(\info)) {
+        if (*hash<auto> msg = getExampleMessage()) {
             return msg;
         }
         return AbstractDataProvider::getExampleEventDataImpl(event_id);
@@ -255,6 +254,25 @@ public class GmailMessageEventDataType inherits HashDataType {
             "short_desc": "Message attachments",
             "desc": "Message attachments",
             "type": new ListDataType("AttachmentList", new GmailAttachmentEventDataType(), True),
+        }));
+        addField(new QoreDataField({
+            "name": "superseded_count",
+            "display_name": "Superseded Message Count",
+            "short_desc": "How many older messages this event collapsed away",
+            "desc": "How many older messages this event collapsed away.\n\n"
+                "Only present when the watch runs with `snapshot_mode` set and this event stood in for a "
+                "backlog; a consumer can use it to tell a collapsed event from an ordinary one",
+            "type": AbstractDataProviderTypeMap."*int",
+        }));
+        addField(new QoreDataField({
+            "name": "superseded_ids",
+            "display_name": "Superseded Message IDs",
+            "short_desc": "The IDs of the older messages this event collapsed away",
+            "desc": "The IDs of the older messages this event collapsed away, oldest first.\n\n"
+                "Only present when the watch runs with `snapshot_mode` set. The messages are still "
+                "addressable with the `trash-message` and `delete-message` actions unless the watch's "
+                "`superseded_action` option already removed them",
+            "type": new ListDataType("SupersededMessageIdList", AbstractDataProviderTypeMap."string", True),
         }));
     }
 }

--- a/qlib/GmailDataProvider/GmailMessageWatchDataProviderBase.qc
+++ b/qlib/GmailDataProvider/GmailMessageWatchDataProviderBase.qc
@@ -26,7 +26,7 @@
 public namespace GmailDataProvider {
 #! The parent class for Gmail REST APIs
 public class GmailMessageWatchDataProviderBase inherits GoogleDataProvider::GoogleDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractOrderedWatchDataProvider {
     public {
         #! Constructor options
         const ConstructorOptions = {
@@ -73,7 +73,92 @@ public class GmailMessageWatchDataProviderBase inherits GoogleDataProvider::Goog
                 "type": (AbstractDataProviderTypeMap."date",),
                 "desc": "Do not retrieve emails earlier than the given date",
             },
+            "snapshot_mode": <DataProviderOptionInfo>{
+                "display_name": "Latest Message Only?",
+                "short_desc": "Collapse a backlog to its latest message instead of replaying it?",
+                "type": (AbstractDataProviderTypeMap."bool",),
+                "desc": "Collapse a backlog to its latest message instead of replaying it.\n\n"
+                    "Some feeds are snapshots rather than a log: each message restates the current state, so "
+                    "after an outage only the last one is worth processing. With this option set, each polling "
+                    "cycle raises one event per group (see `snapshot_key`) carrying the newest matching message, "
+                    "and reports the messages it collapsed away in the event's `superseded_count` and "
+                    "`superseded_ids` fields. The messages that are collapsed away are never fetched in full, "
+                    "so a large backlog costs one message retrieval, not one per message.\n\n"
+                    "Leave this unset for a feed where every message must be processed",
+            },
+            "snapshot_key": <DataProviderOptionInfo>{
+                "display_name": "Snapshot Grouping",
+                "short_desc": "How messages are grouped before the latest one is selected",
+                "type": (AbstractDataProviderTypeMap."string",),
+                "desc": "How matching messages are grouped before the latest one in each group is selected; "
+                    "ignored unless `snapshot_mode` is set.\n\n"
+                    "- `all`: one global group, so each cycle raises a single event carrying the newest "
+                    "matching message\n"
+                    "- `thread`: group by Gmail thread, so each cycle raises one event per thread carrying that "
+                    "thread's newest message",
+                "default_value": SnapshotKeyAll,
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "value": SnapshotKeyAll,
+                        "display_name": "Latest Overall",
+                        "desc": "Retain the single newest matching message",
+                    },
+                    <AllowedValueInfo>{
+                        "value": SnapshotKeyThread,
+                        "display_name": "Latest Per Thread",
+                        "desc": "Retain the newest message in each Gmail thread",
+                    },
+                ),
+            },
+            "superseded_action": <DataProviderOptionInfo>{
+                "display_name": "Superseded Message Action",
+                "short_desc": "What to do with messages that were collapsed away",
+                "type": (AbstractDataProviderTypeMap."string",),
+                "desc": "What to do with the messages that `snapshot_mode` collapsed away; ignored unless "
+                    "`snapshot_mode` is set.\n\n"
+                    "- `ignore`: leave them in the mailbox, so they remain available for audit; they are not "
+                    "raised as events again because the watch cursor has moved past them\n"
+                    "- `trash`: move them to the Gmail trash, where they can still be recovered\n"
+                    "- `delete`: delete them permanently; **this cannot be undone**\n\n"
+                    "A removal that fails is logged and the message is left in place; it is not retried, "
+                    "because its event has already been raised and the watch cursor has already moved past it",
+                "default_value": WSA_IGNORE,
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "value": WSA_IGNORE,
+                        "display_name": "Keep",
+                        "desc": "Leave superseded messages in the mailbox",
+                    },
+                    <AllowedValueInfo>{
+                        "value": WSA_TRASH,
+                        "display_name": "Move to Trash",
+                        "desc": "Move superseded messages to the Gmail trash",
+                    },
+                    <AllowedValueInfo>{
+                        "value": WSA_DELETE,
+                        "display_name": "Delete Permanently",
+                        "desc": "Delete superseded messages permanently",
+                    },
+                ),
+            },
+            "max_messages_per_cycle": <DataProviderOptionInfo>{
+                "display_name": "Maximum Messages Per Cycle",
+                "short_desc": "The maximum number of messages delivered in one polling cycle",
+                "type": (AbstractDataProviderTypeMap."int",),
+                "desc": "The maximum number of messages delivered in one polling cycle; unset or `0` means no "
+                    "limit.\n\n"
+                    "The limit is applied from the **oldest** end of the backlog, so the watch cursor still "
+                    "advances contiguously and the remaining messages are delivered by the following cycles "
+                    "rather than skipped. Use it to bound the work a single cycle can do when a large backlog "
+                    "may accumulate",
+            },
         };
+
+        #! Snapshot grouping: retain the newest matching message overall
+        const SnapshotKeyAll = "all";
+
+        #! Snapshot grouping: retain the newest message in each Gmail thread
+        const SnapshotKeyThread = "thread";
 
         #! Minimum poll interval in seconds
         const MinPollInterval = 30;
@@ -114,11 +199,14 @@ public class GmailMessageWatchDataProviderBase inherits GoogleDataProvider::Goog
         #! Match query
         string q;
 
-        #! Current epoch for polling (tracks latest message timestamp)
-        int poll_epoch;
+        #! Current epoch for polling (tracks latest message timestamp); 0 until the first message
+        int poll_epoch = 0;
 
         #! Message IDs already processed at current epoch (deduplication)
         hash<string, bool> last_msg = {};
+
+        #! How messages are grouped in snapshot mode
+        string snapshot_key = SnapshotKeyAll;
 
         #! Setup info for polling (initialized on first poll)
         hash<auto> setup_info;
@@ -128,7 +216,7 @@ public class GmailMessageWatchDataProviderBase inherits GoogleDataProvider::Goog
     constructor(GoogleRestClient::GoogleRestClientIo rest,
             hash<string, hash<DataProviderOptionInfo>> constructor_options, *hash<auto> options)
             : GoogleDataProviderBase(rest),
-              AbstractWatchDataProviderBase(GmailMessageWatchDataProviderBase::getPollInterval(
+              AbstractOrderedWatchDataProvider(GmailMessageWatchDataProviderBase::getPollInterval(
                   DataProviderDataContextHelper::getHash(){keys constructor_options} + options)) {
         *hash<auto> copts = checkOptions("CONSTRUCTOR-ERROR", constructor_options,
             DataProviderDataContextHelper::getHash(){keys constructor_options} + options);
@@ -158,8 +246,21 @@ public class GmailMessageWatchDataProviderBase inherits GoogleDataProvider::Goog
             start_date = copts.start_date;
             poll_epoch = mktime(start_date);
         }
+        if (copts.snapshot_key.val()) {
+            if (copts.snapshot_key != SnapshotKeyAll && copts.snapshot_key != SnapshotKeyThread) {
+                throw "CONSTRUCTOR-ERROR", sprintf("snapshot_key %y is unknown; expecting one of %y",
+                    copts.snapshot_key, (SnapshotKeyAll, SnapshotKeyThread));
+            }
+            snapshot_key = copts.snapshot_key;
+        }
+        setWatchPolicy(copts.snapshot_mode ?? False, copts.superseded_action, copts.max_messages_per_cycle);
 
         q = copts.q;
+    }
+
+    #! Gmail lists messages newest-first, so the watch reverses them before delivery
+    string getSourceOrdering() {
+        return WSO_DESCENDING;
     }
 
     #! Returns the effective poll interval in seconds
@@ -174,12 +275,12 @@ public class GmailMessageWatchDataProviderBase inherits GoogleDataProvider::Goog
         };
     }
 
-    #! Performs a single polling operation
-    private pollOnce() {
+    #! Returns the message type used to validate and convert retrieved messages
+    private hash<auto> getSetupInfo() {
         if (!setup_info) {
             setup_info = setup();
         }
-        pollOnceIntern(\setup_info);
+        return setup_info;
     }
 
     #! Restores the Gmail polling cursor
@@ -218,109 +319,240 @@ public class GmailMessageWatchDataProviderBase inherits GoogleDataProvider::Goog
         last_msg = next_ids;
     }
 
-    #! Perform one poll
-    private *hash<auto> pollOnceIntern(reference<hash<auto>> setup) {
-        # check for matching mail
-        try {
-            hash<auto> res;
-            string gmail_query = q;
-            if (poll_epoch) {
-                # Include the preceding second so messages sharing the checkpoint second can be
-                # deduplicated by ID instead of being lost if Gmail applies a strict timestamp bound.
-                gmail_query += sprintf(" after:%d", poll_epoch - 1);
+    #! Lists every message matching the watch query, following pagination
+    /** @param gmail_query the Gmail search expression
+        @param max_pages stop after this many pages; unset means walk every page
+
+        @return the listed message stubs, newest first as Gmail returns them, or an empty list if
+        shutdown interrupted the walk
+
+        @note Every page in scope is walked by default. A partial list is not usable: Gmail lists
+        newest-first, so stopping early yields the newest messages and delivering any of them would
+        advance the watch cursor past older messages that were never listed. If shutdown interrupts
+        the walk, this method therefore returns nothing at all and the cycle does no work.
+    */
+    private list<hash<auto>> listMessages(string gmail_query, *int max_pages) {
+        list<hash<auto>> listed = ();
+        *string page_token;
+        int pages = 0;
+        while (True) {
+            # 500 is the maximum page size the Gmail API accepts; using it minimizes round trips
+            string this_uri = "gmail/v1/users/me/messages?maxResults=500&q=" + encode_url(gmail_query);
+            if (page_token.val()) {
+                this_uri += "&pageToken=" + encode_url(page_token);
             }
-            string this_uri = "gmail/v1/users/me/messages?q=" + encode_url(gmail_query);
             LoggerWrapper::debug("Gmail polling using URI: %y epoch: %y poll_interval: %ds", this_uri, poll_epoch,
                 poll_secs);
-            res = rest.restGet(this_uri).body;
-            int match;
-            list<hash<auto>> messages;
-            foreach hash<auto> minfo in (res.messages) {
-                # check for shutdown between REST calls
-                if (isStopping()) {
-                    break;
-                }
-                # retrieve each email
-                string msguri = sprintf("gmail/v1/users/me/messages/%s", minfo.id);
-                hash<auto> msg = rest.restGet(msguri).body;
-
-                # try to decode body as base64 if there is a Content-Transfer-Encoding header
-                # do not allow message bodies to be re-encoded as base64
-                processHeaders(\msg.payload, GmailMessageEventDataType::Fields,
-                    GmailMessageEventDataType::PartFields);
-
-                # check message structure and convert types where necessary
-                msg = setup.msgtype.acceptsValue(msg);
-
-                # convert base64-decoded message bodies to strings if they have text MIME types
-                processBody(\msg.payload);
-
-                # Fetch the page before delivery and process it oldest-first. Gmail lists newest
-                # messages first; advancing a durable timestamp in that order could skip an older
-                # message if delivery of a later item failed.
-                push messages, msg;
+            hash<auto> res = rest.restGet(this_uri).body;
+            ++pages;
+            if (res.messages) {
+                listed += res.messages;
             }
-            messages = sort(messages, int sub (hash<auto> left, hash<auto> right) {
-                return left.internalDate <=> right.internalDate;
-            });
-            foreach hash<auto> msg in (messages) {
-                int msg_epoch = msg.internalDate / 1000;
-                if (isStopping()) {
-                    break;
+            page_token = res.nextPageToken;
+            if (!page_token.val()) {
+                break;
+            }
+            if (isStopping()) {
+                LoggerWrapper::debug("Gmail: shutting down during pagination after %d page(s); discarding the "
+                    "partial list so the cursor cannot advance past unlisted messages", pages);
+                return ();
+            }
+            if (max_pages && pages >= max_pages) {
+                break;
+            }
+        }
+        LoggerWrapper::debug("Gmail: listed %d message(s) over %d page(s)", listed.size(), pages);
+        return listed;
+    }
+
+    #! Retrieves and normalizes one message in full
+    private hash<auto> getFullMessage(string message_id) {
+        hash<auto> msg = rest.restGet(sprintf("gmail/v1/users/me/messages/%s", message_id)).body;
+
+        # try to decode body as base64 if there is a Content-Transfer-Encoding header
+        # do not allow message bodies to be re-encoded as base64
+        processHeaders(\msg.payload, GmailMessageEventDataType::Fields,
+            GmailMessageEventDataType::PartFields);
+
+        # check message structure and convert types where necessary
+        msg = getSetupInfo().msgtype.acceptsValue(msg);
+
+        # convert base64-decoded message bodies to strings if they have text MIME types
+        processBody(\msg.payload);
+        return msg;
+    }
+
+    #! Returns the message's position in the feed in seconds since the epoch
+    private static int getMessageEpoch(auto internal_date) {
+        return int(internal_date) / 1000;
+    }
+
+    #! Returns @ref True if the cycle needs a cheap ordering pass before fetching payloads
+    /** Collapsing a backlog or bounding a batch means deciding which messages to deliver before
+        paying for their payloads, which needs each message's timestamp up front. Without either
+        option every listed message is delivered anyway, so the full retrieval doubles as the
+        ordering pass and no extra API call is made.
+    */
+    private bool usesOrderingPass() {
+        return hasSnapshotMode() || getMaxItemsPerCycle() > 0;
+    }
+
+    #! Returns the cycle's candidate messages
+    private list<hash<WatchItemInfo>> fetchWatchItems() {
+        string gmail_query = q;
+        if (poll_epoch) {
+            # Include the preceding second so messages sharing the checkpoint second can be
+            # deduplicated by ID instead of being lost if Gmail applies a strict timestamp bound.
+            gmail_query += sprintf(" after:%d", poll_epoch - 1);
+        }
+        bool ordering_pass = usesOrderingPass();
+        list<hash<WatchItemInfo>> items = ();
+        foreach hash<auto> minfo in (listMessages(gmail_query)) {
+            # check for shutdown between REST calls
+            if (isStopping()) {
+                return ();
+            }
+            hash<auto> msg;
+            if (ordering_pass) {
+                # "minimal" returns the message's identity, thread, and internalDate without its
+                # payload, so a message that is about to be collapsed away costs almost nothing
+                msg = rest.restGet(sprintf("gmail/v1/users/me/messages/%s?format=minimal", minfo.id)).body;
+            } else {
+                msg = getFullMessage(minfo.id);
+            }
+            push items, <WatchItemInfo>{
+                "id": msg.id,
+                "order_key": GmailMessageWatchDataProviderBase::getMessageEpoch(msg.internalDate),
+                "group_key": snapshot_key == SnapshotKeyThread ? msg.threadId : NOTHING,
+                "data": ordering_pass ? NOTHING : msg,
+            };
+        }
+        return items;
+    }
+
+    #! Returns @ref True if the message lies beyond the durable cursor
+    private bool isNewWatchItem(hash<WatchItemInfo> item) {
+        int msg_epoch = item.order_key;
+        if (msg_epoch > poll_epoch) {
+            return True;
+        }
+        if (msg_epoch == poll_epoch) {
+            return !last_msg{item.id};
+        }
+        return False;
+    }
+
+    #! Retrieves the message payload, including attachment data when requested
+    private auto fetchWatchItemPayload(hash<WatchItemInfo> item) {
+        hash<auto> msg = item.data ?? getFullMessage(item.id);
+        if (retrieve_attachments) {
+            msg = addAttachments(msg);
+            LoggerWrapper::info("Gmail: matched message %y attachments: %d", msg.id, msg.attachments.size());
+        } else {
+            LoggerWrapper::info("Gmail: matched message %y", msg.id);
+        }
+        return msg;
+    }
+
+    #! Retrieves and attaches the message's attachment data
+    private hash<auto> addAttachments(hash<auto> msg) {
+        msg.attachments = ();
+        foreach hash<auto> part in (msg.payload.parts) {
+            if (*string aid = part.body.attachmentId) {
+                # retrieve attachment; skip on error to preserve the message event
+                string atturi = sprintf("gmail/v1/users/me/messages/%s/attachments/%s", msg.id, aid);
+                try {
+                    hash<auto> att = rest.restGet(atturi).body;
+                    msg.attachments += getAttachment(att, part.headers);
+                } catch (hash<ExceptionInfo> att_ex) {
+                    LoggerWrapper::warn("Gmail: failed to retrieve attachment %y for message %y: %s",
+                        aid, msg.id, get_exception_string(att_ex));
                 }
-                if (msg_epoch < poll_epoch || (msg_epoch == poll_epoch && last_msg{msg.id})) {
-                    continue;
-                }
-                if (retrieve_attachments) {
-                    msg.attachments = ();
-                    foreach hash<auto> part in (msg.payload.parts) {
-                        if (*string aid = part.body.attachmentId) {
-                            # retrieve attachment; skip on error to preserve the message event
-                            string atturi = sprintf("gmail/v1/users/me/messages/%s/attachments/%s", msg.id,
-                                aid);
-                            try {
-                                hash<auto> att = rest.restGet(atturi).body;
-                                msg.attachments += getAttachment(att, part.headers);
-                            } catch (hash<ExceptionInfo> att_ex) {
-                                LoggerWrapper::warn("Gmail: failed to retrieve attachment %y for message %y: %s",
-                                    aid, msg.id, get_exception_string(att_ex));
-                            }
-                        }
-                    }
-                    LoggerWrapper::info("Gmail: matched message %y attachments: %d", msg.id,
-                        msg.attachments.size());
+            }
+        }
+        return msg;
+    }
+
+    #! Raises the event for one message
+    private dispatchWatchItem(hash<WatchItemInfo> item, auto payload, list<hash<WatchItemInfo>> superseded) {
+        hash<auto> msg = payload;
+        if (superseded) {
+            msg += {
+                "superseded_count": superseded.size(),
+                "superseded_ids": map $1.id, superseded,
+            };
+        }
+        messageReceived(msg);
+    }
+
+    #! Durably advances the Gmail cursor to the given message
+    private advanceWatchCursor(hash<WatchItemInfo> item) {
+        int msg_epoch = item.order_key;
+        bool epoch_updated = msg_epoch > poll_epoch;
+        commitCheckpoint(msg_epoch, item.id);
+        if (epoch_updated) {
+            LoggerWrapper::debug("Gmail using new epoch: %y", poll_epoch);
+        }
+    }
+
+    #! Deletes the source message when the watch was configured to do so
+    /** @note the message is deleted because its event was raised, which is not the same as the
+        consumer having processed it; see @ref watch_removal_semantics
+    */
+    private afterWatchItemDispatched(hash<WatchItemInfo> item, auto payload) {
+        if (delete_messages) {
+            rest.restDel(sprintf("gmail/v1/users/me/messages/%s", item.id));
+            LoggerWrapper::info("Gmail: deleted matched message %y", item.id);
+        }
+    }
+
+    #! Trashes or deletes the messages that snapshot mode collapsed away
+    /** A failure is logged per message and does not stop the others: the retained event has already
+        been raised and its cursor committed, so nothing can be lost by continuing, and the message
+        left behind is simply not raised again.
+    */
+    private applySupersededAction(list<hash<WatchItemInfo>> superseded) {
+        string action = getSupersededAction();
+        if (action == WSA_IGNORE) {
+            return;
+        }
+        foreach hash<WatchItemInfo> item in (superseded) {
+            try {
+                if (action == WSA_TRASH) {
+                    rest.restPost(sprintf("gmail/v1/users/me/messages/%s/trash", item.id), {});
                 } else {
-                    LoggerWrapper::info("Gmail: matched message %y", msg.id);
+                    rest.restDel(sprintf("gmail/v1/users/me/messages/%s", item.id));
                 }
-
-                if (setup.test_mode) {
-                    return msg;
-                }
-                ++match;
-                messageReceived(msg);
-                bool epoch_updated = msg_epoch > poll_epoch;
-                commitCheckpoint(msg_epoch, msg.id);
-                if (delete_messages) {
-                    string deluri = sprintf("gmail/v1/users/me/messages/%s", msg.id);
-                    rest.restDel(deluri);
-                    LoggerWrapper::info("Gmail: deleted matched message %y", msg.id);
-                }
-                if (epoch_updated) {
-                    LoggerWrapper::debug("Gmail using new epoch: %y", poll_epoch);
-                }
+                LoggerWrapper::info("Gmail: applied superseded action %y to message %y", action, item.id);
+            } catch (hash<ExceptionInfo> ex) {
+                LoggerWrapper::warn("Gmail: could not apply superseded action %y to message %y: %s; the message "
+                    "is left in place and will not be raised again", action, item.id, get_exception_string(ex));
             }
-            if (!match) {
-                LoggerWrapper::debug("Gmail: matched no messages");
+        }
+    }
+
+    #! Returns one matching message for use as example event data, without delivering it
+    private *hash<auto> getExampleMessage() {
+        try {
+            # one page is enough for an example
+            foreach hash<auto> minfo in (listMessages(q, 1)) {
+                hash<auto> msg = getFullMessage(minfo.id);
+                return retrieve_attachments ? addAttachments(msg) : msg;
             }
         } catch (hash<ExceptionInfo> ex) {
-            if (setup.test_mode) {
-                LoggerWrapper::error("Gmail error retrieving emails in test mode: %s", get_exception_string(ex));
-                return;
-            }
-
-            LoggerWrapper::error("Gmail error retrieving emails: %s; polling again in %ds", get_exception_string(ex),
-                poll_secs);
+            LoggerWrapper::error("Gmail error retrieving example message: %s", get_exception_string(ex));
         }
+    }
+
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        LoggerWrapper::error("Gmail error retrieving emails: %s; polling again in %ds", get_exception_string(ex),
+            poll_secs);
+    }
+
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        LoggerWrapper::logArgs(LoggerLevel::INFO, "Gmail: " + fmt, argv);
     }
 
     #! Process headers and body

--- a/qlib/GoHighLevelDataProvider/GoHighLevelWatchDataProviderBase.qc
+++ b/qlib/GoHighLevelDataProvider/GoHighLevelWatchDataProviderBase.qc
@@ -91,7 +91,7 @@ public class GoHighLevelWatchDataProviderBase inherits GoHighLevelDataProviderBa
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/GoHighLevelDataProvider/GoHighLevelWatchDataProviderBase.qc
+++ b/qlib/GoHighLevelDataProvider/GoHighLevelWatchDataProviderBase.qc
@@ -29,7 +29,7 @@ public namespace GoHighLevelDataProvider {
 
 #! Base class for GoHighLevel polling watch data providers
 public class GoHighLevelWatchDataProviderBase inherits GoHighLevelDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -49,19 +49,11 @@ public class GoHighLevelWatchDataProviderBase inherits GoHighLevelDataProviderBa
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client
     constructor(GoHighLevelRestClient::GoHighLevelRestClient rest, *hash<auto> options)
             : GoHighLevelDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -74,51 +66,32 @@ public class GoHighLevelWatchDataProviderBase inherits GoHighLevelDataProviderBa
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                # check for shutdown between iterations
-                if (isStopping()) {
-                    break;
-                }
-                string id = getRecordId(record);
+    #! Returns the record's identity using the provider's own accessor
+    private *string getWatchRecordId(hash<auto> record) {
+        return getRecordId(record);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
+    #! Returns the record's position in the feed using the provider's own accessor
+    private *date getWatchRecordTimestamp(hash<auto> record) {
+        return getRecordTimestamp(record);
+    }
 
-                # Check timestamp to avoid old records
-                *date record_time = getRecordTimestamp(record);
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Mark as seen
-                seen_ids{id} = True;
-
-                # Notify observers
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune seen_ids if it gets too large
-            if (seen_ids.size() > MaxSeenIds) {
-                seen_ids = {};
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/GorgiasDataProvider/GorgiasWatchDataProviderBase.qc
+++ b/qlib/GorgiasDataProvider/GorgiasWatchDataProviderBase.qc
@@ -74,7 +74,7 @@ public class GorgiasWatchDataProviderBase inherits GorgiasDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/GorgiasDataProvider/GorgiasWatchDataProviderBase.qc
+++ b/qlib/GorgiasDataProvider/GorgiasWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace GorgiasDataProvider {
 
 #! Base class for Gorgias polling watch data providers
 public class GorgiasWatchDataProviderBase inherits GorgiasDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -41,20 +41,12 @@ public class GorgiasWatchDataProviderBase inherits GorgiasDataProviderBase,
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client (async)
     constructor(RestClientIo::RestClientIo rest, *hash<auto> options)
             : GorgiasDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval,
-                  MinPollInterval)) {
-        last_check = now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval,
+                  MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -67,56 +59,22 @@ public class GorgiasWatchDataProviderBase inherits GorgiasDataProviderBase,
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                if (isStopping()) {
-                    break;
-                }
-                string id = string(record.id);
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
-
-                # Check timestamp to avoid old records
-                *date record_time;
-                *string ts = record{getTimestampField()};
-                if (ts) {
-                    record_time = date(ts);
-                }
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
-
-                seen_ids{id} = True;
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune oldest half of seen_ids if it gets too large
-            if (seen_ids.size() > 10000) {
-                list<string> all_keys = keys seen_ids;
-                int half = all_keys.size() / 2;
-                foreach string k in (all_keys[0..half-1]) {
-                    delete seen_ids{k};
-                }
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err,
-                ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/ImapClientDataProvider/ImapClientDataProvider.qm
+++ b/qlib/ImapClientDataProvider/ImapClientDataProvider.qm
@@ -249,6 +249,13 @@ module ImapClientDataProvider {
 
     @subsection imapclientdataprovider_v1_0 ImapClientDataProvider 1.0
     - initial release of the module
+    - a watch sweep stops at the first message whose delivery fails instead of continuing with the next
+      UID; continuing advanced the monotonic UID cursor past the failed message and dropped it permanently
+      on what may well have been a transient error
+    - documented that the first poll with no stored checkpoint establishes a baseline from the mailbox's
+      current highest UID, so mail that was already there — including mail that arrived while the watch
+      was not running — is never reported, and that configuring checkpoint persistence closes that gap
+      across restarts
 */
 
 #! Contains all public definitions in the ImapClientDataProvider module

--- a/qlib/ImapClientDataProvider/ImapWatchDataProviders.qc
+++ b/qlib/ImapClientDataProvider/ImapWatchDataProviders.qc
@@ -39,10 +39,26 @@ public const EVENT_IMAP_ATTACHMENT_MATCHED = "IMAP-ATTACHMENT-MATCHED";
     so a message is reported exactly once even across reconnects. If the server resets \c uidvalidity the
     watch starts again from the current end of the mailbox rather than re-reporting the whole mailbox.
 
+    @par The first poll establishes a baseline
+    With no stored checkpoint, the first poll records the mailbox's current highest UID and reports
+    nothing, so <b>mail that was already in the mailbox when the watch first started is never
+    reported</b> — including mail that arrived while the watch was not running. This is deliberate:
+    without a cursor there is no way to tell mail that has already been handled from mail that has
+    not, and reporting a whole mailbox on first start would flood the consumer.
+
+    To make the gap disappear across restarts, configure
+    @ref DataProvider::AbstractWatchDataProviderBase::setCheckpointPersistence() "checkpoint persistence";
+    the cursor then survives a reload and mail that arrived while the watch was down is reported on
+    the next poll. Without it, the baseline is re-established on every start.
+
+    @par Removal is dispatch-aware
+    \c mark_seen and \c delete_messages act once a message's event has been <b>raised</b>, which is
+    not the same as the consumer having <b>processed</b> it; see @ref watch_removal_semantics.
+
     @since %ImapClientDataProvider 1.0
 */
 public class ImapWatchDataProviderBase inherits ImapClientDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractOrderedWatchDataProvider {
     public {
         #! Constructor options shared by the watch providers
         const WatchOptions = ImapClientDataProviderBase::ConstructorOptions + {
@@ -127,13 +143,16 @@ public class ImapWatchDataProviderBase inherits ImapClientDataProviderBase,
 
         #! True once IDLE has been entered on the connection
         bool idling = False;
+
+        #! True when messages were flagged \Deleted in the current cycle and must be expunged
+        bool expunge_needed = False;
     }
     #! @endcond
 
     #! Creates the object from constructor options
     constructor(*hash<auto> options, hash<string, hash<DataProviderOptionInfo>> con_opts = WatchOptions)
             : ImapClientDataProviderBase(options, con_opts),
-              AbstractWatchDataProviderBase(options.poll_interval ?? 60) {
+              AbstractOrderedWatchDataProvider(options.poll_interval ?? 60) {
         setWatchOptions(options);
     }
 
@@ -143,7 +162,7 @@ public class ImapWatchDataProviderBase inherits ImapClientDataProviderBase,
     */
     constructor(ImapClient::ImapClient imap, *hash<auto> options)
             : ImapClientDataProviderBase(imap),
-              AbstractWatchDataProviderBase(options.poll_interval ?? 60) {
+              AbstractOrderedWatchDataProvider(options.poll_interval ?? 60) {
         setWatchOptions(options);
     }
 
@@ -192,6 +211,25 @@ public class ImapWatchDataProviderBase inherits ImapClientDataProviderBase,
         return criteria;
     }
 
+    #! IMAP \c UID \c SEARCH returns UIDs in ascending order
+    string getSourceOrdering() {
+        return WSO_ASCENDING;
+    }
+
+    #! Returns the highest UID reported so far; -1 until the first poll establishes the baseline
+    /** @since %ImapClientDataProvider 1.0
+    */
+    int getLastUid() {
+        return last_uid;
+    }
+
+    #! Returns the mailbox UID validity value the baseline was established against
+    /** @since %ImapClientDataProvider 1.0
+    */
+    *int getUidValidity() {
+        return uidvalidity;
+    }
+
     #! @cond nodoc
     #! Cancels any in-flight polling operation so the polling thread can exit promptly
     private cancelPollOperation() {
@@ -224,7 +262,7 @@ public class ImapWatchDataProviderBase inherits ImapClientDataProviderBase,
             logInfo("watching mailbox %y from UID %d with criteria %y", mailbox, last_uid, criteria);
         } else {
             uidvalidity = status.uidvalidity;
-            processNewMessages();
+            sweep();
         }
 
         # Wait for the server to push a change when it can. A pushed update is swept immediately
@@ -232,7 +270,7 @@ public class ImapWatchDataProviderBase inherits ImapClientDataProviderBase,
         # returns, so returning here without sweeping would delay every pushed message by up to that
         # interval — exactly what IDLE exists to avoid.
         if (waitForChange()) {
-            processNewMessages();
+            sweep();
         }
     }
 
@@ -240,47 +278,75 @@ public class ImapWatchDataProviderBase inherits ImapClientDataProviderBase,
     /** @return the number of messages reported
 
         @note The baseline is advanced and the follow-up actions applied only for messages that were
-        reported successfully. Advancing past a message whose delivery failed would drop it
-        permanently on a transient error, and flagging or deleting a message that observers never
-        received would destroy mail that was never handled — so a failed message is left in place and
-        retried on the next cycle.
+        reported successfully, and the sweep stops at the first failure rather than continuing.
+        Advancing past a message whose delivery failed would drop it permanently on a transient
+        error, and flagging or deleting a message that observers never received would destroy mail
+        that was never handled — so a failed message is left in place and retried on the next cycle,
+        together with every message after it.
     */
-    private int processNewMessages() {
-        string search = sprintf("UID %d:* %s", last_uid + 1, criteria);
-        list<int> uids = imap.uidSearch(search);
-
-        int reported = 0;
-        bool expunge_needed = False;
-        foreach int uid in (uids) {
-            # "UID n:*" is inclusive of the baseline on some servers, so filter explicitly
-            if (uid <= last_uid) {
-                continue;
-            }
-            try {
-                reportMessage(uid);
-            } catch (hash<ExceptionInfo> ex) {
-                logPollError(ex);
-                # leave the baseline where it is so this message is retried
-                continue;
-            }
-            ++reported;
-            # max(): stay correct even if a server ever returns UIDs out of order
-            if (uid > last_uid) {
-                commitCheckpoint(uidvalidity, uid);
-            }
-
-            if (mark_seen) {
-                imap.markSeen(uid);
-            }
-            if (delete_messages) {
-                imap.markDeleted(uid);
-                expunge_needed = True;
-            }
-        }
+    private int sweep() {
+        expunge_needed = False;
+        hash<WatchCycleInfo> info = runWatchCycle(fetchWatchItems());
         if (expunge_needed) {
+            # one expunge per sweep rather than one per message: expunge is a mailbox-wide operation
+            # and the UIDs already reported are durable, so batching it cannot lose a message
             imap.expunge();
+            expunge_needed = False;
         }
-        return reported;
+        return info.dispatched;
+    }
+
+    #! Returns the UIDs matching the criteria above the current baseline
+    private list<hash<WatchItemInfo>> fetchWatchItems() {
+        string search = sprintf("UID %d:* %s", last_uid + 1, criteria);
+        list<hash<WatchItemInfo>> items = ();
+        foreach int uid in (imap.uidSearch(search)) {
+            push items, <WatchItemInfo>{
+                "id": string(uid),
+                "order_key": uid,
+                "data": uid,
+            };
+        }
+        return items;
+    }
+
+    #! Returns @ref True if the UID lies above the baseline
+    /** \c "UID n:*" is inclusive of the baseline on some servers, so the check is explicit
+    */
+    private bool isNewWatchItem(hash<WatchItemInfo> item) {
+        return item.order_key > last_uid;
+    }
+
+    #! Raises the provider's event(s) for one message
+    private dispatchWatchItem(hash<WatchItemInfo> item, auto payload, list<hash<WatchItemInfo>> superseded) {
+        reportMessage(item.order_key);
+    }
+
+    #! Durably advances the mailbox baseline to the given UID
+    private advanceWatchCursor(hash<WatchItemInfo> item) {
+        commitCheckpoint(uidvalidity, item.order_key);
+    }
+
+    #! Applies the configured follow-up actions to a reported message
+    /** @note the message is flagged because its event was raised, which is not the same as the
+        consumer having processed it; see @ref watch_removal_semantics
+    */
+    private afterWatchItemDispatched(hash<WatchItemInfo> item, auto payload) {
+        int uid = item.order_key;
+        if (mark_seen) {
+            imap.markSeen(uid);
+        }
+        if (delete_messages) {
+            imap.markDeleted(uid);
+            expunge_needed = True;
+        }
+    }
+
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        if (logger) {
+            logArgs(LoggerLevel::INFO, "ImapWatch: " + fmt, argv);
+        }
     }
 
     #! Waits for the server to report a mailbox change, when it supports doing so

--- a/qlib/InsightlyDataProvider/InsightlyWatchDataProviderBase.qc
+++ b/qlib/InsightlyDataProvider/InsightlyWatchDataProviderBase.qc
@@ -74,7 +74,7 @@ public class InsightlyWatchDataProviderBase inherits InsightlyDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/InsightlyDataProvider/InsightlyWatchDataProviderBase.qc
+++ b/qlib/InsightlyDataProvider/InsightlyWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace InsightlyDataProvider {
 
 #! Base class for Insightly polling watch data providers
 public class InsightlyWatchDataProviderBase inherits InsightlyDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -41,20 +41,12 @@ public class InsightlyWatchDataProviderBase inherits InsightlyDataProviderBase,
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client (async)
     constructor(RestClientIo::RestClientIo rest, *hash<auto> options)
             : InsightlyDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval,
-                  MinPollInterval)) {
-        last_check = now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval,
+                  MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -67,56 +59,22 @@ public class InsightlyWatchDataProviderBase inherits InsightlyDataProviderBase,
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                if (isStopping()) {
-                    break;
-                }
-                string id = string(record{getIdField()});
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
-
-                # Check timestamp to avoid old records
-                *date record_time;
-                *string ts = record.DATE_CREATED_UTC;
-                if (ts) {
-                    record_time = date(ts);
-                }
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
-
-                seen_ids{id} = True;
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune oldest half of seen_ids if it gets too large
-            if (seen_ids.size() > 10000) {
-                list<string> all_keys = keys seen_ids;
-                int half = all_keys.size() / 2;
-                foreach string k in (all_keys[0..half-1]) {
-                    delete seen_ids{k};
-                }
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err,
-                ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/KatanaDataProvider/KatanaWatchDataProviderBase.qc
+++ b/qlib/KatanaDataProvider/KatanaWatchDataProviderBase.qc
@@ -72,7 +72,7 @@ public class KatanaWatchDataProviderBase inherits KatanaDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns the event types supported by this provider

--- a/qlib/KatanaDataProvider/KatanaWatchDataProviderBase.qc
+++ b/qlib/KatanaDataProvider/KatanaWatchDataProviderBase.qc
@@ -15,7 +15,7 @@ public namespace KatanaDataProvider {
     \c last_check, and prunes \c seen_ids when it grows beyond 10000 entries.
 */
 public class KatanaWatchDataProviderBase inherits KatanaDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -37,20 +37,12 @@ public class KatanaWatchDataProviderBase inherits KatanaDataProviderBase,
         };
     }
 
-    private {
-        #! Last check timestamp; advanced each successful poll cycle
-        date last_check;
-
-        #! Set of seen record IDs to avoid duplicate notifications
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with an async REST client and options
     constructor(*RestClientIo::RestClientIo rest, *hash<auto> options)
             : KatanaDataProviderBase(rest),
-              AbstractWatchDataProviderBase(
-                  max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(
+                  max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor — stops the polling thread
@@ -65,62 +57,22 @@ public class KatanaWatchDataProviderBase inherits KatanaDataProviderBase,
         }
     }
 
-    #! Polls for new/updated records once and fires events for each
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                if (isStopping()) {
-                    break;
-                }
-                string id = string(record{getIdField()});
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # skip already-emitted records
-                if (seen_ids{id}) {
-                    continue;
-                }
-
-                # advance last_check based on record's timestamp if available
-                *date record_time;
-                *string ts_field = getTimestampField();
-                if (ts_field) {
-                    auto raw = record{ts_field};
-                    if (raw.typeCode() == NT_DATE) {
-                        record_time = raw;
-                    } else if (raw.typeCode() == NT_STRING && raw.val()) {
-                        record_time = date(raw);
-                    }
-                }
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
-
-                seen_ids{id} = True;
-                notifyObservers(getEventName(), record);
-            }
-
-            if (new_last_check > last_check) {
-                last_check = new_last_check;
-            }
-
-            # cap memory usage: prune oldest half of seen_ids beyond 10000
-            if (seen_ids.size() > 10000) {
-                list<string> all_keys = keys seen_ids;
-                int half = all_keys.size() / 2;
-                foreach string k in (all_keys[0..half-1]) {
-                    delete seen_ids{k};
-                }
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            error("Error polling for %s events: %s: %s", getEventName(), ex.err, ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns the event types supported by this provider

--- a/qlib/KeapDataProvider/KeapWatchDataProviderBase.qc
+++ b/qlib/KeapDataProvider/KeapWatchDataProviderBase.qc
@@ -89,7 +89,7 @@ public class KeapWatchDataProviderBase inherits KeapDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/KeapDataProvider/KeapWatchDataProviderBase.qc
+++ b/qlib/KeapDataProvider/KeapWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace KeapDataProvider {
 
 #! Base class for Keap polling watch data providers
 public class KeapWatchDataProviderBase inherits KeapDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -47,19 +47,11 @@ public class KeapWatchDataProviderBase inherits KeapDataProviderBase,
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client
     constructor(KeapRestClient::KeapRestClient rest, *hash<auto> options)
             : KeapDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -72,51 +64,32 @@ public class KeapWatchDataProviderBase inherits KeapDataProviderBase,
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                # check for shutdown between iterations
-                if (isStopping()) {
-                    break;
-                }
-                string id = getRecordId(record);
+    #! Returns the record's identity using the provider's own accessor
+    private *string getWatchRecordId(hash<auto> record) {
+        return getRecordId(record);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
+    #! Returns the record's position in the feed using the provider's own accessor
+    private *date getWatchRecordTimestamp(hash<auto> record) {
+        return getRecordTimestamp(record);
+    }
 
-                # Check timestamp to avoid old records
-                *date record_time = getRecordTimestamp(record);
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Mark as seen
-                seen_ids{id} = True;
-
-                # Notify observers
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune seen_ids if it gets too large
-            if (seen_ids.size() > MaxSeenIds) {
-                seen_ids = {};
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/KitDataProvider/KitWatchDataProviderBase.qc
+++ b/qlib/KitDataProvider/KitWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace KitDataProvider {
 
 #! Base class for Kit polling watch data providers
 public class KitWatchDataProviderBase inherits KitDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -41,19 +41,11 @@ public class KitWatchDataProviderBase inherits KitDataProviderBase,
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client
     constructor(KitRestClient::KitRestClient rest, *hash<auto> options)
             : KitDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -66,55 +58,22 @@ public class KitWatchDataProviderBase inherits KitDataProviderBase,
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                if (isStopping()) {
-                    break;
-                }
-                string id = string(record.id);
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
-
-                # Check timestamp to avoid old records
-                *date record_time;
-                *string ts = record{getTimestampField()};
-                if (ts) {
-                    record_time = date(ts);
-                }
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
-
-                seen_ids{id} = True;
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune oldest half of seen_ids if it gets too large
-            if (seen_ids.size() > 10000) {
-                list<string> all_keys = keys seen_ids;
-                int half = all_keys.size() / 2;
-                foreach string k in (all_keys[0..half-1]) {
-                    delete seen_ids{k};
-                }
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/KitDataProvider/KitWatchDataProviderBase.qc
+++ b/qlib/KitDataProvider/KitWatchDataProviderBase.qc
@@ -73,7 +73,7 @@ public class KitWatchDataProviderBase inherits KitDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/OneDriveDataProvider/OneDriveWatchChangesDataProvider.qc
+++ b/qlib/OneDriveDataProvider/OneDriveWatchChangesDataProvider.qc
@@ -83,6 +83,46 @@ public class OneDriveWatchChangesDataProvider inherits OneDriveDataProviderBase,
     }
 
     #! Polls for changes using delta query
+    #! The Microsoft Graph delta feed returns changes in ascending change order
+    /** The delta link is an opaque cursor, so this provider is a documented exemption from the
+        shared ordered template (@ref DataProvider::AbstractOrderedWatchDataProvider): there is no
+        per-change key to sort or compare against. Changes are delivered in the order the delta feed
+        returns them, and the replacement delta link is made durable only once every change has been
+        delivered.
+    */
+    string getSourceOrdering() {
+        return WSO_ASCENDING;
+    }
+
+    #! Restores the delta link
+    private restoreCheckpoint(hash<auto> checkpoint) {
+        if (checkpoint.version.typeCode() != NT_INT || checkpoint.version != 1
+                || checkpoint.delta_link.typeCode() != NT_STRING || !checkpoint.delta_link.val()) {
+            throw "WATCH-CHECKPOINT-ERROR", "invalid OneDrive watch checkpoint; expecting version 1 and a "
+                "non-empty delta_link";
+        }
+        delta_link = checkpoint.delta_link;
+        # a restored delta link means the baseline has already been established
+        first_poll = False;
+    }
+
+    #! Durably advances the delta link
+    private commitCheckpoint(string next_delta_link) {
+        if (!next_delta_link.val()) {
+            throw "WATCH-CHECKPOINT-ERROR", "cannot persist an empty OneDrive delta link";
+        }
+        persistCheckpoint({
+            "version": 1,
+            "delta_link": next_delta_link,
+        });
+        delta_link = next_delta_link;
+    }
+
+    #! Polls once, advancing the delta link only after every change has been delivered
+    /** @note The replacement delta link is stored only after every change it supersedes has been
+        raised. Storing it first would skip the whole batch if delivery then failed; storing it
+        afterwards means a failure re-reads the batch, so delivery is at-least-once.
+    */
     private pollOnce() {
         try {
             string path;
@@ -98,9 +138,11 @@ public class OneDriveWatchChangesDataProvider inherits OneDriveDataProviderBase,
 
             # Fetch all pages of changes
             list<hash<auto>> changes = ();
+            *string next_delta_link;
             while (True) {
                 if (isStopping()) {
-                    break;
+                    # the delta link stays where it is, so this batch is read again
+                    return;
                 }
                 hash<auto> response = doRestCommand("GET", path);
                 if (response.body.value) {
@@ -110,8 +152,7 @@ public class OneDriveWatchChangesDataProvider inherits OneDriveDataProviderBase,
                     next_link =~ s/^https:\/\/graph\.microsoft\.com\/v1\.0\///;
                     path = next_link;
                 } else {
-                    # Save the delta link for next poll
-                    delta_link = response.body."@odata.deltaLink";
+                    next_delta_link = response.body."@odata.deltaLink";
                     break;
                 }
             }
@@ -119,15 +160,24 @@ public class OneDriveWatchChangesDataProvider inherits OneDriveDataProviderBase,
             if (first_poll) {
                 # On first poll, seed the cursor without firing events
                 first_poll = False;
+                if (next_delta_link.val()) {
+                    commitCheckpoint(next_delta_link);
+                }
                 return;
             }
 
             # Notify observers for each change
             foreach hash<auto> item in (changes) {
                 if (isStopping()) {
-                    break;
+                    # the delta link stays where it is, so the remaining changes are read again
+                    return;
                 }
                 notifyObservers(EVENT_FILE_CHANGE, item);
+            }
+
+            # the batch has been delivered, so the replacement delta link can be made durable
+            if (next_delta_link.val()) {
+                commitCheckpoint(next_delta_link);
             }
         } catch (hash<ExceptionInfo> ex) {
             error("Error polling for %s events: %s: %s", EVENT_FILE_CHANGE, ex.err, ex.desc);

--- a/qlib/SendCloudDataProvider/SendCloudWatchDataProviderBase.qc
+++ b/qlib/SendCloudDataProvider/SendCloudWatchDataProviderBase.qc
@@ -93,7 +93,7 @@ public class SendCloudWatchDataProviderBase inherits SendCloudDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        info(vsprintf(fmt, argv));
+        info("%s", vsprintf(fmt, argv));
     }
 
     #! Returns example event data for the given event

--- a/qlib/SendCloudDataProvider/SendCloudWatchDataProviderBase.qc
+++ b/qlib/SendCloudDataProvider/SendCloudWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace SendCloudDataProvider {
 
 #! Base class for polling-based SendCloud watch providers
 public class SendCloudWatchDataProviderBase inherits SendCloudDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Watch constructor options (extend with per-subclass options if needed)
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -50,16 +50,14 @@ public class SendCloudWatchDataProviderBase inherits SendCloudDataProviderBase,
     }
 
     private {
-        #! Last check timestamp (updated each poll cycle)
-        date last_check;
     }
 
     #! Creates the object from a RestClientIo client plus options
     constructor(*RestClientIo::RestClientIo rest, *hash<auto> options)
             : SendCloudDataProviderBase(rest),
-              AbstractWatchDataProviderBase(
-                  max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(
+                  max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Cancels in-flight REST operations for graceful shutdown
@@ -69,30 +67,33 @@ public class SendCloudWatchDataProviderBase inherits SendCloudDataProviderBase,
         }
     }
 
-    #! Polls for new/changed records and emits events
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date newest = last_check;
-            foreach hash<auto> record in (records) {
-                if (!shouldEmit(record)) {
-                    continue;
-                }
-                *string ts_str = record{getTimestampField()};
-                if (ts_str.val()) {
-                    date ts = date(ts_str);
-                    if (ts > newest) {
-                        newest = ts;
-                    }
-                }
-                notifyObservers(getEventName(), record);
+    #! The upstream ordering is not relied on; records are ordered by timestamp before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
+
+    #! Returns the cycle's candidate records, less the ones the provider filters out
+    private list<hash<WatchItemInfo>> fetchWatchItems() {
+        list<hash<WatchItemInfo>> items = ();
+        foreach hash<WatchItemInfo> item in (AbstractTimestampWatchDataProvider::fetchWatchItems()) {
+            if (shouldEmit(item.data)) {
+                push items, item;
             }
-            if (newest > last_check) {
-                last_check = newest;
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            error("Error polling for %s events: %s: %s", getEventName(), ex.err, ex.desc);
         }
+        return items;
+    }
+
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        error("Error polling for %s events: %s: %s", getEventName(), ex.err, ex.desc);
+    }
+
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        info(vsprintf(fmt, argv));
     }
 
     #! Returns example event data for the given event

--- a/qlib/ShippoDataProvider/ShippoWatchDataProviderBase.qc
+++ b/qlib/ShippoDataProvider/ShippoWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace ShippoDataProvider {
 
 #! Base class for Shippo polling watch data providers
 public class ShippoWatchDataProviderBase inherits ShippoDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Maximum number of seen IDs to track before pruning
         const MaxSeenIds = 10000;
@@ -50,26 +50,18 @@ public class ShippoWatchDataProviderBase inherits ShippoDataProviderBase,
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client
     constructor(ShippoRestClient::ShippoRestClient rest, *hash<auto> options)
             : ShippoDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Creates the object with a connection
     constructor(ShippoRestClient::ShippoRestConnection conn, *hash<auto> options)
             : ShippoDataProviderBase(conn),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -82,58 +74,33 @@ public class ShippoWatchDataProviderBase inherits ShippoDataProviderBase,
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            # Get records created since last check
-            hash<auto> params = getQueryParams();
+    #! The upstream ordering is not relied on; records are ordered by timestamp before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            hash<auto> response = doGet(getResourcePath(), params);
-            list<auto> records = response.results ?? ();
+    #! Fetches every record changed at or after the given timestamp
+    private list<hash<auto>> fetchRecords(date since) {
+        hash<auto> response = doGet(getResourcePath(), getQueryParams());
+        return response.results ?? ();
+    }
 
-            date new_last_check = last_check;
+    #! Returns the record field holding the record's position in the feed
+    private string getTimestampField() {
+        return "object_created";
+    }
 
-            foreach hash<auto> record in (records) {
-                # check for shutdown between iterations
-                if (isStopping()) {
-                    break;
-                }
-                string id = string(record{getIdField()});
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
-
-                # Check if this is a new record (created after last check)
-                *string created_time = record.object_created;
-                if (created_time) {
-                    date record_time = date(created_time);
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
-
-                # Mark as seen
-                seen_ids{id} = True;
-
-                # Notify observers
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune seen_ids if it gets too large (time-based filtering is primary dedup)
-            if (seen_ids.size() > MaxSeenIds) {
-                seen_ids = {};
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            # Log error but continue polling
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getResourcePath(), ex.err, ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns query parameters for the poll request

--- a/qlib/ShippoDataProvider/ShippoWatchDataProviderBase.qc
+++ b/qlib/ShippoDataProvider/ShippoWatchDataProviderBase.qc
@@ -100,7 +100,7 @@ public class ShippoWatchDataProviderBase inherits ShippoDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns query parameters for the poll request

--- a/qlib/SmartSheetDataProvider/SmartSheetWatchDataProviderBase.qc
+++ b/qlib/SmartSheetDataProvider/SmartSheetWatchDataProviderBase.qc
@@ -81,6 +81,44 @@ public class SmartSheetWatchDataProviderBase inherits SmartSheetDataProviderBase
     }
 
     #! Polls for new events once
+    #! The Smartsheet event stream is returned in ascending event order
+    /** The stream position is an opaque cursor, so this provider is a documented exemption from the
+        shared ordered template (@ref DataProvider::AbstractOrderedWatchDataProvider): there is no
+        per-event key to sort or compare against. Events are delivered in the order the stream
+        returns them, and the stream position is made durable only once a whole page has been
+        delivered.
+    */
+    string getSourceOrdering() {
+        return WSO_ASCENDING;
+    }
+
+    #! Restores the event stream position
+    private restoreCheckpoint(hash<auto> checkpoint) {
+        if (checkpoint.version.typeCode() != NT_INT || checkpoint.version != 1
+                || checkpoint.stream_position.typeCode() != NT_STRING || !checkpoint.stream_position.val()) {
+            throw "WATCH-CHECKPOINT-ERROR", "invalid Smartsheet watch checkpoint; expecting version 1 and a "
+                "non-empty stream_position";
+        }
+        stream_position = checkpoint.stream_position;
+    }
+
+    #! Durably advances the event stream position
+    private commitCheckpoint(string next_position) {
+        if (!next_position.val()) {
+            throw "WATCH-CHECKPOINT-ERROR", "cannot persist an empty Smartsheet stream position";
+        }
+        persistCheckpoint({
+            "version": 1,
+            "stream_position": next_position,
+        });
+        stream_position = next_position;
+    }
+
+    #! Polls once, advancing the stream position only after the page has been delivered
+    /** @note The stream position returned with a page is stored only after every event on that page
+        has been raised. Storing it first would skip the whole page if delivery then failed; storing
+        it afterwards means a failure re-reads the page, so delivery is at-least-once.
+    */
     private pollOnce() {
         try {
             hash<auto> params;
@@ -93,15 +131,11 @@ public class SmartSheetWatchDataProviderBase inherits SmartSheetDataProviderBase
 
             hash<auto> response = doGet("events", params);
 
-            # Update stream position for next poll
-            if (response.nextStreamPosition) {
-                stream_position = response.nextStreamPosition;
-            }
-
             if (response.data) {
                 foreach hash<auto> event in (response.data) {
                     if (isStopping()) {
-                        break;
+                        # the stream position stays where it is, so this page is read again
+                        return;
                     }
                     # Filter by event type and object type
                     if (!matchesEvent(event)) {
@@ -111,6 +145,11 @@ public class SmartSheetWatchDataProviderBase inherits SmartSheetDataProviderBase
                     hash<auto> enriched = enrichEvent(event);
                     notifyObservers(event_type, enriched);
                 }
+            }
+
+            # Update stream position for next poll now that the page has been delivered
+            if (response.nextStreamPosition) {
+                commitCheckpoint(response.nextStreamPosition);
             }
         } catch (hash<ExceptionInfo> ex) {
             if (isStopping()) {

--- a/qlib/SquareDataProvider/SquareWatchDataProviderBase.qc
+++ b/qlib/SquareDataProvider/SquareWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace SquareDataProvider {
 
 #! Base class for Square polling watch data providers
 public class SquareWatchDataProviderBase inherits SquareDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -47,19 +47,11 @@ public class SquareWatchDataProviderBase inherits SquareDataProviderBase,
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client
     constructor(SquareRestClient::SquareRestClient rest, *hash<auto> options)
             : SquareDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -72,51 +64,32 @@ public class SquareWatchDataProviderBase inherits SquareDataProviderBase,
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                # check for shutdown between iterations
-                if (isStopping()) {
-                    break;
-                }
-                string id = getRecordId(record);
+    #! Returns the record's identity using the provider's own accessor
+    private *string getWatchRecordId(hash<auto> record) {
+        return getRecordId(record);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
+    #! Returns the record's position in the feed using the provider's own accessor
+    private *date getWatchRecordTimestamp(hash<auto> record) {
+        return getRecordTimestamp(record);
+    }
 
-                # Check timestamp to avoid old records
-                *date record_time = getRecordTimestamp(record);
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Mark as seen
-                seen_ids{id} = True;
-
-                # Notify observers
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune seen_ids if it gets too large
-            if (seen_ids.size() > MaxSeenIds) {
-                seen_ids = {};
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/SquareDataProvider/SquareWatchDataProviderBase.qc
+++ b/qlib/SquareDataProvider/SquareWatchDataProviderBase.qc
@@ -89,7 +89,7 @@ public class SquareWatchDataProviderBase inherits SquareDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/SquarespaceDataProvider/SquarespaceWatchDataProviderBase.qc
+++ b/qlib/SquarespaceDataProvider/SquarespaceWatchDataProviderBase.qc
@@ -89,7 +89,7 @@ public class SquarespaceWatchDataProviderBase inherits SquarespaceDataProviderBa
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/SquarespaceDataProvider/SquarespaceWatchDataProviderBase.qc
+++ b/qlib/SquarespaceDataProvider/SquarespaceWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace SquarespaceDataProvider {
 
 #! Base class for Squarespace polling watch data providers
 public class SquarespaceWatchDataProviderBase inherits SquarespaceDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -47,19 +47,11 @@ public class SquarespaceWatchDataProviderBase inherits SquarespaceDataProviderBa
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client
     constructor(SquarespaceRestClient::SquarespaceRestClient rest, *hash<auto> options)
             : SquarespaceDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -72,51 +64,32 @@ public class SquarespaceWatchDataProviderBase inherits SquarespaceDataProviderBa
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                # check for shutdown between iterations
-                if (isStopping()) {
-                    break;
-                }
-                string id = getRecordId(record);
+    #! Returns the record's identity using the provider's own accessor
+    private *string getWatchRecordId(hash<auto> record) {
+        return getRecordId(record);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
+    #! Returns the record's position in the feed using the provider's own accessor
+    private *date getWatchRecordTimestamp(hash<auto> record) {
+        return getRecordTimestamp(record);
+    }
 
-                # Check timestamp to avoid old records
-                *date record_time = getRecordTimestamp(record);
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Mark as seen
-                seen_ids{id} = True;
-
-                # Notify observers
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune seen_ids if it gets too large
-            if (seen_ids.size() > MaxSeenIds) {
-                seen_ids = {};
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/SystemeIoDataProvider/SystemeIoWatchDataProviderBase.qc
+++ b/qlib/SystemeIoDataProvider/SystemeIoWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace SystemeIoDataProvider {
 
 #! Base class for Systeme.io polling watch data providers
 public class SystemeIoWatchDataProviderBase inherits SystemeIoDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -48,20 +48,12 @@ public class SystemeIoWatchDataProviderBase inherits SystemeIoDataProviderBase,
         };
     }
 
-    private {
-        #! Timestamp of last successful poll for filtering
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client (async)
     constructor(RestClientIo::RestClientIo rest, *hash<auto> options)
             : SystemeIoDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval,
-                  MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval,
+                  MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -74,53 +66,22 @@ public class SystemeIoWatchDataProviderBase inherits SystemeIoDataProviderBase,
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                if (isStopping()) {
-                    break;
-                }
-                string id = string(record.id);
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
-
-                # Check record timestamp against last_check
-                *string ts = record{getTimestampField()};
-                if (ts) {
-                    date record_time = date(ts);
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
-
-                seen_ids{id} = True;
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune oldest half of seen_ids if it gets too large
-            if (seen_ids.size() > 10000) {
-                list<string> all_keys = keys seen_ids;
-                int half = all_keys.size() / 2;
-                foreach string k in (all_keys[0..half-1]) {
-                    delete seen_ids{k};
-                }
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err,
-                ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/SystemeIoDataProvider/SystemeIoWatchDataProviderBase.qc
+++ b/qlib/SystemeIoDataProvider/SystemeIoWatchDataProviderBase.qc
@@ -81,7 +81,7 @@ public class SystemeIoWatchDataProviderBase inherits SystemeIoDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns a hash of all supported event types

--- a/qlib/TableauDataProvider/TableauPollEventDataProviderBase.qc
+++ b/qlib/TableauDataProvider/TableauPollEventDataProviderBase.qc
@@ -106,7 +106,7 @@ public class TableauPollEventDataProviderBase inherits TableauDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
 

--- a/qlib/TableauDataProvider/TableauPollEventDataProviderBase.qc
+++ b/qlib/TableauDataProvider/TableauPollEventDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace TableauDataProvider {
 
 #! Base class for Tableau polling event data providers
 public class TableauPollEventDataProviderBase inherits TableauDataProviderBase,
-        DataProvider::DelayedObservable {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for polling watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -48,38 +48,19 @@ public class TableauPollEventDataProviderBase inherits TableauDataProviderBase,
     }
 
     private {
-        #! Mutex for thread synchronization
-        Mutex lck();
-
-        #! Condition variable for sleeping
-        Condition cond();
-
-        #! Background thread ID
-        int io_tid;
-
-        #! Stop flag
-        bool stop = False;
-
         #! Poll interval in seconds
         int poll_secs;
 
         #! Start date for filtering
         date start_date;
-
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
     }
 
     #! Creates the object with a REST client
     constructor(TableauRestClient::TableauRestClient rest, *hash<auto> options)
-            : TableauDataProviderBase(rest) {
-        poll_secs = options.poll_interval ?? DefaultPollInterval;
-        if (poll_secs < MinPollInterval) {
-            poll_secs = MinPollInterval;
-        }
+            : TableauDataProviderBase(rest),
+              AbstractTimestampWatchDataProvider(TableauPollEventDataProviderBase::getPollInterval(options),
+                  options.start_date) {
+        poll_secs = TableauPollEventDataProviderBase::getPollInterval(options);
         if (options.start_date) {
             start_date = options.start_date;
         }
@@ -90,120 +71,44 @@ public class TableauPollEventDataProviderBase inherits TableauDataProviderBase,
         stopEventsIntern();
     }
 
-    #! Called when observers are ready
-    observersReady() {
-        lck.lock();
-        on_exit lck.unlock();
-        if (io_tid) {
-            return;
-        }
-        io_tid = background pollThread();
+    #! Returns the effective poll interval in seconds
+    private static int getPollInterval(*hash<auto> options) {
+        return max(options.poll_interval ?? DefaultPollInterval, MinPollInterval);
     }
 
-    #! Stops event generation
-    stopEvents() {
-        stopEventsIntern();
+    #! Cancels any in-flight REST request during shutdown
+    private cancelPollOperation() {
+        rest.close();
     }
 
-    #! Internal method to stop events
-    private stopEventsIntern() {
-        lck.lock();
-        on_exit lck.unlock();
-        stop = True;
-        cond.broadcast();
-        # Wait for the polling thread to exit; no timeout needed since pollThread always broadcasts on exit
-        while (io_tid) {
-            cond.wait(lck);
-        }
+    #! The upstream ordering is not relied on; records are ordered by timestamp before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
     }
 
-    #! Returns True if events are still being generated
-    bool isActive() {
-        return !stop && io_tid > 0;
+    #! Returns the record's identity using the provider's own accessor
+    private *string getWatchRecordId(hash<auto> record) {
+        return getRecordId(record);
     }
 
-    #! The polling thread
-    private pollThread() {
-        on_exit {
-            lck.lock();
-            on_exit lck.unlock();
-            remove io_tid;
-            cond.broadcast();
-        }
-
-        # Initialize tracking state
-        last_check = start_date ?? now_us();
-
-        while (True) {
-            # Check stop flag under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-            }
-
-            pollOnce();
-
-            # Wait for next poll interval under lock
-            {
-                lck.lock();
-                on_exit lck.unlock();
-                if (stop) {
-                    break;
-                }
-                cond.wait(lck, poll_secs * 1000);
-            }
-        }
+    #! Returns the record's position in the feed using the provider's own accessor
+    private *date getWatchRecordTimestamp(hash<auto> record) {
+        return getRecordTimestamp(record);
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
-
-            foreach hash<auto> record in (records) {
-                # check for shutdown between iterations
-                if (stop) {
-                    break;
-                }
-                string id = getRecordId(record);
-
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
-
-                # Check timestamp to avoid old records
-                *date record_time = getRecordTimestamp(record);
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
-
-                # Mark as seen
-                seen_ids{id} = True;
-
-                # Notify observers
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune seen_ids if it gets too large
-            if (seen_ids.size() > MaxSeenIds) {
-                seen_ids = {};
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
-        }
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
     }
+
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+    }
+
 
     #! Returns the timestamp from a record for deduplication
     private *date getRecordTimestamp(hash<auto> record) {

--- a/qlib/TallyDataProvider/TallyWatchDataProviderBase.qc
+++ b/qlib/TallyDataProvider/TallyWatchDataProviderBase.qc
@@ -88,6 +88,52 @@ public class TallyWatchDataProviderBase inherits TallyDataProviderBase,
     }
 
     #! Polls for new submissions
+    #! Tally returns submissions newest-first with no monotonic position to checkpoint against
+    /** Submissions are deduplicated by ID rather than ordered, so no ordering guarantee can be
+        offered. This provider is a documented exemption from the shared ordered template
+        (@ref DataProvider::AbstractOrderedWatchDataProvider) because the API exposes no comparable
+        per-submission position; its cursor is nonetheless durable.
+    */
+    string getSourceOrdering() {
+        return WSO_UNORDERED;
+    }
+
+    #! Restores the submission cursor
+    private restoreCheckpoint(hash<auto> checkpoint) {
+        if (checkpoint.version.typeCode() != NT_INT || checkpoint.version != 1
+                || checkpoint.seen_ids.typeCode() != NT_LIST) {
+            throw "WATCH-CHECKPOINT-ERROR", "invalid Tally watch checkpoint; expecting version 1 and a seen_ids "
+                "list";
+        }
+        hash<string, bool> restored = {};
+        foreach auto id in (checkpoint.seen_ids) {
+            if (id.typeCode() != NT_STRING || !id.val()) {
+                throw "WATCH-CHECKPOINT-ERROR", "invalid Tally watch checkpoint; submission IDs must be non-empty "
+                    "strings";
+            }
+            restored{id} = True;
+        }
+        last_submission_id = checkpoint.last_submission_id;
+        seen_ids = restored;
+        # a restored cursor means the baseline has already been established
+        first_poll = False;
+    }
+
+    #! Durably advances the submission cursor
+    private commitCheckpoint(*string submission_id, hash<string, bool> delivered) {
+        persistCheckpoint({
+            "version": 1,
+            "last_submission_id": submission_id,
+            "seen_ids": keys delivered,
+        });
+        last_submission_id = submission_id;
+        seen_ids = delivered;
+    }
+
+    #! Polls once, advancing the cursor only after every new submission has been delivered
+    /** @note Advancing the cursor after a partial sweep would mark submissions as seen that were
+        never delivered, so the cursor moves only once the whole sweep has succeeded.
+    */
     private pollOnce() {
         if (!form_id) {
             error("Cannot poll for submissions: form_id not set");
@@ -95,33 +141,33 @@ public class TallyWatchDataProviderBase inherits TallyDataProviderBase,
         }
         try {
             list<hash<auto>> records = fetchRecords();
+            hash<string, bool> delivered = seen_ids;
             if (first_poll) {
                 # on first poll, seed the cursor and seen IDs without firing events
-                first_poll = False;
                 foreach hash<auto> record in (records) {
-                    seen_ids{record.id ?? ""} = True;
+                    delivered{record.id ?? ""} = True;
                 }
-                if (records.size()) {
-                    last_submission_id = records.last().id;
-                }
+                commitCheckpoint(records.size() ? records.last().id : last_submission_id, delivered);
+                first_poll = False;
                 return;
             }
             foreach hash<auto> record in (records) {
+                if (isStopping()) {
+                    # the cursor stays where it is, so the remaining submissions are swept again
+                    return;
+                }
                 string record_id = record.id ?? "";
-                if (seen_ids{record_id}) {
+                if (delivered{record_id}) {
                     continue;
                 }
-                seen_ids{record_id} = True;
                 notifyObservers(getEventName(), record);
+                delivered{record_id} = True;
             }
-            # update cursor to last seen ID
-            if (records.size()) {
-                last_submission_id = records.last().id;
+            # prune the delivered set if too large
+            if (delivered.size() > MaxSeenIds) {
+                delivered = {};
             }
-            # prune seen_ids if too large
-            if (seen_ids.size() > MaxSeenIds) {
-                seen_ids = {};
-            }
+            commitCheckpoint(records.size() ? records.last().id : last_submission_id, delivered);
         } catch (hash<ExceptionInfo> ex) {
             error("Error polling for %s events: %s: %s", getEventName(), ex.err, ex.desc);
         }

--- a/qlib/UnbounceDataProvider/UnbounceWatchDataProviderBase.qc
+++ b/qlib/UnbounceDataProvider/UnbounceWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace UnbounceDataProvider {
 
 #! Base class for Unbounce polling watch data providers
 public class UnbounceWatchDataProviderBase inherits UnbounceDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -47,20 +47,12 @@ public class UnbounceWatchDataProviderBase inherits UnbounceDataProviderBase,
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client
     constructor(*RestClientIo::RestClientIo rest, *hash<auto> options)
             : UnbounceDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval,
-                  MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval,
+                  MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -73,51 +65,32 @@ public class UnbounceWatchDataProviderBase inherits UnbounceDataProviderBase,
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            list<hash<auto>> records = fetchRecords(last_check);
-            date new_last_check = last_check;
+    #! The upstream ordering is not guaranteed, so the watch orders records itself before delivery
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
 
-            foreach hash<auto> record in (records) {
-                # check for shutdown between iterations
-                if (isStopping()) {
-                    break;
-                }
-                string id = getRecordId(record);
+    #! Returns the record's identity using the provider's own accessor
+    private *string getWatchRecordId(hash<auto> record) {
+        return getRecordId(record);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
+    #! Returns the record's position in the feed using the provider's own accessor
+    private *date getWatchRecordTimestamp(hash<auto> record) {
+        return getRecordTimestamp(record);
+    }
 
-                # Check timestamp to avoid old records
-                *date record_time = getRecordTimestamp(record);
-                if (record_time) {
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Mark as seen
-                seen_ids{id} = True;
-
-                # Notify observers
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune seen_ids if it gets too large
-            if (seen_ids.size() > MaxSeenIds) {
-                seen_ids = {};
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/UnbounceDataProvider/UnbounceWatchDataProviderBase.qc
+++ b/qlib/UnbounceDataProvider/UnbounceWatchDataProviderBase.qc
@@ -90,7 +90,7 @@ public class UnbounceWatchDataProviderBase inherits UnbounceDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns the timestamp from a record for deduplication

--- a/qlib/UnleashedDataProvider/UnleashedWatchDataProviderBase.qc
+++ b/qlib/UnleashedDataProvider/UnleashedWatchDataProviderBase.qc
@@ -90,36 +90,84 @@ public class UnleashedWatchDataProviderBase inherits UnleashedDataProviderBase,
     }
 
     #! Performs a single polling operation
+    #! The upstream feed carries no reliable per-record ordering key
+    /** Records are deduplicated by ID and the cursor is a wall-clock poll boundary, so no ordering
+        guarantee can be offered; consumers must not assume that events arrive in source order.
+
+        This provider is a documented exemption from the shared ordered template
+        (@ref DataProvider::AbstractOrderedWatchDataProvider) because its API exposes no monotonic
+        per-record position to order or checkpoint against. Its cursor is nonetheless durable.
+    */
+    string getSourceOrdering() {
+        return WSO_UNORDERED;
+    }
+
+    #! Restores the poll-boundary cursor
+    private restoreCheckpoint(hash<auto> checkpoint) {
+        if (checkpoint.version.typeCode() != NT_INT || checkpoint.version != 1
+                || checkpoint.since.typeCode() != NT_DATE || !checkpoint.since.absolute()
+                || checkpoint.seen_ids.typeCode() != NT_LIST) {
+            throw "WATCH-CHECKPOINT-ERROR", "invalid watch checkpoint; expecting version 1, an absolute since "
+                "date/time value, and a seen_ids list";
+        }
+        hash<string, bool> restored = {};
+        foreach auto id in (checkpoint.seen_ids) {
+            if (id.typeCode() != NT_STRING || !id.val()) {
+                throw "WATCH-CHECKPOINT-ERROR", "invalid watch checkpoint; record IDs must be non-empty strings";
+            }
+            restored{id} = True;
+        }
+        since = checkpoint.since;
+        seen_ids = restored;
+    }
+
+    #! Durably advances the poll-boundary cursor
+    /** The IDs delivered are stored with the boundary, because a wall-clock cursor alone cannot tell
+        a record that has already been delivered from one that arrived in the same instant.
+    */
+    private commitCheckpoint(date poll_start, hash<string, bool> delivered) {
+        if (!poll_start.absolute()) {
+            throw "WATCH-CHECKPOINT-ERROR", "cannot persist a relative date/time value as a watch cursor";
+        }
+        persistCheckpoint({
+            "version": 1,
+            "since": poll_start,
+            "seen_ids": keys delivered,
+        });
+        since = poll_start;
+        seen_ids = delivered;
+    }
+
+    #! Polls once, advancing the cursor only after every record has been delivered
+    /** @note The cursor is advanced only once the whole sweep has succeeded. Advancing it after a
+        partial sweep would move the poll boundary past records that were never delivered.
+    */
     private pollOnce() {
         date poll_start = now_us();
         list<hash<auto>> records = pollOnceImpl();
 
+        hash<string, bool> delivered = seen_ids;
         foreach hash<auto> record in (records) {
             if (isStopping()) {
-                break;
+                # the cursor stays where it is, so the remaining records are swept again
+                return;
             }
             string id = getRecordId(record);
-            if (!seen_ids{id}) {
-                seen_ids{id} = True;
+            if (!delivered{id}) {
                 notifyObservers(getEventName(), record);
+                delivered{id} = True;
             }
         }
 
-        # Update since time for next poll
-        since = poll_start;
-
-        # Clean up old seen_ids periodically (keep last 10000)
-        if (seen_ids.size() > 10000) {
-            # Remove oldest half
-            int count = 0;
-            foreach string key in (keys seen_ids) {
-                if (count++ < 5000) {
-                    remove seen_ids{key};
-                } else {
-                    break;
-                }
+        # Clean up old IDs periodically (keep the most recent 5000)
+        if (delivered.size() > 10000) {
+            list<string> all_keys = keys delivered;
+            foreach string key in (all_keys[0..4999]) {
+                remove delivered{key};
             }
         }
+
+        commitCheckpoint(poll_start, delivered);
     }
 
     #! Called when a polling error occurs

--- a/qlib/ZohoBooksDataProvider/ZohoBooksWatchDataProviderBase.qc
+++ b/qlib/ZohoBooksDataProvider/ZohoBooksWatchDataProviderBase.qc
@@ -93,7 +93,7 @@ public class ZohoBooksWatchDataProviderBase inherits ZohoBooksDataProviderBase,
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns query parameters for the poll request

--- a/qlib/ZohoBooksDataProvider/ZohoBooksWatchDataProviderBase.qc
+++ b/qlib/ZohoBooksDataProvider/ZohoBooksWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace ZohoBooksDataProvider {
 
 #! Base class for Zoho Books polling watch data providers
 public class ZohoBooksWatchDataProviderBase inherits ZohoBooksDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Maximum number of seen IDs to track before pruning
         const MaxSeenIds = 10000;
@@ -50,19 +50,11 @@ public class ZohoBooksWatchDataProviderBase inherits ZohoBooksDataProviderBase,
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client
     constructor(ZohoBooksRestClient::ZohoBooksRestClient rest, *hash<auto> options)
             : ZohoBooksDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -75,58 +67,33 @@ public class ZohoBooksWatchDataProviderBase inherits ZohoBooksDataProviderBase,
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            # Get records modified since last check
-            hash<auto> params = getQueryParams();
+    #! The API is queried newest-first; records are reversed into delivery order
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_DESCENDING;
+    }
 
-            hash<auto> response = doGet(getResourcePath(), params);
-            list<auto> records = response{getResourceKey()} ?? ();
+    #! Fetches every record changed at or after the given timestamp
+    private list<hash<auto>> fetchRecords(date since) {
+        hash<auto> response = doGet(getResourcePath(), getQueryParams());
+        return response{getResourceKey()} ?? ();
+    }
 
-            date new_last_check = last_check;
+    #! Returns the record field holding the record's position in the feed
+    private string getTimestampField() {
+        return "created_time";
+    }
 
-            foreach hash<auto> record in (records) {
-                # check for shutdown between iterations
-                if (isStopping()) {
-                    break;
-                }
-                string id = string(record{getIdField()});
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
-
-                # Check if this is a new record (created after last check)
-                *string created_time = record.created_time;
-                if (created_time) {
-                    date record_time = date(created_time);
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
-
-                # Mark as seen
-                seen_ids{id} = True;
-
-                # Notify observers
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune seen_ids if it gets too large (time-based filtering is primary dedup)
-            if (seen_ids.size() > MaxSeenIds) {
-                seen_ids = {};
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            # Log error but continue polling
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getResourcePath(), ex.err, ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns query parameters for the poll request

--- a/qlib/ZohoInventoryDataProvider/ZohoInventoryWatchDataProviderBase.qc
+++ b/qlib/ZohoInventoryDataProvider/ZohoInventoryWatchDataProviderBase.qc
@@ -93,7 +93,7 @@ public class ZohoInventoryWatchDataProviderBase inherits ZohoInventoryDataProvid
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns query parameters for the poll request

--- a/qlib/ZohoInventoryDataProvider/ZohoInventoryWatchDataProviderBase.qc
+++ b/qlib/ZohoInventoryDataProvider/ZohoInventoryWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace ZohoInventoryDataProvider {
 
 #! Base class for Zoho Inventory polling watch data providers
 public class ZohoInventoryWatchDataProviderBase inherits ZohoInventoryDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Maximum number of seen IDs to track before pruning
         const MaxSeenIds = 10000;
@@ -50,19 +50,11 @@ public class ZohoInventoryWatchDataProviderBase inherits ZohoInventoryDataProvid
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client
     constructor(ZohoInventoryRestClient::ZohoInventoryRestClient rest, *hash<auto> options)
             : ZohoInventoryDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -75,58 +67,33 @@ public class ZohoInventoryWatchDataProviderBase inherits ZohoInventoryDataProvid
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            # Get records modified since last check
-            hash<auto> params = getQueryParams();
+    #! The API is queried newest-first; records are reversed into delivery order
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_DESCENDING;
+    }
 
-            hash<auto> response = doGet(getResourcePath(), params);
-            list<auto> records = response{getResourceKey()} ?? ();
+    #! Fetches every record changed at or after the given timestamp
+    private list<hash<auto>> fetchRecords(date since) {
+        hash<auto> response = doGet(getResourcePath(), getQueryParams());
+        return response{getResourceKey()} ?? ();
+    }
 
-            date new_last_check = last_check;
+    #! Returns the record field holding the record's position in the feed
+    private string getTimestampField() {
+        return "created_time";
+    }
 
-            foreach hash<auto> record in (records) {
-                # check for shutdown between iterations
-                if (isStopping()) {
-                    break;
-                }
-                string id = string(record{getIdField()});
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
-
-                # Check if this is a new record (created after last check)
-                *string created_time = record.created_time;
-                if (created_time) {
-                    date record_time = date(created_time);
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
-
-                # Mark as seen
-                seen_ids{id} = True;
-
-                # Notify observers
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-
-            # Prune seen_ids if it gets too large (time-based filtering is primary dedup)
-            if (seen_ids.size() > MaxSeenIds) {
-                seen_ids = {};
-            }
-        } catch (hash<ExceptionInfo> ex) {
-            # Log error but continue polling
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getResourcePath(), ex.err, ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns query parameters for the poll request

--- a/qlib/ZohoInvoiceDataProvider/ZohoInvoiceWatchDataProviderBase.qc
+++ b/qlib/ZohoInvoiceDataProvider/ZohoInvoiceWatchDataProviderBase.qc
@@ -90,7 +90,7 @@ public class ZohoInvoiceWatchDataProviderBase inherits ZohoInvoiceDataProviderBa
 
     #! Logs an informational message about a polling cycle
     private logWatchInfo(string fmt, ...) {
-        log(LoggerLevel::INFO, vsprintf(fmt, argv));
+        log(LoggerLevel::INFO, "%s", vsprintf(fmt, argv));
     }
 
     #! Returns query parameters for the poll request

--- a/qlib/ZohoInvoiceDataProvider/ZohoInvoiceWatchDataProviderBase.qc
+++ b/qlib/ZohoInvoiceDataProvider/ZohoInvoiceWatchDataProviderBase.qc
@@ -27,7 +27,7 @@ public namespace ZohoInvoiceDataProvider {
 
 #! Base class for Zoho Invoice polling watch data providers
 public class ZohoInvoiceWatchDataProviderBase inherits ZohoInvoiceDataProviderBase,
-        DataProvider::AbstractWatchDataProviderBase {
+        DataProvider::AbstractTimestampWatchDataProvider {
     public {
         #! Constructor options for watch providers
         const WatchConstructorOptions = BaseConstructorOptions + {
@@ -47,19 +47,11 @@ public class ZohoInvoiceWatchDataProviderBase inherits ZohoInvoiceDataProviderBa
         };
     }
 
-    private {
-        #! Last check time
-        date last_check;
-
-        #! Set of seen IDs to avoid duplicates
-        hash<string, bool> seen_ids;
-    }
-
     #! Creates the object with a REST client
     constructor(ZohoInvoiceRestClient::ZohoInvoiceRestClient rest, *hash<auto> options)
             : ZohoInvoiceDataProviderBase(rest),
-              AbstractWatchDataProviderBase(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval)) {
-        last_check = options.start_date ?? now_us();
+              AbstractTimestampWatchDataProvider(max(options.poll_interval ?? DefaultPollInterval, MinPollInterval),
+                  options.start_date) {
     }
 
     #! Destructor - stops the polling thread
@@ -72,53 +64,33 @@ public class ZohoInvoiceWatchDataProviderBase inherits ZohoInvoiceDataProviderBa
         rest.close();
     }
 
-    #! Polls for new records once
-    private pollOnce() {
-        try {
-            # Get records modified since last check
-            hash<auto> params = getQueryParams();
+    #! The API is queried newest-first; records are reversed into delivery order
+    /** Records are sorted by their timestamp and delivered oldest-first, and the durable cursor
+        advances only after a record has been delivered successfully.
+    */
+    string getSourceOrdering() {
+        return WSO_DESCENDING;
+    }
 
-            hash<auto> response = doGet(getResourcePath(), params);
-            list<auto> records = response{getResourceKey()} ?? ();
+    #! Fetches every record changed at or after the given timestamp
+    private list<hash<auto>> fetchRecords(date since) {
+        hash<auto> response = doGet(getResourcePath(), getQueryParams());
+        return response{getResourceKey()} ?? ();
+    }
 
-            date new_last_check = last_check;
+    #! Returns the record field holding the record's position in the feed
+    private string getTimestampField() {
+        return "created_time";
+    }
 
-            foreach hash<auto> record in (records) {
-                # check for shutdown between iterations
-                if (isStopping()) {
-                    break;
-                }
-                string id = string(record{getIdField()});
+    #! Logs an error raised during a polling cycle
+    private logPollError(hash<ExceptionInfo> ex) {
+        log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getEventName(), ex.err, ex.desc);
+    }
 
-                # Skip if already seen
-                if (seen_ids{id}) {
-                    continue;
-                }
-
-                # Check if this is a new record (created after last check)
-                *string created_time = record.created_time;
-                if (created_time) {
-                    date record_time = date(created_time);
-                    if (record_time <= last_check) {
-                        continue;
-                    }
-                    if (record_time > new_last_check) {
-                        new_last_check = record_time;
-                    }
-                }
-
-                # Mark as seen
-                seen_ids{id} = True;
-
-                # Notify observers
-                notifyObservers(getEventName(), record);
-            }
-
-            last_check = new_last_check;
-        } catch (hash<ExceptionInfo> ex) {
-            # Log error but continue polling
-            log(LoggerLevel::ERROR, "Error polling %s: %s: %s", getResourcePath(), ex.err, ex.desc);
-        }
+    #! Logs an informational message about a polling cycle
+    private logWatchInfo(string fmt, ...) {
+        log(LoggerLevel::INFO, vsprintf(fmt, argv));
     }
 
     #! Returns query parameters for the poll request


### PR DESCRIPTION
Closes the Qore-side work for #5377 and #5378.

## The problem

Watch data providers each solved the same problems separately, and mostly got them wrong in the same way. A watch cursor is monotonic, so dispatching a newer item before an older one advances the cursor past an item that has not been delivered — and a failure at that point drops the older item permanently. Several providers also advanced their cursor *before* dispatching, and none of them survived a host reload.

## What this adds

**`AbstractOrderedWatchDataProvider`** implements the sequence once, with typed `WatchItemInfo` / `WatchCycleInfo` contracts:

```
fetch -> discard items at or before the cursor -> sort ascending
      -> optional snapshot collapse -> optional dispatch budget
      -> dispatch -> persist and advance -> post-success hook -> superseded action
```

Items are cheap descriptors, not payloads, so ordering and collapse decisions happen before anything expensive is retrieved. A dispatch failure **stops the cycle** instead of continuing.

**`AbstractTimestampWatchDataProvider`** implements the common "records changed since *t*" cursor on top: a durable timestamp plus the IDs delivered at exactly that timestamp, which is what makes the cursor safe at its own boundary.

## #5377 — Gmail

- **Pagination**: follows `nextPageToken` and processes every page in one cycle. Previously only the first page was ever seen, so a backlog larger than one page was never fully delivered.
- **Ordering**: Gmail lists newest-first; messages are now delivered oldest-first with the cursor advancing only after a successful delivery.
- **`snapshot_mode`**: collapses a backlog to the newest message overall, or to the newest per thread with `snapshot_key: "thread"`. The event reports what it stood in for in `superseded_count` / `superseded_ids`.
- **`superseded_action`**: `ignore` (default), `trash`, or `delete`. A removal that fails is logged and the message left in place — it is not retried, because the retained event is already delivered and the cursor has already moved past it.
- **`max_messages_per_cycle`**: bounded from the **oldest** end, so the cursor still advances contiguously and the remainder is delivered by later cycles rather than skipped.
- Collapsed messages are selected from `format=minimal` metadata, so a large backlog costs one full retrieval per group rather than one per message.

## #5378 — the contract and the other providers

- **Dispatch-order contract** documented on `pollOnce()`; every provider declares `getSourceOrdering()` (ascending / descending / unordered / unknown) and `hasAscendingDispatch()`.
- **IMAP** moved onto the template, which fixed a real bug: its sweep used `continue` after a delivery failure, stepping the monotonic UID cursor over the failed message.
- **33 other providers** migrated. 28 timestamp-based ones moved to the timestamp base; BaseLinker moved to the ordered template with its journal `log_id` as the key; Tableau dropped ~80 lines of duplicated thread/sleep/stop machinery.
- **Cursor-before-dispatch bugs fixed** in the providers whose APIs expose no comparable per-item position: OneDrive stored the replacement delta link before raising any event (a failure skipped the whole batch), Smartsheet did the same with its stream position, and Tally / Cin7Core / Unleashed marked records seen as they went. All now advance only after the sweep succeeds. These keep their own poll loops with a documented exemption saying why.
- **Durability** documented: with a persistence callback, delivery is at-least-once across reloads; without one, restart behavior is provider-specific. IMAP's first-poll baseline gap is now documented explicitly.
- **Removal semantics** documented: options that remove the source item act on event *dispatch*, not consumer *processing*.

## Tests

| Suite | Cases |
|---|---|
| `DataProvider/OrderedWatchDataProvider.qtest` | 12 — descending input dispatches ascending, stop-not-skip on failure, failed checkpoint writes, snapshot collapse and grouping, superseded-action failure, dispatch budget, timestamp cursor restore/validation |
| `GmailDataProvider/GmailWatchOrdering.qtest` | 10 — ordering regression against a mock newest-first mailbox, same-second messages, pagination across 5 pages, snapshot collapse, thread grouping, trash/delete, budget |
| `DataProvider/WatchProviderOrderingAudit.qtest` | 3 — walks all 242 loaded watch classes; fails if any inherits the "unknown" default without declaring it, or is left abstract by an incomplete migration |
| `ImapClientDataProvider.qtest` | +1 case proving a failed sweep stops rather than skips |

All 33 affected provider suites pass.

## Out of scope

The Qorus-side database-backed persistence callback and the end-to-end service-reload test (#5378 item 7) live in the Qorus repo; this PR provides the API they plug into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)