### PR TITLE
Fix AOT module state retention across short-lived Programs

### DIFF
--- a/examples/test/qore/classes/Program/program-memory.qtest
+++ b/examples/test/qore/classes/Program/program-memory.qtest
@@ -6,6 +6,7 @@
 
 %prepend-module-path "${SCRIPT_DIR}/../../../../../qlib"
 %requires QUnit
+%requires FsUtil
 %exec-class ProgramMemoryTest
 
 class ProgramMemoryImportedBaseClass {
@@ -36,6 +37,8 @@ class ProgramMemoryTest inherits QUnit::Test {
         addTestCase("child Program class handles are reclaimed", \classHandleReclamationTest());
         addTestCase("objects outliving their Program release class handles",
             \objectClassHandleReclamationTest());
+        addTestCase("AOT module imports reclaim per-Program init state",
+            \aotModuleProgramReclamationTest());
         addTestCase("imported classes can be used as base classes with constructor arguments",
             \importedBaseClassConstructorArgTest());
         set_return_value(main());
@@ -93,6 +96,76 @@ class ProgramMemoryTest inherits QUnit::Test {
             "allocations");
     }
 
+    aotModuleProgramReclamationTest() {
+        string tmp_dir = make_tmp_dir();
+        on_exit remove_tree(tmp_dir);
+
+        string qm_path = tmp_dir + "/ProgramMemoryAOT.qm";
+        string qmod_path = tmp_dir + "/ProgramMemoryAOT.qmod";
+        File source();
+        source.open2(qm_path, O_WRONLY | O_CREAT | O_TRUNC);
+        source.write("%modern
+module ProgramMemoryAOT {
+    version = \"1.0\";
+    desc = \"Program AOT module lifetime test\";
+    author = \"Qore\";
+    license = \"MIT\";
+    init = sub () {
+        code<int(int)> increment = int sub (int value) {
+            return value + 1;
+        };
+        ProgramMemoryAOT::InitCount = increment(ProgramMemoryAOT::InitCount ?? 0);
+    };
+}
+
+public namespace ProgramMemoryAOT {
+    public our int InitCount;
+}
+");
+        source.close();
+
+        string qore_bin = ENV.QORE_BIN ?? ENV.QORE_BINARY ?? QORE_ARGV[0] ?? "qore";
+        string libqore_dir = ENV.QORE_LIBDIR ?? dirname(qore_bin);
+        string qcc_bin = ENV.QCC ?? ENV.QORE_QCC
+            ?? (is_file(libqore_dir + "/qcc") ? libqore_dir + "/qcc" : "qcc");
+        string compile_out = backquote(sprintf(
+            "QORE_LIBDIR=%s LD_LIBRARY_PATH=%s %s -m --strip-source -o %s %s 2>&1",
+            libqore_dir, libqore_dir, qcc_bin, qmod_path, qm_path));
+        assertTrue(is_file(qmod_path), "compiled AOT module: " + compile_out);
+
+        # Warm the process-wide AOT module and its shadow metadata before tracking.
+        Program warmup();
+        warmup.loadModule(qmod_path);
+        delete warmup;
+
+        if (!hasAllocTracking()) {
+            testSkip("allocation-tracking build required for leak-byte assertion");
+        }
+
+        int init_count = runSequentialAotModuleCycles(qmod_path, 100);
+        assertEq(101, init_count,
+            "AOT module init markers must not outlive their Program");
+
+        # Warm the larger loop path before measuring so that IR interpreter
+        # capacity growth is not attributed to AOT module imports.
+        init_count = runSequentialAotModuleCycles(qmod_path, 200);
+        assertEq(301, init_count, "AOT module init must run once in every warmup Program");
+
+        # End feature detection before measuring the allocation slope.
+        call_function("stop_alloc_tracking");
+        call_function("start_alloc_tracking");
+        init_count = runSequentialAotModuleCycles(qmod_path, 100);
+        hash<auto> result_100 = call_function("stop_alloc_tracking");
+        assertEq(401, init_count, "AOT module init must run once in every Program");
+
+        call_function("start_alloc_tracking");
+        init_count = runSequentialAotModuleCycles(qmod_path, 200);
+        hash<auto> result_200 = call_function("stop_alloc_tracking");
+        assertEq(601, init_count, "AOT module init must run once in every Program");
+        assertLe(getLiveBytes(result_100) + 1024, getLiveBytes(result_200),
+            "AOT module import allocations must remain bounded as Program count grows");
+    }
+
     #! An imported class must be usable as a base class with base class constructor arguments
     /** Base class nodes store the canonical (primary) class pointer, while base class constructor
         argument lists are resolved to the importing Program's wrapper for the same class; matching
@@ -119,6 +192,17 @@ int sub get() { return (new Child()).get(); }", "test");
             rethrow;
         }
         return True;
+    }
+
+    private int runSequentialAotModuleCycles(string qmod_path, int cycles) {
+        int init_count;
+        for (int i = 0; i < cycles; ++i) {
+            Program pgm();
+            pgm.loadModule(qmod_path);
+            init_count = pgm.getGlobalVariable("ProgramMemoryAOT::InitCount");
+            delete pgm;
+        }
+        return init_count;
     }
 
     private static int getLiveBytes(hash<auto> result) {

--- a/include/qore/intern/Function.h
+++ b/include/qore/intern/Function.h
@@ -320,7 +320,8 @@ public:
         const char* parseLocFile = nullptr,
         int parseLocFirstLine = 0,
         int parseLocLastLine = 0,
-        std::vector<uint8_t>&& paramFlags = std::vector<uint8_t>());
+        std::vector<uint8_t>&& paramFlags = std::vector<uint8_t>(),
+        QoreProgram* localOwnerPgm = nullptr);
 
     DLLLOCAL void replaceResolvedTypes(const QoreTypeInfo* retType,
         std::vector<const QoreTypeInfo*>&& paramTypes);

--- a/include/qore/intern/QoreAOTBinary.h
+++ b/include/qore/intern/QoreAOTBinary.h
@@ -2946,7 +2946,10 @@ std::unique_ptr<QoreIRFunction> deserializeIRFunction(
     bool use_parent_locals_for_all_slots = false,
     //! Optional body-local table already resolved by the surrounding AOT context.
     //! Indexed in serialized body-local order.
-    const std::vector<LocalVar*>* direct_body_locals = nullptr);
+    const std::vector<LocalVar*>* direct_body_locals = nullptr,
+    //! Optional Program that owns newly created LocalVars. Namespace and type
+    //! resolution still use pgm.
+    QoreProgram* local_owner_pgm = nullptr);
 
 //! Compress metadata blob using zlib
 /** Compresses the serialized metadata blob to reduce size and LLVM compilation overhead.
@@ -3026,7 +3029,8 @@ QoreValue readOneExpr(
         const QoreAOTBinaryReader& rdr, const uint8_t*& p, const uint8_t* e,
         std::string& err, QoreProgram* pgm,
         LocalVar** locals, int num_locals,
-        Var** globals, int num_globals);
+        Var** globals, int num_globals,
+        QoreProgram* local_owner_pgm = nullptr);
 
 //! Read one top-level serialized IR instruction expression field.
 //!
@@ -3038,6 +3042,7 @@ QoreValue readOneTopLevelIRExpr(
         const QoreAOTBinaryReader& rdr, const uint8_t*& p, const uint8_t* e,
         std::string& err, QoreProgram* pgm,
         LocalVar** locals, int num_locals,
-        Var** globals, int num_globals);
+        Var** globals, int num_globals,
+        QoreProgram* local_owner_pgm = nullptr);
 
 #endif

--- a/include/qore/intern/QoreAOTExprRegistry.h
+++ b/include/qore/intern/QoreAOTExprRegistry.h
@@ -72,6 +72,7 @@ struct AOTExprReadCtx {
     int num_locals;                 //!< Number of local variables
     Var** globals;                  //!< Global variable array for GLOBAL_VARREF resolution
     int num_globals;                //!< Number of global variables
+    QoreProgram* local_owner_pgm;   //!< Optional owner for newly deserialized LocalVars
 };
 
 //! Expression handler function types

--- a/include/qore/intern/QoreAOTInstRegistry.h
+++ b/include/qore/intern/QoreAOTInstRegistry.h
@@ -66,6 +66,7 @@ struct AOTInstReadCtx {
     const std::unordered_map<std::string, class LocalVar*>& local_map;
     const AOTExprReadFunc& readExpr;
     QoreProgram* pgm;
+    QoreProgram* local_owner_pgm;
     std::string& error;
     //! Slot-indexed local variable map for disambiguation of same-named variables
     const std::unordered_map<uint32_t, LocalVar*>* slot_to_local = nullptr;

--- a/include/qore/intern/qore_program_private.h
+++ b/include/qore/intern/qore_program_private.h
@@ -64,6 +64,7 @@ class QoreSandboxManager;
 #include <cstdarg>
 #include <map>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 #include <set>
@@ -422,6 +423,11 @@ public:
     //! per class removes ~(methods-per-class) emplaces × (classes) off the
     //! hot path.  Same safety argument as shared_aot_argv.
     std::unordered_map<const QoreClass*, LocalVar*> shared_aot_self;
+
+    //! AOT modules whose deferred init functions have run in this Program.
+    /** This state belongs to the target Program so teardown cannot leave stale
+        raw Program pointers in process-wide AOT module state. */
+    std::unordered_set<std::string> initialized_aot_modules;
 
     // for the thread counter, used only with plock
     QoreCondition pcond;

--- a/lib/Function.cpp
+++ b/lib/Function.cpp
@@ -1644,13 +1644,16 @@ void UserSignature::setupFromAOTMetadata(
         const char* parseLocFile,
         int parseLocFirstLine,
         int parseLocLastLine,
-        std::vector<uint8_t>&& paramFlags) {
+        std::vector<uint8_t>&& paramFlags,
+        QoreProgram* localOwnerPgm) {
     returnTypeInfo = retType;
     clearTypeParameterSubstitutionCache();
 
     const size_t nparams = paramTypes.size();
 
     qore_program_private* pp = qore_program_private::get(*pgm);
+    qore_program_private* local_pp = localOwnerPgm
+        ? qore_program_private::get(*localOwnerPgm) : pp;
     // Override the default `loc = getLocation(0, 0)` (null-file, line 0)
     // with a program-interned `(file, first_line, last_line)` location when
     // the caller knows the declaring source path.  The parser sets this to
@@ -1676,7 +1679,7 @@ void UserSignature::setupFromAOTMetadata(
     lv.resize(nparams);
     for (size_t i = 0; i < nparams; ++i) {
         const char* pname = i < paramNames.size() ? paramNames[i].c_str() : "";
-        lv[i] = pp->createLocalVar(pname, getParamLocalTypeInfo(paramTypes[i]));
+        lv[i] = local_pp->createLocalVar(pname, getParamLocalTypeInfo(paramTypes[i]));
         if (paramReadOnlyList[i]) {
             lv[i]->setReadOnly();
         }
@@ -1697,9 +1700,9 @@ void UserSignature::setupFromAOTMetadata(
     // and LLVM lowering rely on it for the static borrowed-reference semantics
     // of constructor/method self.
     if (classTypeInfo) {
-        LocalVar*& cached = pp->shared_aot_self[classTypeInfo];
+        LocalVar*& cached = local_pp->shared_aot_self[classTypeInfo];
         if (!cached) {
-            cached = pp->createLocalVar("self", classTypeInfo->getTypeInfo());
+            cached = local_pp->createLocalVar("self", classTypeInfo->getTypeInfo());
             cached->setSelf();
         } else if (!cached->isSelf()) {
             cached->setSelf();
@@ -1713,10 +1716,10 @@ void UserSignature::setupFromAOTMetadata(
     // instantiates its own frame-local slot via the thread-local stack.
     // Removes ~N (one-per-variant) deque emplaces on the hot path (qwf:
     // 656 k variants).
-    if (!pp->shared_aot_argv) {
-        pp->shared_aot_argv = pp->createLocalVar("argv", autoListOrNothingTypeInfo);
+    if (!local_pp->shared_aot_argv) {
+        local_pp->shared_aot_argv = local_pp->createLocalVar("argv", autoListOrNothingTypeInfo);
     }
-    argvid = pp->shared_aot_argv;
+    argvid = local_pp->shared_aot_argv;
 
     // Set flags
     varargs = hasVarargs;

--- a/lib/QoreAOTExprHandlers.cpp
+++ b/lib/QoreAOTExprHandlers.cpp
@@ -202,7 +202,7 @@ static QoreValue read_expr_func_call(AOTExprReadCtx& ctx) {
             for (uint8_t j = 0; j < num_args; ++j) {
                 std::string arg_err;
                 QoreValue arg = readOneExpr(ctx.reader, ctx.ptr, ctx.end, arg_err, ctx.pgm,
-                    ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+                    ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
                 if (!arg_err.empty()) {
                     ctx.error = arg_err;
                     arg.discard(nullptr);
@@ -325,7 +325,7 @@ static QoreValue read_expr_self_method_call(AOTExprReadCtx& ctx) {
             for (uint8_t j = 0; j < num_args; ++j) {
                 std::string arg_err;
                 QoreValue arg = readOneExpr(ctx.reader, ctx.ptr, ctx.end, arg_err, ctx.pgm,
-                    ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+                    ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
                 if (!arg_err.empty()) {
                     ctx.error = arg_err;
                     arg.discard(nullptr);
@@ -440,7 +440,7 @@ static QoreValue read_expr_static_method_call(AOTExprReadCtx& ctx) {
         for (uint8_t j = 0; j < num_args; ++j) {
             std::string arg_err;
             QoreValue arg = readOneExpr(ctx.reader, ctx.ptr, ctx.end, arg_err, ctx.pgm,
-                ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+                ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
             if (!arg_err.empty()) {
                 ctx.error = arg_err;
                 args_list->deref(nullptr);
@@ -650,7 +650,7 @@ static QoreValue read_expr_new_object(AOTExprReadCtx& ctx) {
         for (uint8_t j = 0; j < num_args; ++j) {
             std::string arg_err;
             QoreValue arg = readOneExpr(ctx.reader, ctx.ptr, ctx.end, arg_err, ctx.pgm,
-                ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+                ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
             if (!arg_err.empty()) {
                 ctx.error = arg_err;
                 args_list->deref(nullptr);
@@ -1069,7 +1069,8 @@ static QoreValue read_expr_closure_create(AOTExprReadCtx& ctx) {
     closure_sig->setupFromAOTMetadata(
         ctx.pgm, ret_type,
         std::move(param_names), std::move(param_types), std::move(defaults),
-        closure_sig_has_varargs, closure_class);
+        closure_sig_has_varargs, closure_class, nullptr, 0, 0,
+        std::vector<uint8_t>(), ctx.local_owner_pgm);
     if (closure_needs_extra_args) {
         closure_variant->setFlag(QCF_USES_EXTRA_ARGS);
     }
@@ -1141,11 +1142,12 @@ static QoreValue read_expr_closure_create(AOTExprReadCtx& ctx) {
             ? nullptr : closure_locals_vec.data();
         int cnt = static_cast<int>(closure_locals_vec.size());
         return readOneTopLevelIRExpr(rdr, p, e, err, ctx.pgm,
-            arr, cnt, ctx.globals, ctx.num_globals);
+            arr, cnt, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     };
     auto closure_ir = deserializeIRFunction(ctx.reader, ctx.ptr, ir_end_ptr, ctx.pgm,
         readExprCb, &enclosing_locals, ir_error,
-        ctx.locals, ctx.num_locals, &closure_locals_vec);
+        ctx.locals, ctx.num_locals, &closure_locals_vec, false, nullptr,
+        ctx.local_owner_pgm);
     ctx.ptr = ir_end_ptr;  // Ensure we advance past IR data
 
     if (!closure_ir) {
@@ -1321,7 +1323,7 @@ static bool write_expr_callref_call(AOTExprWriteCtx& ctx) {
 static QoreValue read_expr_callref_call(AOTExprReadCtx& ctx) {
     std::string callee_err;
     QoreValue callee = readOneExpr(ctx.reader, ctx.ptr, ctx.end, callee_err,
-        ctx.pgm, ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.pgm, ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!callee_err.empty()) {
         ctx.error = "CALLREF_CALL callee: " + callee_err;
         return QoreValue();
@@ -1338,7 +1340,7 @@ static QoreValue read_expr_callref_call(AOTExprReadCtx& ctx) {
         for (uint8_t i = 0; i < nargs; ++i) {
             std::string arg_err;
             QoreValue arg = readOneExpr(ctx.reader, ctx.ptr, ctx.end, arg_err,
-                ctx.pgm, ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+                ctx.pgm, ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
             if (!arg_err.empty()) {
                 delete args;
                 callee.discard(nullptr);
@@ -1529,7 +1531,7 @@ static QoreValue read_expr_obj_method_ref_expr(AOTExprReadCtx& ctx) {
 
     std::string target_err;
     QoreValue target = readOneExpr(ctx.reader, ctx.ptr, ctx.end, target_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!target_err.empty()) {
         ctx.error = target_err;
         target.discard(nullptr);
@@ -1647,7 +1649,7 @@ static QoreValue read_expr_scoped_new_object(AOTExprReadCtx& ctx) {
         for (uint8_t j = 0; j < num_args; ++j) {
             std::string arg_err;
             QoreValue arg = readOneExpr(ctx.reader, ctx.ptr, ctx.end, arg_err, ctx.pgm,
-                ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+                ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
             if (!arg_err.empty()) {
                 ctx.error = arg_err;
                 args_list->deref(nullptr);
@@ -1746,7 +1748,7 @@ static QoreValue read_expr_hashdecl_new(AOTExprReadCtx& ctx) {
         for (uint8_t j = 0; j < num_args; ++j) {
             std::string arg_err;
             QoreValue arg = readOneExpr(ctx.reader, ctx.ptr, ctx.end, arg_err, ctx.pgm,
-                ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+                ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
             if (!arg_err.empty()) {
                 arg.discard(nullptr);
                 call_args->push(QoreValue(), nullptr);
@@ -1822,7 +1824,7 @@ static QoreValue read_expr_complex_hash_new(AOTExprReadCtx& ctx) {
         for (uint8_t j = 0; j < num_args; ++j) {
             std::string arg_err;
             QoreValue arg = readOneExpr(ctx.reader, ctx.ptr, ctx.end, arg_err, ctx.pgm,
-                ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+                ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
             if (!arg_err.empty()) {
                 arg.discard(nullptr);
                 call_args->push(QoreValue(), nullptr);
@@ -1892,7 +1894,7 @@ static QoreValue read_expr_complex_list_new(AOTExprReadCtx& ctx) {
     if (num_args > 0) {
         std::string arg_err;
         arg_val = readOneExpr(ctx.reader, ctx.ptr, ctx.end, arg_err, ctx.pgm,
-            ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+            ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
         if (!arg_err.empty()) {
             arg_val.discard(nullptr);
             arg_val = QoreValue();
@@ -1944,7 +1946,7 @@ static QoreValue read_expr_complex_buffer_new(AOTExprReadCtx& ctx) {
     if (num_args > 0) {
         std::string arg_err;
         arg_val = readOneExpr(ctx.reader, ctx.ptr, ctx.end, arg_err, ctx.pgm,
-            ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+            ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
         if (!arg_err.empty()) {
             arg_val.discard(nullptr);
             arg_val = QoreValue();
@@ -2075,7 +2077,7 @@ static QoreValue read_expr_hash_literal(AOTExprReadCtx& ctx) {
         const char* key_str = ctx.reader.readStringRef(ctx.ptr);
         std::string val_err;
         QoreValue val = readOneExpr(ctx.reader, ctx.ptr, ctx.end, val_err, ctx.pgm,
-            ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+            ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
         if (!val_err.empty()) {
             ctx.error = val_err;
             val.discard(nullptr);
@@ -2123,10 +2125,10 @@ static QoreValue read_expr_parse_hash(AOTExprReadCtx& ctx) {
     for (uint8_t j = 0; j < num_pairs; ++j) {
         std::string key_err;
         QoreValue key = readOneExpr(ctx.reader, ctx.ptr, ctx.end, key_err, ctx.pgm,
-            ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+            ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
         std::string val_err;
         QoreValue val = readOneExpr(ctx.reader, ctx.ptr, ctx.end, val_err, ctx.pgm,
-            ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+            ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
         if (!key_err.empty() || !val_err.empty()) {
             key.discard(nullptr);
             val.discard(nullptr);
@@ -2157,13 +2159,15 @@ static bool write_expr_hash_deref(AOTExprWriteCtx& ctx) {
 
 static QoreValue read_expr_hash_deref(AOTExprReadCtx& ctx) {
     std::string left_err;
-    QoreValue left = readOneExpr(ctx.reader, ctx.ptr, ctx.end, left_err, ctx.pgm, ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+    QoreValue left = readOneExpr(ctx.reader, ctx.ptr, ctx.end, left_err, ctx.pgm,
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!left_err.empty()) {
         ctx.error = left_err;
         return QoreValue();
     }
     std::string right_err;
-    QoreValue right = readOneExpr(ctx.reader, ctx.ptr, ctx.end, right_err, ctx.pgm, ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+    QoreValue right = readOneExpr(ctx.reader, ctx.ptr, ctx.end, right_err, ctx.pgm,
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!right_err.empty()) {
         ctx.error = right_err;
         left.discard(nullptr);
@@ -2220,7 +2224,8 @@ static QoreValue read_expr_parse_ref(AOTExprReadCtx& ctx) {
         type_path = ctx.reader.readStringRef(ctx.ptr);
     }
     std::string inner_err;
-    QoreValue inner = readOneExpr(ctx.reader, ctx.ptr, ctx.end, inner_err, ctx.pgm, ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+    QoreValue inner = readOneExpr(ctx.reader, ctx.ptr, ctx.end, inner_err, ctx.pgm,
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!inner_err.empty()) {
         ctx.error = inner_err;
         return QoreValue();
@@ -2308,7 +2313,7 @@ static bool read_expr_cast_inner(AOTExprReadCtx& ctx, QoreValue& inner) {
     }
     std::string inner_err;
     inner = readOneExpr(ctx.reader, ctx.ptr, ctx.end, inner_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!inner_err.empty()) {
         ctx.error = inner_err;
         inner.discard(nullptr);
@@ -2665,7 +2670,7 @@ static QoreValue read_expr_list_literal(AOTExprReadCtx& ctx) {
     for (uint8_t j = 0; j < count; ++j) {
         std::string val_err;
         QoreValue val = readOneExpr(ctx.reader, ctx.ptr, ctx.end, val_err, ctx.pgm,
-            ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+            ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
         if (!val_err.empty()) {
             ctx.error = val_err;
             val.discard(nullptr);
@@ -2710,7 +2715,7 @@ static QoreValue read_expr_dot_eval_target(AOTExprReadCtx& ctx) {
     // Target expression
     std::string target_err;
     QoreValue target = readOneExpr(ctx.reader, ctx.ptr, ctx.end, target_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!target_err.empty()) {
         ctx.error = "DOT_EVAL_TARGET target: " + target_err;
         target.discard(nullptr);
@@ -2725,7 +2730,7 @@ static QoreValue read_expr_dot_eval_target(AOTExprReadCtx& ctx) {
         for (uint8_t j = 0; j < num_args; ++j) {
             std::string arg_err;
             QoreValue arg = readOneExpr(ctx.reader, ctx.ptr, ctx.end, arg_err, ctx.pgm,
-                ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+                ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
             if (!arg_err.empty()) {
                 ctx.error = "DOT_EVAL_TARGET arg " + std::to_string(j) + ": " + arg_err;
                 arg.discard(nullptr);
@@ -2794,7 +2799,7 @@ static bool write_expr_dot_eval_expr(AOTExprWriteCtx& ctx) {
 
 static QoreValue read_expr_dot_eval_expr(AOTExprReadCtx& ctx) {
     return readOneExpr(ctx.reader, ctx.ptr, ctx.end, ctx.error, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
 }
 
 // ============================================================================
@@ -2836,10 +2841,10 @@ static bool write_expr_plus(AOTExprWriteCtx& ctx) {
 static QoreValue read_expr_plus(AOTExprReadCtx& ctx) {
     std::string left_err;
     QoreValue left = readOneExpr(ctx.reader, ctx.ptr, ctx.end, left_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string right_err;
     QoreValue right = readOneExpr(ctx.reader, ctx.ptr, ctx.end, right_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!left_err.empty() || !right_err.empty()) {
         left.discard(nullptr);
         right.discard(nullptr);
@@ -2870,10 +2875,10 @@ static bool write_expr_square_bracket(AOTExprWriteCtx& ctx) {
 static QoreValue read_expr_square_bracket(AOTExprReadCtx& ctx) {
     std::string left_err;
     QoreValue left = readOneExpr(ctx.reader, ctx.ptr, ctx.end, left_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string right_err;
     QoreValue right = readOneExpr(ctx.reader, ctx.ptr, ctx.end, right_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!left_err.empty() || !right_err.empty()) {
         left.discard(nullptr);
         right.discard(nullptr);
@@ -2902,13 +2907,13 @@ static bool write_expr_square_bracket_range(AOTExprWriteCtx& ctx) {
 static QoreValue read_expr_square_bracket_range(AOTExprReadCtx& ctx) {
     std::string src_err;
     QoreValue src = readOneExpr(ctx.reader, ctx.ptr, ctx.end, src_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string start_err;
     QoreValue start = readOneExpr(ctx.reader, ctx.ptr, ctx.end, start_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string stop_err;
     QoreValue stop = readOneExpr(ctx.reader, ctx.ptr, ctx.end, stop_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!src_err.empty() || !start_err.empty() || !stop_err.empty()) {
         src.discard(nullptr);
         start.discard(nullptr);
@@ -2938,7 +2943,7 @@ static bool write_expr_exists(AOTExprWriteCtx& ctx) {
 static QoreValue read_expr_exists(AOTExprReadCtx& ctx) {
     std::string operand_err;
     QoreValue operand = readOneExpr(ctx.reader, ctx.ptr, ctx.end, operand_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!operand_err.empty()) {
         operand.discard(nullptr);
         ctx.error = operand_err;
@@ -2990,10 +2995,10 @@ static bool write_expr_minus(AOTExprWriteCtx& ctx) {
 static QoreValue read_expr_minus(AOTExprReadCtx& ctx) {
     std::string left_err;
     QoreValue left = readOneExpr(ctx.reader, ctx.ptr, ctx.end, left_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string right_err;
     QoreValue right = readOneExpr(ctx.reader, ctx.ptr, ctx.end, right_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!left_err.empty() || !right_err.empty()) {
         left.discard(nullptr);
         right.discard(nullptr);
@@ -3024,10 +3029,10 @@ static bool write_expr_multiply(AOTExprWriteCtx& ctx) {
 static QoreValue read_expr_multiply(AOTExprReadCtx& ctx) {
     std::string left_err;
     QoreValue left = readOneExpr(ctx.reader, ctx.ptr, ctx.end, left_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string right_err;
     QoreValue right = readOneExpr(ctx.reader, ctx.ptr, ctx.end, right_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!left_err.empty() || !right_err.empty()) {
         left.discard(nullptr);
         right.discard(nullptr);
@@ -3054,10 +3059,10 @@ static bool write_expr_divide(AOTExprWriteCtx& ctx) {
 static QoreValue read_expr_divide(AOTExprReadCtx& ctx) {
     std::string left_err;
     QoreValue left = readOneExpr(ctx.reader, ctx.ptr, ctx.end, left_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string right_err;
     QoreValue right = readOneExpr(ctx.reader, ctx.ptr, ctx.end, right_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!left_err.empty() || !right_err.empty()) {
         left.discard(nullptr);
         right.discard(nullptr);
@@ -3084,10 +3089,10 @@ static bool write_expr_modulo(AOTExprWriteCtx& ctx) {
 static QoreValue read_expr_modulo(AOTExprReadCtx& ctx) {
     std::string left_err;
     QoreValue left = readOneExpr(ctx.reader, ctx.ptr, ctx.end, left_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string right_err;
     QoreValue right = readOneExpr(ctx.reader, ctx.ptr, ctx.end, right_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!left_err.empty() || !right_err.empty()) {
         left.discard(nullptr);
         right.discard(nullptr);
@@ -3116,7 +3121,7 @@ static bool write_expr_keys(AOTExprWriteCtx& ctx) {
 static QoreValue read_expr_keys(AOTExprReadCtx& ctx) {
     std::string operand_err;
     QoreValue operand = readOneExpr(ctx.reader, ctx.ptr, ctx.end, operand_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!operand_err.empty()) {
         operand.discard(nullptr);
         ctx.error = operand_err;
@@ -3171,7 +3176,7 @@ static QoreValue read_expr_instanceof(AOTExprReadCtx& ctx) {
     const char* type_path = ctx.reader.readStringRef(ctx.ptr);
     std::string operand_err;
     QoreValue operand = readOneExpr(ctx.reader, ctx.ptr, ctx.end, operand_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!operand_err.empty()) {
         operand.discard(nullptr);
         ctx.error = operand_err;
@@ -3245,7 +3250,7 @@ static QoreValue read_regex_match_payload(AOTExprReadCtx& ctx, AOTExprKind kind)
     int64_t options = QoreAOTBinaryReader::readI64(ctx.ptr);
     std::string operand_err;
     QoreValue operand = readOneExpr(ctx.reader, ctx.ptr, ctx.end, operand_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!operand_err.empty()) {
         operand.discard(nullptr);
         ctx.error = operand_err;
@@ -3348,7 +3353,7 @@ static bool write_expr_post_dec(AOTExprWriteCtx& ctx) {
 static QoreValue read_expr_pre_inc(AOTExprReadCtx& ctx) {
     std::string operand_err;
     QoreValue operand = readOneExpr(ctx.reader, ctx.ptr, ctx.end, operand_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!operand_err.empty()) {
         operand.discard(nullptr);
         ctx.error = operand_err;
@@ -3360,7 +3365,7 @@ static QoreValue read_expr_pre_inc(AOTExprReadCtx& ctx) {
 static QoreValue read_expr_pre_dec(AOTExprReadCtx& ctx) {
     std::string operand_err;
     QoreValue operand = readOneExpr(ctx.reader, ctx.ptr, ctx.end, operand_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!operand_err.empty()) {
         operand.discard(nullptr);
         ctx.error = operand_err;
@@ -3372,7 +3377,7 @@ static QoreValue read_expr_pre_dec(AOTExprReadCtx& ctx) {
 static QoreValue read_expr_post_inc(AOTExprReadCtx& ctx) {
     std::string operand_err;
     QoreValue operand = readOneExpr(ctx.reader, ctx.ptr, ctx.end, operand_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!operand_err.empty()) {
         operand.discard(nullptr);
         ctx.error = operand_err;
@@ -3384,7 +3389,7 @@ static QoreValue read_expr_post_inc(AOTExprReadCtx& ctx) {
 static QoreValue read_expr_post_dec(AOTExprReadCtx& ctx) {
     std::string operand_err;
     QoreValue operand = readOneExpr(ctx.reader, ctx.ptr, ctx.end, operand_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!operand_err.empty()) {
         operand.discard(nullptr);
         ctx.error = operand_err;
@@ -3415,10 +3420,10 @@ template <typename NodeT>
 static QoreValue read_binary_expr(AOTExprReadCtx& ctx) {
     std::string left_err;
     QoreValue left = readOneExpr(ctx.reader, ctx.ptr, ctx.end, left_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string right_err;
     QoreValue right = readOneExpr(ctx.reader, ctx.ptr, ctx.end, right_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!left_err.empty() || !right_err.empty()) {
         left.discard(nullptr);
         right.discard(nullptr);
@@ -3595,7 +3600,7 @@ static bool write_expr_log_not(AOTExprWriteCtx& ctx) {
 static QoreValue read_expr_log_not(AOTExprReadCtx& ctx) {
     std::string operand_err;
     QoreValue operand = readOneExpr(ctx.reader, ctx.ptr, ctx.end, operand_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!operand_err.empty()) {
         operand.discard(nullptr);
         ctx.error = operand_err;
@@ -3622,7 +3627,7 @@ static bool write_expr_unary_minus(AOTExprWriteCtx& ctx) {
 static QoreValue read_expr_unary_minus(AOTExprReadCtx& ctx) {
     std::string operand_err;
     QoreValue operand = readOneExpr(ctx.reader, ctx.ptr, ctx.end, operand_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!operand_err.empty()) {
         operand.discard(nullptr);
         ctx.error = operand_err;
@@ -3673,13 +3678,13 @@ static bool write_expr_question(AOTExprWriteCtx& ctx) {
 static QoreValue read_expr_question(AOTExprReadCtx& ctx) {
     std::string cond_err;
     QoreValue cond = readOneExpr(ctx.reader, ctx.ptr, ctx.end, cond_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string true_err;
     QoreValue true_expr = readOneExpr(ctx.reader, ctx.ptr, ctx.end, true_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string false_err;
     QoreValue false_expr = readOneExpr(ctx.reader, ctx.ptr, ctx.end, false_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!cond_err.empty() || !true_err.empty() || !false_err.empty()) {
         cond.discard(nullptr);
         true_expr.discard(nullptr);
@@ -3775,13 +3780,13 @@ static QoreValue read_expr_map(AOTExprReadCtx& ctx) {
 static QoreValue read_expr_map_select(AOTExprReadCtx& ctx) {
     std::string map_err;
     QoreValue map_expr = readOneExpr(ctx.reader, ctx.ptr, ctx.end, map_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string source_err;
     QoreValue source = readOneExpr(ctx.reader, ctx.ptr, ctx.end, source_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string where_err;
     QoreValue where_expr = readOneExpr(ctx.reader, ctx.ptr, ctx.end, where_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!map_err.empty() || !source_err.empty() || !where_err.empty()) {
         map_expr.discard(nullptr);
         source.discard(nullptr);
@@ -3795,13 +3800,13 @@ static QoreValue read_expr_map_select(AOTExprReadCtx& ctx) {
 static QoreValue read_expr_hash_map(AOTExprReadCtx& ctx) {
     std::string key_err;
     QoreValue key_expr = readOneExpr(ctx.reader, ctx.ptr, ctx.end, key_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string val_err;
     QoreValue val_expr = readOneExpr(ctx.reader, ctx.ptr, ctx.end, val_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string source_err;
     QoreValue source = readOneExpr(ctx.reader, ctx.ptr, ctx.end, source_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!key_err.empty() || !val_err.empty() || !source_err.empty()) {
         key_expr.discard(nullptr);
         val_expr.discard(nullptr);
@@ -3815,16 +3820,16 @@ static QoreValue read_expr_hash_map(AOTExprReadCtx& ctx) {
 static QoreValue read_expr_hash_map_select(AOTExprReadCtx& ctx) {
     std::string key_err;
     QoreValue key_expr = readOneExpr(ctx.reader, ctx.ptr, ctx.end, key_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string val_err;
     QoreValue val_expr = readOneExpr(ctx.reader, ctx.ptr, ctx.end, val_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string source_err;
     QoreValue source = readOneExpr(ctx.reader, ctx.ptr, ctx.end, source_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string where_err;
     QoreValue where_expr = readOneExpr(ctx.reader, ctx.ptr, ctx.end, where_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!key_err.empty() || !val_err.empty() || !source_err.empty() || !where_err.empty()) {
         key_expr.discard(nullptr);
         val_expr.discard(nullptr);
@@ -3864,7 +3869,7 @@ static bool write_expr_iterate(AOTExprWriteCtx& ctx) {
 static QoreValue read_expr_iterate(AOTExprReadCtx& ctx) {
     std::string source_err;
     QoreValue source = readOneExpr(ctx.reader, ctx.ptr, ctx.end, source_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!source_err.empty()) {
         source.discard(nullptr);
         ctx.error = source_err;
@@ -3892,10 +3897,10 @@ static QoreValue read_expr_streaming(AOTExprReadCtx& ctx) {
         QoreAOTBinaryReader::readU8(ctx.ptr));
     std::string predicate_err;
     QoreValue predicate = readOneExpr(ctx.reader, ctx.ptr, ctx.end, predicate_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     std::string source_err;
     QoreValue source = readOneExpr(ctx.reader, ctx.ptr, ctx.end, source_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!predicate_err.empty() || !source_err.empty()) {
         predicate.discard(nullptr);
         source.discard(nullptr);
@@ -3925,7 +3930,7 @@ template <typename NodeT>
 static QoreValue read_unary_expr(AOTExprReadCtx& ctx) {
     std::string operand_err;
     QoreValue operand = readOneExpr(ctx.reader, ctx.ptr, ctx.end, operand_err, ctx.pgm,
-        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals);
+        ctx.locals, ctx.num_locals, ctx.globals, ctx.num_globals, ctx.local_owner_pgm);
     if (!operand_err.empty()) {
         operand.discard(nullptr);
         ctx.error = operand_err;

--- a/lib/QoreAOTExprRegistry.cpp
+++ b/lib/QoreAOTExprRegistry.cpp
@@ -53,7 +53,8 @@ extern QoreValue readOneExpr(
         const QoreAOTBinaryReader& rdr, const uint8_t*& p, const uint8_t* e,
         std::string& err, QoreProgram* pgm,
         LocalVar** locals, int num_locals,
-        Var** globals, int num_globals);
+        Var** globals, int num_globals,
+        QoreProgram* local_owner_pgm);
 
 // Include all handler implementations (Phase 3.2 extracted handlers)
 #include "QoreAOTExprHandlers.cpp"

--- a/lib/QoreAOTInstRegistry.cpp
+++ b/lib/QoreAOTInstRegistry.cpp
@@ -705,7 +705,8 @@ static std::unique_ptr<QoreIRInstruction> readLocal(
         QoreAOTTypeResolver type_resolver(ctx.pgm);
         const QoreTypeInfo* ti = (ltype && *ltype)
             ? type_resolver.resolve(ltype, type_error) : nullptr;
-        qore_program_private* pp = qore_program_private::get(*ctx.pgm);
+        qore_program_private* pp = qore_program_private::get(
+            *(ctx.local_owner_pgm ? ctx.local_owner_pgm : ctx.pgm));
         lv = pp->createLocalVar(lname, ti);
     }
     if (lv && read_only && !lv->isReadOnly()) {
@@ -816,7 +817,7 @@ static std::unique_ptr<QoreIRInstruction> readOnBlockExit(
         // Without this, parent-slot references in the handler would allocate fresh
         // LocalVars whose name pointers don't match what evalTiered pushed.
         nested_handler = deserializeIRFunction(ctx.reader, ctx.ptr, ctx.end, ctx.pgm, ctx.readExpr,
-            &ctx.local_map, ctx.error);
+            &ctx.local_map, ctx.error, nullptr, 0, nullptr, false, nullptr, ctx.local_owner_pgm);
         if (!nested_handler) {
             ctx.error = "failed to deserialize nested OnBlockExit handler IR: " + ctx.error;
             return nullptr;

--- a/lib/QoreAOTRuntime.cpp
+++ b/lib/QoreAOTRuntime.cpp
@@ -1618,7 +1618,8 @@ QoreValue readOneExpr(
         const QoreAOTBinaryReader& rdr, const uint8_t*& p, const uint8_t* e,
         std::string& err, QoreProgram* pgm,
         LocalVar** locals, int num_locals,
-        Var** globals, int num_globals) {
+        Var** globals, int num_globals,
+        QoreProgram* local_owner_pgm) {
     uint8_t ekind = QoreAOTBinaryReader::readU8(p);
     AOTExprKind ek = static_cast<AOTExprKind>(ekind);
 
@@ -1628,7 +1629,9 @@ QoreValue readOneExpr(
         err = "unsupported expression kind " + std::to_string(ekind);
         return QoreValue();
     }
-    AOTExprReadCtx rctx{rdr, p, e, pgm, err, locals, num_locals, globals, num_globals};
+    AOTExprReadCtx rctx{
+        rdr, p, e, pgm, err, locals, num_locals, globals, num_globals, local_owner_pgm
+    };
     return kinfo->read_fn(rctx);
 }
 
@@ -1636,14 +1639,16 @@ QoreValue readOneTopLevelIRExpr(
         const QoreAOTBinaryReader& rdr, const uint8_t*& p, const uint8_t* e,
         std::string& err, QoreProgram* pgm,
         LocalVar** locals, int num_locals,
-        Var** globals, int num_globals) {
+        Var** globals, int num_globals,
+        QoreProgram* local_owner_pgm) {
     const uint8_t* start = p;
     uint8_t kind_byte = QoreAOTBinaryReader::readU8(p);
     if (static_cast<AOTExprKind>(kind_byte) == AOTExprKind::GENERIC_EVAL) {
         return QoreValue();
     }
     p = start;
-    return readOneExpr(rdr, p, e, err, pgm, locals, num_locals, globals, num_globals);
+    return readOneExpr(rdr, p, e, err, pgm, locals, num_locals, globals, num_globals,
+        local_owner_pgm);
 }
 
 // ---- Expression Tree Deserializer ----
@@ -1959,7 +1964,8 @@ static QoreAOTContext* buildContextFromSlotMap(
         QoreAOTTypeResolver* shared_type_resolver = nullptr,
         std::string* build_error = nullptr,
         std::shared_ptr<const QoreAOTDebugMetadata> debug_metadata = nullptr,
-        const uint8_t* slot_maps_start = nullptr) {
+        const uint8_t* slot_maps_start = nullptr,
+        QoreProgram* local_owner_pgm = nullptr) {
     const uint8_t* entry_payload_start = ptr;
     auto setBuildError = [name, build_error](const std::string& msg) {
         if (build_error && build_error->empty()) {
@@ -2036,6 +2042,8 @@ static QoreAOTContext* buildContextFromSlotMap(
     ctx->allocate();
 
     qore_program_private* pp = qore_program_private::get(*pgm);
+    qore_program_private* local_pp = local_owner_pgm
+        ? qore_program_private::get(*local_owner_pgm) : pp;
 
     // Get UserSignature for param resolution
     UserSignature* sig = uvb ? uvb->getUserSignature() : nullptr;
@@ -2180,7 +2188,7 @@ static QoreAOTContext* buildContextFromSlotMap(
                         type_error.clear();
                     }
                 }
-                lv = pp->createLocalVar(lname ? lname : "", ti);
+                lv = local_pp->createLocalVar(lname ? lname : "", ti);
             }
         }
 
@@ -2412,7 +2420,7 @@ static QoreAOTContext* buildContextFromSlotMap(
                     for (uint8_t j = 0; j < num_args; ++j) {
                         std::string arg_err;
                         QoreValue arg = readOneExpr(reader, ptr, end, arg_err, pgm,
-                            ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals);
+                            ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals, local_owner_pgm);
                         if (!arg_err.empty()) {
                             printd(0, "AOT v2: error reading complex hash arg %d for '%s': %s\n",
                                 j, ref1 ? ref1 : "", arg_err.c_str());
@@ -2475,7 +2483,7 @@ static QoreAOTContext* buildContextFromSlotMap(
                 if (num_args > 0) {
                     std::string arg_err;
                     arg_val = readOneExpr(reader, ptr, end, arg_err, pgm,
-                        ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals);
+                        ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals, local_owner_pgm);
                     if (!arg_err.empty()) {
                         printd(0, "AOT v2: error reading complex list arg for '%s': %s\n",
                             ref1 ? ref1 : "", arg_err.c_str());
@@ -2519,7 +2527,7 @@ static QoreAOTContext* buildContextFromSlotMap(
                 if (num_args > 0) {
                     std::string arg_err;
                     arg_val = readOneExpr(reader, ptr, end, arg_err, pgm,
-                        ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals);
+                        ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals, local_owner_pgm);
                     if (!arg_err.empty()) {
                         printd(0, "AOT v2: error reading complex buffer arg for '%s': %s\n",
                             ref1 ? ref1 : "", arg_err.c_str());
@@ -2560,7 +2568,7 @@ static QoreAOTContext* buildContextFromSlotMap(
                     for (uint8_t j = 0; j < num_args; ++j) {
                         std::string arg_err;
                         QoreValue arg = readOneExpr(reader, ptr, end, arg_err, pgm,
-                            ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals);
+                            ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals, local_owner_pgm);
                         if (!arg_err.empty()) {
                             printd(0, "AOT v2: error reading hashdecl arg %d for '%s': %s\n",
                                 j, ref1 ? ref1 : "", arg_err.c_str());
@@ -2675,7 +2683,7 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::CALLREF_CALL: {
                 std::string callee_err;
                 QoreValue callee = readOneExpr(reader, ptr, end, callee_err, pgm,
-                    ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals);
+                    ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals, local_owner_pgm);
                 if (!callee_err.empty()) {
                     printd(0, "AOT v2: error reading callref callee for slot %d: %s\n",
                         i, callee_err.c_str());
@@ -2690,7 +2698,7 @@ static QoreAOTContext* buildContextFromSlotMap(
                     for (uint8_t j = 0; j < num_args; ++j) {
                         std::string arg_err;
                         QoreValue arg = readOneExpr(reader, ptr, end, arg_err, pgm,
-                            ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals);
+                            ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals, local_owner_pgm);
                         if (!arg_err.empty()) {
                             printd(0, "AOT v2: error reading callref arg %d for slot %d: %s\n",
                                 j, i, arg_err.c_str());
@@ -2777,7 +2785,7 @@ static QoreAOTContext* buildContextFromSlotMap(
                 ref1 = reader.readStringRef(ptr);   // method_name
                 std::string child_err;
                 QoreValue target = readOneExpr(reader, ptr, end, child_err, pgm,
-                    ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals);
+                    ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals, local_owner_pgm);
                 if (!child_err.empty()) {
                     printd(0, "AOT v2: error reading obj method ref target for '%s': %s\n",
                         ref1 ? ref1 : "", child_err.c_str());
@@ -2847,7 +2855,7 @@ static QoreAOTContext* buildContextFromSlotMap(
                     for (uint8_t j = 0; j < num_args; ++j) {
                         std::string arg_err;
                         QoreValue arg = readOneExpr(reader, ptr, end, arg_err, pgm,
-                            ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals);
+                            ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals, local_owner_pgm);
                         if (!arg_err.empty()) {
                             printd(0, "AOT v2: error reading static method arg %d for '%s::%s': %s\n",
                                 j, ref1 ? ref1 : "", ref2 ? ref2 : "", arg_err.c_str());
@@ -2961,7 +2969,7 @@ static QoreAOTContext* buildContextFromSlotMap(
                     std::string val_err;
                     // readOneExpr reads its own ekind byte from ptr
                     QoreValue val = readOneExpr(reader, ptr, end, val_err, pgm,
-                        ctx->locals, num_locals, ctx->globals, num_globals);
+                        ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                     if (!hash_ok) {
                         val.discard(nullptr);
                     } else if (!val_err.empty()) {
@@ -2988,10 +2996,10 @@ static QoreAOTContext* buildContextFromSlotMap(
                 for (uint8_t j = 0; j < num_pairs; ++j) {
                     std::string key_err;
                     QoreValue key = readOneExpr(reader, ptr, end, key_err, pgm,
-                        ctx->locals, num_locals, ctx->globals, num_globals);
+                        ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                     std::string val_err;
                     QoreValue val = readOneExpr(reader, ptr, end, val_err, pgm,
-                        ctx->locals, num_locals, ctx->globals, num_globals);
+                        ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                     if (!hash_ok) {
                         key.discard(nullptr);
                         val.discard(nullptr);
@@ -3021,7 +3029,7 @@ static QoreAOTContext* buildContextFromSlotMap(
                 for (uint8_t j = 0; j < count; ++j) {
                     std::string val_err;
                     QoreValue val = readOneExpr(reader, ptr, end, val_err, pgm,
-                        ctx->locals, num_locals, ctx->globals, num_globals);
+                        ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                     if (!list_ok) {
                         val.discard(nullptr);
                     } else if (!val_err.empty()) {
@@ -3053,7 +3061,7 @@ static QoreAOTContext* buildContextFromSlotMap(
                 }
                 std::string inner_err;
                 QoreValue inner = readOneExpr(reader, ptr, end, inner_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!inner_err.empty()) {
                     printd(2, "AOT v2: PARSE_REF inner error for expr slot %d of '%s': %s\n",
                         i, name, inner_err.c_str());
@@ -3138,10 +3146,10 @@ static QoreAOTContext* buildContextFromSlotMap(
                 // left (base expr) + right (key expr) — uses readOneExpr to consume both sub-expressions
                 std::string left_err;
                 QoreValue left = readOneExpr(reader, ptr, end, left_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string right_err;
                 QoreValue right = readOneExpr(reader, ptr, end, right_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!left_err.empty() || !right_err.empty()) {
                     left.discard(nullptr);
                     right.discard(nullptr);
@@ -3155,10 +3163,10 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::PLUS: {
                 std::string left_err;
                 QoreValue left = readOneExpr(reader, ptr, end, left_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string right_err;
                 QoreValue right = readOneExpr(reader, ptr, end, right_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!left_err.empty() || !right_err.empty()) {
                     left.discard(nullptr);
                     right.discard(nullptr);
@@ -3172,10 +3180,10 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::RANGE: {
                 std::string left_err;
                 QoreValue left = readOneExpr(reader, ptr, end, left_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string right_err;
                 QoreValue right = readOneExpr(reader, ptr, end, right_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!left_err.empty() || !right_err.empty()) {
                     left.discard(nullptr);
                     right.discard(nullptr);
@@ -3189,10 +3197,10 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::SQUARE_BRACKET: {
                 std::string left_err;
                 QoreValue left = readOneExpr(reader, ptr, end, left_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string right_err;
                 QoreValue right = readOneExpr(reader, ptr, end, right_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!left_err.empty() || !right_err.empty()) {
                     left.discard(nullptr);
                     right.discard(nullptr);
@@ -3206,13 +3214,13 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::SQUARE_BRACKET_RANGE: {
                 std::string src_err;
                 QoreValue src = readOneExpr(reader, ptr, end, src_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string start_err;
                 QoreValue start = readOneExpr(reader, ptr, end, start_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string stop_err;
                 QoreValue stop = readOneExpr(reader, ptr, end, stop_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!src_err.empty() || !start_err.empty() || !stop_err.empty()) {
                     src.discard(nullptr);
                     start.discard(nullptr);
@@ -3227,7 +3235,7 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::EXISTS: {
                 std::string operand_err;
                 QoreValue operand = readOneExpr(reader, ptr, end, operand_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!operand_err.empty()) {
                     operand.discard(nullptr);
                     has_unsupported = true;
@@ -3247,10 +3255,10 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::MINUS: {
                 std::string left_err;
                 QoreValue left = readOneExpr(reader, ptr, end, left_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string right_err;
                 QoreValue right = readOneExpr(reader, ptr, end, right_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!left_err.empty() || !right_err.empty()) {
                     left.discard(nullptr);
                     right.discard(nullptr);
@@ -3264,10 +3272,10 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::MULTIPLY: {
                 std::string left_err;
                 QoreValue left = readOneExpr(reader, ptr, end, left_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string right_err;
                 QoreValue right = readOneExpr(reader, ptr, end, right_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!left_err.empty() || !right_err.empty()) {
                     left.discard(nullptr);
                     right.discard(nullptr);
@@ -3281,10 +3289,10 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::DIVIDE: {
                 std::string left_err;
                 QoreValue left = readOneExpr(reader, ptr, end, left_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string right_err;
                 QoreValue right = readOneExpr(reader, ptr, end, right_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!left_err.empty() || !right_err.empty()) {
                     left.discard(nullptr);
                     right.discard(nullptr);
@@ -3298,10 +3306,10 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::MODULO: {
                 std::string left_err;
                 QoreValue left = readOneExpr(reader, ptr, end, left_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string right_err;
                 QoreValue right = readOneExpr(reader, ptr, end, right_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!left_err.empty() || !right_err.empty()) {
                     left.discard(nullptr);
                     right.discard(nullptr);
@@ -3319,10 +3327,10 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::SHIFT_RIGHT: {
                 std::string left_err;
                 QoreValue left = readOneExpr(reader, ptr, end, left_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string right_err;
                 QoreValue right = readOneExpr(reader, ptr, end, right_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!left_err.empty() || !right_err.empty()) {
                     left.discard(nullptr);
                     right.discard(nullptr);
@@ -3348,7 +3356,7 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::KEYS: {
                 std::string operand_err;
                 QoreValue operand = readOneExpr(reader, ptr, end, operand_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!operand_err.empty()) {
                     operand.discard(nullptr);
                     has_unsupported = true;
@@ -3366,7 +3374,7 @@ static QoreAOTContext* buildContextFromSlotMap(
                 const char* type_path = reader.readStringRef(ptr);
                 std::string operand_err;
                 QoreValue operand = readOneExpr(reader, ptr, end, operand_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!operand_err.empty()) {
                     operand.discard(nullptr);
                     has_unsupported = true;
@@ -3398,7 +3406,7 @@ static QoreAOTContext* buildContextFromSlotMap(
                 int64_t options = QoreAOTBinaryReader::readI64(ptr);
                 std::string operand_err;
                 QoreValue operand = readOneExpr(reader, ptr, end, operand_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!operand_err.empty() || !pattern) {
                     operand.discard(nullptr);
                     has_unsupported = true;
@@ -3431,7 +3439,7 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::POST_DEC: {
                 std::string operand_err;
                 QoreValue operand = readOneExpr(reader, ptr, end, operand_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!operand_err.empty()) {
                     operand.discard(nullptr);
                     has_unsupported = true;
@@ -3471,10 +3479,10 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::ASSIGN: {
                 std::string left_err;
                 QoreValue left = readOneExpr(reader, ptr, end, left_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string right_err;
                 QoreValue right = readOneExpr(reader, ptr, end, right_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!left_err.empty() || !right_err.empty()) {
                     left.discard(nullptr);
                     right.discard(nullptr);
@@ -3536,7 +3544,7 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::ITERATE: {
                 std::string source_err;
                 QoreValue source = readOneExpr(reader, ptr, end, source_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!source_err.empty()) {
                     source.discard(nullptr);
                     has_unsupported = true;
@@ -3551,10 +3559,10 @@ static QoreAOTContext* buildContextFromSlotMap(
                     QoreAOTBinaryReader::readU8(ptr));
                 std::string predicate_err;
                 QoreValue predicate = readOneExpr(reader, ptr, end, predicate_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string source_err;
                 QoreValue source = readOneExpr(reader, ptr, end, source_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!predicate_err.empty() || !source_err.empty()) {
                     predicate.discard(nullptr);
                     source.discard(nullptr);
@@ -3568,13 +3576,13 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::MAP_SELECT: {
                 std::string map_err;
                 QoreValue map_expr = readOneExpr(reader, ptr, end, map_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string source_err;
                 QoreValue source = readOneExpr(reader, ptr, end, source_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string where_err;
                 QoreValue where_expr = readOneExpr(reader, ptr, end, where_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!map_err.empty() || !source_err.empty() || !where_err.empty()) {
                     map_expr.discard(nullptr);
                     source.discard(nullptr);
@@ -3590,13 +3598,13 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::HASH_MAP_SELECT_OP: {
                 std::string key_err;
                 QoreValue key_expr = readOneExpr(reader, ptr, end, key_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string val_err;
                 QoreValue val_expr = readOneExpr(reader, ptr, end, val_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string source_err;
                 QoreValue source = readOneExpr(reader, ptr, end, source_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (kind == AOTExprKind::HASH_MAP_OP) {
                     if (!key_err.empty() || !val_err.empty() || !source_err.empty()) {
                         key_expr.discard(nullptr);
@@ -3611,7 +3619,7 @@ static QoreAOTContext* buildContextFromSlotMap(
                 }
                 std::string where_err;
                 QoreValue where_expr = readOneExpr(reader, ptr, end, where_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!key_err.empty() || !val_err.empty() || !source_err.empty() || !where_err.empty()) {
                     key_expr.discard(nullptr);
                     val_expr.discard(nullptr);
@@ -3628,7 +3636,7 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::LOG_NOT: {
                 std::string operand_err;
                 QoreValue operand = readOneExpr(reader, ptr, end, operand_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!operand_err.empty()) {
                     operand.discard(nullptr);
                     has_unsupported = true;
@@ -3641,7 +3649,7 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::UNARY_MINUS: {
                 std::string operand_err;
                 QoreValue operand = readOneExpr(reader, ptr, end, operand_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!operand_err.empty()) {
                     operand.discard(nullptr);
                     has_unsupported = true;
@@ -3654,13 +3662,13 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::QUESTION: {
                 std::string cond_err;
                 QoreValue cond = readOneExpr(reader, ptr, end, cond_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string true_err;
                 QoreValue true_expr = readOneExpr(reader, ptr, end, true_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string false_err;
                 QoreValue false_expr = readOneExpr(reader, ptr, end, false_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!cond_err.empty() || !true_err.empty() || !false_err.empty()) {
                     cond.discard(nullptr);
                     true_expr.discard(nullptr);
@@ -3682,7 +3690,7 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::BACKGROUND: {
                 std::string operand_err;
                 QoreValue operand = readOneExpr(reader, ptr, end, operand_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!operand_err.empty()) {
                     operand.discard(nullptr);
                     has_unsupported = true;
@@ -3717,10 +3725,10 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::UNSHIFT: {
                 std::string left_err;
                 QoreValue left = readOneExpr(reader, ptr, end, left_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 std::string right_err;
                 QoreValue right = readOneExpr(reader, ptr, end, right_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!left_err.empty() || !right_err.empty()) {
                     left.discard(nullptr);
                     right.discard(nullptr);
@@ -3737,7 +3745,7 @@ static QoreAOTContext* buildContextFromSlotMap(
             case AOTExprKind::DOT_EVAL_EXPR: {
                 std::string dot_err;
                 QoreValue dot_expr = readOneExpr(reader, ptr, end, dot_err, pgm,
-                    ctx->locals, num_locals, ctx->globals, num_globals);
+                    ctx->locals, num_locals, ctx->globals, num_globals, local_owner_pgm);
                 if (!dot_err.empty()) {
                     dot_expr.discard(nullptr);
                     has_unsupported = true;
@@ -3863,7 +3871,8 @@ static QoreAOTContext* buildContextFromSlotMap(
                 closure_sig->setupFromAOTMetadata(
                     pgm, ret_type,
                     std::move(param_names), std::move(param_types), std::move(defaults),
-                    closure_sig_has_varargs, closure_class);
+                    closure_sig_has_varargs, closure_class, nullptr, 0, 0,
+                    std::vector<uint8_t>(), local_owner_pgm);
                 if (closure_needs_extra_args) {
                     closure_variant->setFlag(QCF_USES_EXTRA_ARGS);
                 }
@@ -3951,18 +3960,19 @@ static QoreAOTContext* buildContextFromSlotMap(
                 // visible to readExprCb when instruction reading fires readExpr
                 // calls.
                 std::string ir_error;
-                auto readExprCb = [pgm, ctx, num_globals, &closure_locals_vec]
+                auto readExprCb = [pgm, ctx, num_globals, &closure_locals_vec, local_owner_pgm]
                         (const QoreAOTBinaryReader& rdr, const uint8_t*& p,
                         const uint8_t* e, std::string& err) -> QoreValue {
                     LocalVar** arr = closure_locals_vec.empty()
                         ? nullptr : closure_locals_vec.data();
                     int cnt = static_cast<int>(closure_locals_vec.size());
                     return readOneTopLevelIRExpr(rdr, p, e, err, pgm,
-                        arr, cnt, ctx->globals, num_globals);
+                        arr, cnt, ctx->globals, num_globals, local_owner_pgm);
                 };
                 auto closure_ir = deserializeIRFunction(reader, ptr, ir_end_ptr, pgm,
                     readExprCb, &enclosing_locals, ir_error,
-                    ctx->locals, num_locals, &closure_locals_vec);
+                    ctx->locals, num_locals, &closure_locals_vec, false, nullptr,
+                    local_owner_pgm);
                 ptr = ir_end_ptr;  // Ensure we advance past IR data
 
                 if (!closure_ir) {
@@ -4378,7 +4388,7 @@ static QoreAOTContext* buildContextFromSlotMap(
                 }
             }
 
-            lv = pp->createLocalVar(blname ? blname : "", ti);
+            lv = local_pp->createLocalVar(blname ? blname : "", ti);
         }
         if ((bl_flags & 0x01) && !lv->closureUse()) {
             lv->setClosureUse();
@@ -4424,7 +4434,7 @@ static QoreAOTContext* buildContextFromSlotMap(
                 if (QoreAOTBinaryReader::readU8(ptr)) {
                     std::string expr_error;
                     QoreValue legacy_delete_lvalue_expr = readOneExpr(reader, ptr, end, expr_error, pgm,
-                        ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals);
+                        ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals, local_owner_pgm);
                     legacy_delete_lvalue_expr.discard(nullptr);
                     if (!expr_error.empty()) {
                         printd(2, "AOT buildCtx: '%s' LValuePath delete expr deser failed: %s\n",
@@ -4617,7 +4627,8 @@ static QoreAOTContext* buildContextFromSlotMap(
                 const uint8_t* handler_ir_end = ptr + handler_ir_size;
                 // Deserialize handler IR function
                 std::string ir_error;
-                auto readExprCb = [pgm, ctx](const QoreAOTBinaryReader& rdr, const uint8_t*& p,
+                auto readExprCb = [pgm, ctx, local_owner_pgm](
+                        const QoreAOTBinaryReader& rdr, const uint8_t*& p,
                         const uint8_t* e, std::string& err) -> QoreValue {
                     // Peek at kind byte for special cases
                     uint8_t kind_byte = QoreAOTBinaryReader::readU8(p);
@@ -4645,11 +4656,11 @@ static QoreAOTContext* buildContextFromSlotMap(
                     // itself. Use a wrapper that re-reads from p-1 by adjusting p.
                     --p;  // unconsume the kind byte so readOneExpr can read it
                     return readOneExpr(rdr, p, e, err, pgm,
-                        ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals);
+                        ctx->locals, ctx->num_locals, ctx->globals, ctx->num_globals, local_owner_pgm);
                 };
                 auto handler = deserializeIRFunction(reader, ptr, end, pgm, readExprCb,
                     &handler_local_map, ir_error,
-                    ctx->locals, num_locals);
+                    ctx->locals, num_locals, nullptr, false, nullptr, local_owner_pgm);
                 if (handler) {
                     // Compute slot IDs for the deserialized handler
                     handler->computeSlotIdsAndEmbed();
@@ -4918,6 +4929,7 @@ static std::unique_ptr<QoreIRInstruction> deserializeIRInstruction(
         const std::unordered_map<uint32_t, LocalVar*>* slot_to_local,
         const AOTExprReadFunc& readExpr,
         QoreProgram* pgm,
+        QoreProgram* local_owner_pgm,
         std::string& error) {
     auto need = [&ptr, end, &error](size_t bytes, const char* field) -> bool {
         if (end < ptr || static_cast<size_t>(end - ptr) < bytes) {
@@ -4999,7 +5011,9 @@ static std::unique_ptr<QoreIRInstruction> deserializeIRInstruction(
         error += "; this usually means qcc emitted malformed or schema-incompatible IR";
         return nullptr;
     }
-    AOTInstReadCtx rctx{reader, ptr, end, blocks, local_map, readExpr, pgm, error, slot_to_local};
+    AOTInstReadCtx rctx{
+        reader, ptr, end, blocks, local_map, readExpr, pgm, local_owner_pgm, error, slot_to_local
+    };
     inst = ginfo->read_fn(opcode_raw, exc_target, operands, result_id, rctx);
     if (!inst) {
         const OpcodeInfo* oi = getOpcodeInfo(opcode_raw);
@@ -5142,7 +5156,8 @@ static std::unique_ptr<QoreIRInstruction> deserializeIRInstruction(
                 QoreAOTTypeResolver type_resolver(pgm);
                 const QoreTypeInfo* ti = (ltype && *ltype)
                     ? type_resolver.resolve(ltype, type_error) : nullptr;
-                qore_program_private* pp = qore_program_private::get(*pgm);
+                qore_program_private* pp = qore_program_private::get(
+                    *(local_owner_pgm ? local_owner_pgm : pgm));
                 lv = pp->createLocalVar(lname, ti);
             }
             if (lv && read_only && !lv->isReadOnly()) {
@@ -5847,7 +5862,8 @@ static std::unique_ptr<QoreIRInstruction> deserializeIRInstruction(
             std::unique_ptr<QoreIRFunction> nested_handler;
             if (has_handler_ir) {
                 nested_handler = deserializeIRFunction(reader, ptr, end, pgm, readExpr,
-                    &local_map, error, parent_locals_arr, num_parent_locals);
+                    &local_map, error, parent_locals_arr, num_parent_locals,
+                    nullptr, false, nullptr, local_owner_pgm);
                 if (!nested_handler) {
                     error = "failed to deserialize nested OnBlockExit handler IR: " + error;
                     return nullptr;
@@ -5976,7 +5992,8 @@ std::unique_ptr<QoreIRFunction> deserializeIRFunction(
         int num_parent_locals,
         std::vector<LocalVar*>* extended_closure_locals,
         bool use_parent_locals_for_all_slots,
-        const std::vector<LocalVar*>* direct_body_locals) {
+        const std::vector<LocalVar*>* direct_body_locals,
+        QoreProgram* local_owner_pgm) {
     const uint8_t* func_start = ptr;
     auto remaining = [&ptr, end]() -> size_t {
         return end >= ptr ? static_cast<size_t>(end - ptr) : 0;
@@ -6139,7 +6156,7 @@ std::unique_ptr<QoreIRFunction> deserializeIRFunction(
         return it != local_map.end() && enclosing_local_set.count(it->second)
             ? it->second : nullptr;
     };
-    auto createLocal = [pgm](const char* lname, const char* ltype) -> LocalVar* {
+    auto createLocal = [pgm, local_owner_pgm](const char* lname, const char* ltype) -> LocalVar* {
         if (!pgm) {
             printd(5, "AOT IR deser: local '%s' not found in enclosing scope and no pgm\n", lname);
             return nullptr;
@@ -6148,7 +6165,8 @@ std::unique_ptr<QoreIRFunction> deserializeIRFunction(
         QoreAOTTypeResolver type_resolver(pgm);
         const QoreTypeInfo* ti = (ltype && *ltype)
             ? type_resolver.resolve(ltype, type_error) : nullptr;
-        qore_program_private* pp = qore_program_private::get(*pgm);
+        qore_program_private* pp = qore_program_private::get(
+            *(local_owner_pgm ? local_owner_pgm : pgm));
         return pp->createLocalVar(lname, ti);
     };
     for (int i = 0; i < num_local_slots; ++i) {
@@ -6371,7 +6389,7 @@ std::unique_ptr<QoreIRFunction> deserializeIRFunction(
                 }
             }
             auto inst = deserializeIRInstruction(reader, ptr, end, func->blocks, local_map,
-                func.get(), &slot_to_local, *effectiveReadExpr, pgm, error);
+                func.get(), &slot_to_local, *effectiveReadExpr, pgm, local_owner_pgm, error);
             if (!inst) {
                 error = "failed to deserialize instruction " + std::to_string(j)
                     + " in block " + std::to_string(i)
@@ -6605,7 +6623,8 @@ static void registerAOTFunctionsFromSlotMaps(
         std::vector<AOTInitFuncExecInfo>* init_func_contexts = nullptr,
         QoreAOTTypeResolver* shared_type_resolver = nullptr,
         std::vector<std::string>* registration_errors = nullptr,
-        std::shared_ptr<const QoreAOTDebugMetadata> debug_metadata = nullptr) {
+        std::shared_ptr<const QoreAOTDebugMetadata> debug_metadata = nullptr,
+        QoreProgram* local_owner_pgm = nullptr) {
     const QoreAOTSectionHeader* sec = reader.findSection(QoreAOTSectionType::SLOT_MAPS);
     if (!sec) {
         printd(0, "AOT v2: no SLOT_MAPS section found\n");
@@ -7095,7 +7114,7 @@ static void registerAOTFunctionsFromSlotMaps(
         std::string build_error;
         QoreAOTContext* ctx = buildContextFromSlotMap(reader, ptr, end, uvb, pgm, *aot_func,
             func_name, entry_end, shared_type_resolver, &build_error, debug_metadata,
-            slot_maps_start);
+            slot_maps_start, local_owner_pgm);
         // Debug: trace init function context building
         if (init_func_contexts && (strncmp(func_name, "__const_init::", 14) == 0
                 || strncmp(func_name, "__svar_init::", 13) == 0)) {
@@ -9022,8 +9041,6 @@ struct AotModuleState {
     std::vector<uint8_t> metadata;
     //! Init function descriptors (target type, ns path, item name) read during module_init
     std::vector<AOTInitFuncDescriptor> init_descriptors;
-    //! Target programs where init functions have already run for this module
-    std::unordered_set<QoreProgram*> init_done_pgms;
     //! Module path/label used for get_module_context_path() during deferred module init
     std::string path;
     //! Progress of the one-time initialization of the shared shadow (module-own) Program's
@@ -10261,9 +10278,10 @@ static void qore_aot_module_ns_init_impl(QoreNamespace* root_ns, QoreNamespace* 
     // Execute deferred init functions for constants/static vars.
     // This must happen AFTER namespace merge so that class hierarchies are fully
     // committed and object constructors can find base class private data slots.
-    // We build init function contexts HERE using the TARGET program's namespace tree
-    // (which has properly committed classes) rather than the module program's tree.
+    // Contexts resolve module symbols against the shared shadow Program, while
+    // generated locals are owned by the importing Program.
     if (mod_name) {
+        qore_program_private* target_pp = qore_program_private::get(*tpgm);
         const QoreAOTFunc* init_funcs = nullptr;
         int init_num_funcs = 0;
         QoreProgram* init_ctx_pgm = nullptr;
@@ -10286,8 +10304,7 @@ static void qore_aot_module_ns_init_impl(QoreNamespace* root_ns, QoreNamespace* 
             }
             if (it != aot_module_map.end() && !it->second.init_descriptors.empty()
                     && !it->second.metadata.empty()
-                    && it->second.init_done_pgms.find(tpgm) == it->second.init_done_pgms.end()) {
-                it->second.init_done_pgms.insert(tpgm);
+                    && target_pp->initialized_aot_modules.insert(mod_name).second) {
                 init_funcs = it->second.funcs;
                 init_num_funcs = it->second.num_funcs;
                 init_ctx_pgm = it->second.pgm ? it->second.pgm : tpgm;
@@ -10313,10 +10330,7 @@ static void qore_aot_module_ns_init_impl(QoreNamespace* root_ns, QoreNamespace* 
                         if (wait_rc == QORE_COND_RESULT_INTERRUPTED) {
                             // This target did not run its init functions, so allow a later import
                             // attempt to retry after the cancellation condition has been handled.
-                            auto retry_state = aot_module_map.find(mod_name);
-                            if (retry_state != aot_module_map.end()) {
-                                retry_state->second.init_done_pgms.erase(tpgm);
-                            }
+                            target_pp->initialized_aot_modules.erase(mod_name);
                             if (!external_xsink) {
                                 xsink.handleExceptions();
                             }
@@ -10357,14 +10371,6 @@ static void qore_aot_module_ns_init_impl(QoreNamespace* root_ns, QoreNamespace* 
         } shadow_finalizer{mod_name, write_shadow};
 
         if (!init_descriptors.empty() && !init_metadata.empty()) {
-            // Build function table from the stored function pointers.
-            // Only include init functions (__const_init::, __svar_init::,
-            // __module_init::) — regular user functions were already registered
-            // during the module init pass against the MODULE's namespace tree
-            // (which includes private functions).  The TARGET namespace tree
-            // used here only contains public functions (merged via
-            // mergeUserPublic), so namespace-private functions would fail
-            // lookup and produce spurious "unresolved local slot" warnings.
             std::unordered_map<std::string, const QoreAOTFunc*> func_map;
             for (int i = 0; init_funcs && i < init_num_funcs; ++i) {
                 const char* fname = init_funcs[i].name;
@@ -10380,20 +10386,9 @@ static void qore_aot_module_ns_init_impl(QoreNamespace* root_ns, QoreNamespace* 
                     mod_name, func_map.size());
             }
 
-            // Build init function contexts from slot maps.
-            //
-            // We pass the MODULE's own program (it->second.pgm) rather than the
-            // target program (tpgm). The module's program has all dependencies
-            // loaded (e.g. reflection — providing Qore::Reflection::IntType),
-            // so RUNTIME_CONST_REF slot resolution for cross-module constants
-            // finds the right ConstantEntry. The target program may not have
-            // those dependencies loaded as top-level namespaces.
-            //
-            // Classes and hashdecls are merged into the target namespace tree
-            // by scanMergeCommittedNamespace above, but the module's own
-            // program still holds references to everything the AOT-compiled
-            // init code was lowered against, so the module program is the
-            // natural context for slot resolution.
+            // Resolve names and types against the module Program because it has all
+            // dependencies loaded. Newly deserialized LocalVars belong to the target
+            // Program, so repeated imports are reclaimed with that Program.
             assert(init_ctx_pgm);
             QoreAOTBinaryReader init_reader;
             std::string reader_error;
@@ -10407,30 +10402,23 @@ static void qore_aot_module_ns_init_impl(QoreNamespace* root_ns, QoreNamespace* 
                 auto debug_metadata = makeAOTDebugMetadata(init_reader,
                     init_metadata.data(), static_cast<int>(init_metadata.size()));
                 {
-                    // Lock the thread-current Program before the per-module shadow builder.  Static
-                    // method references decoded below acquire this parse context.  Taking the shadow
-                    // lock first can deadlock with the first importer, which already owns the shadow
-                    // Program's parse context and is waiting to build the same module's init contexts.
                     CurrentProgramRuntimeParseContextHelper current_pch;
-                    // Serialize only builders for this module's shared shadow Program.  Context
-                    // deserialization can resolve APIs in another Program and wait for its parse
-                    // lock; taking that context above gives every same-module importer one lock order
-                    // (Program parse context, then shadow builder), while the per-module scope avoids
-                    // coupling unrelated module loads.
                     assert(shadow_build_lock);
                     AutoLocker shadow_build_al(*shadow_build_lock);
                     registerAOTFunctionsFromSlotMaps(init_reader, target_root_priv,
                         init_ctx_pgm, func_map, registered, &init_func_contexts, nullptr,
-                        &registration_errors, debug_metadata);
+                        &registration_errors, debug_metadata, tpgm);
                 }
 
                 if (aotInitTraceEnabled()) {
-                    fprintf(stderr, "[aot-init] ns_init module=%s registered=%d contexts=%zu remaining=%zu\n",
+                    fprintf(stderr,
+                        "[aot-init] ns_init module=%s registered=%d contexts=%zu remaining=%zu\n",
                         mod_name, registered, init_func_contexts.size(), func_map.size());
                 }
                 if (!registration_errors.empty()) {
                     std::string msg = makeAOTRegistrationFailureMessage(mod_name, registered,
-                        static_cast<int>(func_map.size() + registered), &func_map, &registration_errors);
+                        static_cast<int>(func_map.size() + registered), &func_map,
+                        &registration_errors);
                     raise_ns_init_error(std::string("AOT ns_init '")
                         + (mod_name ? mod_name : "(unknown)") + "': " + msg);
                     return;
@@ -10440,13 +10428,6 @@ static void qore_aot_module_ns_init_impl(QoreNamespace* root_ns, QoreNamespace* 
                 if (!init_func_contexts.empty()) {
                     printd(2, "AOT ns_init '%s': executing %d init functions\n",
                         mod_name, (int)init_func_contexts.size());
-                    // Execute against the target program (tpgm) so objects
-                    // constructed during init find committed class hierarchies.
-                    // Pass init_ctx_pgm (the module's own program) as shadow so
-                    // results are also mirrored into the module's own
-                    // ConstantEntries — subsequent init functions built against
-                    // the module program will then read correct values via
-                    // RuntimeConstantRefNode.
                     executeInitFunctions(tpgm, init_func_contexts,
                         init_descriptors, mod_name,
                         init_ctx_pgm != tpgm ? init_ctx_pgm : nullptr,
@@ -11375,7 +11356,6 @@ static void executeInitFunctions(
         }
     }
 
-    // Clean up init function contexts
     for (auto& info : exec_infos) {
         delete info.ctx;
     }

--- a/lib/QoreProgram.cpp
+++ b/lib/QoreProgram.cpp
@@ -1214,6 +1214,11 @@ void qore_program_private::waitForTerminationAndClear(ExceptionSink* xsink) {
         // no manual delete loop needed.
         local_var_list.clear();
 
+        // Deferred AOT module initialization is scoped to this Program. Release
+        // the per-Program markers together with the parse data so repeated
+        // short-lived Program imports cannot retain module-name allocations.
+        std::unordered_set<std::string>().swap(initialized_aot_modules);
+
         // clear program location
         //update_runtime_location(&loc_builtin);
     }


### PR DESCRIPTION
Fixes #5381.

Related Qorus lifecycle acceptance issue: qoretechnologies/qorus#391.

## Changes

- move deferred AOT init markers from process-wide raw `QoreProgram*` storage to importer-owned Program state
- keep symbol/type resolution in the permanent module shadow while allocating deserialized locals from the importing Program
- propagate local ownership through expressions, instructions, handlers, closures, and signatures
- add a stripped-source AOT regression covering pointer reuse, init counts, closure locals, and bounded 100-vs-200-cycle tracked live bytes

## Local validation

- Release allocation-tracking build: pass
- focused Program AOT lifecycle test: 6 assertions pass
- `AOTModuleContextPath.qtest`: 9 cases / 44 assertions pass
- `AOTReadonlyConstBindings.qtest`: 1 case / 4 assertions pass
- stripped-source `on_exit` selection: 2 cases / 4 assertions pass
- stripped-source closure selection: 7 cases / 14 assertions pass
- unchanged runtime fails the lifecycle regression deterministically (expected init count 101, actual 97)
- Qorus post-warm 100-cycle lifecycle run: tail RSS slope 190.9 KiB/cycle vs 194.7 KiB/cycle control; heap slope 0 in both